### PR TITLE
feat: deploy workflow + Calendly CTA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Build & Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    # Only deploy when Cloudflare secrets are configured
+    if: ${{ vars.DEPLOY_ENABLED == 'true' }}
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=ss-web

--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -7,7 +7,7 @@ interface Props {
 
 const {
   variant = 'primary',
-  href = 'mailto:scott@smd.services?subject=Assessment%20Call%20Request',
+  href = 'https://calendly.com/smd-services/assessment',
   class: className = '',
 } = Astro.props
 


### PR DESCRIPTION
## Summary
- Adds Cloudflare Pages deploy workflow (`deploy.yml`) with secrets guard — only runs when `DEPLOY_ENABLED` repo variable is set to `true`
- Updates all CTA buttons to link to Calendly booking page (`https://calendly.com/smd-services/assessment`) instead of mailto fallback

## To activate deployment
1. Create Cloudflare Pages project `ss-web`
2. Add repo secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
3. Add repo variable: `DEPLOY_ENABLED` = `true`
4. Point `smd.services` domain to the Pages project

## Test plan
- [x] `npm run verify` passes (29 tests, typecheck, lint, format, build)
- [x] Build output is 80KB total
- [x] Sitemap generates correctly
- [x] OG image present and renders
- [ ] Verify Calendly URL resolves once booking page is created
- [ ] Verify deploy workflow runs after secrets are configured

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)