### PR TITLE
feat: replace Team Invisibility with Employee Retention scenario

### DIFF
--- a/src/components/ProblemCards.astro
+++ b/src/components/ProblemCards.astro
@@ -5,7 +5,7 @@ const problems = [
   { name: 'Financial Blindness', quote: "I have no idea if we're making money" },
   { name: 'Scheduling Chaos', quote: 'Double-bookings happen all the time' },
   { name: 'Manual Communication', quote: 'I personally text every customer' },
-  { name: 'Team Invisibility', quote: "I don't know what my team is doing" },
+  { name: 'Employee Retention', quote: 'I keep losing good people' },
 ]
 ---
 


### PR DESCRIPTION
## Summary
- Replaces "Team Invisibility" scenario card with "Employee Retention" ("I keep losing good people")
- Validated through market research: retention is a stronger pain point that owners feel as direct cost, while team invisibility requires behavior change tools alone can't solve
- Hiring was considered but rejected — owners frame hiring as a market problem, not a process problem. Retention points inward at fixable systems (onboarding, role clarity, check-ins)

## Test plan
- [x] `npm run verify` passes
- [ ] Visual check: 6th card on landing page reads "I keep losing good people" / Employee Retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)