### PR TITLE
fix: rewrite site copy to remove AI-generated patterns

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -3,10 +3,11 @@
     <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Why Us</h2>
     <div class="mt-8 border-l-4 border-brand pl-6">
       <p class="text-lg leading-relaxed text-gray-700">
-        We're a Phoenix-based operations team that helps small businesses stop running on duct tape.
-        We've seen the same six problems in hundreds of businesses — and we know how to fix them
-        fast. No long-term contracts, no bloated proposals. Just a 10-day sprint that gets your
-        operations where they should be.
+        We're based in Phoenix and we work with small businesses that have outgrown their systems.
+        The kind where the owner is still the answer to every question, leads live in a spreadsheet
+        (or someone's head), and half the tools they're paying for aren't set up right. We come in
+        for ten days, pick the two or three things that'll make the biggest difference, and get them
+        working. That's it.
       </p>
     </div>
   </div>

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -5,11 +5,11 @@ import CtaButton from './CtaButton.astro'
 <section id="book" class="bg-brand px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg text-center">
     <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-      Ready to Fix Your Operations?
+      Let's Talk About Your Business
     </h2>
     <p class="mx-auto mt-4 max-w-2xl text-lg text-blue-100">
-      Book a 60-minute assessment call. We'll identify your top 3 problems and show you exactly how
-      we'd solve them.
+      60-minute call. We'll ask you how things actually run, and you'll walk away knowing exactly
+      what to fix first.
     </p>
     <div class="mt-10">
       <CtaButton variant="outline-white" href="/book">Book Your Assessment Call</CtaButton>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -5,11 +5,11 @@ import CtaButton from './CtaButton.astro'
 <section class="bg-white px-4 py-20 sm:py-28">
   <div class="mx-auto max-w-screen-lg text-center">
     <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-      We Fix the Operations Problems You've Been Meaning to Fix for Months
+      Your Business Has Outgrown Its Processes
     </h1>
     <p class="mx-auto mt-6 max-w-2xl text-lg text-gray-600">
-      Your business has outgrown duct-tape processes. We diagnose the bottlenecks, choose the right
-      tools, and implement real solutions — all in a 10-day sprint.
+      You know what needs fixing. You just haven't had the time. We come in, figure out what's
+      costing you the most, and fix it. Ten days, fixed price, done.
     </p>
     <div class="mt-10">
       <CtaButton href="/book">Book Your Assessment Call</CtaButton>

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -4,25 +4,25 @@ const steps = [
     day: 'Day 1',
     title: 'Audit Call',
     description:
-      'We walk through your day, watch how things actually work, and identify the top 3 problems holding your business back.',
+      'We get on the phone for an hour and walk through your day. How do jobs get scheduled? Where do leads go? What happens when a customer calls? We figure out where things break down.',
   },
   {
     day: 'Days 2\u20135',
-    title: 'Design & Build',
+    title: 'Build It Out',
     description:
-      'We choose the simplest tools that solve your problems, build the workflows, and configure everything end-to-end.',
+      'We pick the tools, set them up, build the workflows, and connect everything. You keep running your business while we work.',
   },
   {
     day: 'Days 6\u20137',
-    title: 'Training & Handoff',
+    title: 'Train Your Team',
     description:
-      'Your team gets hands-on training, written how-to docs, and an internal champion who knows the new systems inside out.',
+      'Hands-on walkthrough with your team. Everyone gets written docs so nobody has to remember how it works.',
   },
   {
     day: 'Days 8\u201310',
-    title: 'Buffer & Polish',
+    title: 'Adjust and Wrap Up',
     description:
-      'We handle feedback, adjust based on real usage, and make sure everything works before we walk away.',
+      "Your team uses the new systems for real. We're on call to fix anything that doesn't work the way it should.",
   },
 ]
 ---

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -3,14 +3,14 @@ const verticals = [
   {
     title: 'Home Services',
     subtitle: 'Plumbers, HVAC, Electricians, Contractors',
-    pain: 'Scheduling chaos, leads falling through cracks, no visibility into what your crew is doing',
-    fix: 'Centralized scheduling, automated follow-up, team accountability systems',
+    pain: "Jobs get double-booked because the schedule lives in three places. Leads come in from the website and nobody follows up. You find out a job went sideways after the customer's already angry.",
+    fix: 'One schedule everyone can see, automatic lead follow-up, and a system so you know what your crew is doing without calling them.',
   },
   {
     title: 'Professional Services',
     subtitle: 'Accountants, Attorneys, Consultants',
-    pain: 'Everything runs through you, clients waiting on responses, pipeline tracked in your head',
-    fix: 'Documented processes, client communication systems, pipeline management',
+    pain: "Every client question routes to you. Your pipeline is a mental list. That thing you've been meaning to systematize has been on your list for a year.",
+    fix: "Processes your team can follow without asking you, a real pipeline you can look at, and client communication that doesn't depend on one person.",
   },
 ]
 ---

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -5,16 +5,16 @@ import Footer from '../components/Footer.astro'
 
 <Base
   title="Book Your Assessment Call — SMD Services"
-  description="Schedule a 60-minute operations assessment with SMD Services. We'll identify your top 3 bottlenecks and show you exactly how we'd fix them."
+  description="Schedule a 60-minute operations assessment. We'll figure out what's costing you the most time and tell you how we'd fix it."
 >
   <main>
     <!-- Header -->
     <section class="border-b border-gray-200 bg-white px-4 py-4">
       <div class="mx-auto flex max-w-screen-lg items-center justify-between">
-        <a href="/" class="text-lg font-bold text-brand hover:text-brand-dark transition">
+        <a href="/" class="text-lg font-bold text-brand transition hover:text-brand-dark">
           SMD Services
         </a>
