### PR TITLE
fix: replace placeholder D1 and KV resource IDs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,7 +18,7 @@ pages_build_output_dir = "dist"
 [[d1_databases]]
 binding = "DB"
 database_name = "ss-console-db"
-database_id = "LOCAL_D1_PLACEHOLDER"
+database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 
 # ---------- R2 (documents, transcripts, SOWs) ----------
 [[r2_buckets]]
@@ -28,7 +28,7 @@ bucket_name = "ss-console-storage"
 # ---------- Workers KV (sessions) ----------
 [[kv_namespaces]]
 binding = "SESSIONS"
-id = "LOCAL_KV_PLACEHOLDER"
+id = "4570dcc1e154476f889bc9fcfc28b2b9"
 
 # ---------- Secrets (set via wrangler secret put) ----------
 # RESEND_API_KEY — Resend transactional email API key


### PR DESCRIPTION
## Summary
- Created `ss-console-db` (D1) and `SESSIONS` (KV) in Cloudflare
- Replaced `LOCAL_D1_PLACEHOLDER` and `LOCAL_KV_PLACEHOLDER` in `wrangler.toml` with real resource IDs
- Unblocks Cloudflare Pages deploy (was failing with "Invalid KV namespace ID")

## Test plan
- [x] `npm run verify` passes (231/231 tests)
- [ ] Deploy to Cloudflare Pages succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)