### PR TITLE
docs: add tone & positioning standard to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance for Claude Code agents working in this repository.
 
 ## About This Venture
 
-**SMD Services** is a services venture under SMDurgan, LLC. It is NOT a SaaS product — it is a consulting business that sells fixed-price operations cleanup engagements to Phoenix-area small businesses (5–50 employees).
+**SMD Services** is a services venture under SMDurgan, LLC. It is NOT a SaaS product — it is a consulting business that sells operations cleanup engagements to Phoenix-area small businesses (10–25 employees).
 
-**Revenue target:** $5,000 in collected revenue within 30 calendar days of launch.
+**Objective:** Launch the agency and reach profitability.
 
-**Core offering:** Package 2 — Operations Cleanup ($2,500–$3,500 per engagement). We diagnose 2–3 of the most acute operational problems in a business and fix them in a 10-day sprint: process documentation, tool selection, system configuration, training, and handoff.
+**Core offering:** Operations Cleanup — scope-based pricing per engagement. We work with the business owner to understand their objectives, identify what's getting in the way, and build the right solution: process documentation, tool selection, configuration, training, and handoff. Engagement length varies based on scope.
 
-**Positioning:** We solve problems. Not "AI-powered" anything. A chef isn't hired for his knife. The value is an experienced outsider who can see the bottlenecks the owner can't, make fast decisions on tools and processes, and implement in days what the owner has been meaning to do for months.
+**Positioning:** We help growing businesses figure out what needs to change and build the right solution together. Not "AI-powered" anything. A chef isn't hired for his knife. The value is a collaborative team that works alongside the owner — someone who can see the operation with fresh eyes, make fast decisions on tools and processes, and implement in days what the owner has been meaning to do for months.
 
 ## What This Repo Is For
 
@@ -42,6 +42,48 @@ This creates a session, loads documentation, and establishes handoff context.
 - **Scope discipline.** Discover additional work mid-task — finish current scope, file a new issue.
 - **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min — stop and escalate.
 
+## Tone & Positioning Standard
+
+**These rules apply to ALL external-facing content: website copy, outreach, proposals, collateral, and any client-facing language. They also apply to internal content that may inform external copy (e.g., one-liners, scripts).**
+
+### 1. Objectives over problems
+
+Frame engagements around understanding business objectives, not just diagnosing problems. Recognizing a problem is a start, but without knowing the objective — what the business is trying to achieve — we can't truly solve it. The owner often knows the pain but hasn't articulated the goal. Part of our value is helping them discover the real objective through conversation. Don't give them a faster horse.
+
+- **Do:** "We start by understanding where you're trying to go, then figure out what's in the way."
+- **Don't:** "We diagnose your top problems and fix them."
+
+### 2. Collaborative, not diagnostic
+
+We are a peer working alongside the owner, not an expert arriving to audit them. The owner has the vision. We have operational experience. We figure it out together.
+
+- **Do:** "We work alongside you," "Let's figure out what needs to change," "together"
+- **Don't:** "We audit your operations," "We tell you what to fix," "We come in and pick the things that matter"
+
+### 3. No fixed timeframes in external content
+
+Timeframes are scoped per engagement, just like pricing. Do not publish specific durations for any phase of the engagement — the call, implementation, training, or support. Internally, use timeframes for planning, but never commit them in client-facing content.
+
+- **Do:** "We start with a conversation," "Hands-on training with your team"
+- **Don't:** "1-hour call," "10-day sprint," "60-minute training," "2-week support window"
+
+### 4. No published dollar amounts
+
+No dollar amounts appear on the website or in marketing materials. The client sees a project price in their proposal — never on a public page.
+
+### 5. "Solution" not "systems" in marketing contexts
+
+"Systems" sounds scary to business owners — it implies software and one more thing to learn. Not all solutions are software; sometimes it's a better process, a clearer role, or a simpler workflow. Use "solution" in positioning contexts. "System" is fine when referring to a specific literal tool (e.g., "data migration and system setup").
+
+- **Do:** "Build the right solution," "the right solution to get you there"
+- **Don't:** "Build better systems," "Your systems should keep up"
+
+### 6. Voice standard (from Decision #20)
+
+Always "we" / "our team." Never "I" / "the consultant." See Decision Stack #20 for full details.
+
+---
+
 ## The Business Model
 
 ### The 6 Universal SMB Operations Problems
@@ -67,21 +109,22 @@ Every 5–50 employee business has 3–4 of these. The assessment call identifie
 | Contractor/trades                            | Estimating/quoting + scheduling + team accountability |
 | Restaurant/food service                      | Team communication + inventory + financial visibility |
 
-### Delivery Timeline (10-Day Playbook)
+### Engagement Phases
 
