### PR TITLE
feat: Claude API extraction integration for assessments (#83)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,6 +15,7 @@ type CfEnv = {
   STORAGE: R2Bucket
   SESSIONS: KVNamespace
   RESEND_API_KEY?: string
+  ANTHROPIC_API_KEY?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>

--- a/src/lib/claude/extract.ts
+++ b/src/lib/claude/extract.ts
@@ -1,0 +1,152 @@
+/**
+ * Claude API client for assessment transcript extraction.
+ *
+ * Uses raw fetch against the Anthropic Messages API — no SDK dependency.
+ * This keeps the Cloudflare Workers bundle small and avoids Node.js runtime
+ * requirements that the SDK brings along.
+ *
+ * @see Decision #17 — Assessment Call Capture
+ * @see Deliverable #34 — MacWhisper extraction prompt
+ */
+
+import {
+  EXTRACTION_SYSTEM_PROMPT,
+  buildExtractionUserPrompt,
+  validateExtraction,
+} from '../../portal/assessments/extraction-prompt'
+import type { AssessmentExtraction } from '../../portal/assessments/extraction-schema'
+
+export type { AssessmentExtraction }
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 4096
+
+/**
+ * Error thrown when the Claude API returns an unexpected response.
+ */
+export class ExtractionApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly responseBody?: string
+  ) {
+    super(message)
+    this.name = 'ExtractionApiError'
+  }
+}
+
+/**
+ * Error thrown when the extraction output fails schema validation.
+ */
+export class ExtractionValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly validationErrors: string[]
+  ) {
+    super(message)
+    this.name = 'ExtractionValidationError'
+  }
+}
+
+/**
+ * Call the Claude API to extract structured assessment data from a transcript.
+ *
+ * 1. Sends the extraction system prompt + transcript to Claude
+ * 2. Parses the JSON response
+ * 3. Validates against the AssessmentExtraction schema
+ * 4. Returns the validated result
+ *
+ * @param apiKey - Anthropic API key
+ * @param transcript - Full MacWhisper speaker-separated transcript text
+ * @returns Validated AssessmentExtraction object
+ * @throws ExtractionApiError if the API call fails or returns unexpected format
+ * @throws ExtractionValidationError if the response does not match the schema
+ */
+export async function extractAssessment(
+  apiKey: string,
+  transcript: string
+): Promise<AssessmentExtraction> {
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: EXTRACTION_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: buildExtractionUserPrompt(transcript),
+        },
+      ],
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '<unreadable>')
+    throw new ExtractionApiError(
+      `Claude API returned ${response.status}: ${response.statusText}`,
+      response.status,
+      body
+    )
+  }
+
+  const result = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>
+  }
+
+  // The Messages API returns content as an array of content blocks.
+  // We expect a single text block containing the JSON.
+  const contentBlocks = result?.content
+  if (!Array.isArray(contentBlocks) || contentBlocks.length === 0) {
+    throw new ExtractionApiError(
+      'Claude API returned empty content',
+      response.status,
+      JSON.stringify(result)
+    )
+  }
+
+  const textBlock = contentBlocks.find((block) => block.type === 'text')
+  if (!textBlock?.text) {
+    throw new ExtractionApiError(
+      'Claude API response contained no text content block',
+      response.status,
+      JSON.stringify(result)
+    )
+  }
+
+  // Parse the JSON from the text response.
+  // Claude may wrap it in code fences despite the prompt saying not to.
+  let rawText = textBlock.text.trim()
+  if (rawText.startsWith('```')) {
+    rawText = rawText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(rawText)
+  } catch {
+    throw new ExtractionApiError(
+      'Claude API response was not valid JSON',
+      response.status,
+      rawText.slice(0, 500)
+    )
+  }
+
+  // Validate against the schema
+  const validation = validateExtraction(parsed)
+  if (!validation.valid) {
+    throw new ExtractionValidationError(
+      `Extraction output failed validation: ${validation.errors.join('; ')}`,
+      validation.errors
+    )
+  }
+
+  return parsed as AssessmentExtraction
+}

