### PR TITLE
feat: full visual overhaul — Stitch-informed design system

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,12 +1,12 @@
 <section class="bg-white px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg">
     <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Why Us</h2>
-    <div class="mt-8 border-l-4 border-brand pl-6">
+    <div class="mt-8 border-l-4 border-accent pl-6">
       <p class="text-lg leading-relaxed text-gray-700">
         We're based in Phoenix and we work with small businesses that have outgrown their systems.
         The kind where the owner is still the answer to every question, leads live in a spreadsheet
-        (or someone's head), and half the tools they're paying for aren't set up right. We come in
-        for ten days, pick the two or three things that'll make the biggest difference, and get them
+        or someone's head, and half the tools they're paying for aren't set up right. We come in for
+        ten days, pick the two or three things that'll make the biggest difference, and get them
         working. That's it.
       </p>
     </div>

--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  variant?: 'primary' | 'outline' | 'outline-white'
+  variant?: 'primary' | 'accent' | 'outline-white'
   href?: string
   class?: string
 }
@@ -8,11 +8,11 @@ interface Props {
 const { variant = 'primary', href = '/book', class: className = '' } = Astro.props
 
 const base =
-  'inline-block rounded-lg px-6 py-3 font-semibold transition focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2'
+  'inline-block rounded-lg px-6 py-3 font-semibold transition focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2'
 const variants = {
-  primary: 'bg-brand text-white hover:bg-brand-dark',
-  outline: 'border-2 border-brand text-brand hover:bg-brand hover:text-white',
-  'outline-white': 'border-2 border-white text-white hover:bg-white hover:text-brand',
+  primary: 'bg-primary text-white hover:bg-primary-light shadow-lg',
+  accent: 'bg-accent text-white hover:bg-accent-dark',
+  'outline-white': 'border-2 border-white text-white hover:bg-white hover:text-primary',
 }
 ---
 

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -2,17 +2,17 @@
 import CtaButton from './CtaButton.astro'
 ---
 
-<section id="book" class="bg-brand px-4 py-16 sm:py-24">
+<section id="book" class="bg-primary px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg text-center">
     <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
       Let's Talk About Your Business
     </h2>
-    <p class="mx-auto mt-4 max-w-2xl text-lg text-blue-100">
+    <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-400">
       60-minute call. We'll ask you how things actually run, and you'll walk away knowing exactly
       what to fix first.
     </p>
     <div class="mt-10">
-      <CtaButton variant="outline-white" href="/book">Book Your Assessment Call</CtaButton>
+      <CtaButton variant="accent" href="/book">Book Your Assessment Call</CtaButton>
     </div>
   </div>
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,11 +1,6 @@
----
-const year = new Date().getFullYear()
----
-
-<footer class="bg-gray-900 px-4 py-8">
-  <div class="mx-auto max-w-screen-lg text-center text-sm text-gray-400">
-    <p class="font-semibold text-gray-200">SMD Services</p>
-    <p class="mt-1">Phoenix, AZ</p>
-    <p class="mt-3">&copy; {year} SMD Services. All rights reserved.</p>
+<footer class="bg-slate-50 px-4 py-8">
+  <div class="mx-auto max-w-screen-lg text-center">
+    <p class="text-sm font-semibold text-slate-700">SMD Services &middot; Phoenix, Arizona</p>
+    <p class="mt-1 text-xs text-slate-500">&copy; 2026 SMDurgan, LLC</p>
   </div>
 </footer>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,18 +2,18 @@
 import CtaButton from './CtaButton.astro'
 ---
 
-<section class="bg-white px-4 py-20 sm:py-28">
+<section class="bg-primary px-4 py-24 sm:py-32">
   <div class="mx-auto max-w-screen-lg text-center">
-    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+    <h1 class="text-4xl font-extrabold tracking-tight text-white sm:text-6xl">
       Growing Businesses Need Better Systems. We Can Help.
     </h1>
-    <p class="mx-auto mt-6 max-w-2xl text-lg text-gray-600">
+    <p class="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-slate-300">
       You know your business better than anyone. We know how to pick the right tools and make them
       actually work. We're a small business too, and we work with you to figure out which changes
-      will make the biggest difference. Ten days, fixed price, done.
+      will make the biggest difference.
     </p>
     <div class="mt-10">
-      <CtaButton href="/book">Book Your Assessment Call</CtaButton>
+      <CtaButton variant="accent" href="/book">Book Your Assessment Call</CtaButton>
     </div>
   </div>
 </section>

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -4,7 +4,7 @@ const steps = [
     day: 'Day 1',
     title: 'Audit Call',
     description:
-      'We get on the phone for an hour and walk through your day. How do jobs get scheduled? Where do leads go? What happens when a customer calls? We figure out where things break down.',
+      'We get on the phone for an hour and walk through your day. How do jobs get scheduled? Where do leads go? What happens when something goes wrong? We figure out where things break down.',
   },
   {
     day: 'Days 2\u20135',
@@ -30,16 +30,16 @@ const steps = [
 <section class="bg-white px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg">
     <h2 class="text-center text-3xl font-bold text-gray-900">How It Works</h2>
-    <div class="mt-12 space-y-8 border-l-2 border-brand pl-8">
+    <div class="mt-12 space-y-8 border-l-2 border-primary pl-8">
       {
         steps.map((step) => (
           <div class="relative">
-            <div class="absolute -left-[calc(2rem+5px)] top-1 h-2.5 w-2.5 rounded-full bg-brand" />
-            <span class="inline-flex items-center rounded-full bg-brand px-3 py-1 text-sm font-semibold text-white">
+            <div class="absolute -left-[calc(2rem+5px)] top-1 h-2.5 w-2.5 rounded-full bg-primary" />
+            <span class="inline-flex items-center rounded-full bg-primary px-3 py-1 text-sm font-semibold text-white">
               {step.day}
             </span>
             <h3 class="mt-2 text-xl font-bold text-gray-900">{step.title}</h3>
-            <p class="mt-1 text-gray-600">{step.description}</p>
+            <p class="mt-1 text-slate-600">{step.description}</p>
           </div>
         ))
       }

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,12 @@
+---
+import CtaButton from './CtaButton.astro'
+---
+
+<header
+  class="sticky top-0 z-50 border-b border-slate-200/50 bg-slate-50/95 px-4 py-3 backdrop-blur-sm"
+>
+  <div class="mx-auto flex max-w-screen-lg items-center justify-between">
+    <a href="/" class="text-sm font-semibold tracking-tight text-primary">SMD Services</a>
+    <CtaButton href="/book" class="px-5 py-2 text-sm">Book Your Assessment Call</CtaButton>
+  </div>
+</header>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -8,14 +8,14 @@ import CtaButton from './CtaButton.astro'
       Simple, Fixed-Price Engagement
     </h2>
     <div
-      class="mx-auto mt-12 max-w-md rounded-xl border border-gray-200 bg-white p-8 shadow-lg sm:p-10"
+      class="mx-auto mt-12 max-w-md rounded-lg border border-gray-200 bg-white p-8 shadow-sm sm:p-10"
     >
-      <p class="text-center text-sm font-semibold uppercase tracking-wide text-gray-500">
+      <p class="text-center text-xs font-bold uppercase tracking-wider text-slate-500">
         Operations Cleanup
       </p>
-      <p class="mt-1 text-center text-base text-gray-600">10-Day Sprint</p>
-      <p class="mt-6 text-center text-5xl font-bold text-brand">$3,500</p>
-      <p class="mt-2 text-center text-sm text-gray-500">50% at signing, 50% on Day 8</p>
+      <p class="mt-1 text-center text-base text-slate-600">10-Day Engagement</p>
+      <p class="mt-6 text-center text-5xl font-bold text-accent">$3,500</p>
+      <p class="mt-2 text-center text-sm text-slate-500">50% at signing, 50% on Day 8</p>
       <ul class="mt-8 space-y-3 text-gray-700">
         {
           [
@@ -28,7 +28,7 @@ import CtaButton from './CtaButton.astro'
           ].map((item) => (
             <li class="flex items-start gap-3">
               <svg
-                class="mt-0.5 h-5 w-5 shrink-0 text-brand"
+                class="mt-0.5 h-5 w-5 shrink-0 text-accent"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/src/components/ProblemCards.astro
+++ b/src/components/ProblemCards.astro
@@ -9,15 +9,17 @@ const problems = [
 ]
 ---
 
-<section class="bg-gray-50 px-4 py-16 sm:py-24">
+<section class="bg-surface px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg">
     <h2 class="text-center text-3xl font-bold text-gray-900">Sound Familiar?</h2>
     <div class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {
         problems.map((problem) => (
           <div class="rounded-lg bg-white p-6 shadow-sm">
-            <p class="text-lg italic text-gray-700">"{problem.quote}"</p>
-            <p class="mt-4 font-semibold text-brand">{problem.name}</p>
+            <p class="text-lg italic leading-snug text-slate-800">"{problem.quote}"</p>
+            <p class="mt-4 text-xs font-bold uppercase tracking-wider text-accent">
+              {problem.name}
+            </p>
           </div>
         ))
       }

--- a/src/components/WhatYouGet.astro
+++ b/src/components/WhatYouGet.astro
@@ -1,4 +1,4 @@
-<section class="bg-gray-50 px-4 py-16 sm:py-24">
+<section class="bg-surface px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg">
     <h2 class="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
       What You Get
@@ -15,7 +15,7 @@
         ].map((item) => (
           <li class="flex items-start gap-3">
             <svg
-              class="mt-0.5 h-6 w-6 shrink-0 text-green-600"
+              class="mt-0.5 h-6 w-6 shrink-0 text-accent"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -15,7 +15,7 @@ const verticals = [
 ]
 ---
 
-<section class="bg-gray-50 px-4 py-16 sm:py-24">
+<section class="bg-surface px-4 py-16 sm:py-24">
   <div class="mx-auto max-w-screen-lg">
     <h2 class="text-center text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
       Who We Help
@@ -25,15 +25,15 @@ const verticals = [
         verticals.map((v) => (
           <div class="rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
             <h3 class="text-xl font-bold text-gray-900">{v.title}</h3>
-            <p class="mt-1 text-sm text-gray-500">{v.subtitle}</p>
+            <p class="mt-1 text-sm text-slate-500">{v.subtitle}</p>
             <div class="mt-6">
-              <p class="text-sm font-semibold uppercase tracking-wide text-gray-500">
+              <p class="text-xs font-bold uppercase tracking-wider text-slate-500">
                 Sound familiar?
               </p>
               <p class="mt-2 text-gray-700">{v.pain}</p>
             </div>
             <div class="mt-4">
-              <p class="text-sm font-semibold uppercase tracking-wide text-brand">We fix this</p>
+              <p class="text-xs font-bold uppercase tracking-wider text-accent">We fix this</p>
               <p class="mt-2 text-gray-700">{v.fix}</p>
             </div>
           </div>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -9,30 +9,30 @@ import Footer from '../components/Footer.astro'
 >
   <main>
     <!-- Header -->
-    <section class="border-b border-gray-200 bg-white px-4 py-4">
+    <section class="border-b border-slate-200 bg-slate-50 px-4 py-4">
       <div class="mx-auto flex max-w-screen-lg items-center justify-between">
-        <a href="/" class="text-lg font-bold text-brand transition hover:text-brand-dark">
+        <a href="/" class="text-sm font-semibold tracking-tight text-primary transition">
           SMD Services
         </a>
-        <a href="/" class="text-sm text-gray-500 transition hover:text-gray-700">
+        <a href="/" class="text-sm text-slate-500 transition hover:text-slate-700">
           &larr; Back to home
         </a>
       </div>
     </section>
 
     <!-- Booking Section -->
-    <section class="bg-gray-50 px-4 py-12 sm:py-16">
+    <section class="bg-surface px-4 py-12 sm:py-16">
       <div class="mx-auto max-w-screen-lg">
         <div class="text-center">
           <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
             Book Your Assessment Call
           </h1>
-          <p class="mx-auto mt-4 max-w-2xl text-lg text-gray-600">
+          <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
             Pick a time that works. We'll call you, ask how things run, and tell you what we'd fix
             first. It takes about an hour.
           </p>
         </div>
-        <div class="mx-auto mt-10 max-w-3xl overflow-hidden rounded-xl bg-white shadow-lg">
+        <div class="mx-auto mt-10 max-w-3xl overflow-hidden rounded-lg bg-white shadow-sm">
           <div
             class="calendly-inline-widget"
             data-url="https://calendly.com/smd-services/assessment?hide_gdpr_banner=1"
@@ -52,36 +52,36 @@ import Footer from '../components/Footer.astro'
         <div class="mx-auto mt-10 grid max-w-3xl gap-8 sm:grid-cols-3">
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-lg font-bold text-brand"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary text-lg font-bold text-white"
             >
               1
             </div>
             <h3 class="mt-4 font-semibold text-gray-900">You walk us through your day</h3>
-            <p class="mt-2 text-sm text-gray-600">
+            <p class="mt-2 text-sm text-slate-600">
               How do customers find you? How do jobs get scheduled? What happens when something goes
               wrong? We want to see how it actually works, not the brochure version.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-lg font-bold text-brand"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary text-lg font-bold text-white"
             >
               2
             </div>
             <h3 class="mt-4 font-semibold text-gray-900">We tell you what we'd fix first</h3>
-            <p class="mt-2 text-sm text-gray-600">
+            <p class="mt-2 text-sm text-slate-600">
               Every business has a short list of things that would make the biggest difference.
               We'll tell you what yours are and why.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-brand-light text-lg font-bold text-brand"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary text-lg font-bold text-white"
             >
               3
             </div>
             <h3 class="mt-4 font-semibold text-gray-900">You decide if you want help</h3>
-            <p class="mt-2 text-sm text-gray-600">
+            <p class="mt-2 text-sm text-slate-600">
               If it makes sense to work together, we'll send you a proposal with the scope, price,
               and timeline. If not, you still got a free hour of advice.
             </p>
@@ -91,7 +91,7 @@ import Footer from '../components/Footer.astro'
     </section>
 
     <!-- FAQ -->
-    <section class="bg-gray-50 px-4 py-12 sm:py-16">
+    <section class="bg-surface px-4 py-12 sm:py-16">
       <div class="mx-auto max-w-screen-lg">
         <h2 class="text-center text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
           Common Questions
@@ -99,14 +99,14 @@ import Footer from '../components/Footer.astro'
         <dl class="mx-auto mt-10 max-w-2xl space-y-8">
           <div>
             <dt class="font-semibold text-gray-900">Does the assessment call cost anything?</dt>
-            <dd class="mt-2 text-gray-600">
+            <dd class="mt-2 text-slate-600">
               No. If we can help, we'll send a proposal after the call. If we can't, you still got a
               useful conversation about your operations. Either way it costs you nothing but time.
             </dd>
           </div>
           <div>
             <dt class="font-semibold text-gray-900">Do I need to prepare anything?</dt>
-            <dd class="mt-2 text-gray-600">
+            <dd class="mt-2 text-slate-600">
               Just be ready to talk honestly about how things work. We'll ask questions. The less
               polished, the better. We need to see the real version, not the one you'd show an
               investor.
@@ -114,14 +114,14 @@ import Footer from '../components/Footer.astro'
           </div>
           <div>
             <dt class="font-semibold text-gray-900">What happens after the call?</dt>
-            <dd class="mt-2 text-gray-600">
+            <dd class="mt-2 text-slate-600">
               If there's a fit, you get a proposal within 48 hours. Fixed price, clear scope, no
               surprises. If there's not a fit, we'll tell you that too.
             </dd>
           </div>
           <div>
             <dt class="font-semibold text-gray-900">What size business is this for?</dt>
-            <dd class="mt-2 text-gray-600">
+            <dd class="mt-2 text-slate-600">
               Phoenix-area businesses with roughly 5 to 50 employees. Big enough that the owner
               can't do everything themselves anymore, small enough that hiring a full-time
               operations person doesn't make sense yet.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
 import Hero from '../components/Hero.astro'
 import ProblemCards from '../components/ProblemCards.astro'
 import HowItWorks from '../components/HowItWorks.astro'
@@ -12,6 +13,7 @@ import Footer from '../components/Footer.astro'
 ---
 
 <Base title="SMD Services — Operations Consulting for Phoenix Small Businesses">
+  <Nav />
   <main>
     <Hero />
     <ProblemCards />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,12 @@
 @import 'tailwindcss';
 
 @theme {
-  --color-brand: #1e40af;
-  --color-brand-light: #dbeafe;
-  --color-brand-dark: #1e3a8a;
+  --color-primary: #0f172a;
+  --color-primary-light: #1e293b;
+  --color-accent: #0d9488;
+  --color-accent-dark: #0f766e;
+  --color-surface: #f3f4f6;
+  --color-surface-dark: #e5e7eb;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Complete visual redesign based on Stitch design exploration (Screen 4 look + Screen 3 copy)
- New color system: slate-900 primary (`#0F172A`) + teal-600 accent (`#0D9488`)
- Dark hero section, sticky nav, alternating section backgrounds, dark CTA band
- New `Nav.astro` component with sticky header
- All components updated to new design tokens
- Book page restyled to match

## Test plan
- [ ] `npm run verify` passes
- [ ] Homepage: dark hero, teal CTAs, alternating gray/white sections, dark bottom CTA
- [ ] /book page: matching color scheme, Calendly embed functional
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)