### PR TITLE
fix: rewrite hero and about copy — collaborative tone, no fixed timeframes

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -3,11 +3,10 @@
     <h2 class="text-3xl font-bold text-slate-900">Why Us</h2>
     <div class="mt-8 border-l-4 border-primary pl-6">
       <p class="text-lg leading-relaxed text-slate-600">
-        We're based in Phoenix and we work with small businesses that have outgrown their systems.
-        The kind where the owner is still the answer to every question, leads live in a spreadsheet
-        or someone's head, and half the tools they're paying for aren't set up right. We come in for
-        ten days, pick the two or three things that'll make the biggest difference, and get them
-        working. That's it.
+        We're based in Phoenix and we work with small businesses that have hit that in-between stage
+        — too big for the owner to run everything alone, not big enough for a full-time operations
+        hire. We start by understanding where you're trying to go, figure out what's in the way, and
+        build the right systems to get you there.
       </p>
     </div>
   </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,12 +7,11 @@ import CtaButton from './CtaButton.astro'
     <h1
       class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-slate-900 md:text-7xl"
     >
-      Growing Businesses Need Better Systems. We Can Help.
+      Your Business Is Growing. Your Systems Should Too.
     </h1>
     <p class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-slate-600">
-      You know your business better than anyone. We know how to pick the right tools and make them
-      actually work. We're a small business too, and we work with you to figure out which changes
-      will make the biggest difference.
+      You know where you're headed. We work alongside you to figure out what needs to change — and
+      build it together.
     </p>
     <CtaButton href="/book">Book a Call</CtaButton>
   </div>


### PR DESCRIPTION
## Summary
- Hero: replace "We know how to pick the right tools" with collaborative framing — "We work alongside you to figure out what needs to change — and build it together"
- Hero headline: "Your Business Is Growing. Your Systems Should Too."
- About: remove "ten days" fixed timeframe and diagnostic "pick two or three things" framing, rewrite around understanding objectives

## Test plan
- [x] `npm run verify` passes
- [ ] Visual review of hero and about sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)