### PR TITLE
feat: add contact CRUD and engagement role data layer

### DIFF
--- a/src/lib/db/contacts.ts
+++ b/src/lib/db/contacts.ts
@@ -1,0 +1,318 @@
+/**
+ * Contact data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ */
+
+export interface Contact {
+  id: string
+  org_id: string
+  client_id: string
+  name: string
+  email: string | null
+  phone: string | null
+  title: string | null
+  notes: string | null
+  created_at: string
+}
+
+export interface CreateContactData {
+  name: string
+  email?: string | null
+  phone?: string | null
+  title?: string | null
+  notes?: string | null
+}
+
+export interface UpdateContactData {
+  name?: string
+  email?: string | null
+  phone?: string | null
+  title?: string | null
+  notes?: string | null
+}
+
+export type EngagementContactRole = 'owner' | 'decision_maker' | 'champion'
+
+export const ENGAGEMENT_CONTACT_ROLES: { value: EngagementContactRole; label: string }[] = [
+  { value: 'owner', label: 'Owner' },
+  { value: 'decision_maker', label: 'Decision Maker' },
+  { value: 'champion', label: 'Champion' },
+]
+
+export interface EngagementContact {
+  id: string
+  engagement_id: string
+  contact_id: string
+  role: string
+  is_primary: number
+  notes: string | null
+  created_at: string
+  /** Joined from contacts table */
+  contact_name?: string
+  contact_email?: string | null
+  contact_phone?: string | null
+  contact_title?: string | null
+}
+
+/**
+ * List contacts for a client, scoped to an organization.
+ */
+export async function listContacts(
+  db: D1Database,
+  orgId: string,
+  clientId: string
+): Promise<Contact[]> {
+  const result = await db
+    .prepare('SELECT * FROM contacts WHERE org_id = ? AND client_id = ? ORDER BY name ASC')
+    .bind(orgId, clientId)
+    .all<Contact>()
+  return result.results
+}
+
+/**
+ * Get a single contact by ID, scoped to an organization.
+ */
+export async function getContact(
+  db: D1Database,
+  orgId: string,
+  contactId: string
+): Promise<Contact | null> {
+  const result = await db
+    .prepare('SELECT * FROM contacts WHERE id = ? AND org_id = ?')
+    .bind(contactId, orgId)
+    .first<Contact>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new contact linked to a client. Returns the created contact record.
+ */
+export async function createContact(
+  db: D1Database,
+  orgId: string,
+  clientId: string,
+  data: CreateContactData
+): Promise<Contact> {
+  const id = crypto.randomUUID()
+
+  await db
+    .prepare(
+      `INSERT INTO contacts (id, org_id, client_id, name, email, phone, title, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      clientId,
+      data.name,
+      data.email ?? null,
+      data.phone ?? null,
+      data.title ?? null,
+      data.notes ?? null
+    )
+    .run()
+
+  const contact = await getContact(db, orgId, id)
+  if (!contact) {
+    throw new Error('Failed to retrieve created contact')
+  }
+  return contact
+}
+
+/**
+ * Update an existing contact. Returns the updated contact record.
+ */
+export async function updateContact(
+  db: D1Database,
+  orgId: string,
+  contactId: string,
+  data: UpdateContactData
+): Promise<Contact | null> {
+  const existing = await getContact(db, orgId, contactId)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | null)[] = []
+
+  if (data.name !== undefined) {
+    fields.push('name = ?')
+    params.push(data.name)
+  }
+
+  if (data.email !== undefined) {
+    fields.push('email = ?')
+    params.push(data.email)
+  }
+
+  if (data.phone !== undefined) {
+    fields.push('phone = ?')
+    params.push(data.phone)
+  }
+
+  if (data.title !== undefined) {
+    fields.push('title = ?')
+    params.push(data.title)
+  }
+
+  if (data.notes !== undefined) {
+    fields.push('notes = ?')
+    params.push(data.notes)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  const sql = `UPDATE contacts SET ${fields.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(contactId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getContact(db, orgId, contactId)
+}
+
+/**
+ * Delete a contact. Returns true if the contact was found and deleted.
+ *
+ * Hard delete — contacts table has no soft-delete column.
+ * Also removes any engagement_contacts rows referencing this contact.
+ */
+export async function deleteContact(
+  db: D1Database,
+  orgId: string,
+  contactId: string
+): Promise<boolean> {
+  const existing = await getContact(db, orgId, contactId)
+  if (!existing) {
+    return false
+  }
+
+  // Remove engagement role assignments first
+  await db.prepare('DELETE FROM engagement_contacts WHERE contact_id = ?').bind(contactId).run()
+
+  await db.prepare('DELETE FROM contacts WHERE id = ? AND org_id = ?').bind(contactId, orgId).run()
+
+  return true
+}
+
+/**
+ * Assign a contact to an engagement role.
+ *
+ * A single contact can hold multiple roles on the same engagement (OQ-003).
+ * The UNIQUE(engagement_id, contact_id, role) constraint prevents duplicate
+ * role assignments.
+ *
+ * If isPrimary is true, clears any existing primary flag on the engagement first.
+ */
+export async function assignEngagementRole(
+  db: D1Database,
+  engagementId: string,
+  contactId: string,
+  role: EngagementContactRole,
+  isPrimary: boolean = false,
+  notes?: string | null
+): Promise<EngagementContact> {
+  const id = crypto.randomUUID()
+
+  // If setting as primary, clear existing primary flags on this engagement
+  if (isPrimary) {
+    await db
+      .prepare('UPDATE engagement_contacts SET is_primary = 0 WHERE engagement_id = ?')
+      .bind(engagementId)
+      .run()
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO engagement_contacts (id, engagement_id, contact_id, role, is_primary, notes)
+     VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(id, engagementId, contactId, role, isPrimary ? 1 : 0, notes ?? null)
+    .run()
+
+  const result = await db
+    .prepare('SELECT * FROM engagement_contacts WHERE id = ?')
+    .bind(id)
+    .first<EngagementContact>()
+
+  if (!result) {
+    throw new Error('Failed to retrieve created engagement contact')
+  }
+  return result
+}
+
+/**
+ * Remove a contact's role assignment from an engagement.
+ */
+export async function removeEngagementRole(
+  db: D1Database,
+  engagementContactId: string
+): Promise<boolean> {
+  const result = await db
+    .prepare('DELETE FROM engagement_contacts WHERE id = ?')
+    .bind(engagementContactId)
+    .run()
+
+  return (result.meta?.changes ?? 0) > 0
+}
+
+/**
+ * List contacts with their roles for an engagement.
+ * Joins engagement_contacts with contacts to include contact details.
+ */
+export async function getEngagementContacts(
+  db: D1Database,
+  engagementId: string
+): Promise<EngagementContact[]> {
+  const result = await db
+    .prepare(
+      `SELECT
+        ec.id,
+        ec.engagement_id,
+        ec.contact_id,
+        ec.role,
+        ec.is_primary,
+        ec.notes,
+        ec.created_at,
+        c.name AS contact_name,
+        c.email AS contact_email,
+        c.phone AS contact_phone,
+        c.title AS contact_title
+      FROM engagement_contacts ec
+      JOIN contacts c ON c.id = ec.contact_id
+      WHERE ec.engagement_id = ?
+      ORDER BY ec.is_primary DESC, c.name ASC`
+    )
+    .bind(engagementId)
+    .all<EngagementContact>()
+
+  return result.results
+}
+
+/**
+ * Update the primary POC flag for an engagement contact.
+ * Clears all other primary flags on the engagement first.
+ */
+export async function setEngagementPrimary(
+  db: D1Database,
+  engagementId: string,
+  engagementContactId: string
+): Promise<void> {
+  await db
+    .prepare('UPDATE engagement_contacts SET is_primary = 0 WHERE engagement_id = ?')
+    .bind(engagementId)
+    .run()
+
+  await db
+    .prepare('UPDATE engagement_contacts SET is_primary = 1 WHERE id = ? AND engagement_id = ?')
+    .bind(engagementContactId, engagementId)
+    .run()
+}

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -2,6 +2,7 @@
 import '../../../styles/global.css'
 import { getClient, CLIENT_STATUSES, CLIENT_VERTICALS } from '../../../lib/db/clients'
 import type { ClientStatus } from '../../../lib/db/clients'
+import { listContacts } from '../../../lib/db/contacts'
 
 /**
  * Client detail/edit page.
@@ -25,13 +26,18 @@ if (!client) {
   return Astro.redirect('/admin/clients?error=not_found')
 }
 
+const contacts = await listContacts(env.DB, session.orgId, id)
+
 const url = Astro.url
 const saved = url.searchParams.get('saved') === '1'
+const contactsSaved = url.searchParams.get('contacts_saved') === '1'
+const contactDeleted = url.searchParams.get('contact_deleted') === '1'
 const errorParam = url.searchParams.get('error') || ''
 
 const errorMessages: Record<string, string> = {
   missing: 'Business name and source are required.',
   server: 'Something went wrong. Please try again.',
+  contact_not_found: 'Contact not found.',
 }
 
 const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
@@ -151,6 +157,22 @@ const outsideBuyBox =
         saved && (
           <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
             Client updated successfully.
+          </div>
+        )
+      }
+
+      {
+        contactsSaved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Contact added successfully.
+          </div>
+        )
+      }
+
+      {
+        contactDeleted && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Contact deleted.
           </div>
         )
       }
@@ -348,6 +370,82 @@ const outsideBuyBox =
           </button>
         </div>
       </form>
+
+      <!-- Contacts Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-bold text-slate-900">
+            Contacts
+            <span class="text-sm font-normal text-slate-400 ml-1">({contacts.length})</span>
+          </h2>
+          <a
+            href={`/admin/clients/${client.id}/contacts/new`}
+            class="inline-flex items-center gap-2 bg-primary text-white px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 4v16m8-8H4"></path>
+            </svg>
+            Add Contact
+          </a>
+        </div>
+
+        {
+          contacts.length > 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {contacts.map((contact) => (
+                <a
+                  href={`/admin/clients/${client.id}/contacts/${contact.id}`}
+                  class="flex items-center justify-between px-4 py-3 hover:bg-slate-50 transition-colors"
+                >
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium text-slate-900 truncate">{contact.name}</p>
+                    <p class="text-xs text-slate-500 mt-0.5">
+                      {contact.title ?? ''}
+                      {contact.title && contact.email ? ' · ' : ''}
+                      {contact.email ?? ''}
+                      {(contact.title || contact.email) && contact.phone ? ' · ' : ''}
+                      {contact.phone ?? ''}
+                    </p>
+                  </div>
+                  <svg
+                    class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </a>
+              ))}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400">No contacts yet.</p>
+              <a
+                href={`/admin/clients/${client.id}/contacts/new`}
+                class="text-sm text-primary hover:text-primary-hover mt-1 inline-block"
+              >
+                Add the first contact
+              </a>
+            </div>
+          )
+        }
+      </div>
     </main>
 
     <script>

--- a/src/pages/admin/clients/[id]/contacts/[contactId].astro
+++ b/src/pages/admin/clients/[id]/contacts/[contactId].astro
@@ -1,0 +1,246 @@
+---
+import '../../../../../styles/global.css'
+import { getClient } from '../../../../../lib/db/clients'
+import { getContact } from '../../../../../lib/db/contacts'
+
+/**
+ * Contact detail/edit page.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Displays all contact fields in an editable form.
+ * Form POSTs to /api/admin/clients/:id/contacts/:contactId which updates and redirects.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id, contactId } = Astro.params
+
+if (!id || !contactId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, id)
+
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const contact = await getContact(env.DB, session.orgId, contactId)
+
+if (!contact) {
+  return Astro.redirect(`/admin/clients/${id}?error=contact_not_found`)
+}
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  missing: 'Contact name is required.',
+  server: 'Something went wrong. Please try again.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>{contact.name} — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">{contact.name}</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-6">{contact.name}</h1>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Contact updated successfully.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <form
+        method="POST"
+        action={`/api/admin/clients/${client.id}/contacts/${contact.id}`}
+        class="bg-white rounded-lg border border-slate-200 p-6 space-y-6"
+      >
+        <!-- Name -->
+        <div>
+          <label for="name" class="block text-sm font-medium text-slate-700 mb-1">
+            Name <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            required
+            value={contact.name}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Email -->
+        <div>
+          <label for="email" class="block text-sm font-medium text-slate-700 mb-1">Email</label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            value={contact.email ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Phone -->
+        <div>
+          <label for="phone" class="block text-sm font-medium text-slate-700 mb-1">Phone</label>
+          <input
+            type="tel"
+            id="phone"
+            name="phone"
+            value={contact.phone ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Title -->
+        <div>
+          <label for="title" class="block text-sm font-medium text-slate-700 mb-1">Title</label>
+          <input
+            type="text"
+            id="title"
+            name="title"
+            value={contact.title ?? ''}
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <!-- Notes -->
+        <div>
+          <label for="notes" class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows="3"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            >{contact.notes ?? ''}</textarea
+          >
+        </div>
+
+        <!-- Metadata -->
+        <div class="pt-4 border-t border-slate-200 text-xs text-slate-400">
+          <span class="font-medium">Added:</span>
+          {
+            new Date(contact.created_at).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-4 border-t border-slate-200">
+          <a
+            href={`/admin/clients/${client.id}`}
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Back to Client
+          </a>
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              id="delete-btn"
+              class="text-sm text-red-600 hover:text-red-800 transition-colors"
+            >
+              Delete Contact
+            </button>
+            <button
+              type="submit"
+              class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+            >
+              Save Changes
+            </button>
+          </div>
+        </div>
+      </form>
+
+      <!-- Hidden delete form -->
+      <form
+        id="delete-form"
+        method="POST"
+        action={`/api/admin/clients/${client.id}/contacts/${contact.id}`}
+        class="hidden"
+      >
+        <input type="hidden" name="_method" value="DELETE" />
+      </form>
+    </main>
+
+    <script>
+      const deleteBtn = document.getElementById('delete-btn')
+      const deleteForm = document.getElementById('delete-form') as HTMLFormElement
+
+      if (deleteBtn && deleteForm) {
+        deleteBtn.addEventListener('click', () => {
+          if (confirm('Are you sure you want to delete this contact? This cannot be undone.')) {
+            deleteForm.submit()
+          }
+        })
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/admin/clients/[id]/contacts/new.astro
+++ b/src/pages/admin/clients/[id]/contacts/new.astro
@@ -1,0 +1,184 @@
+---
+import '../../../../../styles/global.css'
+import { getClient } from '../../../../../lib/db/clients'
+
+/**
+ * Add contact form, nested under a client.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Form POSTs to /api/admin/clients/:id/contacts which creates the record and redirects.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id } = Astro.params
+
+if (!id) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, id)
+
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const url = Astro.url
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  missing: 'Contact name is required.',
+  server: 'Something went wrong. Please try again.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Add Contact — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Add Contact</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-6">Add Contact</h1>
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <form
+        method="POST"
+        action={`/api/admin/clients/${client.id}/contacts`}
+        class="bg-white rounded-lg border border-slate-200 p-6 space-y-6"
+      >
+        <!-- Name -->
+        <div>
+          <label for="name" class="block text-sm font-medium text-slate-700 mb-1">
+            Name <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            required
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. Jane Smith"
+          />
+        </div>
+
+        <!-- Email -->
+        <div>
+          <label for="email" class="block text-sm font-medium text-slate-700 mb-1">Email</label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. jane@example.com"
+          />
+        </div>
+
+        <!-- Phone -->
+        <div>
+          <label for="phone" class="block text-sm font-medium text-slate-700 mb-1">Phone</label>
+          <input
+            type="tel"
+            id="phone"
+            name="phone"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. (602) 555-0123"
+          />
+        </div>
+
+        <!-- Title -->
+        <div>
+          <label for="title" class="block text-sm font-medium text-slate-700 mb-1">Title</label>
+          <input
+            type="text"
+            id="title"
+            name="title"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="e.g. Office Manager, Owner"
+          />
+        </div>
+
+        <!-- Notes -->
+        <div>
+          <label for="notes" class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows="3"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="Any additional context..."></textarea>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-4 border-t border-slate-200">
+          <a
+            href={`/admin/clients/${client.id}`}
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Cancel
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Add Contact
+          </button>
+        </div>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/pages/api/admin/clients/[id]/contacts/[contactId].ts
+++ b/src/pages/api/admin/clients/[id]/contacts/[contactId].ts
@@ -1,0 +1,83 @@
+import type { APIRoute } from 'astro'
+import { getClient } from '../../../../../../lib/db/clients'
+import { updateContact, deleteContact } from '../../../../../../lib/db/contacts'
+
+/**
+ * POST /api/admin/clients/:id/contacts/:contactId
+ *
+ * Updates an existing contact and redirects to the contact edit page.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Accepts the same fields as create. Only non-empty fields are updated.
+ * If _method=DELETE is present in the form data, deletes the contact instead.
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const clientId = params.id
+  const contactId = params.contactId
+  if (!clientId || !contactId) {
+    return new Response(JSON.stringify({ error: 'Client ID and Contact ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  // Verify client exists and belongs to org
+  const client = await getClient(env.DB, session.orgId, clientId)
+  if (!client) {
+    return redirect('/admin/clients?error=not_found', 302)
+  }
+
+  try {
+    const formData = await request.formData()
+
+    // Handle delete via _method override
+    const method = formData.get('_method')
+    if (method === 'DELETE') {
+      const deleted = await deleteContact(env.DB, session.orgId, contactId)
+      if (!deleted) {
+        return redirect(`/admin/clients/${clientId}?error=contact_not_found`, 302)
+      }
+      return redirect(`/admin/clients/${clientId}?contact_deleted=1`, 302)
+    }
+
+    const name = formData.get('name')
+
+    // Validate required fields
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return redirect(`/admin/clients/${clientId}/contacts/${contactId}?error=missing`, 302)
+    }
+
+    const email = formData.get('email')
+    const phone = formData.get('phone')
+    const title = formData.get('title')
+    const notes = formData.get('notes')
+
+    const updated = await updateContact(env.DB, session.orgId, contactId, {
+      name: name.trim(),
+      email: email && typeof email === 'string' && email.trim() ? email.trim() : null,
+      phone: phone && typeof phone === 'string' && phone.trim() ? phone.trim() : null,
+      title: title && typeof title === 'string' && title.trim() ? title.trim() : null,
+      notes: notes && typeof notes === 'string' ? notes.trim() || null : null,
+    })
+
+    if (!updated) {
+      return redirect(`/admin/clients/${clientId}?error=contact_not_found`, 302)
+    }
+
+    return redirect(`/admin/clients/${clientId}/contacts/${contactId}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/clients/[id]/contacts/[contactId]] Update error:', err)
+    return redirect(`/admin/clients/${clientId}/contacts/${contactId}?error=server`, 302)
+  }
+}

--- a/src/pages/api/admin/clients/[id]/contacts/index.ts
+++ b/src/pages/api/admin/clients/[id]/contacts/index.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from 'astro'
+import { getClient } from '../../../../../../lib/db/clients'
+import { createContact } from '../../../../../../lib/db/contacts'
+
+/**
+ * POST /api/admin/clients/:id/contacts
+ *
+ * Creates a new contact linked to a client and redirects to the client detail page.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields:
+ *   - name (required)
+ *   - email
+ *   - phone
+ *   - title
+ *   - notes
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const clientId = params.id
+  if (!clientId) {
+    return new Response(JSON.stringify({ error: 'Client ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  // Verify client exists and belongs to org
+  const client = await getClient(env.DB, session.orgId, clientId)
+  if (!client) {
+    return redirect('/admin/clients?error=not_found', 302)
+  }
+
+  try {
+    const formData = await request.formData()
+    const name = formData.get('name')
+
+    // Validate required fields
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return redirect(`/admin/clients/${clientId}/contacts/new?error=missing`, 302)
+    }
+
+    const email = formData.get('email')
+    const phone = formData.get('phone')
+    const title = formData.get('title')
+    const notes = formData.get('notes')
+
+    await createContact(env.DB, session.orgId, clientId, {
+      name: name.trim(),
+      email: email && typeof email === 'string' && email.trim() ? email.trim() : null,
+      phone: phone && typeof phone === 'string' && phone.trim() ? phone.trim() : null,
+      title: title && typeof title === 'string' && title.trim() ? title.trim() : null,
+      notes: notes && typeof notes === 'string' && notes.trim() ? notes.trim() : null,
+    })
+
+    return redirect(`/admin/clients/${clientId}?contacts_saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/clients/[id]/contacts] Create error:', err)
+    return redirect(`/admin/clients/${clientId}/contacts/new?error=server`, 302)
+  }
+}

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('contacts: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/contacts.ts'), 'utf-8')
+
+  it('contacts.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/contacts.ts'))).toBe(true)
+  })
+
+  it('exports listContacts function', () => {
+    expect(source()).toContain('export async function listContacts')
+  })
+
+  it('exports getContact function', () => {
+    expect(source()).toContain('export async function getContact')
+  })
+
+  it('exports createContact function', () => {
+    expect(source()).toContain('export async function createContact')
+  })
+
+  it('exports updateContact function', () => {
+    expect(source()).toContain('export async function updateContact')
+  })
+
+  it('exports deleteContact function', () => {
+    expect(source()).toContain('export async function deleteContact')
+  })
+
+  it('exports assignEngagementRole function', () => {
+    expect(source()).toContain('export async function assignEngagementRole')
+  })
+
+  it('exports getEngagementContacts function', () => {
+    expect(source()).toContain('export async function getEngagementContacts')
+  })
+
+  it('exports removeEngagementRole function', () => {
+    expect(source()).toContain('export async function removeEngagementRole')
+  })
+
+  it('exports setEngagementPrimary function', () => {
+    expect(source()).toContain('export async function setEngagementPrimary')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    // Ensure bind() is used for parameterized queries
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('scopes contact queries to org_id', () => {
+    const code = source()
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('defines all valid engagement contact roles', () => {
+    const code = source()
+    expect(code).toContain("'owner'")
+    expect(code).toContain("'decision_maker'")
+    expect(code).toContain("'champion'")
+  })
+
+  it('exports ENGAGEMENT_CONTACT_ROLES constant', () => {
+    expect(source()).toContain('export const ENGAGEMENT_CONTACT_ROLES')
+  })
+
+  it('exports EngagementContactRole type', () => {
+    expect(source()).toContain('export type EngagementContactRole')
+  })
+
+  it('supports primary POC flag per engagement', () => {
+    const code = source()
+    expect(code).toContain('is_primary')
+  })
+
+  it('clears existing primary flags when setting new primary', () => {
+    const code = source()
+    expect(code).toContain('UPDATE engagement_contacts SET is_primary = 0')
+  })
+
+  it('joins contacts table when listing engagement contacts', () => {
+    const code = source()
+    expect(code).toContain('JOIN contacts c ON c.id = ec.contact_id')
+  })
+
+  it('orders engagement contacts with primary first', () => {
+    const code = source()
+    expect(code).toContain('ORDER BY ec.is_primary DESC')
+  })
+
+  it('cleans up engagement_contacts on contact delete', () => {
+    const code = source()
+    expect(code).toContain('DELETE FROM engagement_contacts WHERE contact_id = ?')
+  })
+})
+
+describe('contacts: API routes', () => {
+  it('create endpoint exists at src/pages/api/admin/clients/[id]/contacts/index.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/clients/[id]/contacts/index.ts'))).toBe(true)
+  })
+
+  it('update endpoint exists at src/pages/api/admin/clients/[id]/contacts/[contactId].ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/clients/[id]/contacts/[contactId].ts'))).toBe(
+      true
+    )
+  })
+
+  it('create endpoint validates required name field', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/index.ts'),
+      'utf-8'
+    )
+    expect(code).toContain("'name'")
+    expect(code).toContain('error=missing')
+  })
+
+  it('create endpoint calls createContact', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/index.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('createContact')
+  })
+
+  it('update endpoint calls updateContact', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/[contactId].ts'),
+      'utf-8'
+    )
+    expect(code).toContain('updateContact')
+  })
+
+  it('update endpoint supports DELETE via _method override', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/[contactId].ts'),
+      'utf-8'
+    )
+    expect(code).toContain('_method')
+    expect(code).toContain("'DELETE'")
+    expect(code).toContain('deleteContact')
+  })
+
+  it('create endpoint reads form data', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/index.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('request.formData()')
+  })
+
+  it('update endpoint reads form data', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/[contactId].ts'),
+      'utf-8'
+    )
+    expect(code).toContain('request.formData()')
+  })
+
+  it('endpoints verify admin session', () => {
+    const createCode = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/index.ts'),
+      'utf-8'
+    )
+    const updateCode = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/[contactId].ts'),
+      'utf-8'
+    )
+    expect(createCode).toContain("session.role !== 'admin'")
+    expect(updateCode).toContain("session.role !== 'admin'")
+  })
+
+  it('create endpoint verifies client exists before creating contact', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/index.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('getClient')
+  })
+
+  it('update endpoint verifies client exists before updating contact', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/clients/[id]/contacts/[contactId].ts'),
+      'utf-8'
+    )
+    expect(code).toContain('getClient')
+  })
+})
+
+describe('contacts: create form page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/contacts/new.astro'), 'utf-8')
+
+  it('create page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id]/contacts/new.astro'))).toBe(true)
+  })
+
+  it('form posts to /api/admin/clients/:id/contacts', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('/api/admin/clients/${client.id}/contacts')
+  })
+
+  it('includes all contact fields', () => {
+    const code = source()
+    expect(code).toContain('name="name"')
+    expect(code).toContain('name="email"')
+    expect(code).toContain('name="phone"')
+    expect(code).toContain('name="title"')
+    expect(code).toContain('name="notes"')
+  })
+
+  it('marks name as required', () => {
+    const code = source()
+    expect(code).toMatch(/id="name"[\s\S]*?required/)
+  })
+
+  it('uses session data from auth middleware', () => {
+    expect(source()).toContain('Astro.locals.session')
+  })
+
+  it('loads client via getClient for context', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('shows breadcrumb with client name', () => {
+    const code = source()
+    expect(code).toContain('client.business_name')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('contacts: detail/edit page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/contacts/[contactId].astro'), 'utf-8')
+
+  it('detail page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id]/contacts/[contactId].astro'))).toBe(
+      true
+    )
+  })
+
+  it('loads contact via getContact', () => {
+    expect(source()).toContain('getContact')
+  })
+
+  it('redirects if contact not found', () => {
+    const code = source()
+    expect(code).toContain('error=contact_not_found')
+  })
+
+  it('form posts to /api/admin/clients/:id/contacts/:contactId', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('/api/admin/clients/${client.id}/contacts/${contact.id}')
+  })
+
+  it('pre-populates form fields with contact data', () => {
+    const code = source()
+    expect(code).toContain('value={contact.name}')
+    expect(code).toContain('contact.email')
+    expect(code).toContain('contact.phone')
+    expect(code).toContain('contact.title')
+  })
+
+  it('shows success message after save', () => {
+    const code = source()
+    expect(code).toContain("get('saved')")
+    expect(code).toContain('Contact updated successfully')
+  })
+
+  it('supports delete via hidden form', () => {
+    const code = source()
+    expect(code).toContain('delete-form')
+    expect(code).toContain('_method')
+    expect(code).toContain('DELETE')
+  })
+
+  it('displays created_at metadata', () => {
+    const code = source()
+    expect(code).toContain('contact.created_at')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('contacts: client detail page integration', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/clients/[id].astro'), 'utf-8')
+
+  it('client detail page imports listContacts', () => {
+    expect(source()).toContain('listContacts')
+  })
+
+  it('client detail page displays contacts section', () => {
+    const code = source()
+    expect(code).toContain('Contacts')
+  })
+
+  it('client detail page links to add contact form', () => {
+    const code = source()
+    expect(code).toContain('/contacts/new')
+    expect(code).toContain('Add Contact')
+  })
+
+  it('client detail page links to contact detail pages', () => {
+    const code = source()
+    expect(code).toContain('/contacts/${contact.id}')
+  })
+
+  it('client detail page shows contact name, title, email, phone', () => {
+    const code = source()
+    expect(code).toContain('contact.name')
+    expect(code).toContain('contact.title')
+    expect(code).toContain('contact.email')
+    expect(code).toContain('contact.phone')
+  })
+
+  it('shows contact saved success message', () => {
+    const code = source()
+    expect(code).toContain('contacts_saved')
+    expect(code).toContain('Contact added successfully')
+  })
+
+  it('shows contact deleted success message', () => {
+    const code = source()
+    expect(code).toContain('contact_deleted')
+    expect(code).toContain('Contact deleted')
+  })
+})


### PR DESCRIPTION
## Summary
- Add `src/lib/db/contacts.ts` data access layer with full contact CRUD (list, get, create, update, delete) scoped to org/client
- Add engagement role assignment functions (assign, remove, list, set primary POC) supporting owner, decision_maker, and champion roles with multi-role per contact (OQ-003)
- Add contact create/edit UI pages nested under client detail (`/admin/clients/:id/contacts/new` and `/admin/clients/:id/contacts/:contactId`)
- Add API routes for contact CRUD with form data handling, admin auth verification, and _method DELETE override
- Add contacts section to client detail page showing contact list with add/edit links and success/delete messages
- Add 56 tests covering data layer, API routes, UI pages, and client detail integration

Closes #69

## Test plan
- [ ] Verify `npm run verify` passes (typecheck, format, lint, build, test)
- [ ] Create a client, then add contacts via the client detail page
- [ ] Edit a contact and verify fields persist
- [ ] Delete a contact and verify it is removed from the client detail page
- [ ] Verify contacts are always scoped to client context (breadcrumbs, redirects)

Generated with [Claude Code](https://claude.com/claude-code)