### PR TITLE
fix: soften retention case study tone

### DIFF
--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -31,7 +31,7 @@ const studies = [
     vertical: 'Professional Services',
     business: 'Insurance Agency, 15 employees, Chandler',
     challenge:
-      'The agency lost four staff members in a year. The owner chalked it up to pay and the job market. But the pattern was clear: new hires had no structured onboarding and were left to figure things out on their own. Every account manager handled policies differently. There was no way to know if you were doing a good job until a client complained. Good people left for agencies that had their act together.',
+      'The agency lost four staff members in a year. The owner chalked it up to pay and the job market. But the pattern was clear: new hires had no structured onboarding and were left to figure things out on their own. Every account manager handled policies differently. There was no way to know if you were doing a good job until a client complained. Good people moved on to places where they felt more supported.',
     solution:
       "A structured onboarding process so new hires know exactly what to expect and aren't guessing from day one. Documented workflows for common policy types so the team handles things the same way. Simple tracking so managers can see workload and the owner can spot problems before they turn into resignations.",
     problems: ['Employee turnover', 'Team invisibility', 'Owner bottleneck'],


### PR DESCRIPTION
## Summary
- Changed "Good people left for agencies that had their act together" to "Good people moved on to places where they felt more supported"
- The original phrasing implied the prospect's business is disorganized, which is judgmental and counterproductive

## Test plan
- [ ] `npm run verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)