--- a/src/pages/admin/clients/[id]/assessments/[assessmentId].astro
+++ b/src/pages/admin/clients/[id]/assessments/[assessmentId].astro
@@ -39,6 +39,7 @@ if (!assessment) {
 
 const url = Astro.url
 const saved = url.searchParams.get('saved') === '1'
+const extracted = url.searchParams.get('extracted') === '1'
 const errorParam = url.searchParams.get('error') || ''
 const warningParam = url.searchParams.get('warning') || ''
 
@@ -46,9 +47,32 @@ const errorMessages: Record<string, string> = {
   server: 'Something went wrong. Please try again.',
   invalid_status: 'Invalid status selection.',
   invalid_transition: 'That status transition is not allowed.',
+  no_transcript: 'Upload a transcript before running extraction.',
+  no_api_key: 'Anthropic API key is not configured. Contact an administrator.',
+  transcript_missing: 'Transcript file could not be found in storage.',
+  extraction_failed: 'Extraction failed. Check the server logs for details.',
 }
 
 const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Parse extraction JSON for structured display
+let extractionData:
+  | import('../../../../../portal/assessments/extraction-schema').AssessmentExtraction
+  | null = null
+if (assessment.extraction) {
+  try {
+    extractionData = JSON.parse(assessment.extraction)
+  } catch {
+    // If the JSON is malformed, leave extractionData as null
+  }
+}
+
+// Check if API key is configured for the extract button state
+const hasApiKey = !!Astro.locals.runtime.env.ANTHROPIC_API_KEY
+
+// Determine if the extract button should be shown:
+// transcript exists AND extraction is empty/null
+const showExtractButton = !!assessment.transcript_path && !assessment.extraction
 
 // Parse JSON fields
 const problems: ProblemId[] = assessment.problems ? JSON.parse(assessment.problems) : []
@@ -145,6 +169,14 @@ const booksBehind = disqualifiers?.soft?.books_behind === true
         saved && (
           <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
             Assessment updated successfully.
+          </div>
+        )
+      }
+
+      {
+        extracted && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Extraction completed successfully. Review the results below.
           </div>
         )
       }
@@ -319,7 +351,282 @@ const booksBehind = disqualifiers?.soft?.books_behind === true
               Accepts .txt, .md, .srt, .vtt, or .json from MacWhisper.
             </p>
           </div>
