### PR TITLE
feat: assessment capture + transcript upload

### DIFF
--- a/src/lib/db/assessments.ts
+++ b/src/lib/db/assessments.ts
@@ -1,0 +1,262 @@
+/**
+ * Assessment data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ */
+
+export interface Assessment {
+  id: string
+  org_id: string
+  client_id: string
+  scheduled_at: string | null
+  completed_at: string | null
+  duration_minutes: number | null
+  transcript_path: string | null
+  extraction: string | null
+  problems: string | null
+  disqualifiers: string | null
+  champion_name: string | null
+  champion_role: string | null
+  status: string
+  notes: string | null
+  created_at: string
+}
+
+export type AssessmentStatus = 'scheduled' | 'completed' | 'disqualified' | 'converted'
+
+export const ASSESSMENT_STATUSES: { value: AssessmentStatus; label: string }[] = [
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'disqualified', label: 'Disqualified' },
+  { value: 'converted', label: 'Converted' },
+]
+
+/**
+ * Valid status transitions enforced at the application layer.
+ *
+ * scheduled   -> completed | disqualified
+ * completed   -> disqualified | converted
+ * disqualified -> (terminal)
+ * converted   -> (terminal)
+ */
+export const VALID_TRANSITIONS: Record<AssessmentStatus, AssessmentStatus[]> = {
+  scheduled: ['completed', 'disqualified'],
+  completed: ['disqualified', 'converted'],
+  disqualified: [],
+  converted: [],
+}
+
+export interface CreateAssessmentData {
+  scheduled_at?: string | null
+  notes?: string | null
+}
+
+export interface UpdateAssessmentData {
+  scheduled_at?: string | null
+  completed_at?: string | null
+  duration_minutes?: number | null
+  transcript_path?: string | null
+  extraction?: string | null
+  problems?: string | null
+  disqualifiers?: string | null
+  champion_name?: string | null
+  champion_role?: string | null
+  notes?: string | null
+}
+
+/**
+ * List assessments for an organization, optionally filtered by client.
+ */
+export async function listAssessments(
+  db: D1Database,
+  orgId: string,
+  clientId?: string
+): Promise<Assessment[]> {
+  const conditions: string[] = ['org_id = ?']
+  const params: (string | number)[] = [orgId]
+
+  if (clientId) {
+    conditions.push('client_id = ?')
+    params.push(clientId)
+  }
+
+  const where = conditions.join(' AND ')
+  const sql = `SELECT * FROM assessments WHERE ${where} ORDER BY created_at DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<Assessment>()
+  return result.results
+}
+
+/**
+ * Get a single assessment by ID, scoped to an organization.
+ */
+export async function getAssessment(
+  db: D1Database,
+  orgId: string,
+  assessmentId: string
+): Promise<Assessment | null> {
+  const result = await db
+    .prepare('SELECT * FROM assessments WHERE id = ? AND org_id = ?')
+    .bind(assessmentId, orgId)
+    .first<Assessment>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new assessment linked to a client. Returns the created record.
+ */
+export async function createAssessment(
+  db: D1Database,
+  orgId: string,
+  clientId: string,
+  data: CreateAssessmentData
+): Promise<Assessment> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  await db
+    .prepare(
+      `INSERT INTO assessments (id, org_id, client_id, scheduled_at, status, notes, created_at)
+     VALUES (?, ?, ?, ?, 'scheduled', ?, ?)`
+    )
+    .bind(id, orgId, clientId, data.scheduled_at ?? null, data.notes ?? null, now)
+    .run()
+
+  const assessment = await getAssessment(db, orgId, id)
+  if (!assessment) {
+    throw new Error('Failed to retrieve created assessment')
+  }
+  return assessment
+}
+
+/**
+ * Update an existing assessment. Returns the updated record.
+ */
+export async function updateAssessment(
+  db: D1Database,
+  orgId: string,
+  assessmentId: string,
+  data: UpdateAssessmentData
+): Promise<Assessment | null> {
+  const existing = await getAssessment(db, orgId, assessmentId)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.scheduled_at !== undefined) {
+    fields.push('scheduled_at = ?')
+    params.push(data.scheduled_at)
+  }
+
+  if (data.completed_at !== undefined) {
+    fields.push('completed_at = ?')
+    params.push(data.completed_at)
+  }
+
+  if (data.duration_minutes !== undefined) {
+    fields.push('duration_minutes = ?')
+    params.push(data.duration_minutes)
+  }
+
+  if (data.transcript_path !== undefined) {
+    fields.push('transcript_path = ?')
+    params.push(data.transcript_path)
+  }
+
+  if (data.extraction !== undefined) {
+    fields.push('extraction = ?')
+    params.push(data.extraction)
+  }
+
+  if (data.problems !== undefined) {
+    fields.push('problems = ?')
+    params.push(data.problems)
+  }
+
+  if (data.disqualifiers !== undefined) {
+    fields.push('disqualifiers = ?')
+    params.push(data.disqualifiers)
+  }
+
+  if (data.champion_name !== undefined) {
+    fields.push('champion_name = ?')
+    params.push(data.champion_name)
+  }
+
+  if (data.champion_role !== undefined) {
+    fields.push('champion_role = ?')
+    params.push(data.champion_role)
+  }
+
+  if (data.notes !== undefined) {
+    fields.push('notes = ?')
+    params.push(data.notes)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  const sql = `UPDATE assessments SET ${fields.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(assessmentId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getAssessment(db, orgId, assessmentId)
+}
+
+/**
+ * Transition assessment status with validation.
+ * Returns the updated record or null if the assessment was not found.
+ * Throws if the transition is invalid.
+ */
+export async function updateAssessmentStatus(
+  db: D1Database,
+  orgId: string,
+  assessmentId: string,
+  newStatus: AssessmentStatus
+): Promise<Assessment | null> {
+  const existing = await getAssessment(db, orgId, assessmentId)
+  if (!existing) {
+    return null
+  }
+
+  const currentStatus = existing.status as AssessmentStatus
+  const validNext = VALID_TRANSITIONS[currentStatus] ?? []
+
+  if (!validNext.includes(newStatus)) {
+    throw new Error(
+      `Invalid status transition: ${currentStatus} -> ${newStatus}. Valid transitions: ${validNext.join(', ') || 'none (terminal state)'}`
+    )
+  }
+
+  // When transitioning to completed, auto-set completed_at if not already set
+  const updates: string[] = ['status = ?']
+  const params: (string | number | null)[] = [newStatus]
+
+  if (newStatus === 'completed' && !existing.completed_at) {
+    updates.push('completed_at = ?')
+    params.push(new Date().toISOString())
+  }
+
+  const sql = `UPDATE assessments SET ${updates.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(assessmentId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getAssessment(db, orgId, assessmentId)
+}

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -1,0 +1,66 @@
+/**
+ * R2 storage helpers for file uploads.
+ *
+ * Transcript files are stored with a structured key pattern:
+ *   {orgId}/assessments/{assessmentId}/transcript/{filename}
+ *
+ * This ensures tenant isolation and logical grouping within the R2 bucket.
+ */
+
+/**
+ * Upload a transcript file to R2.
+ *
+ * @param r2 - The R2 bucket binding (STORAGE)
+ * @param orgId - Organization ID for tenant scoping
+ * @param assessmentId - Assessment this transcript belongs to
+ * @param file - The File object from form data
+ * @returns The R2 key where the file was stored
+ */
+export async function uploadTranscript(
+  r2: R2Bucket,
+  orgId: string,
+  assessmentId: string,
+  file: File
+): Promise<string> {
+  // Sanitize filename — keep only alphanumeric, dots, hyphens, underscores
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
+  const key = `${orgId}/assessments/${assessmentId}/transcript/${safeName}`
+
+  const arrayBuffer = await file.arrayBuffer()
+
+  await r2.put(key, arrayBuffer, {
+    httpMetadata: {
+      contentType: file.type || 'application/octet-stream',
+    },
+    customMetadata: {
+      originalName: file.name,
+      uploadedAt: new Date().toISOString(),
+    },
+  })
+
+  return key
+}
+
+/**
+ * Get a transcript URL or key for download.
+ *
+ * In Phase 1, this returns the R2 key directly. The admin can
+ * use an API route to stream the file content.
+ *
+ * @param key - The R2 key of the stored transcript
+ * @returns The key (or presigned URL in future phases)
+ */
+export function getTranscriptUrl(key: string): string {
+  return key
+}
+
+/**
+ * Retrieve a transcript object from R2.
+ *
+ * @param r2 - The R2 bucket binding
+ * @param key - The R2 key of the stored transcript
+ * @returns The R2Object or null if not found
+ */
+export async function getTranscript(r2: R2Bucket, key: string): Promise<R2ObjectBody | null> {
+  return r2.get(key)
+}

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -3,6 +3,7 @@ import '../../../styles/global.css'
 import { getClient, CLIENT_STATUSES, CLIENT_VERTICALS } from '../../../lib/db/clients'
 import type { ClientStatus } from '../../../lib/db/clients'
 import { listContacts } from '../../../lib/db/contacts'
+import { listAssessments, ASSESSMENT_STATUSES } from '../../../lib/db/assessments'
 
 /**
  * Client detail/edit page.
@@ -27,6 +28,7 @@ if (!client) {
 }
 
 const contacts = await listContacts(env.DB, session.orgId, id)
+const assessments = await listAssessments(env.DB, session.orgId, id)
 
 const url = Astro.url
 const saved = url.searchParams.get('saved') === '1'
@@ -77,6 +79,22 @@ const getProgressionTextColor = (index: number) => {
 // Buy box check
 const outsideBuyBox =
   client.employee_count !== null && (client.employee_count < 10 || client.employee_count > 25)
+
+// Assessment status color helper
+const assessmentStatusColor = (s: string) => {
+  switch (s) {
+    case 'scheduled':
+      return 'bg-blue-100 text-blue-800'
+    case 'completed':
+      return 'bg-green-100 text-green-800'
+    case 'disqualified':
+      return 'bg-red-100 text-red-800'
+    case 'converted':
+      return 'bg-purple-100 text-purple-800'
+    default:
+      return 'bg-slate-100 text-slate-600'
+  }
+}
 ---
 
 <!doctype html>
@@ -441,6 +459,91 @@ const outsideBuyBox =
                 class="text-sm text-primary hover:text-primary-hover mt-1 inline-block"
               >
                 Add the first contact
+              </a>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Assessments Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">Assessments</h2>
+          <a
+            href={`/admin/clients/${client.id}/assessments/new`}
+            class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 4v16m8-8H4"></path>
+            </svg>
+            New Assessment
+          </a>
+        </div>
+
+        {
+          assessments.length > 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {assessments.map((a) => (
+                <a
+                  href={`/admin/clients/${client.id}/assessments/${a.id}`}
+                  class="flex items-center justify-between px-4 py-3 hover:bg-slate-50 transition-colors"
+                >
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                      <p class="text-sm font-medium text-slate-900">
+                        {a.scheduled_at
+                          ? new Date(a.scheduled_at).toLocaleDateString('en-US', {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric',
+                            })
+                          : 'Unscheduled'}
+                      </p>
+                      <span
+                        class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${assessmentStatusColor(a.status)}`}
+                      >
+                        {ASSESSMENT_STATUSES.find((s) => s.value === a.status)?.label ?? a.status}
+                      </span>
+                    </div>
+                    <p class="text-xs text-slate-500 mt-0.5">
+                      {a.transcript_path ? 'Transcript uploaded' : 'No transcript'}
+                      {a.champion_name ? ` · Champion: ${a.champion_name}` : ''}
+                    </p>
+                  </div>
+                  <svg
+                    class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </a>
+              ))}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400 mb-2">No assessments yet.</p>
+              <a
+                href={`/admin/clients/${client.id}/assessments/new`}
+                class="text-sm text-primary hover:text-primary-hover font-medium"
+              >
+                Schedule the first assessment
               </a>
             </div>
           )

