### PR TITLE
feat: SignWell e-signature integration (#73)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -16,6 +16,8 @@ type CfEnv = {
   SESSIONS: KVNamespace
   RESEND_API_KEY?: string
   ANTHROPIC_API_KEY?: string
+  SIGNWELL_API_KEY?: string
+  SIGNWELL_WEBHOOK_SECRET?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>

--- a/src/lib/signwell/client.ts
+++ b/src/lib/signwell/client.ts
@@ -1,0 +1,92 @@
+/**
+ * SignWell API client using raw fetch.
+ *
+ * No SDK — uses direct HTTP calls to the SignWell REST API v1.
+ * All methods require a valid API key and return typed responses.
+ *
+ * API base: https://www.signwell.com/api/v1/
+ */
+
+import type { SignWellCreateDocumentRequest, SignWellDocument } from './types'
+
+const SIGNWELL_API_BASE = 'https://www.signwell.com/api/v1'
+
+/**
+ * Create a signature request by sending a document to SignWell.
+ *
+ * Uploads the PDF (base64 or URL), sets up signer fields, and
+ * configures the webhook callback for completion notifications.
+ *
+ * @param apiKey - SignWell API key
+ * @param params - Document creation parameters
+ * @returns The created SignWell document
+ */
+export async function createSignatureRequest(
+  apiKey: string,
+  params: SignWellCreateDocumentRequest
+): Promise<SignWellDocument> {
+  const response = await fetch(`${SIGNWELL_API_BASE}/documents`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': apiKey,
+    },
+    body: JSON.stringify(params),
+  })
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`SignWell createSignatureRequest failed (${response.status}): ${errorBody}`)
+  }
+
+  return response.json() as Promise<SignWellDocument>
+}
+
+/**
+ * Get a document by ID from SignWell.
+ *
+ * @param apiKey - SignWell API key
+ * @param docId - SignWell document ID
+ * @returns The SignWell document details
+ */
+export async function getDocument(apiKey: string, docId: string): Promise<SignWellDocument> {
+  const response = await fetch(`${SIGNWELL_API_BASE}/documents/${docId}`, {
+    method: 'GET',
+    headers: {
+      'X-Api-Key': apiKey,
+    },
+  })
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`SignWell getDocument failed (${response.status}): ${errorBody}`)
+  }
+
+  return response.json() as Promise<SignWellDocument>
+}
+
+/**
+ * Download the completed (signed) PDF for a document.
+ *
+ * Only available after all signers have completed signing.
+ *
+ * @param apiKey - SignWell API key
+ * @param docId - SignWell document ID
+ * @returns The signed PDF as a Uint8Array
+ */
+export async function getSignedPdf(apiKey: string, docId: string): Promise<Uint8Array> {
+  const response = await fetch(`${SIGNWELL_API_BASE}/documents/${docId}/completed_pdf`, {
+    method: 'GET',
+    headers: {
+      'X-Api-Key': apiKey,
+    },
+  })
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`SignWell getSignedPdf failed (${response.status}): ${errorBody}`)
+  }
+
+  const buffer = await response.arrayBuffer()
+  return new Uint8Array(buffer)
+}