+
+          {/* Extract with Claude button */}
+          {
+            showExtractButton && (
+              <div class="pt-2 border-t border-slate-100">
+                {hasApiKey ? (
+                  <form
+                    method="POST"
+                    action={`/api/admin/assessments/${assessment.id}`}
+                    id="extract-form"
+                  >
+                    <input type="hidden" name="action" value="extract" />
+                    <button
+                      type="submit"
+                      class="inline-flex items-center gap-2 bg-indigo-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-indigo-700 transition-colors"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                      </svg>
+                      Extract with Claude
+                    </button>
+                    <p class="mt-1 text-xs text-slate-400">
+                      Sends the transcript to Claude for automated extraction into structured data.
+                    </p>
+                  </form>
+                ) : (
+                  <div>
+                    <button
+                      type="button"
+                      disabled
+                      class="inline-flex items-center gap-2 bg-slate-300 text-slate-500 px-4 py-2 rounded-md text-sm font-medium cursor-not-allowed"
+                      title="Anthropic API key is not configured"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                      </svg>
+                      Extract with Claude
+                    </button>
+                    <p class="mt-1 text-xs text-amber-500">
+                      API key not configured. Contact an administrator.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )
+          }
         </div>
+
+        <!-- Extraction Result Display -->
+        {
+          extractionData && (
+            <div
+              class="bg-white rounded-lg border border-slate-200 p-6 space-y-5"
+              id="extraction-result"
+            >
+              <div class="flex items-center justify-between">
+                <h2 class="text-base font-semibold text-slate-900">Extraction Results</h2>
+                <span class="text-xs text-slate-400">
+                  Extracted{' '}
+                  {new Date(extractionData.extracted_at).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+              </div>
+
+              {/* Executive Summary */}
+              <div>
+                <h3 class="text-sm font-medium text-slate-700 mb-1">Executive Summary</h3>
+                <p class="text-sm text-slate-600 bg-slate-50 p-3 rounded-lg">
+                  {extractionData.executive_summary}
+                </p>
+              </div>
+
+              {/* Business Profile */}
+              <div class="grid grid-cols-3 gap-3 text-sm">
+                <div class="bg-slate-50 p-3 rounded-lg">
+                  <span class="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                    Business
+                  </span>
+                  <p class="text-slate-900 mt-0.5">{extractionData.business_name}</p>
+                </div>
+                <div class="bg-slate-50 p-3 rounded-lg">
+                  <span class="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                    Vertical
+                  </span>
+                  <p class="text-slate-900 mt-0.5">{extractionData.business_type}</p>
+                </div>
+                <div class="bg-slate-50 p-3 rounded-lg">
+                  <span class="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                    Employees
+                  </span>
+                  <p class="text-slate-900 mt-0.5">{extractionData.employee_count ?? 'Unknown'}</p>
+                </div>
+              </div>
+
+              {/* Problems Identified */}
+              <div>
+                <h3 class="text-sm font-medium text-slate-700 mb-2">Problems Identified</h3>
+                <div class="space-y-3">
+                  {extractionData.identified_problems.map((problem) => (
+                    <div class="border border-slate-100 rounded-lg p-3">
+                      <div class="flex items-center gap-2 mb-1">
+                        <span
+                          class:list={[
+                            'inline-block px-2 py-0.5 rounded text-xs font-medium',
+                            problem.severity === 'high' && 'bg-red-100 text-red-700',
+                            problem.severity === 'medium' && 'bg-amber-100 text-amber-700',
+                            problem.severity === 'low' && 'bg-slate-100 text-slate-600',
+                          ]}
+                        >
+                          {problem.severity}
+                        </span>
+                        <span class="text-sm font-medium text-slate-900">
+                          {PROBLEM_LABELS[problem.problem_id as ProblemId] ?? problem.problem_id}
+                        </span>
+                      </div>
+                      <p class="text-sm text-slate-600">{problem.summary}</p>
+                      {problem.owner_quotes.length > 0 && (
+                        <div class="mt-2 space-y-1">
+                          {problem.owner_quotes.map((quote) => (
+                            <p class="text-xs text-slate-500 italic pl-3 border-l-2 border-slate-200">
+                              "{quote}"
+                            </p>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Champion Candidate */}
+              {extractionData.champion_candidate && (
+                <div>
+                  <h3 class="text-sm font-medium text-slate-700 mb-2">Champion Candidate</h3>
+                  <div class="bg-slate-50 p-3 rounded-lg text-sm">
+                    <div class="flex items-center gap-2 mb-1">
+                      <span class="font-medium text-slate-900">
+                        {extractionData.champion_candidate.name ?? 'Unknown'}
+                      </span>
+                      {extractionData.champion_candidate.role && (
+                        <span class="text-slate-500">
+                          — {extractionData.champion_candidate.role}
+                        </span>
+                      )}
+                      <span
+                        class:list={[
+                          'inline-block px-2 py-0.5 rounded text-xs font-medium',
+                          extractionData.champion_candidate.confidence === 'strong' &&
+                            'bg-green-100 text-green-700',
+                          extractionData.champion_candidate.confidence === 'moderate' &&
+                            'bg-amber-100 text-amber-700',
+                          extractionData.champion_candidate.confidence === 'weak' &&
+                            'bg-red-100 text-red-700',
+                        ]}
+                      >
+                        {extractionData.champion_candidate.confidence}
+                      </span>
+                    </div>
+                    <p class="text-slate-600">{extractionData.champion_candidate.evidence}</p>
+                  </div>
+                </div>
+              )}
+
+              {/* Disqualification Flags */}
+              {(extractionData.disqualification_flags.hard.not_decision_maker ||
+                extractionData.disqualification_flags.hard.scope_exceeds_sprint ||
+                extractionData.disqualification_flags.hard.no_tech_baseline ||
+                extractionData.disqualification_flags.soft.no_champion ||
+                extractionData.disqualification_flags.soft.books_behind ||
+                extractionData.disqualification_flags.soft.no_willingness_to_change) && (
+                <div>
+                  <h3 class="text-sm font-medium text-slate-700 mb-2">Disqualification Flags</h3>
+                  <div class="space-y-1 text-sm">
+                    {extractionData.disqualification_flags.hard.not_decision_maker && (
+                      <p class="text-red-700 flex items-center gap-1">
+                        <span class="inline-block w-2 h-2 rounded-full bg-red-500 flex-shrink-0" />
+                        Hard: Not speaking to the decision maker
+                      </p>
+                    )}
+                    {extractionData.disqualification_flags.hard.scope_exceeds_sprint && (
+                      <p class="text-red-700 flex items-center gap-1">
+                        <span class="inline-block w-2 h-2 rounded-full bg-red-500 flex-shrink-0" />
+                        Hard: Scope exceeds engagement
+                      </p>
+                    )}
+                    {extractionData.disqualification_flags.hard.no_tech_baseline && (
+                      <p class="text-red-700 flex items-center gap-1">
+                        <span class="inline-block w-2 h-2 rounded-full bg-red-500 flex-shrink-0" />
+                        Hard: No tech baseline
+                      </p>
+                    )}
+                    {extractionData.disqualification_flags.soft.no_champion && (
+                      <p class="text-amber-700 flex items-center gap-1">
+                        <span class="inline-block w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+                        Soft: No champion identified
+                      </p>
+                    )}
+                    {extractionData.disqualification_flags.soft.books_behind && (
+                      <p class="text-amber-700 flex items-center gap-1">
+                        <span class="inline-block w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+                        Soft: Books more than 30 days behind
+                      </p>
+                    )}
+                    {extractionData.disqualification_flags.soft.no_willingness_to_change && (
+                      <p class="text-amber-700 flex items-center gap-1">
+                        <span class="inline-block w-2 h-2 rounded-full bg-amber-500 flex-shrink-0" />
+                        Soft: No willingness to change
+                      </p>
+                    )}
+                    {extractionData.disqualification_flags.notes && (
+                      <p class="text-slate-500 text-xs mt-1">
+                        {extractionData.disqualification_flags.notes}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Quote Drivers */}
+              <div>
+                <h3 class="text-sm font-medium text-slate-700 mb-2">Quote Drivers</h3>
+                <div class="grid grid-cols-2 gap-3 text-sm">
+                  <div class="bg-slate-50 p-3 rounded-lg">
+                    <span class="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                      Complexity
+                    </span>
+                    <p
+                      class:list={[
+                        'mt-0.5 font-medium',
+                        extractionData.quote_drivers.estimated_complexity === 'high' &&
+                          'text-red-700',
+                        extractionData.quote_drivers.estimated_complexity === 'medium' &&
+                          'text-amber-700',
+                        extractionData.quote_drivers.estimated_complexity === 'low' &&
+                          'text-green-700',
+                      ]}
+                    >
+                      {extractionData.quote_drivers.estimated_complexity}
+                    </p>
+                  </div>
+                  <div class="bg-slate-50 p-3 rounded-lg">
+                    <span class="text-xs font-medium text-slate-400 uppercase tracking-wide">
+                      Recommended
+                    </span>
+                    <p class="text-slate-900 mt-0.5">
+                      {extractionData.quote_drivers.recommended_problems
+                        .map((pid) => PROBLEM_LABELS[pid as ProblemId] ?? pid)
+                        .join(', ')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Additional Notes */}
+              {extractionData.additional_notes && (
+                <div>
+                  <h3 class="text-sm font-medium text-slate-700 mb-1">Additional Notes</h3>
+                  <p class="text-sm text-slate-600">{extractionData.additional_notes}</p>
+                </div>
+              )}
+            </div>
+          )
+        }
 
         <!-- Extraction JSON -->
         <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">

--- a/src/pages/api/admin/assessments/[id].ts
+++ b/src/pages/api/admin/assessments/[id].ts
@@ -5,9 +5,10 @@ import {
   updateAssessmentStatus,
 } from '../../../../lib/db/assessments'
 import type { AssessmentStatus } from '../../../../lib/db/assessments'
-import { uploadTranscript } from '../../../../lib/storage/r2'
+import { uploadTranscript, getTranscript } from '../../../../lib/storage/r2'
 import { PROBLEM_IDS } from '../../../../portal/assessments/extraction-schema'
 import type { ProblemId } from '../../../../portal/assessments/extraction-schema'
+import { extractAssessment } from '../../../../lib/claude/extract'
 
 /**
  * POST /api/admin/assessments/:id
@@ -89,6 +90,61 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
         `/admin/clients/${existing.client_id}/assessments/${assessmentId}?saved=1`,
         302
       )
+    }
+
+    // Handle Claude API extraction
+    if (action === 'extract') {
+      // Verify transcript exists
+      if (!existing.transcript_path) {
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?error=no_transcript`,
+          302
+        )
+      }
+
+      // Verify API key is configured
+      const apiKey = env.ANTHROPIC_API_KEY
+      if (!apiKey) {
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?error=no_api_key`,
+          302
+        )
+      }
+
+      // Fetch transcript text from R2
+      const transcriptObject = await getTranscript(env.STORAGE, existing.transcript_path)
+      if (!transcriptObject) {
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?error=transcript_missing`,
+          302
+        )
+      }
+      const transcriptText = await transcriptObject.text()
+
+      // Call Claude API for extraction
+      try {
+        const result = await extractAssessment(apiKey, transcriptText)
+
+        // Update assessment record with extraction results
+        await updateAssessment(env.DB, session.orgId, assessmentId, {
+          extraction: JSON.stringify(result),
+          problems: JSON.stringify(result.identified_problems.map((p) => p.problem_id)),
+          champion_name: result.champion_candidate?.name ?? null,
+          champion_role: result.champion_candidate?.role ?? null,
+          disqualifiers: JSON.stringify(result.disqualification_flags),
+        })
+
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?extracted=1`,
+          302
+        )
+      } catch (err) {
+        console.error('[api/admin/assessments/[id]] Extraction error:', err)
+        return redirect(
+          `/admin/clients/${existing.client_id}/assessments/${assessmentId}?error=extraction_failed`,
+          302
+        )
+      }
     }
 
     // Handle general update

--- a/tests/claude-extract.test.ts
+++ b/tests/claude-extract.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('claude extraction: client module', () => {
+  const source = () => readFileSync(resolve('src/lib/claude/extract.ts'), 'utf-8')
+
+  it('extract.ts exists', () => {
+    expect(existsSync(resolve('src/lib/claude/extract.ts'))).toBe(true)
+  })
+
+  it('exports extractAssessment function', () => {
+    expect(source()).toContain('export async function extractAssessment')
+  })
+
+  it('exports ExtractionApiError class', () => {
+    expect(source()).toContain('export class ExtractionApiError')
+  })
+
+  it('exports ExtractionValidationError class', () => {
+    expect(source()).toContain('export class ExtractionValidationError')
+  })
+
+  it('uses raw fetch to Anthropic API (no SDK)', () => {
+    const code = source()
+    expect(code).toContain('https://api.anthropic.com/v1/messages')
+    expect(code).toContain('fetch(')
+    // Should not import the Anthropic SDK
+    expect(code).not.toContain('@anthropic-ai/sdk')
+    expect(code).not.toContain("from 'anthropic'")
+  })
+
+  it('includes x-api-key header', () => {
+    expect(source()).toContain("'x-api-key': apiKey")
+  })
+
+  it('includes anthropic-version header', () => {
+    const code = source()
+    expect(code).toContain("'anthropic-version': ANTHROPIC_VERSION")
+    expect(code).toContain("ANTHROPIC_VERSION = '2023-06-01'")
+  })
+
+  it('includes content-type header', () => {
+    expect(source()).toContain("'content-type': 'application/json'")
+  })
+
+  it('uses the correct model', () => {
+    expect(source()).toContain('claude-sonnet-4-20250514')
+  })
+
+  it('sets max_tokens to 4096', () => {
+    expect(source()).toContain('4096')
+    expect(source()).toContain('max_tokens: MAX_TOKENS')
+  })
+
+  it('imports and uses EXTRACTION_SYSTEM_PROMPT', () => {
+    const code = source()
+    expect(code).toContain('EXTRACTION_SYSTEM_PROMPT')
+    expect(code).toContain('system: EXTRACTION_SYSTEM_PROMPT')
+  })
+
+  it('imports and uses buildExtractionUserPrompt', () => {
+    const code = source()
+    expect(code).toContain('buildExtractionUserPrompt')
+    expect(code).toContain('buildExtractionUserPrompt(transcript)')
+  })
+
+  it('calls validateExtraction on the response', () => {
+    const code = source()
+    expect(code).toContain('validateExtraction')
+    expect(code).toContain('validateExtraction(parsed)')
+  })
+
+  it('throws ExtractionValidationError on invalid extraction output', () => {
+    const code = source()
+    expect(code).toContain('!validation.valid')
+    expect(code).toContain('new ExtractionValidationError')
+  })
+
+  it('throws ExtractionApiError on non-OK response', () => {
+    const code = source()
+    expect(code).toContain('!response.ok')
+    expect(code).toContain('new ExtractionApiError')
+  })
+
+  it('handles code fences in Claude response', () => {
+    const code = source()
+    expect(code).toContain('startsWith')
+    expect(code).toContain('```')
+  })
+
+  it('parses text content block from Messages API response', () => {
+    const code = source()
+    expect(code).toContain('contentBlocks')
+    expect(code).toContain("block.type === 'text'")
+  })
+})
+
+describe('claude extraction: API route integration', () => {
+  const source = () => readFileSync(resolve('src/pages/api/admin/assessments/[id].ts'), 'utf-8')
+
+  it('API route imports extractAssessment', () => {
+    expect(source()).toContain("import { extractAssessment } from '../../../../lib/claude/extract'")
+  })
+
+  it('API route imports getTranscript from R2', () => {
+    expect(source()).toContain('getTranscript')
+  })
+
+  it('API route handles action === extract', () => {
+    const code = source()
+    expect(code).toContain("action === 'extract'")
+  })
+
+  it('API route checks transcript_path exists before extraction', () => {
+    const code = source()
+    expect(code).toContain('!existing.transcript_path')
+    expect(code).toContain('no_transcript')
+  })
+
+  it('API route checks ANTHROPIC_API_KEY from env', () => {
+    const code = source()
+    expect(code).toContain('env.ANTHROPIC_API_KEY')
+    expect(code).toContain('no_api_key')
+  })
+
+  it('API route fetches transcript text from R2', () => {
+    const code = source()
+    expect(code).toContain('getTranscript(env.STORAGE, existing.transcript_path)')
+    expect(code).toContain('transcriptObject.text()')
+  })
+
+  it('API route calls extractAssessment with apiKey and transcript', () => {
+    expect(source()).toContain('extractAssessment(apiKey, transcriptText)')
+  })
+
+  it('API route updates assessment with extraction result', () => {
+    const code = source()
+    expect(code).toContain('JSON.stringify(result)')
+    expect(code).toContain('result.identified_problems.map')
+    expect(code).toContain('result.champion_candidate?.name')
+    expect(code).toContain('result.champion_candidate?.role')
+    expect(code).toContain('result.disqualification_flags')
+  })
+
+  it('API route redirects with extracted=1 on success', () => {
+    expect(source()).toContain('?extracted=1')
+  })
+
+  it('API route redirects with error on extraction failure', () => {
+    expect(source()).toContain('extraction_failed')
+  })
+
+  it('API route logs extraction errors', () => {
+    expect(source()).toContain('Extraction error')
+  })
+})
+
+describe('claude extraction: assessment detail page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/assessments/[assessmentId].astro'), 'utf-8')
+
+  it('page shows Extract with Claude button', () => {
+    const code = source()
+    expect(code).toContain('Extract with Claude')
+    expect(code).toContain('extract-form')
+  })
+
+  it('extract form posts action=extract to assessment API', () => {
+    const code = source()
+    expect(code).toContain('name="action" value="extract"')
+    expect(code).toContain('/api/admin/assessments/${assessment.id}')
+  })
+
+  it('extract button only visible when transcript exists and extraction is empty', () => {
+    const code = source()
+    expect(code).toContain('showExtractButton')
+    expect(code).toContain('!!assessment.transcript_path && !assessment.extraction')
+  })
+
+  it('extract button disabled when API key not configured', () => {
+    const code = source()
+    expect(code).toContain('hasApiKey')
+    expect(code).toContain('API key not configured')
+    expect(code).toContain('disabled')
+  })
+
+  it('page handles extracted=1 query param for success message', () => {
+    const code = source()
+    expect(code).toContain("get('extracted')")
+    expect(code).toContain('Extraction completed successfully')
+  })
+
+  it('page parses extraction JSON for structured display', () => {
+    const code = source()
+    expect(code).toContain('extractionData')
+    expect(code).toContain('JSON.parse(assessment.extraction)')
+  })
+
+  it('page displays extraction result section when data exists', () => {
+    const code = source()
+    expect(code).toContain('extraction-result')
+    expect(code).toContain('Extraction Results')
+  })
+
+  it('extraction result displays problems with severity badges', () => {
+    const code = source()
+    expect(code).toContain('identified_problems.map')
+    expect(code).toContain('problem.severity')
+    expect(code).toContain('problem.summary')
+  })
+
+  it('extraction result displays champion candidate', () => {
+    const code = source()
+    expect(code).toContain('champion_candidate')
+    expect(code).toContain('Champion Candidate')
+  })
+
+  it('extraction result displays disqualification flags', () => {
+    const code = source()
+    expect(code).toContain('disqualification_flags')
+    expect(code).toContain('Disqualification Flags')
+  })
+
+  it('extraction result displays owner quotes', () => {
+    const code = source()
+    expect(code).toContain('owner_quotes')
+  })
+
+  it('extraction result displays executive summary', () => {
+    const code = source()
+    expect(code).toContain('executive_summary')
+    expect(code).toContain('Executive Summary')
+  })
+
+  it('page includes error messages for extraction failures', () => {
+    const code = source()
+    expect(code).toContain('no_transcript')
+    expect(code).toContain('no_api_key')
+    expect(code).toContain('extraction_failed')
+    expect(code).toContain('transcript_missing')
+  })
+})
+
+describe('claude extraction: env type declaration', () => {
+  it('env.d.ts includes ANTHROPIC_API_KEY', () => {
+    const code = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(code).toContain('ANTHROPIC_API_KEY')
+  })
+
+  it('ANTHROPIC_API_KEY is optional', () => {
+    const code = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(code).toContain('ANTHROPIC_API_KEY?: string')
+  })
+})
+
+describe('claude extraction: prompt and schema imports', () => {
+  it('extraction-prompt.ts exists', () => {
+    expect(existsSync(resolve('src/portal/assessments/extraction-prompt.ts'))).toBe(true)
+  })
+
+  it('extraction-schema.ts exists', () => {
+    expect(existsSync(resolve('src/portal/assessments/extraction-schema.ts'))).toBe(true)
+  })
+
+  it('extraction-prompt exports validateExtraction', () => {
+    const code = readFileSync(resolve('src/portal/assessments/extraction-prompt.ts'), 'utf-8')
+    expect(code).toContain('export function validateExtraction')
+  })
+
+  it('extraction-schema exports AssessmentExtraction interface', () => {
+    const code = readFileSync(resolve('src/portal/assessments/extraction-schema.ts'), 'utf-8')
+    expect(code).toContain('export interface AssessmentExtraction')
+  })
+
+  it('extract.ts correctly imports from extraction-prompt', () => {
+    const code = readFileSync(resolve('src/lib/claude/extract.ts'), 'utf-8')
+    expect(code).toContain("from '../../portal/assessments/extraction-prompt'")
+  })
+
+  it('extract.ts imports type from extraction-schema', () => {
+    const code = readFileSync(resolve('src/lib/claude/extract.ts'), 'utf-8')
+    expect(code).toContain("from '../../portal/assessments/extraction-schema'")
+  })
+
+  it('extract.ts imports validateExtraction from extraction-prompt', () => {
+    const code = readFileSync(resolve('src/lib/claude/extract.ts'), 'utf-8')
+    expect(code).toContain('validateExtraction')
+    expect(code).toContain("from '../../portal/assessments/extraction-prompt'")
+  })
+})


### PR DESCRIPTION
## Summary
- Add `src/lib/claude/extract.ts` — raw-fetch client for the Anthropic Messages API that sends the extraction prompt + transcript and validates the structured JSON response
- Extend the assessment API route (`/api/admin/assessments/[id]`) with `action=extract` handling: fetches transcript from R2, calls Claude, persists extraction results (problems, champion, disqualifiers) to D1
- Add "Extract with Claude" button to the assessment detail page (visible when transcript exists and extraction is empty; disabled when API key is not configured)
- Add structured extraction result display above the manual form fields showing executive summary, identified problems with severity badges, champion candidate, disqualification flags, and quote drivers
- Add `ANTHROPIC_API_KEY` to the `CfEnv` type in `env.d.ts`
- Add 50 scaffold tests verifying file structure, exports, code patterns, and integration points

## Test plan
- [ ] Verify `npm run verify` passes (typecheck, format, lint, build, 411 tests)
- [ ] Upload a transcript to an assessment, confirm the "Extract with Claude" button appears
- [ ] With `ANTHROPIC_API_KEY` set, click Extract and verify structured results populate
- [ ] Without `ANTHROPIC_API_KEY`, confirm the button is disabled with a tooltip message
- [ ] Verify extraction results display correctly (problems, champion, flags, quote drivers)
- [ ] Verify manual form fields still work after extraction populates data
- [ ] Verify existing assessment flows (status transitions, save) are unaffected

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)