### PR TITLE
fix: replace systems with solution in marketing copy

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -6,7 +6,7 @@
         We're based in Phoenix and we work with small businesses that have hit that in-between stage
         — too big for the owner to run everything alone, not big enough for a full-time operations
         hire. We start by understanding where you're trying to go, figure out what's in the way, and
-        build the right systems to get you there.
+        build the right solution to get you there.
       </p>
     </div>
   </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,11 +7,11 @@ import CtaButton from './CtaButton.astro'
     <h1
       class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-slate-900 md:text-7xl"
     >
-      Your Business Is Growing. Your Systems Should Too.
+      Your Business Is Growing. How You Run It Should Too.
     </h1>
     <p class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-slate-600">
       You know where you're headed. We work alongside you to figure out what needs to change — and
-      build it together.
+      build the right solution together.
     </p>
     <CtaButton href="/book">Book a Call</CtaButton>
   </div>

--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -4,7 +4,7 @@ const schema = {
   '@type': 'LocalBusiness',
   name: 'SMD Services',
   description:
-    'Operations consulting for Phoenix small businesses. We help growing businesses build better systems — the right tools, real workflows, and teams that can run them.',
+    'Operations consulting for Phoenix small businesses. We help growing businesses run better — the right tools, real workflows, and teams that own them.',
   url: 'https://smd.services',
   email: 'scott@smd.services',
   address: {


### PR DESCRIPTION
## Summary
- Hero: "Your Systems Should Too" → "How You Run It Should Too"; "build it together" → "build the right solution together"
- About: "build the right systems to get you there" → "build the right solution to get you there"
- JsonLd: "build better systems" → "run better" (structured data description)

"Systems" sounds scary and implies software. Not all solutions are software — sometimes it's a better process, a clearer role, or a simpler workflow.

## Test plan
- [x] `npm run verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)