--- a/src/lib/signwell/types.ts
+++ b/src/lib/signwell/types.ts
@@ -1,0 +1,96 @@
+/**
+ * TypeScript types for the SignWell e-signature API.
+ *
+ * Based on the SignWell API v1 documentation.
+ * These types cover the subset of the API used by the SMD Services portal:
+ * document creation, document retrieval, and webhook payloads.
+ */
+
+/**
+ * Signer details for a signature request.
+ */
+export interface SignWellSigner {
+  id: string
+  name: string
+  email: string
+  signed_at: string | null
+}
+
+/**
+ * Field placement on a document for signature collection.
+ */
+export interface SignWellField {
+  type: 'signature' | 'date' | 'text' | 'initials'
+  required: boolean
+  page: number
+  x: number
+  y: number
+  width?: number
+  height?: number
+  api_id?: string
+}
+
+/**
+ * Request body for POST /documents to create a signature request.
+ *
+ * Supports either file_url (R2 presigned URL) or file (base64-encoded PDF).
+ * We use file (base64) since R2 objects are not publicly accessible.
+ */
+export interface SignWellCreateDocumentRequest {
+  /** Display name for the document in SignWell */
+  name: string
+  /** Base64-encoded file content */
+  file_base64?: string
+  /** Public URL to the file (alternative to file_base64) */
+  file_url?: string
+  /** Original filename */
+  original_filename?: string
+  /** Signer details */
+  signers: {
+    id: string
+    name: string
+    email: string
+  }[]
+  /** Webhook callback URL for completion events */
+  callback_url?: string
+  /** Field placements for signature blocks */
+  fields: (SignWellField & { signer_id: string })[]
+  /** Whether to send the signing request via email immediately */
+  draft?: boolean
+  /** Custom message to include in the signing email */
+  custom_requester_name?: string
+  custom_requester_email?: string
+  /** Subject line for signing email */
+  subject?: string
+  /** Message body for signing email */
+  message?: string
+}
+
+/**
+ * SignWell document object returned by the API.
+ */
+export interface SignWellDocument {
+  id: string
+  name: string
+  status: 'draft' | 'pending' | 'completed' | 'cancelled' | 'expired'
+  signers: SignWellSigner[]
+  completed_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Webhook payload sent by SignWell when a document event occurs.
+ *
+ * The primary event we handle is `document_completed`.
+ */
+export interface SignWellWebhookPayload {
+  event: 'document_completed' | 'document_expired' | 'document_cancelled'
+  data: {
+    id: string
+    name: string
+    status: string
+    signers: SignWellSigner[]
+    completed_at: string | null
+  }
+}

--- a/src/lib/webhooks/signwell-handler.ts
+++ b/src/lib/webhooks/signwell-handler.ts
@@ -1,0 +1,263 @@
+/**
+ * SignWell webhook handler — two-phase pattern.
+ *
+ * Follows the architecture from docs/spikes/d1-batch-api.md EXACTLY:
+ *
+ * Phase 1 — Atomic D1 Batch (all-or-nothing):
+ *   1. Look up quote by signwell_doc_id
+ *   2. Idempotency check: if quote.status === 'accepted', return early
+ *   3. Generate UUIDs for new engagement and deposit invoice BEFORE the batch
+ *   4. db.batch([
+ *        updateQuoteStatus to 'accepted' with accepted_at,
+ *        updateClientStatus to 'active',
+ *        createEngagement from quote data,
+ *        createDepositInvoice (draft status, amount = quote.deposit_amount)
+ *      ])
+ *
+ * Phase 2 — Best-effort side effects:
+ *   1. Download signed PDF from SignWell API
+ *   2. Upload to R2 at {orgId}/quotes/{quoteId}/signed-sow.pdf
+ *   3. Update quote.signed_sow_path
+ *   4. Send confirmation email to client via Resend
+ *
+ * Returns 200 after Phase 1 succeeds, even if Phase 2 fails.
+ */
+
+import type { SignWellWebhookPayload } from '../signwell/types'
+import { getSignedPdf } from '../signwell/client'
+import type { Quote } from '../db/quotes'
+
+/**
+ * Look up a quote by its SignWell document ID.
+ * Not scoped to org_id because webhooks don't carry org context —
+ * the signwell_doc_id is globally unique.
+ */
+async function getQuoteBySignWellDocId(
+  db: D1Database,
+  signwellDocId: string
+): Promise<Quote | null> {
+  const result = await db
+    .prepare('SELECT * FROM quotes WHERE signwell_doc_id = ?')
+    .bind(signwellDocId)
+    .first<Quote>()
+
+  return result ?? null
+}
+
+/**
+ * Look up the primary contact email for a client.
+ */
+async function getClientPrimaryEmail(
+  db: D1Database,
+  orgId: string,
+  clientId: string
+): Promise<string | null> {
+  const contact = await db
+    .prepare(
+      'SELECT email FROM contacts WHERE org_id = ? AND client_id = ? AND email IS NOT NULL ORDER BY created_at ASC LIMIT 1'
+    )
+    .bind(orgId, clientId)
+    .first<{ email: string }>()
+
+  return contact?.email ?? null
+}
+
+/**
+ * Handle the document_completed webhook event from SignWell.
+ *
+ * @param db - D1 database binding
+ * @param storage - R2 bucket binding
+ * @param apiKey - SignWell API key for downloading signed PDF
+ * @param resendApiKey - Resend API key for sending confirmation emails (optional)
+ * @param payload - The parsed webhook payload
+ * @returns Response to send back to SignWell (200 or 500)
+ */
+export async function handleDocumentCompleted(
+  db: D1Database,
+  storage: R2Bucket,
+  apiKey: string,
+  resendApiKey: string | undefined,
+  payload: SignWellWebhookPayload
+): Promise<Response> {
+  const documentId = payload.data.id
+  const now = new Date().toISOString()
+
+  // --- Pre-batch reads (outside transaction) ---
+
+  // 1. Look up quote by SignWell document ID
+  const quote = await getQuoteBySignWellDocId(db, documentId)
+  if (!quote) {
+    console.log(`[signwell-handler] Unknown SignWell document: ${documentId}`)
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // 2. Idempotency guard — if already accepted, skip processing
+  if (quote.status === 'accepted') {
+    console.log(`[signwell-handler] Quote ${quote.id} already accepted, skipping`)
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Phase 1: Atomic D1 batch ---
+
+  const engagementId = crypto.randomUUID()
+  const invoiceId = crypto.randomUUID()
+
+  try {
+    await db.batch([
+      // 1. Update quote status to 'accepted'
+      db
+        .prepare(
+          `UPDATE quotes SET status = 'accepted', accepted_at = ?, updated_at = ?
+         WHERE id = ? AND org_id = ? AND status = 'sent'`
+        )
+        .bind(now, now, quote.id, quote.org_id),
+
+      // 2. Update client status to 'active'
+      db
+        .prepare(
+          `UPDATE clients SET status = 'active', updated_at = ?
+         WHERE id = ? AND org_id = ?`
+        )
+        .bind(now, quote.client_id, quote.org_id),
+
+      // 3. Create engagement from quote data
+      db
+        .prepare(
+          `INSERT INTO engagements (id, org_id, client_id, quote_id, status, estimated_hours, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'scheduled', ?, ?, ?)`
+        )
+        .bind(engagementId, quote.org_id, quote.client_id, quote.id, quote.total_hours, now, now),
+
+      // 4. Create deposit invoice (draft status)
+      db
+        .prepare(
+          `INSERT INTO invoices (id, org_id, engagement_id, client_id, type, amount, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'deposit', ?, 'draft', ?, ?)`
+        )
+        .bind(
+          invoiceId,
+          quote.org_id,
+          engagementId,
+          quote.client_id,
+          quote.deposit_amount,
+          now,
+          now
+        ),
+    ])
+  } catch (err) {
+    // Batch failed — all changes rolled back. Safe to let the webhook retry.
+    console.error('[signwell-handler] Phase 1 batch failed:', err)
+    return new Response(JSON.stringify({ error: 'INTERNAL_ERROR' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Phase 2: Side effects (best-effort) ---
+  // These run after the batch succeeds. If any fail, the database state
+  // is correct but side effects are incomplete.
+
+  // 2a. Download signed PDF from SignWell and upload to R2
+  const signedSowPath = `${quote.org_id}/quotes/${quote.id}/signed-sow.pdf`
+
+  try {
+    const signedPdf = await getSignedPdf(apiKey, documentId)
+    await storage.put(signedSowPath, signedPdf, {
+      httpMetadata: {
+        contentType: 'application/pdf',
+      },
+      customMetadata: {
+        signedAt: now,
+        quoteId: quote.id,
+        signwellDocId: documentId,
+      },
+    })
+
+    // 2b. Update quote with signed_sow_path
+    await db
+      .prepare(`UPDATE quotes SET signed_sow_path = ?, updated_at = ? WHERE id = ? AND org_id = ?`)
+      .bind(signedSowPath, now, quote.id, quote.org_id)
+      .run()
+  } catch (err) {
+    console.error('[signwell-handler] Failed to upload signed PDF to R2:', err)
+    // Non-fatal: PDF can be re-fetched from SignWell later
+  }
+
+  // 2c. Send confirmation email to client
+  if (resendApiKey) {
+    try {
+      const clientEmail = await getClientPrimaryEmail(db, quote.org_id, quote.client_id)
+      if (clientEmail) {
+        const client = await db
+          .prepare('SELECT business_name FROM clients WHERE id = ? AND org_id = ?')
+          .bind(quote.client_id, quote.org_id)
+          .first<{ business_name: string }>()
+
+        await fetch('https://api.resend.com/emails', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${resendApiKey}`,
+          },
+          body: JSON.stringify({
+            from: 'SMD Services <noreply@smd.services>',
+            to: clientEmail,
+            subject: 'SOW Signed — Next Steps',
+            html: signatureConfirmationEmailHtml(client?.business_name ?? 'there'),
+          }),
+        })
+      }
+    } catch (err) {
+      console.error('[signwell-handler] Failed to send confirmation email:', err)
+      // Non-fatal: admin can trigger manually
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Simple confirmation email HTML sent after SOW is signed.
+ */
+function signatureConfirmationEmailHtml(businessName: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;text-align:center;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi ${businessName},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Your Statement of Work has been signed successfully. We're excited to get started working together.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Our team will be in touch shortly with next steps, including the deposit invoice and scheduling details.
+      </p>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        If you have any questions, reply directly to this email.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}

--- a/src/pages/admin/clients/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/clients/[id]/quotes/[quoteId].astro
@@ -42,6 +42,9 @@ const errorMessages: Record<string, string> = {
   server: 'Something went wrong. Please try again.',
   invalid_transition: 'That status transition is not allowed.',
   client_not_found: 'Client not found.',
+  no_sow: 'Generate a SOW PDF first before sending for signature.',
+  already_sent: 'This quote has already been sent for signature.',
+  no_contact_email: 'No contact email found. Add a contact with an email address first.',
 }
 
 const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
@@ -49,7 +52,11 @@ const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurr
 // Status helpers
 const currentStatus = quote.status as QuoteStatus
 const isDraft = currentStatus === 'draft'
+const isSent = currentStatus === 'sent'
 const hasSow = !!quote.sow_path
+const hasSignwell = !!quote.signwell_doc_id
+const hasSignedSow = !!quote.signed_sow_path
+const canSendForSignature = hasSow && !hasSignwell && (isDraft || isSent)
 
 // Status badge colors
 const statusColorMap: Record<string, string> = {
@@ -190,7 +197,7 @@ const getProblemLabel = (problem: string) => {
           )
         }
         {
-          isDraft && hasSow && (
+          isDraft && hasSow && !hasSignwell && (
             <form method="POST" action={`/api/admin/quotes/${quote.id}`} class="inline">
               <input type="hidden" name="action" value="send" />
               <button
@@ -198,6 +205,23 @@ const getProblemLabel = (problem: string) => {
                 class="px-4 py-2 rounded-md text-sm font-medium transition-colors bg-blue-600 text-white hover:bg-blue-700"
               >
                 Send to Client
+              </button>
+            </form>
+          )
+        }
+        {
+          canSendForSignature && (
+            <form
+              method="POST"
+              action={`/api/admin/quotes/${quote.id}/sign`}
+              class="inline"
+              data-signwell-sign
+            >
+              <button
+                type="submit"
+                class="px-4 py-2 rounded-md text-sm font-medium transition-colors bg-indigo-600 text-white hover:bg-indigo-700"
+              >
+                Send for Signature
               </button>
             </form>
           )
@@ -229,6 +253,73 @@ const getProblemLabel = (problem: string) => {
           )
         }
       </div>
+
+      <!-- SignWell Status -->
+      {
+        isSent && hasSignwell && !hasSignedSow && (
+          <div
+            class="mb-6 p-4 bg-indigo-50 border border-indigo-200 rounded-lg"
+            data-signwell-status="awaiting"
+          >
+            <div class="flex items-center gap-3">
+              <svg
+                class="w-5 h-5 text-indigo-600 flex-shrink-0 animate-pulse"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                />
+              </svg>
+              <div class="flex-1">
+                <p class="text-sm font-medium text-indigo-800">Awaiting Signature</p>
+                <p class="text-xs text-indigo-600">
+                  Sent via SignWell — waiting for client to sign
+                </p>
+              </div>
+            </div>
+          </div>
+        )
+      }
+      {
+        hasSignedSow && (
+          <div
+            class="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg"
+            data-signwell-status="signed"
+          >
+            <div class="flex items-center gap-3">
+              <svg
+                class="w-5 h-5 text-green-600 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div class="flex-1">
+                <p class="text-sm font-medium text-green-800">Signed SOW</p>
+                <p class="text-xs text-green-600 truncate">{quote.signed_sow_path}</p>
+              </div>
+              <a
+                href={`/api/admin/quotes/${quote.id}/signed-sow`}
+                class="text-sm font-medium text-green-700 hover:text-green-900 underline"
+                data-signed-sow-link
+              >
+                View Signed SOW
+              </a>
+            </div>
+          </div>
+        )
+      }
 
       <!-- SOW PDF Section -->
       {

--- a/src/pages/api/admin/quotes/[id]/sign.ts
+++ b/src/pages/api/admin/quotes/[id]/sign.ts
@@ -1,0 +1,185 @@
+import type { APIRoute } from 'astro'
+import { getQuote } from '../../../../../lib/db/quotes'
+import { getClient } from '../../../../../lib/db/clients'
+import { listContacts } from '../../../../../lib/db/contacts'
+import { getPdf } from '../../../../../lib/storage/r2'
+import { createSignatureRequest } from '../../../../../lib/signwell/client'
+import type { SignWellCreateDocumentRequest } from '../../../../../lib/signwell/types'
+
+/**
+ * POST /api/admin/quotes/:id/sign
+ *
+ * Sends a quote's SOW PDF to SignWell for e-signature collection.
+ *
+ * Preconditions:
+ * - Quote status must be 'draft' or 'sent'
+ * - sow_path must exist (SOW PDF already generated)
+ * - No signwell_doc_id yet (not already sent for signature)
+ *
+ * Process:
+ * 1. Retrieve SOW PDF from R2
+ * 2. Get client's primary contact for signer details
+ * 3. Create signature request in SignWell
+ * 4. Store signwell_doc_id on the quote
+ * 5. Transition quote to 'sent' if currently 'draft'
+ * 6. Redirect back to quote detail page
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ locals, redirect, params, url }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const quoteId = params.id
+  if (!quoteId) {
+    return new Response(JSON.stringify({ error: 'Quote ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  // Verify SignWell API key is configured
+  const apiKey = env.SIGNWELL_API_KEY
+  if (!apiKey) {
+    console.error('[api/admin/quotes/[id]/sign] SIGNWELL_API_KEY not configured')
+    return redirect(`/admin/clients?error=server`, 302)
+  }
+
+  try {
+    // 1. Get quote and verify preconditions
+    const quote = await getQuote(env.DB, session.orgId, quoteId)
+    if (!quote) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    if (quote.status !== 'draft' && quote.status !== 'sent') {
+      return redirect(
+        `/admin/clients/${quote.client_id}/quotes/${quoteId}?error=invalid_transition`,
+        302
+      )
+    }
+
+    if (!quote.sow_path) {
+      return redirect(`/admin/clients/${quote.client_id}/quotes/${quoteId}?error=no_sow`, 302)
+    }
+
+    if (quote.signwell_doc_id) {
+      return redirect(`/admin/clients/${quote.client_id}/quotes/${quoteId}?error=already_sent`, 302)
+    }
+
+    // 2. Get SOW PDF from R2
+    const pdfObject = await getPdf(env.STORAGE, quote.sow_path)
+    if (!pdfObject) {
+      console.error(`[api/admin/quotes/[id]/sign] SOW PDF not found in R2: ${quote.sow_path}`)
+      return redirect(`/admin/clients/${quote.client_id}/quotes/${quoteId}?error=server`, 302)
+    }
+
+    const pdfBuffer = await pdfObject.arrayBuffer()
+    const pdfBase64 = btoa(String.fromCharCode(...new Uint8Array(pdfBuffer)))
+
+    // 3. Get client and primary contact for signer details
+    const client = await getClient(env.DB, session.orgId, quote.client_id)
+    if (!client) {
+      return redirect(
+        `/admin/clients/${quote.client_id}/quotes/${quoteId}?error=client_not_found`,
+        302
+      )
+    }
+
+    const contacts = await listContacts(env.DB, session.orgId, quote.client_id)
+    const primaryContact = contacts.find((c) => c.email) ?? contacts[0]
+
+    if (!primaryContact?.email) {
+      return redirect(
+        `/admin/clients/${quote.client_id}/quotes/${quoteId}?error=no_contact_email`,
+        302
+      )
+    }
+
+    // 4. Build the webhook callback URL
+    const callbackUrl = new URL('/api/webhooks/signwell', url.origin).toString()
+
+    // 5. Create signature request in SignWell
+    const signerId = crypto.randomUUID()
+
+    const signRequest: SignWellCreateDocumentRequest = {
+      name: `SOW — ${client.business_name}`,
+      file_base64: pdfBase64,
+      original_filename: 'sow.pdf',
+      signers: [
+        {
+          id: signerId,
+          name: primaryContact.name,
+          email: primaryContact.email,
+        },
+      ],
+      callback_url: callbackUrl,
+      fields: [
+        {
+          type: 'signature',
+          required: true,
+          page: 1,
+          x: 72,
+          y: 680,
+          width: 200,
+          height: 40,
+          signer_id: signerId,
+          api_id: 'client_signature',
+        },
+        {
+          type: 'date',
+          required: true,
+          page: 1,
+          x: 72,
+          y: 730,
+          width: 120,
+          height: 20,
+          signer_id: signerId,
+          api_id: 'client_date',
+        },
+      ],
+      draft: false,
+      custom_requester_name: 'SMD Services',
+      subject: `SOW for Signature — ${client.business_name}`,
+      message: `Hi ${primaryContact.name}, please review and sign the attached Statement of Work. If you have any questions, reply directly to this email.`,
+    }
+
+    const signwellDoc = await createSignatureRequest(apiKey, signRequest)
+
+    // 6. Update quote with signwell_doc_id
+    const now = new Date().toISOString()
+    const updates: string[] = ['signwell_doc_id = ?', 'updated_at = ?']
+    const updateParams: (string | null)[] = [signwellDoc.id, now]
+
+    // 7. Transition to 'sent' if currently 'draft'
+    if (quote.status === 'draft') {
+      const sentAt = new Date()
+      const expiresAt = new Date(sentAt.getTime() + 5 * 24 * 60 * 60 * 1000)
+
+      updates.push("status = 'sent'")
+      updates.push('sent_at = ?')
+      updateParams.push(sentAt.toISOString())
+      updates.push('expires_at = ?')
+      updateParams.push(expiresAt.toISOString())
+    }
+
+    const sql = `UPDATE quotes SET ${updates.join(', ')} WHERE id = ? AND org_id = ?`
+    updateParams.push(quoteId, session.orgId)
+
+    await env.DB.prepare(sql)
+      .bind(...updateParams)
+      .run()
+
+    return redirect(`/admin/clients/${quote.client_id}/quotes/${quoteId}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/quotes/[id]/sign] Error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/webhooks/signwell.ts
+++ b/src/pages/api/webhooks/signwell.ts
@@ -1,0 +1,113 @@
+import type { APIRoute } from 'astro'
+import type { SignWellWebhookPayload } from '../../../lib/signwell/types'
+import { handleDocumentCompleted } from '../../../lib/webhooks/signwell-handler'
+
+/**
+ * POST /api/webhooks/signwell
+ *
+ * Receives webhook callbacks from SignWell when document events occur.
+ *
+ * This is an unauthenticated endpoint — SignWell webhooks do not carry
+ * session tokens. Security is enforced via HMAC-SHA256 signature verification
+ * using the SIGNWELL_WEBHOOK_SECRET.
+ *
+ * Only processes `document_completed` events. All other events are
+ * acknowledged with 200 but not acted upon.
+ */
+export const POST: APIRoute = async ({ request, locals }) => {
+  const env = locals.runtime.env
+
+  const webhookSecret = env.SIGNWELL_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[webhook/signwell] SIGNWELL_WEBHOOK_SECRET not configured')
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Signature verification ---
+  const rawBody = await request.text()
+  const signature = request.headers.get('x-signwell-signature') ?? ''
+
+  const isValid = await verifySignature(rawBody, signature, webhookSecret)
+  if (!isValid) {
+    console.error('[webhook/signwell] Invalid webhook signature')
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Parse payload ---
+  let payload: SignWellWebhookPayload
+  try {
+    payload = JSON.parse(rawBody) as SignWellWebhookPayload
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Dispatch by event type ---
+  if (payload.event === 'document_completed') {
+    const apiKey = env.SIGNWELL_API_KEY
+    if (!apiKey) {
+      console.error('[webhook/signwell] SIGNWELL_API_KEY not configured')
+      return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    return handleDocumentCompleted(env.DB, env.STORAGE, apiKey, env.RESEND_API_KEY, payload)
+  }
+
+  // Acknowledge all other events without processing
+  return new Response(JSON.stringify({ ok: true, event: payload.event }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Verify the HMAC-SHA256 signature of the webhook payload.
+ *
+ * SignWell signs the raw request body with the webhook secret using
+ * HMAC-SHA256 and sends the hex-encoded digest in the
+ * x-signwell-signature header.
+ *
+ * Uses the Web Crypto API (available in Cloudflare Workers).
+ */
+async function verifySignature(body: string, signature: string, secret: string): Promise<boolean> {
+  if (!signature) {
+    return false
+  }
+
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(body))
+  const digest = Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  // Constant-time comparison to prevent timing attacks
+  if (digest.length !== signature.length) {
+    return false
+  }
+
+  let mismatch = 0
+  for (let i = 0; i < digest.length; i++) {
+    mismatch |= digest.charCodeAt(i) ^ signature.charCodeAt(i)
+  }
+
+  return mismatch === 0
+}

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('signwell: types', () => {
+  const source = () => readFileSync(resolve('src/lib/signwell/types.ts'), 'utf-8')
+
+  it('types.ts exists', () => {
+    expect(existsSync(resolve('src/lib/signwell/types.ts'))).toBe(true)
+  })
+
+  it('exports SignWellCreateDocumentRequest type', () => {
+    expect(source()).toContain('export interface SignWellCreateDocumentRequest')
+  })
+
+  it('exports SignWellDocument type', () => {
+    expect(source()).toContain('export interface SignWellDocument')
+  })
+
+  it('exports SignWellWebhookPayload type', () => {
+    expect(source()).toContain('export interface SignWellWebhookPayload')
+  })
+
+  it('exports SignWellSigner type', () => {
+    expect(source()).toContain('export interface SignWellSigner')
+  })
+
+  it('SignWellCreateDocumentRequest includes file_base64 for PDF upload', () => {
+    const code = source()
+    expect(code).toContain('file_base64')
+  })
+
+  it('SignWellCreateDocumentRequest includes signers array', () => {
+    const code = source()
+    expect(code).toContain('signers')
+  })
+
+  it('SignWellCreateDocumentRequest includes callback_url for webhooks', () => {
+    const code = source()
+    expect(code).toContain('callback_url')
+  })
+
+  it('SignWellCreateDocumentRequest includes fields array', () => {
+    const code = source()
+    expect(code).toContain('fields')
+  })
+
+  it('SignWellWebhookPayload includes document_completed event', () => {
+    const code = source()
+    expect(code).toContain('document_completed')
+  })
+
+  it('SignWellSigner includes signed_at field', () => {
+    const code = source()
+    expect(code).toContain('signed_at')
+  })
+})
+
+describe('signwell: API client', () => {
+  const source = () => readFileSync(resolve('src/lib/signwell/client.ts'), 'utf-8')
+
+  it('client.ts exists', () => {
+    expect(existsSync(resolve('src/lib/signwell/client.ts'))).toBe(true)
+  })
+
+  it('exports createSignatureRequest function', () => {
+    expect(source()).toContain('export async function createSignatureRequest')
+  })
+
+  it('exports getDocument function', () => {
+    expect(source()).toContain('export async function getDocument')
+  })
+
+  it('exports getSignedPdf function', () => {
+    expect(source()).toContain('export async function getSignedPdf')
+  })
+
+  it('uses correct API base URL', () => {
+    expect(source()).toContain('https://www.signwell.com/api/v1')
+  })
+
+  it('createSignatureRequest calls POST /documents', () => {
+    const code = source()
+    expect(code).toContain('/documents')
+    expect(code).toContain("method: 'POST'")
+  })
+
+  it('getDocument calls GET /documents/:id', () => {
+    const code = source()
+    expect(code).toContain('`${SIGNWELL_API_BASE}/documents/${docId}`')
+    expect(code).toContain("method: 'GET'")
+  })
+
+  it('getSignedPdf calls GET /documents/:id/completed_pdf', () => {
+    expect(source()).toContain('/completed_pdf')
+  })
+
+  it('sends API key via X-Api-Key header', () => {
+    const code = source()
+    expect(code).toContain("'X-Api-Key': apiKey")
+  })
+
+  it('sends Content-Type: application/json for POST requests', () => {
+    expect(source()).toContain("'Content-Type': 'application/json'")
+  })
+
+  it('throws descriptive errors on non-ok responses', () => {
+    const code = source()
+    expect(code).toContain('response.ok')
+    expect(code).toContain('throw new Error')
+  })
+
+  it('uses raw fetch — no SDK dependency', () => {
+    const code = source()
+    expect(code).toContain('await fetch(')
+    expect(code).not.toContain('import { SignWell')
+    expect(code).not.toContain("from 'signwell'")
+  })
+})
+
+describe('signwell: webhook handler', () => {
+  const source = () => readFileSync(resolve('src/lib/webhooks/signwell-handler.ts'), 'utf-8')
+
+  it('signwell-handler.ts exists', () => {
+    expect(existsSync(resolve('src/lib/webhooks/signwell-handler.ts'))).toBe(true)
+  })
+
+  it('exports handleDocumentCompleted function', () => {
+    expect(source()).toContain('export async function handleDocumentCompleted')
+  })
+
+  it('looks up quote by signwell_doc_id', () => {
+    const code = source()
+    expect(code).toContain('signwell_doc_id')
+    expect(code).toContain('getQuoteBySignWellDocId')
+  })
+
+  it('implements idempotency check — returns early if already accepted', () => {
+    const code = source()
+    expect(code).toContain("quote.status === 'accepted'")
+    expect(code).toContain('already accepted, skipping')
+  })
+
+  it('generates UUIDs for engagement and invoice BEFORE the batch', () => {
+    const code = source()
+    // engagementId and invoiceId must be generated before db.batch()
+    const engagementIdIdx = code.indexOf('const engagementId = crypto.randomUUID()')
+    const invoiceIdIdx = code.indexOf('const invoiceId = crypto.randomUUID()')
+    const batchIdx = code.indexOf('await db.batch(')
+    expect(engagementIdIdx).toBeGreaterThan(-1)
+    expect(invoiceIdIdx).toBeGreaterThan(-1)
+    expect(batchIdx).toBeGreaterThan(-1)
+    expect(engagementIdIdx).toBeLessThan(batchIdx)
+    expect(invoiceIdIdx).toBeLessThan(batchIdx)
+  })
+
+  it('uses db.batch() for atomic multi-table writes', () => {
+    expect(source()).toContain('await db.batch(')
+  })
+
+  it('batch updates quote status to accepted', () => {
+    const code = source()
+    expect(code).toContain("status = 'accepted'")
+    expect(code).toContain('accepted_at')
+  })
+
+  it('batch updates client status to active', () => {
+    const code = source()
+    expect(code).toContain("UPDATE clients SET status = 'active'")
+  })
+
+  it('batch creates engagement record', () => {
+    const code = source()
+    expect(code).toContain('INSERT INTO engagements')
+    expect(code).toContain('engagementId')
+  })
+
+  it('batch creates deposit invoice with draft status', () => {
+    const code = source()
+    expect(code).toContain('INSERT INTO invoices')
+    expect(code).toContain("'deposit'")
+    expect(code).toContain("'draft'")
+  })
+
+  it('follows two-phase structure — returns 200 after Phase 1 even if Phase 2 fails', () => {
+    const code = source()
+    // Phase 2 side effects are in separate try/catch blocks after the batch
+    expect(code).toContain('Phase 2: Side effects (best-effort)')
+    expect(code).toContain('Non-fatal')
+  })
+
+  it('returns 500 on Phase 1 batch failure', () => {
+    const code = source()
+    expect(code).toContain('Phase 1 batch failed')
+    expect(code).toContain('status: 500')
+  })
+
+  it('uploads signed PDF to R2 in Phase 2', () => {
+    const code = source()
+    expect(code).toContain('signed-sow.pdf')
+    expect(code).toContain('storage.put')
+  })
+
+  it('updates quote signed_sow_path in Phase 2', () => {
+    const code = source()
+    expect(code).toContain('signed_sow_path')
+    expect(code).toContain('signedSowPath')
+  })
+
+  it('sends confirmation email via Resend in Phase 2', () => {
+    const code = source()
+    expect(code).toContain('api.resend.com/emails')
+    expect(code).toContain('SOW Signed')
+  })
+
+  it('uses parameterized queries with .bind()', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // No template literal injection in SQL
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('returns unknown document as 200 (non-retryable)', () => {
+    const code = source()
+    expect(code).toContain('Unknown SignWell document')
+    // Should still return 200 for unknown documents
+    const unknownBlock = code.substring(
+      code.indexOf('Unknown SignWell document'),
+      code.indexOf('Unknown SignWell document') + 200
+    )
+    expect(unknownBlock).toContain('status: 200')
+  })
+})
+
+describe('signwell: webhook route', () => {
+  const source = () => readFileSync(resolve('src/pages/api/webhooks/signwell.ts'), 'utf-8')
+
+  it('signwell.ts webhook route exists', () => {
+    expect(existsSync(resolve('src/pages/api/webhooks/signwell.ts'))).toBe(true)
+  })
+
+  it('exports POST handler', () => {
+    expect(source()).toContain('export const POST')
+  })
+
+  it('implements HMAC-SHA256 signature verification', () => {
+    const code = source()
+    expect(code).toContain('verifySignature')
+    expect(code).toContain('HMAC')
+    expect(code).toContain('SHA-256')
+  })
+
+  it('reads signature from x-signwell-signature header', () => {
+    expect(source()).toContain('x-signwell-signature')
+  })
+
+  it('returns 401 for invalid signatures', () => {
+    const code = source()
+    expect(code).toContain('Invalid signature')
+    expect(code).toContain('status: 401')
+  })
+
+  it('checks for SIGNWELL_WEBHOOK_SECRET configuration', () => {
+    expect(source()).toContain('SIGNWELL_WEBHOOK_SECRET')
+  })
+
+  it('checks for SIGNWELL_API_KEY configuration', () => {
+    expect(source()).toContain('SIGNWELL_API_KEY')
+  })
+
+  it('dispatches document_completed events to handler', () => {
+    const code = source()
+    expect(code).toContain("payload.event === 'document_completed'")
+    expect(code).toContain('handleDocumentCompleted')
+  })
+
+  it('acknowledges non-completed events with 200', () => {
+    const code = source()
+    expect(code).toContain('payload.event')
+    expect(code).toContain('status: 200')
+  })
+
+  it('uses constant-time comparison for signature check', () => {
+    const code = source()
+    expect(code).toContain('mismatch |=')
+    expect(code).toContain('charCodeAt')
+  })
+
+  it('does NOT use auth middleware (webhooks are unauthenticated)', () => {
+    const code = source()
+    expect(code).not.toContain("session.role !== 'admin'")
+    expect(code).not.toContain('locals.session')
+  })
+
+  it('parses raw body for both signature verification and JSON parsing', () => {
+    const code = source()
+    expect(code).toContain('request.text()')
+    expect(code).toContain('JSON.parse(rawBody)')
+  })
+})
+
+describe('signwell: send-for-signature route', () => {
+  const source = () => readFileSync(resolve('src/pages/api/admin/quotes/[id]/sign.ts'), 'utf-8')
+
+  it('sign.ts route exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/quotes/[id]/sign.ts'))).toBe(true)
+  })
+
+  it('exports POST handler', () => {
+    expect(source()).toContain('export const POST')
+  })
+
+  it('verifies admin session', () => {
+    const code = source()
+    expect(code).toContain("session.role !== 'admin'")
+  })
+
+  it('checks quote status is draft or sent', () => {
+    const code = source()
+    expect(code).toContain("quote.status !== 'draft'")
+    expect(code).toContain("quote.status !== 'sent'")
+  })
+
+  it('verifies sow_path exists', () => {
+    expect(source()).toContain('quote.sow_path')
+  })
+
+  it('prevents duplicate signwell sends (checks signwell_doc_id)', () => {
+    expect(source()).toContain('quote.signwell_doc_id')
+  })
+
+  it('retrieves SOW PDF from R2', () => {
+    const code = source()
+    expect(code).toContain('getPdf')
+    expect(code).toContain('env.STORAGE')
+  })
+
+  it('converts PDF to base64 for SignWell API', () => {
+    expect(source()).toContain('pdfBase64')
+  })
+
+  it('gets client primary contact for signer details', () => {
+    const code = source()
+    expect(code).toContain('listContacts')
+    expect(code).toContain('primaryContact')
+  })
+
+  it('calls createSignatureRequest with signer and field placements', () => {
+    const code = source()
+    expect(code).toContain('createSignatureRequest')
+    expect(code).toContain('signers')
+    expect(code).toContain('fields')
+  })
+
+  it('includes signature and date field placements', () => {
+    const code = source()
+    expect(code).toContain("type: 'signature'")
+    expect(code).toContain("type: 'date'")
+  })
+
+  it('sets callback_url for webhook', () => {
+    expect(source()).toContain('callback_url')
+  })
+
+  it('stores signwell_doc_id on the quote', () => {
+    const code = source()
+    expect(code).toContain('signwell_doc_id = ?')
+    expect(code).toContain('signwellDoc.id')
+  })
+
+  it('transitions draft to sent when sending for signature', () => {
+    const code = source()
+    expect(code).toContain("status = 'sent'")
+    expect(code).toContain('sent_at')
+    expect(code).toContain('expires_at')
+  })
+
+  it('redirects back to quote detail page on success', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients/')
+    expect(code).toContain('saved=1')
+  })
+
+  it('uses parameterized queries with .bind()', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+})
+
+describe('signwell: quote detail page integration', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/quotes/[quoteId].astro'), 'utf-8')
+
+  it('includes Send for Signature button', () => {
+    const code = source()
+    expect(code).toContain('Send for Signature')
+    expect(code).toContain('/sign')
+  })
+
+  it('shows Send for Signature when SOW exists and no signwell_doc_id', () => {
+    const code = source()
+    expect(code).toContain('canSendForSignature')
+  })
+
+  it('shows Awaiting Signature badge when signwell_doc_id exists and sent', () => {
+    const code = source()
+    expect(code).toContain('Awaiting Signature')
+    expect(code).toContain('hasSignwell')
+  })
+
+  it('includes View Signed SOW link when signed_sow_path exists', () => {
+    const code = source()
+    expect(code).toContain('View Signed SOW')
+    expect(code).toContain('hasSignedSow')
+  })
+
+  it('tracks signwell status with data attributes', () => {
+    const code = source()
+    expect(code).toContain('data-signwell-status="awaiting"')
+    expect(code).toContain('data-signwell-status="signed"')
+  })
+
+  it('uses data-signwell-sign attribute on signature form', () => {
+    expect(source()).toContain('data-signwell-sign')
+  })
+
+  it('uses data-signed-sow-link attribute on view link', () => {
+    expect(source()).toContain('data-signed-sow-link')
+  })
+})
+
+describe('signwell: env.d.ts bindings', () => {
+  const source = () => readFileSync(resolve('src/env.d.ts'), 'utf-8')
+
+  it('declares SIGNWELL_API_KEY in CfEnv', () => {
+    expect(source()).toContain('SIGNWELL_API_KEY')
+  })
+
+  it('declares SIGNWELL_WEBHOOK_SECRET in CfEnv', () => {
+    expect(source()).toContain('SIGNWELL_WEBHOOK_SECRET')
+  })
+
+  it('SignWell bindings are optional (using ?)', () => {
+    const code = source()
+    expect(code).toContain('SIGNWELL_API_KEY?: string')
+    expect(code).toContain('SIGNWELL_WEBHOOK_SECRET?: string')
+  })
+})


### PR DESCRIPTION
## Summary

- **SignWell API client** (`src/lib/signwell/client.ts`) — raw `fetch` against the SignWell v1 REST API for creating signature requests, retrieving documents, and downloading signed PDFs. No SDK dependency.
- **Two-phase webhook handler** (`src/lib/webhooks/signwell-handler.ts`) — follows the `d1-batch-api` spike pattern exactly: atomic `db.batch()` in Phase 1 (quote accepted, client active, engagement created, deposit invoice created), best-effort side effects in Phase 2 (signed PDF to R2, confirmation email via Resend). Returns 200 after Phase 1 even if Phase 2 fails.
- **Webhook route** (`src/pages/api/webhooks/signwell.ts`) — HMAC-SHA256 signature verification using Web Crypto API with constant-time comparison. Dispatches `document_completed` events to the handler.
- **Admin send-for-signature route** (`src/pages/api/admin/quotes/[id]/sign.ts`) — retrieves SOW PDF from R2, base64-encodes it, sends to SignWell with signer details and callback URL, stores `signwell_doc_id`, transitions draft quotes to sent.
- **Quote detail page updates** — "Send for Signature" button, "Awaiting Signature" badge, "View Signed SOW" link with data attributes for testability.
- **78 new tests** covering file existence, exports, API client patterns, webhook handler two-phase structure, idempotency checks, signature verification, and UI integration.

## Key design decisions

- Idempotency guard: checks `quote.status === 'accepted'` before processing (webhooks can be delivered multiple times)
- All entity IDs generated with `crypto.randomUUID()` before the batch (no cross-statement dependency)
- Webhook returns 500 only on Phase 1 failure (triggers retry); returns 200 after successful batch even if side effects fail
- Unknown SignWell documents acknowledged with 200 (non-retryable)

## Test plan

- [x] `npm run verify` passes (0 errors, lint clean, build successful, 707/707 tests pass)
- [ ] Manual test: configure `SIGNWELL_API_KEY` and `SIGNWELL_WEBHOOK_SECRET` in wrangler.toml secrets
- [ ] Manual test: generate SOW PDF, click "Send for Signature", verify SignWell receives document
- [ ] Manual test: sign document in SignWell, verify webhook creates engagement + invoice atomically
- [ ] Manual test: verify signed PDF uploaded to R2 and confirmation email sent

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)