### PR TITLE
fix: correct Cloudflare Pages project name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=ss-web
+          command: pages deploy dist --project-name=ss-web-c2l


### PR DESCRIPTION
## Summary
- Updates deploy workflow project name from `ss-web` to `ss-web-c2l` to match the actual Cloudflare Pages project

## Test plan
- [ ] Merge and verify deploy workflow triggers successfully
- [ ] Confirm site loads at ss-web-c2l.pages.dev and smd.services

🤖 Generated with [Claude Code](https://claude.com/claude-code)