### PR TITLE
feat: add case studies section to homepage

### DIFF
--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -1,0 +1,80 @@
+---
+const studies = [
+  {
+    vertical: 'Home Services',
+    business: 'HVAC Company, 18 employees, East Valley',
+    challenge:
+      "The owner was dispatching every job personally. The schedule lived in three places: a whiteboard, a shared Google Calendar, and text messages. Leads from the website sat in a Gmail inbox until someone got around to checking it. The owner hadn't taken a full day off in two years because every question came back to them.",
+    solution:
+      "One dispatching workflow the whole crew can see, in the office or out in the field. Lead capture that puts new inquiries into a tracked pipeline with same-day follow-up. A daily check-in so the owner knows what's happening without picking up the phone.",
+    problems: ['Scheduling chaos', 'Lead leakage', 'Owner bottleneck'],
+  },
+  {
+    vertical: 'Professional Services',
+    business: 'Accounting Firm, 12 employees, Scottsdale',
+    challenge:
+      'Every client question went straight to the founding partner, even routine ones the team could handle. The sales pipeline was a mental list. Client onboarding took weeks because every step was manual and different every time. The partner wanted to focus on advisory work but spent most of the day fielding questions and approving things.',
+    solution:
+      "A documented intake and onboarding process the team can follow without asking the partner. A visible pipeline so everyone knows where prospects stand. Templated communication for routine client questions, so the partner's time goes to work that actually needs them.",
+    problems: ['Owner bottleneck', 'Manual communication', 'Lead leakage'],
+  },
+  {
+    vertical: 'Home Services',
+    business: 'Plumbing Company, 14 employees, North Phoenix',
+    challenge:
+      'Website leads came in through a contact form and sat unread for days. Double-bookings happened weekly because the office and field crews were on different calendars. The owner had no idea which jobs were profitable. The books were months behind and pricing was based on gut feel.',
+    solution:
+      'Lead capture tied to automatic assignment and follow-up, so nothing sits unread. One scheduling tool the whole crew can get to from the field. Clean books with job-level profitability, so pricing decisions come from real numbers instead of gut feel.',
+    problems: ['Lead leakage', 'Scheduling chaos', 'Financial blindness'],
+  },
+]
+---
+
+<section class="bg-white px-6 py-24">
+  <div class="mx-auto max-w-5xl">
+    <div class="mb-4 text-center">
+      <h2 class="text-3xl font-bold text-slate-900">What We Do</h2>
+      <p class="mx-auto mt-4 max-w-2xl text-slate-500">
+        Different businesses, similar patterns. Here's the kind of work we take on.
+      </p>
+    </div>
+
+    <div class="mt-12 space-y-8">
+      {
+        studies.map((study) => (
+          <div class="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div class="border-b border-slate-100 bg-slate-50 px-8 py-5">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full bg-primary px-3 py-1 text-xs font-semibold text-white">
+                  {study.vertical}
+                </span>
+                <h3 class="text-lg font-bold text-slate-900">{study.business}</h3>
+              </div>
+              <div class="mt-3 flex flex-wrap gap-2">
+                {study.problems.map((problem) => (
+                  <span class="rounded-full bg-slate-200 px-3 py-1 text-xs font-medium text-slate-600">
+                    {problem}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div class="grid gap-0 md:grid-cols-2">
+              <div class="border-b border-slate-100 px-8 py-6 md:border-b-0 md:border-r">
+                <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  The situation
+                </p>
+                <p class="mt-3 leading-relaxed text-slate-600">{study.challenge}</p>
+              </div>
+              <div class="px-8 py-6">
+                <p class="text-xs font-semibold uppercase tracking-wider text-primary">
+                  What we build
+                </p>
+                <p class="mt-3 leading-relaxed text-slate-600">{study.solution}</p>
+              </div>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import WhatYouGet from '../components/WhatYouGet.astro'
 import Pricing from '../components/Pricing.astro'
 import About from '../components/About.astro'
 import WhoWeHelp from '../components/WhoWeHelp.astro'
+import CaseStudies from '../components/CaseStudies.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 ---
@@ -22,6 +23,7 @@ import Footer from '../components/Footer.astro'
     <Pricing />
     <About />
     <WhoWeHelp />
+    <CaseStudies />
     <FinalCta />
   </main>
   <Footer />


### PR DESCRIPTION
## Summary
- New "What We Do" section with three representative scenarios: HVAC (East Valley), accounting (Scottsdale), plumbing (North Phoenix)
- Each card shows the situation and the solution we build, covering both launch verticals (home services + professional services)
- Placed after "Who We Help" section, before the final CTA

## Test plan
- [ ] `npm run verify` passes
- [ ] Visual review of new section on homepage
- [ ] Copy reviewed for tone compliance (no em dashes, no fixed timeframes, no dollar amounts, "we" voice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)