### PR TITLE
fix: refine book page copy — collaborative tone, no fixed timeframes

### DIFF
--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -57,7 +57,7 @@ import Footer from '../components/Footer.astro'
             <h3 class="mt-4 font-bold text-slate-900">You walk us through your day</h3>
             <p class="mt-2 text-sm text-slate-600">
               How do customers find you? How do jobs get scheduled? What happens when something goes
-              wrong? We want to see how it actually works, not the brochure version.
+              wrong? We're just trying to understand how things really work day to day.
             </p>
           </div>
           <div class="text-center">
@@ -66,7 +66,7 @@ import Footer from '../components/Footer.astro'
             >
               2
             </div>
-            <h3 class="mt-4 font-bold text-slate-900">We share what we'd focus on</h3>
+            <h3 class="mt-4 font-bold text-slate-900">We figure out what matters most</h3>
             <p class="mt-2 text-sm text-slate-600">
               Together we identify what would make the biggest difference for where you're trying to
               go — and why those things matter most right now.
@@ -96,23 +96,24 @@ import Footer from '../components/Footer.astro'
           <div>
             <dt class="font-semibold text-slate-900">Does the assessment call cost anything?</dt>
             <dd class="mt-2 text-slate-600">
-              No. If we can help, we'll send a proposal after the call. If we can't, you still got a
-              useful conversation about your operations. Either way it costs you nothing but time.
+              No. If it makes sense to work together, we'll send a proposal after the call. If not,
+              you still got a useful conversation about your operations. Either way it costs you
+              nothing but time.
             </dd>
           </div>
           <div>
             <dt class="font-semibold text-slate-900">Do I need to prepare anything?</dt>
             <dd class="mt-2 text-slate-600">
               Just be ready to talk honestly about how things work. We'll ask questions. The less
-              polished, the better. We need to see the real version, not the one you'd show an
-              investor.
+              polished, the better — the real version of how things run is what helps us figure out
+              the right path forward.
             </dd>
           </div>
           <div>
             <dt class="font-semibold text-slate-900">What happens after the call?</dt>
             <dd class="mt-2 text-slate-600">
-              If there's a fit, you get a proposal within 48 hours. Fixed price, clear scope, no
-              surprises. If there's not a fit, we'll tell you that too.
+              If it makes sense to work together, you get a proposal. Fixed price, clear scope, no
+              surprises. If not, we'll tell you that too — no pressure either way.
             </dd>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- Softened step 1 description — removed "not the brochure version" framing
- Changed step 2 heading from diagnostic ("We share what we'd focus on") to collaborative ("We figure out what matters most")
- Replaced "If we can help / If we can't" with mutual "If it makes sense to work together" in FAQ
- Removed "within 48 hours" fixed timeframe from post-call FAQ
- Replaced "not the one you'd show an investor" with collaborative framing in preparation FAQ

## Test plan
- [x] `npm run verify` passes (28 tests, clean build)
- [ ] Review /book page copy reads naturally and matches main page tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)