### PR TITLE
feat: engagement management + milestones (#77)

### DIFF
--- a/src/lib/db/engagements.ts
+++ b/src/lib/db/engagements.ts
@@ -1,0 +1,302 @@
+/**
+ * Engagement data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ */
+
+export interface Engagement {
+  id: string
+  org_id: string
+  client_id: string
+  quote_id: string
+  scope_summary: string | null
+  start_date: string | null
+  estimated_end: string | null
+  actual_end: string | null
+  handoff_date: string | null
+  safety_net_end: string | null
+  status: string
+  estimated_hours: number | null
+  actual_hours: number
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type EngagementStatus =
+  | 'scheduled'
+  | 'active'
+  | 'handoff'
+  | 'safety_net'
+  | 'completed'
+  | 'cancelled'
+
+export const ENGAGEMENT_STATUSES: { value: EngagementStatus; label: string }[] = [
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'active', label: 'Active' },
+  { value: 'handoff', label: 'Handoff' },
+  { value: 'safety_net', label: 'Safety Net' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
+]
+
+/**
+ * Valid status transitions enforced at the application layer.
+ *
+ * scheduled   -> active | cancelled
+ * active      -> handoff | cancelled
+ * handoff     -> safety_net | cancelled
+ * safety_net  -> completed | cancelled
+ * completed   -> (terminal)
+ * cancelled   -> (terminal)
+ */
+export const VALID_TRANSITIONS: Record<EngagementStatus, EngagementStatus[]> = {
+  scheduled: ['active', 'cancelled'],
+  active: ['handoff', 'cancelled'],
+  handoff: ['safety_net', 'cancelled'],
+  safety_net: ['completed', 'cancelled'],
+  completed: [],
+  cancelled: [],
+}
+
+export interface CreateEngagementData {
+  client_id: string
+  quote_id: string
+  scope_summary?: string | null
+  start_date?: string | null
+  estimated_end?: string | null
+  estimated_hours?: number | null
+  notes?: string | null
+}
+
+export interface UpdateEngagementData {
+  scope_summary?: string | null
+  start_date?: string | null
+  estimated_end?: string | null
+  actual_end?: string | null
+  handoff_date?: string | null
+  safety_net_end?: string | null
+  estimated_hours?: number | null
+  actual_hours?: number | null
+  notes?: string | null
+}
+
+/**
+ * List engagements for an organization, optionally filtered by client.
+ */
+export async function listEngagements(
+  db: D1Database,
+  orgId: string,
+  clientId?: string
+): Promise<Engagement[]> {
+  const conditions: string[] = ['org_id = ?']
+  const params: (string | number)[] = [orgId]
+
+  if (clientId) {
+    conditions.push('client_id = ?')
+    params.push(clientId)
+  }
+
+  const where = conditions.join(' AND ')
+  const sql = `SELECT * FROM engagements WHERE ${where} ORDER BY created_at DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<Engagement>()
+  return result.results
+}
+
+/**
+ * Get a single engagement by ID, scoped to an organization.
+ */
+export async function getEngagement(
+  db: D1Database,
+  orgId: string,
+  engagementId: string
+): Promise<Engagement | null> {
+  const result = await db
+    .prepare('SELECT * FROM engagements WHERE id = ? AND org_id = ?')
+    .bind(engagementId, orgId)
+    .first<Engagement>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new engagement. Returns the created engagement record.
+ */
+export async function createEngagement(
+  db: D1Database,
+  orgId: string,
+  data: CreateEngagementData
+): Promise<Engagement> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  await db
+    .prepare(
+      `INSERT INTO engagements (id, org_id, client_id, quote_id, scope_summary, start_date, estimated_end, status, estimated_hours, notes, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      data.client_id,
+      data.quote_id,
+      data.scope_summary ?? null,
+      data.start_date ?? null,
+      data.estimated_end ?? null,
+      data.estimated_hours ?? null,
+      data.notes ?? null,
+      now,
+      now
+    )
+    .run()
+
+  const engagement = await getEngagement(db, orgId, id)
+  if (!engagement) {
+    throw new Error('Failed to retrieve created engagement')
+  }
+  return engagement
+}
+
+/**
+ * Update an existing engagement. Returns the updated engagement record.
+ */
+export async function updateEngagement(
+  db: D1Database,
+  orgId: string,
+  engagementId: string,
+  data: UpdateEngagementData
+): Promise<Engagement | null> {
+  const existing = await getEngagement(db, orgId, engagementId)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.scope_summary !== undefined) {
+    fields.push('scope_summary = ?')
+    params.push(data.scope_summary)
+  }
+
+  if (data.start_date !== undefined) {
+    fields.push('start_date = ?')
+    params.push(data.start_date)
+  }
+
+  if (data.estimated_end !== undefined) {
+    fields.push('estimated_end = ?')
+    params.push(data.estimated_end)
+  }
+
+  if (data.actual_end !== undefined) {
+    fields.push('actual_end = ?')
+    params.push(data.actual_end)
+  }
+
+  if (data.handoff_date !== undefined) {
+    fields.push('handoff_date = ?')
+    params.push(data.handoff_date)
+  }
+
+  if (data.safety_net_end !== undefined) {
+    fields.push('safety_net_end = ?')
+    params.push(data.safety_net_end)
+  }
+
+  if (data.estimated_hours !== undefined) {
+    fields.push('estimated_hours = ?')
+    params.push(data.estimated_hours)
+  }
+
+  if (data.actual_hours !== undefined) {
+    fields.push('actual_hours = ?')
+    params.push(data.actual_hours)
+  }
+
+  if (data.notes !== undefined) {
+    fields.push('notes = ?')
+    params.push(data.notes)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  fields.push("updated_at = datetime('now')")
+
+  const sql = `UPDATE engagements SET ${fields.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(engagementId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getEngagement(db, orgId, engagementId)
+}
+
+/**
+ * Transition engagement status with validation.
+ * Returns the updated record or null if the engagement was not found.
+ * Throws if the transition is invalid.
+ *
+ * When transitioning to handoff, auto-sets handoff_date to now and
+ * safety_net_end to handoff_date + 14 days.
+ */
+export async function updateEngagementStatus(
+  db: D1Database,
+  orgId: string,
+  engagementId: string,
+  newStatus: EngagementStatus
+): Promise<Engagement | null> {
+  const existing = await getEngagement(db, orgId, engagementId)
+  if (!existing) {
+    return null
+  }
+
+  const currentStatus = existing.status as EngagementStatus
+  const validNext = VALID_TRANSITIONS[currentStatus] ?? []
+
+  if (!validNext.includes(newStatus)) {
+    throw new Error(
+      `Invalid status transition: ${currentStatus} -> ${newStatus}. Valid transitions: ${validNext.join(', ') || 'none (terminal state)'}`
+    )
+  }
+
+  const updates: string[] = ['status = ?', "updated_at = datetime('now')"]
+  const params: (string | number | null)[] = [newStatus]
+
+  // When transitioning to handoff, auto-set handoff_date and safety_net_end
+  if (newStatus === 'handoff') {
+    const handoffDate = new Date()
+    const safetyNetEnd = new Date(handoffDate)
+    safetyNetEnd.setDate(safetyNetEnd.getDate() + 14)
+
+    updates.push('handoff_date = ?')
+    params.push(handoffDate.toISOString())
+    updates.push('safety_net_end = ?')
+    params.push(safetyNetEnd.toISOString())
+  }
+
+  // When transitioning to completed, auto-set actual_end
+  if (newStatus === 'completed' && !existing.actual_end) {
+    updates.push('actual_end = ?')
+    params.push(new Date().toISOString())
+  }
+
+  const sql = `UPDATE engagements SET ${updates.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(engagementId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getEngagement(db, orgId, engagementId)
+}

--- a/src/lib/db/milestones.ts
+++ b/src/lib/db/milestones.ts
@@ -1,0 +1,254 @@
+/**
+ * Milestone data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ */
+
+export interface Milestone {
+  id: string
+  engagement_id: string
+  name: string
+  description: string | null
+  due_date: string | null
+  completed_at: string | null
+  status: string
+  payment_trigger: number
+  sort_order: number
+  created_at: string
+}
+
+export type MilestoneStatus = 'pending' | 'in_progress' | 'completed' | 'skipped'
+
+export const MILESTONE_STATUSES: { value: MilestoneStatus; label: string }[] = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'skipped', label: 'Skipped' },
+]
+
+/**
+ * Valid status transitions enforced at the application layer.
+ *
+ * pending     -> in_progress | skipped
+ * in_progress -> completed | skipped
+ * completed   -> (terminal)
+ * skipped     -> (terminal)
+ */
+export const VALID_TRANSITIONS: Record<MilestoneStatus, MilestoneStatus[]> = {
+  pending: ['in_progress', 'skipped'],
+  in_progress: ['completed', 'skipped'],
+  completed: [],
+  skipped: [],
+}
+
+export interface CreateMilestoneData {
+  name: string
+  description?: string | null
+  due_date?: string | null
+  payment_trigger?: boolean
+  sort_order?: number
+}
+
+export interface UpdateMilestoneData {
+  name?: string
+  description?: string | null
+  due_date?: string | null
+  payment_trigger?: boolean
+  sort_order?: number
+}
+
+/**
+ * List milestones for an engagement, ordered by sort_order ascending.
+ */
+export async function listMilestones(db: D1Database, engagementId: string): Promise<Milestone[]> {
+  const result = await db
+    .prepare('SELECT * FROM milestones WHERE engagement_id = ? ORDER BY sort_order ASC')
+    .bind(engagementId)
+    .all<Milestone>()
+  return result.results
+}
+
+/**
+ * Get a single milestone by ID.
+ */
+export async function getMilestone(db: D1Database, milestoneId: string): Promise<Milestone | null> {
+  const result = await db
+    .prepare('SELECT * FROM milestones WHERE id = ?')
+    .bind(milestoneId)
+    .first<Milestone>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new milestone linked to an engagement. Returns the created record.
+ */
+export async function createMilestone(
+  db: D1Database,
+  engagementId: string,
+  data: CreateMilestoneData
+): Promise<Milestone> {
+  const id = crypto.randomUUID()
+
+  await db
+    .prepare(
+      `INSERT INTO milestones (id, engagement_id, name, description, due_date, status, payment_trigger, sort_order)
+     VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)`
+    )
+    .bind(
+      id,
+      engagementId,
+      data.name,
+      data.description ?? null,
+      data.due_date ?? null,
+      data.payment_trigger ? 1 : 0,
+      data.sort_order ?? 0
+    )
+    .run()
+
+  const milestone = await getMilestone(db, id)
+  if (!milestone) {
+    throw new Error('Failed to retrieve created milestone')
+  }
+  return milestone
+}
+
+/**
+ * Update an existing milestone. Returns the updated record.
+ */
+export async function updateMilestone(
+  db: D1Database,
+  milestoneId: string,
+  data: UpdateMilestoneData
+): Promise<Milestone | null> {
+  const existing = await getMilestone(db, milestoneId)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.name !== undefined) {
+    fields.push('name = ?')
+    params.push(data.name)
+  }
+
+  if (data.description !== undefined) {
+    fields.push('description = ?')
+    params.push(data.description)
+  }
+
+  if (data.due_date !== undefined) {
+    fields.push('due_date = ?')
+    params.push(data.due_date)
+  }
+
+  if (data.payment_trigger !== undefined) {
+    fields.push('payment_trigger = ?')
+    params.push(data.payment_trigger ? 1 : 0)
+  }
+
+  if (data.sort_order !== undefined) {
+    fields.push('sort_order = ?')
+    params.push(data.sort_order)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  const sql = `UPDATE milestones SET ${fields.join(', ')} WHERE id = ?`
+  params.push(milestoneId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getMilestone(db, milestoneId)
+}
+
+/**
+ * Transition milestone status with validation.
+ * Returns the updated record or null if the milestone was not found.
+ * Throws if the transition is invalid.
+ *
+ * When transitioning to completed, auto-sets completed_at.
+ */
+export async function updateMilestoneStatus(
+  db: D1Database,
+  milestoneId: string,
+  newStatus: MilestoneStatus
+): Promise<Milestone | null> {
+  const existing = await getMilestone(db, milestoneId)
+  if (!existing) {
+    return null
+  }
+
+  const currentStatus = existing.status as MilestoneStatus
+  const validNext = VALID_TRANSITIONS[currentStatus] ?? []
+
+  if (!validNext.includes(newStatus)) {
+    throw new Error(
+      `Invalid status transition: ${currentStatus} -> ${newStatus}. Valid transitions: ${validNext.join(', ') || 'none (terminal state)'}`
+    )
+  }
+
+  const updates: string[] = ['status = ?']
+  const params: (string | number | null)[] = [newStatus]
+
+  // When transitioning to completed, auto-set completed_at
+  if (newStatus === 'completed') {
+    updates.push('completed_at = ?')
+    params.push(new Date().toISOString())
+  }
+
+  const sql = `UPDATE milestones SET ${updates.join(', ')} WHERE id = ?`
+  params.push(milestoneId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getMilestone(db, milestoneId)
+}
+
+/**
+ * Bulk create milestones for an engagement (e.g. from a template).
+ * Returns the array of created milestones.
+ */
+export async function bulkCreateMilestones(
+  db: D1Database,
+  engagementId: string,
+  milestones: CreateMilestoneData[]
+): Promise<Milestone[]> {
+  const created: Milestone[] = []
+
+  for (let i = 0; i < milestones.length; i++) {
+    const data = milestones[i]
+    const milestone = await createMilestone(db, engagementId, {
+      ...data,
+      sort_order: data.sort_order ?? i,
+    })
+    created.push(milestone)
+  }
+
+  return created
+}
+
+/**
+ * Delete a milestone. Returns true if the milestone was found and deleted.
+ */
+export async function deleteMilestone(db: D1Database, milestoneId: string): Promise<boolean> {
+  const existing = await getMilestone(db, milestoneId)
+  if (!existing) {
+    return false
+  }
+
+  await db.prepare('DELETE FROM milestones WHERE id = ?').bind(milestoneId).run()
+
+  return true
+}

--- a/src/pages/admin/clients/[id].astro
+++ b/src/pages/admin/clients/[id].astro
@@ -4,6 +4,7 @@ import { getClient, CLIENT_STATUSES, CLIENT_VERTICALS } from '../../../lib/db/cl
 import type { ClientStatus } from '../../../lib/db/clients'
 import { listContacts } from '../../../lib/db/contacts'
 import { listAssessments, ASSESSMENT_STATUSES } from '../../../lib/db/assessments'
+import { listEngagements, ENGAGEMENT_STATUSES } from '../../../lib/db/engagements'
 
 /**
  * Client detail/edit page.
@@ -29,6 +30,7 @@ if (!client) {
 
 const contacts = await listContacts(env.DB, session.orgId, id)
 const assessments = await listAssessments(env.DB, session.orgId, id)
+const engagements = await listEngagements(env.DB, session.orgId, id)
 
 const url = Astro.url
 const saved = url.searchParams.get('saved') === '1'
@@ -91,6 +93,26 @@ const assessmentStatusColor = (s: string) => {
       return 'bg-red-100 text-red-800'
     case 'converted':
       return 'bg-purple-100 text-purple-800'
+    default:
+      return 'bg-slate-100 text-slate-600'
+  }
+}
+
+// Engagement status color helper
+const engagementStatusColor = (s: string) => {
+  switch (s) {
+    case 'scheduled':
+      return 'bg-blue-100 text-blue-800'
+    case 'active':
+      return 'bg-green-100 text-green-800'
+    case 'handoff':
+      return 'bg-amber-100 text-amber-800'
+    case 'safety_net':
+      return 'bg-purple-100 text-purple-800'
+    case 'completed':
+      return 'bg-emerald-100 text-emerald-800'
+    case 'cancelled':
+      return 'bg-red-100 text-red-800'
     default:
       return 'bg-slate-100 text-slate-600'
   }
@@ -544,6 +566,106 @@ const assessmentStatusColor = (s: string) => {
                 class="text-sm text-primary hover:text-primary-hover font-medium"
               >
                 Schedule the first assessment
+              </a>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Engagements Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">Engagements</h2>
+          <a
+            href={`/admin/clients/${client.id}/engagements/new`}
+            class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 4v16m8-8H4"></path>
+            </svg>
+            New Engagement
+          </a>
+        </div>
+
+        {
+          engagements.length > 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {engagements.map((e) => (
+                <a
+                  href={`/admin/clients/${client.id}/engagements/${e.id}`}
+                  class="flex items-center justify-between px-4 py-3 hover:bg-slate-50 transition-colors"
+                >
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                      <p class="text-sm font-medium text-slate-900">
+                        {e.start_date
+                          ? new Date(e.start_date).toLocaleDateString('en-US', {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric',
+                            })
+                          : 'Not scheduled'}
+                        {e.estimated_end && (
+                          <span class="text-slate-400">
+                            {' '}
+                            &mdash;{' '}
+                            {new Date(e.estimated_end).toLocaleDateString('en-US', {
+                              year: 'numeric',
+                              month: 'short',
+                              day: 'numeric',
+                            })}
+                          </span>
+                        )}
+                      </p>
+                      <span
+                        class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${engagementStatusColor(e.status)}`}
+                      >
+                        {ENGAGEMENT_STATUSES.find((s) => s.value === e.status)?.label ?? e.status}
+                      </span>
+                    </div>
+                    <p class="text-xs text-slate-500 mt-0.5">
+                      {e.scope_summary
+                        ? e.scope_summary.length > 80
+                          ? e.scope_summary.slice(0, 80) + '...'
+                          : e.scope_summary
+                        : 'No scope summary'}
+                      {e.estimated_hours ? ` · ${e.estimated_hours}h estimated` : ''}
+                    </p>
+                  </div>
+                  <svg
+                    class="w-4 h-4 text-slate-400 flex-shrink-0 ml-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </a>
+              ))}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400 mb-2">No engagements yet.</p>
+              <a
+                href={`/admin/clients/${client.id}/engagements/new`}
+                class="text-sm text-primary hover:text-primary-hover font-medium"
+              >
+                Create the first engagement
               </a>
             </div>
           )

--- a/src/pages/admin/clients/[id]/engagements/[engId].astro
+++ b/src/pages/admin/clients/[id]/engagements/[engId].astro
@@ -1,0 +1,720 @@
+---
+import '../../../../../styles/global.css'
+import { getClient } from '../../../../../lib/db/clients'
+import {
+  getEngagement,
+  ENGAGEMENT_STATUSES,
+  VALID_TRANSITIONS,
+} from '../../../../../lib/db/engagements'
+import type { EngagementStatus } from '../../../../../lib/db/engagements'
+import {
+  listMilestones,
+  MILESTONE_STATUSES,
+  VALID_TRANSITIONS as MILESTONE_TRANSITIONS,
+} from '../../../../../lib/db/milestones'
+import type { MilestoneStatus } from '../../../../../lib/db/milestones'
+import { getEngagementContacts, ENGAGEMENT_CONTACT_ROLES } from '../../../../../lib/db/contacts'
+
+/**
+ * Engagement detail/edit page.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Displays engagement details, status transitions, milestones, and contact roles.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId, engId: engagementId } = Astro.params
+
+if (!clientId || !engagementId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+if (!engagement) {
+  return Astro.redirect(`/admin/clients/${clientId}?error=engagement_not_found`)
+}
+
+const milestones = await listMilestones(env.DB, engagementId)
+const engagementContacts = await getEngagementContacts(env.DB, engagementId)
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const milestoneAdded = url.searchParams.get('milestone_added') === '1'
+const milestoneDeleted = url.searchParams.get('milestone_deleted') === '1'
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+  invalid_status: 'Invalid status selection.',
+  invalid_transition: 'That status transition is not allowed.',
+  missing: 'Required fields are missing.',
+  not_found: 'Record not found.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Status transitions
+const currentStatus = engagement.status as EngagementStatus
+const validNextStatuses = VALID_TRANSITIONS[currentStatus] ?? []
+
+// Status progression indicator
+const statusOrder: EngagementStatus[] = [
+  'scheduled',
+  'active',
+  'handoff',
+  'safety_net',
+  'completed',
+  'cancelled',
+]
+const currentStatusIndex = statusOrder.indexOf(currentStatus)
+
+const getProgressionColor = (index: number) => {
+  if (engagement.status === 'cancelled') {
+    return index === statusOrder.indexOf('cancelled') ? 'bg-red-500' : 'bg-slate-200'
+  }
+  if (index <= currentStatusIndex) {
+    return 'bg-primary'
+  }
+  return 'bg-slate-200'
+}
+
+const getProgressionTextColor = (index: number) => {
+  if (engagement.status === 'cancelled') {
+    return index === statusOrder.indexOf('cancelled')
+      ? 'text-red-700 font-medium'
+      : 'text-slate-400'
+  }
+  if (index <= currentStatusIndex) {
+    return 'text-primary font-medium'
+  }
+  return 'text-slate-400'
+}
+
+// Status badge colors
+const statusColorMap: Record<string, string> = {
+  scheduled: 'bg-blue-100 text-blue-800',
+  active: 'bg-green-100 text-green-800',
+  handoff: 'bg-amber-100 text-amber-800',
+  safety_net: 'bg-purple-100 text-purple-800',
+  completed: 'bg-emerald-100 text-emerald-800',
+  cancelled: 'bg-red-100 text-red-800',
+}
+
+// Milestone status badge colors
+const milestoneStatusColor = (s: string) => {
+  switch (s) {
+    case 'pending':
+      return 'bg-slate-100 text-slate-600'
+    case 'in_progress':
+      return 'bg-blue-100 text-blue-800'
+    case 'completed':
+      return 'bg-green-100 text-green-800'
+    case 'skipped':
+      return 'bg-slate-100 text-slate-400'
+    default:
+      return 'bg-slate-100 text-slate-600'
+  }
+}
+
+// Show safety net info when relevant
+const showSafetyNet = engagement.status === 'handoff' || engagement.status === 'safety_net'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Engagement — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Engagement</li>
+        </ol>
+      </nav>
+
+      <div class="flex items-center gap-3 mb-2">
+        <h1 class="text-2xl font-bold text-slate-900">Engagement</h1>
+        <span
+          class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColorMap[engagement.status] ?? 'bg-slate-100 text-slate-600'}`}
+        >
+          {
+            ENGAGEMENT_STATUSES.find((s) => s.value === engagement.status)?.label ??
+              engagement.status
+          }
+        </span>
+      </div>
+      <p class="text-sm text-slate-500 mb-6">
+        {client.business_name}
+      </p>
+
+      <!-- Status progression indicator -->
+      <div class="mb-6">
+        <div class="flex items-center gap-1 mb-2">
+          {
+            statusOrder
+              .filter((s) => s !== 'cancelled')
+              .map((status, index) => (
+                <>
+                  <div class="flex flex-col items-center">
+                    <div class={`w-3 h-3 rounded-full ${getProgressionColor(index)}`} />
+                    <span class={`text-[10px] mt-1 ${getProgressionTextColor(index)}`}>
+                      {ENGAGEMENT_STATUSES.find((s) => s.value === status)?.label}
+                    </span>
+                  </div>
+                  {index < statusOrder.length - 2 && (
+                    <div
+                      class={`flex-1 h-0.5 mb-4 ${index < currentStatusIndex && engagement.status !== 'cancelled' ? 'bg-primary' : 'bg-slate-200'}`}
+                    />
+                  )}
+                </>
+              ))
+          }
+        </div>
+        {
+          engagement.status === 'cancelled' && (
+            <p class="text-xs text-red-600 font-medium">Status: Cancelled</p>
+          )
+        }
+      </div>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Engagement updated successfully.
+          </div>
+        )
+      }
+
+      {
+        milestoneAdded && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Milestone added successfully.
+          </div>
+        )
+      }
+
+      {
+        milestoneDeleted && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Milestone deleted.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <!-- Safety Net Info -->
+      {
+        showSafetyNet && engagement.safety_net_end && (
+          <div class="mb-4 p-3 bg-purple-50 border border-purple-200 rounded-lg text-sm text-purple-700">
+            <strong>Safety net ends:</strong>{' '}
+            {new Date(engagement.safety_net_end).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })}
+            {engagement.handoff_date && (
+              <span class="ml-3 text-purple-500">
+                (Handed off:{' '}
+                {new Date(engagement.handoff_date).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+                )
+              </span>
+            )}
+          </div>
+        )
+      }
+
+      <!-- Status Transitions -->
+      {
+        validNextStatuses.length > 0 && (
+          <div class="mb-6 bg-white rounded-lg border border-slate-200 p-4">
+            <h2 class="text-sm font-medium text-slate-700 mb-3">Status Transition</h2>
+            <div class="flex flex-wrap gap-2">
+              {validNextStatuses.map((nextStatus) => (
+                <form
+                  method="POST"
+                  action={`/api/admin/engagements/${engagement.id}`}
+                  class="inline"
+                >
+                  <input type="hidden" name="action" value="transition_status" />
+                  <input type="hidden" name="new_status" value={nextStatus} />
+                  <button
+                    type="submit"
+                    class:list={[
+                      'px-4 py-2 rounded-md text-sm font-medium transition-colors',
+                      nextStatus === 'active' && 'bg-green-600 text-white hover:bg-green-700',
+                      nextStatus === 'handoff' && 'bg-amber-600 text-white hover:bg-amber-700',
+                      nextStatus === 'safety_net' && 'bg-purple-600 text-white hover:bg-purple-700',
+                      nextStatus === 'completed' &&
+                        'bg-emerald-600 text-white hover:bg-emerald-700',
+                      nextStatus === 'cancelled' && 'bg-red-600 text-white hover:bg-red-700',
+                    ]}
+                  >
+                    {ENGAGEMENT_STATUSES.find((s) => s.value === nextStatus)?.label ?? nextStatus}
+                  </button>
+                </form>
+              ))}
+            </div>
+          </div>
+        )
+      }
+
+      <!-- Engagement Details Form -->
+      <form method="POST" action={`/api/admin/engagements/${engagement.id}`} class="space-y-6">
+        <!-- Scope Summary -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Scope</h2>
+
+          <div>
+            <label for="scope_summary" class="block text-sm font-medium text-slate-700 mb-1">
+              Scope Summary
+            </label>
+            <textarea
+              id="scope_summary"
+              name="scope_summary"
+              rows="3"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="Brief description of engagement scope..."
+              >{engagement.scope_summary ?? ''}</textarea
+            >
+          </div>
+        </div>
+
+        <!-- Dates & Hours -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Dates & Hours</h2>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="start_date" class="block text-sm font-medium text-slate-700 mb-1">
+                Start Date
+              </label>
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value={engagement.start_date ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="estimated_end" class="block text-sm font-medium text-slate-700 mb-1">
+                Estimated End
+              </label>
+              <input
+                type="date"
+                id="estimated_end"
+                name="estimated_end"
+                value={engagement.estimated_end ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="estimated_hours" class="block text-sm font-medium text-slate-700 mb-1">
+                Estimated Hours
+              </label>
+              <input
+                type="number"
+                id="estimated_hours"
+                name="estimated_hours"
+                step="0.5"
+                min="0"
+                value={engagement.estimated_hours ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="actual_hours" class="block text-sm font-medium text-slate-700 mb-1">
+                Actual Hours
+              </label>
+              <input
+                type="number"
+                id="actual_hours"
+                name="actual_hours"
+                step="0.5"
+                min="0"
+                value={engagement.actual_hours ?? ''}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- Notes -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Notes</h2>
+          <div>
+            <textarea
+              id="notes"
+              name="notes"
+              rows="3"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="General notes about this engagement..."
+              >{engagement.notes ?? ''}</textarea
+            >
+          </div>
+        </div>
+
+        <!-- Metadata -->
+        <div
+          class="bg-white rounded-lg border border-slate-200 p-6 grid grid-cols-2 gap-4 text-xs text-slate-400"
+        >
+          <div>
+            <span class="font-medium">Created:</span>
+            {
+              new Date(engagement.created_at).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            }
+          </div>
+          <div>
+            <span class="font-medium">Updated:</span>
+            {
+              new Date(engagement.updated_at).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            }
+          </div>
+          {
+            engagement.actual_end && (
+              <div>
+                <span class="font-medium">Completed:</span>
+                {new Date(engagement.actual_end).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </div>
+            )
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-2">
+          <a
+            href={`/admin/clients/${client.id}`}
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Back to Client
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Save Changes
+          </button>
+        </div>
+      </form>
+
+      <!-- Milestones Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">
+            Milestones
+            <span class="text-sm font-normal text-slate-400 ml-1">({milestones.length})</span>
+          </h2>
+        </div>
+
+        {
+          milestones.length > 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {milestones.map((m) => {
+                const mStatus = m.status as MilestoneStatus
+                const mValidNext = MILESTONE_TRANSITIONS[mStatus] ?? []
+                return (
+                  <div class="px-4 py-3">
+                    <div class="flex items-center justify-between">
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2">
+                          <p class="text-sm font-medium text-slate-900">{m.name}</p>
+                          <span
+                            class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${milestoneStatusColor(m.status)}`}
+                          >
+                            {MILESTONE_STATUSES.find((s) => s.value === m.status)?.label ??
+                              m.status}
+                          </span>
+                          {m.payment_trigger === 1 && (
+                            <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                              Payment Trigger
+                            </span>
+                          )}
+                        </div>
+                        {m.description && (
+                          <p class="text-xs text-slate-500 mt-0.5">{m.description}</p>
+                        )}
+                        <div class="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                          {m.due_date && (
+                            <span>
+                              Due:{' '}
+                              {new Date(m.due_date).toLocaleDateString('en-US', {
+                                month: 'short',
+                                day: 'numeric',
+                              })}
+                            </span>
+                          )}
+                          {m.completed_at && (
+                            <span>
+                              Completed:{' '}
+                              {new Date(m.completed_at).toLocaleDateString('en-US', {
+                                month: 'short',
+                                day: 'numeric',
+                              })}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div class="flex items-center gap-1 flex-shrink-0 ml-2">
+                        {mValidNext.map((nextStatus) => (
+                          <form
+                            method="POST"
+                            action={`/api/admin/engagements/${engagement.id}/milestones`}
+                            class="inline"
+                          >
+                            <input type="hidden" name="action" value="transition_status" />
+                            <input type="hidden" name="milestone_id" value={m.id} />
+                            <input type="hidden" name="new_status" value={nextStatus} />
+                            <button
+                              type="submit"
+                              class:list={[
+                                'px-2 py-1 rounded text-xs font-medium transition-colors',
+                                nextStatus === 'in_progress' &&
+                                  'bg-blue-100 text-blue-700 hover:bg-blue-200',
+                                nextStatus === 'completed' &&
+                                  'bg-green-100 text-green-700 hover:bg-green-200',
+                                nextStatus === 'skipped' &&
+                                  'bg-slate-100 text-slate-500 hover:bg-slate-200',
+                              ]}
+                            >
+                              {MILESTONE_STATUSES.find((s) => s.value === nextStatus)?.label ??
+                                nextStatus}
+                            </button>
+                          </form>
+                        ))}
+                        {mStatus === 'pending' && (
+                          <form
+                            method="POST"
+                            action={`/api/admin/engagements/${engagement.id}/milestones`}
+                            class="inline"
+                            onsubmit="return confirm('Delete this milestone?')"
+                          >
+                            <input type="hidden" name="_method" value="DELETE" />
+                            <input type="hidden" name="milestone_id" value={m.id} />
+                            <button
+                              type="submit"
+                              class="px-2 py-1 rounded text-xs font-medium bg-red-50 text-red-500 hover:bg-red-100 transition-colors"
+                            >
+                              Delete
+                            </button>
+                          </form>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400 mb-2">No milestones yet.</p>
+            </div>
+          )
+        }
+
+        <!-- Add Milestone Form -->
+        <div class="mt-4 bg-white rounded-lg border border-slate-200 p-6">
+          <h3 class="text-sm font-medium text-slate-700 mb-3">Add Milestone</h3>
+          <form
+            method="POST"
+            action={`/api/admin/engagements/${engagement.id}/milestones`}
+            class="space-y-4"
+          >
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <label for="milestone_name" class="block text-sm font-medium text-slate-700 mb-1">
+                  Name <span class="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  id="milestone_name"
+                  name="name"
+                  required
+                  class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                  placeholder="e.g. Solution Design"
+                />
+              </div>
+              <div>
+                <label
+                  for="milestone_due_date"
+                  class="block text-sm font-medium text-slate-700 mb-1"
+                >
+                  Due Date
+                </label>
+                <input
+                  type="date"
+                  id="milestone_due_date"
+                  name="due_date"
+                  class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                />
+              </div>
+            </div>
+            <div>
+              <label
+                for="milestone_description"
+                class="block text-sm font-medium text-slate-700 mb-1"
+              >
+                Description
+              </label>
+              <input
+                type="text"
+                id="milestone_description"
+                name="description"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="Brief description..."
+              />
+            </div>
+            <div class="flex items-center gap-4">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="payment_trigger"
+                  class="rounded border-slate-300 text-primary focus:ring-primary"
+                />
+                <span class="text-sm text-slate-700">Payment trigger</span>
+              </label>
+              <div class="flex items-center gap-2">
+                <label for="milestone_sort_order" class="text-sm text-slate-700">Order:</label>
+                <input
+                  type="number"
+                  id="milestone_sort_order"
+                  name="sort_order"
+                  min="0"
+                  value={milestones.length}
+                  class="w-16 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                />
+              </div>
+            </div>
+            <div class="flex justify-end">
+              <button
+                type="submit"
+                class="bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+              >
+                Add Milestone
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <!-- Engagement Contacts Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">
+            Contact Roles
+            <span class="text-sm font-normal text-slate-400 ml-1"
+              >({engagementContacts.length})</span
+            >
+          </h2>
+        </div>
+
+        {
+          engagementContacts.length > 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {engagementContacts.map((ec) => (
+                <div class="flex items-center justify-between px-4 py-3">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                      <p class="text-sm font-medium text-slate-900">{ec.contact_name}</p>
+                      <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-600">
+                        {ENGAGEMENT_CONTACT_ROLES.find((r) => r.value === ec.role)?.label ??
+                          ec.role}
+                      </span>
+                      {ec.is_primary === 1 && (
+                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
+                          Primary
+                        </span>
+                      )}
+                    </div>
+                    <p class="text-xs text-slate-500 mt-0.5">
+                      {ec.contact_title ?? ''}
+                      {ec.contact_title && ec.contact_email ? ' · ' : ''}
+                      {ec.contact_email ?? ''}
+                      {(ec.contact_title || ec.contact_email) && ec.contact_phone ? ' · ' : ''}
+                      {ec.contact_phone ?? ''}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400">No contact roles assigned yet.</p>
+            </div>
+          )
+        }
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/clients/[id]/engagements/new.astro
+++ b/src/pages/admin/clients/[id]/engagements/new.astro
@@ -1,0 +1,333 @@
+---
+import '../../../../../styles/global.css'
+import { getClient } from '../../../../../lib/db/clients'
+
+/**
+ * Create new engagement form.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Form POSTs to /api/admin/engagements which creates the record and redirects.
+ *
+ * Loads accepted quotes for the client to populate the quote dropdown.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId } = Astro.params
+
+if (!clientId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+// Load accepted quotes for this client
+const quotesResult = await env.DB.prepare(
+  "SELECT id, total_hours, total_price, version, created_at FROM quotes WHERE org_id = ? AND client_id = ? AND status = 'accepted' ORDER BY created_at DESC"
+)
+  .bind(session.orgId, clientId)
+  .all<{
+    id: string
+    total_hours: number
+    total_price: number
+    version: number
+    created_at: string
+  }>()
+
+const quotes = quotesResult.results
+
+const url = Astro.url
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+  missing: 'Required fields are missing.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>New Engagement — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">New Engagement</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-6">New Engagement</h1>
+      <p class="text-sm text-slate-500 mb-6">
+        Create a new engagement for <strong>{client.business_name}</strong>.
+      </p>
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      {
+        quotes.length === 0 && (
+          <div class="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700">
+            No accepted quotes found for this client. An accepted quote is required to create an
+            engagement.
+          </div>
+        )
+      }
+
+      <form method="POST" action="/api/admin/engagements" class="space-y-6">
+        <input type="hidden" name="client_id" value={client.id} />
+
+        <!-- Quote Selection -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Quote</h2>
+
+          <div>
+            <label for="quote_id" class="block text-sm font-medium text-slate-700 mb-1">
+              Accepted Quote <span class="text-red-500">*</span>
+            </label>
+            <select
+              id="quote_id"
+              name="quote_id"
+              required
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            >
+              <option value="">Select a quote</option>
+              {
+                quotes.map((q) => (
+                  <option value={q.id}>
+                    v{q.version} — {q.total_hours}h — ${q.total_price.toLocaleString()} —{' '}
+                    {new Date(q.created_at).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+        </div>
+
+        <!-- Dates & Hours -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Schedule</h2>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="start_date" class="block text-sm font-medium text-slate-700 mb-1">
+                Start Date
+              </label>
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="estimated_end" class="block text-sm font-medium text-slate-700 mb-1">
+                Estimated End
+              </label>
+              <input
+                type="date"
+                id="estimated_end"
+                name="estimated_end"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label for="estimated_hours" class="block text-sm font-medium text-slate-700 mb-1">
+              Estimated Hours
+            </label>
+            <input
+              type="number"
+              id="estimated_hours"
+              name="estimated_hours"
+              step="0.5"
+              min="0"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+            />
+          </div>
+        </div>
+
+        <!-- Scope -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Scope</h2>
+
+          <div>
+            <label for="scope_summary" class="block text-sm font-medium text-slate-700 mb-1">
+              Scope Summary
+            </label>
+            <textarea
+              id="scope_summary"
+              name="scope_summary"
+              rows="3"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="Brief description of what this engagement covers..."></textarea>
+          </div>
+        </div>
+
+        <!-- Notes -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Notes</h2>
+
+          <div>
+            <textarea
+              id="notes"
+              name="notes"
+              rows="3"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="Any additional notes..."></textarea>
+          </div>
+        </div>
+
+        <!-- Default Milestones -->
+        <div class="bg-white rounded-lg border border-slate-200 p-6 space-y-4">
+          <h2 class="text-base font-semibold text-slate-900">Default Milestones</h2>
+          <p class="text-sm text-slate-500">
+            Add milestones to create with this engagement. You can add more later.
+          </p>
+
+          <div id="milestones-container" class="space-y-3">
+            <!-- Default milestones will be added via JS -->
+          </div>
+
+          <button
+            type="button"
+            id="add-milestone-btn"
+            class="inline-flex items-center gap-2 text-sm text-primary hover:text-primary-hover font-medium transition-colors"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 4v16m8-8H4"></path>
+            </svg>
+            Add Milestone
+          </button>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between pt-4 border-t border-slate-200">
+          <a
+            href={`/admin/clients/${client.id}`}
+            class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            Cancel
+          </a>
+          <button
+            type="submit"
+            class="bg-primary text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Create Engagement
+          </button>
+        </div>
+      </form>
+    </main>
+
+    <script>
+      const container = document.getElementById('milestones-container')!
+      const addBtn = document.getElementById('add-milestone-btn')!
+      let milestoneCount = 0
+
+      function addMilestoneRow() {
+        const row = document.createElement('div')
+        row.className = 'p-3 border border-slate-200 rounded-lg space-y-3'
+        row.innerHTML = `
+          <div class="flex items-center justify-between">
+            <span class="text-xs font-medium text-slate-500">Milestone ${milestoneCount + 1}</span>
+            <button type="button" class="remove-milestone text-xs text-red-500 hover:text-red-700">Remove</button>
+          </div>
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <input type="text" name="milestone_name" placeholder="Name *" required
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary" />
+            </div>
+            <div>
+              <input type="date" name="milestone_due_date"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary" />
+            </div>
+          </div>
+          <div>
+            <input type="text" name="milestone_description" placeholder="Description"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary" />
+          </div>
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" name="milestone_payment_trigger"
+              class="rounded border-slate-300 text-primary focus:ring-primary" />
+            <span class="text-sm text-slate-700">Payment trigger</span>
+          </label>
+        `
+
+        row.querySelector('.remove-milestone')!.addEventListener('click', () => {
+          row.remove()
+        })
+
+        container.appendChild(row)
+        milestoneCount++
+      }
+
+      addBtn.addEventListener('click', addMilestoneRow)
+    </script>
+  </body>
+</html>

--- a/src/pages/api/admin/engagements/[id].ts
+++ b/src/pages/api/admin/engagements/[id].ts
@@ -1,0 +1,109 @@
+import type { APIRoute } from 'astro'
+import {
+  getEngagement,
+  updateEngagement,
+  updateEngagementStatus,
+} from '../../../../lib/db/engagements'
+import type { EngagementStatus } from '../../../../lib/db/engagements'
+
+/**
+ * POST /api/admin/engagements/:id
+ *
+ * Updates an existing engagement from form data.
+ * Handles field updates and status transitions.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const engagementId = params.id
+  if (!engagementId) {
+    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const existing = await getEngagement(env.DB, session.orgId, engagementId)
+    if (!existing) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const action = formData.get('action')
+
+    // Handle status transition as a separate action
+    if (action === 'transition_status') {
+      const newStatus = formData.get('new_status')
+      if (!newStatus || typeof newStatus !== 'string') {
+        return redirect(
+          `/admin/clients/${existing.client_id}/engagements/${engagementId}?error=invalid_status`,
+          302
+        )
+      }
+
+      try {
+        await updateEngagementStatus(
+          env.DB,
+          session.orgId,
+          engagementId,
+          newStatus as EngagementStatus
+        )
+      } catch (err) {
+        console.error('[api/admin/engagements/[id]] Status transition error:', err)
+        return redirect(
+          `/admin/clients/${existing.client_id}/engagements/${engagementId}?error=invalid_transition`,
+          302
+        )
+      }
+
+      return redirect(
+        `/admin/clients/${existing.client_id}/engagements/${engagementId}?saved=1`,
+        302
+      )
+    }
+
+    // Handle general update
+    const scopeSummary = formData.get('scope_summary')
+    const startDate = formData.get('start_date')
+    const estimatedEnd = formData.get('estimated_end')
+    const estimatedHours = formData.get('estimated_hours')
+    const actualHours = formData.get('actual_hours')
+    const notes = formData.get('notes')
+
+    await updateEngagement(env.DB, session.orgId, engagementId, {
+      scope_summary:
+        scopeSummary && typeof scopeSummary === 'string' ? scopeSummary.trim() || null : undefined,
+      start_date:
+        startDate && typeof startDate === 'string' && startDate.trim() ? startDate.trim() : null,
+      estimated_end:
+        estimatedEnd && typeof estimatedEnd === 'string' && estimatedEnd.trim()
+          ? estimatedEnd.trim()
+          : null,
+      estimated_hours:
+        estimatedHours && typeof estimatedHours === 'string' && estimatedHours.trim()
+          ? parseFloat(estimatedHours) || null
+          : null,
+      actual_hours:
+        actualHours && typeof actualHours === 'string' && actualHours.trim()
+          ? parseFloat(actualHours) || null
+          : undefined,
+      notes: notes && typeof notes === 'string' ? notes.trim() || null : undefined,
+    })
+
+    return redirect(`/admin/clients/${existing.client_id}/engagements/${engagementId}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/engagements/[id]] Update error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/engagements/[id]/milestones.ts
+++ b/src/pages/api/admin/engagements/[id]/milestones.ts
@@ -1,0 +1,141 @@
+import type { APIRoute } from 'astro'
+import { getEngagement } from '../../../../../lib/db/engagements'
+import {
+  createMilestone,
+  getMilestone,
+  updateMilestoneStatus,
+  deleteMilestone,
+} from '../../../../../lib/db/milestones'
+import type { MilestoneStatus } from '../../../../../lib/db/milestones'
+
+/**
+ * POST /api/admin/engagements/:id/milestones
+ *
+ * Creates a new milestone for an engagement, handles status transitions,
+ * or deletes a milestone (via _method=DELETE).
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields for create:
+ *   - name (required)
+ *   - description
+ *   - due_date
+ *   - payment_trigger
+ *   - sort_order
+ *
+ * Form fields for status transition:
+ *   - action: "transition_status"
+ *   - milestone_id (required)
+ *   - new_status (required)
+ *
+ * Form fields for delete:
+ *   - _method: "DELETE"
+ *   - milestone_id (required)
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const engagementId = params.id
+  if (!engagementId) {
+    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+    if (!engagement) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const method = formData.get('_method')
+    const action = formData.get('action')
+
+    const detailUrl = `/admin/clients/${engagement.client_id}/engagements/${engagementId}`
+
+    // Handle DELETE
+    if (method === 'DELETE') {
+      const milestoneId = formData.get('milestone_id')
+      if (!milestoneId || typeof milestoneId !== 'string') {
+        return redirect(`${detailUrl}?error=missing`, 302)
+      }
+
+      const milestone = await getMilestone(env.DB, milestoneId.trim())
+      if (!milestone || milestone.engagement_id !== engagementId) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      await deleteMilestone(env.DB, milestoneId.trim())
+      return redirect(`${detailUrl}?milestone_deleted=1`, 302)
+    }
+
+    // Handle status transition
+    if (action === 'transition_status') {
+      const milestoneId = formData.get('milestone_id')
+      const newStatus = formData.get('new_status')
+
+      if (
+        !milestoneId ||
+        typeof milestoneId !== 'string' ||
+        !newStatus ||
+        typeof newStatus !== 'string'
+      ) {
+        return redirect(`${detailUrl}?error=invalid_status`, 302)
+      }
+
+      const milestone = await getMilestone(env.DB, milestoneId.trim())
+      if (!milestone || milestone.engagement_id !== engagementId) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      try {
+        await updateMilestoneStatus(env.DB, milestoneId.trim(), newStatus as MilestoneStatus)
+      } catch (err) {
+        console.error('[api/admin/engagements/[id]/milestones] Status transition error:', err)
+        return redirect(`${detailUrl}?error=invalid_transition`, 302)
+      }
+
+      return redirect(`${detailUrl}?saved=1`, 302)
+    }
+
+    // Handle create
+    const name = formData.get('name')
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return redirect(`${detailUrl}?error=missing`, 302)
+    }
+
+    const description = formData.get('description')
+    const dueDate = formData.get('due_date')
+    const paymentTrigger = formData.get('payment_trigger')
+    const sortOrder = formData.get('sort_order')
+
+    await createMilestone(env.DB, engagementId, {
+      name: name.trim(),
+      description:
+        description && typeof description === 'string' && description.trim()
+          ? description.trim()
+          : null,
+      due_date: dueDate && typeof dueDate === 'string' && dueDate.trim() ? dueDate.trim() : null,
+      payment_trigger: paymentTrigger === 'on' || paymentTrigger === '1',
+      sort_order:
+        sortOrder && typeof sortOrder === 'string' && sortOrder.trim()
+          ? parseInt(sortOrder, 10) || 0
+          : 0,
+    })
+
+    return redirect(`${detailUrl}?milestone_added=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/engagements/[id]/milestones] Error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/engagements/index.ts
+++ b/src/pages/api/admin/engagements/index.ts
@@ -1,0 +1,117 @@
+import type { APIRoute } from 'astro'
+import { createEngagement } from '../../../../lib/db/engagements'
+import { createMilestone } from '../../../../lib/db/milestones'
+
+/**
+ * POST /api/admin/engagements
+ *
+ * Creates a new engagement from form data and redirects to the engagement detail page.
+ * Optionally creates default milestones if included in the form.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields:
+ *   - client_id (required)
+ *   - quote_id (required)
+ *   - start_date
+ *   - estimated_end
+ *   - scope_summary
+ *   - estimated_hours
+ *   - notes
+ *   - milestone_name[] (repeatable)
+ *   - milestone_description[] (repeatable)
+ *   - milestone_due_date[] (repeatable)
+ *   - milestone_payment_trigger[] (repeatable)
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const formData = await request.formData()
+    const clientId = formData.get('client_id')
+    const quoteId = formData.get('quote_id')
+
+    if (
+      !clientId ||
+      typeof clientId !== 'string' ||
+      !clientId.trim() ||
+      !quoteId ||
+      typeof quoteId !== 'string' ||
+      !quoteId.trim()
+    ) {
+      return redirect(`/admin/clients?error=missing`, 302)
+    }
+
+    const env = locals.runtime.env
+    const startDate = formData.get('start_date')
+    const estimatedEnd = formData.get('estimated_end')
+    const scopeSummary = formData.get('scope_summary')
+    const estimatedHours = formData.get('estimated_hours')
+    const notes = formData.get('notes')
+
+    const engagement = await createEngagement(env.DB, session.orgId, {
+      client_id: clientId.trim(),
+      quote_id: quoteId.trim(),
+      start_date:
+        startDate && typeof startDate === 'string' && startDate.trim() ? startDate.trim() : null,
+      estimated_end:
+        estimatedEnd && typeof estimatedEnd === 'string' && estimatedEnd.trim()
+          ? estimatedEnd.trim()
+          : null,
+      scope_summary:
+        scopeSummary && typeof scopeSummary === 'string' && scopeSummary.trim()
+          ? scopeSummary.trim()
+          : null,
+      estimated_hours:
+        estimatedHours && typeof estimatedHours === 'string' && estimatedHours.trim()
+          ? parseFloat(estimatedHours) || null
+          : null,
+      notes: notes && typeof notes === 'string' && notes.trim() ? notes.trim() : null,
+    })
+
+    // Create default milestones if provided
+    const milestoneNames = formData.getAll('milestone_name')
+    for (let i = 0; i < milestoneNames.length; i++) {
+      const name = milestoneNames[i]
+      if (!name || typeof name !== 'string' || !name.trim()) continue
+
+      const descriptions = formData.getAll('milestone_description')
+      const dueDates = formData.getAll('milestone_due_date')
+      const paymentTriggers = formData.getAll('milestone_payment_trigger')
+
+      const description = descriptions[i]
+      const dueDate = dueDates[i]
+      const paymentTrigger = paymentTriggers[i]
+
+      await createMilestone(env.DB, engagement.id, {
+        name: name.trim(),
+        description:
+          description && typeof description === 'string' && description.trim()
+            ? description.trim()
+            : null,
+        due_date: dueDate && typeof dueDate === 'string' && dueDate.trim() ? dueDate.trim() : null,
+        payment_trigger: paymentTrigger === 'on' || paymentTrigger === '1',
+        sort_order: i,
+      })
+    }
+
+    return redirect(`/admin/clients/${clientId.trim()}/engagements/${engagement.id}`, 302)
+  } catch (err) {
+    console.error('[api/admin/engagements] Create error:', err)
+    const formData = await request
+      .clone()
+      .formData()
+      .catch(() => null)
+    const clientId = formData?.get('client_id')
+    if (clientId && typeof clientId === 'string') {
+      return redirect(`/admin/clients/${clientId}/engagements/new?error=server`, 302)
+    }
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/tests/engagements.test.ts
+++ b/tests/engagements.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('engagements: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/engagements.ts'), 'utf-8')
+
+  it('engagements.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/engagements.ts'))).toBe(true)
+  })
+
+  it('exports listEngagements function', () => {
+    expect(source()).toContain('export async function listEngagements')
+  })
+
+  it('exports getEngagement function', () => {
+    expect(source()).toContain('export async function getEngagement')
+  })
+
+  it('exports createEngagement function', () => {
+    expect(source()).toContain('export async function createEngagement')
+  })
+
+  it('exports updateEngagement function', () => {
+    expect(source()).toContain('export async function updateEngagement')
+  })
+
+  it('exports updateEngagementStatus function', () => {
+    expect(source()).toContain('export async function updateEngagementStatus')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('scopes all queries to org_id', () => {
+    const code = source()
+    expect(code).toContain("'org_id = ?'")
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('supports optional client_id filter in listEngagements', () => {
+    const code = source()
+    expect(code).toContain("'client_id = ?'")
+  })
+
+  it('defines all valid engagement statuses', () => {
+    const code = source()
+    expect(code).toContain("'scheduled'")
+    expect(code).toContain("'active'")
+    expect(code).toContain("'handoff'")
+    expect(code).toContain("'safety_net'")
+    expect(code).toContain("'completed'")
+    expect(code).toContain("'cancelled'")
+  })
+
+  it('exports ENGAGEMENT_STATUSES constant', () => {
+    expect(source()).toContain('export const ENGAGEMENT_STATUSES')
+  })
+
+  it('exports VALID_TRANSITIONS for status state machine', () => {
+    expect(source()).toContain('export const VALID_TRANSITIONS')
+  })
+
+  it('enforces valid status transitions', () => {
+    const code = source()
+    expect(code).toContain('VALID_TRANSITIONS')
+    expect(code).toContain('Invalid status transition')
+  })
+
+  it('defines valid transitions: scheduled -> active | cancelled', () => {
+    const code = source()
+    expect(code).toContain("scheduled: ['active', 'cancelled']")
+  })
+
+  it('defines valid transitions: active -> handoff | cancelled', () => {
+    const code = source()
+    expect(code).toContain("active: ['handoff', 'cancelled']")
+  })
+
+  it('defines valid transitions: handoff -> safety_net | cancelled', () => {
+    const code = source()
+    expect(code).toContain("handoff: ['safety_net', 'cancelled']")
+  })
+
+  it('defines valid transitions: safety_net -> completed | cancelled', () => {
+    const code = source()
+    expect(code).toContain("safety_net: ['completed', 'cancelled']")
+  })
+
+  it('completed and cancelled are terminal states', () => {
+    const code = source()
+    expect(code).toContain('completed: []')
+    expect(code).toContain('cancelled: []')
+  })
+
+  it('auto-sets safety_net_end when transitioning to handoff', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'handoff'")
+    expect(code).toContain('safety_net_end')
+    expect(code).toContain('handoff_date')
+    // 14-day calculation
+    expect(code).toContain('getDate() + 14')
+  })
+
+  it('auto-sets actual_end when transitioning to completed', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'completed'")
+    expect(code).toContain('actual_end')
+  })
+})
+
+describe('engagements: API routes', () => {
+  it('create endpoint exists at src/pages/api/admin/engagements/index.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/engagements/index.ts'))).toBe(true)
+  })
+
+  it('update endpoint exists at src/pages/api/admin/engagements/[id].ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/engagements/[id].ts'))).toBe(true)
+  })
+
+  it('milestones endpoint exists at src/pages/api/admin/engagements/[id]/milestones.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/engagements/[id]/milestones.ts'))).toBe(true)
+  })
+
+  it('create endpoint validates required fields', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/engagements/index.ts'), 'utf-8')
+    expect(code).toContain('client_id')
+    expect(code).toContain('quote_id')
+    expect(code).toContain('createEngagement')
+  })
+
+  it('create endpoint reads form data', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/engagements/index.ts'), 'utf-8')
+    expect(code).toContain('request.formData()')
+  })
+
+  it('create endpoint supports default milestones', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/engagements/index.ts'), 'utf-8')
+    expect(code).toContain('milestone_name')
+    expect(code).toContain('createMilestone')
+  })
+
+  it('update endpoint handles status transitions', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/engagements/[id].ts'), 'utf-8')
+    expect(code).toContain('transition_status')
+    expect(code).toContain('updateEngagementStatus')
+  })
+
+  it('update endpoint handles field updates', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/engagements/[id].ts'), 'utf-8')
+    expect(code).toContain('updateEngagement')
+    expect(code).toContain('scope_summary')
+    expect(code).toContain('estimated_hours')
+  })
+
+  it('milestones endpoint supports create', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/engagements/[id]/milestones.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('createMilestone')
+    expect(code).toContain('name')
+  })
+
+  it('milestones endpoint supports _method=DELETE', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/engagements/[id]/milestones.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('_method')
+    expect(code).toContain('DELETE')
+    expect(code).toContain('deleteMilestone')
+  })
+
+  it('milestones endpoint supports status transitions', () => {
+    const code = readFileSync(
+      resolve('src/pages/api/admin/engagements/[id]/milestones.ts'),
+      'utf-8'
+    )
+    expect(code).toContain('transition_status')
+    expect(code).toContain('updateMilestoneStatus')
+  })
+
+  it('endpoints verify admin session', () => {
+    const createCode = readFileSync(resolve('src/pages/api/admin/engagements/index.ts'), 'utf-8')
+    const updateCode = readFileSync(resolve('src/pages/api/admin/engagements/[id].ts'), 'utf-8')
+    const milestonesCode = readFileSync(
+      resolve('src/pages/api/admin/engagements/[id]/milestones.ts'),
+      'utf-8'
+    )
+    expect(createCode).toContain("session.role !== 'admin'")
+    expect(updateCode).toContain("session.role !== 'admin'")
+    expect(milestonesCode).toContain("session.role !== 'admin'")
+  })
+})
+
+describe('engagements: create form page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/engagements/new.astro'), 'utf-8')
+
+  it('create page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id]/engagements/new.astro'))).toBe(true)
+  })
+
+  it('form posts to /api/admin/engagements', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('action="/api/admin/engagements"')
+  })
+
+  it('includes hidden client_id field', () => {
+    expect(source()).toContain('name="client_id"')
+  })
+
+  it('includes quote_id dropdown', () => {
+    const code = source()
+    expect(code).toContain('name="quote_id"')
+    expect(code).toContain('Select a quote')
+  })
+
+  it('loads accepted quotes for the client', () => {
+    const code = source()
+    expect(code).toContain("status = 'accepted'")
+    expect(code).toContain('quotes')
+  })
+
+  it('includes schedule fields', () => {
+    const code = source()
+    expect(code).toContain('name="start_date"')
+    expect(code).toContain('name="estimated_end"')
+    expect(code).toContain('name="estimated_hours"')
+  })
+
+  it('includes scope_summary field', () => {
+    expect(source()).toContain('name="scope_summary"')
+  })
+
+  it('includes notes field', () => {
+    expect(source()).toContain('name="notes"')
+  })
+
+  it('includes default milestones section', () => {
+    const code = source()
+    expect(code).toContain('milestone_name')
+    expect(code).toContain('milestone_description')
+    expect(code).toContain('milestone_due_date')
+    expect(code).toContain('milestone_payment_trigger')
+  })
+
+  it('has add/remove milestone functionality', () => {
+    const code = source()
+    expect(code).toContain('Add Milestone')
+    expect(code).toContain('Remove')
+    expect(code).toContain('add-milestone-btn')
+  })
+
+  it('loads client data for display', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('has breadcrumb navigation', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients')
+    expect(code).toContain('client.business_name')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('engagements: detail/edit page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/engagements/[engId].astro'), 'utf-8')
+
+  it('detail page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id]/engagements/[engId].astro'))).toBe(true)
+  })
+
+  it('loads engagement via getEngagement', () => {
+    expect(source()).toContain('getEngagement')
+  })
+
+  it('loads client via getClient for breadcrumb', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('form posts to /api/admin/engagements/:id', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('/api/admin/engagements/${engagement.id}')
+  })
+
+  it('shows status progression indicator', () => {
+    const code = source()
+    expect(code).toContain('statusOrder')
+    expect(code).toContain('getProgressionColor')
+  })
+
+  it('shows status transition buttons', () => {
+    const code = source()
+    expect(code).toContain('Status Transition')
+    expect(code).toContain('VALID_TRANSITIONS')
+    expect(code).toContain('transition_status')
+    expect(code).toContain('new_status')
+  })
+
+  it('displays current status badge', () => {
+    const code = source()
+    expect(code).toContain('ENGAGEMENT_STATUSES')
+    expect(code).toContain('statusColorMap')
+  })
+
+  it('displays scope summary', () => {
+    const code = source()
+    expect(code).toContain('scope_summary')
+    expect(code).toContain('engagement.scope_summary')
+  })
+
+  it('displays dates and hours fields', () => {
+    const code = source()
+    expect(code).toContain('start_date')
+    expect(code).toContain('estimated_end')
+    expect(code).toContain('estimated_hours')
+    expect(code).toContain('actual_hours')
+  })
+
+  it('displays milestones with status badges', () => {
+    const code = source()
+    expect(code).toContain('listMilestones')
+    expect(code).toContain('MILESTONE_STATUSES')
+    expect(code).toContain('milestoneStatusColor')
+  })
+
+  it('displays milestone status transition buttons', () => {
+    const code = source()
+    expect(code).toContain('MILESTONE_TRANSITIONS')
+    expect(code).toContain('milestone_id')
+  })
+
+  it('displays payment trigger badges on milestones', () => {
+    const code = source()
+    expect(code).toContain('payment_trigger')
+    expect(code).toContain('Payment Trigger')
+  })
+
+  it('displays engagement contact role assignments', () => {
+    const code = source()
+    expect(code).toContain('getEngagementContacts')
+    expect(code).toContain('ENGAGEMENT_CONTACT_ROLES')
+    expect(code).toContain('Contact Roles')
+  })
+
+  it('displays safety net end date when in handoff or safety_net status', () => {
+    const code = source()
+    expect(code).toContain('showSafetyNet')
+    expect(code).toContain('safety_net_end')
+    expect(code).toContain('Safety net ends')
+  })
+
+  it('shows success message after save', () => {
+    const code = source()
+    expect(code).toContain("get('saved')")
+    expect(code).toContain('Engagement updated successfully')
+  })
+
+  it('has breadcrumb navigation back to client', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients/${client.id}')
+    expect(code).toContain('client.business_name')
+  })
+
+  it('includes add milestone form', () => {
+    const code = source()
+    expect(code).toContain('Add Milestone')
+    expect(code).toContain('/milestones')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('engagements: client detail page integration', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/clients/[id].astro'), 'utf-8')
+
+  it('client detail page imports listEngagements', () => {
+    expect(source()).toContain('listEngagements')
+  })
+
+  it('client detail page imports ENGAGEMENT_STATUSES', () => {
+    expect(source()).toContain('ENGAGEMENT_STATUSES')
+  })
+
+  it('client detail page loads engagements for this client', () => {
+    const code = source()
+    expect(code).toContain('listEngagements')
+    expect(code).toContain('engagements')
+  })
+
+  it('client detail page has engagements section', () => {
+    const code = source()
+    expect(code).toContain('Engagements')
+    expect(code).toContain('New Engagement')
+  })
+
+  it('client detail page links to new engagement form', () => {
+    const code = source()
+    expect(code).toContain('/engagements/new')
+  })
+
+  it('client detail page links to engagement detail', () => {
+    const code = source()
+    expect(code).toContain('/engagements/${e.id}')
+  })
+
+  it('shows engagement status in the list', () => {
+    const code = source()
+    expect(code).toContain('engagementStatusColor')
+    expect(code).toContain('e.status')
+  })
+
+  it('shows empty state when no engagements', () => {
+    const code = source()
+    expect(code).toContain('No engagements yet')
+    expect(code).toContain('Create the first engagement')
+  })
+})

--- a/tests/milestones.test.ts
+++ b/tests/milestones.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('milestones: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/milestones.ts'), 'utf-8')
+
+  it('milestones.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/milestones.ts'))).toBe(true)
+  })
+
+  it('exports listMilestones function', () => {
+    expect(source()).toContain('export async function listMilestones')
+  })
+
+  it('exports getMilestone function', () => {
+    expect(source()).toContain('export async function getMilestone')
+  })
+
+  it('exports createMilestone function', () => {
+    expect(source()).toContain('export async function createMilestone')
+  })
+
+  it('exports updateMilestone function', () => {
+    expect(source()).toContain('export async function updateMilestone')
+  })
+
+  it('exports updateMilestoneStatus function', () => {
+    expect(source()).toContain('export async function updateMilestoneStatus')
+  })
+
+  it('exports bulkCreateMilestones function', () => {
+    expect(source()).toContain('export async function bulkCreateMilestones')
+  })
+
+  it('exports deleteMilestone function', () => {
+    expect(source()).toContain('export async function deleteMilestone')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('orders milestones by sort_order ASC', () => {
+    const code = source()
+    expect(code).toContain('ORDER BY sort_order ASC')
+  })
+
+  it('defines all valid milestone statuses', () => {
+    const code = source()
+    expect(code).toContain("'pending'")
+    expect(code).toContain("'in_progress'")
+    expect(code).toContain("'completed'")
+    expect(code).toContain("'skipped'")
+  })
+
+  it('exports MILESTONE_STATUSES constant', () => {
+    expect(source()).toContain('export const MILESTONE_STATUSES')
+  })
+
+  it('exports VALID_TRANSITIONS for status state machine', () => {
+    expect(source()).toContain('export const VALID_TRANSITIONS')
+  })
+
+  it('enforces valid status transitions', () => {
+    const code = source()
+    expect(code).toContain('VALID_TRANSITIONS')
+    expect(code).toContain('Invalid status transition')
+  })
+
+  it('defines valid transitions: pending -> in_progress | skipped', () => {
+    const code = source()
+    expect(code).toContain("pending: ['in_progress', 'skipped']")
+  })
+
+  it('defines valid transitions: in_progress -> completed | skipped', () => {
+    const code = source()
+    expect(code).toContain("in_progress: ['completed', 'skipped']")
+  })
+
+  it('completed and skipped are terminal states', () => {
+    const code = source()
+    expect(code).toContain('completed: []')
+    expect(code).toContain('skipped: []')
+  })
+
+  it('auto-sets completed_at when transitioning to completed', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'completed'")
+    expect(code).toContain('completed_at')
+  })
+
+  it('supports payment_trigger flag', () => {
+    const code = source()
+    expect(code).toContain('payment_trigger')
+  })
+
+  it('bulkCreateMilestones creates multiple milestones', () => {
+    const code = source()
+    expect(code).toContain('bulkCreateMilestones')
+    expect(code).toContain('createMilestone')
+    // Should iterate over array
+    expect(code).toContain('milestones.length')
+  })
+
+  it('bulkCreateMilestones assigns sort_order sequentially', () => {
+    const code = source()
+    // Should use index for default sort order
+    expect(code).toContain('sort_order: data.sort_order ?? i')
+  })
+
+  it('createMilestone handles sort_order', () => {
+    const code = source()
+    expect(code).toContain('sort_order')
+  })
+})


### PR DESCRIPTION
## Summary
- Add engagement data layer (`src/lib/db/engagements.ts`) with full status machine: scheduled -> active -> handoff -> safety_net -> completed/cancelled. Auto-sets handoff_date and safety_net_end (handoff + 14 days) on handoff transition, auto-sets actual_end on completion.
- Add milestone data layer (`src/lib/db/milestones.ts`) with status machine: pending -> in_progress -> completed/skipped. Supports payment_trigger flag, sort_order, bulk create, and auto-sets completed_at on completion.
- Add API routes for engagement CRUD, status transitions, and milestone CRUD with `_method=DELETE` support.
- Add engagement detail page with status progression indicator, milestone list with inline status transitions, contact role display, safety net date display, and add-milestone form.
- Add new engagement form with accepted quote dropdown, schedule fields, scope summary, and dynamic default milestones section.
- Integrate engagements section into client detail page with status badges and links.
- 95 new tests across `tests/engagements.test.ts` (72) and `tests/milestones.test.ts` (23).

## Test plan
- [x] All 456 tests pass (including 95 new)
- [x] TypeScript typecheck passes with 0 errors
- [x] Prettier formatting passes
- [x] ESLint passes
- [x] Astro build succeeds

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)