### PR TITLE
feat: add automated lead generation pipeline framework

### DIFF
--- a/docs/collateral/lead-automation-blueprint.md
+++ b/docs/collateral/lead-automation-blueprint.md
@@ -40,8 +40,8 @@ Google Places API          Outscraper (review text)         Claude API
                                                     +---------+---------+
                                                     |                   |
                                                     v                   v
-                                            Google Sheet          Slack alert
-                                          "Qualified Leads"    "#lead-signals"
+                                            Google Sheet
+                                          "Qualified Leads"
 ```
 
 ### How It Works
@@ -107,7 +107,7 @@ Return JSON:
 }
 ```
 
-**Step 4 — Route and notify.** Filter for pain_score >= 7. Push qualified leads to a Google Sheet with columns: Business Name, Phone, Website, Category, Area, Pain Score, Top Problems, Evidence Quotes, Suggested Outreach Angle, Date Found. Send a Slack notification for each.
+**Step 4 — Route and record.** Filter for pain_score >= 7. Push qualified leads to a Google Sheet with columns: Business Name, Phone, Website, Category, Area, Pain Score, Top Problems, Evidence Quotes, Suggested Outreach Angle, Date Found. New leads appear in the daily digest email (see Daily Digest Scenario).
 
 ### Cost Estimate
 
@@ -131,8 +131,8 @@ Return JSON:
 SerpAPI (Google Jobs)        Claude API                 Google Sheet
 (daily job search)    -->   (analyze job desc)   -->   "Job Signal Leads"
        |                          |                          |
-  Job listings              Qualification:               Slack alert
-  (title, company,          - Is this a small co?        "#lead-signals"
+  Job listings              Qualification:               Google Sheet
+  (title, company,          - Is this a small co?        "Job Signal Leads"
    description,             - Is the pain operational?
    location, date)          - Which of the 6 problems?
                             - Draft outreach angle
@@ -200,7 +200,7 @@ Return JSON:
 }
 ```
 
-**Step 4 — Route qualified leads.** Push to the "Job Signal Leads" sheet. Slack notification.
+**Step 4 — Route qualified leads.** Push to the "Job Signal Leads" sheet. Appears in the daily digest email.
 
 **The outreach timing advantage:** The company just posted the job. They're actively feeling the pain. Your outreach arrives while the wound is fresh — not 6 months later when they've already hired someone and forgotten how bad it was.
 
@@ -337,7 +337,7 @@ Set up a Make.com scenario that:
 - Queries Reddit API for keyword matches in target subreddits
 - Watches a Google Alerts Gmail label for new alerts
 - Deduplicates against Data Store
-- Sends a daily Slack digest: "Here are today's conversations worth joining"
+- Sends a daily Gmail digest: "Here are today's conversations worth joining"
 
 You spend 15 minutes in the morning reading the digest and responding where you can add value.
 
@@ -377,7 +377,7 @@ This is the simplest pipeline — it's a CRM drip, not a data mining operation.
    - If relationship is "intro call done" but no referrals yet: Draft a gentle touch
    - If relationship is "prospect" with no intro call: Draft a follow-up to the original outreach
 4. Push drafts to Gmail draft folder for human review and send
-5. Send Slack reminder: "3 partner check-ins ready in your drafts"
+5. Send a summary email to self: "3 partner check-ins ready in your drafts"
 
 **The AI layer:** Claude drafts the check-in emails, personalized per partner based on their firm's focus areas and your relationship history. You review and send — never fully automated outreach.
 
@@ -398,16 +398,17 @@ This is the simplest pipeline — it's a CRM drip, not a data mining operation.
 
 ### Scenario Map
 
-| Scenario         | Trigger     | Schedule                         | Est. Ops/Month |
-| ---------------- | ----------- | -------------------------------- | -------------- |
-| Review Discovery | Scheduled   | Monthly (rebuild business list)  | 500            |
-| Review Scan      | Scheduled   | Weekly (pull new reviews, score) | 2,000          |
-| Job Monitor      | Scheduled   | Daily (query SerpAPI, qualify)   | 3,000          |
-| City Permits     | Scheduled   | Daily (SODA API query)           | 1,000          |
-| ACC/ADOR Intake  | Gmail watch | On new email (process filings)   | 500            |
-| Social Digest    | Scheduled   | Daily (Reddit + Google Alerts)   | 500            |
-| Partner Nurture  | Scheduled   | Weekly (check-ins)               | 200            |
-| **Total**        |             |                                  | **~7,700/mo**  |
+| Scenario         | Trigger     | Schedule                                    | Est. Ops/Month |
+| ---------------- | ----------- | ------------------------------------------- | -------------- |
+| Review Discovery | Scheduled   | Monthly (rebuild business list)             | 500            |
+| Review Scan      | Scheduled   | Weekly (pull new reviews, score)            | 1,500          |
+| Job Monitor      | Scheduled   | Daily (query SerpAPI, qualify)              | 2,500          |
+| City Permits     | Scheduled   | Daily (SODA API query)                      | 800            |
+| ACC/ADOR Intake  | Gmail watch | On new email (process filings)              | 500            |
+| Social Digest    | Scheduled   | Daily (Reddit + Google Alerts → email)      | 500            |
+| Partner Nurture  | Scheduled   | Weekly (check-ins → Gmail drafts)           | 200            |
+| Daily Digest     | Scheduled   | Daily 6:30am (morning email, all pipelines) | 1,500          |
+| **Total**        |             |                                             | **~8,000/mo**  |
 
 The Make.com Pro plan ($16/mo, 10,000 ops) covers this. If volume grows, additional ops are ~$9/10K.
 
@@ -429,7 +430,7 @@ The Make.com Pro plan ($16/mo, 10,000 ops) covers this. If volume grows, additio
 - "Referral Partners" — bookkeeper/CPA tracking (already exists)
 - "Master Pipeline" — consolidated view of all qualified leads across sources
 
-**Slack Channel:** `#lead-signals` — real-time notifications for high-scoring leads from any pipeline.
+**Daily Digest Email:** A single morning email via Gmail summarizing all new leads across all pipelines from the past 24 hours. Google Sheets are the dashboard — the digest is a daily nudge to check them.
 
 ---
 
@@ -456,7 +457,7 @@ For context: one closed engagement at our rates covers 6+ months of this entire 
 Build Pipeline 2 (Job Posting Monitor) first. Why:
 
 - SerpAPI is a single API with excellent docs
-- The Make.com scenario is straightforward (HTTP → Iterator → Claude → Filter → Sheets → Slack)
+- The Make.com scenario is straightforward (HTTP → Iterator → Claude → Filter → Sheets)
 - Job postings are the strongest intent signal — these companies are actively trying to solve the problem
 - Daily cadence means you see results immediately
 
@@ -465,11 +466,11 @@ Also set up Pipeline 4 (Social Listening) — Google Alerts and Reddit monitorin
 **Deliverables:**
 
 - [ ] SerpAPI account, Google Jobs endpoint tested
-- [ ] Make.com scenario: Job Monitor (8 queries → dedup → Claude qualify → Sheets + Slack)
+- [ ] Make.com scenario: Job Monitor (8 queries → dedup → Claude qualify → Sheets)
 - [ ] Google Alerts configured for target keywords
-- [ ] Make.com scenario: Social Digest (Reddit API + Gmail alerts → daily Slack digest)
+- [ ] Make.com scenario: Social Digest (Reddit API + Gmail alerts → daily email digest)
+- [ ] Make.com scenario: Daily Digest (morning email summarizing all new leads)
 - [ ] Google Sheets created: "Job Signal Leads," "Social Opportunities"
-- [ ] Slack channel: #lead-signals
 
 ### Phase 2: The Review Engine (Week 3-4)
 
@@ -480,7 +481,7 @@ Build Pipeline 1 (Review Mining). This is the most complex pipeline but the most
 - [ ] Outscraper account, review extraction tested
 - [ ] Google Places API: business discovery queries built for each target vertical
 - [ ] Make.com scenario: Review Discovery (monthly business list refresh)
-- [ ] Make.com scenario: Review Scan (weekly review pull → Claude scoring → Sheets + Slack)
+- [ ] Make.com scenario: Review Scan (weekly review pull → Claude scoring → Sheets)
 - [ ] Google Sheet: "Review Signal Leads"
 - [ ] Claude prompt tuned on real review data (test against known businesses)
 
@@ -504,7 +505,7 @@ Build Pipeline 5 (Referral Partner Nurture). By now you have active bookkeeper r
 **Deliverables:**
 
 - [ ] Bookkeeper prospect sheet enhanced with check-in tracking columns
-- [ ] Make.com scenario: Partner Nurture (weekly → identify due check-ins → Claude draft → Gmail drafts → Slack reminder)
+- [ ] Make.com scenario: Partner Nurture (weekly → identify due check-ins → Claude draft → Gmail drafts → summary email)
 
 ### Phase 5: Optimization (Ongoing)
 
@@ -606,4 +607,4 @@ Step-by-step build guides for each Make.com scenario:
 - #108 — Pipeline 3: New Business Detection
 - #109 — Pipeline 4: Social Listening
 - #110 — Pipeline 5: Partner Nurture + Buttondown
-- #111 — API accounts, Make.com setup, Slack channel
+- #111 — API accounts, Make.com setup, Gmail digest

