### PR TITLE
feat: add employee retention case study

### DIFF
--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -27,6 +27,15 @@ const studies = [
       'Lead capture tied to automatic assignment and follow-up, so nothing sits unread. One scheduling tool the whole crew can get to from the field. Clean books with job-level profitability, so pricing decisions come from real numbers instead of gut feel.',
     problems: ['Lead leakage', 'Scheduling chaos', 'Financial blindness'],
   },
+  {
+    vertical: 'Professional Services',
+    business: 'Insurance Agency, 15 employees, Chandler',
+    challenge:
+      'The agency lost four staff members in a year. The owner chalked it up to pay and the job market. But the pattern was clear: new hires had no structured onboarding and were left to figure things out on their own. Every account manager handled policies differently. There was no way to know if you were doing a good job until a client complained. Good people left for agencies that had their act together.',
+    solution:
+      "A structured onboarding process so new hires know exactly what to expect and aren't guessing from day one. Documented workflows for common policy types so the team handles things the same way. Simple tracking so managers can see workload and the owner can spot problems before they turn into resignations.",
+    problems: ['Employee turnover', 'Team invisibility', 'Owner bottleneck'],
+  },
 ]
 ---
 


### PR DESCRIPTION
## Summary
- Fourth case study: insurance agency losing staff due to operational chaos, not pay
- Educates owners that turnover is often an operations problem: no onboarding, inconsistent processes, no feedback until something breaks
- Balances the section to 2 home services + 2 professional services scenarios

## Test plan
- [ ] `npm run verify` passes
- [ ] Visual review of new card on homepage
- [ ] Copy reviewed for tone compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)