### PR TITLE
feat: add client CRUD and pipeline view

### DIFF
--- a/src/lib/db/clients.ts
+++ b/src/lib/db/clients.ts
@@ -1,0 +1,258 @@
+/**
+ * Client data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ */
+
+export interface Client {
+  id: string
+  org_id: string
+  business_name: string
+  vertical: string | null
+  employee_count: number | null
+  years_in_business: number | null
+  source: string | null
+  referred_by: string | null
+  status: string
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type ClientVertical =
+  | 'home_services'
+  | 'professional_services'
+  | 'contractor_trades'
+  | 'retail_salon'
+  | 'restaurant'
+  | 'other'
+
+export type ClientStatus = 'prospect' | 'assessed' | 'quoted' | 'active' | 'completed' | 'dead'
+
+export const CLIENT_VERTICALS: { value: ClientVertical; label: string }[] = [
+  { value: 'home_services', label: 'Home Services' },
+  { value: 'professional_services', label: 'Professional Services' },
+  { value: 'contractor_trades', label: 'Contractor / Trades' },
+  { value: 'retail_salon', label: 'Retail / Salon / Spa' },
+  { value: 'restaurant', label: 'Restaurant / Food Service' },
+  { value: 'other', label: 'Other' },
+]
+
+export const CLIENT_STATUSES: { value: ClientStatus; label: string }[] = [
+  { value: 'prospect', label: 'Prospect' },
+  { value: 'assessed', label: 'Assessed' },
+  { value: 'quoted', label: 'Quoted' },
+  { value: 'active', label: 'Active' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'dead', label: 'Dead' },
+]
+
+export interface ClientFilters {
+  status?: string
+  vertical?: string
+  source?: string
+}
+
+export interface CreateClientData {
+  business_name: string
+  vertical?: string | null
+  employee_count?: number | null
+  years_in_business?: number | null
+  source: string
+  referred_by?: string | null
+  status?: string
+  notes?: string | null
+}
+
+export interface UpdateClientData {
+  business_name?: string
+  vertical?: string | null
+  employee_count?: number | null
+  years_in_business?: number | null
+  source?: string
+  referred_by?: string | null
+  status?: string
+  notes?: string | null
+}
+
+/**
+ * List clients for an organization with optional filters.
+ */
+export async function listClients(
+  db: D1Database,
+  orgId: string,
+  filters?: ClientFilters
+): Promise<Client[]> {
+  const conditions: string[] = ['org_id = ?']
+  const params: (string | number)[] = [orgId]
+
+  if (filters?.status) {
+    conditions.push('status = ?')
+    params.push(filters.status)
+  }
+
+  if (filters?.vertical) {
+    conditions.push('vertical = ?')
+    params.push(filters.vertical)
+  }
+
+  if (filters?.source) {
+    conditions.push('source = ?')
+    params.push(filters.source)
+  }
+
+  const where = conditions.join(' AND ')
+  const sql = `SELECT * FROM clients WHERE ${where} ORDER BY updated_at DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<Client>()
+  return result.results
+}
+
+/**
+ * Get a single client by ID, scoped to an organization.
+ */
+export async function getClient(
+  db: D1Database,
+  orgId: string,
+  clientId: string
+): Promise<Client | null> {
+  const result = await db
+    .prepare('SELECT * FROM clients WHERE id = ? AND org_id = ?')
+    .bind(clientId, orgId)
+    .first<Client>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new client. Returns the created client record.
+ */
+export async function createClient(
+  db: D1Database,
+  orgId: string,
+  data: CreateClientData
+): Promise<Client> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  await db
+    .prepare(
+      `INSERT INTO clients (id, org_id, business_name, vertical, employee_count, years_in_business, source, referred_by, status, notes, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      data.business_name,
+      data.vertical ?? null,
+      data.employee_count ?? null,
+      data.years_in_business ?? null,
+      data.source,
+      data.referred_by ?? null,
+      data.status ?? 'prospect',
+      data.notes ?? null,
+      now,
+      now
+    )
+    .run()
+
+  // Return the created record
+  const client = await getClient(db, orgId, id)
+  if (!client) {
+    throw new Error('Failed to retrieve created client')
+  }
+  return client
+}
+
+/**
+ * Update an existing client. Returns the updated client record.
+ */
+export async function updateClient(
+  db: D1Database,
+  orgId: string,
+  clientId: string,
+  data: UpdateClientData
+): Promise<Client | null> {
+  // Verify client exists and belongs to org
+  const existing = await getClient(db, orgId, clientId)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.business_name !== undefined) {
+    fields.push('business_name = ?')
+    params.push(data.business_name)
+  }
+
+  if (data.vertical !== undefined) {
+    fields.push('vertical = ?')
+    params.push(data.vertical)
+  }
+
+  if (data.employee_count !== undefined) {
+    fields.push('employee_count = ?')
+    params.push(data.employee_count)
+  }
+
+  if (data.years_in_business !== undefined) {
+    fields.push('years_in_business = ?')
+    params.push(data.years_in_business)
+  }
+
+  if (data.source !== undefined) {
+    fields.push('source = ?')
+    params.push(data.source)
+  }
+
+  if (data.referred_by !== undefined) {
+    fields.push('referred_by = ?')
+    params.push(data.referred_by)
+  }
+
+  if (data.status !== undefined) {
+    fields.push('status = ?')
+    params.push(data.status)
+  }
+
+  if (data.notes !== undefined) {
+    fields.push('notes = ?')
+    params.push(data.notes)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  fields.push("updated_at = datetime('now')")
+
+  const sql = `UPDATE clients SET ${fields.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(clientId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getClient(db, orgId, clientId)
+}
+
+/**
+ * Get distinct source values for an organization (for filter dropdowns).
+ */
+export async function listClientSources(db: D1Database, orgId: string): Promise<string[]> {
+  const result = await db
+    .prepare(
+      'SELECT DISTINCT source FROM clients WHERE org_id = ? AND source IS NOT NULL ORDER BY source'
+    )
+    .bind(orgId)
+    .all<{ source: string }>()
+
+  return result.results.map((r) => r.source)
+}

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -1,0 +1,370 @@
+---
+import '../../../styles/global.css'
+import { getClient, CLIENT_STATUSES, CLIENT_VERTICALS } from '../../../lib/db/clients'
+import type { ClientStatus } from '../../../lib/db/clients'
+
+/**
+ * Client detail/edit page.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Displays all client fields in an editable form.
+ * Form POSTs to /api/admin/clients/:id which updates and redirects back here.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id } = Astro.params
+
+if (!id) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, id)
+
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  missing: 'Business name and source are required.',
+  server: 'Something went wrong. Please try again.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Status progression for visual indicator
+const statusOrder: ClientStatus[] = [
+  'prospect',
+  'assessed',
+  'quoted',
+  'active',
+  'completed',
+  'dead',
+]
+const currentStatusIndex = statusOrder.indexOf(client.status as ClientStatus)
+
+// Determine status progression colors
+const getProgressionColor = (index: number) => {
+  if (client.status === 'dead') {
+    return index === statusOrder.indexOf('dead') ? 'bg-red-500' : 'bg-slate-200'
+  }
+  if (index <= currentStatusIndex) {
+    return 'bg-primary'
+  }
+  return 'bg-slate-200'
+}
+
+const getProgressionTextColor = (index: number) => {
+  if (client.status === 'dead') {
+    return index === statusOrder.indexOf('dead') ? 'text-red-700 font-medium' : 'text-slate-400'
+  }
+  if (index <= currentStatusIndex) {
+    return 'text-primary font-medium'
+  }
+  return 'text-slate-400'
+}
+
+// Buy box check
+const outsideBuyBox =
+  client.employee_count !== null && (client.employee_count < 10 || client.employee_count > 25)
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>{client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">{client.business_name}</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-2">{client.business_name}</h1>
+
+      <!-- Status progression indicator -->
+      <div class="mb-6">
+        <div class="flex items-center gap-1 mb-2">
+          {
+            statusOrder
+              .filter((s) => s !== 'dead')
+              .map((status, index) => (
+                <>
+                  <div class="flex flex-col items-center">
+                    <div class={`w-3 h-3 rounded-full ${getProgressionColor(index)}`} />
+                    <span class={`text-[10px] mt-1 ${getProgressionTextColor(index)}`}>
+                      {CLIENT_STATUSES.find((s) => s.value === status)?.label}
+                    </span>
+                  </div>
+                  {index < statusOrder.length - 2 && (
+                    <div
+                      class={`flex-1 h-0.5 mb-4 ${index < currentStatusIndex && client.status !== 'dead' ? 'bg-primary' : 'bg-slate-200'}`}
+                    />
+                  )}
+                </>
+              ))
+          }
+        </div>
+        {client.status === 'dead' && <p class="text-xs text-red-600 font-medium">Status: Dead</p>}
+      </div>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Client updated successfully.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      {
+        outsideBuyBox && (
+          <div class="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700">
+            Outside typical buy box of 10-25 employees
+          </div>
+        )
+      }
+
+      <form
+        method="POST"
+        action={`/api/admin/clients/${client.id}`}
+        class="bg-white rounded-lg border border-slate-200 p-6 space-y-6"
+      >
+        <!-- Business Name -->
+        <div>
+          <label for="business_name" class="block text-sm font-medium text-slate-700 mb-1">
+            Business Name <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="business_name"
+            name="business_name"
+            required
+            value={client.business_name}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Vertical -->
+        <div>
+          <label for="vertical" class="block text-sm font-medium text-slate-700 mb-1"
+            >Vertical</label
+          >
+          <select
+            id="vertical"
+            name="vertical"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          >
+            <option value="">Select a vertical</option>
+            {
+              CLIENT_VERTICALS.map((v) => (
+                <option value={v.value} selected={client.vertical === v.value}>
+                  {v.label}
+                </option>
+              ))
+            }
+          </select>
+        </div>
+
+        <!-- Employee Count -->
+        <div>
+          <label for="employee_count" class="block text-sm font-medium text-slate-700 mb-1"
+            >Employee Count</label
+          >
+          <input
+            type="number"
+            id="employee_count"
+            name="employee_count"
+            min="1"
+            value={client.employee_count ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+          <p
+            id="buy-box-warning"
+            class:list={['mt-1.5 text-xs text-amber-600', { hidden: !outsideBuyBox }]}
+            aria-live="polite"
+          >
+            Outside typical buy box of 10-25 employees
+          </p>
+        </div>
+
+        <!-- Years in Business -->
+        <div>
+          <label for="years_in_business" class="block text-sm font-medium text-slate-700 mb-1"
+            >Years in Business</label
+          >
+          <input
+            type="number"
+            id="years_in_business"
+            name="years_in_business"
+            min="0"
+            value={client.years_in_business ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Source -->
+        <div>
+          <label for="source" class="block text-sm font-medium text-slate-700 mb-1">
+            Source <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="source"
+            name="source"
+            required
+            value={client.source ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Referred By -->
+        <div>
+          <label for="referred_by" class="block text-sm font-medium text-slate-700 mb-1"
+            >Referred By</label
+          >
+          <input
+            type="text"
+            id="referred_by"
+            name="referred_by"
+            value={client.referred_by ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Status -->
+        <div>
+          <label for="status" class="block text-sm font-medium text-slate-700 mb-1">Status</label>
+          <select
+            id="status"
+            name="status"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          >
+            {
+              CLIENT_STATUSES.map((s) => (
+                <option value={s.value} selected={client.status === s.value}>
+                  {s.label}
+                </option>
+              ))
+            }
+          </select>
+        </div>
+
+        <!-- Notes -->
+        <div>
+          <label for="notes" class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows="3"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            >{client.notes ?? ''}</textarea
+          >
+        </div>
+
+        <!-- Metadata -->
+        <div class="grid grid-cols-2 gap-4 pt-4 border-t border-slate-200 text-xs text-slate-400">
+          <div>
+            <span class="font-medium">Created:</span>
+            {
+              new Date(client.created_at).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            }
+          </div>
+          <div>
+            <span class="font-medium">Updated:</span>
+            {
+              new Date(client.updated_at).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            }
+          </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-4 border-t border-slate-200">
+          <a
+            href="/admin/clients"
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Back to Clients
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Save Changes
+          </button>
+        </div>
+      </form>
+    </main>
+
+    <script>
+      // OQ-001: Soft warning when employee_count outside 10-25 buy box
+      const employeeInput = document.getElementById('employee_count') as HTMLInputElement
+      const buyBoxWarning = document.getElementById('buy-box-warning') as HTMLElement
+
+      if (employeeInput && buyBoxWarning) {
+        employeeInput.addEventListener('input', () => {
+          const val = parseInt(employeeInput.value, 10)
+          if (!isNaN(val) && (val < 10 || val > 25)) {
+            buyBoxWarning.classList.remove('hidden')
+          } else {
+            buyBoxWarning.classList.add('hidden')
+          }
+        })
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/admin/clients/index.astro
+++ b/src/pages/admin/clients/index.astro
@@ -1,0 +1,350 @@
+---
+import '../../../styles/global.css'
+import {
+  listClients,
+  listClientSources,
+  CLIENT_STATUSES,
+  CLIENT_VERTICALS,
+} from '../../../lib/db/clients'
+import type { ClientStatus } from '../../../lib/db/clients'
+
+/**
+ * Pipeline view — lists all clients with status/vertical/source filters.
+ *
+ * Protected by auth middleware (session guaranteed).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Read filters from query params
+const url = Astro.url
+const filterStatus = url.searchParams.get('status') || ''
+const filterVertical = url.searchParams.get('vertical') || ''
+const filterSource = url.searchParams.get('source') || ''
+const errorParam = url.searchParams.get('error') || ''
+
+const filters: Record<string, string> = {}
+if (filterStatus) filters.status = filterStatus
+if (filterVertical) filters.vertical = filterVertical
+if (filterSource) filters.source = filterSource
+
+const clients = await listClients(env.DB, session.orgId, filters)
+const sources = await listClientSources(env.DB, session.orgId)
+
+// Group clients by status for the pipeline view
+const statusOrder: ClientStatus[] = [
+  'prospect',
+  'assessed',
+  'quoted',
+  'active',
+  'completed',
+  'dead',
+]
+const grouped = new Map<string, typeof clients>()
+for (const s of statusOrder) {
+  grouped.set(s, [])
+}
+for (const client of clients) {
+  const group = grouped.get(client.status)
+  if (group) {
+    group.push(client)
+  }
+}
+
+// Helper to get vertical label
+const verticalLabel = (v: string | null) => {
+  if (!v) return '—'
+  return CLIENT_VERTICALS.find((cv) => cv.value === v)?.label ?? v
+}
+
+// Helper to get status badge color
+const statusColor = (s: string) => {
+  switch (s) {
+    case 'prospect':
+      return 'bg-blue-100 text-blue-800'
+    case 'assessed':
+      return 'bg-amber-100 text-amber-800'
+    case 'quoted':
+      return 'bg-purple-100 text-purple-800'
+    case 'active':
+      return 'bg-green-100 text-green-800'
+    case 'completed':
+      return 'bg-slate-100 text-slate-600'
+    case 'dead':
+      return 'bg-red-100 text-red-800'
+    default:
+      return 'bg-slate-100 text-slate-600'
+  }
+}
+
+const hasActiveFilters = filterStatus || filterVertical || filterSource
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Clients — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-4 py-8">
+      <!-- Page header -->
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-bold text-slate-900">Clients</h1>
+          <p class="text-sm text-slate-500 mt-1">
+            {clients.length} client{clients.length !== 1 ? 's' : ''}
+            {hasActiveFilters ? ' (filtered)' : ''}
+          </p>
+        </div>
+        <a
+          href="/admin/clients/new"
+          class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+        >
+          <svg
+            class="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"
+            ></path>
+          </svg>
+          Add Client
+        </a>
+      </div>
+
+      {
+        errorParam === 'not_found' && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            Client not found.
+          </div>
+        )
+      }
+
+      <!-- Filters -->
+      <form method="GET" action="/admin/clients" class="mb-6">
+        <div class="bg-white rounded-lg border border-slate-200 p-4 flex flex-wrap items-end gap-4">
+          <div class="flex-1 min-w-[150px]">
+            <label for="filter-status" class="block text-xs font-medium text-slate-500 mb-1"
+              >Status</label
+            >
+            <select
+              id="filter-status"
+              name="status"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All statuses</option>
+              {
+                CLIENT_STATUSES.map((s) => (
+                  <option value={s.value} selected={filterStatus === s.value}>
+                    {s.label}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+          <div class="flex-1 min-w-[150px]">
+            <label for="filter-vertical" class="block text-xs font-medium text-slate-500 mb-1"
+              >Vertical</label
+            >
+            <select
+              id="filter-vertical"
+              name="vertical"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All verticals</option>
+              {
+                CLIENT_VERTICALS.map((v) => (
+                  <option value={v.value} selected={filterVertical === v.value}>
+                    {v.label}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+          <div class="flex-1 min-w-[150px]">
+            <label for="filter-source" class="block text-xs font-medium text-slate-500 mb-1"
+              >Source</label
+            >
+            <select
+              id="filter-source"
+              name="source"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All sources</option>
+              {
+                sources.map((s) => (
+                  <option value={s} selected={filterSource === s}>
+                    {s}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+          <div class="flex gap-2">
+            <button
+              type="submit"
+              class="bg-slate-900 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-slate-800 transition-colors"
+            >
+              Filter
+            </button>
+            {
+              hasActiveFilters && (
+                <a
+                  href="/admin/clients"
+                  class="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 transition-colors"
+                >
+                  Clear
+                </a>
+              )
+            }
+          </div>
+        </div>
+      </form>
+
+      <!-- Pipeline columns (when no status filter active) -->
+      {
+        !filterStatus ? (
+          <div class="space-y-6">
+            {statusOrder.map((status) => {
+              const group = grouped.get(status) ?? []
+              const statusInfo = CLIENT_STATUSES.find((s) => s.value === status)
+              return (
+                <div>
+                  <div class="flex items-center gap-2 mb-3">
+                    <span
+                      class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColor(status)}`}
+                    >
+                      {statusInfo?.label ?? status}
+                    </span>
+                    <span class="text-xs text-slate-400">{group.length}</span>
+                  </div>
+                  {group.length > 0 ? (
+                    <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+                      {group.map((client) => (
+                        <a
+                          href={`/admin/clients/${client.id}`}
+                          class="flex items-center justify-between px-4 py-3 hover:bg-slate-50 transition-colors"
+                        >
+                          <div class="flex-1 min-w-0">
+                            <p class="text-sm font-medium text-slate-900 truncate">
+                              {client.business_name}
+                            </p>
+                            <p class="text-xs text-slate-500 mt-0.5">
+                              {verticalLabel(client.vertical)}
+                              {client.employee_count ? ` · ${client.employee_count} employees` : ''}
+                              {client.source ? ` · ${client.source}` : ''}
+                            </p>
+                          </div>
+                          <svg
+                            class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M9 5l7 7-7 7"
+                            />
+                          </svg>
+                        </a>
+                      ))}
+                    </div>
+                  ) : (
+                    <div class="bg-white rounded-lg border border-slate-200 border-dashed p-4 text-center">
+                      <p class="text-sm text-slate-400">No clients</p>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          /* Flat list when status filter is active */
+          <div>
+            {clients.length > 0 ? (
+              <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+                {clients.map((client) => (
+                  <a
+                    href={`/admin/clients/${client.id}`}
+                    class="flex items-center justify-between px-4 py-3 hover:bg-slate-50 transition-colors"
+                  >
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2">
+                        <p class="text-sm font-medium text-slate-900 truncate">
+                          {client.business_name}
+                        </p>
+                        <span
+                          class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusColor(client.status)}`}
+                        >
+                          {CLIENT_STATUSES.find((s) => s.value === client.status)?.label ??
+                            client.status}
+                        </span>
+                      </div>
+                      <p class="text-xs text-slate-500 mt-0.5">
+                        {verticalLabel(client.vertical)}
+                        {client.employee_count ? ` · ${client.employee_count} employees` : ''}
+                        {client.source ? ` · ${client.source}` : ''}
+                      </p>
+                    </div>
+                    <svg
+                      class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </a>
+                ))}
+              </div>
+            ) : (
+              <div class="bg-white rounded-lg border border-slate-200 border-dashed p-8 text-center">
+                <p class="text-sm text-slate-400">No clients match the current filters.</p>
+              </div>
+            )}
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/clients/new.astro
+++ b/src/pages/admin/clients/new.astro
@@ -1,0 +1,242 @@
+---
+import '../../../styles/global.css'
+import { CLIENT_STATUSES, CLIENT_VERTICALS } from '../../../lib/db/clients'
+
+/**
+ * Create new client form.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Form POSTs to /api/admin/clients which creates the record and redirects.
+ */
+
+const session = Astro.locals.session!
+
+const url = Astro.url
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  missing: 'Business name and source are required.',
+  server: 'Something went wrong. Please try again.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Add Client — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Add Client</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-6">Add Client</h1>
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <form
+        method="POST"
+        action="/api/admin/clients"
+        class="bg-white rounded-lg border border-slate-200 p-6 space-y-6"
+      >
+        <!-- Business Name -->
+        <div>
+          <label for="business_name" class="block text-sm font-medium text-slate-700 mb-1">
+            Business Name <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="business_name"
+            name="business_name"
+            required
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. Phoenix Plumbing Co."
+          />
+        </div>
+
+        <!-- Vertical -->
+        <div>
+          <label for="vertical" class="block text-sm font-medium text-slate-700 mb-1"
+            >Vertical</label
+          >
+          <select
+            id="vertical"
+            name="vertical"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          >
+            <option value="">Select a vertical</option>
+            {CLIENT_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
+          </select>
+        </div>
+
+        <!-- Employee Count -->
+        <div>
+          <label for="employee_count" class="block text-sm font-medium text-slate-700 mb-1"
+            >Employee Count</label
+          >
+          <input
+            type="number"
+            id="employee_count"
+            name="employee_count"
+            min="1"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. 15"
+          />
+          <p id="buy-box-warning" class="mt-1.5 text-xs text-amber-600 hidden" aria-live="polite">
+            Outside typical buy box of 10-25 employees
+          </p>
+        </div>
+
+        <!-- Years in Business -->
+        <div>
+          <label for="years_in_business" class="block text-sm font-medium text-slate-700 mb-1"
+            >Years in Business</label
+          >
+          <input
+            type="number"
+            id="years_in_business"
+            name="years_in_business"
+            min="0"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. 8"
+          />
+        </div>
+
+        <!-- Source -->
+        <div>
+          <label for="source" class="block text-sm font-medium text-slate-700 mb-1">
+            Source <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="source"
+            name="source"
+            required
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. BNI, Chamber, Referral, Website"
+          />
+        </div>
+
+        <!-- Referred By -->
+        <div>
+          <label for="referred_by" class="block text-sm font-medium text-slate-700 mb-1"
+            >Referred By</label
+          >
+          <input
+            type="text"
+            id="referred_by"
+            name="referred_by"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. John Smith, ABC Accounting"
+          />
+        </div>
+
+        <!-- Status -->
+        <div>
+          <label for="status" class="block text-sm font-medium text-slate-700 mb-1">Status</label>
+          <select
+            id="status"
+            name="status"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          >
+            {
+              CLIENT_STATUSES.map((s) => (
+                <option value={s.value} selected={s.value === 'prospect'}>
+                  {s.label}
+                </option>
+              ))
+            }
+          </select>
+        </div>
+
+        <!-- Notes -->
+        <div>
+          <label for="notes" class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows="3"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="Any additional context..."></textarea>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-4 border-t border-slate-200">
+          <a
+            href="/admin/clients"
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Cancel
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Create Client
+          </button>
+        </div>
+      </form>
+    </main>
+
+    <script>
+      // OQ-001: Soft warning when employee_count outside 10-25 buy box
+      const employeeInput = document.getElementById('employee_count') as HTMLInputElement
+      const buyBoxWarning = document.getElementById('buy-box-warning') as HTMLElement
+
+      if (employeeInput && buyBoxWarning) {
+        employeeInput.addEventListener('input', () => {
+          const val = parseInt(employeeInput.value, 10)
+          if (!isNaN(val) && (val < 10 || val > 25)) {
+            buyBoxWarning.classList.remove('hidden')
+          } else {
+            buyBoxWarning.classList.add('hidden')
+          }
+        })
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -47,10 +47,21 @@ const session = Astro.locals.session!
 
     <main class="max-w-5xl mx-auto px-4 py-8">
       <h2 class="text-xl font-semibold text-slate-900 mb-4">Dashboard</h2>
-      <div class="bg-white rounded-lg border border-slate-200 p-6">
-        <p class="text-slate-600">
-          Welcome back. The admin portal is under construction — more features coming soon.
-        </p>
+      <div class="grid gap-4">
+        <a
+          href="/admin/clients"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <h3
+            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+          >
+            Clients
+          </h3>
+          <p class="text-sm text-slate-500 mt-1">
+            Manage your client pipeline — create, edit, and track clients through the engagement
+            lifecycle.
+          </p>
+        </a>
       </div>
     </main>
   </body>

--- a/src/pages/api/admin/clients/[id].ts
+++ b/src/pages/api/admin/clients/[id].ts
@@ -1,0 +1,85 @@
+import type { APIRoute } from 'astro'
+import { updateClient } from '../../../../lib/db/clients'
+
+/**
+ * PUT /api/admin/clients/:id
+ *
+ * Updates an existing client from form data and redirects back to the client detail page.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Accepts the same fields as create. Only non-empty fields are updated.
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const clientId = params.id
+  if (!clientId) {
+    return new Response(JSON.stringify({ error: 'Client ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const formData = await request.formData()
+    const businessName = formData.get('business_name')
+    const source = formData.get('source')
+
+    // Validate required fields
+    if (
+      !businessName ||
+      typeof businessName !== 'string' ||
+      !businessName.trim() ||
+      !source ||
+      typeof source !== 'string' ||
+      !source.trim()
+    ) {
+      return redirect(`/admin/clients/${clientId}?error=missing`, 302)
+    }
+
+    const env = locals.runtime.env
+    const vertical = formData.get('vertical')
+    const employeeCount = formData.get('employee_count')
+    const yearsInBusiness = formData.get('years_in_business')
+    const referredBy = formData.get('referred_by')
+    const status = formData.get('status')
+    const notes = formData.get('notes')
+
+    const updated = await updateClient(env.DB, session.orgId, clientId, {
+      business_name: businessName.trim(),
+      vertical:
+        vertical && typeof vertical === 'string' && vertical.trim() ? vertical.trim() : null,
+      employee_count:
+        employeeCount && typeof employeeCount === 'string' && employeeCount.trim()
+          ? parseInt(employeeCount, 10) || null
+          : null,
+      years_in_business:
+        yearsInBusiness && typeof yearsInBusiness === 'string' && yearsInBusiness.trim()
+          ? parseInt(yearsInBusiness, 10) || null
+          : null,
+      source: source.trim(),
+      referred_by:
+        referredBy && typeof referredBy === 'string' && referredBy.trim()
+          ? referredBy.trim()
+          : null,
+      status: status && typeof status === 'string' && status.trim() ? status.trim() : undefined,
+      notes: notes && typeof notes === 'string' ? notes.trim() || null : undefined,
+    })
+
+    if (!updated) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    return redirect(`/admin/clients/${clientId}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/clients/[id]] Update error:', err)
+    return redirect(`/admin/clients/${clientId}?error=server`, 302)
+  }
+}

--- a/src/pages/api/admin/clients/index.ts
+++ b/src/pages/api/admin/clients/index.ts
@@ -1,0 +1,81 @@
+import type { APIRoute } from 'astro'
+import { createClient } from '../../../../lib/db/clients'
+
+/**
+ * POST /api/admin/clients
+ *
+ * Creates a new client from form data and redirects to the client detail page.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields:
+ *   - business_name (required)
+ *   - vertical
+ *   - employee_count
+ *   - years_in_business
+ *   - source (required per OQ-002)
+ *   - referred_by
+ *   - status
+ *   - notes
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const formData = await request.formData()
+    const businessName = formData.get('business_name')
+    const source = formData.get('source')
+
+    // Validate required fields
+    if (
+      !businessName ||
+      typeof businessName !== 'string' ||
+      !businessName.trim() ||
+      !source ||
+      typeof source !== 'string' ||
+      !source.trim()
+    ) {
+      return redirect('/admin/clients/new?error=missing', 302)
+    }
+
+    const env = locals.runtime.env
+    const vertical = formData.get('vertical')
+    const employeeCount = formData.get('employee_count')
+    const yearsInBusiness = formData.get('years_in_business')
+    const referredBy = formData.get('referred_by')
+    const status = formData.get('status')
+    const notes = formData.get('notes')
+
+    const client = await createClient(env.DB, session.orgId, {
+      business_name: businessName.trim(),
+      vertical:
+        vertical && typeof vertical === 'string' && vertical.trim() ? vertical.trim() : null,
+      employee_count:
+        employeeCount && typeof employeeCount === 'string' && employeeCount.trim()
+          ? parseInt(employeeCount, 10) || null
+          : null,
+      years_in_business:
+        yearsInBusiness && typeof yearsInBusiness === 'string' && yearsInBusiness.trim()
+          ? parseInt(yearsInBusiness, 10) || null
+          : null,
+      source: source.trim(),
+      referred_by:
+        referredBy && typeof referredBy === 'string' && referredBy.trim()
+          ? referredBy.trim()
+          : null,
+      status: status && typeof status === 'string' && status.trim() ? status.trim() : 'prospect',
+      notes: notes && typeof notes === 'string' && notes.trim() ? notes.trim() : null,
+    })
+
+    return redirect(`/admin/clients/${client.id}`, 302)
+  } catch (err) {
+    console.error('[api/admin/clients] Create error:', err)
+    return redirect('/admin/clients/new?error=server', 302)
+  }
+}

--- a/tests/clients.test.ts
+++ b/tests/clients.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('clients: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/clients.ts'), 'utf-8')
+
+  it('clients.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/clients.ts'))).toBe(true)
+  })
+
+  it('exports listClients function', () => {
+    expect(source()).toContain('export async function listClients')
+  })
+
+  it('exports getClient function', () => {
+    expect(source()).toContain('export async function getClient')
+  })
+
+  it('exports createClient function', () => {
+    expect(source()).toContain('export async function createClient')
+  })
+
+  it('exports updateClient function', () => {
+    expect(source()).toContain('export async function updateClient')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    // Ensure bind() is used for parameterized queries
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('scopes all queries to org_id', () => {
+    const code = source()
+    // listClients, getClient, createClient, updateClient all include org_id
+    expect(code).toContain("'org_id = ?'")
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('supports status, vertical, and source filters in listClients', () => {
+    const code = source()
+    expect(code).toContain("'status = ?'")
+    expect(code).toContain("'vertical = ?'")
+    expect(code).toContain("'source = ?'")
+  })
+
+  it('defines all valid client verticals', () => {
+    const code = source()
+    expect(code).toContain('home_services')
+    expect(code).toContain('professional_services')
+    expect(code).toContain('contractor_trades')
+    expect(code).toContain('retail_salon')
+    expect(code).toContain('restaurant')
+    expect(code).toContain("'other'")
+  })
+
+  it('defines all valid client statuses', () => {
+    const code = source()
+    expect(code).toContain("'prospect'")
+    expect(code).toContain("'assessed'")
+    expect(code).toContain("'quoted'")
+    expect(code).toContain("'active'")
+    expect(code).toContain("'completed'")
+    expect(code).toContain("'dead'")
+  })
+
+  it('exports CLIENT_VERTICALS and CLIENT_STATUSES constants', () => {
+    const code = source()
+    expect(code).toContain('export const CLIENT_VERTICALS')
+    expect(code).toContain('export const CLIENT_STATUSES')
+  })
+
+  it('exports listClientSources for filter dropdowns', () => {
+    expect(source()).toContain('export async function listClientSources')
+  })
+})
+
+describe('clients: API routes', () => {
+  it('create endpoint exists at src/pages/api/admin/clients/index.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/clients/index.ts'))).toBe(true)
+  })
+
+  it('update endpoint exists at src/pages/api/admin/clients/[id].ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/clients/[id].ts'))).toBe(true)
+  })
+
+  it('create endpoint validates required fields', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/clients/index.ts'), 'utf-8')
+    expect(code).toContain('business_name')
+    expect(code).toContain('source')
+    expect(code).toContain('error=missing')
+  })
+
+  it('create endpoint calls createClient', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/clients/index.ts'), 'utf-8')
+    expect(code).toContain('createClient')
+  })
+
+  it('update endpoint calls updateClient', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/clients/[id].ts'), 'utf-8')
+    expect(code).toContain('updateClient')
+  })
+
+  it('create endpoint reads form data (server-rendered form submission)', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/clients/index.ts'), 'utf-8')
+    expect(code).toContain('request.formData()')
+  })
+
+  it('update endpoint reads form data', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/clients/[id].ts'), 'utf-8')
+    expect(code).toContain('request.formData()')
+  })
+
+  it('endpoints verify admin session', () => {
+    const createCode = readFileSync(resolve('src/pages/api/admin/clients/index.ts'), 'utf-8')
+    const updateCode = readFileSync(resolve('src/pages/api/admin/clients/[id].ts'), 'utf-8')
+    expect(createCode).toContain("session.role !== 'admin'")
+    expect(updateCode).toContain("session.role !== 'admin'")
+  })
+})
+
+describe('clients: pipeline view page', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/clients/index.astro'), 'utf-8')
+
+  it('pipeline page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/index.astro'))).toBe(true)
+  })
+
+  it('uses session data from auth middleware', () => {
+    expect(source()).toContain('Astro.locals.session')
+  })
+
+  it('calls listClients to load client data', () => {
+    expect(source()).toContain('listClients')
+  })
+
+  it('provides status filter control', () => {
+    const code = source()
+    expect(code).toContain('filter-status')
+    expect(code).toContain('name="status"')
+  })
+
+  it('provides vertical filter control', () => {
+    const code = source()
+    expect(code).toContain('filter-vertical')
+    expect(code).toContain('name="vertical"')
+  })
+
+  it('provides source filter control', () => {
+    const code = source()
+    expect(code).toContain('filter-source')
+    expect(code).toContain('name="source"')
+  })
+
+  it('groups clients by status for pipeline view', () => {
+    const code = source()
+    expect(code).toContain('grouped')
+    expect(code).toContain('statusOrder')
+  })
+
+  it('includes Add Client button linking to new page', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients/new')
+    expect(code).toContain('Add Client')
+  })
+
+  it('links each client to detail page', () => {
+    expect(source()).toContain('/admin/clients/${client.id}')
+  })
+
+  it('displays business_name, vertical, employee_count, source', () => {
+    const code = source()
+    expect(code).toContain('client.business_name')
+    expect(code).toContain('client.employee_count')
+    expect(code).toContain('client.source')
+    expect(code).toContain('verticalLabel')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('clients: create form page', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/clients/new.astro'), 'utf-8')
+
+  it('create page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/new.astro'))).toBe(true)
+  })
+
+  it('form posts to /api/admin/clients', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('action="/api/admin/clients"')
+  })
+
+  it('includes all client fields', () => {
+    const code = source()
+    expect(code).toContain('name="business_name"')
+    expect(code).toContain('name="vertical"')
+    expect(code).toContain('name="employee_count"')
+    expect(code).toContain('name="years_in_business"')
+    expect(code).toContain('name="source"')
+    expect(code).toContain('name="referred_by"')
+    expect(code).toContain('name="status"')
+    expect(code).toContain('name="notes"')
+  })
+
+  it('marks business_name as required', () => {
+    const code = source()
+    // Check that business_name input has required attribute
+    expect(code).toMatch(/id="business_name"[\s\S]*?required/)
+  })
+
+  it('marks source as required (OQ-002)', () => {
+    const code = source()
+    // Check that source input has required attribute
+    expect(code).toMatch(/id="source"[\s\S]*?required/)
+  })
+
+  it('includes buy box warning for employee count (OQ-001)', () => {
+    const code = source()
+    expect(code).toContain('buy-box-warning')
+    expect(code).toContain('Outside typical buy box of 10-25 employees')
+  })
+
+  it('has client-side buy box warning logic', () => {
+    const code = source()
+    expect(code).toContain('val < 10 || val > 25')
+  })
+
+  it('uses vertical dropdown with CHECK values', () => {
+    const code = source()
+    expect(code).toContain('CLIENT_VERTICALS')
+    expect(code).toContain('Select a vertical')
+  })
+
+  it('defaults status to prospect', () => {
+    const code = source()
+    expect(code).toContain("s.value === 'prospect'")
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('clients: detail/edit page', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/clients/[id].astro'), 'utf-8')
+
+  it('detail page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id].astro'))).toBe(true)
+  })
+
+  it('loads client via getClient', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('redirects to clients list if client not found', () => {
+    const code = source()
+    expect(code).toContain("Astro.redirect('/admin/clients?error=not_found')")
+  })
+
+  it('form posts to /api/admin/clients/:id', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('/api/admin/clients/${client.id}')
+  })
+
+  it('pre-populates form fields with client data', () => {
+    const code = source()
+    expect(code).toContain('value={client.business_name}')
+    expect(code).toContain('client.vertical === v.value')
+    expect(code).toContain('client.employee_count')
+    expect(code).toContain('client.source')
+  })
+
+  it('shows status progression indicator', () => {
+    const code = source()
+    expect(code).toContain('statusOrder')
+    expect(code).toContain('getProgressionColor')
+  })
+
+  it('shows success message after save', () => {
+    const code = source()
+    expect(code).toContain("get('saved')")
+    expect(code).toContain('Client updated successfully')
+  })
+
+  it('shows buy box warning when employee count outside 10-25', () => {
+    const code = source()
+    expect(code).toContain('outsideBuyBox')
+    expect(code).toContain('Outside typical buy box of 10-25 employees')
+  })
+
+  it('displays created_at and updated_at metadata', () => {
+    const code = source()
+    expect(code).toContain('client.created_at')
+    expect(code).toContain('client.updated_at')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('clients: admin dashboard integration', () => {
+  it('admin dashboard links to clients page', () => {
+    const code = readFileSync(resolve('src/pages/admin/index.astro'), 'utf-8')
+    expect(code).toContain('/admin/clients')
+    expect(code).toContain('Clients')
+  })
+})


### PR DESCRIPTION
## Summary
- Add client data access layer (`src/lib/db/clients.ts`) with parameterized queries for create, read, update, list, and source listing
- Add pipeline view (`/admin/clients`) showing clients grouped by status with filters for status, vertical, and source
- Add create client form (`/admin/clients/new`) and detail/edit page (`/admin/clients/[id]`) with status progression indicator
- Add API routes (`/api/admin/clients`) for server-side form handling with validation
- Enforce OQ-001 (soft warning for employee count outside 10-25 buy box) and OQ-002 (source field required)
- Add 53 tests covering data access layer, API routes, pages, and admin dashboard integration

## Test plan
- [ ] Verify `npm run verify` passes (typecheck, format, lint, build, 231 tests)
- [ ] Create a client with all fields — confirm redirect to detail page
- [ ] Edit a client — confirm save success message and data persistence
- [ ] Verify buy box warning appears when employee count < 10 or > 25
- [ ] Verify source field is required on both create and edit forms
- [ ] Test pipeline view filters (status, vertical, source) and clear button
- [ ] Verify pipeline groups clients by status when no status filter is active
- [ ] Confirm all pages are noindexed and protected by admin auth middleware

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)