### PR TITLE
fix: revert project name to ss-web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=ss-web-c2l
+          command: pages deploy dist --project-name=ss-web


### PR DESCRIPTION
## Summary
- Reverts deploy workflow project name from `ss-web-c2l` back to `ss-web`
- The `.pages.dev` subdomain suffix is Cloudflare's collision avoidance, not the project name used by the API

## Test plan
- [ ] Deploy workflow succeeds after merge
- [ ] Site loads at smd.services

🤖 Generated with [Claude Code](https://claude.com/claude-code)