--- a/src/pages/admin/clients/[id]/assessments/[assessmentId].astro
+++ b/src/pages/admin/clients/[id]/assessments/[assessmentId].astro
@@ -1,0 +1,585 @@
+---
+import '../../../../../styles/global.css'
+import { getClient } from '../../../../../lib/db/clients'
+import {
+  getAssessment,
+  ASSESSMENT_STATUSES,
+  VALID_TRANSITIONS,
+} from '../../../../../lib/db/assessments'
+import type { AssessmentStatus } from '../../../../../lib/db/assessments'
+import { PROBLEM_IDS, PROBLEM_LABELS } from '../../../../../portal/assessments/extraction-schema'
+import type { ProblemId } from '../../../../../portal/assessments/extraction-schema'
+
+/**
+ * Assessment detail/edit page.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Displays all assessment fields in an editable form.
+ * Supports transcript upload, extraction JSON paste, problem mapping,
+ * champion capture, disqualification flags, and status transitions.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId, assessmentId } = Astro.params
+
+if (!clientId || !assessmentId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const assessment = await getAssessment(env.DB, session.orgId, assessmentId)
+if (!assessment) {
+  return Astro.redirect(`/admin/clients/${clientId}?error=assessment_not_found`)
+}
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const errorParam = url.searchParams.get('error') || ''
+const warningParam = url.searchParams.get('warning') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+  invalid_status: 'Invalid status selection.',
+  invalid_transition: 'That status transition is not allowed.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Parse JSON fields
+const problems: ProblemId[] = assessment.problems ? JSON.parse(assessment.problems) : []
+const disqualifiers = assessment.disqualifiers
+  ? JSON.parse(assessment.disqualifiers)
+  : { hard: {}, soft: {}, notes: '' }
+
+// Status transitions
+const currentStatus = assessment.status as AssessmentStatus
+const validNextStatuses = VALID_TRANSITIONS[currentStatus] ?? []
+
+// Status indicator colors
+const statusColorMap: Record<string, string> = {
+  scheduled: 'bg-blue-100 text-blue-800',
+  completed: 'bg-green-100 text-green-800',
+  disqualified: 'bg-red-100 text-red-800',
+  converted: 'bg-purple-100 text-purple-800',
+}
+
+// Financial prerequisite warning (OQ-004)
+const showFinancialWarning = warningParam === 'financial_prerequisite'
+const hasFinancialProblem = problems.includes('financial_blindness')
+const booksBehind = disqualifiers?.soft?.books_behind === true
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Assessment — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Assessment</li>
+        </ol>
+      </nav>
+
+      <div class="flex items-center gap-3 mb-2">
+        <h1 class="text-2xl font-bold text-slate-900">Assessment</h1>
+        <span
+          class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColorMap[assessment.status] ?? 'bg-slate-100 text-slate-600'}`}
+        >
+          {
+            ASSESSMENT_STATUSES.find((s) => s.value === assessment.status)?.label ??
+              assessment.status
+          }
+        </span>
+      </div>
+      <p class="text-sm text-slate-500 mb-6">
+        {client.business_name}
+      </p>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Assessment updated successfully.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      {
+        showFinancialWarning && (
+          <div
+            id="financial-warning"
+            class="mb-4 p-4 bg-amber-50 border border-amber-200 rounded-lg"
+          >
+            <p class="text-sm font-medium text-amber-800 mb-2">
+              Financial Prerequisite Warning (OQ-004)
+            </p>
+            <p class="text-sm text-amber-700 mb-3">
+              This assessment has "Financial blindness" identified as a problem and/or indicates the
+              books are more than 30 days behind. Converting with unresolved financial issues may
+              affect engagement scope and timeline.
+            </p>
+            <form
+              method="POST"
+              action={`/api/admin/assessments/${assessment.id}`}
+              class="flex items-center gap-3"
+            >
+              <input type="hidden" name="action" value="transition_status" />
+              <input type="hidden" name="new_status" value="converted" />
+              <input type="hidden" name="financial_confirmed" value="yes" />
+              <button
+                type="submit"
+                class="bg-amber-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-amber-700 transition-colors"
+              >
+                Confirm and Convert
+              </button>
+              <a
+                href={`/admin/clients/${client.id}/assessments/${assessment.id}`}
+                class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+              >
+                Cancel
+              </a>
+            </form>
+          </div>
+        )
+      }
+
+      <!-- Status Transitions -->
+      {
+        validNextStatuses.length > 0 && (
+          <div class="mb-6 bg-white rounded-lg border border-slate-200 p-4">
+            <h2 class="text-sm font-medium text-slate-700 mb-3">Status Transition</h2>
+            <div class="flex flex-wrap gap-2">
+              {validNextStatuses.map((nextStatus) => (
+                <form
+                  method="POST"
+                  action={`/api/admin/assessments/${assessment.id}`}
+                  class="inline"
+                >
+                  <input type="hidden" name="action" value="transition_status" />
+                  <input type="hidden" name="new_status" value={nextStatus} />
+                  <button
+                    type="submit"
+                    class:list={[
+                      'px-4 py-2 rounded-md text-sm font-medium transition-colors',
+                      nextStatus === 'completed' && 'bg-green-600 text-white hover:bg-green-700',
+                      nextStatus === 'disqualified' && 'bg-red-600 text-white hover:bg-red-700',
+                      nextStatus === 'converted' && 'bg-purple-600 text-white hover:bg-purple-700',
+                    ]}
+                  >
+                    {ASSESSMENT_STATUSES.find((s) => s.value === nextStatus)?.label ?? nextStatus}
+                  </button>
+                </form>
+              ))}
+            </div>
+          </div>
+        )
+      }
+
+      <!-- Main edit form -->
+      <form
+        method="POST"
+        action={`/api/admin/assessments/${assessment.id}`}
+        enctype="multipart/form-data"
+        class="space-y-6"
+      >
+        <!-- Scheduling -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Scheduling</h2>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="scheduled_at" class="block text-sm font-medium text-slate-700 mb-1">
+                Scheduled Date/Time
+              </label>
+              <input
+                type="datetime-local"
+                id="scheduled_at"
+                name="scheduled_at"
+                value={assessment.scheduled_at ? assessment.scheduled_at.slice(0, 16) : ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="duration_minutes" class="block text-sm font-medium text-slate-700 mb-1">
+                Duration (minutes)
+              </label>
+              <input
+                type="number"
+                id="duration_minutes"
+                name="duration_minutes"
+                min="1"
+                value={assessment.duration_minutes ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- Transcript Upload -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Transcript</h2>
+
+          {
+            assessment.transcript_path ? (
+              <div class="flex items-center gap-3 p-3 bg-green-50 border border-green-200 rounded-lg">
+                <svg
+                  class="w-5 h-5 text-green-600 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm font-medium text-green-800">Transcript uploaded</p>
+                  <p class="text-xs text-green-600 truncate">{assessment.transcript_path}</p>
+                </div>
+                <a
+                  href={`/api/admin/assessments/${assessment.id}/transcript`}
+                  class="text-sm text-green-700 hover:text-green-900 font-medium underline"
+                >
+                  Download
+                </a>
+              </div>
+            ) : (
+              <p class="text-sm text-slate-400">No transcript uploaded yet.</p>
+            )
+          }
+
+          <div>
+            <label for="transcript" class="block text-sm font-medium text-slate-700 mb-1">
+              {assessment.transcript_path ? 'Replace transcript' : 'Upload transcript'}
+            </label>
+            <input
+              type="file"
+              id="transcript"
+              name="transcript"
+              accept=".txt,.md,.srt,.vtt,.json"
+              class="w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200"
+            />
+            <p class="mt-1 text-xs text-slate-400">
+              Accepts .txt, .md, .srt, .vtt, or .json from MacWhisper.
+            </p>
+          </div>
+        </div>
+
+        <!-- Extraction JSON -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Extraction JSON</h2>
+          <p class="text-sm text-slate-500">
+            Paste the structured JSON output from Claude after processing the transcript.
+          </p>
+          <div>
+            <label for="extraction" class="block text-sm font-medium text-slate-700 mb-1">
+              Extraction Data
+            </label>
+            <textarea
+              id="extraction"
+              name="extraction"
+              rows="10"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 font-mono focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder='{"schema_version": "1.0", ...}'>{assessment.extraction ?? ''}</textarea
+            >
+          </div>
+        </div>
+
+        <!-- Problem Mapping -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Identified Problems</h2>
+          <p class="text-sm text-slate-500">
+            Select the problems identified during this assessment.
+          </p>
+
+          <div class="space-y-3">
+            {
+              PROBLEM_IDS.map((problemId) => (
+                <label class="flex items-start gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors cursor-pointer">
+                  <input
+                    type="checkbox"
+                    name={`problem_${problemId}`}
+                    checked={problems.includes(problemId)}
+                    class="mt-0.5 rounded border-slate-300 text-primary focus:ring-primary"
+                  />
+                  <div>
+                    <span class="text-sm font-medium text-slate-900">
+                      {PROBLEM_LABELS[problemId]}
+                    </span>
+                    <p class="text-xs text-slate-400 mt-0.5">
+                      {
+                        {
+                          owner_bottleneck: '"I can\'t take a day off" — No documented processes',
+                          lead_leakage:
+                            '"Leads fall through the cracks" — No CRM, no follow-up system',
+                          financial_blindness:
+                            '"I have no idea if we\'re making money" — Books behind, gut-feel pricing',
+                          scheduling_chaos:
+                            '"Double-bookings happen all the time" — No centralized scheduling',
+                          manual_communication:
+                            '"I personally text every customer" — Every message is manual',
+                          team_invisibility:
+                            '"I don\'t know what my team is doing" — No task tracking or accountability',
+                        }[problemId]
+                      }
+                    </p>
+                  </div>
+                </label>
+              ))
+            }
+          </div>
+        </div>
+
+        <!-- Champion Candidate -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Champion Candidate</h2>
+          <p class="text-sm text-slate-500">
+            The internal person who will own the solution post-delivery.
+          </p>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="champion_name" class="block text-sm font-medium text-slate-700 mb-1">
+                Name
+              </label>
+              <input
+                type="text"
+                id="champion_name"
+                name="champion_name"
+                value={assessment.champion_name ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="e.g. Derek"
+              />
+            </div>
+            <div>
+              <label for="champion_role" class="block text-sm font-medium text-slate-700 mb-1">
+                Role
+              </label>
+              <input
+                type="text"
+                id="champion_role"
+                name="champion_role"
+                value={assessment.champion_role ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="e.g. Office manager"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- Disqualification Flags -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Disqualification Flags</h2>
+
+          <div>
+            <h3 class="text-sm font-medium text-red-700 mb-2">Hard Disqualifiers</h3>
+            <p class="text-xs text-slate-400 mb-3">Any true value is an automatic no.</p>
+            <div class="space-y-2">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="dq_not_decision_maker"
+                  checked={disqualifiers?.hard?.not_decision_maker === true}
+                  class="rounded border-slate-300 text-red-600 focus:ring-red-500"
+                />
+                <span class="text-sm text-slate-700">Not speaking to the owner/check-writer</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="dq_scope_exceeds_sprint"
+                  checked={disqualifiers?.hard?.scope_exceeds_sprint === true}
+                  class="rounded border-slate-300 text-red-600 focus:ring-red-500"
+                />
+                <span class="text-sm text-slate-700"
+                  >Scope exceeds engagement (multi-location, ERP, franchise)</span
+                >
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="dq_no_tech_baseline"
+                  checked={disqualifiers?.hard?.no_tech_baseline === true}
+                  class="rounded border-slate-300 text-red-600 focus:ring-red-500"
+                />
+                <span class="text-sm text-slate-700">No tech baseline (no email, no internet)</span>
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-sm font-medium text-amber-700 mb-2">Soft Disqualifiers</h3>
+            <p class="text-xs text-slate-400 mb-3">Yellow flags that need probing.</p>
+            <div class="space-y-2">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="dq_no_champion"
+                  checked={disqualifiers?.soft?.no_champion === true}
+                  class="rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+                />
+                <span class="text-sm text-slate-700">No internal champion identified</span>
+              </label>
+              <label id="books-behind-label" class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="dq_books_behind"
+                  checked={disqualifiers?.soft?.books_behind === true}
+                  class="rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+                />
+                <span class="text-sm text-slate-700">Books more than 30 days behind</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="dq_no_willingness_to_change"
+                  checked={disqualifiers?.soft?.no_willingness_to_change === true}
+                  class="rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+                />
+                <span class="text-sm text-slate-700">No willingness to change</span>
+              </label>
+            </div>
+          </div>
+
+          {
+            (booksBehind || (hasFinancialProblem && booksBehind)) && (
+              <div class="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700">
+                <strong>OQ-004 Notice:</strong> Books are flagged as more than 30 days behind. This
+                is a soft warning for the financial prerequisite gate — conversion will require
+                admin confirmation.
+              </div>
+            )
+          }
+
+          <div>
+            <label for="dq_notes" class="block text-sm font-medium text-slate-700 mb-1">
+              Disqualification Notes
+            </label>
+            <textarea
+              id="dq_notes"
+              name="dq_notes"
+              rows="2"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="Notes on any flags triggered...">{disqualifiers?.notes ?? ''}</textarea
+            >
+          </div>
+        </div>
+
+        <!-- Notes -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Notes</h2>
+          <div>
+            <textarea
+              id="notes"
+              name="notes"
+              rows="3"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="General notes about this assessment..."
+              >{assessment.notes ?? ''}</textarea
+            >
+          </div>
+        </div>
+
+        <!-- Metadata -->
+        <div
+          class="bg-white rounded-lg border border-slate-200 p-6 grid grid-cols-2 gap-4 text-xs text-slate-400"
+        >
+          <div>
+            <span class="font-medium">Created:</span>
+            {
+              new Date(assessment.created_at).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            }
+          </div>
+          {
+            assessment.completed_at && (
+              <div>
+                <span class="font-medium">Completed:</span>
+                {new Date(assessment.completed_at).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </div>
+            )
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-2">
+          <a
+            href={`/admin/clients/${client.id}`}
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Back to Client
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Save Changes
+          </button>
+        </div>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/clients/[id]/assessments/new.astro
+++ b/src/pages/admin/clients/[id]/assessments/new.astro
@@ -1,0 +1,151 @@
+---
+import '../../../../../styles/global.css'
+import { getClient } from '../../../../../lib/db/clients'
+
+/**
+ * Create new assessment form.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Form POSTs to /api/admin/assessments which creates the record and redirects.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId } = Astro.params
+
+if (!clientId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const url = Astro.url
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>New Assessment — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">New Assessment</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-6">Schedule Assessment</h1>
+      <p class="text-sm text-slate-500 mb-6">
+        Create a new assessment for <strong>{client.business_name}</strong>.
+      </p>
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <form
+        method="POST"
+        action="/api/admin/assessments"
+        class="bg-white rounded-lg border border-slate-200 p-6 space-y-6"
+      >
+        <input type="hidden" name="client_id" value={client.id} />
+
+        <!-- Scheduled Date/Time -->
+        <div>
+          <label for="scheduled_at" class="block text-sm font-medium text-slate-700 mb-1">
+            Scheduled Date/Time
+          </label>
+          <input
+            type="datetime-local"
+            id="scheduled_at"
+            name="scheduled_at"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+          <p class="mt-1 text-xs text-slate-400">Leave blank if not yet scheduled.</p>
+        </div>
+
+        <!-- Notes -->
+        <div>
+          <label for="notes" class="block text-sm font-medium text-slate-700 mb-1">Notes</label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows="3"
+            class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            placeholder="Any context for this assessment..."></textarea>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-4 border-t border-slate-200">
+          <a
+            href={`/admin/clients/${client.id}`}
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Cancel
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Create Assessment
+          </button>
+        </div>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/pages/api/admin/assessments/[id].ts
+++ b/src/pages/api/admin/assessments/[id].ts
@@ -1,0 +1,177 @@
+import type { APIRoute } from 'astro'
+import {
+  getAssessment,
+  updateAssessment,
+  updateAssessmentStatus,
+} from '../../../../lib/db/assessments'
+import type { AssessmentStatus } from '../../../../lib/db/assessments'
+import { uploadTranscript } from '../../../../lib/storage/r2'
+import { PROBLEM_IDS } from '../../../../portal/assessments/extraction-schema'
+import type { ProblemId } from '../../../../portal/assessments/extraction-schema'
+
+/**
+ * POST /api/admin/assessments/:id
+ *
+ * Updates an existing assessment from form data.
+ * Handles transcript upload, extraction JSON, problem mapping, champion info,
+ * disqualification flags, and status transitions.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const assessmentId = params.id
+  if (!assessmentId) {
+    return new Response(JSON.stringify({ error: 'Assessment ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const existing = await getAssessment(env.DB, session.orgId, assessmentId)
+    if (!existing) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const action = formData.get('action')
+
+    // Handle status transition as a separate action
+    if (action === 'transition_status') {
+      const newStatus = formData.get('new_status')
+      if (!newStatus || typeof newStatus !== 'string') {
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?error=invalid_status`,
+          302
+        )
+      }
+
+      // Check financial prerequisite gate (OQ-004)
+      const financialConfirmed = formData.get('financial_confirmed')
+      if (
+        newStatus === 'converted' &&
+        existing.problems &&
+        existing.problems.includes('financial_blindness') &&
+        financialConfirmed !== 'yes'
+      ) {
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?warning=financial_prerequisite`,
+          302
+        )
+      }
+
+      try {
+        await updateAssessmentStatus(
+          env.DB,
+          session.orgId,
+          assessmentId,
+          newStatus as AssessmentStatus
+        )
+      } catch (err) {
+        console.error('[api/admin/assessments/[id]] Status transition error:', err)
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?error=invalid_transition`,
+          302
+        )
+      }
+
+      return redirect(
+        `/admin/clients/${existing.client_id}/assessments/${assessmentId}?saved=1`,
+        302
+      )
+    }
+
+    // Handle general update
+    const scheduledAt = formData.get('scheduled_at')
+    const durationMinutes = formData.get('duration_minutes')
+    const extraction = formData.get('extraction')
+    const championName = formData.get('champion_name')
+    const championRole = formData.get('champion_role')
+    const notes = formData.get('notes')
+
+    // Build problems JSON from checkboxes
+    const selectedProblems: ProblemId[] = []
+    for (const problemId of PROBLEM_IDS) {
+      if (formData.get(`problem_${problemId}`) === 'on') {
+        selectedProblems.push(problemId)
+      }
+    }
+
+    // Build disqualifiers JSON from checkboxes
+    const disqualifiers = {
+      hard: {
+        not_decision_maker: formData.get('dq_not_decision_maker') === 'on',
+        scope_exceeds_sprint: formData.get('dq_scope_exceeds_sprint') === 'on',
+        no_tech_baseline: formData.get('dq_no_tech_baseline') === 'on',
+      },
+      soft: {
+        no_champion: formData.get('dq_no_champion') === 'on',
+        books_behind: formData.get('dq_books_behind') === 'on',
+        no_willingness_to_change: formData.get('dq_no_willingness_to_change') === 'on',
+      },
+      notes:
+        formData.get('dq_notes') && typeof formData.get('dq_notes') === 'string'
+          ? (formData.get('dq_notes') as string).trim()
+          : '',
+    }
+
+    // Handle transcript upload
+    let transcriptPath: string | undefined = undefined
+    const transcriptFile = formData.get('transcript')
+    if (transcriptFile && transcriptFile instanceof File && transcriptFile.size > 0) {
+      transcriptPath = await uploadTranscript(
+        env.STORAGE,
+        session.orgId,
+        assessmentId,
+        transcriptFile
+      )
+    }
+
+    const updateData: Record<string, string | number | null | undefined> = {
+      scheduled_at:
+        scheduledAt && typeof scheduledAt === 'string' && scheduledAt.trim()
+          ? new Date(scheduledAt.trim()).toISOString()
+          : null,
+      duration_minutes:
+        durationMinutes && typeof durationMinutes === 'string' && durationMinutes.trim()
+          ? parseInt(durationMinutes, 10) || null
+          : null,
+      extraction:
+        extraction && typeof extraction === 'string' && extraction.trim()
+          ? extraction.trim()
+          : existing.extraction,
+      problems: JSON.stringify(selectedProblems),
+      disqualifiers: JSON.stringify(disqualifiers),
+      champion_name:
+        championName && typeof championName === 'string' && championName.trim()
+          ? championName.trim()
+          : null,
+      champion_role:
+        championRole && typeof championRole === 'string' && championRole.trim()
+          ? championRole.trim()
+          : null,
+      notes: notes && typeof notes === 'string' ? notes.trim() || null : undefined,
+    }
+
+    if (transcriptPath !== undefined) {
+      updateData.transcript_path = transcriptPath
+    }
+
+    await updateAssessment(env.DB, session.orgId, assessmentId, updateData)
+
+    return redirect(`/admin/clients/${existing.client_id}/assessments/${assessmentId}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/assessments/[id]] Update error:', err)
+    return redirect(`/admin/clients?error=server`, 302)
+  }
+}

--- a/src/pages/api/admin/assessments/[id]/transcript.ts
+++ b/src/pages/api/admin/assessments/[id]/transcript.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from 'astro'
+import { getAssessment } from '../../../../../lib/db/assessments'
+import { getTranscript } from '../../../../../lib/storage/r2'
+
+/**
+ * GET /api/admin/assessments/:id/transcript
+ *
+ * Streams the transcript file from R2.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const GET: APIRoute = async ({ locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const assessmentId = params.id
+  if (!assessmentId) {
+    return new Response(JSON.stringify({ error: 'Assessment ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  const assessment = await getAssessment(env.DB, session.orgId, assessmentId)
+  if (!assessment || !assessment.transcript_path) {
+    return new Response(JSON.stringify({ error: 'Transcript not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const object = await getTranscript(env.STORAGE, assessment.transcript_path)
+  if (!object) {
+    return new Response(JSON.stringify({ error: 'Transcript file not found in storage' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const originalName = object.customMetadata?.originalName ?? 'transcript.txt'
+
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': object.httpMetadata?.contentType ?? 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${originalName}"`,
+    },
+  })
+}

--- a/src/pages/api/admin/assessments/index.ts
+++ b/src/pages/api/admin/assessments/index.ts
@@ -1,0 +1,58 @@
+import type { APIRoute } from 'astro'
+import { createAssessment } from '../../../../lib/db/assessments'
+
+/**
+ * POST /api/admin/assessments
+ *
+ * Creates a new assessment from form data and redirects to the assessment detail page.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields:
+ *   - client_id (required)
+ *   - scheduled_at
+ *   - notes
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const formData = await request.formData()
+    const clientId = formData.get('client_id')
+
+    if (!clientId || typeof clientId !== 'string' || !clientId.trim()) {
+      return redirect('/admin/clients?error=missing', 302)
+    }
+
+    const env = locals.runtime.env
+    const scheduledAt = formData.get('scheduled_at')
+    const notes = formData.get('notes')
+
+    const assessment = await createAssessment(env.DB, session.orgId, clientId.trim(), {
+      scheduled_at:
+        scheduledAt && typeof scheduledAt === 'string' && scheduledAt.trim()
+          ? new Date(scheduledAt.trim()).toISOString()
+          : null,
+      notes: notes && typeof notes === 'string' && notes.trim() ? notes.trim() : null,
+    })
+
+    return redirect(`/admin/clients/${clientId.trim()}/assessments/${assessment.id}`, 302)
+  } catch (err) {
+    console.error('[api/admin/assessments] Create error:', err)
+    const formData = await request
+      .clone()
+      .formData()
+      .catch(() => null)
+    const clientId = formData?.get('client_id')
+    if (clientId && typeof clientId === 'string') {
+      return redirect(`/admin/clients/${clientId}/assessments/new?error=server`, 302)
+    }
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/tests/assessments.test.ts
+++ b/tests/assessments.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('assessments: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/assessments.ts'), 'utf-8')
+
+  it('assessments.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/assessments.ts'))).toBe(true)
+  })
+
+  it('exports listAssessments function', () => {
+    expect(source()).toContain('export async function listAssessments')
+  })
+
+  it('exports getAssessment function', () => {
+    expect(source()).toContain('export async function getAssessment')
+  })
+
+  it('exports createAssessment function', () => {
+    expect(source()).toContain('export async function createAssessment')
+  })
+
+  it('exports updateAssessment function', () => {
+    expect(source()).toContain('export async function updateAssessment')
+  })
+
+  it('exports updateAssessmentStatus function', () => {
+    expect(source()).toContain('export async function updateAssessmentStatus')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('scopes all queries to org_id', () => {
+    const code = source()
+    expect(code).toContain("'org_id = ?'")
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('supports optional client_id filter in listAssessments', () => {
+    const code = source()
+    expect(code).toContain("'client_id = ?'")
+  })
+
+  it('defines all valid assessment statuses', () => {
+    const code = source()
+    expect(code).toContain("'scheduled'")
+    expect(code).toContain("'completed'")
+    expect(code).toContain("'disqualified'")
+    expect(code).toContain("'converted'")
+  })
+
+  it('exports ASSESSMENT_STATUSES constant', () => {
+    expect(source()).toContain('export const ASSESSMENT_STATUSES')
+  })
+
+  it('exports VALID_TRANSITIONS for status state machine', () => {
+    expect(source()).toContain('export const VALID_TRANSITIONS')
+  })
+
+  it('enforces valid status transitions', () => {
+    const code = source()
+    // Should check current status against valid transitions
+    expect(code).toContain('VALID_TRANSITIONS')
+    expect(code).toContain('Invalid status transition')
+  })
+
+  it('auto-sets completed_at when transitioning to completed', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'completed'")
+    expect(code).toContain('completed_at')
+  })
+
+  it('defines valid transitions: scheduled -> completed | disqualified', () => {
+    const code = source()
+    // The VALID_TRANSITIONS object should allow these transitions
+    expect(code).toContain("scheduled: ['completed', 'disqualified']")
+  })
+
+  it('defines valid transitions: completed -> disqualified | converted', () => {
+    const code = source()
+    expect(code).toContain("completed: ['disqualified', 'converted']")
+  })
+
+  it('disqualified and converted are terminal states', () => {
+    const code = source()
+    expect(code).toContain('disqualified: []')
+    expect(code).toContain('converted: []')
+  })
+})
+
+describe('assessments: R2 storage helper', () => {
+  const source = () => readFileSync(resolve('src/lib/storage/r2.ts'), 'utf-8')
+
+  it('r2.ts exists', () => {
+    expect(existsSync(resolve('src/lib/storage/r2.ts'))).toBe(true)
+  })
+
+  it('exports uploadTranscript function', () => {
+    expect(source()).toContain('export async function uploadTranscript')
+  })
+
+  it('exports getTranscriptUrl function', () => {
+    expect(source()).toContain('export function getTranscriptUrl')
+  })
+
+  it('exports getTranscript function', () => {
+    expect(source()).toContain('export async function getTranscript')
+  })
+
+  it('uses structured key pattern with org scoping', () => {
+    const code = source()
+    expect(code).toContain('orgId')
+    expect(code).toContain('assessmentId')
+    expect(code).toContain('/transcript/')
+  })
+
+  it('sanitizes filenames for R2 keys', () => {
+    const code = source()
+    expect(code).toContain('replace')
+    // Should only allow safe characters
+    expect(code).toContain(/[^a-zA-Z0-9._-]/.source)
+  })
+
+  it('stores content type metadata', () => {
+    expect(source()).toContain('contentType')
+  })
+
+  it('stores original filename in custom metadata', () => {
+    expect(source()).toContain('originalName')
+  })
+})
+
+describe('assessments: API routes', () => {
+  it('create endpoint exists at src/pages/api/admin/assessments/index.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/assessments/index.ts'))).toBe(true)
+  })
+
+  it('update endpoint exists at src/pages/api/admin/assessments/[id].ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/assessments/[id].ts'))).toBe(true)
+  })
+
+  it('transcript download endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/assessments/[id]/transcript.ts'))).toBe(true)
+  })
+
+  it('create endpoint validates required client_id field', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/index.ts'), 'utf-8')
+    expect(code).toContain('client_id')
+    expect(code).toContain('createAssessment')
+  })
+
+  it('create endpoint reads form data', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/index.ts'), 'utf-8')
+    expect(code).toContain('request.formData()')
+  })
+
+  it('update endpoint handles status transitions', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(code).toContain('transition_status')
+    expect(code).toContain('updateAssessmentStatus')
+  })
+
+  it('update endpoint handles transcript upload', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(code).toContain('uploadTranscript')
+    expect(code).toContain('transcript')
+  })
+
+  it('update endpoint handles extraction JSON', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(code).toContain('extraction')
+  })
+
+  it('update endpoint handles problem mapping via checkboxes', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(code).toContain('PROBLEM_IDS')
+    expect(code).toContain('selectedProblems')
+  })
+
+  it('update endpoint handles disqualification flags', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(code).toContain('dq_not_decision_maker')
+    expect(code).toContain('dq_scope_exceeds_sprint')
+    expect(code).toContain('dq_no_tech_baseline')
+    expect(code).toContain('dq_no_champion')
+    expect(code).toContain('dq_books_behind')
+    expect(code).toContain('dq_no_willingness_to_change')
+  })
+
+  it('update endpoint implements financial prerequisite gate (OQ-004)', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(code).toContain('financial_confirmed')
+    expect(code).toContain('financial_blindness')
+    expect(code).toContain('financial_prerequisite')
+  })
+
+  it('endpoints verify admin session', () => {
+    const createCode = readFileSync(resolve('src/pages/api/admin/assessments/index.ts'), 'utf-8')
+    const updateCode = readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+    expect(createCode).toContain("session.role !== 'admin'")
+    expect(updateCode).toContain("session.role !== 'admin'")
+  })
+
+  it('transcript endpoint verifies admin session', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/assessments/[id]/transcript.ts'),
+      'utf-8'
+    )
+    expect(code).toContain("session.role !== 'admin'")
+  })
+
+  it('transcript endpoint returns file as download', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/assessments/[id]/transcript.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('Content-Disposition')
+    expect(code).toContain('attachment')
+  })
+})
+
+describe('assessments: create form page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/assessments/new.astro'), 'utf-8')
+
+  it('create page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id]/assessments/new.astro'))).toBe(true)
+  })
+
+  it('form posts to /api/admin/assessments', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('action="/api/admin/assessments"')
+  })
+
+  it('includes hidden client_id field', () => {
+    expect(source()).toContain('name="client_id"')
+  })
+
+  it('includes scheduled_at field', () => {
+    expect(source()).toContain('name="scheduled_at"')
+  })
+
+  it('includes notes field', () => {
+    expect(source()).toContain('name="notes"')
+  })
+
+  it('loads client data for display', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('has breadcrumb navigation', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients')
+    expect(code).toContain('client.business_name')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('assessments: detail/edit page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/assessments/[assessmentId].astro'), 'utf-8')
+
+  it('detail page exists', () => {
+    expect(
+      existsSync(resolve('src/pages/admin/clients/[id]/assessments/[assessmentId].astro'))
+    ).toBe(true)
+  })
+
+  it('loads assessment via getAssessment', () => {
+    expect(source()).toContain('getAssessment')
+  })
+
+  it('loads client via getClient for breadcrumb', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('form posts to /api/admin/assessments/:id', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('/api/admin/assessments/${assessment.id}')
+  })
+
+  it('uses multipart form data for file upload', () => {
+    expect(source()).toContain('enctype="multipart/form-data"')
+  })
+
+  it('includes transcript file upload input', () => {
+    const code = source()
+    expect(code).toContain('type="file"')
+    expect(code).toContain('name="transcript"')
+    expect(code).toContain('.txt')
+  })
+
+  it('shows transcript download link when uploaded', () => {
+    const code = source()
+    expect(code).toContain('Transcript uploaded')
+    expect(code).toContain('Download')
+    expect(code).toContain('/transcript')
+  })
+
+  it('includes extraction JSON textarea', () => {
+    const code = source()
+    expect(code).toContain('name="extraction"')
+    expect(code).toContain('Extraction JSON')
+  })
+
+  it('includes problem mapping checkboxes for all 6 problems', () => {
+    const code = source()
+    expect(code).toContain('PROBLEM_IDS')
+    expect(code).toContain('PROBLEM_LABELS')
+    expect(code).toContain('problem_${problemId}')
+  })
+
+  it('includes champion name and role fields', () => {
+    const code = source()
+    expect(code).toContain('name="champion_name"')
+    expect(code).toContain('name="champion_role"')
+  })
+
+  it('includes hard disqualification flag checkboxes', () => {
+    const code = source()
+    expect(code).toContain('name="dq_not_decision_maker"')
+    expect(code).toContain('name="dq_scope_exceeds_sprint"')
+    expect(code).toContain('name="dq_no_tech_baseline"')
+  })
+
+  it('includes soft disqualification flag checkboxes', () => {
+    const code = source()
+    expect(code).toContain('name="dq_no_champion"')
+    expect(code).toContain('name="dq_books_behind"')
+    expect(code).toContain('name="dq_no_willingness_to_change"')
+  })
+
+  it('shows status transition buttons', () => {
+    const code = source()
+    expect(code).toContain('Status Transition')
+    expect(code).toContain('VALID_TRANSITIONS')
+    expect(code).toContain('transition_status')
+    expect(code).toContain('new_status')
+  })
+
+  it('displays current status badge', () => {
+    const code = source()
+    expect(code).toContain('ASSESSMENT_STATUSES')
+    expect(code).toContain('statusColorMap')
+  })
+
+  it('shows success message after save', () => {
+    const code = source()
+    expect(code).toContain("get('saved')")
+    expect(code).toContain('Assessment updated successfully')
+  })
+
+  it('implements financial prerequisite soft warning (OQ-004)', () => {
+    const code = source()
+    expect(code).toContain('financial_prerequisite')
+    expect(code).toContain('Financial Prerequisite Warning')
+    expect(code).toContain('OQ-004')
+    expect(code).toContain('financial_confirmed')
+    expect(code).toContain('Confirm and Convert')
+  })
+
+  it('shows OQ-004 notice when books_behind is flagged', () => {
+    const code = source()
+    expect(code).toContain('booksBehind')
+    expect(code).toContain('OQ-004 Notice')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+
+  it('has breadcrumb back to client', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients/${client.id}')
+    expect(code).toContain('client.business_name')
+  })
+})
+
+describe('assessments: client detail page integration', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/clients/[id].astro'), 'utf-8')
+
+  it('client detail page imports listAssessments', () => {
+    expect(source()).toContain('listAssessments')
+  })
+
+  it('client detail page loads assessments for this client', () => {
+    const code = source()
+    expect(code).toContain('listAssessments')
+    expect(code).toContain('assessments')
+  })
+
+  it('client detail page has assessments section', () => {
+    const code = source()
+    expect(code).toContain('Assessments')
+    expect(code).toContain('New Assessment')
+  })
+
+  it('client detail page links to new assessment form', () => {
+    const code = source()
+    expect(code).toContain('/assessments/new')
+  })
+
+  it('client detail page links to assessment detail', () => {
+    const code = source()
+    expect(code).toContain('/assessments/${a.id}')
+  })
+
+  it('shows assessment status in the list', () => {
+    const code = source()
+    expect(code).toContain('ASSESSMENT_STATUSES')
+    expect(code).toContain('a.status')
+  })
+
+  it('shows empty state when no assessments', () => {
+    const code = source()
+    expect(code).toContain('No assessments yet')
+    expect(code).toContain('Schedule the first assessment')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds complete assessment CRUD workflow with data access layer, R2 file storage, and admin UI
- Implements assessment status state machine: scheduled -> completed -> disqualified/converted
- Includes transcript upload to R2, extraction JSON paste, problem mapping (6 universal SMB problems), champion capture, disqualification flags, and financial prerequisite gate (OQ-004)

## What Changed
- **`src/lib/db/assessments.ts`** — Assessment data access layer: listAssessments, getAssessment, createAssessment, updateAssessment, updateAssessmentStatus with transition validation
- **`src/lib/storage/r2.ts`** — R2 upload/download helpers with tenant-scoped key structure
- **`src/pages/api/admin/assessments/`** — API routes for CRUD, status transitions, and transcript download
- **`src/pages/admin/clients/[id]/assessments/new.astro`** — Create assessment form
- **`src/pages/admin/clients/[id]/assessments/[assessmentId].astro`** — Full assessment detail/edit with all features
- **`src/pages/admin/clients/[id].astro`** — Added assessments section to client detail page
- **`tests/assessments.test.ts`** — 74 tests covering data layer, API routes, UI pages, and integration

## Acceptance Criteria
- [x] Admin can create an assessment for a client
- [x] Admin can upload a transcript file (stored in R2)
- [x] Admin can paste/store extraction JSON
- [x] Problems mapped to standard categories via UI
- [x] Assessment status transitions work correctly
- [x] Soft warning shown for financial problem prerequisite (OQ-004)

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, build, 305 tests)
- [ ] Manual: Create assessment from client detail page
- [ ] Manual: Upload transcript file and verify download works
- [ ] Manual: Paste extraction JSON and save
- [ ] Manual: Toggle problem checkboxes and verify persistence
- [ ] Manual: Transition status scheduled -> completed -> converted
- [ ] Manual: Verify financial prerequisite warning when converting with financial_blindness flagged

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)