-| Days | Phase                  | Activities                                                                                       |
-| ---- | ---------------------- | ------------------------------------------------------------------------------------------------ |
-| 1    | Audit call (60–90 min) | Walk through their day, "show me how you do X," identify top 3 pain points, write scope document |
-| 2–3  | Solution design        | Choose simplest tools, build templates/workflows/docs, configure tools and integrations          |
-| 4–5  | Implementation         | Migrate data, connect systems, test end-to-end                                                   |
-| 6–7  | Training               | 60-min walkthrough, hands-on practice, deliver "how to" docs, identify internal champion         |
-| 8–10 | Buffer + polish        | Handle feedback, adjust based on real use, final handoff                                         |
+| Phase            | Activities                                                                        |
+| ---------------- | --------------------------------------------------------------------------------- |
+| Assessment call  | Walk through their day, "show me how you do X," identify top 3 pain points        |
+| Solution design  | Choose simplest tools, design workflows, estimate scope and price, send proposal  |
+| Implementation   | Build templates/workflows/docs, configure tools, migrate data, connect systems    |
+| Training         | Hands-on walkthrough, practice, deliver "how to" docs, identify internal champion |
+| Handoff + polish | Handle feedback, adjust based on real use, final handoff                          |
 
 ### Pricing
 
-- **Operations Cleanup:** $2,500–$3,500 fixed price (scope determines exact price)
+- **Operations Cleanup:** Scope-based. Internal rate: $150/hr at launch → $175/hr → $200/hr with volume
 - **Paid Assessment (standalone):** $250 — the audit call as a standalone product
 - **Retainer (post-delivery):** $200–500/mo for ongoing support and optimization
+- **No dollar amounts published externally.** Client sees a project price, not hourly rate.
 
 ### The Assessment Call Is the Product
 
@@ -100,7 +143,7 @@ We are in the **pre-launch phase**. Nothing has been sold yet. The immediate pri
 
 - [ ] Assessment call script (the structured conversation guide for the audit call)
 - [ ] Proposal/SOW template (what gets sent after the assessment call)
-- [ ] Pricing framework (decision tree for $2,500 vs $3,500 scoping)
+- [ ] Pricing framework (scope estimation → hours × rate → project price)
 - [ ] One-pager / leave-behind (physical or PDF for networking)
 
 ### Priority 2: Go-to-Market
@@ -108,7 +151,7 @@ We are in the **pre-launch phase**. Nothing has been sold yet. The immediate pri
 - [ ] Vertical selection for initial targeting (pick ONE vertical to start)
 - [ ] Outreach strategy (how to find and reach first 5 prospects)
 - [ ] Landing page (smd.services — simple, credibility-focused)
-- [ ] Pipeline math (how many conversations → proposals → closes to hit $5K)
+- [ ] Pipeline math (how many conversations → proposals → closes to sustain profitability)
 
 ### Priority 3: Delivery Readiness
 
@@ -119,17 +162,17 @@ We are in the **pre-launch phase**. Nothing has been sold yet. The immediate pri
 
 ### Priority 4: Business Model Refinement
 
-- [ ] Payment terms (50/50? milestone-based? on completion?)
+- [x] Payment terms — 50% deposit at signing, 50% at completion (3-milestone for 40+ hr engagements)
 - [ ] Paid assessment as separate entry point ($250 standalone)
 - [ ] Recurring retainer model ($200–500/mo post-delivery)
-- [ ] 30-day revenue timeline (week-by-week plan to hit $5K)
+- [ ] Client data management system (D1 or similar for assessments, quotes, engagements, invoicing)
 
 ## Domain Context
 
 - **Geography:** Phoenix, Arizona metro area
-- **Target:** 5–50 employee businesses — the "too big for one person, too small for a COO" zone
+- **Target:** 10–25 employee businesses — the "too big for one person, too small for a COO" zone
 - **Buyer:** The owner. Sometimes the office manager, but the owner writes the check.
-- **Competition:** Generic "business consultants" (vague), Managed IT providers (technical only), Bookkeepers/accountants (financial only). Nobody is doing the full operations audit + implementation in a fixed-price 10-day sprint.
+- **Competition:** Generic "business consultants" (vague), Managed IT providers (technical only), Bookkeepers/accountants (financial only). Nobody is doing the full operations audit + implementation in a scoped engagement with fixed project pricing.
 - **Referral sources:** Local networking groups (BNI, chamber of commerce), accountants/bookkeepers, commercial insurance agents, SBA/SCORE
 
 ## Tech Stack


### PR DESCRIPTION
## Summary
- Add **Tone & Positioning Standard** section to CLAUDE.md with 6 codified rules that all agents must follow for external-facing content
- Update Positioning paragraph: replace "diagnose problems" / "experienced outsider who can see bottlenecks" with collaborative, objective-focused language
- Update Engagement Phases: remove "60-min" from Training phase
- Filed #62 separately for decision-stack alignment (locked decisions need review)

### The 6 rules now in CLAUDE.md:
1. **Objectives over problems** — understand what the business is trying to achieve
2. **Collaborative, not diagnostic** — peer tone, not expert-from-above
3. **No fixed timeframes** in external content — scope drives timeline
4. **No published dollar amounts** — project price in proposals only
5. **"Solution" not "systems"** in marketing contexts
6. **We-voice** — never "I" / "the consultant"

## Test plan
- [x] `npm run verify` passes
- [ ] Review CLAUDE.md reads coherently with new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)