### PR TITLE
feat: replace fixed pricing with scope-based model

### DIFF
--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,53 +1,68 @@
 <section class="bg-slate-900 px-6 py-24 text-white">
   <div class="mx-auto max-w-4xl">
-    <div class="grid items-center gap-12 md:grid-cols-2">
-      <div>
-        <h2 class="mb-6 text-3xl font-bold">Simple, Transparent Pricing</h2>
-        <p class="mb-8 text-lg text-slate-400">
-          We scope specific problems for a fixed price. No complex retainers, no vague hourly bills.
-        </p>
-        <ul class="space-y-4">
+    <h2 class="mb-4 text-center text-3xl font-bold">
+      Scoped to Your Business. Priced to the Problem.
+    </h2>
+    <p class="mx-auto mb-16 max-w-2xl text-center text-lg text-slate-400">
+      Every business is different. We quote a fixed price after we understand yours — no hourly
+      billing, no open-ended retainers, no surprises.
+    </p>
+
+    <div class="mb-16 grid gap-8 md:grid-cols-3">
+      {
+        [
           {
-            [
-              'Full operations audit and scope document',
-              'Tool selection, setup, and integration',
-              'Process documentation and SOPs',
-              '60-minute team training session',
-              'Written how-to guides for every system',
-              'Two-week post-handoff support',
-            ].map((item) => (
-              <li class="flex items-center gap-3">
-                <svg
-                  class="h-5 w-5 shrink-0 text-primary"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                <span>{item}</span>
-              </li>
-            ))
-          }
-        </ul>
-      </div>
-      <div class="rounded-2xl bg-white p-8 text-slate-900 shadow-xl">
-        <span class="text-xs font-bold uppercase tracking-widest text-slate-500"
-          >Operations Cleanup</span
-        >
-        <div class="mt-2 text-5xl font-extrabold">$3,500</div>
-        <p class="mt-2 text-sm text-slate-400">50% at signing, 50% on Day 8</p>
-        <a
-          class="mt-6 block w-full rounded-lg bg-primary py-4 text-center font-bold text-white transition-colors hover:bg-primary-hover"
-          href="/book"
-        >
-          Book Assessment
-        </a>
-        <p class="mt-4 text-center text-xs text-slate-400">
-          No commitment until after the assessment call.
-        </p>
-      </div>
+            label: 'Diagnose',
+            detail: 'Assessment call to identify your top problems and define the scope.',
+          },
+          {
+            label: 'Quote',
+            detail: 'Fixed price and timeline based on what we find — before you commit.',
+          },
+          {
+            label: 'Deliver',
+            detail: '10-day sprint. Implementation, training, handoff. Done.',
+          },
+        ].map((step) => (
+          <div class="text-center">
+            <p class="text-xl font-bold text-white">{step.label}</p>
+            <p class="mt-2 text-slate-400">{step.detail}</p>
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="mx-auto max-w-xl rounded-2xl bg-white p-8 text-slate-900 shadow-xl">
+      <h3 class="text-center text-xl font-bold">How We Price</h3>
+      <ul class="mt-6 space-y-4">
+        {
+          [
+            'Fixed price — you know the total cost before work starts',
+            'Scoped to 2–3 specific problems, not a vague retainer',
+            '50% at signing, 50% on Day 8 — simple terms',
+            'No commitment until after the assessment call',
+          ].map((item) => (
+            <li class="flex items-start gap-3">
+              <svg
+                class="mt-0.5 h-5 w-5 shrink-0 text-primary"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+              <span>{item}</span>
+            </li>
+          ))
+        }
+      </ul>
+      <a
+        class="mt-8 block w-full rounded-lg bg-primary py-4 text-center font-bold text-white transition-colors hover:bg-primary-hover"
+        href="/book"
+      >
+        Book Your Assessment Call
+      </a>
     </div>
   </div>
 </section>

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -46,9 +46,11 @@ describe('component existence', () => {
 })
 
 describe('content integrity', () => {
-  it('Pricing.astro contains $3,500', () => {
+  it('Pricing.astro does not publish a specific dollar amount', () => {
     const content = readComponent('Pricing.astro')
-    expect(content).toContain('$3,500')
+    expect(content).not.toContain('$3,500')
+    expect(content).not.toContain('$2,500')
+    expect(content).toContain('Book Your Assessment Call')
   })
 
   it('$2,500 does not appear anywhere in src/', () => {


### PR DESCRIPTION
## Summary
- Remove published $3,500 price from the pricing section
- Replace with "Diagnose → Quote → Deliver" process flow and "How We Price" card emphasizing scope-based fixed pricing after assessment
- Update content integrity test to validate no dollar amounts are published

## Context
Competitive research shows successful ops consultants who sell diagnostic + custom implementation never publish prices. The assessment call becomes the pricing conversation, enabling value-based quoting per client.

## Test plan
- [ ] `npm run verify` passes
- [ ] Pricing section renders without dollar amounts on localhost
- [ ] CTA still links to assessment booking

🤖 Generated with [Claude Code](https://claude.com/claude-code)