-        <a href="/" class="text-sm text-gray-500 hover:text-gray-700 transition">
+        <a href="/" class="text-sm text-gray-500 transition hover:text-gray-700">
           &larr; Back to home
         </a>
       </div>
@@ -28,8 +28,8 @@ import Footer from '../components/Footer.astro'
             Book Your Assessment Call
           </h1>
           <p class="mx-auto mt-4 max-w-2xl text-lg text-gray-600">
-            60 minutes. No sales pitch. We'll walk through your operations, identify the biggest
-            bottlenecks, and show you what we'd fix first.
+            Pick a time that works. We'll call you, ask how things run, and tell you what we'd fix
+            first. It takes about an hour.
           </p>
         </div>
         <div class="mx-auto mt-10 max-w-3xl overflow-hidden rounded-xl bg-white shadow-lg">
@@ -47,43 +47,43 @@ import Footer from '../components/Footer.astro'
     <section class="bg-white px-4 py-12 sm:py-16">
       <div class="mx-auto max-w-screen-lg">
         <h2 class="text-center text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
-          What to Expect
+          What Happens on the Call
         </h2>
         <div class="mx-auto mt-10 grid max-w-3xl gap-8 sm:grid-cols-3">
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-brand font-bold text-lg"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-lg font-bold text-brand"
             >
               1
             </div>
-            <h3 class="mt-4 font-semibold text-gray-900">We talk about your day</h3>
+            <h3 class="mt-4 font-semibold text-gray-900">You walk us through your day</h3>
             <p class="mt-2 text-sm text-gray-600">
-              Walk us through how things actually work — not how they're supposed to. Where do
-              things break down? What keeps you up at night?
+              How do customers find you? How do jobs get scheduled? What happens when something goes
+              wrong? We want to see how it actually works, not the brochure version.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-brand font-bold text-lg"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-lg font-bold text-brand"
             >
               2
             </div>
-            <h3 class="mt-4 font-semibold text-gray-900">We identify the top 3 problems</h3>
+            <h3 class="mt-4 font-semibold text-gray-900">We tell you what we'd fix first</h3>
             <p class="mt-2 text-sm text-gray-600">
-              Most businesses have the same core issues. We'll pinpoint which ones are costing you
-              the most time and money right now.
+              Every business has a short list of things that would make the biggest difference.
+              We'll tell you what yours are and why.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-brand font-bold text-lg"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-lg font-bold text-brand"
             >
               3
             </div>
-            <h3 class="mt-4 font-semibold text-gray-900">You get a clear plan</h3>
+            <h3 class="mt-4 font-semibold text-gray-900">You decide if you want help</h3>
             <p class="mt-2 text-sm text-gray-600">
-              We'll outline exactly what we'd fix, what tools we'd use, and what the 10-day sprint
-              looks like. No obligation.
+              If it makes sense to work together, we'll send you a proposal with the scope, price,
+              and timeline. If not, you still got a free hour of advice.
             </p>
           </div>
         </div>
@@ -98,33 +98,33 @@ import Footer from '../components/Footer.astro'
         </h2>
         <dl class="mx-auto mt-10 max-w-2xl space-y-8">
           <div>
-            <dt class="font-semibold text-gray-900">What does the assessment call cost?</dt>
+            <dt class="font-semibold text-gray-900">Does the assessment call cost anything?</dt>
             <dd class="mt-2 text-gray-600">
-              Nothing. The assessment call is free with no obligation. If we're a fit, we'll send a
-              proposal within 48 hours. If not, you'll still walk away with clarity on your biggest
-              operational issues.
+              No. If we can help, we'll send a proposal after the call. If we can't, you still got a
+              useful conversation about your operations. Either way it costs you nothing but time.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-gray-900">How should I prepare?</dt>
+            <dt class="font-semibold text-gray-900">Do I need to prepare anything?</dt>
             <dd class="mt-2 text-gray-600">
-              No prep needed. We'll ask you to walk us through a typical day and show us the tools
-              you use. The more honest you are about what's broken, the more useful the call will
-              be.
+              Just be ready to talk honestly about how things work. We'll ask questions. The less
+              polished, the better. We need to see the real version, not the one you'd show an
+              investor.
             </dd>
           </div>
           <div>
             <dt class="font-semibold text-gray-900">What happens after the call?</dt>
             <dd class="mt-2 text-gray-600">
-              If we identify problems we can solve, you'll receive a fixed-price proposal within 48
-              hours. It includes the exact scope, timeline, and cost. No surprises.
+              If there's a fit, you get a proposal within 48 hours. Fixed price, clear scope, no
+              surprises. If there's not a fit, we'll tell you that too.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-gray-900">What size business do you work with?</dt>
+            <dt class="font-semibold text-gray-900">What size business is this for?</dt>
             <dd class="mt-2 text-gray-600">
-              We work with Phoenix-area businesses with 5 to 50 employees — the "too big for one
-              person, too small for a COO" zone. If that's you, we can help.
+              Phoenix-area businesses with roughly 5 to 50 employees. Big enough that the owner
+              can't do everything themselves anymore, small enough that hiring a full-time
+              operations person doesn't make sense yet.
             </dd>
           </div>
         </dl>


### PR DESCRIPTION
## Summary
- Rewrites all site copy (Hero, About, HowItWorks, FinalCta, WhoWeHelp, book page) to remove AI tells
- Removes em dashes, tricolons, "No X, no Y. Just Z." patterns, generic verbs
- Removes false "hundreds of businesses" claim (pre-launch)
- New tone: conversational, direct, like explaining at a networking event

## Test plan
- [ ] `npm run verify` passes
- [ ] Read through all copy on homepage and /book page for natural tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)