### PR TITLE
fix: eliminate scroll inside Calendly embed

### DIFF
--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -36,7 +36,7 @@ import Footer from '../components/Footer.astro'
           <div
             class="calendly-inline-widget"
             data-url="https://calendly.com/smd-services/assessment?hide_gdpr_banner=1"
-            style="min-width:320px;height:700px;"
+            style="min-width:320px;height:1050px;"
           >
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Increase Calendly embed height from 700px to 1050px to show full scheduler without internal scroll

## Test plan
- [ ] No scrollbar inside the Calendly widget on /book page

🤖 Generated with [Claude Code](https://claude.com/claude-code)