### PR TITLE
feat: client portal magic link auth + invitation system

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,6 +14,7 @@ type CfEnv = {
   DB: D1Database
   STORAGE: R2Bucket
   SESSIONS: KVNamespace
+  RESEND_API_KEY?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>
@@ -31,7 +32,7 @@ interface AuthSession {
 
 declare namespace App {
   interface Locals extends Runtime {
-    /** Populated by auth middleware on /admin/* routes. Null on public routes. */
+    /** Populated by auth middleware on /admin/* and /portal/* routes. Null on public routes. */
     session: AuthSession | null
   }
 }

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -15,3 +15,4 @@ export {
   SESSION_DURATION_MS,
 } from './session'
 export type { SessionData } from './session'
+export { createMagicLink, verifyMagicLink, MAGIC_LINK_EXPIRY_MS } from './magic-link'

--- a/src/lib/auth/magic-link.ts
+++ b/src/lib/auth/magic-link.ts
@@ -1,0 +1,96 @@
+/**
+ * Magic link authentication for client portal access.
+ *
+ * Magic links are single-use, time-limited tokens sent via email.
+ * They provide passwordless authentication for client users.
+ *
+ * Token lifecycle:
+ *   1. createMagicLink() — generates crypto-random token, stores in D1 with 15min expiry
+ *   2. verifyMagicLink() — validates token, marks as used, returns email
+ *
+ * Security constraints (OQ-007):
+ *   - Tokens expire after 15 minutes
+ *   - Tokens are single-use (used_at set on verification)
+ *   - Tokens are 64-character hex strings (32 bytes of entropy)
+ */
+
+export const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000 // 15 minutes
+
+export interface MagicLinkRow {
+  id: string
+  email: string
+  token: string
+  expires_at: string
+  used_at: string | null
+  created_at: string
+}
+
+/**
+ * Generate a cryptographically random token as a hex string.
+ * Uses 32 bytes (256 bits) of entropy — more than sufficient for magic links.
+ */
+function generateToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Create a new magic link for the given email address.
+ *
+ * Stores the token in the magic_links table with a 15-minute expiry.
+ * Returns the raw token (to be embedded in the magic link URL).
+ */
+export async function createMagicLink(db: D1Database, email: string): Promise<string> {
+  const token = generateToken()
+  const id = crypto.randomUUID()
+  const expiresAt = new Date(Date.now() + MAGIC_LINK_EXPIRY_MS).toISOString()
+
+  await db
+    .prepare(
+      `INSERT INTO magic_links (id, email, token, expires_at)
+       VALUES (?, ?, ?, ?)`
+    )
+    .bind(id, email.toLowerCase().trim(), token, expiresAt)
+    .run()
+
+  return token
+}
+
+/**
+ * Verify a magic link token.
+ *
+ * Checks that the token exists, has not expired, and has not been used.
+ * On success, marks the token as used and returns the associated email.
+ * On failure, returns null.
+ */
+export async function verifyMagicLink(db: D1Database, token: string): Promise<string | null> {
+  // Look up the token
+  const row = await db
+    .prepare(`SELECT * FROM magic_links WHERE token = ? LIMIT 1`)
+    .bind(token)
+    .first<MagicLinkRow>()
+
+  if (!row) {
+    return null
+  }
+
+  // Check if already used
+  if (row.used_at !== null) {
+    return null
+  }
+
+  // Check if expired
+  if (new Date(row.expires_at) <= new Date()) {
+    return null
+  }
+
+  // Mark as used (single-use enforcement)
+  await db
+    .prepare(`UPDATE magic_links SET used_at = datetime('now') WHERE id = ?`)
+    .bind(row.id)
+    .run()
+
+  return row.email
+}

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Email module — re-exports for convenience.
+ */
+
+export { sendEmail } from './resend'
+export type { EmailPayload, SendResult } from './resend'
+export { buildMagicLinkUrl, magicLinkEmailHtml, portalInvitationEmailHtml } from './templates'

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,64 @@
+/**
+ * Resend email client for transactional emails.
+ *
+ * Sends emails via the Resend API (https://resend.com/docs/api-reference).
+ * In dev/test environments (no RESEND_API_KEY), logs emails to console instead.
+ *
+ * Sender: SMD Services <team@smd.services>
+ */
+
+const RESEND_API_URL = 'https://api.resend.com/emails'
+const SENDER = 'SMD Services <team@smd.services>'
+
+export interface EmailPayload {
+  to: string
+  subject: string
+  html: string
+}
+
+export interface SendResult {
+  success: boolean
+  id?: string
+  error?: string
+}
+
+/**
+ * Send an email via Resend API.
+ *
+ * If RESEND_API_KEY is not set, logs the email to console (dev/test mode).
+ */
+export async function sendEmail(
+  apiKey: string | undefined,
+  payload: EmailPayload
+): Promise<SendResult> {
+  if (!apiKey) {
+    // Dev/test mode — log instead of sending
+    console.log('[email:dev] Would send email:')
+    console.log(`  To: ${payload.to}`)
+    console.log(`  Subject: ${payload.subject}`)
+    console.log(`  Body length: ${payload.html.length} chars`)
+    return { success: true, id: 'dev-mode' }
+  }
+
+  const response = await fetch(RESEND_API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: SENDER,
+      to: [payload.to],
+      subject: payload.subject,
+      html: payload.html,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    return { success: false, error: `Resend API error ${response.status}: ${body}` }
+  }
+
+  const data = (await response.json()) as { id: string }
+  return { success: true, id: data.id }
+}

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -1,0 +1,103 @@
+/**
+ * Email templates for magic link and portal invitation emails.
+ *
+ * All templates produce self-contained HTML emails with inline styles.
+ * No external CSS or image dependencies.
+ */
+
+/**
+ * Build the magic link URL for token verification.
+ */
+export function buildMagicLinkUrl(baseUrl: string, token: string): string {
+  const url = new URL('/auth/verify', baseUrl)
+  url.searchParams.set('token', token)
+  return url.toString()
+}
+
+/**
+ * Email sent when a client requests a magic link from the portal login page.
+ */
+export function magicLinkEmailHtml(clientName: string, magicLinkUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;text-align:center;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${clientName ? ` ${clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Click the button below to sign in to your portal.
+      </p>
+
+      <a href="${magicLinkUrl}"
+         style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                font-size:14px;font-weight:600;text-decoration:none;
+                padding:12px 32px;border-radius:6px;">
+        Sign in to Portal
+      </a>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        This link expires in 15 minutes and can only be used once.
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:8px 0 0;">
+        If you didn't request this, you can safely ignore this email.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Email sent when an admin first sends a quote to a client (portal invitation).
+ */
+export function portalInvitationEmailHtml(clientName: string, magicLinkUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;text-align:center;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${clientName ? ` ${clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        We've prepared a proposal for you. Your client portal is ready — click below to sign in and review it.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Your portal is where you'll find your proposal, project updates, and everything related to our work together.
+      </p>
+
+      <a href="${magicLinkUrl}"
+         style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                font-size:14px;font-weight:600;text-decoration:none;
+                padding:12px 32px;border-radius:6px;">
+        View Your Proposal
+      </a>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        This link expires in 15 minutes. You can request a new link anytime from the portal login page.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,11 +2,16 @@ import { defineMiddleware } from 'astro:middleware'
 import { parseSessionToken, validateSession, renewSession } from './lib/auth/session'
 
 /**
- * Astro middleware — handles auth for /admin/* routes.
+ * Astro middleware — handles auth for protected routes.
  *
- * - Public routes (/, /book, /api/*, /auth/*): pass through, session = null
- * - Admin routes (/admin/*): validate session cookie, redirect to login if invalid
- * - On valid session: renews expiration (sliding window) and attaches session to locals
+ * Route protection:
+ *   /admin/*      → requires role='admin', redirects to /auth/login
+ *   /api/admin/*  → requires role='admin', returns 401 JSON
+ *   /portal/*     → requires role='client', redirects to /auth/portal-login
+ *   /auth/*       → public (login pages)
+ *   everything else → public
+ *
+ * On valid session: renews expiration (sliding window) and attaches session to locals.
  */
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url
@@ -14,10 +19,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Initialize session as null for all routes
   context.locals.session = null
 
-  // Only protect /admin/* routes
+  // Determine route type
   const isAdminRoute = pathname.startsWith('/admin')
+  const isAdminApiRoute = pathname.startsWith('/api/admin')
+  const isPortalRoute = pathname.startsWith('/portal')
+  const isProtectedRoute = isAdminRoute || isAdminApiRoute || isPortalRoute
 
-  if (!isAdminRoute) {
+  if (!isProtectedRoute) {
     return next()
   }
 
@@ -26,6 +34,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const token = parseSessionToken(cookieHeader)
 
   if (!token) {
+    if (isAdminApiRoute) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (isPortalRoute) {
+      return context.redirect('/auth/portal-login')
+    }
     return context.redirect('/auth/login')
   }
 
@@ -34,6 +51,31 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const sessionData = await validateSession(env.DB, env.SESSIONS, token)
 
   if (!sessionData) {
+    if (isAdminApiRoute) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (isPortalRoute) {
+      return context.redirect('/auth/portal-login')
+    }
+    return context.redirect('/auth/login')
+  }
+
+  // Role-based access control
+  const requiredRole = isAdminRoute || isAdminApiRoute ? 'admin' : 'client'
+  if (sessionData.role !== requiredRole) {
+    if (isAdminApiRoute) {
+      return new Response(JSON.stringify({ error: 'Forbidden' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    // Wrong role — redirect to appropriate login
+    if (isPortalRoute) {
+      return context.redirect('/auth/portal-login')
+    }
     return context.redirect('/auth/login')
   }
 

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -1,0 +1,119 @@
+import type { APIRoute } from 'astro'
+import { createMagicLink } from '../../../lib/auth/magic-link'
+import { sendEmail } from '../../../lib/email/resend'
+import { buildMagicLinkUrl, portalInvitationEmailHtml } from '../../../lib/email/templates'
+
+interface UserRow {
+  id: string
+  org_id: string
+  email: string
+  name: string
+  role: string
+  client_id: string | null
+}
+
+/**
+ * POST /api/admin/resend-invitation
+ *
+ * Admin endpoint to re-send a portal invitation to a client.
+ * Used when the original invitation email bounced (OQ-010: admin corrects
+ * email and re-sends).
+ *
+ * Protected by middleware — requires admin role session.
+ *
+ * Request body (JSON):
+ *   { "userId": string, "email"?: string }
+ *
+ * If email is provided, updates the user's email before sending.
+ * This supports the OQ-010 flow where admin corrects a bounced email.
+ */
+export const POST: APIRoute = async ({ request, locals, url }) => {
+  // Verify admin session (middleware already checks /admin/* routes,
+  // but this is under /api/admin/* so we verify explicitly)
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const body = (await request.json()) as { userId?: string; email?: string }
+    const { userId, email: newEmail } = body
+
+    if (!userId || typeof userId !== 'string') {
+      return new Response(JSON.stringify({ error: 'userId is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const env = locals.runtime.env
+
+    // Look up the client user
+    const user = await env.DB.prepare(`SELECT * FROM users WHERE id = ? AND role = 'client'`)
+      .bind(userId)
+      .first<UserRow>()
+
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Client user not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // If a new email is provided, update the user's email (OQ-010 bounce recovery)
+    let targetEmail = user.email
+    if (newEmail && typeof newEmail === 'string') {
+      const normalizedEmail = newEmail.toLowerCase().trim()
+      if (normalizedEmail !== user.email) {
+        await env.DB.prepare(`UPDATE users SET email = ? WHERE id = ?`)
+          .bind(normalizedEmail, userId)
+          .run()
+        targetEmail = normalizedEmail
+      }
+    }
+
+    // Create magic link
+    const token = await createMagicLink(env.DB, targetEmail)
+
+    // Build verification URL
+    const baseUrl = `${url.protocol}//${url.host}`
+    const magicLinkUrl = buildMagicLinkUrl(baseUrl, token)
+
+    // Send invitation email
+    const html = portalInvitationEmailHtml(user.name, magicLinkUrl)
+    const result = await sendEmail(env.RESEND_API_KEY, {
+      to: targetEmail,
+      subject: 'You have a proposal from SMD Services',
+      html,
+    })
+
+    if (!result.success) {
+      console.error(`[resend-invitation] Failed to send to ${targetEmail}: ${result.error}`)
+      return new Response(JSON.stringify({ error: 'Failed to send email' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        emailId: result.id,
+        sentTo: targetEmail,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )
+  } catch (err) {
+    console.error('[resend-invitation] Error:', err)
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import {
   parseSessionToken,
+  validateSession,
   destroySession,
   buildClearSessionCookie,
 } from '../../../lib/auth/session'
@@ -9,14 +10,26 @@ import {
  * POST /api/auth/logout
  *
  * Destroys the current session (D1 + KV), clears the session cookie,
- * and redirects to the login page.
+ * and redirects to the appropriate login page based on user role.
+ *
+ * - Admin users → /auth/login
+ * - Client users → /auth/portal-login
  */
 export const POST: APIRoute = async ({ request, locals }) => {
   const cookieHeader = request.headers.get('cookie')
   const token = parseSessionToken(cookieHeader)
 
+  let redirectTo = '/auth/login'
+
   if (token) {
     const env = locals.runtime.env
+
+    // Check role before destroying session to determine redirect
+    const session = await validateSession(env.DB, env.SESSIONS, token)
+    if (session?.role === 'client') {
+      redirectTo = '/auth/portal-login'
+    }
+
     await destroySession(env.DB, env.SESSIONS, token)
   }
 
@@ -24,7 +37,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
   return new Response(null, {
     status: 302,
     headers: {
-      Location: '/auth/login',
+      Location: redirectTo,
       'Set-Cookie': clearCookie,
     },
   })

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -1,0 +1,75 @@
+import type { APIRoute } from 'astro'
+import { createMagicLink } from '../../../lib/auth/magic-link'
+import { sendEmail } from '../../../lib/email/resend'
+import { buildMagicLinkUrl, magicLinkEmailHtml } from '../../../lib/email/templates'
+
+interface UserRow {
+  id: string
+  org_id: string
+  email: string
+  name: string
+  role: string
+  client_id: string | null
+}
+
+/**
+ * POST /api/auth/magic-link
+ *
+ * Generates a magic link for the given email and sends it via Resend.
+ * Only works for client-role users (not admin users).
+ *
+ * On success: redirects to portal login with status=sent.
+ * On failure: redirects to portal login with appropriate error.
+ *
+ * Security: Always returns the same response whether or not the email
+ * exists, to prevent email enumeration.
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, url }) => {
+  try {
+    const formData = await request.formData()
+    const email = formData.get('email')
+
+    if (!email || typeof email !== 'string') {
+      return redirect('/auth/portal-login?error=server', 302)
+    }
+
+    const normalizedEmail = email.toLowerCase().trim()
+    const env = locals.runtime.env
+
+    // Look up client user by email
+    const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ? AND role = 'client'`)
+      .bind(normalizedEmail)
+      .first<UserRow>()
+
+    if (!user) {
+      // Don't reveal whether the email exists — show same success message
+      // This prevents email enumeration attacks
+      return redirect('/auth/portal-login?status=sent', 302)
+    }
+
+    // Create magic link token
+    const token = await createMagicLink(env.DB, normalizedEmail)
+
+    // Build the verification URL
+    const baseUrl = `${url.protocol}//${url.host}`
+    const magicLinkUrl = buildMagicLinkUrl(baseUrl, token)
+
+    // Send the email
+    const html = magicLinkEmailHtml(user.name, magicLinkUrl)
+    const result = await sendEmail(env.RESEND_API_KEY, {
+      to: normalizedEmail,
+      subject: 'Sign in to your SMD Services portal',
+      html,
+    })
+
+    if (!result.success) {
+      console.error(`[magic-link] Failed to send email to ${normalizedEmail}: ${result.error}`)
+      // Still show success to prevent enumeration
+    }
+
+    return redirect('/auth/portal-login?status=sent', 302)
+  } catch (err) {
+    console.error('[magic-link] Error:', err)
+    return redirect('/auth/portal-login?error=server', 302)
+  }
+}

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -1,0 +1,103 @@
+---
+import '../../styles/global.css'
+
+/**
+ * Client portal login page — magic link (passwordless) authentication.
+ *
+ * Branded with SMD Services styling. Client enters their email address,
+ * receives a magic link via email, and clicks to authenticate.
+ *
+ * Accessible at portal.smd.services (routed via Astro, same deployment).
+ */
+
+const status = Astro.url.searchParams.get('status')
+const error = Astro.url.searchParams.get('error')
+
+const statusMessages: Record<string, { text: string; type: 'success' | 'error' }> = {
+  sent: { text: 'Check your email — we just sent you a sign-in link.', type: 'success' },
+  expired: { text: 'That link has expired. Enter your email to get a new one.', type: 'error' },
+  invalid: { text: 'That link is invalid or has already been used.', type: 'error' },
+  no_account: {
+    text: "We couldn't find an account with that email. Contact us if you think this is an error.",
+    type: 'error',
+  },
+  server: { text: 'Something went wrong. Please try again.', type: 'error' },
+}
+
+const message = status ? statusMessages[status] : error ? statusMessages[error] : null
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Sign In — SMD Services Portal</title>
+  </head>
+  <body class="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+    <div class="w-full max-w-sm">
+      <div class="text-center mb-8">
+        <h1 class="text-2xl font-bold text-slate-900">SMD Services</h1>
+        <p class="text-sm text-slate-500 mt-1">Client Portal</p>
+      </div>
+
+      <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+        <h2 class="text-lg font-semibold text-slate-900 mb-2">Sign in</h2>
+        <p class="text-sm text-slate-500 mb-6">
+          Enter your email and we'll send you a link to sign in.
+        </p>
+
+        {
+          message && (
+            <div
+              class:list={[
+                'mb-4 px-3 py-2 border rounded text-sm',
+                message.type === 'success'
+                  ? 'bg-green-50 border-green-200 text-green-700'
+                  : 'bg-red-50 border-red-200 text-red-700',
+              ]}
+            >
+              {message.text}
+            </div>
+          )
+        }
+
+        <form method="POST" action="/api/auth/magic-link" class="space-y-4">
+          <div>
+            <label for="email" class="block text-sm font-medium text-slate-700 mb-1"> Email </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              autocomplete="email"
+              class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+                     focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+                     placeholder-slate-400"
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <button
+            type="submit"
+            class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
+                   hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
+                   focus:ring-primary focus:ring-offset-2"
+          >
+            Send sign-in link
+          </button>
+        </form>
+      </div>
+
+      <p class="text-center text-xs text-slate-400 mt-6">
+        &copy; {new Date().getFullYear()} SMD Services
+      </p>
+    </div>
+  </body>
+</html>

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -1,0 +1,73 @@
+---
+import '../../styles/global.css'
+import { verifyMagicLink } from '../../lib/auth/magic-link'
+import { createSession, buildSessionCookie } from '../../lib/auth/session'
+
+/**
+ * Magic link verification page — GET /auth/verify?token=...
+ *
+ * When a client clicks their magic link, this page:
+ *   1. Validates the token (exists, not expired, not used)
+ *   2. Looks up the user by email
+ *   3. Creates a session (7-day expiry)
+ *   4. Redirects to /portal with session cookie set
+ *
+ * On failure, redirects to portal login with an error message.
+ */
+
+const token = Astro.url.searchParams.get('token')
+
+if (!token) {
+  return Astro.redirect('/auth/portal-login?error=invalid')
+}
+
+const env = Astro.locals.runtime.env
+
+// Verify the magic link token
+const email = await verifyMagicLink(env.DB, token)
+
+if (!email) {
+  // Token is invalid, expired, or already used
+  return Astro.redirect('/auth/portal-login?error=invalid')
+}
+
+// Look up the client user by email
+interface UserRow {
+  id: string
+  org_id: string
+  email: string
+  name: string
+  role: string
+  client_id: string | null
+}
+
+const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ? AND role = 'client'`)
+  .bind(email)
+  .first<UserRow>()
+
+if (!user) {
+  return Astro.redirect('/auth/portal-login?error=no_account')
+}
+
+// Update last_login_at
+await env.DB.prepare(`UPDATE users SET last_login_at = datetime('now') WHERE id = ?`)
+  .bind(user.id)
+  .run()
+
+// Create session
+const sessionToken = await createSession(env.DB, env.SESSIONS, {
+  id: user.id,
+  orgId: user.org_id,
+  role: user.role,
+  email: user.email,
+})
+
+// Redirect to portal with session cookie
+return new Response(null, {
+  status: 302,
+  headers: {
+    Location: '/portal',
+    'Set-Cookie': buildSessionCookie(sessionToken),
+  },
+})
+---

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -1,0 +1,57 @@
+---
+import '../../styles/global.css'
+
+/**
+ * Client portal dashboard — protected by auth middleware (role=client).
+ *
+ * If you're seeing this page, the session is valid and the user has client role.
+ * Session data is available via Astro.locals.session.
+ */
+
+const session = Astro.locals.session!
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Portal — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <h1 class="text-lg font-bold text-slate-900">SMD Services</h1>
+          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <h2 class="text-xl font-semibold text-slate-900 mb-4">Welcome</h2>
+      <div class="bg-white rounded-lg border border-slate-200 p-6">
+        <p class="text-slate-600">
+          Your client portal is ready. Proposals, project updates, and documents will appear here.
+        </p>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('magic-link: token module', () => {
+  it('magic-link.ts exists', () => {
+    expect(existsSync(resolve('src/lib/auth/magic-link.ts'))).toBe(true)
+  })
+
+  it('exports createMagicLink and verifyMagicLink', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('export async function createMagicLink')
+    expect(source).toContain('export async function verifyMagicLink')
+  })
+
+  it('tokens expire after 15 minutes', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    // 15 * 60 * 1000 = 900000ms
+    expect(source).toContain('15 * 60 * 1000')
+  })
+
+  it('uses cryptographically random token generation', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('crypto.getRandomValues')
+  })
+
+  it('generates 32-byte (64-char hex) tokens for sufficient entropy', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('Uint8Array(32)')
+  })
+
+  it('enforces single-use tokens by setting used_at', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('used_at')
+    expect(source).toContain("UPDATE magic_links SET used_at = datetime('now')")
+  })
+
+  it('checks token expiration before verification', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('expires_at')
+    expect(source).toContain('new Date(row.expires_at)')
+  })
+
+  it('rejects already-used tokens', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('row.used_at !== null')
+  })
+
+  it('stores tokens in magic_links table', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('INSERT INTO magic_links')
+  })
+
+  it('normalizes email to lowercase on creation', () => {
+    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('email.toLowerCase().trim()')
+  })
+
+  it('is re-exported from auth index module', () => {
+    const source = readFileSync(resolve('src/lib/auth/index.ts'), 'utf-8')
+    expect(source).toContain('createMagicLink')
+    expect(source).toContain('verifyMagicLink')
+    expect(source).toContain('MAGIC_LINK_EXPIRY_MS')
+  })
+})
+
+describe('magic-link: email module', () => {
+  it('resend.ts email client exists', () => {
+    expect(existsSync(resolve('src/lib/email/resend.ts'))).toBe(true)
+  })
+
+  it('templates.ts exists', () => {
+    expect(existsSync(resolve('src/lib/email/templates.ts'))).toBe(true)
+  })
+
+  it('email index module exists', () => {
+    expect(existsSync(resolve('src/lib/email/index.ts'))).toBe(true)
+  })
+
+  it('uses Resend API endpoint', () => {
+    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
+    expect(source).toContain('https://api.resend.com/emails')
+  })
+
+  it('sends from team@smd.services', () => {
+    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
+    expect(source).toContain('team@smd.services')
+  })
+
+  it('logs emails in dev mode when API key is missing', () => {
+    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
+    expect(source).toContain('!apiKey')
+    expect(source).toContain('console.log')
+  })
+
+  it('sends Authorization Bearer header', () => {
+    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
+    expect(source).toContain('Authorization')
+    expect(source).toContain('Bearer')
+  })
+
+  it('magic link email template is branded', () => {
+    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
+    expect(source).toContain('SMD Services')
+    expect(source).toContain('Client Portal')
+  })
+
+  it('magic link email includes 15-minute expiry notice', () => {
+    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
+    expect(source).toContain('15 minutes')
+  })
+
+  it('portal invitation template mentions proposal', () => {
+    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
+    expect(source).toContain('proposal')
+  })
+
+  it('templates export buildMagicLinkUrl helper', () => {
+    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
+    expect(source).toContain('export function buildMagicLinkUrl')
+    expect(source).toContain('/auth/verify')
+  })
+})
+
+describe('magic-link: portal login page', () => {
+  it('portal-login.astro exists', () => {
+    expect(existsSync(resolve('src/pages/auth/portal-login.astro'))).toBe(true)
+  })
+
+  it('form posts to /api/auth/magic-link', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('method="POST"')
+    expect(source).toContain('action="/api/auth/magic-link"')
+  })
+
+  it('includes email input only (no password)', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('name="email"')
+    expect(source).toContain('type="email"')
+    expect(source).not.toContain('type="password"')
+  })
+
+  it('is branded with SMD Services Client Portal', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('SMD Services')
+    expect(source).toContain('Client Portal')
+  })
+
+  it('is not indexed by search engines', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('noindex')
+  })
+
+  it('displays success message when magic link is sent', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('sent')
+    expect(source).toContain('Check your email')
+  })
+
+  it('displays error messages for expired and invalid links', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('expired')
+    expect(source).toContain('invalid')
+  })
+})
+
+describe('magic-link: verify page', () => {
+  it('verify.astro exists', () => {
+    expect(existsSync(resolve('src/pages/auth/verify.astro'))).toBe(true)
+  })
+
+  it('reads token from query params', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain("searchParams.get('token')")
+  })
+
+  it('calls verifyMagicLink to validate token', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain('verifyMagicLink')
+  })
+
+  it('creates a session on successful verification', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain('createSession')
+    expect(source).toContain('buildSessionCookie')
+  })
+
+  it('redirects to /portal on success', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain("'/portal'")
+  })
+
+  it('redirects to portal-login on invalid token', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain('/auth/portal-login?error=invalid')
+  })
+
+  it('looks up client user by email', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain("role = 'client'")
+  })
+
+  it('updates last_login_at on successful verify', () => {
+    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
+    expect(source).toContain('last_login_at')
+  })
+})
+
+describe('magic-link: API endpoint', () => {
+  it('magic-link API endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/auth/magic-link.ts'))).toBe(true)
+  })
+
+  it('handles POST requests', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('export const POST')
+  })
+
+  it('creates magic link and sends email', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('createMagicLink')
+    expect(source).toContain('sendEmail')
+  })
+
+  it('prevents email enumeration by always showing success', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    // Should redirect to sent status even when user not found
+    expect(source).toContain('enumeration')
+    expect(source).toContain('status=sent')
+  })
+
+  it('normalizes email input', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('toLowerCase().trim()')
+  })
+
+  it('only sends to client-role users', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain("role = 'client'")
+  })
+})
+
+describe('magic-link: portal page', () => {
+  it('portal index page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/index.astro'))).toBe(true)
+  })
+
+  it('portal page uses session data', () => {
+    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+    expect(source).toContain('Astro.locals.session')
+  })
+
+  it('portal page includes logout form', () => {
+    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+    expect(source).toContain('/api/auth/logout')
+  })
+
+  it('portal page is not indexed by search engines', () => {
+    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+    expect(source).toContain('noindex')
+  })
+
+  it('portal page is branded with SMD Services Portal', () => {
+    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+    expect(source).toContain('SMD Services')
+    expect(source).toContain('Portal')
+  })
+})
+
+describe('magic-link: admin resend invitation', () => {
+  it('resend-invitation endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/resend-invitation.ts'))).toBe(true)
+  })
+
+  it('handles POST requests', () => {
+    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
+    expect(source).toContain('export const POST')
+  })
+
+  it('verifies admin session', () => {
+    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
+    expect(source).toContain("role !== 'admin'")
+    expect(source).toContain('Unauthorized')
+  })
+
+  it('creates magic link and sends email', () => {
+    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
+    expect(source).toContain('createMagicLink')
+    expect(source).toContain('sendEmail')
+  })
+
+  it('supports email correction for bounced emails (OQ-010)', () => {
+    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
+    // Should update email if a new one is provided
+    expect(source).toContain('UPDATE users SET email')
+    expect(source).toContain('newEmail')
+  })
+
+  it('only targets client-role users', () => {
+    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
+    expect(source).toContain("role = 'client'")
+  })
+})
+
+describe('magic-link: middleware updates', () => {
+  it('middleware protects /portal routes', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain("pathname.startsWith('/portal')")
+  })
+
+  it('middleware protects /api/admin routes', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain("pathname.startsWith('/api/admin')")
+  })
+
+  it('middleware redirects unauthenticated portal users to portal-login', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain("redirect('/auth/portal-login')")
+  })
+
+  it('middleware returns 401 JSON for unauthenticated admin API requests', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain('status: 401')
+  })
+
+  it('middleware enforces role-based access control', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain("'admin'")
+    expect(source).toContain("'client'")
+    expect(source).toContain('requiredRole')
+  })
+
+  it('middleware returns 403 for wrong role on admin API routes', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain('status: 403')
+    expect(source).toContain('Forbidden')
+  })
+})
+
+describe('magic-link: env types', () => {
+  it('CfEnv includes RESEND_API_KEY', () => {
+    const source = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(source).toContain('RESEND_API_KEY')
+  })
+})
+
+describe('magic-link: wrangler config', () => {
+  it('wrangler.toml documents RESEND_API_KEY secret', () => {
+    const source = readFileSync(resolve('wrangler.toml'), 'utf-8')
+    expect(source).toContain('RESEND_API_KEY')
+  })
+})
+
+describe('magic-link: logout', () => {
+  it('logout redirects client users to portal-login', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/logout.ts'), 'utf-8')
+    expect(source).toContain('/auth/portal-login')
+  })
+
+  it('logout checks role to determine redirect', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/logout.ts'), 'utf-8')
+    expect(source).toContain("role === 'client'")
+  })
+})
+
+describe('magic-link: D1 schema', () => {
+  it('magic_links table exists in migration', () => {
+    const sql = readFileSync(resolve('migrations/0001_create_tables.sql'), 'utf-8')
+    expect(sql).toContain('CREATE TABLE magic_links')
+  })
+
+  it('magic_links table has required columns', () => {
+    const sql = readFileSync(resolve('migrations/0001_create_tables.sql'), 'utf-8')
+    expect(sql).toContain('email')
+    expect(sql).toContain('token')
+    expect(sql).toContain('expires_at')
+    expect(sql).toContain('used_at')
+  })
+
+  it('magic_links table has token uniqueness constraint', () => {
+    const sql = readFileSync(resolve('migrations/0001_create_tables.sql'), 'utf-8')
+    expect(sql).toContain('token')
+    expect(sql).toContain('UNIQUE')
+  })
+
+  it('magic_links indexes exist', () => {
+    const sql = readFileSync(resolve('migrations/0002_create_indexes.sql'), 'utf-8')
+    expect(sql).toContain('idx_magic_links_email')
+    expect(sql).toContain('idx_magic_links_expires')
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,3 +29,8 @@ bucket_name = "ss-console-storage"
 [[kv_namespaces]]
 binding = "SESSIONS"
 id = "LOCAL_KV_PLACEHOLDER"
+
+# ---------- Secrets (set via wrangler secret put) ----------
+# RESEND_API_KEY — Resend transactional email API key
+# Set with: wrangler secret put RESEND_API_KEY
+# In dev: emails are logged to console when this secret is absent


### PR DESCRIPTION
## Summary
- Implement passwordless magic link authentication for the client portal (AU-2, CP-1, CP-10, US-010)
- Single-use, time-limited tokens (15min expiry per OQ-007) with 7-day client sessions
- Resend email integration for magic link delivery and portal invitations (from `team@smd.services`)
- Role-based middleware: `/admin/*` requires admin, `/portal/*` requires client, `/api/admin/*` returns 401/403 JSON
- Admin re-send invitation endpoint for bounced emails with email correction (OQ-010)

## Files Changed

**Core modules:**
- `src/lib/auth/magic-link.ts` — Token generation (32-byte crypto-random), storage, verification, single-use enforcement
- `src/lib/email/resend.ts` — Resend API client with dev-mode console logging fallback
- `src/lib/email/templates.ts` — Branded HTML email templates (magic link + portal invitation)

**Pages & API routes:**
- `src/pages/auth/portal-login.astro` — Branded client login page (email-only, no password)
- `src/pages/auth/verify.astro` — Magic link token verification, session creation, redirect to portal
- `src/pages/api/auth/magic-link.ts` — POST: generate + send magic link (prevents email enumeration)
- `src/pages/portal/index.astro` — Client portal placeholder (protected)
- `src/pages/api/admin/resend-invitation.ts` — POST: admin re-sends invitation, supports email correction

**Infrastructure updates:**
- `src/middleware.ts` — Role-based route protection for `/admin/*`, `/api/admin/*`, `/portal/*`
- `src/pages/api/auth/logout.ts` — Role-aware redirect (admin vs client login pages)
- `src/env.d.ts` — Added `RESEND_API_KEY` to `CfEnv` type
- `wrangler.toml` — Documented RESEND_API_KEY secret reference

**Tests:**
- `tests/magic-link.test.ts` — 68 tests covering all modules, pages, API routes, middleware, and schema

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, build, 178 tests)
- [ ] Manual: Create client user in D1, request magic link, verify email logged in dev mode
- [ ] Manual: Click magic link, verify session created and redirect to /portal
- [ ] Manual: Re-click same link, verify rejection (single-use)
- [ ] Manual: Verify /portal redirects to portal-login when unauthenticated
- [ ] Manual: Verify admin re-send invitation endpoint works with corrected email

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)