--- a/docs/collateral/lead-automation-blueprint.md
+++ b/docs/collateral/lead-automation-blueprint.md
@@ -1,0 +1,609 @@
+# Lead Generation Automation Blueprint
+
+**Purpose:** Architecture for automated prospect discovery and qualification. Turns manual networking into a system that surfaces the right 25 people each week — before they know they need help.
+
+**The advantage:** Every other local operations consultant is at chamber mixers and BNI meetings hoping to bump into the right person. Those channels matter and we use them. But we also have five automated pipelines running in the background, finding businesses whose reviews, job postings, and public filings are already telling us exactly what's broken. We show up to the conversation knowing the problem. That's the edge.
+
+---
+
+## The Five Pipelines
+
+| #   | Pipeline                 | Signal                                        | Why It Works                                               | Frequency |
+| --- | ------------------------ | --------------------------------------------- | ---------------------------------------------------------- | --------- |
+| 1   | Review Mining            | Operational complaints in Google/Yelp reviews | You know their exact pain before you call                  | Weekly    |
+| 2   | Job Posting Monitor      | Small companies hiring ops roles              | They're trying to hire their way out of a problem we solve | Daily     |
+| 3   | New Business Detection   | ACC filings, city permits, TPT licenses       | Catch them before the chaos sets in                        | Weekly    |
+| 4   | Social Listening         | Reddit, Facebook groups, Craigslist           | Be the answer, not the pitch                               | Daily     |
+| 5   | Referral Partner Nurture | Automated check-ins with bookkeeper partners  | Keep the warmest channel warm without manual effort        | Weekly    |
+
+---
+
+## Pipeline 1: Review Mining
+
+**The idea:** Scan Google and Yelp reviews for Phoenix-area businesses in our target verticals. Use AI to flag reviews that describe operational problems — missed calls, scheduling chaos, lost paperwork, slow follow-up. These businesses have prospects publicly documenting their pain.
+
+### Data Flow
+
+```
+Google Places API          Outscraper (review text)         Claude API
+(discover businesses) -->  (pull recent reviews)      -->  (score for ops pain)
+       |                          |                              |
+       v                          v                              v
+  Business list             Review corpus              Pain signals + score
+  (name, phone,             (full text,                (which of the 6 problems,
+   address, category,        date-filtered,             severity 1-10,
+   rating, place_id)         per-business)              specific evidence)
+                                                              |
+                                                              v
+                                                     Filter: score >= 7
+                                                              |
+                                                    +---------+---------+
+                                                    |                   |
+                                                    v                   v
+                                            Google Sheet          Slack alert
+                                          "Qualified Leads"    "#lead-signals"
+```
+
+### How It Works
+
+**Step 1 — Discover businesses.** Use Google Places API Text Search to find businesses by vertical + geography. Query examples:
+
+- "plumber Phoenix AZ"
+- "HVAC contractor Scottsdale"
+- "accounting firm Chandler"
+- "dental office Mesa"
+- "auto repair shop Tempe"
+
+The API returns up to 60 results per query (paginated). Run 10-15 queries per vertical to build a master list. This only needs to run monthly — business listings don't change that fast. Store place_ids in the Make.com Data Store for deduplication.
+
+Google's $200/mo free credit covers ~6,250 Text Searches — more than enough.
+
+**Step 2 — Pull recent reviews.** Use Outscraper's Google Maps Reviews API with date filtering. For each business in the master list, request reviews from the last 7 days.
+
+Outscraper is the best fit here because:
+
+- Returns ALL reviews, not the 5-review cap of the official API
+- Supports date range filtering (only pull new reviews since last scan)
+- Cost: ~$3 per 1,000 review tasks
+- At 500 businesses/week: ~$6/month
+
+Alternative: DataForSEO at ~$2 per 1,000 tasks (cheaper but no date filter — you'd pull all and diff locally).
+
+**Step 3 — AI analysis.** Pass each batch of reviews through Claude (via Make.com's native Anthropic module). The prompt:
+
+```
+You are analyzing Google reviews for a {business_type} called "{business_name}"
+in {city}, AZ. Your job is to identify operational problems — NOT service quality
+or product issues.
+
+Look for signals matching these 6 patterns:
+1. Owner bottleneck — "only the owner can help," "had to wait for the boss"
+2. Lead leakage — "never called back," "left a message, no response," "ghosted"
+3. Financial blindness — "surprise charges," "couldn't give me a quote," "billing errors"
+4. Scheduling chaos — "double-booked," "showed up on wrong day," "couldn't get an appointment"
+5. Manual communication — "had to call three times for an update," "no confirmation"
+6. Employee issues — "different person every time," "new guy didn't know what to do"
+
+For each review, extract:
+- The operational signal (which of the 6 problems, if any)
+- The exact quote that shows it
+- Severity (1-10)
+
+Then give the business an overall operational pain score (1-10) based on the
+pattern across all reviews. A single complaint is noise. Repeated patterns are signal.
+
+Return JSON:
+{
+  "business_name": "...",
+  "pain_score": 8,
+  "top_problems": ["scheduling_chaos", "lead_leakage"],
+  "evidence": [
+    {"problem": "lead_leakage", "quote": "Left two messages, never heard back", "severity": 8},
+    ...
+  ],
+  "outreach_angle": "Their customers love their work but keep complaining about
+                      communication gaps. Lead with: 'Your 5-star reviews mention
+                      how hard it is to reach you — we fix that.'"
+}
+```
+
+**Step 4 — Route and notify.** Filter for pain_score >= 7. Push qualified leads to a Google Sheet with columns: Business Name, Phone, Website, Category, Area, Pain Score, Top Problems, Evidence Quotes, Suggested Outreach Angle, Date Found. Send a Slack notification for each.
+
+### Cost Estimate
+
+| Component                                                  | Monthly Cost   |
+| ---------------------------------------------------------- | -------------- |
+| Google Places API (discovery, within free credit)          | $0             |
+| Outscraper (500 businesses/week, recent reviews)           | $6-12          |
+| Claude API (scoring ~100 review batches/week)              | $5-10          |
+| Make.com (shared plan, ~2,000 ops/month for this pipeline) | Shared         |
+| **Pipeline total**                                         | **~$11-22/mo** |
+
+---
+
+## Pipeline 2: Job Posting Monitor
+
+**The idea:** Monitor job postings in Phoenix for roles that signal operational pain at small businesses. A 15-person plumbing company posting for an "office manager" is telling you they've outgrown their current operations. A contractor hiring a "dispatcher" has scheduling chaos. These are warm leads — they're actively trying to solve the problem.
+
+### Data Flow
+
+```
+SerpAPI (Google Jobs)        Claude API                 Google Sheet
+(daily job search)    -->   (analyze job desc)   -->   "Job Signal Leads"
+       |                          |                          |
+  Job listings              Qualification:               Slack alert
+  (title, company,          - Is this a small co?        "#lead-signals"
+   description,             - Is the pain operational?
+   location, date)          - Which of the 6 problems?
+                            - Draft outreach angle
+```
+
+### How It Works
+
+**Step 1 — Query job boards.** Use SerpAPI's Google Jobs endpoint. Google Jobs aggregates from Indeed, LinkedIn, ZipRecruiter, Glassdoor, and direct company postings — one API covers all major sources.
+
+Monitored search terms (each run as a separate query):
+
+- "office manager" in Phoenix, AZ
+- "operations manager" in Phoenix, AZ
+- "dispatcher" in Phoenix, AZ
+- "scheduling coordinator" in Phoenix, AZ
+- "customer service coordinator" in Phoenix, AZ
+- "office administrator" in Phoenix, AZ
+- "front desk manager" in Phoenix, AZ
+- "service coordinator" in Phoenix, AZ
+
+Filter: `date_posted:3days` to catch recent postings. Run daily.
+
+**Step 2 — Dedup and filter.** Check each posting against the Make.com Data Store (by job_id hash or title+company). Only process new postings.
+
+**Step 3 — AI qualification.** Pass the job description to Claude:
+
+```
+You are analyzing a job posting to determine if it signals operational pain at
+a small business (10-50 employees) that could benefit from operations consulting.
+
+Job title: {title}
+Company: {company}
+Location: {location}
+Description: {description}
+
+Evaluate:
+1. Company size signal — Does anything in the posting suggest this is a small business
+   (10-50 employees)? Look for: "small team," "family-owned," "growing company,"
+   single-location indicators, the job combining multiple responsibilities.
+
+2. Operational pain signal — Is this role being created because the business has
+   outgrown its current operations? Look for: "we need someone to organize,"
+   "create processes," "implement systems," "the owner currently handles,"
+   "no existing structure."
+
+3. Which of the 6 problems does this map to?
+
+4. Disqualify if: large company (100+ employees), franchise corporate office,
+   staffing agency, government, or the role is a standard replacement hire
+   with no operational pain signals.
+
+Return JSON:
+{
+  "company": "...",
+  "qualified": true/false,
+  "confidence": "high/medium/low",
+  "company_size_estimate": "10-25",
+  "problems_signaled": ["owner_bottleneck", "scheduling_chaos"],
+  "evidence": "Job description mentions 'owner currently handles all scheduling'
+               and 'no existing processes documented'",
+  "outreach_angle": "They're hiring to solve a problem that's really about
+                      missing processes. Reach out before they hire: 'Before you
+                      add payroll, let us build the systems that make this role
+                      half as big.'"
+}
+```
+
+**Step 4 — Route qualified leads.** Push to the "Job Signal Leads" sheet. Slack notification.
+
+**The outreach timing advantage:** The company just posted the job. They're actively feeling the pain. Your outreach arrives while the wound is fresh — not 6 months later when they've already hired someone and forgotten how bad it was.
+
+### Supplementary: Craigslist RSS
+
+Free. Set up Make.com's RSS module to watch:
+
+- `https://phoenix.craigslist.org/search/jjj?query=office+manager&format=rss`
+- Same for other target job titles
+
+Lower signal quality (anonymous postings, less company info) but catches the smallest businesses that only post on Craigslist. Run through the same AI qualification step.
+
+### Cost Estimate
+
+| Component                                                             | Monthly Cost                            |
+| --------------------------------------------------------------------- | --------------------------------------- |
+| SerpAPI Google Jobs (~8 queries x 1 run/day x 30 days = 240 searches) | $50/mo (well within 5,000/mo base plan) |
+| Craigslist RSS                                                        | $0                                      |
+| Claude API (qualifying ~20-30 postings/day)                           | $10-15                                  |
+| Make.com (shared plan, ~3,000 ops/month for this pipeline)            | Shared                                  |
+| **Pipeline total**                                                    | **~$60-65/mo**                          |
+
+---
+
+## Pipeline 3: New Business Detection
+
+**The idea:** Catch new and growing businesses from public records — business filings, commercial permits, tax license registrations. These are businesses in formation or expansion. They don't have operations problems yet, but they will. Getting in early means being the trusted advisor before the chaos starts.
+
+### Data Flow
+
+```
+SODA API (city permits)         ACC/ADOR data              Claude API
+(automated daily query)  +   (public records req)   -->  (qualify + enrich)
+        |                          |                           |
+  Commercial TI permits      New LLC/corp filings         Qualification:
+  (business name, address,   New TPT licenses             - Is this our target?
+   permit type, date)        (business name, address,     - What vertical?
+                              entity type)                 - Outreach timing
+                                                               |
+                                                               v
+                                                        Google Sheet
+                                                      "New Business Leads"
+```
+
+### Automated Sources (no human needed)
+
+**City Open Data Portals (SODA API):**
+
+Phoenix, Scottsdale, and Chandler publish permit data via Socrata's SODA REST API. A commercial tenant improvement (TI) permit means a business is moving into or expanding a space — direct growth signal.
+
+Make.com's HTTP module queries these directly. Example:
+
+```
+GET https://www.phoenixopendata.com/resource/{dataset-id}.json
+  ?$where=issue_date > '2026-03-23'
+  &$where=permit_type = 'Commercial TI'
+  &$limit=100
+```
+
+Run daily for each city. Free. Fully automated.
+
+**SBA Loan Data:**
+
+Quarterly bulk CSV from data.sba.gov. Filter for Maricopa County zip codes. A business receiving an SBA loan is investing in growth. Download, parse, cross-reference with existing prospect list. Batch process quarterly.
+
+### Semi-Automated Sources (human initiates, system processes)
+
+**Arizona Corporation Commission (ACC):**
+
+No API, but you can email a weekly public records request for new entity filings in Maricopa County. The ACC responds with a data extract (required under ARS 39-121). Once received, upload to a processing pipeline:
+
+- Make.com watches a Gmail inbox or Google Drive folder for the weekly ACC file
+- Parses the CSV/Excel
+- Runs each new entity through AI qualification (is this a 10-50 person business? what vertical?)
+- Pushes qualified entities to the prospect sheet
+
+**Arizona Department of Revenue (ADOR) — TPT Licenses:**
+
+Highest signal source — a new TPT license means the business is actually operating, not just filed paperwork. Same public records request approach as ACC, monthly cadence.
+
+### Cost Estimate
+
+| Component                                        | Monthly Cost             |
+| ------------------------------------------------ | ------------------------ |
+| SODA API queries (Phoenix, Scottsdale, Chandler) | $0                       |
+| SBA data processing (quarterly)                  | $0                       |
+| ACC/ADOR public records processing               | $0 (free public records) |
+| Claude API (qualifying ~50 new entities/week)    | $3-5                     |
+| Make.com (shared plan, ~1,500 ops/month)         | Shared                   |
+| **Pipeline total**                               | **~$3-5/mo**             |
+
+---
+
+## Pipeline 4: Social Listening
+
+**The idea:** Monitor local online communities for people asking questions that signal operational pain. "Does anyone know a good CRM?" "How do you handle scheduling for a team of 12?" "I'm drowning in paperwork." These are people raising their hand. Don't pitch — answer the question. The DMs come to you.
+
+### Channels to Monitor
+
+**Reddit:**
+
+- r/phoenix, r/smallbusiness, r/entrepreneur
+- Reddit has a free API (rate-limited but sufficient)
+- Monitor for keywords: "small business Phoenix," "scheduling software," "CRM recommendation," "overwhelmed business owner," "can't take a day off"
+
+**Facebook Groups:**
+
+- Phoenix-area small business groups
+- Industry-specific groups (Phoenix HVAC contractors, Arizona contractors, etc.)
+- No API — manual monitoring or use a tool like PhantomBuster
+- Highest signal but lowest automation potential
+
+**Google Alerts:**
+
+- Set up alerts for: "small business Phoenix operations," "Phoenix [vertical] hiring office manager"
+- Delivers to Gmail → Make.com watches the inbox → parses the alert → routes interesting results
+
+**Craigslist (services section):**
+
+- Businesses posting in "services offered" → they exist and are marketing
+- RSS feed: `https://phoenix.craigslist.org/search/bbs?format=rss`
+
+### Automation Approach
+
+This pipeline is the least automatable but the most authentic. The play is:
+
+1. **Automated discovery:** Make.com surfaces the posts/threads worth looking at
+2. **Human response:** You (the human) write a genuinely helpful answer
+3. **No pitch in public:** The value is being visibly competent, not selling
+4. **Track engagement:** Log which responses generate DMs or follows
+
+Set up a Make.com scenario that:
+
+- Queries Reddit API for keyword matches in target subreddits
+- Watches a Google Alerts Gmail label for new alerts
+- Deduplicates against Data Store
+- Sends a daily Slack digest: "Here are today's conversations worth joining"
+
+You spend 15 minutes in the morning reading the digest and responding where you can add value.
+
+### Cost Estimate
+
+| Component                              | Monthly Cost |
+| -------------------------------------- | ------------ |
+| Reddit API                             | $0           |
+| Google Alerts                          | $0           |
+| Make.com (shared plan, ~500 ops/month) | Shared       |
+| **Pipeline total**                     | **~$0**      |
+
+---
+
+## Pipeline 5: Referral Partner Nurture
+
+**The idea:** The bookkeeper/CPA referral channel (the 22 prospects in our prospect list) is the highest-converting source. But relationships decay without maintenance. Automate the stay-in-touch cadence so the relationship stays warm even when you're heads-down on a client engagement.
+
+### Automation Approach
+
+This is the simplest pipeline — it's a CRM drip, not a data mining operation.
+
+**Tracking:** Google Sheet with the bookkeeper prospect list (already created). Add columns:
+
+- Last Contact Date
+- Next Check-in Date
+- Relationship Stage (prospect / intro call done / active partner / dormant)
+- Referrals Received (count)
+- Referrals Sent (count)
+
+**Make.com scenario (weekly, Friday morning):**
+
+1. Read the Google Sheet
+2. Filter for partners where Next Check-in Date <= today
+3. For each partner due for check-in:
+   - If relationship is "active partner": Draft a check-in email with something useful (a relevant article, a client win story, a question about their business)
+   - If relationship is "intro call done" but no referrals yet: Draft a gentle touch
+   - If relationship is "prospect" with no intro call: Draft a follow-up to the original outreach
+4. Push drafts to Gmail draft folder for human review and send
+5. Send Slack reminder: "3 partner check-ins ready in your drafts"
+
+**The AI layer:** Claude drafts the check-in emails, personalized per partner based on their firm's focus areas and your relationship history. You review and send — never fully automated outreach.
+
+**Email delivery:** Gmail for 1:1 partner nurture (truly personalized). Buttondown (existing subscription) reserved for future broadcast content — a monthly "operations insight" to the full partner list when the network reaches 10+ active relationships. See `docs/lead-automation/specs/buttondown-integration.md` for details.
+
+### Cost Estimate
+
+| Component                               | Monthly Cost |
+| --------------------------------------- | ------------ |
+| Google Sheets                           | $0           |
+| Claude API (drafting ~5-10 emails/week) | $2-3         |
+| Make.com (shared plan, ~200 ops/month)  | Shared       |
+| **Pipeline total**                      | **~$2-3/mo** |
+
+---
+
+## The Make.com Architecture
+
+### Scenario Map
+
+| Scenario         | Trigger     | Schedule                         | Est. Ops/Month |
+| ---------------- | ----------- | -------------------------------- | -------------- |
+| Review Discovery | Scheduled   | Monthly (rebuild business list)  | 500            |
+| Review Scan      | Scheduled   | Weekly (pull new reviews, score) | 2,000          |
+| Job Monitor      | Scheduled   | Daily (query SerpAPI, qualify)   | 3,000          |
+| City Permits     | Scheduled   | Daily (SODA API query)           | 1,000          |
+| ACC/ADOR Intake  | Gmail watch | On new email (process filings)   | 500            |
+| Social Digest    | Scheduled   | Daily (Reddit + Google Alerts)   | 500            |
+| Partner Nurture  | Scheduled   | Weekly (check-ins)               | 200            |
+| **Total**        |             |                                  | **~7,700/mo**  |
+
+The Make.com Pro plan ($16/mo, 10,000 ops) covers this. If volume grows, additional ops are ~$9/10K.
+
+### Shared Infrastructure
+
+**Make.com Data Store:** Single data store with tables for:
+
+- `seen_businesses` (place_id → prevents reprocessing)
+- `seen_jobs` (job_id_hash → deduplication)
+- `seen_permits` (permit_number → deduplication)
+- `seen_social` (post_id → deduplication)
+
+**Google Sheets (output hub):**
+
+- "Review Signal Leads" — businesses with operational pain in their reviews
+- "Job Signal Leads" — companies hiring ops roles
+- "New Business Leads" — new filings and permits
+- "Social Opportunities" — threads worth responding to
+- "Referral Partners" — bookkeeper/CPA tracking (already exists)
+- "Master Pipeline" — consolidated view of all qualified leads across sources
+
+**Slack Channel:** `#lead-signals` — real-time notifications for high-scoring leads from any pipeline.
+
+---
+
+## Total Cost Model
+
+| Component                                            | Monthly Cost     |
+| ---------------------------------------------------- | ---------------- |
+| Make.com Pro                                         | $16              |
+| SerpAPI (Google Jobs, 5K searches/mo)                | $50              |
+| Outscraper (review extraction)                       | $20-50           |
+| Claude API (all pipelines)                           | $20-33           |
+| Google Places API (within $200 free credit)          | $0               |
+| Reddit API, Craigslist RSS, Google Alerts, SODA APIs | $0               |
+| **Total**                                            | **~$106-149/mo** |
+
+For context: one closed engagement at our rates covers 6+ months of this entire system. The ROI math is almost absurd — the system needs to surface ONE client per year to pay for itself many times over.
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Highest Signal, Lowest Effort (Week 1-2)
+
+Build Pipeline 2 (Job Posting Monitor) first. Why:
+
+- SerpAPI is a single API with excellent docs
+- The Make.com scenario is straightforward (HTTP → Iterator → Claude → Filter → Sheets → Slack)
+- Job postings are the strongest intent signal — these companies are actively trying to solve the problem
+- Daily cadence means you see results immediately
+
+Also set up Pipeline 4 (Social Listening) — Google Alerts and Reddit monitoring are near-zero effort and provide immediate daily content.
+
+**Deliverables:**
+
+- [ ] SerpAPI account, Google Jobs endpoint tested
+- [ ] Make.com scenario: Job Monitor (8 queries → dedup → Claude qualify → Sheets + Slack)
+- [ ] Google Alerts configured for target keywords
+- [ ] Make.com scenario: Social Digest (Reddit API + Gmail alerts → daily Slack digest)
+- [ ] Google Sheets created: "Job Signal Leads," "Social Opportunities"
+- [ ] Slack channel: #lead-signals
+
+### Phase 2: The Review Engine (Week 3-4)
+
+Build Pipeline 1 (Review Mining). This is the most complex pipeline but the most defensible advantage.
+
+**Deliverables:**
+
+- [ ] Outscraper account, review extraction tested
+- [ ] Google Places API: business discovery queries built for each target vertical
+- [ ] Make.com scenario: Review Discovery (monthly business list refresh)
+- [ ] Make.com scenario: Review Scan (weekly review pull → Claude scoring → Sheets + Slack)
+- [ ] Google Sheet: "Review Signal Leads"
+- [ ] Claude prompt tuned on real review data (test against known businesses)
+
+### Phase 3: Public Records (Week 5-6)
+
+Build Pipeline 3 (New Business Detection). Start with the automated sources, add semi-automated later.
+
+**Deliverables:**
+
+- [ ] SODA API endpoints identified for Phoenix, Scottsdale, Chandler commercial permits
+- [ ] Make.com scenario: City Permits (daily SODA query → filter commercial TIs → Sheets)
+- [ ] First ACC public records request submitted (test the process)
+- [ ] First ADOR public records request submitted
+- [ ] Make.com scenario: ACC/ADOR Intake (Gmail watch → parse → qualify → Sheets)
+- [ ] Google Sheet: "New Business Leads"
+
+### Phase 4: Nurture System (Week 7-8)
+
+Build Pipeline 5 (Referral Partner Nurture). By now you have active bookkeeper relationships from manual outreach — automate the maintenance.
+
+**Deliverables:**
+
+- [ ] Bookkeeper prospect sheet enhanced with check-in tracking columns
+- [ ] Make.com scenario: Partner Nurture (weekly → identify due check-ins → Claude draft → Gmail drafts → Slack reminder)
+
+### Phase 5: Optimization (Ongoing)
+
+- Tune Claude prompts based on real qualification results (are the scores accurate?)
+- Adjust query terms based on what's actually surfacing
+- Build the "Master Pipeline" consolidated view
+- Add company enrichment (Apollo.io or manual) for size/revenue filtering
+- Track source attribution: which pipeline produces the leads that actually close?
+
+---
+
+## The Competitive Moat
+
+This system compounds. Every week:
+
+- The business discovery list grows (more businesses being monitored for reviews)
+- The dedup store grows (less wasted processing)
+- The Claude prompts improve (tuned on real data)
+- The referral partner network deepens (automated nurture)
+- You learn which signals actually predict closed deals (feedback loop)
+
+In 6 months, you have a lead generation machine that no other local operations consultant can replicate — not because the technology is hard, but because the system knowledge and prompt tuning took hundreds of iterations to get right.
+
+The manual channels (BNI, chamber, networking) are still essential. They're how you build trust and close deals. But the automated pipelines ensure you're never short on conversations to have. The 25 touches/week target stops being a grind and starts being a selection problem: which of these 40 qualified leads do I reach out to first?
+
+---
+
+## Technical Notes
+
+### Make.com Operations Budget
+
+Operations are the main constraint. Each module execution = 1 operation. A scenario with 10 modules processing 20 items = 200 operations. The Pro plan (10K ops/month) covers the baseline architecture. Monitor usage and purchase additional op packs ($9/10K) as volume scales.
+
+**Optimization tips:**
+
+- Use filters (free, don't count as operations) aggressively before expensive modules (AI calls)
+- Batch review text into single Claude calls where possible (score 5-10 businesses per prompt)
+- Use the Data Store "exists" check before API calls to avoid reprocessing
+
+### API Key Management
+
+- SerpAPI key → Make.com connection
+- Outscraper API key → Make.com connection
+- Google Places API key → Make.com HTTP module (restrict to Places API in Google Cloud Console)
+- Anthropic API key → Make.com Anthropic module
+- Reddit API credentials (OAuth2 app) → Make.com HTTP module
+
+Store all keys in Make.com's connection manager. Never hardcode in scenario configurations.
+
+### Data Retention
+
+Google Sheets is the initial output layer. If volume grows or you want structured querying, migrate to D1 (already in your stack) with a Cloudflare Worker API that Make.com calls via HTTP. But Sheets is fine for the first 6 months — don't over-engineer the storage layer before you've validated the pipelines.
+
+---
+
+## Implementation Files
+
+The blueprint is the architecture document. The implementation details live in:
+
+### Prompts & Schemas (`src/lead-gen/`)
+
+TypeScript prompt library following the `src/portal/assessments/extraction-prompt.ts` pattern. Each prompt exports a system prompt, user prompt builder, manual prompt builder, and validation function.
+
+- `schemas/lead-scoring-schema.ts` — Shared types (PipelineId, ScoringResult, LeadRecord)
+- `schemas/review-signal.ts` — Pipeline 1 output types
+- `schemas/job-signal.ts` — Pipeline 2 output types
+- `schemas/new-business-signal.ts` — Pipeline 3 output types
+- `schemas/partner-email-draft.ts` — Pipeline 5 output types
+- `prompts/review-scoring-prompt.ts` — Pipeline 1 AI scoring
+- `prompts/job-qualification-prompt.ts` — Pipeline 2 AI qualification
+- `prompts/new-business-prompt.ts` — Pipeline 3 AI qualification
+- `prompts/partner-nurture-prompt.ts` — Pipeline 5 email drafting
+
+### Specifications (`docs/lead-automation/specs/`)
+
+- `google-sheets-schema.md` — Column specs for all 6 output sheets
+- `make-data-store-schema.md` — Deduplication table definitions
+- `serpapi-queries.md` — Pipeline 2 API query specs
+- `outscraper-queries.md` — Pipeline 1 API query specs
+- `soda-api-queries.md` — Pipeline 3 city permit API specs
+- `buttondown-integration.md` — Pipeline 5 email delivery spec
+- `api-accounts-checklist.md` — All external account signups
+
+### Make.com Recipes (`docs/lead-automation/recipes/`)
+
+Step-by-step build guides for each Make.com scenario:
+
+- `pipeline-1-review-mining.md` — Two scenarios (discovery + scan)
+- `pipeline-2-job-monitor.md` — Reference pattern for all pipelines
+- `pipeline-3-new-business.md` — Two scenarios (permits + ACC/ADOR intake)
+- `pipeline-4-social-listening.md` — Daily digest scenario
+- `pipeline-5-partner-nurture.md` — Weekly check-in scenario
+
+### GitHub Issues
+
+- #105 — Prompt library + shared schemas
+- #106 — Pipeline 2: Job Posting Monitor
+- #107 — Pipeline 1: Review Mining
+- #108 — Pipeline 3: New Business Detection
+- #109 — Pipeline 4: Social Listening
+- #110 — Pipeline 5: Partner Nurture + Buttondown
+- #111 — API accounts, Make.com setup, Slack channel

--- a/docs/lead-automation/recipes/pipeline-1-review-mining.md
+++ b/docs/lead-automation/recipes/pipeline-1-review-mining.md
@@ -8,7 +8,6 @@
 - Outscraper API key (Medium plan or pay-as-you-go)
 - Anthropic API key
 - Google Sheets: "SMD Lead Generation" spreadsheet with "Review Signal Leads" tab (see google-sheets-schema.md)
-- Slack: #lead-signals channel created
 - Make.com Data Store: `seen_businesses` created (see make-data-store-schema.md)
 
 ---
@@ -168,7 +167,7 @@ The `place_id` is a globally unique identifier for each business — it is the n
 
 ## Scenario B: Weekly Review Scan
 
-Pulls recent reviews for all businesses in the master list, scores them with Claude for operational pain signals, and writes qualified leads to Google Sheets with Slack notifications.
+Pulls recent reviews for all businesses in the master list, scores them with Claude for operational pain signals, and writes qualified leads to Google Sheets.
 
 ### Scenario Overview
 
@@ -184,13 +183,12 @@ Schedule (every Monday 6am)
       -> Parse JSON
       -> Filter: pain_score >= 7
       -> Google Sheets: append to "Review Signal Leads"
-      -> Slack: notification to #lead-signals
       -> Data Store: update seen_businesses (last_scanned, last_pain_score)
 ```
 
-**Total modules per scored business:** ~8
+**Total modules per scored business:** ~7
 **Expected weekly volume:** 200-500 businesses checked. Of those, maybe 20-50 have new reviews. Of those, maybe 5-15 score >= 7.
-**Operations per run:** ~500-1,500 (depends on how many businesses have new reviews)
+**Operations per run:** ~450-1,350 (depends on how many businesses have new reviews)
 
 ---
 
@@ -363,23 +361,7 @@ Businesses scoring 1-6 are not worth outreach. They either have no operational s
 | L: Date Found     | `{{formatDate(now; "YYYY-MM-DD")}}`                                 |
 | M: Status         | `New`                                                               |
 
-#### Step 14: Module 10 — Slack (Notification)
-
-**Module: Slack -> Create a Message**
-
-- Channel: `#lead-signals`
-- Text:
-
-```
-:mag: *New Review Signal Lead*
-*Business:* {{json.business_name}}
-*Pain Score:* {{json.pain_score}}/10
-*Top Problems:* {{join(json.top_problems; ", ")}}
-*Outreach Angle:* {{json.outreach_angle}}
-*Google Rating:* {{iterator2.rating}}/5 ({{iterator2.reviews}} reviews)
-```
-
-#### Step 15: Module 11 — Data Store (Update Business Record)
+#### Step 14: Module 10 — Data Store (Update Business Record)
 
 **Module: Data Store -> Add/replace a record**
 
@@ -395,7 +377,7 @@ Businesses scoring 1-6 are not worth outreach. They either have no operational s
 | `last_review_date` | `{{iterator2.reviews_data[1].review_datetime_utc}}` (most recent review date) |
 | `last_pain_score`  | `{{json.pain_score}}`                                                         |
 
-**Important:** This module should also run for businesses that scored below 7 — update `last_scanned` regardless of score. To achieve this, place this module on a separate path BEFORE the pain score filter, or duplicate it. The simplest approach: use a **Router** after the JSON parse module. One path goes through the pain score filter to Sheets and Slack. The other path always runs the Data Store update.
+**Important:** This module should also run for businesses that scored below 7 — update `last_scanned` regardless of score. To achieve this, place this module on a separate path BEFORE the pain score filter, or duplicate it. The simplest approach: use a **Router** after the JSON parse module. One path goes through the pain score filter to Sheets. The other path always runs the Data Store update.
 
 ---
 
@@ -417,9 +399,8 @@ Businesses scoring 1-6 are not worth outreach. They either have no operational s
 - [ ] Verify businesses with no new reviews are filtered out
 - [ ] Verify Claude produces valid JSON (check Anthropic module output — valid ReviewScoring schema)
 - [ ] Verify businesses with pain_score >= 7 appear in the Google Sheet
-- [ ] Verify Slack notification arrives in #lead-signals with correct formatting
 - [ ] Verify `seen_businesses` Data Store records are updated with `last_scanned` and `last_pain_score`
-- [ ] Check operations count — should be within estimated 500-1,500 per run
+- [ ] Check operations count — should be within estimated 450-1,350 per run
 - [ ] Let scenario run automatically for 3+ weeks, then review all scored leads for accuracy
 
 ---
@@ -439,3 +420,5 @@ After 2-3 weeks of running:
 5. **High Outscraper costs:** Reduce the batch frequency from weekly to biweekly. Or filter the `seen_businesses` list to only scan businesses that have been added or updated in the past 90 days (use the cleanup rule from make-data-store-schema.md).
 
 6. **Operations budget:** Batch scoring (multiple businesses per Claude call) significantly reduces operations. Implement batch scoring once single-business scoring is validated.
+
+> **Note:** Notifications are handled by the Daily Digest scenario (see pipeline-2-job-monitor.md, Daily Digest Scenario section), not per-lead.

--- a/docs/lead-automation/recipes/pipeline-1-review-mining.md
+++ b/docs/lead-automation/recipes/pipeline-1-review-mining.md
@@ -1,0 +1,441 @@
+# Make.com Recipe: Pipeline 1 — Review Mining
+
+**Purpose:** Step-by-step guide to build two Make.com scenarios that discover Phoenix-area businesses and scan their Google reviews for operational pain signals.
+
+**Prerequisites:**
+
+- Google Cloud API key (Places API enabled — see api-accounts-checklist.md)
+- Outscraper API key (Medium plan or pay-as-you-go)
+- Anthropic API key
+- Google Sheets: "SMD Lead Generation" spreadsheet with "Review Signal Leads" tab (see google-sheets-schema.md)
+- Slack: #lead-signals channel created
+- Make.com Data Store: `seen_businesses` created (see make-data-store-schema.md)
+
+---
+
+## Scenario A: Business Discovery (Monthly)
+
+Builds and refreshes the master list of businesses to monitor for review signals. Runs once per month to add new businesses across 14 discovery queries.
+
+### Scenario Overview
+
+```
+Schedule (1st of month)
+  -> Set Variable: discovery queries array (14 queries)
+  -> Iterator: each query
+    -> HTTP: Google Places API Text Search
+    -> Iterator: each business result
+      -> Data Store: check seen_businesses (dedup by place_id)
+      -> Filter: only new businesses
+      -> Data Store: add to seen_businesses
+```
+
+**Total modules per new business:** ~4
+**Expected monthly volume:** 14 queries x 20 results = 280 businesses checked. After dedup, ~20-50 new businesses per month (most are seen on repeat runs).
+**Operations per run:** ~300-500
+
+---
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com -> Scenarios -> Create a new scenario
+2. Name: `Lead Gen: P1a Business Discovery`
+3. Set the schedule: **1st of every month at 5:00 AM** (MST/Arizona time — Arizona does not observe DST)
+
+#### Step 2: Add the Trigger — Scheduled
+
+1. The scenario trigger is **Schedule** (built-in)
+2. Set to run once monthly on the 1st at 5:00 AM
+3. This fires the first module in the chain
+
+#### Step 3: Module 1 — Set Variable (Discovery Queries)
+
+**Module: Tools -> Set multiple variables**
+
+- Variable 1: `queries` (array)
+- Value:
+
+```json
+[
+  "plumber Phoenix AZ",
+  "HVAC contractor Phoenix AZ",
+  "electrician Phoenix AZ",
+  "pest control Phoenix AZ",
+  "landscaping company Phoenix AZ",
+  "plumber Scottsdale AZ",
+  "plumber Chandler AZ",
+  "plumber Mesa AZ",
+  "accounting firm Phoenix AZ",
+  "law firm Phoenix AZ",
+  "insurance agency Phoenix AZ",
+  "dental office Phoenix AZ",
+  "auto repair Phoenix AZ",
+  "veterinarian Phoenix AZ"
+]
+```
+
+These 14 queries are defined in `outscraper-queries.md`. They cover home services, professional services, and secondary verticals across the Phoenix metro area.
+
+#### Step 4: Module 2 — Iterator (Query List)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: `{{queries}}` (from the Set Variable module)
+- This processes each query term one at a time
+
+#### Step 5: Module 3 — HTTP (Google Places Text Search)
+
+**Module: HTTP -> Make a request**
+
+| Setting        | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| URL            | `https://places.googleapis.com/v1/places:searchText` |
+| Method         | POST                                                 |
+| Headers        | See below                                            |
+| Body type      | JSON                                                 |
+| Parse response | Yes                                                  |
+
+**Headers:**
+
+| Header             | Value                                                                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Content-Type`     | `application/json`                                                                                                                                          |
+| `X-Goog-Api-Key`   | `{{GOOGLE_API_KEY}}` (from scenario variable)                                                                                                               |
+| `X-Goog-FieldMask` | `places.id,places.displayName,places.formattedAddress,places.nationalPhoneNumber,places.websiteUri,places.rating,places.userRatingCount,places.primaryType` |
+
+**Request body (JSON):**
+
+```json
+{
+  "textQuery": "{{iterator.value}}",
+  "locationBias": {
+    "circle": {
+      "center": { "latitude": 33.4484, "longitude": -112.074 },
+      "radius": 50000.0
+    }
+  },
+  "maxResultCount": 20
+}
+```
+
+**Error handling:** Add an error route -> Resume (continue to next query if one fails)
+
+**Note:** Each query returns up to 20 results. The `locationBias` centers on downtown Phoenix with a 50km radius covering the metro area. Google's $200/mo free credit covers ~6,250 Text Searches — 14 queries per month is well within budget.
+
+#### Step 6: Module 4 — Iterator (Business Results)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: `{{HTTP.body.places}}` (the places array from the Google Places response)
+- If `places` is empty or undefined, the iterator produces 0 items -> scenario continues to next query
+
+#### Step 7: Module 5 — Data Store (Dedup Check)
+
+**Module: Data Store -> Get a record**
+
+- Data store: `seen_businesses`
+- Key: `{{iterator2.id}}` (the Google Places `place_id`)
+
+The `place_id` is a globally unique identifier for each business — it is the natural dedup key.
+
+#### Step 8: Filter — Only New Businesses
+
+**Add a filter between the Data Store module and the next module:**
+
+- Condition: Data Store module **did NOT return a record** (the record does not exist)
+- In Make.com: the filter checks if the Data Store output bundle is empty
+- Label: "New business only"
+
+#### Step 9: Module 6 — Data Store (Add to Master List)
+
+**Module: Data Store -> Add/replace a record**
+
+- Data store: `seen_businesses`
+- Key: `{{iterator2.id}}`
+- Fields:
+
+| Field              | Value                                  |
+| ------------------ | -------------------------------------- |
+| `place_id`         | `{{iterator2.id}}`                     |
+| `business_name`    | `{{iterator2.displayName.text}}`       |
+| `last_scanned`     | `{{formatDate(now; "YYYY-MM-DD")}}`    |
+| `last_review_date` | (leave empty — no reviews scanned yet) |
+| `last_pain_score`  | (leave empty — not scored yet)         |
+
+---
+
+## Scenario B: Weekly Review Scan
+
+Pulls recent reviews for all businesses in the master list, scores them with Claude for operational pain signals, and writes qualified leads to Google Sheets with Slack notifications.
+
+### Scenario Overview
+
+```
+Schedule (every Monday 6am)
+  -> Data Store: search all records in seen_businesses
+  -> Array Aggregator: collect all place_ids
+  -> Iterator: batch into groups of 10 place_ids
+    -> HTTP: Outscraper Reviews API (batch of 10, cutoff=7 days ago)
+    -> Iterator: each business in response
+      -> Filter: has new reviews (reviews_data not empty)
+      -> Anthropic: score reviews with Claude (review-scoring-prompt)
+      -> Parse JSON
+      -> Filter: pain_score >= 7
+      -> Google Sheets: append to "Review Signal Leads"
+      -> Slack: notification to #lead-signals
+      -> Data Store: update seen_businesses (last_scanned, last_pain_score)
+```
+
+**Total modules per scored business:** ~8
+**Expected weekly volume:** 200-500 businesses checked. Of those, maybe 20-50 have new reviews. Of those, maybe 5-15 score >= 7.
+**Operations per run:** ~500-1,500 (depends on how many businesses have new reviews)
+
+---
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com -> Scenarios -> Create a new scenario
+2. Name: `Lead Gen: P1b Weekly Review Scan`
+3. Set the schedule: **Every Monday at 6:00 AM** (MST/Arizona time)
+
+#### Step 2: Add the Trigger — Scheduled
+
+1. The scenario trigger is **Schedule** (built-in)
+2. Set to run once weekly on Monday at 6:00 AM
+
+#### Step 3: Module 1 — Data Store (Search All Businesses)
+
+**Module: Data Store -> Search records**
+
+- Data store: `seen_businesses`
+- Filter: (none — return all records)
+- Limit: 500 (adjust based on how many businesses are in the master list)
+
+This returns all place_ids from the master list built by Scenario A.
+
+#### Step 4: Module 2 — Array Aggregator (Collect Place IDs)
+
+**Module: Tools -> Array aggregator**
+
+- Source module: Data Store (search records)
+- Aggregated field: `place_id`
+
+This collects all place_ids into a single array for batching.
+
+#### Step 5: Module 3 — Set Variable (Batch into Groups of 10)
+
+Outscraper supports batch requests — multiple place_ids in a single API call. Batch into groups of 10 to reduce HTTP round trips while staying within response size limits.
+
+**Module: Tools -> Set multiple variables**
+
+- Variable: `batch_size` = `10`
+
+Then use a **Math -> Ceil** or **Tools -> Set variable** to calculate the number of batches:
+
+- `batch_count` = `{{ceil(length(arrayAggregator.array) / 10)}}`
+
+#### Step 6: Module 4 — Iterator (Batches)
+
+**Module: Flow Control -> Iterator**
+
+- Use a numeric iterator from 0 to `{{batch_count - 1}}`
+- For each iteration, slice the place_id array: `{{slice(arrayAggregator.array; iterator.value * 10; (iterator.value + 1) * 10)}}`
+
+**Alternative simpler approach:** If batch slicing is complex in Make.com's UI, use the Array Aggregator module with a group size of 10 directly. This groups the incoming Data Store results into bundles of 10.
+
+#### Step 7: Module 5 — HTTP (Outscraper Reviews API)
+
+**Module: HTTP -> Make a request**
+
+| Setting          | Value                                          |
+| ---------------- | ---------------------------------------------- |
+| URL              | `https://api.outscraper.com/maps/reviews-v3`   |
+| Method           | GET                                            |
+| Headers          | `Authorization: Bearer {{OUTSCRAPER_API_KEY}}` |
+| Query parameters | See below                                      |
+| Parse response   | Yes                                            |
+
+**Query parameters:**
+
+| Key            | Value                                                                    |
+| -------------- | ------------------------------------------------------------------------ |
+| `query`        | `{{join(currentBatch; ",")}}` (comma-separated place_ids for this batch) |
+| `reviewsLimit` | `10`                                                                     |
+| `sort`         | `newest`                                                                 |
+| `cutoff`       | `{{formatDate(addDays(now; -7); "X")}}`                                  |
+| `async`        | `false`                                                                  |
+| `language`     | `en`                                                                     |
+
+**Cutoff calculation:** The expression `{{formatDate(addDays(now; -7); "X")}}` produces a Unix timestamp for 7 days ago. The `"X"` format code outputs seconds since epoch.
+
+**Error handling:** Add an error route -> Resume (continue to next batch if one fails)
+
+#### Step 8: Module 6 — Iterator (Businesses in Response)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: `{{HTTP.body}}` (Outscraper returns an array of business objects)
+
+#### Step 9: Filter — Has New Reviews
+
+**Add a filter after the Iterator:**
+
+- Condition: `{{length(iterator2.reviews_data)}}` is greater than `0`
+- Label: "Has new reviews"
+
+Businesses with no reviews in the past 7 days return an empty `reviews_data` array. Skip them — no API cost for Claude, no operations spent.
+
+#### Step 10: Module 7 — Anthropic (Claude Review Scoring)
+
+**Module: Anthropic (Claude) -> Create a Message**
+
+| Setting       | Value                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| Model         | `claude-sonnet-4-6` (cost-effective for scoring tasks)                                                        |
+| Max tokens    | `2048` (reviews generate longer output than job qualification)                                                |
+| System prompt | Paste the full content of `REVIEW_SCORING_SYSTEM_PROMPT` from `src/lead-gen/prompts/review-scoring-prompt.ts` |
+
+**User message:**
+
+```
+Analyze the following reviews for operational pain signals.
+
+Business: {{iterator2.name}}
+Place ID: {{iterator2.place_id}}
+Category: {{iterator2.category}}
+Area: (extract from address or set to "Phoenix Metro")
+Overall Rating: {{iterator2.rating}}/5
+Total Reviews: {{iterator2.reviews}}
+
+Recent Reviews ({{length(iterator2.reviews_data)}}):
+{{#each iterator2.reviews_data}}
+- ({{this.review_rating}} stars, {{this.review_datetime_utc}}) "{{this.review_text}}"
+{{/each}}
+
+Produce a single JSON object matching the ReviewScoring schema.
+```
+
+**Note on iteration syntax:** Make.com does not natively support `{{#each}}`. Instead, use a **Text Aggregator** module before the Anthropic module to concatenate the reviews into a single string, or iterate the reviews array and aggregate. The simpler approach: use a **Set Variable** module with Make.com's `join()` function to build the review text block from the `reviews_data` array.
+
+**Batch scoring alternative:** To save operations, you can batch 5-10 businesses per Claude call using the `buildBatchReviewScoringUserPrompt` format from the prompt file. This requires collecting businesses with new reviews using an aggregator, then making a single Claude call per batch. More efficient but more complex to wire up. Start with single-business scoring and optimize later.
+
+#### Step 11: Module 8 — Parse JSON
+
+**Module: JSON -> Parse JSON**
+
+- JSON string: `{{anthropic.content[1].text}}` (Claude's response text)
+- This converts the string into a structured object for downstream modules
+
+#### Step 12: Filter — Pain Score Threshold
+
+**Add a filter after the JSON parse:**
+
+- Condition: `{{json.pain_score}}` is greater than or equal to `7`
+- Label: "Pain score >= 7"
+
+Businesses scoring 1-6 are not worth outreach. They either have no operational signals (1-3) or isolated incidents that don't indicate a pattern (4-6).
+
+#### Step 13: Module 9 — Google Sheets (Append Row)
+
+**Module: Google Sheets -> Add a Row**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "Review Signal Leads"
+- Column mapping:
+
+| Column            | Value                                                               |
+| ----------------- | ------------------------------------------------------------------- |
+| A: Business Name  | `{{json.business_name}}`                                            |
+| B: Phone          | `{{iterator2.phone}}` (from Outscraper response, if available)      |
+| C: Website        | `{{iterator2.site}}` (from Outscraper response, if available)       |
+| D: Category       | `{{iterator2.category}}`                                            |
+| E: Area           | Extract from address or use `{{iterator2.address}}`                 |
+| F: Google Rating  | `{{iterator2.rating}}`                                              |
+| G: Review Count   | `{{iterator2.reviews}}`                                             |
+| H: Pain Score     | `{{json.pain_score}}`                                               |
+| I: Top Problems   | `{{join(json.top_problems; ", ")}}`                                 |
+| J: Evidence       | `{{json.signals[1].quote}}` (first signal quote — or join multiple) |
+| K: Outreach Angle | `{{json.outreach_angle}}`                                           |
+| L: Date Found     | `{{formatDate(now; "YYYY-MM-DD")}}`                                 |
+| M: Status         | `New`                                                               |
+
+#### Step 14: Module 10 — Slack (Notification)
+
+**Module: Slack -> Create a Message**
+
+- Channel: `#lead-signals`
+- Text:
+
+```
+:mag: *New Review Signal Lead*
+*Business:* {{json.business_name}}
+*Pain Score:* {{json.pain_score}}/10
+*Top Problems:* {{join(json.top_problems; ", ")}}
+*Outreach Angle:* {{json.outreach_angle}}
+*Google Rating:* {{iterator2.rating}}/5 ({{iterator2.reviews}} reviews)
+```
+
+#### Step 15: Module 11 — Data Store (Update Business Record)
+
+**Module: Data Store -> Add/replace a record**
+
+- Data store: `seen_businesses`
+- Key: `{{iterator2.place_id}}`
+- Fields:
+
+| Field              | Value                                                                         |
+| ------------------ | ----------------------------------------------------------------------------- |
+| `place_id`         | `{{iterator2.place_id}}`                                                      |
+| `business_name`    | `{{iterator2.name}}`                                                          |
+| `last_scanned`     | `{{formatDate(now; "YYYY-MM-DD")}}`                                           |
+| `last_review_date` | `{{iterator2.reviews_data[1].review_datetime_utc}}` (most recent review date) |
+| `last_pain_score`  | `{{json.pain_score}}`                                                         |
+
+**Important:** This module should also run for businesses that scored below 7 — update `last_scanned` regardless of score. To achieve this, place this module on a separate path BEFORE the pain score filter, or duplicate it. The simplest approach: use a **Router** after the JSON parse module. One path goes through the pain score filter to Sheets and Slack. The other path always runs the Data Store update.
+
+---
+
+## Testing Checklist
+
+### Scenario A (Business Discovery)
+
+- [ ] Run scenario manually (right-click -> Run once)
+- [ ] Verify Google Places API returns results (check HTTP module output)
+- [ ] Verify at least some businesses are new (pass the dedup filter)
+- [ ] Verify new businesses appear in the `seen_businesses` Data Store
+- [ ] Run again — second run should have fewer new businesses (dedup working)
+- [ ] Check operations count — should be within estimated 300-500 per run
+
+### Scenario B (Weekly Review Scan)
+
+- [ ] Run scenario manually after Scenario A has populated `seen_businesses`
+- [ ] Verify Outscraper returns review data (check HTTP module output)
+- [ ] Verify businesses with no new reviews are filtered out
+- [ ] Verify Claude produces valid JSON (check Anthropic module output — valid ReviewScoring schema)
+- [ ] Verify businesses with pain_score >= 7 appear in the Google Sheet
+- [ ] Verify Slack notification arrives in #lead-signals with correct formatting
+- [ ] Verify `seen_businesses` Data Store records are updated with `last_scanned` and `last_pain_score`
+- [ ] Check operations count — should be within estimated 500-1,500 per run
+- [ ] Let scenario run automatically for 3+ weeks, then review all scored leads for accuracy
+
+---
+
+## Tuning
+
+After 2-3 weeks of running:
+
+1. **False positives (high pain scores for businesses without real operational pain):** Review the scored signals. If Claude is flagging service quality complaints as operational issues, add more disqualification examples to the system prompt. The distinction between "rude plumber" (service quality) and "never called me back" (operational) is the critical calibration.
+
+2. **False negatives (operational pain missed):** Check businesses that scored 4-6. If they have clear operational patterns that Claude missed, add similar examples to the prompt's calibration section.
+
+3. **Too many results:** Raise the pain score threshold from 7 to 8. Only the most clearly patterned operational failures will pass.
+
+4. **Too few results:** Lower the threshold to 6, or expand the discovery queries in Scenario A to cover more verticals and geographic areas.
+
+5. **High Outscraper costs:** Reduce the batch frequency from weekly to biweekly. Or filter the `seen_businesses` list to only scan businesses that have been added or updated in the past 90 days (use the cleanup rule from make-data-store-schema.md).
+
+6. **Operations budget:** Batch scoring (multiple businesses per Claude call) significantly reduces operations. Implement batch scoring once single-business scoring is validated.

--- a/docs/lead-automation/recipes/pipeline-2-job-monitor.md
+++ b/docs/lead-automation/recipes/pipeline-2-job-monitor.md
@@ -7,7 +7,6 @@
 - SerpAPI account with API key (Developer plan, $50/mo)
 - Anthropic API key
 - Google Sheets: "SMD Lead Generation" spreadsheet with "Job Signal Leads" tab (see google-sheets-schema.md)
-- Slack: #lead-signals channel created
 - Make.com Data Store: `seen_jobs` created (see make-data-store-schema.md)
 
 ---
@@ -23,13 +22,12 @@ Schedule (daily 6am)
     → Anthropic: qualify with Claude
     → Filter: only qualified = true
     → Google Sheets: append row
-    → Slack: notification
     → Data Store: mark as seen
 ```
 
-**Total modules per job processed:** ~8
+**Total modules per job processed:** ~7
 **Expected daily volume:** 5-15 new jobs across 8 queries
-**Operations per run:** ~100-200 (8 queries × ~10 results × ~8 modules for new ones, minus filtered dupes)
+**Operations per run:** ~90-180 (8 queries × ~10 results × ~7 modules for new ones, minus filtered dupes)
 
 ---
 
@@ -191,24 +189,7 @@ Produce a single JSON object matching the JobQualification schema.
 | L: Date Found            | `{{formatDate(now; "YYYY-MM-DD")}}`      |
 | M: Status                | `New`                                    |
 
-### Step 13: Module 9 — Slack (Notification)
-
-**Module: Slack → Create a Message**
-
-- Channel: `#lead-signals`
-- Text:
-
-```
-:briefcase: *New Job Signal Lead*
-*Company:* {{json.company}}
-*Job Posted:* {{iterator2.title}}
-*Confidence:* {{json.confidence}}
-*Problems:* {{join(json.problems_signaled; ", ")}}
-*Outreach Angle:* {{json.outreach_angle}}
-*Link:* {{iterator2.apply_options[1].link}}
-```
-
-### Step 14: Module 10 — Data Store (Mark as Seen)
+### Step 13: Module 9 — Data Store (Mark as Seen)
 
 **Module: Data Store → Add/replace a record**
 
@@ -232,7 +213,7 @@ Add a second path to the scenario for Craigslist:
 - Max items: 10
 - Schedule: Every 6 hours (separate from the main daily SerpAPI run, or triggered by the same schedule)
 
-Connect the RSS output to the same Anthropic → Filter → Sheets → Slack chain.
+Connect the RSS output to the same Anthropic → Filter → Sheets → Data Store chain.
 
 **Differences for Craigslist:**
 
@@ -252,8 +233,7 @@ To monitor multiple Craigslist queries: use a Router module after the schedule t
 - [ ] Verify dedup works: run twice, second run should skip all previously seen jobs
 - [ ] Verify Claude produces valid JSON (check Anthropic module output)
 - [ ] Verify qualified jobs appear in the Google Sheet
-- [ ] Verify Slack notification arrives in #lead-signals
-- [ ] Check operations count — should be within estimated 100-200 per run
+- [ ] Check operations count — should be within estimated 90-180 per run
 - [ ] Let it run for 3 days automatically, then review all qualified leads for accuracy
 
 ---
@@ -266,3 +246,137 @@ After a week of running:
 2. **False negatives:** If small businesses are being incorrectly disqualified, review the disqualified results (they're still in the Data Store with `qualified: false`) and adjust the prompt.
 3. **Volume too low:** Add the expansion queries (see serpapi-queries.md) or increase `chips` from `3days` to `week`.
 4. **Volume too high:** Add a filter for `confidence` — only pass `high` and `medium` to Sheets.
+
+> **Note:** Notifications are handled by the Daily Digest scenario (see below), not per-lead.
+
+---
+
+## Daily Digest Scenario
+
+A separate Make.com scenario that sends one morning email summarizing all new leads across all pipelines.
+
+### Scenario Overview
+
+```
+Schedule (daily 6:30am, runs AFTER all pipeline scenarios)
+  → Google Sheets: search "Job Signal Leads" for rows where Date Found = today
+  → Google Sheets: search "Review Signal Leads" for rows where Date Found = today
+  → Google Sheets: search "New Business Leads" for rows where Date Found = today
+  → Text Aggregator: compile all new leads into a digest
+  → Gmail: send email to self
+```
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com → Scenarios → Create a new scenario
+2. Name: `Lead Gen: Daily Digest`
+3. Set the schedule: **Every day at 6:30 AM** (MST/Arizona time — Arizona does not observe DST)
+
+This runs 30 minutes after the earliest pipeline (P2 Job Monitor at 6:00 AM) and after P3 City Permits (7:00 AM). All pipelines will have completed by 6:30 AM on most days. If P3 runs later, adjust to 7:30 AM.
+
+#### Step 2: Module 1 — Google Sheets (Search Job Signal Leads)
+
+**Module: Google Sheets → Search Rows**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "Job Signal Leads"
+- Filter: `L: Date Found` equals `{{formatDate(now; "YYYY-MM-DD")}}`
+
+#### Step 3: Module 2 — Google Sheets (Search Review Signal Leads)
+
+**Module: Google Sheets → Search Rows**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "Review Signal Leads"
+- Filter: `L: Date Found` equals `{{formatDate(now; "YYYY-MM-DD")}}`
+
+#### Step 4: Module 3 — Google Sheets (Search New Business Leads)
+
+**Module: Google Sheets → Search Rows**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "New Business Leads"
+- Filter: `J: Date Found` equals `{{formatDate(now; "YYYY-MM-DD")}}`
+
+#### Step 5: Module 4 — Text Aggregator (Compile Digest)
+
+**Module: Tools → Set multiple variables**
+
+Build the digest body from the three sheet search results. Use `ifempty` to handle days with no results for a given pipeline.
+
+- Variable: `digest_body`
+- Value:
+
+```
+REVIEW SIGNALS ({{length(sheetsModule2.results)}})
+{{#each sheetsModule2.results}}
+- {{this.A: Business Name}} | Pain: {{this.H: Pain Score}}/10 | {{this.I: Top Problems}} | {{this.K: Outreach Angle}}
+{{/each}}
+
+JOB SIGNALS ({{length(sheetsModule1.results)}})
+{{#each sheetsModule1.results}}
+- {{this.A: Company Name}} hiring {{this.B: Job Title Posted}} | {{this.G: Confidence}} | {{this.H: Problems Signaled}} | {{this.J: Outreach Angle}}
+{{/each}}
+
+NEW BUSINESSES ({{length(sheetsModule3.results)}})
+{{#each sheetsModule3.results}}
+- {{this.A: Business Name}} | {{this.E: Source}} | {{this.G: Vertical Match}} | {{this.I: Outreach Timing}}
+{{/each}}
+
+Full details in the Lead Generation spreadsheet.
+```
+
+**Note on iteration:** Make.com does not support `{{#each}}` natively. Use Text Aggregator modules after each Google Sheets search to concatenate the rows into formatted text blocks, then combine them in a Set Variable module. Alternatively, use Iterator → Text Aggregator chains for each sheet result set.
+
+- Variable: `total_count`
+- Value: `{{length(sheetsModule1.results) + length(sheetsModule2.results) + length(sheetsModule3.results)}}`
+
+#### Step 6: Filter — Only Send if Leads Exist
+
+**Add a filter before the Gmail module:**
+
+- Condition: `{{total_count}}` is greater than `0`
+- Label: "Has new leads"
+
+This prevents sending an empty digest on quiet days.
+
+#### Step 7: Module 5 — Gmail (Send Digest Email)
+
+**Module: Gmail → Send an Email**
+
+| Setting      | Value                                                                             |
+| ------------ | --------------------------------------------------------------------------------- |
+| To           | Your business email address                                                       |
+| Subject      | `Lead Gen Digest — {{formatDate(now; "YYYY-MM-DD")}} — {{total_count}} new leads` |
+| Content      | `{{digest_body}}`                                                                 |
+| Content type | Plain text                                                                        |
+
+**Email format:**
+
+```
+Subject: Lead Gen Digest — {date} — {total_count} new leads
+
+REVIEW SIGNALS ({count})
+- {business_name} | Pain: {score}/10 | {top_problems} | {outreach_angle}
+
+JOB SIGNALS ({count})
+- {company} hiring {title} | {confidence} | {problems} | {outreach_angle}
+
+NEW BUSINESSES ({count})
+- {business_name} | {source} | {vertical} | {outreach_timing}
+
+SOCIAL ({count})
+- {platform}: {title} — {url}
+
+Full details in the Lead Generation spreadsheet.
+```
+
+### Operations Estimate
+
+~50 ops/day (3 sheet searches + aggregation + email)
+
+### Note
+
+This scenario runs once daily after all other scenarios complete. All pipelines write their results to Google Sheets; this scenario reads from those sheets and compiles a single morning summary.

--- a/docs/lead-automation/recipes/pipeline-2-job-monitor.md
+++ b/docs/lead-automation/recipes/pipeline-2-job-monitor.md
@@ -1,0 +1,268 @@
+# Make.com Recipe: Pipeline 2 — Job Posting Monitor
+
+**Purpose:** Step-by-step guide to build the Make.com scenario that monitors Phoenix job postings for operational pain signals at small businesses.
+
+**Prerequisites:**
+
+- SerpAPI account with API key (Developer plan, $50/mo)
+- Anthropic API key
+- Google Sheets: "SMD Lead Generation" spreadsheet with "Job Signal Leads" tab (see google-sheets-schema.md)
+- Slack: #lead-signals channel created
+- Make.com Data Store: `seen_jobs` created (see make-data-store-schema.md)
+
+---
+
+## Scenario Overview
+
+```
+Schedule (daily 6am)
+  → HTTP: SerpAPI query 1
+  → Iterator: each job result
+    → Data Store: check seen_jobs (dedup)
+    → Filter: only new jobs
+    → Anthropic: qualify with Claude
+    → Filter: only qualified = true
+    → Google Sheets: append row
+    → Slack: notification
+    → Data Store: mark as seen
+```
+
+**Total modules per job processed:** ~8
+**Expected daily volume:** 5-15 new jobs across 8 queries
+**Operations per run:** ~100-200 (8 queries × ~10 results × ~8 modules for new ones, minus filtered dupes)
+
+---
+
+## Step-by-Step Build
+
+### Step 1: Create the Scenario
+
+1. In Make.com → Scenarios → Create a new scenario
+2. Name: `Lead Gen: P2 Job Monitor`
+3. Set the schedule: **Every day at 6:00 AM** (MST/Arizona time — Arizona does not observe DST)
+
+### Step 2: Add the Trigger — Scheduled
+
+1. The scenario trigger is **Schedule** (built-in)
+2. Set to run once daily at 6:00 AM
+3. This fires the first module in the chain
+
+### Step 3: Module 1 — HTTP (SerpAPI Query)
+
+We need to run 8 queries. The simplest approach: use a **Set Variable** module to define the query list, then iterate.
+
+**Module: Tools → Set multiple variables**
+
+- Variable 1: `queries` (array)
+- Value:
+
+```json
+[
+  "office manager",
+  "operations manager",
+  "dispatcher",
+  "scheduling coordinator",
+  "customer service coordinator",
+  "office administrator",
+  "front desk manager",
+  "service coordinator"
+]
+```
+
+### Step 4: Module 2 — Iterator (Query List)
+
+**Module: Flow Control → Iterator**
+
+- Source array: `{{queries}}` (from the Set Variable module)
+- This processes each query term one at a time
+
+### Step 5: Module 3 — HTTP (SerpAPI Request)
+
+**Module: HTTP → Make a request**
+
+| Setting          | Value                        |
+| ---------------- | ---------------------------- |
+| URL              | `https://serpapi.com/search` |
+| Method           | GET                          |
+| Query parameters | See below                    |
+| Parse response   | Yes                          |
+
+**Query parameters:**
+| Key | Value |
+|-----|-------|
+| `engine` | `google_jobs` |
+| `q` | `{{iterator.value}}` (the current query term) |
+| `location` | `Phoenix, Arizona, United States` |
+| `chips` | `date_posted:3days` |
+| `api_key` | `{{SERPAPI_API_KEY}}` (from connection or scenario variable) |
+
+**Error handling:** Add an error route → Resume (continue to next query if one fails)
+
+### Step 6: Module 4 — Iterator (Job Results)
+
+**Module: Flow Control → Iterator**
+
+- Source array: `{{HTTP.body.jobs_results}}` (the jobs array from SerpAPI response)
+- If `jobs_results` is empty or undefined, the iterator produces 0 items → scenario continues to next query
+
+### Step 7: Module 5 — Data Store (Dedup Check)
+
+**Module: Data Store → Get a record**
+
+- Data store: `seen_jobs`
+- Key: Use a hash of company + title + location. In Make.com, construct the key:
+  ```
+  {{sha256(iterator2.company_name + "|" + iterator2.title + "|" + iterator2.location)}}
+  ```
+  (If `sha256` is not available natively, use `md5` or concatenate the fields as the key directly — just ensure uniqueness)
+
+**Alternative simpler key:** `{{iterator2.company_name}}_{{iterator2.title}}` (less collision-proof but functional)
+
+### Step 8: Filter — Only New Jobs
+
+**Add a filter between the Data Store module and the next module:**
+
+- Condition: Data Store module **did NOT return a record** (the record does not exist)
+- In Make.com: the filter checks if the Data Store output bundle is empty
+- Label: "New job only"
+
+### Step 9: Module 6 — Anthropic (Claude Qualification)
+
+**Module: Anthropic (Claude) → Create a Message**
+
+| Setting       | Value                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Model         | `claude-sonnet-4-6` (cost-effective for classification tasks)                                                       |
+| Max tokens    | `1024`                                                                                                              |
+| System prompt | Paste the full content of `JOB_QUALIFICATION_SYSTEM_PROMPT` from `src/lead-gen/prompts/job-qualification-prompt.ts` |
+
+**User message:**
+
+```
+Analyze this job posting and determine if it signals operational pain at a small business.
+
+Job title: {{iterator2.title}}
+Company: {{iterator2.company_name}}
+Location: {{iterator2.location}}
+Source: google_jobs
+URL: {{iterator2.apply_options[1].link}}
+
+Description:
+{{iterator2.description}}
+
+Produce a single JSON object matching the JobQualification schema.
+```
+
+### Step 10: Module 7 — Parse JSON
+
+**Module: JSON → Parse JSON**
+
+- JSON string: `{{anthropic.content[1].text}}` (Claude's response text)
+- This converts the string into a structured object you can reference in downstream modules
+
+### Step 11: Filter — Only Qualified
+
+**Add a filter after the JSON parse:**
+
+- Condition: `{{json.qualified}}` equals `true`
+- Label: "Qualified only"
+
+### Step 12: Module 8 — Google Sheets (Append Row)
+
+**Module: Google Sheets → Add a Row**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "Job Signal Leads"
+- Column mapping:
+
+| Column                   | Value                                    |
+| ------------------------ | ---------------------------------------- |
+| A: Company Name          | `{{json.company}}`                       |
+| B: Job Title Posted      | `{{iterator2.title}}`                    |
+| C: Location              | `{{iterator2.location}}`                 |
+| D: Source                | `Google Jobs`                            |
+| E: Company Size Estimate | `{{json.company_size_estimate}}`         |
+| F: Qualified             | `Yes`                                    |
+| G: Confidence            | `{{json.confidence}}`                    |
+| H: Problems Signaled     | `{{join(json.problems_signaled; ", ")}}` |
+| I: Evidence              | `{{json.evidence}}`                      |
+| J: Outreach Angle        | `{{json.outreach_angle}}`                |
+| K: Job Posting URL       | `{{iterator2.apply_options[1].link}}`    |
+| L: Date Found            | `{{formatDate(now; "YYYY-MM-DD")}}`      |
+| M: Status                | `New`                                    |
+
+### Step 13: Module 9 — Slack (Notification)
+
+**Module: Slack → Create a Message**
+
+- Channel: `#lead-signals`
+- Text:
+
+```
+:briefcase: *New Job Signal Lead*
+*Company:* {{json.company}}
+*Job Posted:* {{iterator2.title}}
+*Confidence:* {{json.confidence}}
+*Problems:* {{join(json.problems_signaled; ", ")}}
+*Outreach Angle:* {{json.outreach_angle}}
+*Link:* {{iterator2.apply_options[1].link}}
+```
+
+### Step 14: Module 10 — Data Store (Mark as Seen)
+
+**Module: Data Store → Add/replace a record**
+
+- Data store: `seen_jobs`
+- Key: Same hash as Step 7
+- Fields:
+  - `company_name`: `{{iterator2.company_name}}`
+  - `job_title`: `{{iterator2.title}}`
+  - `first_seen`: `{{formatDate(now; "YYYY-MM-DD")}}`
+  - `qualified`: `{{json.qualified}}`
+
+---
+
+## Craigslist RSS Addition
+
+Add a second path to the scenario for Craigslist:
+
+### Module: RSS → Watch RSS Feed Items
+
+- URL: `https://phoenix.craigslist.org/search/jjj?query=office+manager&format=rss`
+- Max items: 10
+- Schedule: Every 6 hours (separate from the main daily SerpAPI run, or triggered by the same schedule)
+
+Connect the RSS output to the same Anthropic → Filter → Sheets → Slack chain.
+
+**Differences for Craigslist:**
+
+- `source` = `craigslist`
+- `company` may be extracted from the title or set to `"(Craigslist - see posting)"`
+- RSS provides `title`, `link`, `description` (truncated), and `pubDate`
+- Pass the `description` as the job description (it's shorter, Claude will work with what it has)
+
+To monitor multiple Craigslist queries: use a Router module after the schedule trigger, with separate RSS modules for each query term on parallel paths.
+
+---
+
+## Testing Checklist
+
+- [ ] Run scenario manually (right-click → Run once)
+- [ ] Verify SerpAPI returns results (check HTTP module output)
+- [ ] Verify dedup works: run twice, second run should skip all previously seen jobs
+- [ ] Verify Claude produces valid JSON (check Anthropic module output)
+- [ ] Verify qualified jobs appear in the Google Sheet
+- [ ] Verify Slack notification arrives in #lead-signals
+- [ ] Check operations count — should be within estimated 100-200 per run
+- [ ] Let it run for 3 days automatically, then review all qualified leads for accuracy
+
+---
+
+## Tuning
+
+After a week of running:
+
+1. **False positives:** If too many large companies are being qualified, tighten the system prompt examples or add more disqualification criteria.
+2. **False negatives:** If small businesses are being incorrectly disqualified, review the disqualified results (they're still in the Data Store with `qualified: false`) and adjust the prompt.
+3. **Volume too low:** Add the expansion queries (see serpapi-queries.md) or increase `chips` from `3days` to `week`.
+4. **Volume too high:** Add a filter for `confidence` — only pass `high` and `medium` to Sheets.

--- a/docs/lead-automation/recipes/pipeline-3-new-business.md
+++ b/docs/lead-automation/recipes/pipeline-3-new-business.md
@@ -1,0 +1,472 @@
+# Make.com Recipe: Pipeline 3 — New Business Detection
+
+**Purpose:** Step-by-step guide to build two Make.com scenarios that detect new and expanding businesses from city permit feeds and state filing data, then qualify them as potential prospects using Claude.
+
+**Prerequisites:**
+
+- Google Sheets: "SMD Lead Generation" spreadsheet with "New Business Leads" tab (see google-sheets-schema.md)
+- Slack: #lead-signals channel created
+- Anthropic API key
+- Make.com Data Store: `seen_permits` created (see make-data-store-schema.md)
+- Gmail connection (for Scenario B — ACC/ADOR file intake)
+- SODA API dataset IDs identified for Phoenix, Scottsdale, and Chandler (see soda-api-queries.md, Setup Steps section)
+
+**No external API accounts needed for SODA endpoints** — city open data portals are free and require no authentication.
+
+---
+
+## Scenario A: City Permits (Daily)
+
+Queries three city open data portals for new commercial permits issued in the last 24 hours, qualifies each with Claude, and writes qualified leads to Google Sheets.
+
+### Scenario Overview
+
+```
+Schedule (daily 7am)
+  -> Router: 3 paths (one per city)
+    Path 1: HTTP -> Phoenix SODA API (commercial permits, last 24 hours)
+    Path 2: HTTP -> Scottsdale SODA API
+    Path 3: HTTP -> Chandler SODA API
+  -> (each path continues:)
+    -> Iterator: each permit result
+      -> Data Store: check seen_permits (dedup by permit number)
+      -> Filter: only new permits
+      -> Anthropic: qualify with Claude (new-business-prompt)
+      -> Parse JSON
+      -> Filter: outreach_timing != "not_recommended"
+      -> Google Sheets: append to "New Business Leads"
+      -> Slack: notification (if vertical_match is home_services or professional_services)
+      -> Data Store: mark as seen
+```
+
+**Total modules per qualified permit:** ~8
+**Expected daily volume:** 0-10 new commercial permits per day across all 3 cities. Most days will be low volume.
+**Operations per run:** ~50-150 (low volume source)
+
+---
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com -> Scenarios -> Create a new scenario
+2. Name: `Lead Gen: P3a City Permits`
+3. Set the schedule: **Every day at 7:00 AM** (MST/Arizona time — Arizona does not observe DST)
+
+#### Step 2: Add the Trigger — Scheduled
+
+1. The scenario trigger is **Schedule** (built-in)
+2. Set to run once daily at 7:00 AM
+
+#### Step 3: Module 1 — Router (3 City Paths)
+
+**Module: Flow Control -> Router**
+
+Add 3 routes from the router. Each route queries a different city's SODA API. The Router runs all 3 paths in parallel — each city is independent.
+
+Label each route:
+
+- Route 1: "Phoenix Permits"
+- Route 2: "Scottsdale Permits"
+- Route 3: "Chandler Permits"
+
+#### Step 4: Module 2a — HTTP (Phoenix SODA API)
+
+**Module: HTTP -> Make a request** (on Route 1)
+
+| Setting          | Value                                                        |
+| ---------------- | ------------------------------------------------------------ |
+| URL              | `https://www.phoenixopendata.com/resource/{DATASET_ID}.json` |
+| Method           | GET                                                          |
+| Headers          | None (no auth required)                                      |
+| Query parameters | See below                                                    |
+| Parse response   | Yes                                                          |
+
+**Query parameters (as URL query string):**
+
+| Key      | Value                                                                                                    |
+| -------- | -------------------------------------------------------------------------------------------------------- |
+| `$where` | `issue_date > '{{formatDate(addDays(now; -1); "YYYY-MM-DD")}}' AND permit_type_desc LIKE '%COMMERCIAL%'` |
+| `$limit` | `100`                                                                                                    |
+| `$order` | `issue_date DESC`                                                                                        |
+
+**Important:** Replace `{DATASET_ID}` with the actual 4-character Socrata resource ID. To find it:
+
+1. Visit phoenixopendata.com
+2. Search for "building permits"
+3. Note the resource ID from the URL (format: `xxxx-xxxx`)
+4. Click "API" to see the exact column names
+5. Adjust `$where` clause column names to match the actual schema
+
+The `$where` clause column names (`issue_date`, `permit_type_desc`) are templates — the actual column names vary by dataset. See soda-api-queries.md for alternative filter approaches if column names differ.
+
+**Date filter:** The expression `{{formatDate(addDays(now; -1); "YYYY-MM-DD")}}` produces yesterday's date in ISO format, e.g., `2026-03-29`.
+
+**Error handling:** Add an error route -> Resume (continue if this city's API is down)
+
+#### Step 5: Module 2b — HTTP (Scottsdale SODA API)
+
+**Module: HTTP -> Make a request** (on Route 2)
+
+| Setting          | Value                                                                      |
+| ---------------- | -------------------------------------------------------------------------- |
+| URL              | `https://data.scottsdaleaz.gov/resource/{DATASET_ID}.json`                 |
+| Method           | GET                                                                        |
+| Query parameters | Same structure as Phoenix, but adjust column names per Scottsdale's schema |
+| Parse response   | Yes                                                                        |
+
+**Query parameters:**
+
+| Key      | Value                                                                                           |
+| -------- | ----------------------------------------------------------------------------------------------- |
+| `$where` | `issued_date > '{{formatDate(addDays(now; -1); "YYYY-MM-DD")}}' AND permit_type = 'Commercial'` |
+| `$limit` | `100`                                                                                           |
+| `$order` | `issued_date DESC`                                                                              |
+
+Same setup steps: find the dataset ID, confirm column names, test in a browser.
+
+#### Step 6: Module 2c — HTTP (Chandler SODA API)
+
+**Module: HTTP -> Make a request** (on Route 3)
+
+| Setting          | Value                                                    |
+| ---------------- | -------------------------------------------------------- |
+| URL              | `https://data.chandleraz.gov/resource/{DATASET_ID}.json` |
+| Method           | GET                                                      |
+| Query parameters | Same structure, adjusted for Chandler's column names     |
+| Parse response   | Yes                                                      |
+
+**Query parameters:**
+
+| Key      | Value                                                                                         |
+| -------- | --------------------------------------------------------------------------------------------- |
+| `$where` | `issue_date > '{{formatDate(addDays(now; -1); "YYYY-MM-DD")}}' AND work_class = 'Commercial'` |
+| `$limit` | `100`                                                                                         |
+| `$order` | `issue_date DESC`                                                                             |
+
+#### Step 7: Module 3 — Iterator (Permit Results)
+
+**Module: Flow Control -> Iterator** (add one per route, after each HTTP module)
+
+- Source array: `{{HTTP.body}}` (SODA APIs return a JSON array of permit records)
+- If the API returns no results (empty array), the iterator produces 0 items -> scenario moves to the next route
+
+**Field normalization note:** Each city uses different column names. Before passing data downstream, use a **Set Variable** module to normalize fields to a standard format:
+
+| Standard Field  | Phoenix (example)            | Scottsdale (example)            | Chandler (example)           |
+| --------------- | ---------------------------- | ------------------------------- | ---------------------------- |
+| `permit_number` | `{{iterator.permit_number}}` | `{{iterator.permit_no}}`        | `{{iterator.permit_number}}` |
+| `business_name` | `{{iterator.owner_name}}`    | `{{iterator.contractor_name}}`  | `{{iterator.owner_name}}`    |
+| `address`       | `{{iterator.address}}`       | `{{iterator.site_address}}`     | `{{iterator.address}}`       |
+| `permit_date`   | `{{iterator.issue_date}}`    | `{{iterator.issued_date}}`      | `{{iterator.issue_date}}`    |
+| `description`   | `{{iterator.description}}`   | `{{iterator.work_description}}` | `{{iterator.description}}`   |
+| `source`        | `phoenix_permit`             | `scottsdale_permit`             | `chandler_permit`            |
+
+Fill in the actual column names during setup by examining the API responses from each city (see soda-api-queries.md, Normalization section).
+
+#### Step 8: Module 4 — Data Store (Dedup Check)
+
+**Module: Data Store -> Get a record**
+
+- Data store: `seen_permits`
+- Key: `{{permit_number}}` (the normalized permit number from Step 7)
+
+The permit number is a natural unique identifier for each record.
+
+#### Step 9: Filter — Only New Permits
+
+**Add a filter after the Data Store module:**
+
+- Condition: Data Store module **did NOT return a record** (the record does not exist)
+- Label: "New permit only"
+
+#### Step 10: Module 5 — Anthropic (Claude Qualification)
+
+**Module: Anthropic (Claude) -> Create a Message**
+
+| Setting       | Value                                                                                        |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| Model         | `claude-haiku-4-5` (sufficient for this simpler classification task)                         |
+| Max tokens    | `1024`                                                                                       |
+| System prompt | Paste the full content of `SYSTEM_PROMPT` from `src/lead-gen/prompts/new-business-prompt.ts` |
+
+**User message:**
+
+```
+Analyze this new business filing and determine if it's a potential operations consulting prospect.
+
+Business name: {{business_name}}
+Entity type: Commercial Permit
+Address: {{address}}
+Filing date: {{permit_date}}
+Source: {{source}}
+Permit type: {{iterator.permit_type}} (or work_class, depending on city)
+Additional data: {{description}}
+
+Produce a single JSON object matching the NewBusinessQualification schema.
+```
+
+**Why claude-haiku-4-5:** This is a simpler classification task than review scoring. The prompt provides clear heuristics for vertical detection and disqualification criteria. Haiku handles this well at significantly lower cost per call.
+
+**Error handling:** Add an error route -> Resume (if Claude returns invalid JSON, skip this permit and continue)
+
+#### Step 11: Module 6 — Parse JSON
+
+**Module: JSON -> Parse JSON**
+
+- JSON string: `{{anthropic.content[1].text}}` (Claude's response text)
+- This converts the string into a structured object for downstream modules
+
+#### Step 12: Filter — Only Qualified
+
+**Add a filter after the JSON parse:**
+
+- Condition: `{{json.outreach_timing}}` does NOT equal `not_recommended`
+- Label: "Qualified only"
+
+This passes permits where Claude recommends "immediate", "wait_30_days", or "wait_60_days" — all indicating a potential prospect worth tracking.
+
+#### Step 13: Module 7 — Google Sheets (Append Row)
+
+**Module: Google Sheets -> Add a Row**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "New Business Leads"
+- Column mapping:
+
+| Column                | Value                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| A: Business Name      | `{{json.business_name}}`                                                           |
+| B: Entity Type        | `{{json.entity_type}}`                                                             |
+| C: Address            | `{{json.address}}`                                                                 |
+| D: Area               | `{{json.area}}`                                                                    |
+| E: Source             | `{{json.source}}` (e.g., "phoenix_permit", "scottsdale_permit", "chandler_permit") |
+| F: Filing/Permit Date | `{{permit_date}}`                                                                  |
+| G: Vertical Match     | `{{json.vertical_match}}`                                                          |
+| H: Size Estimate      | `{{json.size_estimate}}`                                                           |
+| I: Outreach Timing    | `{{json.outreach_timing}}`                                                         |
+| J: Date Found         | `{{formatDate(now; "YYYY-MM-DD")}}`                                                |
+| K: Status             | `New`                                                                              |
+
+#### Step 14: Module 8 — Slack (Conditional Notification)
+
+**Module: Slack -> Create a Message**
+
+Add a filter BEFORE the Slack module:
+
+- Condition: `{{json.vertical_match}}` equals `home_services` OR `{{json.vertical_match}}` equals `professional_services`
+- Label: "Primary verticals only"
+
+This ensures Slack notifications only fire for businesses in our launch verticals. Other verticals still go to the Google Sheet but don't generate noise in the Slack channel.
+
+- Channel: `#lead-signals`
+- Text:
+
+```
+:building_construction: *New Business Detected*
+*Business:* {{json.business_name}}
+*Source:* {{json.source}}
+*Vertical:* {{json.vertical_match}}
+*Outreach Timing:* {{json.outreach_timing}}
+*Area:* {{json.area}}
+*Outreach Angle:* {{json.outreach_angle}}
+```
+
+#### Step 15: Module 9 — Data Store (Mark as Seen)
+
+**Module: Data Store -> Add/replace a record**
+
+- Data store: `seen_permits`
+- Key: `{{permit_number}}`
+- Fields:
+
+| Field            | Value                               |
+| ---------------- | ----------------------------------- |
+| `record_id`      | `{{permit_number}}`                 |
+| `business_name`  | `{{json.business_name}}`            |
+| `source`         | `{{source}}`                        |
+| `date_processed` | `{{formatDate(now; "YYYY-MM-DD")}}` |
+
+**Important:** This module should run for ALL permits (including disqualified ones) to prevent reprocessing. Place this module BEFORE the qualification filter, or add it to both the qualified and disqualified paths using a Router after the JSON parse.
+
+---
+
+## Scenario B: ACC/ADOR File Intake (On-demand)
+
+Triggered by email — when the Arizona Corporation Commission or ADOR responds to public records requests with data files. Not scheduled; fires when a matching email arrives.
+
+### Scenario Overview
+
+```
+Gmail: Watch for new emails (with label "ACC-ADOR-Data")
+  -> Google Drive: download attachment
+  -> CSV/Excel: parse file
+  -> Iterator: each row
+    -> Data Store: check seen_permits (dedup)
+    -> Filter: only new entries
+    -> Anthropic: qualify with Claude
+    -> Parse JSON
+    -> Filter: qualified
+    -> Google Sheets: append to "New Business Leads"
+    -> Data Store: mark as seen
+```
+
+**Expected volume per file:** 10-100 new entities per ACC weekly extract. 50-200 per ADOR monthly extract.
+**Operations per run:** ~200-1,000 (depends on file size)
+
+---
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com -> Scenarios -> Create a new scenario
+2. Name: `Lead Gen: P3b ACC/ADOR Intake`
+3. Set the schedule: **Immediately** (event-driven, not scheduled)
+
+#### Step 2: Gmail Setup — Create the Label
+
+Before building the scenario, set up Gmail filtering:
+
+1. In Gmail, create a label: `ACC-ADOR-Data`
+2. Create a Gmail filter for emails from ACC (`records@azcc.gov`) and ADOR (verify current email on azdor.gov) that have attachments
+3. Apply the `ACC-ADOR-Data` label automatically
+4. This separates ACC/ADOR data emails from regular inbox traffic
+
+#### Step 3: Module 1 — Gmail (Watch for Emails)
+
+**Module: Gmail -> Watch Emails**
+
+- Label: `ACC-ADOR-Data`
+- Criteria: Has attachment
+- Maximum number of results: 1 (process one email at a time)
+
+This module polls Gmail for new emails with the `ACC-ADOR-Data` label. When a matching email arrives, it triggers the scenario.
+
+#### Step 4: Module 2 — Gmail (Download Attachment)
+
+**Module: Gmail -> Download Attachment** (or use an Iterator on the email's attachments)
+
+- Email ID: `{{gmail.id}}` (from the Watch module)
+- Attachment index: 1 (the first attachment — ACC/ADOR typically sends a single file)
+
+#### Step 5: Module 3 — CSV/Excel Parse
+
+**Module: CSV -> Parse CSV** (for ACC data) or **Microsoft Excel -> Parse Excel** (if ADOR sends .xlsx)
+
+For CSV:
+
+- Source file: `{{gmail.attachments[1].data}}` (the downloaded attachment)
+- Delimiter: `,` (standard CSV)
+- First row is header: Yes
+
+For Excel:
+
+- Source file: `{{gmail.attachments[1].data}}`
+- Sheet: 1 (first sheet)
+- First row is header: Yes
+
+**Handling both formats:** Use a **Router** after the attachment download. Route 1 handles `.csv` files (filter on filename ending in `.csv`). Route 2 handles `.xlsx` files. Both routes feed into the same downstream processing chain.
+
+#### Step 6: Module 4 — Iterator (Each Row)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: The parsed rows from the CSV/Excel module
+
+Each row represents one business filing or TPT license.
+
+#### Step 7: Module 5 — Data Store (Dedup Check)
+
+**Module: Data Store -> Get a record**
+
+- Data store: `seen_permits`
+- Key: Use the filing number or entity number from the row. The exact column depends on the ACC/ADOR file format:
+  - ACC: Entity number or file number (e.g., `{{iterator.entity_number}}`)
+  - ADOR: License number (e.g., `{{iterator.license_number}}`)
+
+#### Step 8: Filter — Only New Entries
+
+**Add a filter:**
+
+- Condition: Data Store module **did NOT return a record**
+- Label: "New entity only"
+
+#### Step 9: Module 6 — Anthropic (Claude Qualification)
+
+**Module: Anthropic (Claude) -> Create a Message**
+
+| Setting       | Value                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| Model         | `claude-haiku-4-5`                                                                            |
+| Max tokens    | `1024`                                                                                        |
+| System prompt | Same as Scenario A — paste `SYSTEM_PROMPT` from `src/lead-gen/prompts/new-business-prompt.ts` |
+
+**User message:**
+
+```
+Analyze this new business filing and determine if it's a potential operations consulting prospect.
+
+Business name: {{iterator.business_name}}
+Entity type: {{iterator.entity_type}}
+Address: {{iterator.address}}
+Filing date: {{iterator.filing_date}}
+Source: acc_filing (or ador_tpt — set based on which label/sender triggered the email)
+Additional data: {{iterator.description}} (or any other relevant columns)
+
+Produce a single JSON object matching the NewBusinessQualification schema.
+```
+
+**Source determination:** Use a **Set Variable** module before the Claude call to set the `source` field based on the email sender. If the email is from `records@azcc.gov`, set source to `acc_filing`. If from ADOR, set to `ador_tpt`.
+
+#### Step 10: Modules 7-9 — Parse, Filter, Sheet, Data Store
+
+These modules are identical to Scenario A Steps 11-15:
+
+1. **Parse JSON** — Parse Claude's response
+2. **Filter** — `outreach_timing` != `not_recommended`
+3. **Google Sheets** — Append to "New Business Leads" (same column mapping as Scenario A, with `source` reflecting `acc_filing` or `ador_tpt`)
+4. **Data Store** — Mark as seen in `seen_permits`
+
+No Slack notification for this scenario — the volume is higher per run and the filings are less time-sensitive than permits. Review the Google Sheet periodically instead.
+
+---
+
+## Testing Checklist
+
+### Scenario A (City Permits)
+
+- [ ] Run scenario manually (right-click -> Run once)
+- [ ] Verify each SODA API returns data (check HTTP module output for all 3 cities)
+- [ ] If a city returns no data, verify the dataset ID and column names are correct by testing the URL in a browser: `https://{portal}/resource/{ID}.json?$limit=5`
+- [ ] Verify dedup works: run twice, second run should skip all previously seen permits
+- [ ] Verify Claude produces valid JSON (check Anthropic module output)
+- [ ] Verify qualified permits appear in the Google Sheet with correct source values
+- [ ] Verify Slack notification fires only for `home_services` and `professional_services` verticals
+- [ ] Check operations count — should be within estimated 50-150 per run
+- [ ] Let scenario run automatically for 5+ days, then review all qualified leads for accuracy
+
+### Scenario B (ACC/ADOR Intake)
+
+- [ ] Send a test email to yourself with the `ACC-ADOR-Data` label and a sample CSV attachment
+- [ ] Verify the Gmail Watch module picks up the email
+- [ ] Verify the CSV is parsed correctly (check column names and data types)
+- [ ] Verify dedup works: process the same file twice, second run should skip all entries
+- [ ] Verify Claude produces valid JSON for each row
+- [ ] Verify qualified entities appear in the Google Sheet
+
+---
+
+## Tuning
+
+After 1-2 weeks of running:
+
+1. **Dataset IDs not found:** The most common setup issue. Visit each city's open data portal, search for building permits, and note the exact resource ID and column names. Test each URL in a browser before entering it in Make.com.
+
+2. **Too many irrelevant permits:** The SODA `$where` filter may be too broad. Tighten the filter to look specifically for tenant improvement permits: `description LIKE '%tenant improvement%'` or `permit_subtype = 'Tenant Improvement'` (adjust column names to match the actual schema).
+
+3. **Too few results:** Broaden the filter. Remove the `COMMERCIAL` restriction and let Claude handle classification — it will disqualify non-commercial permits via the prompt.
+
+4. **Claude over-qualifying:** If too many holding companies, franchises, or non-operational entities are passing qualification, add more disqualification examples to the system prompt. The existing prompt handles common cases but may need tuning for local patterns.
+
+5. **ACC/ADOR file format changes:** When ACC or ADOR changes their file format, the CSV/Excel parse module will break. Update the column mappings and iterator references to match the new format. Keep a sample of each file format for reference.

--- a/docs/lead-automation/recipes/pipeline-3-new-business.md
+++ b/docs/lead-automation/recipes/pipeline-3-new-business.md
@@ -5,7 +5,6 @@
 **Prerequisites:**
 
 - Google Sheets: "SMD Lead Generation" spreadsheet with "New Business Leads" tab (see google-sheets-schema.md)
-- Slack: #lead-signals channel created
 - Anthropic API key
 - Make.com Data Store: `seen_permits` created (see make-data-store-schema.md)
 - Gmail connection (for Scenario B — ACC/ADOR file intake)
@@ -35,13 +34,12 @@ Schedule (daily 7am)
       -> Parse JSON
       -> Filter: outreach_timing != "not_recommended"
       -> Google Sheets: append to "New Business Leads"
-      -> Slack: notification (if vertical_match is home_services or professional_services)
       -> Data Store: mark as seen
 ```
 
-**Total modules per qualified permit:** ~8
+**Total modules per qualified permit:** ~7
 **Expected daily volume:** 0-10 new commercial permits per day across all 3 cities. Most days will be low volume.
-**Operations per run:** ~50-150 (low volume source)
+**Operations per run:** ~40-130 (low volume source)
 
 ---
 
@@ -248,31 +246,7 @@ This passes permits where Claude recommends "immediate", "wait_30_days", or "wai
 | J: Date Found         | `{{formatDate(now; "YYYY-MM-DD")}}`                                                |
 | K: Status             | `New`                                                                              |
 
-#### Step 14: Module 8 — Slack (Conditional Notification)
-
-**Module: Slack -> Create a Message**
-
-Add a filter BEFORE the Slack module:
-
-- Condition: `{{json.vertical_match}}` equals `home_services` OR `{{json.vertical_match}}` equals `professional_services`
-- Label: "Primary verticals only"
-
-This ensures Slack notifications only fire for businesses in our launch verticals. Other verticals still go to the Google Sheet but don't generate noise in the Slack channel.
-
-- Channel: `#lead-signals`
-- Text:
-
-```
-:building_construction: *New Business Detected*
-*Business:* {{json.business_name}}
-*Source:* {{json.source}}
-*Vertical:* {{json.vertical_match}}
-*Outreach Timing:* {{json.outreach_timing}}
-*Area:* {{json.area}}
-*Outreach Angle:* {{json.outreach_angle}}
-```
-
-#### Step 15: Module 9 — Data Store (Mark as Seen)
+#### Step 14: Module 8 — Data Store (Mark as Seen)
 
 **Module: Data Store -> Add/replace a record**
 
@@ -428,7 +402,7 @@ These modules are identical to Scenario A Steps 11-15:
 3. **Google Sheets** — Append to "New Business Leads" (same column mapping as Scenario A, with `source` reflecting `acc_filing` or `ador_tpt`)
 4. **Data Store** — Mark as seen in `seen_permits`
 
-No Slack notification for this scenario — the volume is higher per run and the filings are less time-sensitive than permits. Review the Google Sheet periodically instead.
+No per-lead notification for this scenario — the volume is higher per run and the filings are less time-sensitive than permits. New leads appear in the Daily Digest email (see pipeline-2-job-monitor.md). Review the Google Sheet periodically for additional detail.
 
 ---
 
@@ -442,8 +416,7 @@ No Slack notification for this scenario — the volume is higher per run and the
 - [ ] Verify dedup works: run twice, second run should skip all previously seen permits
 - [ ] Verify Claude produces valid JSON (check Anthropic module output)
 - [ ] Verify qualified permits appear in the Google Sheet with correct source values
-- [ ] Verify Slack notification fires only for `home_services` and `professional_services` verticals
-- [ ] Check operations count — should be within estimated 50-150 per run
+- [ ] Check operations count — should be within estimated 40-130 per run
 - [ ] Let scenario run automatically for 5+ days, then review all qualified leads for accuracy
 
 ### Scenario B (ACC/ADOR Intake)
@@ -470,3 +443,5 @@ After 1-2 weeks of running:
 4. **Claude over-qualifying:** If too many holding companies, franchises, or non-operational entities are passing qualification, add more disqualification examples to the system prompt. The existing prompt handles common cases but may need tuning for local patterns.
 
 5. **ACC/ADOR file format changes:** When ACC or ADOR changes their file format, the CSV/Excel parse module will break. Update the column mappings and iterator references to match the new format. Keep a sample of each file format for reference.
+
+> **Note:** Notifications are handled by the Daily Digest scenario (see pipeline-2-job-monitor.md, Daily Digest Scenario section), not per-lead.

--- a/docs/lead-automation/recipes/pipeline-4-social-listening.md
+++ b/docs/lead-automation/recipes/pipeline-4-social-listening.md
@@ -1,16 +1,15 @@
 # Make.com Recipe: Pipeline 4 — Social Listening
 
-**Purpose:** Step-by-step guide to build a Make.com scenario that monitors Reddit and Google Alerts for conversations relevant to Phoenix-area small business operations, then delivers a curated daily digest to Slack.
+**Purpose:** Step-by-step guide to build a Make.com scenario that monitors Reddit and Google Alerts for conversations relevant to Phoenix-area small business operations, then delivers a curated daily digest via Gmail.
 
 **Prerequisites:**
 
 - Reddit API credentials (OAuth2 app — see setup instructions below)
 - Google Alerts configured and delivering to Gmail with a specific label
 - Gmail connection in Make.com
-- Slack: #lead-signals channel created
 - Make.com Data Store: `seen_social` created (see make-data-store-schema.md)
 
-**No Google Sheets output for this pipeline.** The daily digest goes straight to Slack for human review. The human decides which conversations to engage with. If volume warrants tracking responses, add the "Social Opportunities" sheet later (see google-sheets-schema.md, Sheet 4).
+**No Google Sheets output for this pipeline.** The daily digest is sent via Gmail for human review. The human decides which conversations to engage with. If volume warrants tracking responses, add the "Social Opportunities" sheet later (see google-sheets-schema.md, Sheet 4).
 
 ---
 
@@ -84,7 +83,7 @@ Schedule (daily 7am)
           -> Aggregator: collect all new alerts
   -> (after both paths merge:)
   -> Text Aggregator: combine all results into a single digest
-  -> Slack: post daily digest to #lead-signals
+  -> Gmail: send daily digest email
 ```
 
 **Total modules:** ~15-20
@@ -381,28 +380,38 @@ If either section is empty, note that in the output:
 {{ifempty(alerts_aggregator_text; "(No new Google Alerts today)")}}
 ```
 
-#### Step 21: Filter — Only Post if Content Exists
+#### Step 21: Filter — Only Send if Content Exists
 
-**Add a filter before the Slack module:**
+**Add a filter before the Gmail module:**
 
 - Condition: The combined digest is NOT empty (at least one new Reddit post or Google Alert exists)
 - Label: "Has content"
 
-This prevents posting an empty digest to Slack on quiet days.
+This prevents sending an empty digest on quiet days.
 
-#### Step 22: Module 17 — Slack (Daily Digest)
+#### Step 22: Module 17 — Gmail (Send Daily Digest Email)
 
-**Module: Slack -> Create a Message**
+**Module: Gmail -> Send an Email**
 
-- Channel: `#lead-signals`
-- Text:
+| Setting      | Value                                               |
+| ------------ | --------------------------------------------------- |
+| To           | Your business email address                         |
+| Subject      | `Social Digest — {{formatDate(now; "YYYY-MM-DD")}}` |
+| Content      | See below                                           |
+| Content type | Plain text                                          |
+
+**Email body:**
 
 ```
-:speech_balloon: *Daily Social Digest — {{formatDate(now; "YYYY-MM-DD")}}*
+Social Digest — {{formatDate(now; "YYYY-MM-DD")}}
 
-{{digest}}
+REDDIT
+{{ifempty(reddit_aggregator_text; "(No new Reddit posts today)")}}
 
-_Review these conversations. Reply to relevant threads where SMD Services can add value. Do NOT pitch — contribute genuinely useful advice._
+GOOGLE ALERTS
+{{ifempty(alerts_aggregator_text; "(No new Google Alerts today)")}}
+
+Review these conversations. Reply to relevant threads where SMD Services can add value. Do NOT pitch — contribute genuinely useful advice.
 ```
 
 ---
@@ -415,8 +424,8 @@ _Review these conversations. Reply to relevant threads where SMD Services can ad
 - [ ] Verify dedup works: run twice, second run should skip all previously seen posts
 - [ ] Verify Google Alert emails are picked up by the Gmail module
 - [ ] Verify alert URLs and titles are extracted correctly from email HTML
-- [ ] Verify the combined digest appears in Slack with proper formatting
-- [ ] Verify empty days produce no Slack message (or a "no new content" message, depending on filter choice)
+- [ ] Verify the combined digest arrives via email with proper formatting
+- [ ] Verify empty days produce no email (or a "no new content" message, depending on filter choice)
 - [ ] Check operations count — should be within estimated 100-300 per run
 - [ ] Let scenario run automatically for 5+ days, then review the digests for relevance and signal quality
 

--- a/docs/lead-automation/recipes/pipeline-4-social-listening.md
+++ b/docs/lead-automation/recipes/pipeline-4-social-listening.md
@@ -1,0 +1,439 @@
+# Make.com Recipe: Pipeline 4 — Social Listening
+
+**Purpose:** Step-by-step guide to build a Make.com scenario that monitors Reddit and Google Alerts for conversations relevant to Phoenix-area small business operations, then delivers a curated daily digest to Slack.
+
+**Prerequisites:**
+
+- Reddit API credentials (OAuth2 app — see setup instructions below)
+- Google Alerts configured and delivering to Gmail with a specific label
+- Gmail connection in Make.com
+- Slack: #lead-signals channel created
+- Make.com Data Store: `seen_social` created (see make-data-store-schema.md)
+
+**No Google Sheets output for this pipeline.** The daily digest goes straight to Slack for human review. The human decides which conversations to engage with. If volume warrants tracking responses, add the "Social Opportunities" sheet later (see google-sheets-schema.md, Sheet 4).
+
+---
+
+## Reddit OAuth2 Setup
+
+Before building the scenario, register a Reddit API application:
+
+1. Go to https://www.reddit.com/prefs/apps
+2. Scroll to the bottom and click **"create another app..."**
+3. Fill in:
+   - **name:** `smd-lead-monitor` (or any name)
+   - **type:** Select **"script"** (for personal use / server-side)
+   - **description:** (optional)
+   - **about url:** (leave blank)
+   - **redirect uri:** `https://www.make.com/oauth/cb/reddit` (or any valid URL — script apps don't use redirects, but the field is required)
+4. Click **"create app"**
+5. Note two values:
+   - **client_id:** The string under the app name (e.g., `aBcDeFgHiJkLmN`)
+   - **client_secret:** The string labeled "secret"
+6. Store these securely — you will use them in the Make.com scenario to obtain an access token
+
+**Rate limits:** Reddit's API allows 60 requests per minute for OAuth-authenticated apps. Our scenario makes ~10 requests per run — well within limits.
+
+---
+
+## Google Alerts Setup
+
+Set up Google Alerts to deliver keyword-matched web content to Gmail:
+
+1. Go to https://www.google.com/alerts
+2. Create alerts for these queries:
+   - `"small business" Phoenix operations`
+   - `"business owner" Phoenix "overwhelmed"`
+   - `"office manager" Phoenix hiring`
+   - `"scheduling software" small business`
+   - `"CRM" recommendation small business`
+3. For each alert:
+   - **How often:** As-it-happens (or Once a day)
+   - **Sources:** Automatic
+   - **Language:** English
+   - **Region:** United States
+   - **How many:** Only the best results
+   - **Deliver to:** Your Gmail address
+4. In Gmail, create a label: `Google-Alerts`
+5. Create a Gmail filter: From `googlealerts-noreply@google.com` -> Apply label `Google-Alerts`
+
+---
+
+## Scenario: Daily Social Digest
+
+### Scenario Overview
+
+```
+Schedule (daily 7am)
+  -> Router: 2 paths
+    Path 1: Reddit API
+      -> HTTP: get OAuth2 access token
+      -> Set Variable: Reddit search queries
+      -> Iterator: each query
+        -> HTTP: Reddit search
+        -> Iterator: each post
+          -> Data Store: check seen_social (dedup by Reddit post ID)
+          -> Filter: only new posts
+          -> Aggregator: collect all new posts
+    Path 2: Google Alerts
+      -> Gmail: search for new emails (label "Google-Alerts", since yesterday)
+        -> Iterator: each email
+          -> Text Parser: extract URL and subject from alert email
+          -> Data Store: check seen_social (dedup)
+          -> Filter: only new alerts
+          -> Aggregator: collect all new alerts
+  -> (after both paths merge:)
+  -> Text Aggregator: combine all results into a single digest
+  -> Slack: post daily digest to #lead-signals
+```
+
+**Total modules:** ~15-20
+**Expected daily volume:** 5-30 posts/alerts across all sources. Many days will be quiet.
+**Operations per run:** ~100-300
+
+---
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com -> Scenarios -> Create a new scenario
+2. Name: `Lead Gen: P4 Social Listening`
+3. Set the schedule: **Every day at 7:00 AM** (MST/Arizona time)
+
+#### Step 2: Add the Trigger — Scheduled
+
+1. The scenario trigger is **Schedule** (built-in)
+2. Set to run once daily at 7:00 AM
+
+#### Step 3: Module 1 — Router (2 Paths)
+
+**Module: Flow Control -> Router**
+
+Add 2 routes:
+
+- Route 1: "Reddit Search"
+- Route 2: "Google Alerts"
+
+Both paths run in parallel and their results merge at the end into a single digest.
+
+---
+
+### Path 1: Reddit Search
+
+#### Step 4: Module 2 — HTTP (Reddit OAuth2 Token)
+
+Reddit's API requires an OAuth2 access token. For "script" type apps, use the password grant flow.
+
+**Module: HTTP -> Make a request**
+
+| Setting        | Value                                        |
+| -------------- | -------------------------------------------- |
+| URL            | `https://www.reddit.com/api/v1/access_token` |
+| Method         | POST                                         |
+| Headers        | See below                                    |
+| Body type      | `application/x-www-form-urlencoded`          |
+| Parse response | Yes                                          |
+
+**Headers:**
+
+| Header          | Value                                                             |
+| --------------- | ----------------------------------------------------------------- |
+| `Authorization` | `Basic {{base64(REDDIT_CLIENT_ID + ":" + REDDIT_CLIENT_SECRET)}}` |
+| `User-Agent`    | `smd-lead-monitor/1.0 by SMDServices`                             |
+
+**Body fields:**
+
+| Key          | Value                 |
+| ------------ | --------------------- |
+| `grant_type` | `password`            |
+| `username`   | `{{REDDIT_USERNAME}}` |
+| `password`   | `{{REDDIT_PASSWORD}}` |
+
+**Note:** The `Basic` auth header is the base64-encoded string `client_id:client_secret`. In Make.com, use the `base64` function or manually encode the credentials and paste the result.
+
+The response contains an `access_token` field valid for ~1 hour. Store it in a variable for use in subsequent Reddit API calls.
+
+**Set Variable after this module:**
+
+- `reddit_token` = `{{HTTP.body.access_token}}`
+
+#### Step 5: Module 3 — Set Variable (Reddit Queries)
+
+**Module: Tools -> Set multiple variables**
+
+- Variable: `reddit_queries` (array)
+- Value:
+
+```json
+[
+  "small business Phoenix",
+  "CRM recommendation",
+  "scheduling software small business",
+  "overwhelmed business owner",
+  "office manager hiring Phoenix"
+]
+```
+
+These queries target the intersection of small business operational pain and the Phoenix market. Generic queries ("CRM recommendation") cast a wider net for general industry conversations worth joining.
+
+#### Step 6: Module 4 — Iterator (Reddit Queries)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: `{{reddit_queries}}`
+
+#### Step 7: Module 5 — HTTP (Reddit Search)
+
+**Module: HTTP -> Make a request**
+
+| Setting          | Value                             |
+| ---------------- | --------------------------------- |
+| URL              | `https://oauth.reddit.com/search` |
+| Method           | GET                               |
+| Headers          | See below                         |
+| Query parameters | See below                         |
+| Parse response   | Yes                               |
+
+**Headers:**
+
+| Header          | Value                                 |
+| --------------- | ------------------------------------- |
+| `Authorization` | `Bearer {{reddit_token}}`             |
+| `User-Agent`    | `smd-lead-monitor/1.0 by SMDServices` |
+
+**Query parameters:**
+
+| Key           | Value                                                  |
+| ------------- | ------------------------------------------------------ |
+| `q`           | `{{iterator.value}}` (the current search query)        |
+| `restrict_sr` | `false` (search all of Reddit, not just one subreddit) |
+| `type`        | `link` (posts only, not comments)                      |
+| `t`           | `day` (last 24 hours)                                  |
+| `limit`       | `10` (top 10 results per query)                        |
+
+**Error handling:** Add an error route -> Resume (if Reddit API returns an error, skip this query)
+
+**Subreddit filtering:** The search returns results from all subreddits. To filter for relevant subreddits, add a filter after the next Iterator that checks if `subreddit` is in the target list: `r/phoenix`, `r/smallbusiness`, `r/entrepreneur`, `r/smallbusinessowner`. Alternatively, skip the filter and let all subreddits through — the human reviewing the digest will make the relevance call.
+
+#### Step 8: Module 6 — Iterator (Reddit Posts)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: `{{HTTP.body.data.children}}` (Reddit's API wraps posts in `data.children`)
+
+#### Step 9: Module 7 — Data Store (Dedup Check)
+
+**Module: Data Store -> Get a record**
+
+- Data store: `seen_social`
+- Key: `{{iterator2.data.id}}` (Reddit's post ID, e.g., `t3_abc123`)
+
+Reddit post IDs are globally unique — they are the natural dedup key.
+
+#### Step 10: Filter — Only New Posts
+
+**Add a filter:**
+
+- Condition: Data Store module **did NOT return a record**
+- Label: "New post only"
+
+#### Step 11: Module 8 — Data Store (Mark as Seen)
+
+**Module: Data Store -> Add/replace a record**
+
+- Data store: `seen_social`
+- Key: `{{iterator2.data.id}}`
+- Fields:
+
+| Field        | Value                               |
+| ------------ | ----------------------------------- |
+| `post_id`    | `{{iterator2.data.id}}`             |
+| `platform`   | `reddit`                            |
+| `date_found` | `{{formatDate(now; "YYYY-MM-DD")}}` |
+
+#### Step 12: Module 9 — Text Aggregator (Collect Reddit Posts)
+
+**Module: Tools -> Text aggregator**
+
+- Source module: Filter (new posts only)
+- Row separator: `\n`
+- Text template:
+
+```
+{{counter}}. [Reddit/r/{{iterator2.data.subreddit}}] {{iterator2.data.title}}
+   {{iterator2.data.url}}
+   {{substring(iterator2.data.selftext; 0; 150)}}...
+```
+
+This collects all new Reddit posts into a single text block, numbered, with subreddit, title, URL, and a brief snippet of the post body.
+
+---
+
+### Path 2: Google Alerts
+
+#### Step 13: Module 10 — Gmail (Search for Alert Emails)
+
+**Module: Gmail -> Search Emails**
+
+| Setting                   | Value                                                  |
+| ------------------------- | ------------------------------------------------------ |
+| Label                     | `Google-Alerts`                                        |
+| Search query              | `after:{{formatDate(addDays(now; -1); "YYYY/MM/DD")}}` |
+| Maximum number of results | 20                                                     |
+
+This finds all Google Alert emails received in the past 24 hours.
+
+#### Step 14: Module 11 — Iterator (Each Alert Email)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: The emails returned by the Gmail Search module
+
+#### Step 15: Module 12 — Text Parser (Extract Alert Data)
+
+**Module: Text Parser -> Match Pattern**
+
+Google Alert emails contain the alert subject and a list of matching URLs. Extract the key data:
+
+- **Pattern for URL:** `href="(https?://[^"]+)"` (extracts the first linked URL from the email body)
+- **Pattern for title/subject:** Use the email subject line: `{{iterator.subject}}`
+
+**Alternative approach:** If the email body is HTML, use the **HTML -> Extract from HTML** module to pull the first link and its anchor text.
+
+**Set variables:**
+
+- `alert_url` = extracted URL from the email body
+- `alert_title` = `{{iterator.subject}}`
+- `alert_source` = `Google Alert`
+
+#### Step 16: Module 13 — Data Store (Dedup Check)
+
+**Module: Data Store -> Get a record**
+
+- Data store: `seen_social`
+- Key: `{{sha256(alert_title + "|" + alert_url)}}` (hash of subject + URL for uniqueness)
+
+If `sha256` is not available, use `md5` or a simpler concatenation key.
+
+#### Step 17: Filter — Only New Alerts
+
+**Add a filter:**
+
+- Condition: Data Store module **did NOT return a record**
+- Label: "New alert only"
+
+#### Step 18: Module 14 — Data Store (Mark as Seen)
+
+**Module: Data Store -> Add/replace a record**
+
+- Data store: `seen_social`
+- Key: Same hash as Step 16
+- Fields:
+
+| Field        | Value                               |
+| ------------ | ----------------------------------- | ----------------- |
+| `post_id`    | `{{sha256(alert_title + "           | " + alert_url)}}` |
+| `platform`   | `google_alerts`                     |
+| `date_found` | `{{formatDate(now; "YYYY-MM-DD")}}` |
+
+#### Step 19: Module 15 — Text Aggregator (Collect Alerts)
+
+**Module: Tools -> Text aggregator**
+
+- Source module: Filter (new alerts only)
+- Row separator: `\n`
+- Text template:
+
+```
+{{counter}}. [Google Alert] {{alert_title}}
+   {{alert_url}}
+```
+
+---
+
+### Merge and Deliver
+
+#### Step 20: Module 16 — Set Variable (Combine Digests)
+
+After both Router paths complete, combine the Reddit and Google Alert text blocks.
+
+**Module: Tools -> Set multiple variables**
+
+- Variable: `digest`
+- Value:
+
+```
+*Reddit*
+{{reddit_aggregator_text}}
+
+*Google Alerts*
+{{alerts_aggregator_text}}
+```
+
+If either section is empty, note that in the output:
+
+```
+*Reddit*
+{{ifempty(reddit_aggregator_text; "(No new Reddit posts today)")}}
+
+*Google Alerts*
+{{ifempty(alerts_aggregator_text; "(No new Google Alerts today)")}}
+```
+
+#### Step 21: Filter — Only Post if Content Exists
+
+**Add a filter before the Slack module:**
+
+- Condition: The combined digest is NOT empty (at least one new Reddit post or Google Alert exists)
+- Label: "Has content"
+
+This prevents posting an empty digest to Slack on quiet days.
+
+#### Step 22: Module 17 — Slack (Daily Digest)
+
+**Module: Slack -> Create a Message**
+
+- Channel: `#lead-signals`
+- Text:
+
+```
+:speech_balloon: *Daily Social Digest — {{formatDate(now; "YYYY-MM-DD")}}*
+
+{{digest}}
+
+_Review these conversations. Reply to relevant threads where SMD Services can add value. Do NOT pitch — contribute genuinely useful advice._
+```
+
+---
+
+## Testing Checklist
+
+- [ ] Run scenario manually (right-click -> Run once)
+- [ ] Verify Reddit OAuth2 token is obtained (check first HTTP module output for `access_token`)
+- [ ] Verify Reddit search returns results (check Reddit search HTTP module output)
+- [ ] Verify dedup works: run twice, second run should skip all previously seen posts
+- [ ] Verify Google Alert emails are picked up by the Gmail module
+- [ ] Verify alert URLs and titles are extracted correctly from email HTML
+- [ ] Verify the combined digest appears in Slack with proper formatting
+- [ ] Verify empty days produce no Slack message (or a "no new content" message, depending on filter choice)
+- [ ] Check operations count — should be within estimated 100-300 per run
+- [ ] Let scenario run automatically for 5+ days, then review the digests for relevance and signal quality
+
+---
+
+## Tuning
+
+After 1-2 weeks of running:
+
+1. **Too much noise (irrelevant Reddit posts):** Narrow the search queries. Remove generic queries like "CRM recommendation" if they produce too many irrelevant results. Add subreddit filtering (Step 7 note) to restrict to `r/phoenix`, `r/smallbusiness`, `r/entrepreneur`, `r/smallbusinessowner`.
+
+2. **Too few results:** Add more search queries. Consider adding `"business process" help`, `"QuickBooks" "small business"`, `"employee scheduling"`, or `"growing too fast"`. Also add more Google Alerts for emerging pain-point keywords.
+
+3. **Reddit API errors (401 Unauthorized):** The OAuth2 token expires after ~1 hour. Since the scenario runs once daily, a fresh token is fetched each run. If you see 401 errors, verify the client_id, client_secret, username, and password are correct. Reddit may also require 2FA to be disabled for "script" type apps.
+
+4. **Google Alerts not arriving:** Verify the alerts are configured at google.com/alerts and delivering to your Gmail. Check that the `Google-Alerts` label is being applied by the Gmail filter.
+
+5. **Digest too long:** Reduce the `limit` parameter in Reddit search from 10 to 5. Shorten the snippet length from 150 characters to 80. Cap the digest at 20 items total by adding a `head_limit` to the aggregators.
+
+6. **Want to track responses:** Add the "Social Opportunities" sheet (google-sheets-schema.md, Sheet 4) and an additional path after the digest: Google Sheets -> Add a Row for each item in the digest. This enables tracking which conversations were engaged and what happened.

--- a/docs/lead-automation/recipes/pipeline-5-partner-nurture.md
+++ b/docs/lead-automation/recipes/pipeline-5-partner-nurture.md
@@ -7,9 +7,8 @@
 - Google Sheets: "SMD Lead Generation" spreadsheet with "Referral Partners" tab populated (see google-sheets-schema.md, Sheet 5)
 - Gmail connection in Make.com (for creating drafts)
 - Anthropic API key
-- Slack: #lead-signals channel created
 
-**No external API accounts needed.** This pipeline uses only Gmail, Google Sheets, Anthropic, and Slack — all of which are already configured for Pipelines 1-4.
+**No external API accounts needed.** This pipeline uses only Gmail, Google Sheets, and Anthropic — all of which are already configured for Pipelines 1-4.
 
 ---
 
@@ -28,7 +27,7 @@ Schedule (every Friday 8am)
     -> Parse JSON
     -> Gmail: create draft (to: partner email, subject + body from Claude output)
     -> Google Sheets: update row (Last Contact Date, Next Check-in Date)
-  -> Slack: summary notification ("3 partner check-in drafts ready in Gmail")
+  -> Gmail: send summary email to self ("{count} partner check-in drafts ready")
 ```
 
 **Total modules per partner:** ~5
@@ -76,7 +75,7 @@ This returns all partners whose Next Check-in Date has arrived (or passed) and w
 - Condition: `{{E: Email}}` is not empty
 - Label: "Has email address"
 
-Partners without email addresses cannot receive check-in emails. Skip them. These partners may need manual outreach (phone call, LinkedIn message) — a Slack notification could flag these separately if desired.
+Partners without email addresses cannot receive check-in emails. Skip them. These partners may need manual outreach (phone call, LinkedIn message) — a separate notification could flag these if desired.
 
 #### Step 5: Module 2 — Iterator (Each Partner)
 
@@ -185,20 +184,27 @@ For the initial build, a uniform 14-day cadence for all stages is simpler and re
 - Aggregate function: Count
 - This counts how many drafts were created during this run
 
-#### Step 11: Module 8 — Slack (Summary Notification)
+#### Step 11: Module 8 — Gmail (Summary Email to Self)
 
-**Module: Slack -> Create a Message**
+**Module: Gmail -> Send an Email**
 
-- Channel: `#lead-signals`
-- Text:
+| Setting      | Value                                                        |
+| ------------ | ------------------------------------------------------------ |
+| To           | Your business email address                                  |
+| Subject      | `Partner Nurture — {{numericAggregator.count}} drafts ready` |
+| Content      | See below                                                    |
+| Content type | Plain text                                                   |
+
+**Email body:**
 
 ```
-:handshake: *Partner Check-in Drafts Ready*
+Partner Check-in Drafts Ready
+
 {{numericAggregator.count}} partner check-in email draft(s) created in Gmail.
 Review and send by {{formatDate(addDays(now; 4); "dddd")}} ({{formatDate(addDays(now; 4); "YYYY-MM-DD")}}).
 ```
 
-This posts a single summary message after the entire loop completes — not one notification per partner. The suggested send date is 4 days from Friday (Tuesday), which aligns with the optimal B2B send window.
+This sends a single summary email after the entire loop completes — not one email per partner. The suggested send date is 4 days from Friday (Tuesday), which aligns with the optimal B2B send window.
 
 ---
 
@@ -212,7 +218,7 @@ When the partner list grows to 10+ active partners, add a monthly broadcast scen
 Schedule (1st of month)
   -> Anthropic: draft monthly insights email
   -> HTTP: POST to Buttondown API /v1/emails (status: "draft")
-  -> Slack: "Monthly partner email draft ready in Buttondown"
+  -> Gmail: send email to self ("Monthly partner email draft ready in Buttondown")
 ```
 
 **Module 1: Anthropic**
@@ -252,7 +258,7 @@ The email appears in Buttondown's dashboard as a draft. The human reviews and pu
 - [ ] Verify the draft email contains no dollar amounts or fixed timeframes
 - [ ] Verify the Gmail draft appears in the Drafts folder with correct To, Subject, and Body
 - [ ] Verify the Google Sheet row is updated: Last Contact Date = today, Next Check-in Date = today + 14 (or 21)
-- [ ] Verify the Slack summary message shows the correct count of drafts created
+- [ ] Verify the Gmail summary email shows the correct count of drafts created
 - [ ] Run the scenario twice in a row — the second run should find no partners due for check-in (dates were pushed forward)
 - [ ] Check operations count — should be within estimated 30-80 per run
 - [ ] Let scenario run automatically for 3+ weeks, then review draft quality and cadence
@@ -274,3 +280,5 @@ After 2-3 weeks of running:
 5. **Partner progressed to a new stage:** When a partner moves from "Prospect" to "Intro Call Done" (or any stage change), update the Relationship Stage in the Google Sheet manually. Claude uses this field to select the appropriate email variant. The scenario does not auto-advance stages.
 
 6. **Want to track email opens:** Switch from Gmail drafts to Buttondown for 1:1 emails once the volume justifies it. Buttondown provides open/click tracking that Gmail does not. See `buttondown-integration.md` for the trade-offs (tag-based targeting vs. Gmail simplicity).
+
+> **Note:** Notifications are handled by the Daily Digest scenario (see pipeline-2-job-monitor.md, Daily Digest Scenario section), not per-lead.

--- a/docs/lead-automation/recipes/pipeline-5-partner-nurture.md
+++ b/docs/lead-automation/recipes/pipeline-5-partner-nurture.md
@@ -1,0 +1,276 @@
+# Make.com Recipe: Pipeline 5 — Referral Partner Nurture
+
+**Purpose:** Step-by-step guide to build a Make.com scenario that drafts personalized check-in emails for bookkeeper/CPA referral partners, creates Gmail drafts for human review, and tracks check-in cadence in Google Sheets.
+
+**Prerequisites:**
+
+- Google Sheets: "SMD Lead Generation" spreadsheet with "Referral Partners" tab populated (see google-sheets-schema.md, Sheet 5)
+- Gmail connection in Make.com (for creating drafts)
+- Anthropic API key
+- Slack: #lead-signals channel created
+
+**No external API accounts needed.** This pipeline uses only Gmail, Google Sheets, Anthropic, and Slack — all of which are already configured for Pipelines 1-4.
+
+---
+
+## Scenario: Weekly Partner Check-ins
+
+### Scenario Overview
+
+```
+Schedule (every Friday 8am)
+  -> Google Sheets: search rows in "Referral Partners" tab
+    where Next Check-in Date <= today
+    AND Relationship Stage != "Dormant"
+  -> Filter: email is not empty
+  -> Iterator: each partner due for check-in
+    -> Anthropic: draft check-in email with Claude (partner-nurture-prompt)
+    -> Parse JSON
+    -> Gmail: create draft (to: partner email, subject + body from Claude output)
+    -> Google Sheets: update row (Last Contact Date, Next Check-in Date)
+  -> Slack: summary notification ("3 partner check-in drafts ready in Gmail")
+```
+
+**Total modules per partner:** ~5
+**Expected weekly volume:** 2-8 partners due for check-in per week (depends on list size and check-in cadence)
+**Operations per run:** ~30-80
+
+---
+
+### Step-by-Step Build
+
+#### Step 1: Create the Scenario
+
+1. In Make.com -> Scenarios -> Create a new scenario
+2. Name: `Lead Gen: P5 Partner Nurture`
+3. Set the schedule: **Every Friday at 8:00 AM** (MST/Arizona time — Arizona does not observe DST)
+
+**Why Friday:** Drafts are created Friday morning. The human reviews them over the weekend or first thing Monday. Emails are sent Tuesday-Thursday (optimal B2B send days per the prompt). This gives time for review without making partners wait.
+
+#### Step 2: Add the Trigger — Scheduled
+
+1. The scenario trigger is **Schedule** (built-in)
+2. Set to run once weekly on Friday at 8:00 AM
+
+#### Step 3: Module 1 — Google Sheets (Search Partners Due for Check-in)
+
+**Module: Google Sheets -> Search Rows**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "Referral Partners"
+- Filter:
+
+| Condition | Column                | Operator                 | Value                               |
+| --------- | --------------------- | ------------------------ | ----------------------------------- |
+| 1         | K: Next Check-in Date | is less than or equal to | `{{formatDate(now; "YYYY-MM-DD")}}` |
+| 2         | I: Relationship Stage | does not equal           | `Dormant`                           |
+
+This returns all partners whose Next Check-in Date has arrived (or passed) and who are not in the Dormant stage.
+
+**Note:** If the Google Sheets Search Rows module does not support complex filters natively, use the **Get All Rows** variant and add Make.com filters after the module to apply both conditions.
+
+#### Step 4: Filter — Email Exists
+
+**Add a filter after the Google Sheets module:**
+
+- Condition: `{{E: Email}}` is not empty
+- Label: "Has email address"
+
+Partners without email addresses cannot receive check-in emails. Skip them. These partners may need manual outreach (phone call, LinkedIn message) — a Slack notification could flag these separately if desired.
+
+#### Step 5: Module 2 — Iterator (Each Partner)
+
+**Module: Flow Control -> Iterator**
+
+- Source array: The filtered rows from Google Sheets
+- Each bundle represents one partner due for a check-in
+
+#### Step 6: Module 3 — Anthropic (Claude Email Draft)
+
+**Module: Anthropic (Claude) -> Create a Message**
+
+| Setting       | Value                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| Model         | `claude-sonnet-4-6` (needs good tone and personalization)                                       |
+| Max tokens    | `512` (short emails — 3-5 sentences)                                                            |
+| System prompt | Paste the full content of `SYSTEM_PROMPT` from `src/lead-gen/prompts/partner-nurture-prompt.ts` |
+
+**User message:**
+
+```
+Draft a personalized check-in email for this referral partner.
+
+Firm: {{iterator.A: Firm Name}}
+Contact: {{iterator.B: Contact Name}}
+Area: {{iterator.C: Area}}
+Phone: {{iterator.D: Phone}}
+Email: {{iterator.E: Email}}
+Website: {{iterator.F: Website}}
+Tier: {{iterator.G: Tier}}
+Focus Areas: {{iterator.H: Focus Areas}}
+Relationship Stage: {{iterator.I: Relationship Stage}}
+Last Contact: {{iterator.J: Last Contact Date}}
+Referrals Received (them -> us): {{iterator.L: Referrals Received}}
+Referrals Sent (us -> them): {{iterator.M: Referrals Sent}}
+Notes: {{iterator.N: Notes}}
+
+Produce a single JSON object matching the PartnerEmailDraft schema.
+```
+
+**Why claude-sonnet-4-6:** Partner emails require good tone, personalization, and adherence to the strict voice rules (no "I", no dollar amounts, no fixed timeframes). Claude Sonnet handles these nuances better than Haiku and the volume is low enough (2-8 per week) that the cost difference is negligible.
+
+**Error handling:** Add an error route -> Resume (if Claude returns invalid JSON, skip this partner and continue)
+
+#### Step 7: Module 4 — Parse JSON
+
+**Module: JSON -> Parse JSON**
+
+- JSON string: `{{anthropic.content[1].text}}` (Claude's response text)
+- This converts the string into a structured object with `subject`, `body`, `tone`, `suggested_send_day`, and `notes` fields
+
+#### Step 8: Module 5 — Gmail (Create Draft)
+
+**Module: Gmail -> Create a Draft**
+
+| Setting      | Value                                                 |
+| ------------ | ----------------------------------------------------- |
+| To           | `{{iterator.E: Email}}` (the partner's email address) |
+| Subject      | `{{json.subject}}` (from Claude's output)             |
+| Content      | `{{json.body}}` (from Claude's output)                |
+| Content type | Plain text                                            |
+
+**Important:** This creates a DRAFT, not a sent email. The draft appears in Gmail's Drafts folder for human review. The human reads the draft, makes any edits, and sends manually. This is by design — AI drafts should always be reviewed before sending.
+
+**From address:** The draft will be created from the Gmail account connected to Make.com. Ensure this is the business email (e.g., the smd.services domain) and not a personal account.
+
+#### Step 9: Module 6 — Google Sheets (Update Partner Row)
+
+**Module: Google Sheets -> Update a Row**
+
+- Spreadsheet: "SMD Lead Generation"
+- Sheet: "Referral Partners"
+- Row number: `{{iterator.__ROW_NUMBER__}}` (the row number from the Search Rows result — the exact field name depends on the Make.com Google Sheets module version)
+
+**Column updates:**
+
+| Column                | Value                               | Notes                         |
+| --------------------- | ----------------------------------- | ----------------------------- |
+| J: Last Contact Date  | `{{formatDate(now; "YYYY-MM-DD")}}` | Today's date                  |
+| K: Next Check-in Date | See calculation below               | Depends on relationship stage |
+
+**Next Check-in Date calculation:**
+
+The check-in cadence depends on the relationship stage:
+
+| Relationship Stage | Check-in Interval | Make.com Expression                              |
+| ------------------ | ----------------- | ------------------------------------------------ |
+| Prospect           | Every 14 days     | `{{formatDate(addDays(now; 14); "YYYY-MM-DD")}}` |
+| Intro Sent         | Every 14 days     | `{{formatDate(addDays(now; 14); "YYYY-MM-DD")}}` |
+| Intro Call Done    | Every 14 days     | `{{formatDate(addDays(now; 14); "YYYY-MM-DD")}}` |
+| Active Partner     | Every 21 days     | `{{formatDate(addDays(now; 21); "YYYY-MM-DD")}}` |
+
+In Make.com, use an `if` expression to set the interval based on the relationship stage:
+
+```
+{{if(iterator.I: Relationship Stage = "Active Partner"; formatDate(addDays(now; 21); "YYYY-MM-DD"); formatDate(addDays(now; 14); "YYYY-MM-DD"))}}
+```
+
+For the initial build, a uniform 14-day cadence for all stages is simpler and reasonable. Adjust as the partner list matures.
+
+#### Step 10: Module 7 — Numeric Aggregator (Count Drafts)
+
+**Module: Tools -> Numeric aggregator**
+
+- Source module: Gmail (Create a Draft)
+- Aggregate function: Count
+- This counts how many drafts were created during this run
+
+#### Step 11: Module 8 — Slack (Summary Notification)
+
+**Module: Slack -> Create a Message**
+
+- Channel: `#lead-signals`
+- Text:
+
+```
+:handshake: *Partner Check-in Drafts Ready*
+{{numericAggregator.count}} partner check-in email draft(s) created in Gmail.
+Review and send by {{formatDate(addDays(now; 4); "dddd")}} ({{formatDate(addDays(now; 4); "YYYY-MM-DD")}}).
+```
+
+This posts a single summary message after the entire loop completes — not one notification per partner. The suggested send date is 4 days from Friday (Tuesday), which aligns with the optimal B2B send window.
+
+---
+
+## Buttondown Integration (Future)
+
+When the partner list grows to 10+ active partners, add a monthly broadcast scenario for broader content distribution. This is NOT built in the initial version.
+
+### Future Scenario: Monthly Partner Insights Email
+
+```
+Schedule (1st of month)
+  -> Anthropic: draft monthly insights email
+  -> HTTP: POST to Buttondown API /v1/emails (status: "draft")
+  -> Slack: "Monthly partner email draft ready in Buttondown"
+```
+
+**Module 1: Anthropic**
+
+- Draft a 2-3 paragraph email sharing an anonymized client insight, a small business operations trend, or a relevant observation. Same voice rules apply.
+
+**Module 2: HTTP (Buttondown API)**
+
+| Setting        | Value                                                                                                     |
+| -------------- | --------------------------------------------------------------------------------------------------------- |
+| URL            | `https://api.buttondown.email/v1/emails`                                                                  |
+| Method         | POST                                                                                                      |
+| Headers        | `Authorization: Token {{BUTTONDOWN_API_KEY}}`, `Content-Type: application/json`                           |
+| Body           | `{"subject": "{{claude_subject}}", "body": "{{claude_body}}", "status": "draft", "email_type": "public"}` |
+| Parse response | Yes                                                                                                       |
+
+The email appears in Buttondown's dashboard as a draft. The human reviews and publishes. Buttondown handles delivery, unsubscribe links, and open/click tracking.
+
+**Subscriber sync:** Before this scenario works, import the partner list into Buttondown. See `buttondown-integration.md` for the subscriber sync process (one-time CSV import or API-based sync).
+
+**Do not build this until:**
+
+1. The weekly check-in scenario (above) has been running for 4+ weeks
+2. At least 10 partners are in the "Active Partner" or "Intro Call Done" stage
+3. You have enough anonymized client insights to share meaningful content
+
+---
+
+## Testing Checklist
+
+- [ ] Run scenario manually (right-click -> Run once)
+- [ ] Verify Google Sheets Search returns partners due for check-in (check module output)
+- [ ] If no partners are returned, temporarily set a partner's Next Check-in Date to today and re-run
+- [ ] Verify the email filter skips partners without email addresses
+- [ ] Verify Claude produces valid JSON (check Anthropic module output — valid PartnerEmailDraft schema)
+- [ ] Verify the draft email uses "we" voice, no "I" or "my" (read the body field)
+- [ ] Verify the draft email contains no dollar amounts or fixed timeframes
+- [ ] Verify the Gmail draft appears in the Drafts folder with correct To, Subject, and Body
+- [ ] Verify the Google Sheet row is updated: Last Contact Date = today, Next Check-in Date = today + 14 (or 21)
+- [ ] Verify the Slack summary message shows the correct count of drafts created
+- [ ] Run the scenario twice in a row — the second run should find no partners due for check-in (dates were pushed forward)
+- [ ] Check operations count — should be within estimated 30-80 per run
+- [ ] Let scenario run automatically for 3+ weeks, then review draft quality and cadence
+
+---
+
+## Tuning
+
+After 2-3 weeks of running:
+
+1. **Draft quality too generic:** Add more detail to partner Notes (column N) in the Google Sheet. The more context Claude has — intro call takeaways, industries they serve, referrals exchanged — the more personalized the email. The prompt is designed to use all available context.
+
+2. **Too many partners due at once:** If all partners were added on the same day, they all come due on the same day. Stagger the initial Next Check-in Dates across the first 2-3 weeks when populating the sheet.
+
+3. **Wrong cadence:** If 14 days feels too frequent for prospects, extend to 21 days. If active partners need more frequent check-ins, shorten to 10 days. Adjust the interval expression in Step 9.
+
+4. **Voice violations in drafts:** If Claude occasionally uses "I" or "my", review the system prompt. The examples in `partner-nurture-prompt.ts` should catch most cases, but edge cases may require adding more negative examples to the prompt.
+
+5. **Partner progressed to a new stage:** When a partner moves from "Prospect" to "Intro Call Done" (or any stage change), update the Relationship Stage in the Google Sheet manually. Claude uses this field to select the appropriate email variant. The scenario does not auto-advance stages.
+
+6. **Want to track email opens:** Switch from Gmail drafts to Buttondown for 1:1 emails once the volume justifies it. Buttondown provides open/click tracking that Gmail does not. See `buttondown-integration.md` for the trade-offs (tag-based targeting vs. Gmail simplicity).

--- a/docs/lead-automation/specs/api-accounts-checklist.md
+++ b/docs/lead-automation/specs/api-accounts-checklist.md
@@ -1,0 +1,191 @@
+# API Accounts & Configuration Checklist
+
+External accounts, API keys, and configurations required to run all 5 lead generation pipelines. Ordered by priority: Pipeline 2 (Job Monitor) first, since it has the fewest dependencies and is the fastest to validate end-to-end.
+
+**Estimated time:** 30-45 minutes for all account setup and configuration.
+
+---
+
+## Order of Operations
+
+1. **Verify accounts you already have** (5-10 min)
+2. **Sign up for new services** (5-10 min)
+3. **Configure Google Cloud** if needed (5-10 min)
+4. **Create Make.com connections** (5-10 min)
+5. **Set up Slack channel and Google Sheets** (5 min)
+6. **Create Make.com Data Stores** (5 min)
+
+Pipeline 2 (Job Monitor) requires only: SerpAPI + Anthropic + Google Sheets + Slack. Complete those first and validate the pipeline before configuring the remaining accounts.
+
+---
+
+## 1. Verify Existing Accounts
+
+These accounts should already exist. Verify access and confirm API keys are available.
+
+- [ ] **Make.com** — Pro plan required ($16/mo, 10K operations).
+  - Log in and check **Settings → Subscription** for current plan level.
+  - If on Free or Core, upgrade to Pro.
+  - Signup: [make.com](https://make.com)
+
+- [ ] **Anthropic API** — Claude API access for AI qualification and scoring.
+  - Log in to your Anthropic account and verify an API key exists.
+  - Check usage limits and billing status.
+  - Console: [console.anthropic.com](https://console.anthropic.com)
+
+- [ ] **Google Cloud** — For Places API (Pipeline 1).
+  - Check if a project already exists at [console.cloud.google.com](https://console.cloud.google.com).
+  - If a project exists, verify the Places API is enabled (see Google Cloud setup below).
+  - If no project exists, you'll create one in step 3.
+
+- [ ] **Buttondown** — For Pipeline 5 (Nurture Sequences).
+  - Log in and go to **Settings → API** to verify your API key.
+  - Signup: [buttondown.com](https://buttondown.com)
+
+- [ ] **Slack workspace** — For `#lead-signals` notifications.
+  - Confirm you have admin access to install apps and create channels.
+
+---
+
+## 2. New Account Signups
+
+These are new services that need to be created.
+
+- [ ] **SerpAPI** — Google Jobs search results API. Used by Pipeline 2 (Job Monitor).
+  - Sign up at [serpapi.com](https://serpapi.com).
+  - Select the Developer plan ($50/mo, 5,000 searches).
+  - Copy your API key from the dashboard after signup.
+
+- [ ] **Outscraper** — Google Maps/Reviews scraping API. Used by Pipeline 1 (Review Mining).
+  - Sign up at [outscraper.com](https://outscraper.com).
+  - Select Medium plan ($49/mo) or pay-as-you-go (~$20-50/mo depending on volume).
+  - Copy your API key from the dashboard after signup.
+
+---
+
+## 3. Google Cloud Setup
+
+Skip this section if the Places API is already enabled on an existing project.
+
+- [ ] **Create a Google Cloud project** (or select an existing one).
+  - Go to [console.cloud.google.com](https://console.cloud.google.com).
+  - Click the project dropdown → **New Project**.
+  - Name it something identifiable (e.g., "SMD Lead Gen").
+
+- [ ] **Enable the Places API (New)**.
+  - In the project, go to **APIs & Services → Library**.
+  - Search for "Places API (New)" and click **Enable**.
+
+- [ ] **Create an API key**.
+  - Go to **APIs & Services → Credentials**.
+  - Click **Create Credentials → API Key**.
+  - Restrict the key to the Places API only (under **API restrictions**).
+
+- [ ] **Verify free credit**.
+  - Google Cloud provides $200/mo in free credit for the Maps Platform.
+  - Confirm this is active under **Billing → Overview**.
+
+---
+
+## 4. Make.com Connections
+
+Configure these connections inside Make.com at **Settings → Connections → Add**.
+
+### Priority (needed for Pipeline 2):
+
+- [ ] **Anthropic connection**
+  - Settings → Connections → Add → search "Anthropic" (or use HTTP module).
+  - Paste your Anthropic API key.
+  - If no native Anthropic module exists, use an HTTP module with the API key in the `x-api-key` header.
+
+- [ ] **Google Sheets connection**
+  - Settings → Connections → Add → search "Google Sheets".
+  - Authenticate via OAuth with the Google account that owns the lead gen spreadsheet.
+
+- [ ] **Slack connection**
+  - Settings → Connections → Add → search "Slack".
+  - Authenticate via OAuth. Grant access to post messages.
+  - Select the workspace where `#lead-signals` will live.
+
+### After Pipeline 2 is validated:
+
+- [ ] **SerpAPI connection**
+  - No native Make.com module. Use an **HTTP → Make a request** module.
+  - Pass the API key as a query parameter: `api_key={your_key}`.
+
+- [ ] **Outscraper connection**
+  - No native Make.com module. Use an **HTTP → Make a request** module.
+  - Pass the API key in the `Authorization` header or as a query parameter per Outscraper's docs.
+
+- [ ] **Google Places API connection**
+  - No native Make.com module. Use an **HTTP → Make a request** module.
+  - Pass the API key as a query parameter: `key={your_key}`.
+
+- [ ] **Gmail connection**
+  - Settings → Connections → Add → search "Gmail".
+  - Authenticate via OAuth.
+  - Used for Pipeline 3 (ACC/ADOR email intake) and Pipeline 5 (outreach).
+
+- [ ] **Buttondown connection**
+  - No native Make.com module. Use an **HTTP → Make a request** module.
+  - Pass the API key in the `Authorization` header: `Token {your_key}`.
+
+- [ ] **SODA API connections** (for Pipeline 3 open data portals)
+  - No auth required for public SODA endpoints, but register an app token for higher rate limits.
+  - Use **HTTP → Make a request** modules.
+  - Pass the app token as a query parameter: `$$app_token={your_token}`.
+
+---
+
+## 5. Slack Setup
+
+- [ ] **Create the `#lead-signals` channel**.
+  - In Slack, click **+** next to Channels → Create a channel.
+  - Name: `lead-signals`.
+  - Set to private if preferred.
+
+- [ ] **Invite the Make.com Slack app** to the channel.
+  - In `#lead-signals`, type `/invite @Make` (or the name of the Slack bot created by the Make.com connection).
+
+---
+
+## 6. Google Sheets Setup
+
+- [ ] **Create a new Google Sheet** named "SMD Lead Generation".
+
+- [ ] **Add 6 tabs** to the sheet (see `google-sheets-schema.md` for detailed column specs):
+  - `Pipeline 1 — Review Mining`
+  - `Pipeline 2 — Job Monitor`
+  - `Pipeline 3 — New Business`
+  - `Pipeline 4 — Social Listening`
+  - `Pipeline 5 — Nurture`
+  - `Master Lead List`
+
+- [ ] **Share the sheet** with the Google account connected to Make.com (Editor access).
+
+---
+
+## 7. Make.com Data Stores
+
+- [ ] **Create 4 Data Stores** as defined in `make-data-store-schema.md`:
+  - `seen_businesses` (Pipeline 1 dedup)
+  - `seen_jobs` (Pipeline 2 dedup)
+  - `seen_permits` (Pipeline 3 dedup)
+  - `seen_social` (Pipeline 4 dedup)
+
+See [make-data-store-schema.md](make-data-store-schema.md) for full table schemas, field definitions, and cleanup rules.
+
+---
+
+## Quick Reference: What Each Pipeline Needs
+
+| Pipeline                       | External Services                                       |
+| ------------------------------ | ------------------------------------------------------- |
+| Pipeline 1 — Review Mining     | Outscraper, Google Places API, Anthropic, Sheets, Slack |
+| Pipeline 2 — Job Monitor       | SerpAPI, Anthropic, Sheets, Slack                       |
+| Pipeline 3 — New Business      | SODA APIs, Gmail, Anthropic, Sheets, Slack              |
+| Pipeline 4 — Social Listening  | Reddit (no auth), Google Alerts (Gmail), Sheets, Slack  |
+| Pipeline 5 — Nurture Sequences | Buttondown, Gmail, Sheets                               |
+| All Pipelines                  | Make.com (Pro), Google Sheets, Make.com Data Stores     |
+
+Start with Pipeline 2. It has the fewest dependencies and the fastest path to a working end-to-end test.

--- a/docs/lead-automation/specs/api-accounts-checklist.md
+++ b/docs/lead-automation/specs/api-accounts-checklist.md
@@ -12,10 +12,10 @@ External accounts, API keys, and configurations required to run all 5 lead gener
 2. **Sign up for new services** (5-10 min)
 3. **Configure Google Cloud** if needed (5-10 min)
 4. **Create Make.com connections** (5-10 min)
-5. **Set up Slack channel and Google Sheets** (5 min)
+5. **Set up Google Sheets** (5 min)
 6. **Create Make.com Data Stores** (5 min)
 
-Pipeline 2 (Job Monitor) requires only: SerpAPI + Anthropic + Google Sheets + Slack. Complete those first and validate the pipeline before configuring the remaining accounts.
+Pipeline 2 (Job Monitor) requires only: SerpAPI + Anthropic + Google Sheets + Gmail. Complete those first and validate the pipeline before configuring the remaining accounts.
 
 ---
 
@@ -41,9 +41,6 @@ These accounts should already exist. Verify access and confirm API keys are avai
 - [ ] **Buttondown** — For Pipeline 5 (Nurture Sequences).
   - Log in and go to **Settings → API** to verify your API key.
   - Signup: [buttondown.com](https://buttondown.com)
-
-- [ ] **Slack workspace** — For `#lead-signals` notifications.
-  - Confirm you have admin access to install apps and create channels.
 
 ---
 
@@ -102,11 +99,6 @@ Configure these connections inside Make.com at **Settings → Connections → Ad
   - Settings → Connections → Add → search "Google Sheets".
   - Authenticate via OAuth with the Google account that owns the lead gen spreadsheet.
 
-- [ ] **Slack connection**
-  - Settings → Connections → Add → search "Slack".
-  - Authenticate via OAuth. Grant access to post messages.
-  - Select the workspace where `#lead-signals` will live.
-
 ### After Pipeline 2 is validated:
 
 - [ ] **SerpAPI connection**
@@ -124,7 +116,7 @@ Configure these connections inside Make.com at **Settings → Connections → Ad
 - [ ] **Gmail connection**
   - Settings → Connections → Add → search "Gmail".
   - Authenticate via OAuth.
-  - Used for Pipeline 3 (ACC/ADOR email intake) and Pipeline 5 (outreach).
+  - Used for Pipeline 3 (ACC/ADOR email intake), Pipeline 5 (outreach drafts), and the daily lead digest email sent each morning summarizing new finds across all pipelines.
 
 - [ ] **Buttondown connection**
   - No native Make.com module. Use an **HTTP → Make a request** module.
@@ -137,19 +129,7 @@ Configure these connections inside Make.com at **Settings → Connections → Ad
 
 ---
 
-## 5. Slack Setup
-
-- [ ] **Create the `#lead-signals` channel**.
-  - In Slack, click **+** next to Channels → Create a channel.
-  - Name: `lead-signals`.
-  - Set to private if preferred.
-
-- [ ] **Invite the Make.com Slack app** to the channel.
-  - In `#lead-signals`, type `/invite @Make` (or the name of the Slack bot created by the Make.com connection).
-
----
-
-## 6. Google Sheets Setup
+## 5. Google Sheets Setup
 
 - [ ] **Create a new Google Sheet** named "SMD Lead Generation".
 
@@ -165,7 +145,7 @@ Configure these connections inside Make.com at **Settings → Connections → Ad
 
 ---
 
-## 7. Make.com Data Stores
+## 6. Make.com Data Stores
 
 - [ ] **Create 4 Data Stores** as defined in `make-data-store-schema.md`:
   - `seen_businesses` (Pipeline 1 dedup)
@@ -179,13 +159,14 @@ See [make-data-store-schema.md](make-data-store-schema.md) for full table schema
 
 ## Quick Reference: What Each Pipeline Needs
 
-| Pipeline                       | External Services                                       |
-| ------------------------------ | ------------------------------------------------------- |
-| Pipeline 1 — Review Mining     | Outscraper, Google Places API, Anthropic, Sheets, Slack |
-| Pipeline 2 — Job Monitor       | SerpAPI, Anthropic, Sheets, Slack                       |
-| Pipeline 3 — New Business      | SODA APIs, Gmail, Anthropic, Sheets, Slack              |
-| Pipeline 4 — Social Listening  | Reddit (no auth), Google Alerts (Gmail), Sheets, Slack  |
-| Pipeline 5 — Nurture Sequences | Buttondown, Gmail, Sheets                               |
-| All Pipelines                  | Make.com (Pro), Google Sheets, Make.com Data Stores     |
+| Pipeline                       | External Services                                        |
+| ------------------------------ | -------------------------------------------------------- |
+| Pipeline 1 — Review Mining     | Outscraper, Google Places API, Anthropic, Sheets, Gmail  |
+| Pipeline 2 — Job Monitor       | SerpAPI, Anthropic, Sheets, Gmail                        |
+| Pipeline 3 — New Business      | SODA APIs, Gmail, Anthropic, Sheets                      |
+| Pipeline 4 — Social Listening  | Reddit (no auth), Google Alerts (Gmail), Sheets          |
+| Pipeline 5 — Nurture Sequences | Buttondown, Gmail, Sheets                                |
+| All Pipelines                  | Make.com (Pro), Google Sheets, Make.com Data Stores      |
+| Daily Digest (cross-pipeline)  | Gmail (one morning summary email of all new leads found) |
 
 Start with Pipeline 2. It has the fewest dependencies and the fastest path to a working end-to-end test.

--- a/docs/lead-automation/specs/buttondown-integration.md
+++ b/docs/lead-automation/specs/buttondown-integration.md
@@ -1,0 +1,178 @@
+# Buttondown Integration — Pipeline 5 (Partner Nurture)
+
+**Purpose:** Specification for using Buttondown as the email delivery layer for referral partner nurture emails and future content distribution.
+
+**Account:** Existing Buttondown subscription.
+**API Base:** `https://api.buttondown.email`
+**Docs:** api.buttondown.email
+
+---
+
+## How Buttondown Fits
+
+### Role 1: Transactional Partner Nurture (Pipeline 5 — Now)
+
+Pipeline 5's weekly cycle:
+
+1. Make.com identifies referral partners due for a check-in (from Google Sheet)
+2. Claude drafts a personalized email per partner
+3. **Make.com creates a Buttondown email draft** via API
+4. Human reviews drafts in Buttondown's dashboard
+5. Human approves → Buttondown sends the email
+
+**Why Buttondown over raw Gmail:**
+
+- Better deliverability (proper DKIM/SPF/DMARC via Buttondown's infrastructure)
+- Automatic unsubscribe footer (CAN-SPAM compliance)
+- Open/click tracking (know which partners engage)
+- Clean separation: Gmail for 1:1 conversation, Buttondown for structured outreach
+- Archive of all sent communications
+
+### Role 2: Broadcast Content (Future — Not in Initial Build)
+
+A monthly "operations insight" email to all referral partners and warm contacts. Positions SMD Services as the operations expert in the Phoenix market. This requires having enough partner relationships and content ideas — which come from running the pipelines for a few weeks first.
+
+**Not building this now.** But the subscriber list and Buttondown configuration established through Pipeline 5 provide the infrastructure. When ready, this is just a new Buttondown email with `status: "draft"` targeting the full subscriber list.
+
+---
+
+## Buttondown API — Key Endpoints
+
+### Authentication
+
+```
+Authorization: Token {BUTTONDOWN_API_KEY}
+```
+
+Find your API key at: Buttondown dashboard → Settings → API.
+
+### Create a Subscriber
+
+Add a referral partner to Buttondown's subscriber list.
+
+```
+POST https://api.buttondown.email/v1/subscribers
+Content-Type: application/json
+Authorization: Token {BUTTONDOWN_API_KEY}
+
+{
+  "email": "devin@whytecpapc.com",
+  "metadata": {
+    "firm_name": "Whyte CPA Tax & Accounting",
+    "contact_name": "Devin Whyte",
+    "tier": 1,
+    "relationship_stage": "prospect",
+    "source": "bookkeeper_prospect_list"
+  },
+  "tags": ["referral-partner", "tier-1"]
+}
+```
+
+**Tags to use:**
+
+- `referral-partner` — all bookkeeper/CPA partners
+- `tier-1`, `tier-2`, `tier-3` — from the prospect list
+- `active-partner` — currently referring
+- `prospect` — not yet contacted or early stage
+
+### Create an Email Draft
+
+Create an email that appears in Buttondown's dashboard for human review.
+
+```
+POST https://api.buttondown.email/v1/emails
+Content-Type: application/json
+Authorization: Token {BUTTONDOWN_API_KEY}
+
+{
+  "subject": "Quick check-in from the SMD team",
+  "body": "Hi Devin — Hope the quarter is going well...",
+  "status": "draft",
+  "email_type": "public"
+}
+```
+
+**Status options:**
+
+- `"draft"` — appears in dashboard for review (USE THIS for Pipeline 5)
+- `"about_to_send"` — queued for immediate send (use only after human approval)
+
+**For 1:1 partner emails:** Buttondown doesn't natively support sending to a single subscriber via the email endpoint (emails go to all subscribers or a tag group). For truly 1:1 transactional emails, options:
+
+1. **Tag-based targeting:** Tag each partner uniquely (e.g., `partner-whyte-cpa`) and send to that tag. Works but creates tag sprawl.
+2. **Use Buttondown's "emails to specific subscribers" feature** if available in your plan tier.
+3. **Alternative:** Use Buttondown for the broadcast/newsletter use case (Role 2) and Gmail for 1:1 nurture. Make.com creates Gmail drafts instead.
+
+**Recommendation:** Start with Gmail drafts for 1:1 partner nurture (simpler, truly personalized). Reserve Buttondown for when you're ready for broadcast content to the full partner list. The Make.com scenario recipe (Pipeline 5) should create Gmail drafts, with Buttondown integration added when the partner list is large enough for broadcast.
+
+### List Subscribers
+
+```
+GET https://api.buttondown.email/v1/subscribers
+  ?tag=referral-partner
+Authorization: Token {BUTTONDOWN_API_KEY}
+```
+
+Returns all subscribers with the given tag.
+
+---
+
+## Make.com Integration
+
+### For Pipeline 5 (1:1 Nurture — Gmail Drafts)
+
+Use Make.com's **Gmail → Create a Draft** module:
+
+- **To:** Partner's email from Google Sheet
+- **Subject:** From Claude's draft output
+- **Body:** From Claude's draft output
+- **No send** — human reviews drafts in Gmail and sends manually
+
+### For Future Broadcast (Buttondown)
+
+Use Make.com's **HTTP → Make a request** module:
+
+- **URL:** `https://api.buttondown.email/v1/emails`
+- **Method:** POST
+- **Headers:** `Authorization: Token {BUTTONDOWN_API_KEY}`, `Content-Type: application/json`
+- **Body:** JSON with subject, body, status: "draft"
+- Human reviews in Buttondown dashboard and publishes
+
+---
+
+## Subscriber Sync (One-Time Setup)
+
+Import the 22 partners from the bookkeeper prospect list into Buttondown:
+
+1. Export the Referral Partners Google Sheet as CSV
+2. In Buttondown dashboard → Subscribers → Import
+3. Map columns: email, name (firm_name), tags
+4. Tag all imports as `referral-partner` + their tier tag
+
+Or automate via API: Make.com scenario reads the Google Sheet, iterates over rows with email addresses, and calls `POST /v1/subscribers` for each.
+
+---
+
+## Email Content Guidelines
+
+All emails sent through Buttondown must follow the SMD Services tone standard:
+
+- **"We" voice** — never "I" or "the consultant"
+- **No dollar amounts** — ever
+- **No fixed timeframes** — don't commit to durations
+- **Objectives over problems** — frame around what the business is trying to achieve
+- **Collaborative** — "we work alongside" not "we audit"
+- **"Solution" not "systems"** in body copy
+- **Short** — 3-5 sentences for check-ins, 2-3 paragraphs for broadcast content
+
+---
+
+## Cost
+
+Buttondown subscription is already paid. No incremental cost for Pipeline 5 integration.
+
+| Component               | Monthly Cost                   |
+| ----------------------- | ------------------------------ |
+| Buttondown subscription | $0 incremental (already paid)  |
+| Gmail (for 1:1 drafts)  | $0 (existing Google Workspace) |
+| **Total**               | **$0**                         |

--- a/docs/lead-automation/specs/google-sheets-schema.md
+++ b/docs/lead-automation/specs/google-sheets-schema.md
@@ -1,0 +1,154 @@
+# Google Sheets Schema — Lead Generation Pipelines
+
+This document defines the column structure for 6 Google Sheets used as output destinations for automated lead generation pipelines built in Make.com. Each sheet corresponds to a specific pipeline source.
+
+**Creation order:** Create Sheets 1-5 first, then Sheet 6 (Master Pipeline). The Master Pipeline references data from the other five sheets, so those must exist before consolidation begins.
+
+**Naming convention:** Name each sheet tab exactly as shown (e.g., "Review Signal Leads") so Make.com scenario references remain consistent.
+
+---
+
+## Sheet 1: Review Signal Leads (Pipeline 1)
+
+Source: Google Maps review scraping and AI scoring.
+
+| Column | Header         | Type     | Notes                                                                         |
+| ------ | -------------- | -------- | ----------------------------------------------------------------------------- |
+| A      | Business Name  | text     |                                                                               |
+| B      | Phone          | text     |                                                                               |
+| C      | Website        | URL      | Auto-detect hyperlink                                                         |
+| D      | Category       | text     | e.g., "plumber", "HVAC", "dentist"                                            |
+| E      | Area           | text     | Phoenix sub-area (e.g., "Scottsdale", "Tempe", "Gilbert")                     |
+| F      | Google Rating  | number   | 1-5                                                                           |
+| G      | Review Count   | number   |                                                                               |
+| H      | Pain Score     | number   | 1-10. Conditional format: green (1-3), yellow (4-6), orange (7-8), red (9-10) |
+| I      | Top Problems   | text     | Comma-separated problem IDs (e.g., "1,3,5")                                   |
+| J      | Evidence       | text     | Key review quotes supporting the pain score                                   |
+| K      | Outreach Angle | text     | Suggested opening for outreach                                                |
+| L      | Date Found     | date     | Format: YYYY-MM-DD                                                            |
+| M      | Status         | dropdown | Values: New / Contacted / Responded / Meeting Booked / Dead                   |
+| N      | Notes          | text     | Free-form                                                                     |
+
+---
+
+## Sheet 2: Job Signal Leads (Pipeline 2)
+
+Source: Job posting scraping from Google Jobs, Craigslist, and local job boards.
+
+| Column | Header                | Type     | Notes                                                       |
+| ------ | --------------------- | -------- | ----------------------------------------------------------- |
+| A      | Company Name          | text     |                                                             |
+| B      | Job Title Posted      | text     |                                                             |
+| C      | Location              | text     |                                                             |
+| D      | Source                | text     | e.g., "Google Jobs", "Craigslist"                           |
+| E      | Company Size Estimate | text     | e.g., "10-25", "unknown"                                    |
+| F      | Qualified             | text     | "Yes", "No", "Maybe"                                        |
+| G      | Confidence            | text     | "high", "medium", "low"                                     |
+| H      | Problems Signaled     | text     | Comma-separated problem IDs                                 |
+| I      | Evidence              | text     | Key job description excerpts                                |
+| J      | Outreach Angle        | text     |                                                             |
+| K      | Job Posting URL       | URL      | Auto-detect hyperlink                                       |
+| L      | Date Found            | date     | Format: YYYY-MM-DD                                          |
+| M      | Status                | dropdown | Values: New / Contacted / Responded / Meeting Booked / Dead |
+| N      | Notes                 | text     |                                                             |
+
+---
+
+## Sheet 3: New Business Leads (Pipeline 3)
+
+Source: Public filings — Arizona Corporation Commission, ADOR TPT registrations, city permit feeds, SBA loan data.
+
+| Column | Header             | Type     | Notes                                                                                          |
+| ------ | ------------------ | -------- | ---------------------------------------------------------------------------------------------- |
+| A      | Business Name      | text     |                                                                                                |
+| B      | Entity Type        | text     | LLC, Corp, etc.                                                                                |
+| C      | Address            | text     |                                                                                                |
+| D      | Area               | text     | Phoenix sub-area                                                                               |
+| E      | Source             | text     | "ACC Filing", "ADOR TPT", "Phoenix Permit", "Scottsdale Permit", "Chandler Permit", "SBA Loan" |
+| F      | Filing/Permit Date | date     | Format: YYYY-MM-DD                                                                             |
+| G      | Vertical Match     | text     | Vertical ID or "unknown"                                                                       |
+| H      | Size Estimate      | text     |                                                                                                |
+| I      | Outreach Timing    | text     | "immediate", "wait 30 days", "wait 60 days"                                                    |
+| J      | Date Found         | date     | Format: YYYY-MM-DD                                                                             |
+| K      | Status             | dropdown | Values: New / Contacted / Responded / Meeting Booked / Dead                                    |
+| L      | Notes              | text     |                                                                                                |
+
+---
+
+## Sheet 4: Social Opportunities (Pipeline 4)
+
+Source: Reddit, Facebook groups, Nextdoor, Google Alerts — keyword-monitored posts where a business owner is asking for help or venting about operational pain.
+
+| Column | Header               | Type     | Notes                                            |
+| ------ | -------------------- | -------- | ------------------------------------------------ |
+| A      | Platform             | text     | "Reddit", "Facebook", "Nextdoor", "Google Alert" |
+| B      | Post Title / Subject | text     |                                                  |
+| C      | Author               | text     |                                                  |
+| D      | URL                  | URL      | Auto-detect hyperlink                            |
+| E      | Relevance            | text     | "high", "medium", "low"                          |
+| F      | Topic                | text     | Brief categorization                             |
+| G      | Date Found           | date     | Format: YYYY-MM-DD                               |
+| H      | Responded            | checkbox |                                                  |
+| I      | Response Notes       | text     |                                                  |
+
+---
+
+## Sheet 5: Referral Partners (Pipeline 5)
+
+Source: Bookkeeper/accountant/insurance agent research. Enhances the existing bookkeeper-prospect-list.md structure with relationship tracking.
+
+| Column | Header             | Type     | Notes                                                                      |
+| ------ | ------------------ | -------- | -------------------------------------------------------------------------- |
+| A      | Firm Name          | text     |                                                                            |
+| B      | Contact Name       | text     |                                                                            |
+| C      | Area               | text     |                                                                            |
+| D      | Phone              | text     |                                                                            |
+| E      | Email              | text     |                                                                            |
+| F      | Website            | URL      | Auto-detect hyperlink                                                      |
+| G      | Tier               | number   | 1, 2, or 3                                                                 |
+| H      | Focus Areas        | text     | What verticals/services they specialize in                                 |
+| I      | Relationship Stage | dropdown | Values: Prospect / Intro Sent / Intro Call Done / Active Partner / Dormant |
+| J      | Last Contact Date  | date     | Format: YYYY-MM-DD                                                         |
+| K      | Next Check-in Date | date     | Format: YYYY-MM-DD                                                         |
+| L      | Referrals Received | number   | Count of referrals from them to us                                         |
+| M      | Referrals Sent     | number   | Count of referrals from us to them                                         |
+| N      | Notes              | text     |                                                                            |
+
+---
+
+## Sheet 6: Master Pipeline
+
+Consolidated view across all sources. This is the working pipeline for outreach prioritization and tracking.
+
+| Column | Header          | Type     | Notes                                                       |
+| ------ | --------------- | -------- | ----------------------------------------------------------- |
+| A      | Business Name   | text     |                                                             |
+| B      | Source Pipeline | text     | "Reviews", "Jobs", "New Biz", "Social", "Referral"          |
+| C      | Category        | text     |                                                             |
+| D      | Area            | text     |                                                             |
+| E      | Pain Score      | number   | From AI scoring, or blank for non-scored sources            |
+| F      | Top Problems    | text     |                                                             |
+| G      | Outreach Angle  | text     |                                                             |
+| H      | Date Found      | date     | Format: YYYY-MM-DD                                          |
+| I      | Status          | dropdown | Values: New / Contacted / Responded / Meeting Booked / Dead |
+| J      | Notes           | text     |                                                             |
+
+**Population method:** Manual consolidation. Only promote leads worth pursuing from individual sheets (1-5) into the Master Pipeline. IMPORTRANGE formulas are an option for later automation, but manual curation is recommended initially to maintain signal quality.
+
+---
+
+## Formatting Rules (All Sheets)
+
+Apply these formatting standards when creating each sheet:
+
+1. **Header row (Row 1):** Frozen, bold text, light gray background (`#f3f3f3`).
+2. **Pain Score columns:** Conditional formatting rules:
+   - 1-3: Green background (`#d9ead3`)
+   - 4-6: Yellow background (`#fff2cc`)
+   - 7-8: Orange background (`#fce5cd`)
+   - 9-10: Red background (`#f4cccc`)
+3. **Status columns:** Data validation dropdown. Allowed values listed per sheet above.
+4. **Date columns:** Number format set to `yyyy-mm-dd`.
+5. **URL columns:** Auto-detect hyperlinks enabled.
+6. **New rows from Make.com:** Always append to the bottom of the sheet (never insert).
+7. **New row highlight:** Conditional formatting rule on the Date Found column — highlight the row if Date Found equals today. Use light blue background (`#cfe2f3`) so new rows are immediately visible.

--- a/docs/lead-automation/specs/make-data-store-schema.md
+++ b/docs/lead-automation/specs/make-data-store-schema.md
@@ -1,0 +1,121 @@
+# Make.com Data Store Schema
+
+## What Are Data Stores?
+
+Make.com Data Stores are simple key-value tables that live inside your Make.com account. They act as lightweight databases that scenarios can read from and write to during execution. We use them for **deduplication** — ensuring that each lead generation pipeline doesn't reprocess records it has already seen.
+
+Each Data Store has a defined structure (columns) and a primary key. Scenarios check the Data Store before processing a record: if the key exists, skip it; if not, process it and write the key.
+
+## Creation Instructions
+
+1. Go to **Settings → Data Stores** in your Make.com dashboard (left sidebar, gear icon).
+2. Click **Add data store**.
+3. Enter the name exactly as specified below.
+4. Define the data structure (columns) as documented for each table.
+5. Set the primary key as indicated.
+
+Repeat for all 4 Data Stores.
+
+## Plan Limits
+
+Data Store capacity depends on your Make.com plan:
+
+- **Free plan:** 1 Data Store, 1 MB storage — not sufficient for our pipelines.
+- **Core plan:** Limited Data Stores, 1 MB each.
+- **Pro plan ($16/mo):** Unlimited Data Stores, 1 MB each by default (expandable). Ample for our volume — each record is a few hundred bytes, so 1 MB holds thousands of entries per table.
+
+The Pro plan is required for running these pipelines.
+
+## Dedup Check Pattern
+
+Every pipeline follows the same dedup pattern:
+
+1. **Get a record** — Use the "Data Stores → Get a record" module with the record's key (e.g., `place_id`, `job_hash`).
+2. **Filter** — Add a filter after the Get module. Set the condition to: "The record does NOT exist" (the Get module returns empty).
+3. **Process** — If the filter passes (record not found), continue with the pipeline's processing logic.
+4. **Add/replace a record** — After processing, use "Data Stores → Add/replace a record" to write the key and its fields. This prevents reprocessing on future runs.
+
+If the record already exists, the filter stops execution for that item and the pipeline moves to the next.
+
+---
+
+## Table 1: `seen_businesses`
+
+**Pipeline:** Pipeline 1 — Review Mining
+
+**Purpose:** Prevents rescoring businesses whose reviews haven't changed since the last scan.
+
+| Field              | Type   | Description                                          |
+| ------------------ | ------ | ---------------------------------------------------- |
+| `place_id` (key)   | String | Google Places API `place_id`. Primary key.           |
+| `business_name`    | String | Name of the business.                                |
+| `last_scanned`     | Date   | ISO 8601 date of the most recent scan.               |
+| `last_review_date` | Date   | Date of the most recent review at the time of scan.  |
+| `last_pain_score`  | Number | Previous AI-assigned pain score, for tracking drift. |
+
+**Dedup logic:** Before scoring a business, check if `place_id` exists. If it does, compare `last_review_date` to the current most recent review. If unchanged, skip. If a newer review exists, reprocess and update the record.
+
+**Cleanup rule:** Delete entries where `last_scanned` is older than 90 days. The business may have closed, moved, or become irrelevant. Use a scheduled maintenance scenario or manual cleanup monthly.
+
+---
+
+## Table 2: `seen_jobs`
+
+**Pipeline:** Pipeline 2 — Job Monitor
+
+**Purpose:** Prevents reprocessing the same job posting across runs.
+
+| Field            | Type    | Description                                                              |
+| ---------------- | ------- | ------------------------------------------------------------------------ |
+| `job_hash` (key) | String  | SHA-256 hash of `company_name + job_title + location`. Primary key.      |
+| `company_name`   | String  | Name of the hiring company.                                              |
+| `job_title`      | String  | Title of the job posting.                                                |
+| `first_seen`     | Date    | ISO 8601 date the posting was first detected.                            |
+| `qualified`      | Boolean | Result of AI qualification (`true` = qualified, `false` = disqualified). |
+
+**Dedup logic:** Before processing a job posting, compute its hash and check if `job_hash` exists. If it does, skip entirely. If not, run qualification and write the result.
+
+**Cleanup rule:** Delete entries where `first_seen` is older than 60 days. Job postings expire and the hash space should stay clean.
+
+---
+
+## Table 3: `seen_permits`
+
+**Pipeline:** Pipeline 3 — New Business Detection
+
+**Purpose:** Prevents reprocessing the same permit or business filing.
+
+| Field             | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `record_id` (key) | String | Permit number or ACC filing number. Primary key.                                                                      |
+| `business_name`   | String | Name of the business on the permit or filing.                                                                         |
+| `source`          | String | Origin of the record: `phoenix_permit`, `scottsdale_permit`, `chandler_permit`, `acc_filing`, `ador_tpt`, `sba_loan`. |
+| `date_processed`  | Date   | ISO 8601 date the record was processed by the pipeline.                                                               |
+
+**Dedup logic:** Before processing a permit or filing, check if `record_id` exists. If it does, skip. If not, process and write the record.
+
+**Cleanup rule:** Delete entries where `date_processed` is older than 180 days. Permits and filings are one-time events; keeping them longer than 6 months wastes storage.
+
+---
+
+## Table 4: `seen_social`
+
+**Pipeline:** Pipeline 4 — Social Listening
+
+**Purpose:** Prevents surfacing the same social post or alert twice.
+
+| Field           | Type   | Description                                                            |
+| --------------- | ------ | ---------------------------------------------------------------------- |
+| `post_id` (key) | String | Reddit post ID, or SHA-256 of Google Alert subject + URL. Primary key. |
+| `platform`      | String | Source platform: `reddit`, `google_alerts`, `craigslist`.              |
+| `date_found`    | Date   | ISO 8601 date the post was first detected.                             |
+
+**Dedup logic:** Before processing a social post, check if `post_id` exists. If it does, skip. If not, process and write the record.
+
+**Cleanup rule:** Delete entries where `date_found` is older than 30 days. Social content is ephemeral — old posts are no longer actionable and the table should stay lean.
+
+---
+
+## Maintenance
+
+Run a cleanup scenario monthly (or set a scheduled scenario) that iterates each Data Store and deletes records past their retention window. Alternatively, perform manual cleanup via **Settings → Data Stores → [table name] → Browse records** and sort by date.

--- a/docs/lead-automation/specs/outscraper-queries.md
+++ b/docs/lead-automation/specs/outscraper-queries.md
@@ -1,0 +1,217 @@
+# Outscraper Query Specifications — Pipeline 1 (Review Mining)
+
+**Purpose:** Exact API queries for the Make.com Review Mining scenarios. These queries hit Outscraper's Google Maps Reviews API to pull recent reviews for Phoenix-area businesses by category.
+
+**Account:** Outscraper Medium plan ($49/mo) or pay-as-you-go (~$20-50/mo depending on volume).
+**API Base:** `https://api.outscraper.com`
+**Docs:** outscraper.com/docs
+
+---
+
+## Authentication
+
+All requests include the API key in the Authorization header:
+
+```
+Authorization: Bearer {OUTSCRAPER_API_KEY}
+```
+
+In Make.com: use the HTTP module with a custom header.
+
+---
+
+## Two-Phase Architecture
+
+Pipeline 1 uses two Make.com scenarios:
+
+### Phase 1: Business Discovery (Monthly)
+
+Uses **Google Places API** (not Outscraper) to build the master list of businesses to monitor. See Google Cloud setup in `api-accounts-checklist.md`.
+
+Google Places Text Search:
+
+```
+GET https://places.googleapis.com/v1/places:searchText
+Content-Type: application/json
+X-Goog-Api-Key: {GOOGLE_API_KEY}
+X-Goog-FieldMask: places.id,places.displayName,places.formattedAddress,places.nationalPhoneNumber,places.websiteUri,places.rating,places.userRatingCount,places.primaryType
+
+{
+  "textQuery": "plumber Phoenix AZ",
+  "locationBias": {
+    "circle": {
+      "center": { "latitude": 33.4484, "longitude": -112.0740 },
+      "radius": 50000.0
+    }
+  },
+  "maxResultCount": 20
+}
+```
+
+Discovery queries (run once monthly to refresh the master list):
+
+| #   | Query                            | Vertical              |
+| --- | -------------------------------- | --------------------- |
+| 1   | `plumber Phoenix AZ`             | home_services         |
+| 2   | `HVAC contractor Phoenix AZ`     | home_services         |
+| 3   | `electrician Phoenix AZ`         | home_services         |
+| 4   | `pest control Phoenix AZ`        | home_services         |
+| 5   | `landscaping company Phoenix AZ` | home_services         |
+| 6   | `plumber Scottsdale AZ`          | home_services         |
+| 7   | `plumber Chandler AZ`            | home_services         |
+| 8   | `plumber Mesa AZ`                | home_services         |
+| 9   | `accounting firm Phoenix AZ`     | professional_services |
+| 10  | `law firm Phoenix AZ`            | professional_services |
+| 11  | `insurance agency Phoenix AZ`    | professional_services |
+| 12  | `dental office Phoenix AZ`       | professional_services |
+| 13  | `auto repair Phoenix AZ`         | other                 |
+| 14  | `veterinarian Phoenix AZ`        | other                 |
+
+Each query returns up to 20 results. With pagination (nextPageToken), up to 60. Start with 20 per query — that's 280 businesses in the initial list. Google's $200/mo free credit covers ~6,250 Text Searches.
+
+Store results in the `seen_businesses` Make.com Data Store with place_id as the key.
+
+### Phase 2: Review Scanning (Weekly)
+
+Uses **Outscraper** to pull recent reviews for all businesses in the master list.
+
+---
+
+## Outscraper Reviews API
+
+### Endpoint: Get Reviews
+
+```
+GET https://api.outscraper.com/maps/reviews-v3
+  ?query={PLACE_ID}
+  &reviewsLimit=10
+  &sort=newest
+  &cutoff={UNIX_TIMESTAMP_7_DAYS_AGO}
+  &async=false
+```
+
+### Parameters
+
+| Parameter      | Value                  | Notes                                                                  |
+| -------------- | ---------------------- | ---------------------------------------------------------------------- |
+| `query`        | Google Places place_id | e.g., `ChIJ_abc123`                                                    |
+| `reviewsLimit` | `10`                   | Max reviews to return per business                                     |
+| `sort`         | `newest`               | Sort by most recent first                                              |
+| `cutoff`       | Unix timestamp         | Only reviews after this date. Set to 7 days ago.                       |
+| `async`        | `false`                | Synchronous response (wait for results). Use `true` for large batches. |
+| `language`     | `en`                   | English reviews only                                                   |
+
+### Response Structure (key fields)
+
+```json
+[
+  {
+    "name": "Reliable Rooter Plumbing",
+    "place_id": "ChIJ_abc123",
+    "rating": 4.2,
+    "reviews": 87,
+    "reviews_data": [
+      {
+        "author_title": "John Smith",
+        "review_rating": 3,
+        "review_text": "Had to call three times before anyone picked up...",
+        "review_datetime_utc": "2026-03-25T14:30:00Z",
+        "owner_answer": "We apologize for the inconvenience..."
+      }
+    ]
+  }
+]
+```
+
+**Fields to extract:**
+
+- `name` → business_name for Claude prompt
+- `place_id` → dedup key
+- `rating` → overall_rating for context
+- `reviews` → total_review_count
+- `reviews_data[].author_title` → review author
+- `reviews_data[].review_rating` → individual review star rating
+- `reviews_data[].review_text` → the review text for AI analysis
+- `reviews_data[].review_datetime_utc` → review date
+
+### Batching
+
+Outscraper supports batch requests — multiple place_ids in a single call:
+
+```
+GET https://api.outscraper.com/maps/reviews-v3
+  ?query=ChIJ_abc123,ChIJ_def456,ChIJ_ghi789
+  &reviewsLimit=10
+  &sort=newest
+  &cutoff={UNIX_TIMESTAMP}
+```
+
+Use batches of 10 place_ids per call to reduce HTTP round trips while staying within response size limits.
+
+---
+
+## Cutoff Date Calculation
+
+The `cutoff` parameter uses Unix timestamps. In Make.com, calculate "7 days ago" using:
+
+```
+{{formatDate(addDays(now; -7); "X")}}
+```
+
+This Make.com expression:
+
+1. Gets current datetime (`now`)
+2. Subtracts 7 days (`addDays(now; -7)`)
+3. Formats as Unix timestamp (`"X"`)
+
+---
+
+## Weekly Scan Flow
+
+1. Read all place_ids from the `seen_businesses` Data Store
+2. Batch into groups of 10
+3. For each batch, call Outscraper Reviews API with `cutoff` = 7 days ago
+4. For businesses with new reviews (reviews_data not empty):
+   - Pass to Claude review scoring prompt (batch 5-10 businesses per prompt call)
+   - For scored businesses with pain_score >= 7: write to Google Sheet + Slack notification
+   - Update `seen_businesses` Data Store with `last_scanned` and `last_pain_score`
+5. For businesses with no new reviews: skip (no API cost, no operations spent)
+
+---
+
+## Cost Calculations
+
+### Outscraper Pricing
+
+Reviews extraction: ~$3 per 1,000 place_ids queried (regardless of how many reviews come back).
+
+| Scenario                   | Place IDs/Week | Monthly Cost |
+| -------------------------- | -------------- | ------------ |
+| 200 businesses monitored   | 200/week       | ~$2.40/mo    |
+| 500 businesses monitored   | 500/week       | ~$6.00/mo    |
+| 1,000 businesses monitored | 1,000/week     | ~$12.00/mo   |
+
+### Google Places API (Discovery)
+
+Text Search: $32 per 1,000 requests.
+
+| Scenario                                   | Queries/Month | Monthly Cost                     |
+| ------------------------------------------ | ------------- | -------------------------------- |
+| 14 queries × 1 run/month                   | 14            | ~$0.45 (within $200 free credit) |
+| 14 queries × 4 runs/month (weekly refresh) | 56            | ~$1.80 (within free credit)      |
+
+**Total Pipeline 1 cost: ~$6-12/mo** at 500 businesses monitored weekly.
+
+---
+
+## Outscraper Alternatives
+
+If Outscraper pricing or reliability becomes an issue:
+
+| Service                           | Reviews API            | Cost             | Key Difference                    |
+| --------------------------------- | ---------------------- | ---------------- | --------------------------------- |
+| **DataForSEO**                    | All reviews, paginated | ~$2/1K tasks     | Cheaper but no date cutoff filter |
+| **SerpAPI** (Google Maps Reviews) | All reviews, paginated | $75-150/mo       | More reliable, higher cost        |
+| **Apify** (Google Maps Scraper)   | All reviews            | ~$49/mo platform | More flexible, more setup         |
+
+DataForSEO is the best cost alternative. You'd pull all reviews and filter by date client-side (in Make.com with a filter module after the HTTP response).

--- a/docs/lead-automation/specs/outscraper-queries.md
+++ b/docs/lead-automation/specs/outscraper-queries.md
@@ -173,7 +173,7 @@ This Make.com expression:
 3. For each batch, call Outscraper Reviews API with `cutoff` = 7 days ago
 4. For businesses with new reviews (reviews_data not empty):
    - Pass to Claude review scoring prompt (batch 5-10 businesses per prompt call)
-   - For scored businesses with pain_score >= 7: write to Google Sheet + Slack notification
+   - For scored businesses with pain_score >= 7: write to Google Sheet (included in daily digest email)
    - Update `seen_businesses` Data Store with `last_scanned` and `last_pain_score`
 5. For businesses with no new reviews: skip (no API cost, no operations spent)
 

--- a/docs/lead-automation/specs/serpapi-queries.md
+++ b/docs/lead-automation/specs/serpapi-queries.md
@@ -142,15 +142,15 @@ For our use case, a single page per query is enough. Save the credits.
 
 ## Error Handling
 
-| HTTP Status                | Meaning              | Action                         |
-| -------------------------- | -------------------- | ------------------------------ |
-| 200                        | Success              | Process results                |
-| 200 + empty `jobs_results` | No matching jobs     | Normal — skip, no error        |
-| 401                        | Invalid API key      | Alert in Slack, stop scenario  |
-| 429                        | Rate limited         | Retry after 60 seconds         |
-| 500+                       | SerpAPI server error | Retry once, then skip this run |
+| HTTP Status                | Meaning              | Action                                    |
+| -------------------------- | -------------------- | ----------------------------------------- |
+| 200                        | Success              | Process results                           |
+| 200 + empty `jobs_results` | No matching jobs     | Normal — skip, no error                   |
+| 401                        | Invalid API key      | Send alert email via Gmail, stop scenario |
+| 429                        | Rate limited         | Retry after 60 seconds                    |
+| 500+                       | SerpAPI server error | Retry once, then skip this run            |
 
-In Make.com: add an error handler route on the HTTP module. Route 429/500 errors to a Slack notification. Route 401 to a "break" directive (stops and alerts).
+In Make.com: add an error handler route on the HTTP module. Route 429/500 errors to a Gmail alert email. Route 401 to a "break" directive (stops and alerts).
 
 ---
 

--- a/docs/lead-automation/specs/serpapi-queries.md
+++ b/docs/lead-automation/specs/serpapi-queries.md
@@ -1,0 +1,192 @@
+# SerpAPI Query Specifications — Pipeline 2 (Job Monitor)
+
+**Purpose:** Exact API queries for the Make.com Job Posting Monitor scenario. These queries hit SerpAPI's Google Jobs endpoint, which aggregates from Indeed, LinkedIn, ZipRecruiter, Glassdoor, and direct company postings.
+
+**Account:** SerpAPI Developer plan, $50/mo, 5,000 searches/month.
+**Endpoint:** `https://serpapi.com/search`
+
+---
+
+## Authentication
+
+All requests include the API key as a query parameter:
+
+```
+?api_key={SERPAPI_API_KEY}
+```
+
+In Make.com: use the HTTP module with the API key stored in a connection or scenario variable. Never hardcode.
+
+---
+
+## Query Template
+
+```
+GET https://serpapi.com/search
+  ?engine=google_jobs
+  &q={JOB_TITLE}
+  &location=Phoenix, Arizona, United States
+  &chips=date_posted:3days
+  &api_key={SERPAPI_API_KEY}
+```
+
+### Parameters
+
+| Parameter  | Value                             | Notes                                                            |
+| ---------- | --------------------------------- | ---------------------------------------------------------------- |
+| `engine`   | `google_jobs`                     | Google Jobs aggregation engine                                   |
+| `q`        | Job title search term             | See list below                                                   |
+| `location` | `Phoenix, Arizona, United States` | Covers greater Phoenix metro                                     |
+| `chips`    | `date_posted:3days`               | Only recent postings. Options: `today`, `3days`, `week`, `month` |
+| `api_key`  | Your SerpAPI key                  |                                                                  |
+
+### Response Structure (key fields)
+
+```json
+{
+  "jobs_results": [
+    {
+      "title": "Office Manager",
+      "company_name": "Desert Breeze Plumbing",
+      "location": "Phoenix, AZ",
+      "description": "Full job description text...",
+      "detected_extensions": {
+        "posted_at": "2 days ago",
+        "schedule_type": "Full-time",
+        "salary": "$45,000–$55,000 a year"
+      },
+      "job_id": "eyJqb2JfdGl0bGUiOi...",
+      "apply_options": [
+        {
+          "title": "Indeed",
+          "link": "https://www.indeed.com/..."
+        }
+      ]
+    }
+  ],
+  "search_metadata": {
+    "status": "Success",
+    "total_time_taken": 2.5
+  }
+}
+```
+
+**Fields to extract for the Google Sheet:**
+
+- `company_name` → Column A (Company Name)
+- `title` → Column B (Job Title Posted)
+- `location` → Column C (Location)
+- `"Google Jobs"` → Column D (Source)
+- `description` → Pass to Claude for qualification
+- `apply_options[0].link` → Column K (Job Posting URL)
+- Date of scan → Column L (Date Found)
+
+---
+
+## The 8 Monitored Queries
+
+Run all 8 daily. Each query = 1 SerpAPI credit. 8 queries/day × 30 days = 240 credits/month (well within the 5,000/month plan).
+
+| #   | Query (`q` parameter)          | Rationale                                                      |
+| --- | ------------------------------ | -------------------------------------------------------------- |
+| 1   | `office manager`               | Classic owner bottleneck signal — hiring to offload everything |
+| 2   | `operations manager`           | Direct operations pain signal                                  |
+| 3   | `dispatcher`                   | Scheduling chaos — especially in home services and trades      |
+| 4   | `scheduling coordinator`       | Scheduling chaos signal                                        |
+| 5   | `customer service coordinator` | Manual communication + lead leakage                            |
+| 6   | `office administrator`         | Owner bottleneck — the "everything" role                       |
+| 7   | `front desk manager`           | Patient/client-facing scheduling + communication               |
+| 8   | `service coordinator`          | Home services dispatch + scheduling                            |
+
+### Optional Expansion Queries
+
+Add these if the base 8 aren't generating enough volume:
+
+| #   | Query                      | Rationale                                         |
+| --- | -------------------------- | ------------------------------------------------- |
+| 9   | `bookkeeper`               | Financial blindness — business is behind on books |
+| 10  | `administrative assistant` | Owner bottleneck at smaller companies             |
+| 11  | `receptionist`             | Manual communication — phone chaos                |
+| 12  | `project coordinator`      | Contractor/trades — team invisibility             |
+
+---
+
+## Deduplication Strategy
+
+SerpAPI returns a `job_id` field per result. This is a base64-encoded string unique to each posting.
+
+**Dedup key:** `SHA256(company_name + title + location)` — more stable than `job_id` which can change across queries.
+
+**Make.com Data Store check:**
+
+1. Before processing each job, hash `company_name + title + location`
+2. Check `seen_jobs` Data Store: does this key exist?
+3. If yes → skip (filter module, no operation cost)
+4. If no → process through Claude → write to Data Store after qualification
+
+---
+
+## Pagination
+
+Google Jobs results are NOT paginated in the traditional sense. SerpAPI returns up to ~15 results per query. For Phoenix-specific job titles, this is typically sufficient — most queries return 5-15 results.
+
+If you need more results, you can use the `start` parameter:
+
+```
+&start=10  # Skip first 10, get next page
+```
+
+For our use case, a single page per query is enough. Save the credits.
+
+---
+
+## Error Handling
+
+| HTTP Status                | Meaning              | Action                         |
+| -------------------------- | -------------------- | ------------------------------ |
+| 200                        | Success              | Process results                |
+| 200 + empty `jobs_results` | No matching jobs     | Normal — skip, no error        |
+| 401                        | Invalid API key      | Alert in Slack, stop scenario  |
+| 429                        | Rate limited         | Retry after 60 seconds         |
+| 500+                       | SerpAPI server error | Retry once, then skip this run |
+
+In Make.com: add an error handler route on the HTTP module. Route 429/500 errors to a Slack notification. Route 401 to a "break" directive (stops and alerts).
+
+---
+
+## Cost Calculations
+
+| Scenario                         | Credits/Month | Cost                    |
+| -------------------------------- | ------------- | ----------------------- |
+| 8 queries × 1 run/day × 30 days  | 240           | Included in $50/mo plan |
+| 12 queries × 1 run/day × 30 days | 360           | Included in $50/mo plan |
+| 8 queries × 2 runs/day × 30 days | 480           | Included in $50/mo plan |
+| **Max budget**                   | **5,000**     | **$50/mo**              |
+
+We're using <10% of the plan capacity. Room to add more queries or increase frequency without additional cost.
+
+---
+
+## Craigslist RSS (Supplementary)
+
+Free. No API key needed. Monitored via Make.com's RSS module.
+
+### RSS Feed URLs
+
+| #   | Job Title              | Craigslist RSS URL                                                                  |
+| --- | ---------------------- | ----------------------------------------------------------------------------------- |
+| 1   | office manager         | `https://phoenix.craigslist.org/search/jjj?query=office+manager&format=rss`         |
+| 2   | dispatcher             | `https://phoenix.craigslist.org/search/jjj?query=dispatcher&format=rss`             |
+| 3   | scheduling coordinator | `https://phoenix.craigslist.org/search/jjj?query=scheduling+coordinator&format=rss` |
+| 4   | office administrator   | `https://phoenix.craigslist.org/search/jjj?query=office+administrator&format=rss`   |
+
+### RSS Response Fields
+
+- `title` — Job title (often includes company name)
+- `link` — URL to the Craigslist posting
+- `pubDate` — Publication date
+- `description` — First ~300 characters of the posting
+
+**Limitation:** Craigslist postings are often anonymous (no company name). The description is truncated. Signal quality is lower than Google Jobs, but it catches the smallest businesses that only post on Craigslist.
+
+In Make.com: use the "Watch RSS Feed Items" module, set to check every 6 hours. New items trigger the same Claude qualification as SerpAPI results, but with `source: "craigslist"` and the caveat that company name may be "Anonymous" or extracted from the title.

--- a/docs/lead-automation/specs/soda-api-queries.md
+++ b/docs/lead-automation/specs/soda-api-queries.md
@@ -1,0 +1,228 @@
+# SODA API Query Specifications — Pipeline 3 (New Business Detection)
+
+**Purpose:** Exact API queries for the Make.com New Business Detection scenario. These queries hit the Socrata Open Data API (SODA) endpoints provided by Phoenix, Scottsdale, and Chandler to pull recent commercial building permits.
+
+**Cost:** $0 — all city open data portals are free and require no API key for basic access.
+
+---
+
+## What We're Looking For
+
+Commercial **tenant improvement (TI) permits** are the primary signal. A commercial TI means a business is moving into, expanding, or renovating a commercial space — a direct growth signal. These businesses are either:
+
+- New businesses setting up shop (pre-chaos — great timing for us)
+- Existing businesses expanding (mid-growth — likely feeling operational strain)
+
+---
+
+## SODA API Basics
+
+All three cities use Socrata-powered open data portals. The API is REST-based with SQL-like filtering via `$where` clauses.
+
+**No authentication required** for basic read access. Rate-limited to ~1,000 requests/hour without an app token. For our volume (3 queries/day), no token needed.
+
+### Common Parameters
+
+| Parameter | Usage             | Example                             |
+| --------- | ----------------- | ----------------------------------- |
+| `$where`  | SQL-like filter   | `$where=issue_date > '2026-03-23'`  |
+| `$limit`  | Max rows returned | `$limit=100`                        |
+| `$order`  | Sort order        | `$order=issue_date DESC`            |
+| `$select` | Column projection | `$select=permit_number,description` |
+
+Date format in `$where`: `'YYYY-MM-DD'` (single quotes, ISO format).
+
+---
+
+## Phoenix Open Data
+
+**Portal:** phoenixopendata.com
+**Dataset:** Building Permits
+
+**Note:** The exact dataset resource ID must be confirmed by visiting the portal and finding the building permits dataset. Socrata dataset IDs are 4-character alphanumeric codes (e.g., `abcd-1234`). Visit the portal, search for "building permits" or "commercial permits," and note the resource ID from the URL.
+
+### Query Template
+
+```
+GET https://www.phoenixopendata.com/resource/{DATASET_ID}.json
+  ?$where=issue_date > '{7_DAYS_AGO}'
+    AND permit_type_desc LIKE '%COMMERCIAL%'
+  &$limit=100
+  &$order=issue_date DESC
+```
+
+**Alternative filter approaches** (depends on exact column names in the dataset):
+
+```
+# If the dataset uses work_class or permit_category:
+?$where=issue_date > '{7_DAYS_AGO}' AND work_class = 'Commercial'
+
+# If the dataset uses description text search:
+?$where=issue_date > '{7_DAYS_AGO}' AND description LIKE '%tenant improvement%'
+```
+
+### Expected Response Fields
+
+Typical Socrata building permit fields (exact names vary by dataset):
+
+| Field                               | Maps To                                 |
+| ----------------------------------- | --------------------------------------- |
+| `permit_number`                     | Dedup key for `seen_permits` Data Store |
+| `description` or `work_description` | What's being built/modified             |
+| `issue_date`                        | Filing/Permit Date                      |
+| `owner_name` or `contractor_name`   | Business Name (may need enrichment)     |
+| `address`                           | Address                                 |
+| `permit_type` or `work_class`       | Filter for commercial TIs               |
+| `valuation` or `est_project_cost`   | Scale signal (higher = larger project)  |
+
+---
+
+## Scottsdale Open Data
+
+**Portal:** data.scottsdaleaz.gov
+**Dataset:** Building Permits (search the portal for exact resource ID)
+
+### Query Template
+
+```
+GET https://data.scottsdaleaz.gov/resource/{DATASET_ID}.json
+  ?$where=issued_date > '{7_DAYS_AGO}'
+    AND permit_type = 'Commercial'
+  &$limit=100
+  &$order=issued_date DESC
+```
+
+---
+
+## Chandler Open Data
+
+**Portal:** data.chandleraz.gov
+**Dataset:** Building Permits (search the portal for exact resource ID)
+
+### Query Template
+
+```
+GET https://data.chandleraz.gov/resource/{DATASET_ID}.json
+  ?$where=issue_date > '{7_DAYS_AGO}'
+    AND work_class = 'Commercial'
+  &$limit=100
+  &$order=issue_date DESC
+```
+
+---
+
+## Setup Steps
+
+Before the Make.com scenario will work, you need to identify the actual dataset resource IDs:
+
+### For Each City:
+
+1. Visit the open data portal URL
+2. Search for "building permits" or "permits"
+3. Find the dataset with commercial permit data
+4. Note the 4-character resource ID from the URL (format: `xxxx-xxxx`)
+5. Click "API" or "API Docs" to see the exact column names
+6. Adjust the `$where` clause to match the actual column names
+7. Test the query in a browser — append `.json` to the dataset URL
+
+### Example Browser Test
+
+```
+https://www.phoenixopendata.com/resource/{ID}.json?$limit=5
+```
+
+This returns 5 rows of raw data showing all column names and data types.
+
+---
+
+## Make.com Integration
+
+In Make.com, use the **HTTP → Make a request** module:
+
+1. **URL:** The full SODA query URL (with `$where`, `$limit`, `$order`)
+2. **Method:** GET
+3. **Headers:** None required (no auth)
+4. **Parse response:** Yes (JSON)
+5. **Date calculation:** Use Make.com's `{{formatDate(addDays(now; -7); "YYYY-MM-DD")}}` for the 7-days-ago date
+
+### Date Filter in Make.com
+
+The `$where` clause needs the date dynamically calculated:
+
+```
+$where=issue_date > '{{formatDate(addDays(now; -7); "YYYY-MM-DD")}}'
+  AND work_class = 'Commercial'
+```
+
+In Make.com, this is constructed in the URL field of the HTTP module. Use the expression editor to insert the date function.
+
+---
+
+## Normalization
+
+Each city may use different column names. Normalize to a standard format before passing to Claude or writing to Sheets:
+
+| Standard Field  | Phoenix | Scottsdale | Chandler |
+| --------------- | ------- | ---------- | -------- |
+| `permit_number` | TBD     | TBD        | TBD      |
+| `business_name` | TBD     | TBD        | TBD      |
+| `address`       | TBD     | TBD        | TBD      |
+| `permit_date`   | TBD     | TBD        | TBD      |
+| `permit_type`   | TBD     | TBD        | TBD      |
+| `description`   | TBD     | TBD        | TBD      |
+
+**Fill in the TBD values** during setup by examining actual API responses from each city.
+
+---
+
+## Semi-Automated Sources (ACC / ADOR)
+
+These are NOT API-accessible. They require a human to submit a public records request.
+
+### Arizona Corporation Commission (ACC) — New Entity Filings
+
+**Process:**
+
+1. Email the ACC public records office requesting new entity filings in Maricopa County for the past week
+2. ACC responds with a data extract (legally required under ARS 39-121)
+3. Save the file to a designated Google Drive folder
+4. Make.com watches the folder (Google Drive → Watch Files module)
+5. When a new file appears, parse it (CSV/Excel) and process each entity through the new business qualification prompt
+6. Write qualified entities to the New Business Leads sheet
+
+**ACC Contact:** records@azcc.gov (or current public records email — verify on azcc.gov)
+**Cadence:** Weekly
+
+### Arizona Department of Revenue (ADOR) — New TPT Licenses
+
+**Process:** Same as ACC, but monthly cadence.
+**Contact:** Verify current public records contact on azdor.gov.
+**Signal quality:** Higher than ACC — a TPT license means the business is actually operating, not just filed paperwork.
+
+### SBA Loan Data
+
+**Source:** data.sba.gov — quarterly bulk CSV downloads
+**Process:**
+
+1. Download the quarterly 7(a) and 504 loan data
+2. Filter for Maricopa County zip codes (850xx, 852xx, 853xx)
+3. Process through the new business qualification prompt
+4. Write to New Business Leads sheet with source = "sba_loan"
+
+**Cadence:** Quarterly
+**Lag:** Data is typically 3-6 months old. Good for batch prospecting, not real-time detection.
+
+---
+
+## Cost
+
+| Source                                    | Monthly Cost               |
+| ----------------------------------------- | -------------------------- |
+| Phoenix SODA API                          | $0                         |
+| Scottsdale SODA API                       | $0                         |
+| Chandler SODA API                         | $0                         |
+| ACC public records                        | $0 (free under ARS 39-121) |
+| ADOR public records                       | $0                         |
+| SBA data download                         | $0                         |
+| Claude API (qualifying ~50 entities/week) | ~$3-5                      |
+| **Total**                                 | **~$3-5/mo**               |

--- a/src/lead-gen/prompts/job-qualification-prompt.ts
+++ b/src/lead-gen/prompts/job-qualification-prompt.ts
@@ -1,0 +1,217 @@
+/**
+ * Job Qualification Prompt — Pipeline 2
+ *
+ * Analyzes job postings from Phoenix-area businesses to determine if the
+ * posting signals operational pain that SMD Services could address. A company
+ * hiring an "office manager" or "dispatcher" is often trying to solve with
+ * a hire what we solve with better processes and tools.
+ *
+ * Used in: Make.com scenario → Anthropic module → this prompt
+ * Input: Job posting data from SerpAPI (Google Jobs) or Craigslist RSS
+ * Output: JobQualification JSON (see job-signal.ts)
+ *
+ * @see Decision #2 — Employee Count Range (10-25)
+ * @see Decision #3 — Launch Verticals (home services + professional services)
+ * @see Decision #4 — Disqualification Criteria
+ * @see Decision #20 — Voice Standard ("we" voice)
+ */
+
+import type { JobPostingInput, JobQualification } from '../schemas/job-signal.js'
+
+export type { JobQualification, JobPostingInput }
+
+/**
+ * System prompt for job posting qualification.
+ * Establishes context and scoring criteria for the AI.
+ */
+export const JOB_QUALIFICATION_SYSTEM_PROMPT = `You are a lead qualification assistant for SMD Services, an operations consulting team that works with Phoenix-area small businesses (10–25 employees).
+
+Your job is to analyze a job posting and determine whether it signals operational pain that our team could address. Many small businesses try to hire their way out of operational problems — an "office manager" to create order from chaos, a "dispatcher" because scheduling is broken, a "customer service coordinator" because follow-up is nonexistent. These are our ideal prospects.
+
+## The 6 Universal SMB Operations Problems
+
+Map job posting signals to these canonical problem types:
+
+1. **owner_bottleneck** — The owner is involved in everything. Signals: "report directly to owner," "owner currently handles," "wear many hats," responsibilities spanning 4+ domains.
+2. **lead_leakage** — No follow-up system, leads fall through cracks. Signals: "manage incoming leads," "follow up with prospects," "CRM," "no existing sales process."
+3. **financial_blindness** — Books behind, no visibility. Signals: "bring books current," "organize financial records," "QuickBooks cleanup."
+4. **scheduling_chaos** — No centralized scheduling. Signals: "coordinate schedules," "dispatch," "manage appointments," "double-bookings."
+5. **manual_communication** — Every message is manual. Signals: "respond to all customer inquiries," "send appointment reminders," "personal follow-up with every client."
+6. **team_invisibility** — No task tracking, no accountability. Signals: "create processes," "document procedures," "implement tracking," "nobody knows who's doing what."
+
+## Qualification Criteria
+
+**Qualify (qualified: true) when ALL of these are likely true:**
+- The company appears to have 10-50 employees (some flexibility above our 25 ceiling)
+- The posting signals at least one of the 6 operational problems
+- The company is in or near Phoenix, AZ
+- The role is being created to solve an operational gap, not just to replace a departing employee
+
+**Disqualify (qualified: false) when ANY of these are true:**
+- Large company (100+ employees, multiple locations mentioned, corporate language)
+- Franchise corporate/headquarters office (individual franchise locations ARE qualified)
+- Government agency or school district
+- Staffing/recruitment agency posting on behalf of client
+- Hospital, large medical group, or enterprise organization
+- The role is a standard replacement hire with no operational pain signals
+- Remote/national company that just happens to list Phoenix
+
+## Confidence Levels
+
+- **high** — Strong small business signals AND clear operational pain in the description
+- **medium** — Probable small business but limited pain signals, or clear pain but uncertain size
+- **low** — Ambiguous on both dimensions; worth a look but uncertain
+
+## Output Rules
+
+- Output ONLY valid JSON matching the schema. No markdown, no code fences, no commentary.
+- The outreach_angle must use "we" voice (never "I"). Reference the specific pain from the posting. Never mention pricing or timeframes.
+- Be specific in the evidence field — quote or closely paraphrase the job description.
+- When disqualifying, briefly explain why in disqualification_reason.
+
+## Examples
+
+### Example 1: Qualified (high confidence)
+
+Input job title: "Office Manager / Operations Coordinator"
+Input company: "Desert Breeze Plumbing"
+Input description: "Small family-owned plumbing company looking for someone to bring order to our growing business. Owner currently handles scheduling, customer calls, and invoicing. We need someone to create processes, manage our schedule, and follow up with customers. Must be organized and comfortable with technology. QuickBooks experience a plus."
+
+Output:
+{"company":"Desert Breeze Plumbing","qualified":true,"confidence":"high","company_size_estimate":"10-20","problems_signaled":["owner_bottleneck","scheduling_chaos","manual_communication"],"evidence":"Owner currently handles scheduling, customer calls, and invoicing. Looking for someone to 'create processes' and 'bring order to our growing business.' Multiple operational domains in one role signals severe owner bottleneck.","outreach_angle":"Before adding payroll for this role, it might be worth a conversation. We help businesses like yours build the scheduling and follow-up processes that make this hire half as big — or channel their time toward growth instead of putting out fires.","disqualification_reason":null}
+
+### Example 2: Disqualified (large company)
+
+Input job title: "Operations Manager"
+Input company: "Southwest Medical Associates"
+Input description: "Multi-location healthcare organization seeking an experienced Operations Manager to oversee daily operations across our 6 Phoenix-area clinics. Requires 5+ years healthcare management experience, familiarity with EMR systems, and proven ability to manage teams of 50+."
+
+Output:
+{"company":"Southwest Medical Associates","qualified":false,"confidence":"high","company_size_estimate":"200+","problems_signaled":[],"evidence":"Multi-location (6 clinics), teams of 50+, enterprise healthcare organization.","outreach_angle":"","disqualification_reason":"Large multi-location healthcare organization, well above the 10-25 employee range. Enterprise-scale operations management, not small business operational pain."}
+
+### Example 3: Qualified (medium confidence)
+
+Input job title: "Administrative Assistant"
+Input company: "Copperstate Electrical"
+Input description: "Established electrical contractor seeks organized admin to answer phones, schedule service calls, file permits, and assist with billing. Part-time to start, may become full-time. No experience required, will train."
+
+Output:
+{"company":"Copperstate Electrical","qualified":true,"confidence":"medium","company_size_estimate":"10-25","problems_signaled":["scheduling_chaos","owner_bottleneck"],"evidence":"Single-person admin role covering phones, scheduling, permits, and billing — classic owner bottleneck where the owner has been doing all of this. Part-time to start suggests smaller company testing the waters.","outreach_angle":"If scheduling and phones are eating up enough time to justify a hire, there may be some quick wins we could help with — process and tools that make whoever fills this role more effective from day one.","disqualification_reason":null}`
+
+/**
+ * Builds the user prompt with job posting data inserted.
+ *
+ * @param job - The job posting data from SerpAPI or Craigslist
+ * @returns The complete user prompt to send to Claude
+ */
+export function buildJobQualificationUserPrompt(job: JobPostingInput): string {
+  return `Analyze this job posting and determine if it signals operational pain at a small business.
+
+Job title: ${job.title}
+Company: ${job.company}
+Location: ${job.location}
+Source: ${job.source}
+${job.url ? `URL: ${job.url}` : ''}
+
+Description:
+${job.description}
+
+Produce a single JSON object matching the JobQualification schema.`
+}
+
+/**
+ * Builds the complete prompt for manual testing in Claude's chat interface.
+ * Combines system and user prompts since chat doesn't support separate system messages.
+ *
+ * @param job - The job posting data
+ * @returns The complete prompt string for manual use
+ */
+export function buildManualJobQualificationPrompt(job: JobPostingInput): string {
+  return `${JOB_QUALIFICATION_SYSTEM_PROMPT}
+
+---
+
+${buildJobQualificationUserPrompt(job)}`
+}
+
+/**
+ * Validates that a parsed JSON object conforms to the JobQualification schema.
+ *
+ * @param data - The parsed JSON to validate
+ * @returns An object with `valid` boolean and `errors` array of issues found
+ */
+export function validateJobQualification(data: unknown): {
+  valid: boolean
+  errors: string[]
+} {
+  const errors: string[] = []
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Root must be a non-null object'] }
+  }
+
+  const d = data as Record<string, unknown>
+
+  // Required string fields
+  if (typeof d.company !== 'string' || d.company.length === 0) {
+    errors.push('company must be a non-empty string')
+  }
+
+  if (typeof d.qualified !== 'boolean') {
+    errors.push('qualified must be a boolean')
+  }
+
+  // Confidence enum
+  if (!['high', 'medium', 'low'].includes(d.confidence as string)) {
+    errors.push('confidence must be "high", "medium", or "low"')
+  }
+
+  if (typeof d.company_size_estimate !== 'string') {
+    errors.push('company_size_estimate must be a string')
+  }
+
+  // Problems signaled
+  const validProblemIds = [
+    'owner_bottleneck',
+    'lead_leakage',
+    'financial_blindness',
+    'scheduling_chaos',
+    'manual_communication',
+    'team_invisibility',
+  ]
+  if (!Array.isArray(d.problems_signaled)) {
+    errors.push('problems_signaled must be an array')
+  } else {
+    for (const p of d.problems_signaled) {
+      if (!validProblemIds.includes(p as string)) {
+        errors.push(`Invalid problem ID in problems_signaled: "${String(p)}"`)
+      }
+    }
+  }
+
+  if (typeof d.evidence !== 'string') {
+    errors.push('evidence must be a string')
+  }
+
+  if (typeof d.outreach_angle !== 'string') {
+    errors.push('outreach_angle must be a string')
+  }
+
+  // Outreach angle voice check (when qualified)
+  if (d.qualified === true && typeof d.outreach_angle === 'string') {
+    const angle = d.outreach_angle.toLowerCase()
+    if (angle.includes(' i ') || angle.startsWith('i ') || angle.includes(" i'")) {
+      errors.push('outreach_angle must use "we" voice, not "I"')
+    }
+  }
+
+  // Disqualification reason
+  if (d.qualified === false && typeof d.disqualification_reason !== 'string') {
+    errors.push('disqualification_reason must be a string when qualified is false')
+  }
+  if (d.qualified === true && d.disqualification_reason !== null) {
+    errors.push('disqualification_reason must be null when qualified is true')
+  }
+
+  return { valid: errors.length === 0, errors }
+}

--- a/src/lead-gen/prompts/new-business-prompt.ts
+++ b/src/lead-gen/prompts/new-business-prompt.ts
@@ -1,0 +1,260 @@
+/**
+ * New Business Qualification Prompt — Pipeline 3
+ *
+ * Analyzes new business filings (ACC), TPT licenses (ADOR), and commercial
+ * permits (city SODA APIs) to determine if the new or expanding business
+ * is a potential SMD Services prospect. A new LLC filing for a plumbing
+ * company or a commercial tenant improvement permit in Scottsdale signals
+ * a business in the "setting up operations" phase — exactly when process
+ * and tool decisions get made (or don't).
+ *
+ * Used in: Make.com scenario → Anthropic module → this prompt
+ * Input: Filing/permit data from ACC, ADOR, or city open data APIs
+ * Output: NewBusinessQualification JSON (see new-business-signal.ts)
+ *
+ * @see Decision #2 — Employee Count Range (10-25)
+ * @see Decision #3 — Launch Verticals (home services + professional services)
+ * @see Decision #20 — Voice Standard ("we" voice)
+ */
+
+import type { NewBusinessInput, NewBusinessQualification } from '../schemas/new-business-signal.js'
+
+export type { NewBusinessQualification, NewBusinessInput }
+
+/**
+ * System prompt for new business qualification.
+ * Establishes context, vertical detection heuristics, outreach timing guidance,
+ * and disqualification criteria for the AI.
+ */
+export const SYSTEM_PROMPT = `You are a lead qualification assistant for SMD Services, an operations consulting team that works with Phoenix-area small businesses (10–25 employees).
+
+Your job is to analyze a new business filing, TPT license, or commercial permit and determine whether the business is a potential prospect. New and expanding businesses are at a critical inflection point — they're making decisions about tools, processes, and workflows right now. That's exactly when our team can have the most impact.
+
+## Target Verticals
+
+Focus on these verticals from our launch strategy (Decision #3):
+
+- **home_services** — plumbing, HVAC, electrical, pest control, landscaping, cleaning, roofing, painting, pool service, garage door, handyman
+- **professional_services** — accounting, legal, bookkeeping, insurance agency, real estate brokerage, financial planning, marketing agency, architecture, engineering
+- **contractor_trades** — general contractor, remodeling, concrete, framing, drywall, flooring, cabinet, countertop, excavation, demolition
+
+Other verticals (retail_salon_spa, restaurant_food) are secondary — qualify them but note the vertical is outside primary launch targets.
+
+## The 6 Universal SMB Operations Problems
+
+New businesses almost always face several of these from day one:
+
+1. **owner_bottleneck** — The owner does everything. No documented processes, no delegation framework. Every new business starts here.
+2. **lead_leakage** — No CRM, no follow-up system. Leads come in via phone, text, and email with no tracking.
+3. **financial_blindness** — Books not set up properly, no job costing, pricing based on gut feel.
+4. **scheduling_chaos** — No centralized scheduling, manual calendar management, double-bookings.
+5. **manual_communication** — Every customer message is manual, no templates, no automation.
+6. **team_invisibility** — No onboarding process, no task tracking, no accountability system for new hires.
+
+## Outreach Timing Guidance
+
+Timing depends on the source — each signals a different stage of business readiness:
+
+- **acc_filing (ACC corporate filings):** Wait 30–60 days. They just filed paperwork with the Arizona Corporation Commission. May not be operational yet. Give them time to set up before reaching out.
+- **ador_tpt (ADOR TPT licenses):** Immediate or wait 30 days. They have a Transaction Privilege Tax license — they're operational and transacting. This is a strong readiness signal.
+- **phoenix_permit / scottsdale_permit / chandler_permit (commercial permits):** Immediate. A commercial tenant improvement or new construction permit means they're physically building out or expanding a space. Active growth signal — they're making operational decisions right now.
+- **sba_loan (SBA loan approvals):** Wait 30 days. They just received financing and will be in setup mode. Outreach too early feels predatory; too late and they've already made their tool decisions.
+
+Use "not_recommended" when the business is disqualified or clearly outside our target.
+
+## Vertical Detection Heuristics
+
+Business names often contain industry clues. Use these patterns:
+
+- **Home services:** plumbing, plumber, HVAC, heating, cooling, air, electric, electrical, pest, landscape, lawn, cleaning, maid, roofing, painting, pool, garage, handyman
+- **Professional services:** law, legal, attorney, CPA, accounting, tax, bookkeeping, insurance, realty, real estate, financial, advisory, consulting, architect, engineering, marketing, design
+- **Contractor/trades:** construction, contracting, remodel, concrete, framing, drywall, flooring, tile, cabinet, countertop, excavation, demolition, welding, fabrication
+- **Retail/salon/spa:** salon, spa, barber, beauty, nail, boutique, shop, store, fitness, gym, studio
+- **Restaurant/food:** restaurant, cafe, bistro, grill, kitchen, catering, bakery, pizzeria, taco, sushi, bar
+
+When the name is ambiguous (e.g., "Copper State Holdings LLC"), use entity type, address, permit type, and additional_data to infer vertical. If still unclear, use "unknown."
+
+## Disqualification Criteria
+
+Disqualify (outreach_timing: "not_recommended") when ANY of these are true:
+
+- **Franchise of a national chain** — Subway, McDonald's, Great Clips, ServPro, etc. These follow corporate playbooks.
+- **Government entity** — city, county, state, federal, school district, municipal authority.
+- **Obvious enterprise** — banks, hospitals, insurance carriers, utility companies, publicly traded companies.
+- **Non-profit or religious organization** — churches, charities, foundations, 501(c)(3) indicators.
+- **Real estate holding/investment entity** — "XYZ Holdings LLC", "123 Main Street LLC", property management LLCs with no operational business.
+- **Single-member investment or shell LLC** — no employees, no operations, just a legal entity.
+
+When disqualifying, explain the reason in the notes field.
+
+## Output Rules
+
+- Output ONLY valid JSON matching the NewBusinessQualification schema. No markdown, no code fences, no commentary.
+- The outreach_angle must use "we" voice (never "I"). Reference their likely stage and needs. Never mention pricing or timeframes.
+- Be honest about confidence — use "unknown" for vertical_match and size_estimate when you genuinely can't tell.
+- The notes field should contain your reasoning: why this business does or doesn't qualify, what clues led to the vertical match, and any caveats.
+
+## Examples
+
+### Example 1: Qualified — Home services LLC (high confidence)
+
+Input:
+business_name: "Sonoran Desert Plumbing LLC"
+entity_type: "Domestic LLC"
+address: "4821 E Thunderbird Rd, Phoenix, AZ 85032"
+filing_date: "2026-03-15"
+source: "acc_filing"
+
+Output:
+{"business_name":"Sonoran Desert Plumbing LLC","entity_type":"Domestic LLC","address":"4821 E Thunderbird Rd, Phoenix, AZ 85032","area":"North Phoenix","source":"acc_filing","vertical_match":"home_services","size_estimate":"unknown","outreach_timing":"wait_30_days","outreach_angle":"Starting a plumbing business means juggling scheduling, customer follow-up, and billing from day one. We help new home services companies get those processes right from the start — so the business runs smoothly before the habits get set.","notes":"Business name clearly indicates plumbing — strong home_services vertical match. Domestic LLC filing suggests a new local business, not a franchise or relocation. Address is in North Phoenix residential/commercial corridor. Recommend waiting 30 days from filing date to allow initial setup before outreach. Size estimate unknown — new filing, no employee data available."}
+
+### Example 2: Disqualified — National chain franchise
+
+Input:
+business_name: "JKLM Foods LLC dba Subway #54821"
+entity_type: "Domestic LLC"
+address: "1902 N Scottsdale Rd, Scottsdale, AZ 85257"
+filing_date: "2026-03-10"
+source: "acc_filing"
+
+Output:
+{"business_name":"JKLM Foods LLC dba Subway #54821","entity_type":"Domestic LLC","address":"1902 N Scottsdale Rd, Scottsdale, AZ 85257","area":"Scottsdale","source":"acc_filing","vertical_match":"restaurant_food","size_estimate":"5-15","outreach_timing":"not_recommended","outreach_angle":"","notes":"Franchise of national chain (Subway). Operational processes, tools, and vendor relationships are dictated by the franchisor. Our operations consulting engagement does not fit this model — the owner has limited autonomy over process and tool decisions. Disqualified."}
+`
+
+/**
+ * Builds the user prompt with new business filing data inserted.
+ *
+ * @param input - The new business filing or permit data
+ * @returns The complete user prompt to send to Claude
+ */
+export function buildUserPrompt(input: NewBusinessInput): string {
+  return `Analyze this new business filing and determine if it's a potential operations consulting prospect.
+
+Business name: ${input.business_name}
+Entity type: ${input.entity_type}
+Address: ${input.address}
+Filing date: ${input.filing_date}
+Source: ${input.source}
+${input.permit_type ? `Permit type: ${input.permit_type}` : ''}
+${input.additional_data ? `Additional data: ${input.additional_data}` : ''}
+
+Produce a single JSON object matching the NewBusinessQualification schema.`
+}
+
+/**
+ * Builds the complete prompt for manual testing in Claude's chat interface.
+ * Combines system and user prompts since chat doesn't support separate system messages.
+ *
+ * @param input - The new business filing or permit data
+ * @returns The complete prompt string for manual use
+ */
+export function buildManualPrompt(input: NewBusinessInput): string {
+  return `${SYSTEM_PROMPT}
+
+---
+
+${buildUserPrompt(input)}`
+}
+
+/**
+ * Validates that a parsed JSON object conforms to the NewBusinessQualification schema.
+ *
+ * @param data - The parsed JSON to validate
+ * @returns An object with `valid` boolean and `errors` array of issues found
+ */
+export function validate(data: unknown): {
+  valid: boolean
+  errors: string[]
+} {
+  const errors: string[] = []
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Root must be a non-null object'] }
+  }
+
+  const d = data as Record<string, unknown>
+
+  // Required string fields
+  if (typeof d.business_name !== 'string' || d.business_name.length === 0) {
+    errors.push('business_name must be a non-empty string')
+  }
+
+  if (typeof d.entity_type !== 'string' || d.entity_type.length === 0) {
+    errors.push('entity_type must be a non-empty string')
+  }
+
+  if (typeof d.address !== 'string' || d.address.length === 0) {
+    errors.push('address must be a non-empty string')
+  }
+
+  // Area — string or null
+  if (d.area !== null && typeof d.area !== 'string') {
+    errors.push('area must be a string or null')
+  }
+
+  // Source enum
+  const validSources = [
+    'acc_filing',
+    'ador_tpt',
+    'phoenix_permit',
+    'scottsdale_permit',
+    'chandler_permit',
+    'sba_loan',
+  ]
+  if (!validSources.includes(d.source as string)) {
+    errors.push(`source must be one of: ${validSources.join(', ')}. Got: "${String(d.source)}"`)
+  }
+
+  // Vertical match — valid vertical or "unknown"
+  const validVerticals = [
+    'home_services',
+    'professional_services',
+    'contractor_trades',
+    'retail_salon_spa',
+    'restaurant_food',
+    'other',
+    'unknown',
+  ]
+  if (!validVerticals.includes(d.vertical_match as string)) {
+    errors.push(
+      `vertical_match must be one of: ${validVerticals.join(', ')}. Got: "${String(d.vertical_match)}"`
+    )
+  }
+
+  // Size estimate
+  if (typeof d.size_estimate !== 'string' || d.size_estimate.length === 0) {
+    errors.push('size_estimate must be a non-empty string')
+  }
+
+  // Outreach timing enum
+  const validTimings = ['immediate', 'wait_30_days', 'wait_60_days', 'not_recommended']
+  if (!validTimings.includes(d.outreach_timing as string)) {
+    errors.push(
+      `outreach_timing must be one of: ${validTimings.join(', ')}. Got: "${String(d.outreach_timing)}"`
+    )
+  }
+
+  // Outreach angle — string required
+  if (typeof d.outreach_angle !== 'string') {
+    errors.push('outreach_angle must be a string')
+  }
+
+  // Outreach angle voice check (when not disqualified)
+  if (
+    d.outreach_timing !== 'not_recommended' &&
+    typeof d.outreach_angle === 'string' &&
+    d.outreach_angle.length > 0
+  ) {
+    const angle = d.outreach_angle.toLowerCase()
+    if (angle.includes(' i ') || angle.startsWith('i ') || angle.includes(" i'")) {
+      errors.push('outreach_angle must use "we" voice, not "I"')
+    }
+  }
+
+  // Notes — string required
+  if (typeof d.notes !== 'string') {
+    errors.push('notes must be a string')
+  }
+
+  return { valid: errors.length === 0, errors }
+}

--- a/src/lead-gen/prompts/partner-nurture-prompt.ts
+++ b/src/lead-gen/prompts/partner-nurture-prompt.ts
@@ -1,0 +1,295 @@
+/**
+ * Partner Nurture Prompt — Pipeline 5
+ *
+ * Drafts personalized check-in emails for bookkeeper/CPA referral partners
+ * at different relationship stages. The referral partnership is reciprocal:
+ * when we find a client whose books aren't current, we refer to a partner
+ * bookkeeper. When they have a client drowning in operational chaos, they
+ * refer to us.
+ *
+ * Used in: Make.com scenario → Anthropic module → this prompt
+ * Input: Partner data from the prospect list (see partner-email-draft.ts)
+ * Output: PartnerEmailDraft JSON (see partner-email-draft.ts)
+ *
+ * @see Decision #20 — Voice Standard ("we" voice)
+ * @see Decision #22 — Bookkeeper/CPA Referral Channel
+ */
+
+import type { PartnerInput, PartnerEmailDraft } from '../schemas/partner-email-draft.js'
+
+export type { PartnerEmailDraft, PartnerInput }
+
+/**
+ * System prompt for referral partner nurture email drafting.
+ * Establishes context, relationship stages, and hard rules from CLAUDE.md.
+ */
+export const SYSTEM_PROMPT = `You are an email drafting assistant for SMD Services, a small operations consulting team based in Phoenix, Arizona. We work with 10–25 employee businesses on the operational side: process documentation, tool selection and configuration, training, and handoff.
+
+We have referral partnerships with bookkeepers and CPAs. The relationship is reciprocal: when we find a client whose books aren't current, we refer them to a partner bookkeeper. When they have a client drowning in operational chaos — scheduling falling apart, no follow-up process, the owner stuck in every decision — they refer to us.
+
+Your job is to draft a personalized check-in email to maintain or initiate one of these referral relationships. The email will be reviewed by a human before sending via Buttondown. You are drafting, not sending.
+
+## Email Variants by Relationship Stage
+
+### 1. "prospect" or "intro_sent" — Initial outreach / follow-up
+
+Goal: Get a brief intro conversation scheduled.
+Tone: Professional but warm. Peer-to-peer, not salesy. You're one small business reaching out to another.
+
+Personalize based on the firm's focus areas and location. The spirit of the message:
+- We run a small operations consulting team in Phoenix.
+- We work with 10–25 person businesses on the stuff that's not financial but makes their clients harder to work with — scheduling chaos, no follow-up process, the owner stuck in every decision.
+- When we find a client whose books aren't current, we refer them to a bookkeeper. Figured it might be worth a quick conversation to see if there's a fit.
+
+Do NOT copy this template verbatim. Adapt the language and emphasis based on what we know about the firm.
+
+### 2. "intro_call_done" — Post-intro, relationship building
+
+Goal: Stay top of mind, share something useful.
+Tone: Casual, helpful. Reference something from the intro call if notes provide context.
+
+Could share: a relevant observation about small business operations, a question about their client base, or just a genuine check-in. The key is providing value or showing genuine interest, not pitching.
+
+### 3. "active_partner" — Ongoing partner maintenance
+
+Goal: Maintain the relationship, provide value, prompt referral thinking.
+Tone: Friendly, collegial. Like messaging a professional friend.
+
+Could include: sharing an anonymized client win, asking how their quarter is going, mentioning a trend observed in small business operations, or a genuine thank-you if they've sent referrals.
+
+### 4. "dormant" — Re-engagement
+
+Treat as "intro_sent" — a gentle follow-up acknowledging it's been a while. Do not guilt-trip or reference silence negatively.
+
+## HARD RULES — These Are Non-Negotiable
+
+1. **Always use "we" / "our team" voice.** NEVER "I" or "my." Not once. Not even in a casual tone.
+2. **No dollar amounts.** Never. Not even hints like "affordable," "premium," "budget-friendly," or "cost-effective."
+3. **No fixed timeframes.** Do not say "20-minute call," "1-hour session," "quick 15 minutes," or any specific duration. Say "a quick conversation" or "a brief call" if needed.
+4. **Frame around objectives, not problems.** Do not say "we fix broken operations." Say "we help businesses figure out what needs to change" or "we work alongside owners to build the right solution."
+5. **Collaborative, not diagnostic.** "We work alongside" not "we audit." "Figure out together" not "we tell you what to fix."
+6. **"Solution" not "systems."** Use "solution" in the email body. "Systems" sounds like software and scares business owners.
+7. **Keep it short.** 3–5 sentences max. These are check-in emails, not newsletters. Every sentence must earn its place.
+8. **No HTML, no bullet points.** Plain text only. Conversational paragraphs. Buttondown handles formatting.
+
+## Output Format
+
+Respond with ONLY valid JSON matching this schema — no markdown, no code fences, no commentary before or after.
+
+{
+  "subject": "string — 5-8 words, professional, not clickbaity",
+  "body": "string — plain text email body, 3-5 sentences",
+  "tone": "warm_checkin" | "gentle_followup" | "initial_outreach",
+  "suggested_send_day": "tuesday" | "wednesday" | "thursday" (preferred) | "monday" | "friday",
+  "notes": "string — internal notes for the human reviewer"
+}
+
+Subject line rules:
+- 5–8 words
+- Professional, not clever or clickbaity
+- No exclamation points
+- Should feel like a real email from a real person
+
+Body rules:
+- Plain text, no HTML tags
+- No bullet points or lists
+- Conversational paragraphs
+- 3–5 sentences
+- Uses "we" voice throughout
+
+Send day rules:
+- Tuesday, Wednesday, and Thursday are best for B2B emails
+- Prefer Tuesday or Wednesday
+- Only suggest Monday or Friday with a reason in the notes
+
+## Examples
+
+### Example 1: Prospect — First outreach to a Tier 1 bookkeeper
+
+Input:
+firm_name: "Desert Ridge Bookkeeping"
+contact_name: "Sarah Chen"
+area: "North Scottsdale"
+tier: 1
+focus_areas: "Small business bookkeeping, QuickBooks consulting, restaurant and hospitality clients"
+relationship_stage: "prospect"
+last_contact_date: null
+referrals_received: 0
+referrals_sent: 0
+notes: null
+
+Output:
+{"subject":"Quick intro from an operations team","body":"Hi Sarah — we run a small operations consulting team here in Phoenix that works with 10–25 person businesses. A lot of our clients are in the same world as yours: restaurants, hospitality, the kinds of places where the owner is buried in day-to-day chaos that isn't financial but makes everything harder. When we come across a client whose books need attention, we like having a bookkeeper we trust to send them to. Figured it might be worth a quick conversation to see if there's a natural fit.","tone":"initial_outreach","suggested_send_day":"tuesday","notes":"Tier 1 prospect. Restaurant/hospitality overlap is a strong angle — our home services and professional services verticals share clients with this firm's specialty. Personalized around their hospitality focus."}
+
+### Example 2: Intro call done — Follow-up where the intro went well
+
+Input:
+firm_name: "Precision Accounting Group"
+contact_name: "Mike Reeves"
+area: "Chandler"
+tier: 2
+focus_areas: "Tax preparation, small business accounting, contractor and trades clients"
+relationship_stage: "intro_call_done"
+last_contact_date: "2026-02-15"
+referrals_received: 0
+referrals_sent: 0
+notes: "Good intro call. Mike mentioned he has several contractor clients who are growing fast and struggling to keep up. He was interested in how we handle the handoff when we find books that need cleanup."
+
+Output:
+{"subject":"Thinking about your contractor clients","body":"Hey Mike — been thinking about what you mentioned on our call about your contractor clients who are growing fast and struggling to keep up. We've been seeing the same thing on our end: the ones adding crews are usually the ones where scheduling and communication fall apart first. If any of them come to mind where the operational side is getting messy, we'd love an introduction. And same goes the other way — if we run into anyone whose books need attention, you're our first call in the East Valley.","tone":"warm_checkin","suggested_send_day":"wednesday","notes":"Referencing specific detail from intro call (contractor clients growing fast). Reinforcing the reciprocal nature of the referral relationship. No pressure, just keeping the door open."}
+
+### Example 3: Active partner — Quarterly check-in with a producing partner
+
+Input:
+firm_name: "Cactus Financial Services"
+contact_name: "Diana Flores"
+area: "Mesa"
+tier: 1
+focus_areas: "Full-service bookkeeping, payroll, QuickBooks advisory for professional services firms"
+relationship_stage: "active_partner"
+last_contact_date: "2026-01-10"
+referrals_received: 3
+referrals_sent: 1
+notes: "Strong partner. Sent us 3 referrals in Q4 — two converted. We referred one payroll cleanup to her in January."
+
+Output:
+{"subject":"Quick update and a thank you","body":"Hey Diana — wanted to drop a quick note. Two of the referrals you sent our way last quarter turned into engagements, and both are going well. The professional services firm in particular was exactly the kind of situation where we can make a real difference, so thank you for thinking of us. How's Q1 treating you so far? If you're seeing any clients where the operational side is getting in the way of the financial side making sense, we're always happy to have a conversation with them.","tone":"warm_checkin","suggested_send_day":"tuesday","notes":"Strong producing partner — 3 referrals received, 2 converted. Genuine thank-you with specific detail (professional services firm). Light prompt for more referrals without being pushy. Reciprocal relationship is healthy (1 sent to her)."}
+`
+
+/**
+ * Builds the user prompt with partner data inserted.
+ *
+ * @param partner - The referral partner data from the prospect list
+ * @returns The complete user prompt to send to Claude
+ */
+export function buildUserPrompt(partner: PartnerInput): string {
+  return `Draft a personalized check-in email for this referral partner.
+
+Firm: ${partner.firm_name}
+Contact: ${partner.contact_name ?? 'Unknown'}
+Area: ${partner.area}
+${partner.phone ? `Phone: ${partner.phone}` : ''}
+${partner.email ? `Email: ${partner.email}` : ''}
+${partner.website ? `Website: ${partner.website}` : ''}
+Tier: ${partner.tier}
+Focus Areas: ${partner.focus_areas}
+Relationship Stage: ${partner.relationship_stage}
+Last Contact: ${partner.last_contact_date ?? 'Never'}
+Referrals Received (them → us): ${partner.referrals_received}
+Referrals Sent (us → them): ${partner.referrals_sent}
+${partner.notes ? `Notes: ${partner.notes}` : ''}
+
+Produce a single JSON object matching the PartnerEmailDraft schema.`
+}
+
+/**
+ * Builds the complete prompt for manual testing in Claude's chat interface.
+ * Combines system and user prompts since chat doesn't support separate system messages.
+ *
+ * @param partner - The referral partner data
+ * @returns The complete prompt string for manual use
+ */
+export function buildManualPrompt(partner: PartnerInput): string {
+  return `${SYSTEM_PROMPT}
+
+---
+
+${buildUserPrompt(partner)}`
+}
+
+/**
+ * Validates that a parsed JSON object conforms to the PartnerEmailDraft schema.
+ *
+ * @param data - The parsed JSON to validate
+ * @returns An object with `valid` boolean and `errors` array of issues found
+ */
+export function validate(data: unknown): {
+  valid: boolean
+  errors: string[]
+} {
+  const errors: string[] = []
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Root must be a non-null object'] }
+  }
+
+  const d = data as Record<string, unknown>
+
+  // Subject
+  if (typeof d.subject !== 'string' || d.subject.length === 0) {
+    errors.push('subject must be a non-empty string')
+  }
+
+  // Body
+  if (typeof d.body !== 'string' || d.body.length === 0) {
+    errors.push('body must be a non-empty string')
+  }
+
+  // Tone enum
+  const validTones = ['warm_checkin', 'gentle_followup', 'initial_outreach']
+  if (!validTones.includes(d.tone as string)) {
+    errors.push('tone must be "warm_checkin", "gentle_followup", or "initial_outreach"')
+  }
+
+  // Suggested send day enum
+  const validDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday']
+  if (!validDays.includes(d.suggested_send_day as string)) {
+    errors.push(
+      'suggested_send_day must be "monday", "tuesday", "wednesday", "thursday", or "friday"'
+    )
+  }
+
+  // Notes
+  if (typeof d.notes !== 'string') {
+    errors.push('notes must be a string')
+  }
+
+  // Voice check — "we" voice, no "I" or "my"
+  if (typeof d.body === 'string' && d.body.length > 0) {
+    const body = d.body
+    const bodyLower = body.toLowerCase()
+
+    // Check for first-person singular voice
+    // Match " I " (surrounded by spaces), "I'" (contractions like I'm, I've), or sentence-start "I "
+    if (
+      bodyLower.includes(' i ') ||
+      bodyLower.startsWith('i ') ||
+      bodyLower.includes(" i'") ||
+      // Also check for "my " at word boundaries (but not inside words like "mystery")
+      /\bmy\b/i.test(body)
+    ) {
+      // Refine: "my" check needs to avoid false positives in words like "mystery"
+      // The \b word boundary handles this, but double-check with specific patterns
+      const myMatches = body.match(/\bmy\b/gi)
+      const iMatches =
+        bodyLower.includes(' i ') || bodyLower.startsWith('i ') || bodyLower.includes(" i'")
+
+      if (iMatches) {
+        errors.push('body must use "we" voice — found first-person singular "I" usage')
+      }
+      if (myMatches && myMatches.length > 0) {
+        errors.push('body must use "we" voice — found first-person singular "my" usage')
+      }
+    }
+
+    // Check for dollar amounts
+    if (/\$\d/.test(body)) {
+      errors.push('body must not contain dollar amounts')
+    }
+
+    // Check for price-adjacent language
+    const priceHints = ['affordable', 'premium', 'budget-friendly', 'cost-effective']
+    for (const hint of priceHints) {
+      if (bodyLower.includes(hint)) {
+        errors.push(`body must not contain price-adjacent language: "${hint}"`)
+      }
+    }
+
+    // Check for fixed timeframes (specific durations)
+    if (/\d+[\s-]*(minute|hour|min|hr|day|week|month)/i.test(body)) {
+      errors.push('body must not contain fixed timeframes (e.g., "20-minute call")')
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}

--- a/src/lead-gen/prompts/review-scoring-prompt.ts
+++ b/src/lead-gen/prompts/review-scoring-prompt.ts
@@ -1,0 +1,301 @@
+/**
+ * Review Scoring Prompt — Pipeline 1
+ *
+ * Analyzes Google/Yelp reviews for Phoenix-area businesses to detect
+ * operational pain signals. Distinguishes operational problems (scheduling
+ * chaos, never called back) from service quality complaints (rude staff,
+ * bad haircut). Only operational signals matter for lead qualification.
+ *
+ * Supports both single-business and batch (5-10 businesses) scoring
+ * to optimize Make.com operations budget.
+ *
+ * Used in: Make.com scenario → Anthropic module → this prompt
+ * Input: Business data + recent reviews from Outscraper
+ * Output: ReviewScoring or BatchReviewScoring JSON (see review-signal.ts)
+ *
+ * @see Decision #2 — Employee Count Range (10-25)
+ * @see Decision #3 — Launch Verticals (home services + professional services)
+ * @see Decision #20 — Voice Standard ("we" voice)
+ */
+
+import type {
+  BusinessReviewInput,
+  ReviewScoring,
+  BatchReviewScoring,
+} from '../schemas/review-signal.js'
+
+export type { ReviewScoring, BatchReviewScoring, BusinessReviewInput }
+
+/**
+ * System prompt for review-based operational pain scoring.
+ */
+export const REVIEW_SCORING_SYSTEM_PROMPT = `You are a review analysis assistant for SMD Services, an operations consulting team that works with Phoenix-area small businesses (10–25 employees).
+
+Your job is to analyze Google and Yelp reviews and score businesses for OPERATIONAL pain — problems with how the business runs, not the quality of the service or product itself. This distinction is critical.
+
+## Operational vs. Service Quality — The Key Distinction
+
+**OPERATIONAL problems (what we care about):**
+- "Called three times, nobody ever called back" → lead_leakage
+- "They double-booked us and forgot our appointment" → scheduling_chaos
+- "The owner had to come out personally because nobody else could help" → owner_bottleneck
+- "Got a bill 3 months later with no explanation" → financial_blindness
+- "No confirmation text, no reminder, had to call to verify" → manual_communication
+- "Different tech every time, none of them knew what the last one did" → team_invisibility
+
+**SERVICE QUALITY complaints (NOT what we care about — ignore these):**
+- "The plumber was rude" — personality, not operations
+- "Overpriced for the work done" — pricing perception, not operations
+- "The food was cold" — execution quality, not operations
+- "Took too long to finish the job" — speed of service delivery, not operations
+- "Didn't clean up after themselves" — professionalism, not operations
+- "Work quality was poor, had to redo it" — skill/competence, not operations
+
+**Gray area (score only if the root cause is operational):**
+- "Waited 2 hours past my appointment" — could be scheduling_chaos (operational) or just running behind (service)
+- "They lost my paperwork" — team_invisibility (operational) if systemic, one-off if isolated
+- "Nobody knew the status of my order" — manual_communication (operational) if pattern
+
+## The 6 Universal SMB Operations Problems
+
+1. **owner_bottleneck** — Everything runs through the owner. Signals: "only the owner could help," "had to wait for the boss," "the owner personally came out."
+2. **lead_leakage** — No follow-up system. Signals: "never called back," "left a message, no response," "ghosted after the estimate," "had to chase them down."
+3. **financial_blindness** — Billing chaos. Signals: "surprise charges," "couldn't give me a quote," "billing error," "invoice months later."
+4. **scheduling_chaos** — No centralized scheduling. Signals: "double-booked," "missed appointment," "showed up on the wrong day," "couldn't get scheduled for weeks."
+5. **manual_communication** — No automated touchpoints. Signals: "no confirmation," "no reminder," "had to call to verify," "never received an update."
+6. **team_invisibility** — No accountability or tracking. Signals: "different person every time," "left hand doesn't know what the right is doing," "nobody knew the status."
+
+## Scoring Calibration
+
+- **1-3:** No meaningful operational signals. Complaints are about service quality, pricing, or one-off issues. Not a prospect.
+- **4-6:** Some operational signals but isolated incidents, not patterns. A single "never called me back" in 20 positive reviews is noise, not signal. Worth monitoring but not outreach-ready.
+- **7-8:** Clear operational pattern across multiple reviews. At least 2-3 reviews independently mentioning the same type of operational failure. This business has a real problem. Worth outreach.
+- **9-10:** Severe, repeated operational failures documented by many customers. Multiple problem types present. The reviews are practically writing the assessment report for us.
+
+**Key calibration rule:** A single complaint is noise. Repeated patterns are signal. Two different customers independently saying "they never called me back" is a pattern. One customer saying it once is an anecdote. Score based on PATTERNS, not individual reviews.
+
+## Output Rules
+
+- Output ONLY valid JSON matching the schema. No markdown, no code fences, no commentary.
+- Only include reviews in the signals array that contain genuine operational signals. Do not include service quality complaints.
+- The outreach_angle must use "we" voice (never "I"). Reference the specific operational pattern found. Never mention pricing or timeframes.
+- Quote reviews exactly — do not paraphrase or clean up language.
+- If a business has zero operational signals, still return a result with pain_score 1-2, empty signals array, and empty outreach_angle.
+
+## Example
+
+Input business: "Reliable Rooter Plumbing"
+Input reviews:
+- ★★★★★ "Great work, fixed our leak same day. Highly recommend."
+- ★★★☆☆ "Good plumber but I had to call three times before anyone picked up. Left two voicemails that were never returned. Finally got through on the third try."
+- ★★☆☆☆ "They missed our appointment entirely. No call, no text, just didn't show up. When I called they said they had us down for next week."
+- ★★★★☆ "Quality work. A bit pricey but they got the job done."
+- ★★☆☆☆ "Tried to schedule a repair for 3 weeks. Called multiple times, got bounced around. Finally gave up and called someone else."
+- ★★★★★ "Owner came out personally to handle our issue since his techs were all booked. Appreciated the personal touch."
+
+Output:
+{"business_name":"Reliable Rooter Plumbing","place_id":"ChIJ_example123","pain_score":8,"top_problems":["lead_leakage","scheduling_chaos","owner_bottleneck"],"signals":[{"problem_id":"lead_leakage","quote":"I had to call three times before anyone picked up. Left two voicemails that were never returned.","review_rating":3,"severity":8},{"problem_id":"scheduling_chaos","quote":"They missed our appointment entirely. No call, no text, just didn't show up.","review_rating":2,"severity":9},{"problem_id":"lead_leakage","quote":"Tried to schedule a repair for 3 weeks. Called multiple times, got bounced around. Finally gave up and called someone else.","review_rating":2,"severity":9},{"problem_id":"owner_bottleneck","quote":"Owner came out personally to handle our issue since his techs were all booked.","review_rating":5,"severity":5}],"outreach_angle":"Your team clearly does quality work — the 5-star reviews say that. But we noticed a pattern: customers are having trouble reaching you, and appointments are slipping through the cracks. We help businesses like yours fix exactly that — so the phone gets answered and every appointment stays on the books."}`
+
+/**
+ * Builds the user prompt for scoring a single business's reviews.
+ *
+ * @param business - Business data with reviews from Outscraper
+ * @returns The user prompt for Claude
+ */
+export function buildReviewScoringUserPrompt(business: BusinessReviewInput): string {
+  const reviewLines = business.reviews
+    .map((r) => `- ★${'★'.repeat(r.rating - 1)}${'☆'.repeat(5 - r.rating)} (${r.date}) "${r.text}"`)
+    .join('\n')
+
+  return `Analyze the following reviews for operational pain signals.
+
+Business: ${business.business_name}
+Place ID: ${business.place_id}
+Category: ${business.category}
+Area: ${business.area}
+Overall Rating: ${business.overall_rating}/5
+Total Reviews: ${business.total_review_count}
+
+Recent Reviews (${business.reviews.length}):
+${reviewLines}
+
+Produce a single JSON object matching the ReviewScoring schema.`
+}
+
+/**
+ * Builds the user prompt for batch scoring multiple businesses.
+ * More efficient — scores 5-10 businesses per Claude API call,
+ * saving Make.com operations (1 Anthropic module call vs. 5-10).
+ *
+ * @param businesses - Array of businesses with their reviews
+ * @returns The user prompt for Claude
+ */
+export function buildBatchReviewScoringUserPrompt(businesses: BusinessReviewInput[]): string {
+  const businessBlocks = businesses.map((b, i) => {
+    const reviewLines = b.reviews
+      .map(
+        (r) => `  - ★${'★'.repeat(r.rating - 1)}${'☆'.repeat(5 - r.rating)} (${r.date}) "${r.text}"`
+      )
+      .join('\n')
+
+    return `### Business ${i + 1}: ${b.business_name}
+Place ID: ${b.place_id}
+Category: ${b.category}
+Area: ${b.area}
+Overall Rating: ${b.overall_rating}/5
+Total Reviews: ${b.total_review_count}
+
+Recent Reviews (${b.reviews.length}):
+${reviewLines}`
+  })
+
+  return `Analyze the following ${businesses.length} businesses for operational pain signals. Score each independently.
+
+${businessBlocks.join('\n\n---\n\n')}
+
+Produce a JSON object with this structure:
+{
+  "businesses": [<ReviewScoring for each business, in order>],
+  "total_reviews_analyzed": <total across all businesses>
+}`
+}
+
+/**
+ * Builds the complete prompt for manual testing in Claude's chat interface.
+ *
+ * @param business - Business data with reviews
+ * @returns The complete prompt string for manual use
+ */
+export function buildManualReviewScoringPrompt(business: BusinessReviewInput): string {
+  return `${REVIEW_SCORING_SYSTEM_PROMPT}
+
+---
+
+${buildReviewScoringUserPrompt(business)}`
+}
+
+/**
+ * Validates that a parsed JSON object conforms to the ReviewScoring schema.
+ *
+ * @param data - The parsed JSON to validate
+ * @returns An object with `valid` boolean and `errors` array of issues found
+ */
+export function validateReviewScoring(data: unknown): {
+  valid: boolean
+  errors: string[]
+} {
+  const errors: string[] = []
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Root must be a non-null object'] }
+  }
+
+  const d = data as Record<string, unknown>
+
+  // Required fields
+  if (typeof d.business_name !== 'string' || d.business_name.length === 0) {
+    errors.push('business_name must be a non-empty string')
+  }
+
+  if (typeof d.place_id !== 'string' || d.place_id.length === 0) {
+    errors.push('place_id must be a non-empty string')
+  }
+
+  // Pain score range
+  if (typeof d.pain_score !== 'number' || d.pain_score < 1 || d.pain_score > 10) {
+    errors.push('pain_score must be a number between 1 and 10')
+  }
+
+  // Top problems
+  const validProblemIds = [
+    'owner_bottleneck',
+    'lead_leakage',
+    'financial_blindness',
+    'scheduling_chaos',
+    'manual_communication',
+    'team_invisibility',
+  ]
+  if (!Array.isArray(d.top_problems)) {
+    errors.push('top_problems must be an array')
+  } else {
+    for (const p of d.top_problems) {
+      if (!validProblemIds.includes(p as string)) {
+        errors.push(`Invalid problem ID in top_problems: "${String(p)}"`)
+      }
+    }
+    if (d.top_problems.length > 3) {
+      errors.push('top_problems should have at most 3 entries')
+    }
+  }
+
+  // Signals array
+  if (!Array.isArray(d.signals)) {
+    errors.push('signals must be an array')
+  } else {
+    for (let i = 0; i < (d.signals as unknown[]).length; i++) {
+      const s = (d.signals as Record<string, unknown>[])[i]
+      if (!s || typeof s !== 'object') {
+        errors.push(`signals[${i}] must be an object`)
+        continue
+      }
+      if (!validProblemIds.includes(s.problem_id as string)) {
+        errors.push(`signals[${i}].problem_id must be a valid problem ID`)
+      }
+      if (typeof s.quote !== 'string' || s.quote.length === 0) {
+        errors.push(`signals[${i}].quote must be a non-empty string`)
+      }
+      if (typeof s.review_rating !== 'number' || s.review_rating < 1 || s.review_rating > 5) {
+        errors.push(`signals[${i}].review_rating must be 1-5`)
+      }
+      if (typeof s.severity !== 'number' || s.severity < 1 || s.severity > 10) {
+        errors.push(`signals[${i}].severity must be 1-10`)
+      }
+    }
+  }
+
+  // Outreach angle voice check
+  if (typeof d.outreach_angle === 'string' && d.outreach_angle.length > 0) {
+    const angle = d.outreach_angle.toLowerCase()
+    if (angle.includes(' i ') || angle.startsWith('i ') || angle.includes(" i'")) {
+      errors.push('outreach_angle must use "we" voice, not "I"')
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+/**
+ * Validates a batch scoring result.
+ *
+ * @param data - The parsed JSON to validate
+ * @returns An object with `valid` boolean and `errors` array of issues found
+ */
+export function validateBatchReviewScoring(data: unknown): {
+  valid: boolean
+  errors: string[]
+} {
+  const errors: string[] = []
+
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, errors: ['Root must be a non-null object'] }
+  }
+
+  const d = data as Record<string, unknown>
+
+  if (!Array.isArray(d.businesses)) {
+    errors.push('businesses must be an array')
+  } else {
+    for (let i = 0; i < d.businesses.length; i++) {
+      const result = validateReviewScoring(d.businesses[i])
+      if (!result.valid) {
+        errors.push(...result.errors.map((e) => `businesses[${i}]: ${e}`))
+      }
+    }
+  }
+
+  if (typeof d.total_reviews_analyzed !== 'number') {
+    errors.push('total_reviews_analyzed must be a number')
+  }
+
+  return { valid: errors.length === 0, errors }
+}

--- a/src/lead-gen/schemas/job-signal.ts
+++ b/src/lead-gen/schemas/job-signal.ts
@@ -1,0 +1,84 @@
+/**
+ * Job Signal Schema — Pipeline 2 Output Types
+ *
+ * Defines the structured output contract for the job posting qualification prompt.
+ * When a Phoenix-area job posting signals operational pain at a small business,
+ * the AI produces a JobQualification result matching this schema.
+ *
+ * @see docs/collateral/lead-automation-blueprint.md — Pipeline 2 architecture
+ * @see src/lead-gen/prompts/job-qualification-prompt.ts — The prompt that produces this output
+ */
+
+import type { ProblemId } from './lead-scoring-schema.js'
+import type { ProblemEvidence, ScoringResult } from './lead-scoring-schema.js'
+
+export { type ProblemEvidence, type ScoringResult }
+
+// ---------------------------------------------------------------------------
+// Job qualification output
+// ---------------------------------------------------------------------------
+
+/** Result of AI qualification of a single job posting. */
+export interface JobQualification {
+  /** Company name from the job posting. */
+  company: string
+
+  /** Whether this company qualifies as a prospect. */
+  qualified: boolean
+
+  /** Confidence in the qualification decision. */
+  confidence: 'high' | 'medium' | 'low'
+
+  /**
+   * Estimated employee count range, inferred from the job description.
+   * "unknown" if no signals present.
+   */
+  company_size_estimate: string
+
+  /** Which of the 6 universal problems the job posting signals. */
+  problems_signaled: ProblemId[]
+
+  /**
+   * Key evidence from the job description supporting the qualification.
+   * Direct quotes or close paraphrases from the posting.
+   */
+  evidence: string
+
+  /**
+   * Suggested outreach angle — how to approach this company.
+   * Written in "we" voice, references their specific pain.
+   * Never mentions pricing or fixed timeframes.
+   */
+  outreach_angle: string
+
+  /**
+   * Reason for disqualification, if qualified is false.
+   * Null when qualified is true.
+   */
+  disqualification_reason: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Input data for the prompt
+// ---------------------------------------------------------------------------
+
+/** Raw job posting data as received from SerpAPI or Craigslist. */
+export interface JobPostingInput {
+  /** Job title as listed. */
+  title: string
+
+  /** Company name. */
+  company: string
+
+  /** Location (city, state). */
+  location: string
+
+  /** Full job description text. */
+  description: string
+
+  /** Source platform. */
+  source: 'google_jobs' | 'craigslist' | 'other'
+
+  /** URL to the original posting, if available. */
+  url?: string
+}

--- a/src/lead-gen/schemas/lead-scoring-schema.ts
+++ b/src/lead-gen/schemas/lead-scoring-schema.ts
@@ -1,0 +1,119 @@
+/**
+ * Lead Scoring Schema — Shared Types for Lead Generation Pipelines
+ *
+ * Defines the shared vocabulary used across all 5 lead generation pipelines.
+ * Re-exports canonical problem and vertical types from the assessment schema
+ * to maintain a single source of truth.
+ *
+ * @see docs/collateral/lead-automation-blueprint.md — Pipeline architecture
+ * @see src/portal/assessments/extraction-schema.ts — Canonical problem/vertical types
+ */
+
+// ---------------------------------------------------------------------------
+// Re-exports from assessment schema — single source of truth
+// ---------------------------------------------------------------------------
+
+export {
+  PROBLEM_IDS,
+  PROBLEM_LABELS,
+  VERTICALS,
+  type ProblemId,
+  type Vertical,
+} from '../../portal/assessments/extraction-schema.js'
+
+// ---------------------------------------------------------------------------
+// Lead source pipeline identifiers
+// ---------------------------------------------------------------------------
+
+export const PIPELINE_IDS = [
+  'review_mining',
+  'job_monitor',
+  'new_business',
+  'social_listening',
+  'partner_nurture',
+] as const
+
+export type PipelineId = (typeof PIPELINE_IDS)[number]
+
+export const PIPELINE_LABELS: Record<PipelineId, string> = {
+  review_mining: 'Review Mining',
+  job_monitor: 'Job Posting Monitor',
+  new_business: 'New Business Detection',
+  social_listening: 'Social Listening',
+  partner_nurture: 'Referral Partner Nurture',
+}
+
+// ---------------------------------------------------------------------------
+// Shared scoring types
+// ---------------------------------------------------------------------------
+
+/** A single piece of evidence supporting a problem signal. */
+export interface ProblemEvidence {
+  /** Which of the 6 universal problems this evidence maps to. */
+  problem_id: import('../../portal/assessments/extraction-schema.js').ProblemId
+
+  /** The exact text (review quote, job description excerpt, etc.) that signals the problem. */
+  quote: string
+
+  /** Severity of this specific signal: 1 (barely noticeable) to 10 (screaming pain). */
+  severity: number
+}
+
+/** Scoring result produced by any lead qualification prompt. */
+export interface ScoringResult {
+  /** Overall operational pain score: 1 (no signal) to 10 (severe, multiple problems). */
+  pain_score: number
+
+  /** The top 1-3 problems detected, by canonical ID. */
+  top_problems: import('../../portal/assessments/extraction-schema.js').ProblemId[]
+
+  /** Supporting evidence for the scoring. */
+  evidence: ProblemEvidence[]
+
+  /**
+   * A suggested outreach angle — how to open the conversation with this prospect.
+   * Written in "we" voice, references their specific pain, never mentions pricing
+   * or fixed timeframes.
+   */
+  outreach_angle: string
+}
+
+// ---------------------------------------------------------------------------
+// Lead record — the universal output row for all pipelines
+// ---------------------------------------------------------------------------
+
+/** A qualified lead surfaced by any pipeline, ready for the output sheet. */
+export interface LeadRecord {
+  /** Business name as found in the source data. */
+  business_name: string
+
+  /** Phone number, if available. */
+  phone: string | null
+
+  /** Website URL, if available. */
+  website: string | null
+
+  /** Business category or type (e.g., "plumber", "CPA firm"). */
+  category: string
+
+  /** Phoenix metro sub-area (e.g., "Scottsdale", "Chandler", "Central Phoenix"). */
+  area: string | null
+
+  /** Which pipeline surfaced this lead. */
+  source_pipeline: PipelineId
+
+  /** Overall pain score from AI qualification. */
+  pain_score: number
+
+  /** Top problems detected, as canonical IDs. */
+  top_problems: import('../../portal/assessments/extraction-schema.js').ProblemId[]
+
+  /** Key evidence text (abbreviated for the sheet). */
+  evidence_summary: string
+
+  /** Suggested outreach angle. */
+  outreach_angle: string
+
+  /** ISO 8601 date when this lead was found. */
+  date_found: string
+}

--- a/src/lead-gen/schemas/new-business-signal.ts
+++ b/src/lead-gen/schemas/new-business-signal.ts
@@ -1,0 +1,118 @@
+/**
+ * New Business Signal Schema — Pipeline 3 Output Types
+ *
+ * Defines the structured output contract for the new business qualification prompt.
+ * When a new business filing (ACC), TPT license (ADOR), or commercial permit
+ * (city SODA API) signals a growing or launching business in the Phoenix area,
+ * the AI produces a NewBusinessQualification result matching this schema.
+ *
+ * @see docs/collateral/lead-automation-blueprint.md — Pipeline 3 architecture
+ * @see src/lead-gen/prompts/new-business-prompt.ts — The prompt that produces this output
+ */
+
+import type { Vertical } from './lead-scoring-schema.js'
+
+// ---------------------------------------------------------------------------
+// Source identifiers for new business signals
+// ---------------------------------------------------------------------------
+
+export const NEW_BUSINESS_SOURCES = [
+  'acc_filing',
+  'ador_tpt',
+  'phoenix_permit',
+  'scottsdale_permit',
+  'chandler_permit',
+  'sba_loan',
+] as const
+
+export type NewBusinessSource = (typeof NEW_BUSINESS_SOURCES)[number]
+
+// ---------------------------------------------------------------------------
+// Outreach timing recommendations
+// ---------------------------------------------------------------------------
+
+export const OUTREACH_TIMINGS = [
+  'immediate',
+  'wait_30_days',
+  'wait_60_days',
+  'not_recommended',
+] as const
+
+export type OutreachTiming = (typeof OUTREACH_TIMINGS)[number]
+
+// ---------------------------------------------------------------------------
+// New business qualification output
+// ---------------------------------------------------------------------------
+
+/** Result of AI qualification of a single new business filing or permit. */
+export interface NewBusinessQualification {
+  /** Business name as listed on the filing, license, or permit. */
+  business_name: string
+
+  /** Entity type from the filing (e.g., "LLC", "Corp", "Sole Prop", "Partnership"). */
+  entity_type: string
+
+  /** Registered or physical address from the filing. */
+  address: string
+
+  /** Phoenix metro sub-area (e.g., "Scottsdale", "Chandler", "Central Phoenix"). Null if unknown. */
+  area: string | null
+
+  /** Which public record source this filing came from. */
+  source: NewBusinessSource
+
+  /**
+   * Best-guess vertical match based on business name, permit type, and available context.
+   * "unknown" if the business type cannot be determined from available data.
+   */
+  vertical_match: Vertical | 'unknown'
+
+  /**
+   * Estimated employee count range, inferred from entity type, permit type, and context.
+   * Examples: "10-25", "5-10", "unknown".
+   */
+  size_estimate: string
+
+  /**
+   * Recommended outreach timing based on source type and business readiness.
+   * @see src/lead-gen/prompts/new-business-prompt.ts for timing guidance by source.
+   */
+  outreach_timing: OutreachTiming
+
+  /**
+   * Suggested outreach angle — how to approach this new business.
+   * Written in "we" voice. Never mentions pricing or fixed timeframes.
+   */
+  outreach_angle: string
+
+  /** Additional notes — reasoning, disqualification rationale, or context for the outreach team. */
+  notes: string
+}
+
+// ---------------------------------------------------------------------------
+// Input data for the prompt
+// ---------------------------------------------------------------------------
+
+/** Raw new business data as received from ACC, ADOR, or city SODA APIs. */
+export interface NewBusinessInput {
+  /** Business name as listed on the filing. */
+  business_name: string
+
+  /** Entity type (e.g., "Domestic LLC", "Foreign Corp", "Sole Proprietorship"). */
+  entity_type: string
+
+  /** Registered or physical address. */
+  address: string
+
+  /** Filing or license date (ISO 8601). */
+  filing_date: string
+
+  /** Which public record source this data came from. */
+  source: NewBusinessSource
+
+  /** Permit type, for city permits (e.g., "Commercial TI", "New Construction", "Change of Use"). */
+  permit_type?: string
+
+  /** Any additional data from the source (e.g., SIC code, NAICS, business description). */
+  additional_data?: string
+}

--- a/src/lead-gen/schemas/partner-email-draft.ts
+++ b/src/lead-gen/schemas/partner-email-draft.ts
@@ -1,0 +1,97 @@
+/**
+ * Partner Email Draft Schema — Pipeline 5 Output Types
+ *
+ * Defines the structured output contract for the referral partner nurture prompt.
+ * When Claude drafts a personalized check-in email for a bookkeeper/CPA referral
+ * partner, it produces a PartnerEmailDraft result matching this schema.
+ *
+ * @see docs/collateral/lead-automation-blueprint.md — Pipeline 5 architecture
+ * @see src/lead-gen/prompts/partner-nurture-prompt.ts — The prompt that produces this output
+ * @see Decision #20 — Voice Standard ("we" voice)
+ * @see Decision #22 — Bookkeeper/CPA Referral Channel
+ */
+
+// ---------------------------------------------------------------------------
+// Email draft output
+// ---------------------------------------------------------------------------
+
+/** Tone variant for the drafted email, driven by relationship stage. */
+export type EmailTone = 'warm_checkin' | 'gentle_followup' | 'initial_outreach'
+
+/** Preferred send day for B2B email timing. */
+export type SendDay = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday'
+
+/** Result of AI-drafted check-in email for a referral partner. */
+export interface PartnerEmailDraft {
+  /** Email subject line — short (5-8 words), professional, not clickbaity. */
+  subject: string
+
+  /** Email body — clean prose, plain text, suitable for Buttondown transactional email. */
+  body: string
+
+  /** Tone variant used for this email. */
+  tone: EmailTone
+
+  /** Suggested day of the week to send (Tuesday-Thursday preferred for B2B). */
+  suggested_send_day: SendDay
+
+  /** Internal notes for the human reviewer — not included in the email. */
+  notes: string
+}
+
+// ---------------------------------------------------------------------------
+// Input data for the prompt
+// ---------------------------------------------------------------------------
+
+/** Partner tier indicating referral potential and relationship priority. */
+export type PartnerTier = 1 | 2 | 3
+
+/** Stage of the referral relationship lifecycle. */
+export type RelationshipStage =
+  | 'prospect'
+  | 'intro_sent'
+  | 'intro_call_done'
+  | 'active_partner'
+  | 'dormant'
+
+/** Input data about a referral partner, sourced from the partner prospect list. */
+export interface PartnerInput {
+  /** Name of the bookkeeper/CPA firm. */
+  firm_name: string
+
+  /** Primary contact name at the firm. */
+  contact_name: string | null
+
+  /** Phoenix metro sub-area (e.g., "Scottsdale", "Chandler", "Central Phoenix"). */
+  area: string
+
+  /** Phone number, if available. */
+  phone: string | null
+
+  /** Email address, if available. */
+  email: string | null
+
+  /** Firm website URL, if available. */
+  website: string | null
+
+  /** Partner tier: 1 (highest priority), 2, or 3 (lowest priority). */
+  tier: PartnerTier
+
+  /** What verticals/services the firm specializes in — from the prospect list. */
+  focus_areas: string
+
+  /** Current stage of the referral relationship. */
+  relationship_stage: RelationshipStage
+
+  /** Date of most recent contact (ISO 8601), or null if no prior contact. */
+  last_contact_date: string | null
+
+  /** Number of referrals received from this partner to us. */
+  referrals_received: number
+
+  /** Number of referrals sent from us to this partner. */
+  referrals_sent: number
+
+  /** Any relevant context or history notes. */
+  notes: string | null
+}

--- a/src/lead-gen/schemas/review-signal.ts
+++ b/src/lead-gen/schemas/review-signal.ts
@@ -1,0 +1,121 @@
+/**
+ * Review Signal Schema — Pipeline 1 Output Types
+ *
+ * Defines the structured output contract for the review scoring prompt.
+ * When Google/Yelp reviews for a Phoenix-area business reveal operational
+ * pain patterns, the AI produces a ReviewScoring result matching this schema.
+ *
+ * @see docs/collateral/lead-automation-blueprint.md — Pipeline 1 architecture
+ * @see src/lead-gen/prompts/review-scoring-prompt.ts — The prompt that produces this output
+ */
+
+import type { ProblemId, ProblemEvidence } from './lead-scoring-schema.js'
+
+export { type ProblemEvidence }
+
+// ---------------------------------------------------------------------------
+// Review scoring output — single business
+// ---------------------------------------------------------------------------
+
+/** A single review that contains an operational signal. */
+export interface ReviewSignal {
+  /** Which of the 6 universal problems this review maps to. */
+  problem_id: ProblemId
+
+  /** The exact quote from the review that signals the problem. */
+  quote: string
+
+  /** Star rating of this specific review (1-5). */
+  review_rating: number
+
+  /** Severity of the operational signal: 1-10. */
+  severity: number
+}
+
+/** Result of AI scoring for a single business's reviews. */
+export interface ReviewScoring {
+  /** Business name. */
+  business_name: string
+
+  /** Google Places place_id for deduplication. */
+  place_id: string
+
+  /**
+   * Overall operational pain score: 1 (no signal) to 10 (severe, repeated patterns).
+   * Scoring calibration:
+   * - 1-3: No meaningful operational signals. Complaints are about service quality, not operations.
+   * - 4-6: Some operational signals but isolated incidents, not patterns.
+   * - 7-8: Clear operational pattern across multiple reviews. Worth outreach.
+   * - 9-10: Severe, repeated operational failures documented by multiple customers.
+   */
+  pain_score: number
+
+  /** The top 1-3 problems detected, by canonical ID. Ordered by severity. */
+  top_problems: ProblemId[]
+
+  /** Individual review signals supporting the score. */
+  signals: ReviewSignal[]
+
+  /**
+   * Suggested outreach angle — how to approach this business.
+   * References their specific pain as seen in reviews.
+   * Written in "we" voice. Never mentions pricing or fixed timeframes.
+   */
+  outreach_angle: string
+}
+
+// ---------------------------------------------------------------------------
+// Batch scoring output — multiple businesses in one call
+// ---------------------------------------------------------------------------
+
+/** Result of a batch scoring call (5-10 businesses per prompt). */
+export interface BatchReviewScoring {
+  /** Array of scored businesses. */
+  businesses: ReviewScoring[]
+
+  /** Total reviews analyzed across all businesses. */
+  total_reviews_analyzed: number
+}
+
+// ---------------------------------------------------------------------------
+// Input data for the prompt
+// ---------------------------------------------------------------------------
+
+/** A single review as received from Outscraper or similar API. */
+export interface ReviewInput {
+  /** Review author name. */
+  author: string
+
+  /** Star rating (1-5). */
+  rating: number
+
+  /** Full review text. */
+  text: string
+
+  /** Review date (ISO 8601 or human-readable). */
+  date: string
+}
+
+/** Input data for scoring a single business's reviews. */
+export interface BusinessReviewInput {
+  /** Business name. */
+  business_name: string
+
+  /** Google Places place_id. */
+  place_id: string
+
+  /** Business category (e.g., "plumber", "HVAC", "dentist"). */
+  category: string
+
+  /** Phoenix sub-area. */
+  area: string
+
+  /** Google overall rating (1-5). */
+  overall_rating: number
+
+  /** Total review count on Google. */
+  total_review_count: number
+
+  /** The reviews to analyze (recent reviews from Outscraper). */
+  reviews: ReviewInput[]
+}


### PR DESCRIPTION
## Summary

- Complete implementation framework for 5 automated lead generation pipelines (Review Mining, Job Posting Monitor, New Business Detection, Social Listening, Referral Partner Nurture)
- TypeScript prompt library with AI scoring prompts, schemas, and validation functions following the `extraction-prompt.ts` pattern
- Make.com scenario recipes (step-by-step build guides) for all 7 scenarios across 5 pipelines
- API query specs for SerpAPI, Outscraper, SODA (city permits), and Buttondown
- Google Sheets column specs, Make.com Data Store schemas, and API accounts checklist
- Updated blueprint with Buttondown integration and cross-references to implementation files

## What This Enables

Automated prospect discovery at ~$106-149/mo that surfaces qualified leads from:
1. **Google reviews** scored for operational pain signals (not service quality complaints)
2. **Job postings** where small companies are hiring ops roles (office manager, dispatcher, etc.)
3. **City commercial permits** and state business filings (new/growing businesses)
4. **Reddit/social conversations** where owners signal operational pain
5. **Automated partner nurture** keeping bookkeeper referral relationships warm

## Files (21 new, 1 modified)

**Prompts & Schemas (9 files):** `src/lead-gen/`
**Specs (7 files):** `docs/lead-automation/specs/`
**Recipes (5 files):** `docs/lead-automation/recipes/`
**Updated:** `docs/collateral/lead-automation-blueprint.md`

## Related Issues

Closes #105. References #106, #107, #108, #109, #110, #111.

## Test plan

- [x] All TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Prettier formatting passes
- [x] ESLint passes
- [x] Astro build succeeds
- [x] All 74 existing tests pass
- [ ] Test each prompt in Claude chat against real Phoenix data before wiring into Make.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)