### PR TITLE
feat: embed Calendly scheduler inline on landing page

### DIFF
--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -1,7 +1,3 @@
----
-import CtaButton from './CtaButton.astro'
----
-
 <section id="book" class="bg-brand px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg text-center">
     <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
@@ -11,8 +7,14 @@ import CtaButton from './CtaButton.astro'
       Book a 60-minute assessment call. We'll identify your top 3 problems and show you exactly how
       we'd solve them.
     </p>
-    <div class="mt-10">
-      <CtaButton variant="outline-white">Book Your Assessment Call</CtaButton>
+    <div class="mx-auto mt-10 max-w-3xl overflow-hidden rounded-xl bg-white shadow-lg">
+      <div
+        class="calendly-inline-widget"
+        data-url="https://calendly.com/smd-services/assessment?hide_gdpr_banner=1"
+        style="min-width:320px;height:700px;"
+      >
+      </div>
     </div>
   </div>
 </section>
+<script is:inline src="https://assets.calendly.com/assets/external/widget.js" async></script>


### PR DESCRIPTION
## Summary
- Replaces external Calendly link in the #book section with an inline Calendly widget
- Visitors book directly on smd.services without leaving the page
- Hero and Pricing CTAs still scroll to #book — now they land on the embedded scheduler

## Test plan
- [ ] Calendly widget loads in the #book section
- [ ] Booking flow completes without leaving smd.services
- [ ] Mobile responsive (widget adapts to viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)