### PR TITLE
feat: add time tracking and parking lot (#78, #79)

### DIFF
--- a/src/lib/db/parking-lot.ts
+++ b/src/lib/db/parking-lot.ts
@@ -1,0 +1,200 @@
+/**
+ * Parking lot data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ *
+ * Parking lot items capture scope requests that surface during an engagement
+ * but fall outside the current SOW. Items are dispositioned as fold_in (absorb
+ * into current scope), follow_on (create a new quote), or dropped.
+ */
+
+export interface ParkingLotItem {
+  id: string
+  engagement_id: string
+  description: string
+  requested_by: string | null
+  requested_at: string
+  disposition: string | null
+  disposition_note: string | null
+  reviewed_at: string | null
+  follow_on_quote_id: string | null
+  created_at: string
+}
+
+export type Disposition = 'fold_in' | 'follow_on' | 'dropped'
+
+export const DISPOSITIONS: { value: Disposition; label: string }[] = [
+  { value: 'fold_in', label: 'Fold In' },
+  { value: 'follow_on', label: 'Follow-on' },
+  { value: 'dropped', label: 'Dropped' },
+]
+
+export interface CreateParkingLotItemData {
+  description: string
+  requested_by?: string | null
+}
+
+export interface UpdateParkingLotItemData {
+  description?: string
+  requested_by?: string | null
+}
+
+/**
+ * List parking lot items for an engagement, ordered by created_at DESC.
+ */
+export async function listParkingLotItems(
+  db: D1Database,
+  engagementId: string
+): Promise<ParkingLotItem[]> {
+  const result = await db
+    .prepare('SELECT * FROM parking_lot WHERE engagement_id = ? ORDER BY created_at DESC')
+    .bind(engagementId)
+    .all<ParkingLotItem>()
+  return result.results
+}
+
+/**
+ * Get a single parking lot item by ID.
+ */
+export async function getParkingLotItem(
+  db: D1Database,
+  id: string
+): Promise<ParkingLotItem | null> {
+  const result = await db
+    .prepare('SELECT * FROM parking_lot WHERE id = ?')
+    .bind(id)
+    .first<ParkingLotItem>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new parking lot item linked to an engagement. Returns the created record.
+ */
+export async function createParkingLotItem(
+  db: D1Database,
+  engagementId: string,
+  data: CreateParkingLotItemData
+): Promise<ParkingLotItem> {
+  const id = crypto.randomUUID()
+
+  await db
+    .prepare(
+      `INSERT INTO parking_lot (id, engagement_id, description, requested_by)
+     VALUES (?, ?, ?, ?)`
+    )
+    .bind(id, engagementId, data.description, data.requested_by ?? null)
+    .run()
+
+  const item = await getParkingLotItem(db, id)
+  if (!item) {
+    throw new Error('Failed to retrieve created parking lot item')
+  }
+  return item
+}
+
+/**
+ * Update an existing parking lot item (description and requested_by only).
+ * Returns the updated record.
+ */
+export async function updateParkingLotItem(
+  db: D1Database,
+  id: string,
+  data: UpdateParkingLotItemData
+): Promise<ParkingLotItem | null> {
+  const existing = await getParkingLotItem(db, id)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.description !== undefined) {
+    fields.push('description = ?')
+    params.push(data.description)
+  }
+
+  if (data.requested_by !== undefined) {
+    fields.push('requested_by = ?')
+    params.push(data.requested_by)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  const sql = `UPDATE parking_lot SET ${fields.join(', ')} WHERE id = ?`
+  params.push(id)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getParkingLotItem(db, id)
+}
+
+/**
+ * Dispose of a parking lot item. Sets disposition, disposition_note, and reviewed_at.
+ * Returns the updated record.
+ */
+export async function disposeParkingLotItem(
+  db: D1Database,
+  id: string,
+  disposition: Disposition,
+  note?: string | null
+): Promise<ParkingLotItem | null> {
+  const existing = await getParkingLotItem(db, id)
+  if (!existing) {
+    return null
+  }
+
+  const now = new Date().toISOString()
+
+  await db
+    .prepare(
+      'UPDATE parking_lot SET disposition = ?, disposition_note = ?, reviewed_at = ? WHERE id = ?'
+    )
+    .bind(disposition, note ?? null, now, id)
+    .run()
+
+  return getParkingLotItem(db, id)
+}
+
+/**
+ * Link a follow-on quote to a parking lot item.
+ * Returns the updated record.
+ */
+export async function linkFollowOnQuote(
+  db: D1Database,
+  id: string,
+  quoteId: string
+): Promise<ParkingLotItem | null> {
+  const existing = await getParkingLotItem(db, id)
+  if (!existing) {
+    return null
+  }
+
+  await db
+    .prepare('UPDATE parking_lot SET follow_on_quote_id = ? WHERE id = ?')
+    .bind(quoteId, id)
+    .run()
+
+  return getParkingLotItem(db, id)
+}
+
+/**
+ * Delete a parking lot item. Returns true if the item was found and deleted.
+ */
+export async function deleteParkingLotItem(db: D1Database, id: string): Promise<boolean> {
+  const existing = await getParkingLotItem(db, id)
+  if (!existing) {
+    return false
+  }
+
+  await db.prepare('DELETE FROM parking_lot WHERE id = ?').bind(id).run()
+
+  return true
+}

--- a/src/lib/db/time-entries.ts
+++ b/src/lib/db/time-entries.ts
@@ -1,0 +1,198 @@
+/**
+ * Time entry data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ *
+ * After every create/update/delete, recalculateActualHours is called
+ * to keep engagements.actual_hours in sync with the SUM of time_entries.
+ */
+
+export interface TimeEntry {
+  id: string
+  engagement_id: string
+  date: string
+  hours: number
+  description: string | null
+  category: string | null
+  created_at: string
+}
+
+export type TimeEntryCategory =
+  | 'solution_design'
+  | 'implementation'
+  | 'training'
+  | 'admin'
+  | 'other'
+
+export const TIME_ENTRY_CATEGORIES: { value: TimeEntryCategory; label: string }[] = [
+  { value: 'solution_design', label: 'Solution Design' },
+  { value: 'implementation', label: 'Implementation' },
+  { value: 'training', label: 'Training' },
+  { value: 'admin', label: 'Admin' },
+  { value: 'other', label: 'Other' },
+]
+
+export interface CreateTimeEntryData {
+  date: string
+  hours: number
+  description?: string | null
+  category?: string | null
+}
+
+export interface UpdateTimeEntryData {
+  date?: string
+  hours?: number
+  description?: string | null
+  category?: string | null
+}
+
+/**
+ * List time entries for an engagement, ordered by date DESC.
+ */
+export async function listTimeEntries(db: D1Database, engagementId: string): Promise<TimeEntry[]> {
+  const result = await db
+    .prepare('SELECT * FROM time_entries WHERE engagement_id = ? ORDER BY date DESC')
+    .bind(engagementId)
+    .all<TimeEntry>()
+  return result.results
+}
+
+/**
+ * Get a single time entry by ID.
+ */
+export async function getTimeEntry(db: D1Database, id: string): Promise<TimeEntry | null> {
+  const result = await db
+    .prepare('SELECT * FROM time_entries WHERE id = ?')
+    .bind(id)
+    .first<TimeEntry>()
+
+  return result ?? null
+}
+
+/**
+ * Recalculate engagement actual_hours from the SUM of time_entries.hours.
+ * Called automatically after create/update/delete.
+ */
+export async function recalculateActualHours(db: D1Database, engagementId: string): Promise<void> {
+  const result = await db
+    .prepare('SELECT COALESCE(SUM(hours), 0) as total FROM time_entries WHERE engagement_id = ?')
+    .bind(engagementId)
+    .first<{ total: number }>()
+
+  const total = result?.total ?? 0
+
+  await db
+    .prepare("UPDATE engagements SET actual_hours = ?, updated_at = datetime('now') WHERE id = ?")
+    .bind(total, engagementId)
+    .run()
+}
+
+/**
+ * Create a new time entry linked to an engagement. Returns the created record.
+ * Automatically recalculates engagement actual_hours after insert.
+ */
+export async function createTimeEntry(
+  db: D1Database,
+  engagementId: string,
+  data: CreateTimeEntryData
+): Promise<TimeEntry> {
+  const id = crypto.randomUUID()
+
+  await db
+    .prepare(
+      `INSERT INTO time_entries (id, org_id, engagement_id, date, hours, description, category)
+     VALUES (?, (SELECT org_id FROM engagements WHERE id = ?), ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      engagementId,
+      engagementId,
+      data.date,
+      data.hours,
+      data.description ?? null,
+      data.category ?? null
+    )
+    .run()
+
+  await recalculateActualHours(db, engagementId)
+
+  const entry = await getTimeEntry(db, id)
+  if (!entry) {
+    throw new Error('Failed to retrieve created time entry')
+  }
+  return entry
+}
+
+/**
+ * Update an existing time entry. Returns the updated record.
+ * Automatically recalculates engagement actual_hours after update.
+ */
+export async function updateTimeEntry(
+  db: D1Database,
+  id: string,
+  data: UpdateTimeEntryData
+): Promise<TimeEntry | null> {
+  const existing = await getTimeEntry(db, id)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.date !== undefined) {
+    fields.push('date = ?')
+    params.push(data.date)
+  }
+
+  if (data.hours !== undefined) {
+    fields.push('hours = ?')
+    params.push(data.hours)
+  }
+
+  if (data.description !== undefined) {
+    fields.push('description = ?')
+    params.push(data.description)
+  }
+
+  if (data.category !== undefined) {
+    fields.push('category = ?')
+    params.push(data.category)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  const sql = `UPDATE time_entries SET ${fields.join(', ')} WHERE id = ?`
+  params.push(id)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  await recalculateActualHours(db, existing.engagement_id)
+
+  return getTimeEntry(db, id)
+}
+
+/**
+ * Delete a time entry. Returns true if the entry was found and deleted.
+ * Automatically recalculates engagement actual_hours after delete.
+ */
+export async function deleteTimeEntry(db: D1Database, id: string): Promise<boolean> {
+  const existing = await getTimeEntry(db, id)
+  if (!existing) {
+    return false
+  }
+
+  const engagementId = existing.engagement_id
+
+  await db.prepare('DELETE FROM time_entries WHERE id = ?').bind(id).run()
+
+  await recalculateActualHours(db, engagementId)
+
+  return true
+}

--- a/src/pages/admin/clients/[id]/engagements/[engId].astro
+++ b/src/pages/admin/clients/[id]/engagements/[engId].astro
@@ -14,6 +14,8 @@ import {
 } from '../../../../../lib/db/milestones'
 import type { MilestoneStatus } from '../../../../../lib/db/milestones'
 import { getEngagementContacts, ENGAGEMENT_CONTACT_ROLES } from '../../../../../lib/db/contacts'
+import { listTimeEntries } from '../../../../../lib/db/time-entries'
+import { listParkingLotItems } from '../../../../../lib/db/parking-lot'
 
 /**
  * Engagement detail/edit page.
@@ -42,6 +44,20 @@ if (!engagement) {
 
 const milestones = await listMilestones(env.DB, engagementId)
 const engagementContacts = await getEngagementContacts(env.DB, engagementId)
+const timeEntries = await listTimeEntries(env.DB, engagementId)
+const parkingLotItems = await listParkingLotItems(env.DB, engagementId)
+
+// Time tracking summary
+const totalLoggedHours = timeEntries.reduce((sum, e) => sum + e.hours, 0)
+const estimatedHours = engagement.estimated_hours ?? 0
+const hoursPercentage =
+  estimatedHours > 0 ? Math.round((totalLoggedHours / estimatedHours) * 100) : 0
+const hoursVariance = totalLoggedHours - estimatedHours
+const isOverBudget = estimatedHours > 0 && totalLoggedHours > estimatedHours
+
+// Parking lot summary
+const parkingLotTotal = parkingLotItems.length
+const parkingLotUndispositioned = parkingLotItems.filter((i) => !i.disposition).length
 
 const url = Astro.url
 const saved = url.searchParams.get('saved') === '1'
@@ -714,6 +730,130 @@ const showSafetyNet = engagement.status === 'handoff' || engagement.status === '
             </div>
           )
         }
+      </div>
+
+      <!-- Time Tracking Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">
+            Time Tracking
+            <span class="text-sm font-normal text-slate-400 ml-1"
+              >({timeEntries.length} entries)</span
+            >
+          </h2>
+          <a
+            href={`/admin/clients/${client.id}/engagements/${engagement.id}/time`}
+            class="text-sm text-primary hover:text-primary-hover font-medium transition-colors"
+          >
+            View All
+          </a>
+        </div>
+
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <div class="grid grid-cols-3 gap-4 mb-3">
+            <div>
+              <p class="text-xs text-slate-500">Estimated</p>
+              <p class="text-sm font-semibold text-slate-900">
+                {estimatedHours > 0 ? `${estimatedHours}h` : '--'}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-slate-500">Actual</p>
+              <p
+                class:list={[
+                  'text-sm font-semibold',
+                  isOverBudget ? 'text-red-600' : 'text-slate-900',
+                ]}
+              >
+                {totalLoggedHours}h
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-slate-500">Variance</p>
+              <p
+                class:list={[
+                  'text-sm font-semibold',
+                  hoursVariance > 0
+                    ? 'text-red-600'
+                    : hoursVariance < 0
+                      ? 'text-green-600'
+                      : 'text-slate-900',
+                ]}
+              >
+                {
+                  estimatedHours > 0
+                    ? `${hoursVariance > 0 ? '+' : ''}${hoursVariance.toFixed(1)}h`
+                    : '--'
+                }
+              </p>
+            </div>
+          </div>
+          {
+            estimatedHours > 0 && (
+              <div>
+                <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+                  <span>Progress</span>
+                  <span>{hoursPercentage}%</span>
+                </div>
+                <div class="w-full bg-slate-100 rounded-full h-2">
+                  <div
+                    class:list={[
+                      'h-2 rounded-full transition-all',
+                      isOverBudget
+                        ? 'bg-red-500'
+                        : hoursPercentage >= 80
+                          ? 'bg-amber-500'
+                          : 'bg-primary',
+                    ]}
+                    style={`width: ${Math.min(hoursPercentage, 100)}%`}
+                  />
+                </div>
+              </div>
+            )
+          }
+        </div>
+      </div>
+
+      <!-- Parking Lot Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">
+            Parking Lot
+            <span class="text-sm font-normal text-slate-400 ml-1">({parkingLotTotal} items)</span>
+          </h2>
+          <a
+            href={`/admin/clients/${client.id}/engagements/${engagement.id}/parking-lot`}
+            class="text-sm text-primary hover:text-primary-hover font-medium transition-colors"
+          >
+            View All
+          </a>
+        </div>
+
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          {
+            parkingLotTotal > 0 ? (
+              <div class="grid grid-cols-2 gap-4">
+                <div>
+                  <p class="text-xs text-slate-500">Total Items</p>
+                  <p class="text-sm font-semibold text-slate-900">{parkingLotTotal}</p>
+                </div>
+                <div>
+                  <p class="text-xs text-slate-500">Needs Review</p>
+                  <p
+                    class:list={[
+                      'text-sm font-semibold',
+                      parkingLotUndispositioned > 0 ? 'text-amber-600' : 'text-slate-900',
+                    ]}
+                  >
+                    {parkingLotUndispositioned}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <p class="text-sm text-slate-400 text-center">No parking lot items yet.</p>
+            )
+          }
+        </div>
       </div>
     </main>
   </body>

--- a/src/pages/admin/clients/[id]/engagements/[engId]/parking-lot.astro
+++ b/src/pages/admin/clients/[id]/engagements/[engId]/parking-lot.astro
@@ -1,0 +1,373 @@
+---
+import '../../../../../../styles/global.css'
+import { getClient } from '../../../../../../lib/db/clients'
+import { getEngagement } from '../../../../../../lib/db/engagements'
+import { listParkingLotItems, DISPOSITIONS } from '../../../../../../lib/db/parking-lot'
+
+/**
+ * Parking lot page for an engagement.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Lists parking lot items with disposition controls, and provides an add form.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId, engId: engagementId } = Astro.params
+
+if (!clientId || !engagementId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+if (!engagement) {
+  return Astro.redirect(`/admin/clients/${clientId}?error=engagement_not_found`)
+}
+
+const items = await listParkingLotItems(env.DB, engagementId)
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const deleted = url.searchParams.get('deleted') === '1'
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+  missing: 'Required fields are missing.',
+  not_found: 'Record not found.',
+  invalid_status: 'Invalid disposition selection.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Count stats
+const totalItems = items.length
+const undispositioned = items.filter((i) => !i.disposition).length
+
+// Color coding for disposition status
+const dispositionColor = (disposition: string | null) => {
+  switch (disposition) {
+    case 'fold_in':
+      return 'bg-green-100 text-green-800 border-green-200'
+    case 'follow_on':
+      return 'bg-blue-100 text-blue-800 border-blue-200'
+    case 'dropped':
+      return 'bg-slate-100 text-slate-500 border-slate-200'
+    default:
+      return 'bg-amber-50 text-amber-800 border-amber-200'
+  }
+}
+
+const dispositionBadge = (disposition: string | null) => {
+  switch (disposition) {
+    case 'fold_in':
+      return 'bg-green-100 text-green-700'
+    case 'follow_on':
+      return 'bg-blue-100 text-blue-700'
+    case 'dropped':
+      return 'bg-slate-100 text-slate-500'
+    default:
+      return 'bg-amber-100 text-amber-700'
+  }
+}
+
+const dispositionLabel = (disposition: string | null) =>
+  DISPOSITIONS.find((d) => d.value === disposition)?.label ?? 'Undispositioned'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Parking Lot — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a
+              href={`/admin/clients/${client.id}/engagements/${engagement.id}`}
+              class="hover:text-slate-700">Engagement</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Parking Lot</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-2">Parking Lot</h1>
+      <p class="text-sm text-slate-500 mb-6">{client.business_name}</p>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Parking lot item saved successfully.
+          </div>
+        )
+      }
+
+      {
+        deleted && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Parking lot item deleted.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <!-- Summary -->
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <p class="text-xs text-slate-500 mb-1">Total Items</p>
+            <p class="text-xl font-bold text-slate-900">{totalItems}</p>
+          </div>
+          <div>
+            <p class="text-xs text-slate-500 mb-1">Needs Review</p>
+            <p
+              class:list={[
+                'text-xl font-bold',
+                undispositioned > 0 ? 'text-amber-600' : 'text-slate-900',
+              ]}
+            >
+              {undispositioned}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Add Item Form -->
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-3">Add Item</h2>
+        <form method="POST" action="/api/admin/parking-lot" class="space-y-4">
+          <input type="hidden" name="engagement_id" value={engagement.id} />
+          <input type="hidden" name="client_id" value={client.id} />
+
+          <div>
+            <label for="item_description" class="block text-sm font-medium text-slate-700 mb-1">
+              Description <span class="text-red-500">*</span>
+            </label>
+            <textarea
+              id="item_description"
+              name="description"
+              rows="2"
+              required
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="What was requested..."></textarea>
+          </div>
+
+          <div>
+            <label for="item_requested_by" class="block text-sm font-medium text-slate-700 mb-1">
+              Requested By
+            </label>
+            <input
+              type="text"
+              id="item_requested_by"
+              name="requested_by"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="Who requested this..."
+            />
+          </div>
+
+          <div class="flex justify-end">
+            <button
+              type="submit"
+              class="bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+            >
+              Add Item
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <!-- Items List -->
+      <div>
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">
+            Items
+            <span class="text-sm font-normal text-slate-400 ml-1">({totalItems})</span>
+          </h2>
+        </div>
+
+        {
+          items.length > 0 ? (
+            <div class="space-y-3">
+              {items.map((item) => (
+                <div class={`bg-white rounded-lg border p-4 ${dispositionColor(item.disposition)}`}>
+                  <div class="flex items-start justify-between mb-2">
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2 mb-1">
+                        <span
+                          class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${dispositionBadge(item.disposition)}`}
+                        >
+                          {dispositionLabel(item.disposition)}
+                        </span>
+                        <span class="text-xs text-slate-400">
+                          {new Date(item.created_at).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric',
+                          })}
+                        </span>
+                      </div>
+                      <p class="text-sm text-slate-900">{item.description}</p>
+                      {item.requested_by && (
+                        <p class="text-xs text-slate-500 mt-1">Requested by: {item.requested_by}</p>
+                      )}
+                      {item.disposition_note && (
+                        <p class="text-xs text-slate-500 mt-1 italic">
+                          Note: {item.disposition_note}
+                        </p>
+                      )}
+                    </div>
+                    <form
+                      method="POST"
+                      action={`/api/admin/parking-lot/${item.id}`}
+                      class="flex-shrink-0 ml-2"
+                      onsubmit="return confirm('Delete this parking lot item?')"
+                    >
+                      <input type="hidden" name="_method" value="DELETE" />
+                      <input type="hidden" name="client_id" value={client.id} />
+                      <button
+                        type="submit"
+                        class="px-2 py-1 rounded text-xs font-medium bg-red-50 text-red-500 hover:bg-red-100 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </form>
+                  </div>
+
+                  {/* Disposition controls for undispositioned items */}
+                  {!item.disposition && (
+                    <form
+                      method="POST"
+                      action={`/api/admin/parking-lot/${item.id}`}
+                      class="mt-3 pt-3 border-t border-slate-200 space-y-2"
+                    >
+                      <input type="hidden" name="action" value="dispose" />
+                      <input type="hidden" name="client_id" value={client.id} />
+                      <div class="grid grid-cols-2 gap-3">
+                        <div>
+                          <label class="block text-xs font-medium text-slate-600 mb-1">
+                            Disposition
+                          </label>
+                          <select
+                            name="disposition"
+                            required
+                            class="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                          >
+                            <option value="">Select...</option>
+                            {DISPOSITIONS.map((d) => (
+                              <option value={d.value}>{d.label}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div>
+                          <label class="block text-xs font-medium text-slate-600 mb-1">Note</label>
+                          <input
+                            type="text"
+                            name="disposition_note"
+                            class="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                            placeholder="Optional note..."
+                          />
+                        </div>
+                      </div>
+                      <div class="flex justify-end">
+                        <button
+                          type="submit"
+                          class="bg-slate-700 text-white px-3 py-1 rounded text-xs font-medium hover:bg-slate-800 transition-colors"
+                        >
+                          Dispose
+                        </button>
+                      </div>
+                    </form>
+                  )}
+
+                  {/* Follow-on quote link for follow_on items */}
+                  {item.disposition === 'follow_on' && !item.follow_on_quote_id && (
+                    <div class="mt-3 pt-3 border-t border-blue-200">
+                      <a
+                        href={`/admin/clients/${client.id}/quotes/new?engagement_id=${engagement.id}&parking_lot_id=${item.id}`}
+                        class="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
+                      >
+                        Create Follow-on Quote
+                      </a>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400 mb-2">No parking lot items yet.</p>
+              <p class="text-xs text-slate-400">
+                Use the form above to capture out-of-scope requests.
+              </p>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Back link -->
+      <div class="mt-6">
+        <a
+          href={`/admin/clients/${client.id}/engagements/${engagement.id}`}
+          class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+        >
+          Back to Engagement
+        </a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/clients/[id]/engagements/[engId]/time.astro
+++ b/src/pages/admin/clients/[id]/engagements/[engId]/time.astro
@@ -1,0 +1,345 @@
+---
+import '../../../../../../styles/global.css'
+import { getClient } from '../../../../../../lib/db/clients'
+import { getEngagement } from '../../../../../../lib/db/engagements'
+import { listTimeEntries, TIME_ENTRY_CATEGORIES } from '../../../../../../lib/db/time-entries'
+
+/**
+ * Time tracking page for an engagement.
+ *
+ * Protected by auth middleware (session guaranteed).
+ * Lists time entries, shows estimated vs actual hours, and provides add/delete forms.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId, engId: engagementId } = Astro.params
+
+if (!clientId || !engagementId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+if (!engagement) {
+  return Astro.redirect(`/admin/clients/${clientId}?error=engagement_not_found`)
+}
+
+const entries = await listTimeEntries(env.DB, engagementId)
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const deleted = url.searchParams.get('deleted') === '1'
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+  missing: 'Required fields are missing.',
+  not_found: 'Record not found.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Hours comparison
+const estimated = engagement.estimated_hours ?? 0
+const actual = engagement.actual_hours ?? 0
+const percentage = estimated > 0 ? Math.round((actual / estimated) * 100) : 0
+const variance = actual - estimated
+const isOverBudget = estimated > 0 && actual > estimated
+
+// Category label helper
+const categoryLabel = (cat: string | null) =>
+  TIME_ENTRY_CATEGORIES.find((c) => c.value === cat)?.label ?? cat ?? 'Uncategorized'
+
+// Today's date for default value
+const today = new Date().toISOString().split('T')[0]
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Time Tracking — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a
+              href={`/admin/clients/${client.id}/engagements/${engagement.id}`}
+              class="hover:text-slate-700">Engagement</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Time Tracking</li>
+        </ol>
+      </nav>
+
+      <h1 class="text-2xl font-bold text-slate-900 mb-2">Time Tracking</h1>
+      <p class="text-sm text-slate-500 mb-6">{client.business_name}</p>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Time entry saved successfully.
+          </div>
+        )
+      }
+
+      {
+        deleted && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Time entry deleted.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <!-- Hours Summary -->
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">Hours Summary</h2>
+        <div class="grid grid-cols-3 gap-4 mb-4">
+          <div>
+            <p class="text-xs text-slate-500 mb-1">Estimated</p>
+            <p class="text-xl font-bold text-slate-900">
+              {estimated > 0 ? `${estimated}h` : '--'}
+            </p>
+          </div>
+          <div>
+            <p class="text-xs text-slate-500 mb-1">Actual</p>
+            <p class:list={['text-xl font-bold', isOverBudget ? 'text-red-600' : 'text-slate-900']}>
+              {actual}h
+            </p>
+          </div>
+          <div>
+            <p class="text-xs text-slate-500 mb-1">Variance</p>
+            <p
+              class:list={[
+                'text-xl font-bold',
+                variance > 0 ? 'text-red-600' : variance < 0 ? 'text-green-600' : 'text-slate-900',
+              ]}
+            >
+              {estimated > 0 ? `${variance > 0 ? '+' : ''}${variance.toFixed(1)}h` : '--'}
+            </p>
+          </div>
+        </div>
+
+        {
+          estimated > 0 && (
+            <div>
+              <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+                <span>Progress</span>
+                <span>{percentage}%</span>
+              </div>
+              <div class="w-full bg-slate-100 rounded-full h-2.5">
+                <div
+                  class:list={[
+                    'h-2.5 rounded-full transition-all',
+                    isOverBudget ? 'bg-red-500' : percentage >= 80 ? 'bg-amber-500' : 'bg-primary',
+                  ]}
+                  style={`width: ${Math.min(percentage, 100)}%`}
+                />
+              </div>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Add Entry Form -->
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-3">Add Entry</h2>
+        <form method="POST" action="/api/admin/time-entries" class="space-y-4">
+          <input type="hidden" name="engagement_id" value={engagement.id} />
+          <input type="hidden" name="client_id" value={client.id} />
+
+          <div class="grid grid-cols-3 gap-4">
+            <div>
+              <label for="entry_date" class="block text-sm font-medium text-slate-700 mb-1">
+                Date <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="date"
+                id="entry_date"
+                name="date"
+                required
+                value={today}
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="entry_hours" class="block text-sm font-medium text-slate-700 mb-1">
+                Hours <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                id="entry_hours"
+                name="hours"
+                required
+                step="0.25"
+                min="0.25"
+                placeholder="1.5"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="entry_category" class="block text-sm font-medium text-slate-700 mb-1">
+                Category
+              </label>
+              <select
+                id="entry_category"
+                name="category"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              >
+                <option value="">Select...</option>
+                {TIME_ENTRY_CATEGORIES.map((c) => <option value={c.value}>{c.label}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label for="entry_description" class="block text-sm font-medium text-slate-700 mb-1">
+              Description
+            </label>
+            <input
+              type="text"
+              id="entry_description"
+              name="description"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="What was done..."
+            />
+          </div>
+
+          <div class="flex justify-end">
+            <button
+              type="submit"
+              class="bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+            >
+              Add Entry
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <!-- Time Entries List -->
+      <div>
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">
+            Entries
+            <span class="text-sm font-normal text-slate-400 ml-1">({entries.length})</span>
+          </h2>
+        </div>
+
+        {
+          entries.length > 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {entries.map((entry) => (
+                <div class="px-4 py-3">
+                  <div class="flex items-center justify-between">
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2">
+                        <p class="text-sm font-medium text-slate-900">{entry.hours}h</p>
+                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-600">
+                          {categoryLabel(entry.category)}
+                        </span>
+                        <span class="text-xs text-slate-400">
+                          {new Date(entry.date).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric',
+                          })}
+                        </span>
+                      </div>
+                      {entry.description && (
+                        <p class="text-xs text-slate-500 mt-0.5">{entry.description}</p>
+                      )}
+                    </div>
+                    <form
+                      method="POST"
+                      action={`/api/admin/time-entries/${entry.id}`}
+                      class="flex-shrink-0 ml-2"
+                      onsubmit="return confirm('Delete this time entry?')"
+                    >
+                      <input type="hidden" name="_method" value="DELETE" />
+                      <input type="hidden" name="client_id" value={client.id} />
+                      <button
+                        type="submit"
+                        class="px-2 py-1 rounded text-xs font-medium bg-red-50 text-red-500 hover:bg-red-100 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </form>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+              <p class="text-sm text-slate-400 mb-2">No time entries yet.</p>
+              <p class="text-xs text-slate-400">Use the form above to log time.</p>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Back link -->
+      <div class="mt-6">
+        <a
+          href={`/admin/clients/${client.id}/engagements/${engagement.id}`}
+          class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+        >
+          Back to Engagement
+        </a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/api/admin/parking-lot/[id].ts
+++ b/src/pages/api/admin/parking-lot/[id].ts
@@ -1,0 +1,127 @@
+import type { APIRoute } from 'astro'
+import {
+  getParkingLotItem,
+  updateParkingLotItem,
+  disposeParkingLotItem,
+  deleteParkingLotItem,
+} from '../../../../lib/db/parking-lot'
+import type { Disposition } from '../../../../lib/db/parking-lot'
+import { getEngagement } from '../../../../lib/db/engagements'
+
+/**
+ * POST /api/admin/parking-lot/:id
+ *
+ * Updates, disposes, or deletes a parking lot item.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields for update:
+ *   - action: "update"
+ *   - client_id (required, for redirect)
+ *   - description
+ *   - requested_by
+ *
+ * Form fields for disposition:
+ *   - action: "dispose"
+ *   - client_id (required, for redirect)
+ *   - disposition (required: fold_in | follow_on | dropped)
+ *   - disposition_note
+ *
+ * Form fields for delete:
+ *   - _method: "DELETE"
+ *   - client_id (required, for redirect)
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const itemId = params.id
+  if (!itemId) {
+    return new Response(JSON.stringify({ error: 'Parking lot item ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const item = await getParkingLotItem(env.DB, itemId)
+    if (!item) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    // Verify the engagement belongs to this org
+    const engagement = await getEngagement(env.DB, session.orgId, item.engagement_id)
+    if (!engagement) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const clientId = formData.get('client_id')
+    const clientIdStr =
+      clientId && typeof clientId === 'string' ? clientId.trim() : engagement.client_id
+
+    const parkingLotUrl = `/admin/clients/${clientIdStr}/engagements/${item.engagement_id}/parking-lot`
+
+    const method = formData.get('_method')
+    const action = formData.get('action')
+
+    // Handle DELETE
+    if (method === 'DELETE') {
+      await deleteParkingLotItem(env.DB, itemId)
+      return redirect(`${parkingLotUrl}?deleted=1`, 302)
+    }
+
+    // Handle disposition
+    if (action === 'dispose') {
+      const disposition = formData.get('disposition')
+      if (!disposition || typeof disposition !== 'string') {
+        return redirect(`${parkingLotUrl}?error=missing`, 302)
+      }
+
+      const validDispositions: Disposition[] = ['fold_in', 'follow_on', 'dropped']
+      if (!validDispositions.includes(disposition as Disposition)) {
+        return redirect(`${parkingLotUrl}?error=invalid_status`, 302)
+      }
+
+      const dispositionNote = formData.get('disposition_note')
+
+      await disposeParkingLotItem(
+        env.DB,
+        itemId,
+        disposition as Disposition,
+        dispositionNote && typeof dispositionNote === 'string' && dispositionNote.trim()
+          ? dispositionNote.trim()
+          : null
+      )
+
+      return redirect(`${parkingLotUrl}?saved=1`, 302)
+    }
+
+    // Handle update
+    const description = formData.get('description')
+    const requestedBy = formData.get('requested_by')
+
+    await updateParkingLotItem(env.DB, itemId, {
+      description:
+        description && typeof description === 'string' && description.trim()
+          ? description.trim()
+          : undefined,
+      requested_by:
+        requestedBy !== null && typeof requestedBy === 'string'
+          ? requestedBy.trim() || null
+          : undefined,
+    })
+
+    return redirect(`${parkingLotUrl}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/parking-lot/[id]] Error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/parking-lot/index.ts
+++ b/src/pages/api/admin/parking-lot/index.ts
@@ -1,0 +1,70 @@
+import type { APIRoute } from 'astro'
+import { getEngagement } from '../../../../lib/db/engagements'
+import { createParkingLotItem } from '../../../../lib/db/parking-lot'
+
+/**
+ * POST /api/admin/parking-lot
+ *
+ * Creates a new parking lot item for an engagement.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields:
+ *   - engagement_id (required)
+ *   - client_id (required, for redirect)
+ *   - description (required)
+ *   - requested_by
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const formData = await request.formData()
+    const engagementId = formData.get('engagement_id')
+    const clientId = formData.get('client_id')
+
+    if (
+      !engagementId ||
+      typeof engagementId !== 'string' ||
+      !clientId ||
+      typeof clientId !== 'string'
+    ) {
+      return redirect('/admin/clients?error=missing', 302)
+    }
+
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId.trim())
+    if (!engagement) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const parkingLotUrl = `/admin/clients/${clientId.trim()}/engagements/${engagementId.trim()}/parking-lot`
+
+    const description = formData.get('description')
+    if (!description || typeof description !== 'string' || !description.trim()) {
+      return redirect(`${parkingLotUrl}?error=missing`, 302)
+    }
+
+    const requestedBy = formData.get('requested_by')
+
+    await createParkingLotItem(env.DB, engagementId.trim(), {
+      description: description.trim(),
+      requested_by:
+        requestedBy && typeof requestedBy === 'string' && requestedBy.trim()
+          ? requestedBy.trim()
+          : null,
+    })
+
+    return redirect(`${parkingLotUrl}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/parking-lot] Create error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/time-entries/[id].ts
+++ b/src/pages/api/admin/time-entries/[id].ts
@@ -1,0 +1,94 @@
+import type { APIRoute } from 'astro'
+import { getTimeEntry, updateTimeEntry, deleteTimeEntry } from '../../../../lib/db/time-entries'
+import { getEngagement } from '../../../../lib/db/engagements'
+
+/**
+ * POST /api/admin/time-entries/:id
+ *
+ * Updates or deletes a time entry (via _method=DELETE).
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields for update:
+ *   - client_id (required, for redirect)
+ *   - date
+ *   - hours
+ *   - description
+ *   - category
+ *
+ * Form fields for delete:
+ *   - _method: "DELETE"
+ *   - client_id (required, for redirect)
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entryId = params.id
+  if (!entryId) {
+    return new Response(JSON.stringify({ error: 'Time entry ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const entry = await getTimeEntry(env.DB, entryId)
+    if (!entry) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    // Verify the engagement belongs to this org
+    const engagement = await getEngagement(env.DB, session.orgId, entry.engagement_id)
+    if (!engagement) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const clientId = formData.get('client_id')
+    const clientIdStr =
+      clientId && typeof clientId === 'string' ? clientId.trim() : engagement.client_id
+
+    const timeUrl = `/admin/clients/${clientIdStr}/engagements/${entry.engagement_id}/time`
+
+    const method = formData.get('_method')
+
+    // Handle DELETE
+    if (method === 'DELETE') {
+      await deleteTimeEntry(env.DB, entryId)
+      return redirect(`${timeUrl}?deleted=1`, 302)
+    }
+
+    // Handle update
+    const date = formData.get('date')
+    const hours = formData.get('hours')
+    const description = formData.get('description')
+    const category = formData.get('category')
+
+    await updateTimeEntry(env.DB, entryId, {
+      date: date && typeof date === 'string' && date.trim() ? date.trim() : undefined,
+      hours:
+        hours && typeof hours === 'string' && hours.trim()
+          ? parseFloat(hours) || undefined
+          : undefined,
+      description:
+        description !== null && typeof description === 'string'
+          ? description.trim() || null
+          : undefined,
+      category:
+        category !== null && typeof category === 'string' ? category.trim() || null : undefined,
+    })
+
+    return redirect(`${timeUrl}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/time-entries/[id]] Error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/time-entries/index.ts
+++ b/src/pages/api/admin/time-entries/index.ts
@@ -1,0 +1,90 @@
+import type { APIRoute } from 'astro'
+import { getEngagement } from '../../../../lib/db/engagements'
+import { createTimeEntry } from '../../../../lib/db/time-entries'
+
+/**
+ * POST /api/admin/time-entries
+ *
+ * Creates a new time entry for an engagement.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields:
+ *   - engagement_id (required)
+ *   - client_id (required, for redirect)
+ *   - date (required)
+ *   - hours (required)
+ *   - description
+ *   - category
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const formData = await request.formData()
+    const engagementId = formData.get('engagement_id')
+    const clientId = formData.get('client_id')
+
+    if (
+      !engagementId ||
+      typeof engagementId !== 'string' ||
+      !clientId ||
+      typeof clientId !== 'string'
+    ) {
+      return redirect('/admin/clients?error=missing', 302)
+    }
+
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId.trim())
+    if (!engagement) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const timeUrl = `/admin/clients/${clientId.trim()}/engagements/${engagementId.trim()}/time`
+
+    const date = formData.get('date')
+    const hours = formData.get('hours')
+
+    if (
+      !date ||
+      typeof date !== 'string' ||
+      !date.trim() ||
+      !hours ||
+      typeof hours !== 'string' ||
+      !hours.trim()
+    ) {
+      return redirect(`${timeUrl}?error=missing`, 302)
+    }
+
+    const parsedHours = parseFloat(hours)
+    if (isNaN(parsedHours) || parsedHours <= 0) {
+      return redirect(`${timeUrl}?error=missing`, 302)
+    }
+
+    const description = formData.get('description')
+    const category = formData.get('category')
+
+    await createTimeEntry(env.DB, engagementId.trim(), {
+      date: date.trim(),
+      hours: parsedHours,
+      description:
+        description && typeof description === 'string' && description.trim()
+          ? description.trim()
+          : null,
+      category:
+        category && typeof category === 'string' && category.trim() ? category.trim() : null,
+    })
+
+    return redirect(`${timeUrl}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/time-entries] Create error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/tests/parking-lot.test.ts
+++ b/tests/parking-lot.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('parking-lot: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/parking-lot.ts'), 'utf-8')
+
+  it('parking-lot.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/parking-lot.ts'))).toBe(true)
+  })
+
+  it('exports listParkingLotItems function', () => {
+    expect(source()).toContain('export async function listParkingLotItems')
+  })
+
+  it('exports getParkingLotItem function', () => {
+    expect(source()).toContain('export async function getParkingLotItem')
+  })
+
+  it('exports createParkingLotItem function', () => {
+    expect(source()).toContain('export async function createParkingLotItem')
+  })
+
+  it('exports updateParkingLotItem function', () => {
+    expect(source()).toContain('export async function updateParkingLotItem')
+  })
+
+  it('exports disposeParkingLotItem function', () => {
+    expect(source()).toContain('export async function disposeParkingLotItem')
+  })
+
+  it('exports linkFollowOnQuote function', () => {
+    expect(source()).toContain('export async function linkFollowOnQuote')
+  })
+
+  it('exports deleteParkingLotItem function', () => {
+    expect(source()).toContain('export async function deleteParkingLotItem')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('orders parking lot items by created_at DESC', () => {
+    const code = source()
+    expect(code).toContain('ORDER BY created_at DESC')
+  })
+
+  it('defines all valid dispositions', () => {
+    const code = source()
+    expect(code).toContain("'fold_in'")
+    expect(code).toContain("'follow_on'")
+    expect(code).toContain("'dropped'")
+  })
+
+  it('exports DISPOSITIONS constant', () => {
+    expect(source()).toContain('export const DISPOSITIONS')
+  })
+
+  it('exports ParkingLotItem interface', () => {
+    expect(source()).toContain('export interface ParkingLotItem')
+  })
+
+  it('exports Disposition type', () => {
+    expect(source()).toContain('export type Disposition')
+  })
+
+  it('disposeParkingLotItem sets disposition, disposition_note, and reviewed_at', () => {
+    const code = source()
+    const disposeFnStart = code.indexOf('export async function disposeParkingLotItem')
+    const disposeFnEnd = code.indexOf('export async function', disposeFnStart + 1)
+    const disposeFn = code.slice(disposeFnStart, disposeFnEnd)
+    expect(disposeFn).toContain('disposition')
+    expect(disposeFn).toContain('disposition_note')
+    expect(disposeFn).toContain('reviewed_at')
+  })
+
+  it('linkFollowOnQuote sets follow_on_quote_id', () => {
+    const code = source()
+    const linkFnStart = code.indexOf('export async function linkFollowOnQuote')
+    const linkFnEnd = code.indexOf('export async function', linkFnStart + 1)
+    const linkFn = code.slice(linkFnStart, linkFnEnd)
+    expect(linkFn).toContain('follow_on_quote_id')
+    expect(linkFn).toContain('quoteId')
+  })
+
+  it('ParkingLotItem interface includes follow_on_quote_id', () => {
+    expect(source()).toContain('follow_on_quote_id')
+  })
+
+  it('ParkingLotItem interface includes requested_by', () => {
+    expect(source()).toContain('requested_by')
+  })
+
+  it('ParkingLotItem interface includes requested_at', () => {
+    expect(source()).toContain('requested_at')
+  })
+})
+
+describe('parking-lot: API routes', () => {
+  it('create endpoint exists at src/pages/api/admin/parking-lot/index.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/parking-lot/index.ts'))).toBe(true)
+  })
+
+  it('update/dispose/delete endpoint exists at src/pages/api/admin/parking-lot/[id].ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/parking-lot/[id].ts'))).toBe(true)
+  })
+
+  it('create endpoint validates required fields', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/parking-lot/index.ts'), 'utf-8')
+    expect(code).toContain('engagement_id')
+    expect(code).toContain('description')
+    expect(code).toContain('createParkingLotItem')
+  })
+
+  it('create endpoint reads form data', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/parking-lot/index.ts'), 'utf-8')
+    expect(code).toContain('request.formData()')
+  })
+
+  it('update endpoint supports _method=DELETE', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/parking-lot/[id].ts'), 'utf-8')
+    expect(code).toContain('_method')
+    expect(code).toContain('DELETE')
+    expect(code).toContain('deleteParkingLotItem')
+  })
+
+  it('update endpoint supports disposition action', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/parking-lot/[id].ts'), 'utf-8')
+    expect(code).toContain("action === 'dispose'")
+    expect(code).toContain('disposeParkingLotItem')
+    expect(code).toContain('disposition')
+    expect(code).toContain('disposition_note')
+  })
+
+  it('update endpoint validates disposition values', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/parking-lot/[id].ts'), 'utf-8')
+    expect(code).toContain('fold_in')
+    expect(code).toContain('follow_on')
+    expect(code).toContain('dropped')
+  })
+
+  it('endpoints verify admin session', () => {
+    const createCode = readFileSync(resolve('src/pages/api/admin/parking-lot/index.ts'), 'utf-8')
+    const updateCode = readFileSync(resolve('src/pages/api/admin/parking-lot/[id].ts'), 'utf-8')
+    expect(createCode).toContain("session.role !== 'admin'")
+    expect(updateCode).toContain("session.role !== 'admin'")
+  })
+})
+
+describe('parking-lot: admin page', () => {
+  const source = () =>
+    readFileSync(
+      resolve('src/pages/admin/clients/[id]/engagements/[engId]/parking-lot.astro'),
+      'utf-8'
+    )
+
+  it('parking lot page exists', () => {
+    expect(
+      existsSync(resolve('src/pages/admin/clients/[id]/engagements/[engId]/parking-lot.astro'))
+    ).toBe(true)
+  })
+
+  it('loads parking lot items via listParkingLotItems', () => {
+    expect(source()).toContain('listParkingLotItems')
+  })
+
+  it('loads engagement via getEngagement', () => {
+    expect(source()).toContain('getEngagement')
+  })
+
+  it('loads client via getClient for breadcrumb', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('form posts to /api/admin/parking-lot', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('action="/api/admin/parking-lot"')
+  })
+
+  it('includes description and requested_by fields', () => {
+    const code = source()
+    expect(code).toContain('name="description"')
+    expect(code).toContain('name="requested_by"')
+  })
+
+  it('shows disposition controls for undispositioned items', () => {
+    const code = source()
+    expect(code).toContain('name="disposition"')
+    expect(code).toContain('name="disposition_note"')
+    expect(code).toContain('Dispose')
+  })
+
+  it('shows color coding for disposition status', () => {
+    const code = source()
+    expect(code).toContain('dispositionColor')
+    expect(code).toContain('dispositionBadge')
+    expect(code).toContain('bg-green-100') // fold_in
+    expect(code).toContain('bg-blue-100') // follow_on
+    expect(code).toContain('bg-amber-50') // undispositioned
+  })
+
+  it('has follow-on quote link for follow_on items', () => {
+    const code = source()
+    expect(code).toContain('Create Follow-on Quote')
+    expect(code).toContain('follow_on_quote_id')
+  })
+
+  it('has breadcrumb navigation', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients')
+    expect(code).toContain('client.business_name')
+    expect(code).toContain('Parking Lot')
+  })
+
+  it('has delete button per item', () => {
+    const code = source()
+    expect(code).toContain('_method')
+    expect(code).toContain('DELETE')
+    expect(code).toContain('Delete')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+
+  it('shows DISPOSITIONS in select dropdown', () => {
+    const code = source()
+    expect(code).toContain('DISPOSITIONS')
+    expect(code).toContain('<select')
+  })
+
+  it('shows empty state when no items', () => {
+    const code = source()
+    expect(code).toContain('No parking lot items yet')
+  })
+
+  it('shows summary with total items and needs review count', () => {
+    const code = source()
+    expect(code).toContain('Total Items')
+    expect(code).toContain('Needs Review')
+    expect(code).toContain('undispositioned')
+  })
+})
+
+describe('parking-lot: engagement detail integration', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/engagements/[engId].astro'), 'utf-8')
+
+  it('engagement detail page imports listParkingLotItems', () => {
+    expect(source()).toContain('listParkingLotItems')
+  })
+
+  it('engagement detail page has parking lot section', () => {
+    const code = source()
+    expect(code).toContain('Parking Lot')
+    expect(code).toContain('parkingLotItems')
+  })
+
+  it('engagement detail page shows item count and undispositioned count', () => {
+    const code = source()
+    expect(code).toContain('parkingLotTotal')
+    expect(code).toContain('parkingLotUndispositioned')
+  })
+
+  it('engagement detail page links to parking lot page', () => {
+    const code = source()
+    expect(code).toContain('/parking-lot')
+    expect(code).toContain('View All')
+  })
+})

--- a/tests/time-entries.test.ts
+++ b/tests/time-entries.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('time-entries: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/time-entries.ts'), 'utf-8')
+
+  it('time-entries.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/time-entries.ts'))).toBe(true)
+  })
+
+  it('exports listTimeEntries function', () => {
+    expect(source()).toContain('export async function listTimeEntries')
+  })
+
+  it('exports getTimeEntry function', () => {
+    expect(source()).toContain('export async function getTimeEntry')
+  })
+
+  it('exports createTimeEntry function', () => {
+    expect(source()).toContain('export async function createTimeEntry')
+  })
+
+  it('exports updateTimeEntry function', () => {
+    expect(source()).toContain('export async function updateTimeEntry')
+  })
+
+  it('exports deleteTimeEntry function', () => {
+    expect(source()).toContain('export async function deleteTimeEntry')
+  })
+
+  it('exports recalculateActualHours function', () => {
+    expect(source()).toContain('export async function recalculateActualHours')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('orders time entries by date DESC', () => {
+    const code = source()
+    expect(code).toContain('ORDER BY date DESC')
+  })
+
+  it('recalculateActualHours sums hours from time_entries', () => {
+    const code = source()
+    expect(code).toContain('SUM(hours)')
+    expect(code).toContain('UPDATE engagements SET actual_hours')
+  })
+
+  it('createTimeEntry calls recalculateActualHours', () => {
+    const code = source()
+    // Find the createTimeEntry function and verify it calls recalculate
+    const createFnStart = code.indexOf('export async function createTimeEntry')
+    const createFnEnd = code.indexOf('export async function', createFnStart + 1)
+    const createFn = code.slice(createFnStart, createFnEnd)
+    expect(createFn).toContain('recalculateActualHours')
+  })
+
+  it('updateTimeEntry calls recalculateActualHours', () => {
+    const code = source()
+    const updateFnStart = code.indexOf('export async function updateTimeEntry')
+    const updateFnEnd = code.indexOf('export async function', updateFnStart + 1)
+    const updateFn = code.slice(updateFnStart, updateFnEnd)
+    expect(updateFn).toContain('recalculateActualHours')
+  })
+
+  it('deleteTimeEntry calls recalculateActualHours', () => {
+    const code = source()
+    const deleteFnStart = code.indexOf('export async function deleteTimeEntry')
+    const deleteFn = code.slice(deleteFnStart)
+    expect(deleteFn).toContain('recalculateActualHours')
+  })
+
+  it('defines all valid time entry categories', () => {
+    const code = source()
+    expect(code).toContain("'solution_design'")
+    expect(code).toContain("'implementation'")
+    expect(code).toContain("'training'")
+    expect(code).toContain("'admin'")
+    expect(code).toContain("'other'")
+  })
+
+  it('exports TIME_ENTRY_CATEGORIES constant', () => {
+    expect(source()).toContain('export const TIME_ENTRY_CATEGORIES')
+  })
+
+  it('exports TimeEntry interface', () => {
+    expect(source()).toContain('export interface TimeEntry')
+  })
+
+  it('exports TimeEntryCategory type', () => {
+    expect(source()).toContain('export type TimeEntryCategory')
+  })
+
+  it('recalculate uses COALESCE for zero-entry case', () => {
+    expect(source()).toContain('COALESCE(SUM(hours), 0)')
+  })
+})
+
+describe('time-entries: API routes', () => {
+  it('create endpoint exists at src/pages/api/admin/time-entries/index.ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/time-entries/index.ts'))).toBe(true)
+  })
+
+  it('update/delete endpoint exists at src/pages/api/admin/time-entries/[id].ts', () => {
+    expect(existsSync(resolve('src/pages/api/admin/time-entries/[id].ts'))).toBe(true)
+  })
+
+  it('create endpoint validates required fields', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/time-entries/index.ts'), 'utf-8')
+    expect(code).toContain('engagement_id')
+    expect(code).toContain('date')
+    expect(code).toContain('hours')
+    expect(code).toContain('createTimeEntry')
+  })
+
+  it('create endpoint reads form data', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/time-entries/index.ts'), 'utf-8')
+    expect(code).toContain('request.formData()')
+  })
+
+  it('update/delete endpoint supports _method=DELETE', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/time-entries/[id].ts'), 'utf-8')
+    expect(code).toContain('_method')
+    expect(code).toContain('DELETE')
+    expect(code).toContain('deleteTimeEntry')
+  })
+
+  it('update/delete endpoint supports update', () => {
+    const code = readFileSync(resolve('src/pages/api/admin/time-entries/[id].ts'), 'utf-8')
+    expect(code).toContain('updateTimeEntry')
+  })
+
+  it('endpoints verify admin session', () => {
+    const createCode = readFileSync(resolve('src/pages/api/admin/time-entries/index.ts'), 'utf-8')
+    const updateCode = readFileSync(resolve('src/pages/api/admin/time-entries/[id].ts'), 'utf-8')
+    expect(createCode).toContain("session.role !== 'admin'")
+    expect(updateCode).toContain("session.role !== 'admin'")
+  })
+})
+
+describe('time-entries: admin page', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/engagements/[engId]/time.astro'), 'utf-8')
+
+  it('time tracking page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/clients/[id]/engagements/[engId]/time.astro'))).toBe(
+      true
+    )
+  })
+
+  it('loads time entries via listTimeEntries', () => {
+    expect(source()).toContain('listTimeEntries')
+  })
+
+  it('loads engagement via getEngagement', () => {
+    expect(source()).toContain('getEngagement')
+  })
+
+  it('loads client via getClient for breadcrumb', () => {
+    expect(source()).toContain('getClient')
+  })
+
+  it('form posts to /api/admin/time-entries', () => {
+    const code = source()
+    expect(code).toContain('method="POST"')
+    expect(code).toContain('action="/api/admin/time-entries"')
+  })
+
+  it('includes date, hours, category, and description fields', () => {
+    const code = source()
+    expect(code).toContain('name="date"')
+    expect(code).toContain('name="hours"')
+    expect(code).toContain('name="category"')
+    expect(code).toContain('name="description"')
+  })
+
+  it('shows estimated vs actual hours comparison', () => {
+    const code = source()
+    expect(code).toContain('Hours Summary')
+    expect(code).toContain('Estimated')
+    expect(code).toContain('Actual')
+    expect(code).toContain('Variance')
+  })
+
+  it('shows progress bar for hours', () => {
+    const code = source()
+    expect(code).toContain('Progress')
+    expect(code).toContain('percentage')
+  })
+
+  it('has breadcrumb navigation', () => {
+    const code = source()
+    expect(code).toContain('/admin/clients')
+    expect(code).toContain('client.business_name')
+    expect(code).toContain('Time Tracking')
+  })
+
+  it('has delete button per entry', () => {
+    const code = source()
+    expect(code).toContain('_method')
+    expect(code).toContain('DELETE')
+    expect(code).toContain('Delete')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+
+  it('displays TIME_ENTRY_CATEGORIES in select', () => {
+    const code = source()
+    expect(code).toContain('TIME_ENTRY_CATEGORIES')
+    expect(code).toContain('<select')
+  })
+
+  it('shows empty state when no entries', () => {
+    const code = source()
+    expect(code).toContain('No time entries yet')
+  })
+})
+
+describe('time-entries: engagement detail integration', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/engagements/[engId].astro'), 'utf-8')
+
+  it('engagement detail page imports listTimeEntries', () => {
+    expect(source()).toContain('listTimeEntries')
+  })
+
+  it('engagement detail page has time tracking section', () => {
+    const code = source()
+    expect(code).toContain('Time Tracking')
+    expect(code).toContain('timeEntries')
+  })
+
+  it('engagement detail page shows hours summary', () => {
+    const code = source()
+    expect(code).toContain('estimatedHours')
+    expect(code).toContain('totalLoggedHours')
+    expect(code).toContain('hoursVariance')
+  })
+
+  it('engagement detail page links to time tracking page', () => {
+    const code = source()
+    expect(code).toContain('/time')
+    expect(code).toContain('View All')
+  })
+})


### PR DESCRIPTION
## Summary
- **Time tracking** (#78): Data layer (`time-entries.ts`) with automatic `recalculateActualHours` that keeps `engagements.actual_hours` in sync via SUM aggregation. Admin page with add/delete forms, hours summary with estimated vs actual progress bar, and category select (solution_design, implementation, training, admin, other). API routes for create, update, and delete.
- **Parking lot** (#79): Data layer (`parking-lot.ts`) for capturing out-of-scope requests during engagements. Three-option disposition workflow (fold_in, follow_on, dropped) with color-coded status. Follow-on items link to quote creation. Admin page with disposition controls, summary stats, and add/delete forms. API routes for create, update, dispose, and delete.
- **Engagement detail integration**: Both features surface summary cards on the engagement detail page with "View All" links to their dedicated pages.
- **90 new tests** covering data layer exports, parameterized queries, API routes, admin pages, and engagement detail integration. All 717 tests pass (2 pre-existing build-output failures unrelated to this PR).

## Test plan
- [ ] Verify `npm run test` passes (717/719, 2 pre-existing failures)
- [ ] Verify `npm run lint` passes
- [ ] Verify `npm run format:check` passes
- [ ] Review time entry creation flow: date, hours, category, description
- [ ] Review `recalculateActualHours` updates `engagements.actual_hours` after create/update/delete
- [ ] Review parking lot disposition workflow: fold_in (green), follow_on (blue), dropped (slate), undispositioned (amber)
- [ ] Review "Create Follow-on Quote" link appears for follow_on items
- [ ] Review engagement detail page shows time tracking and parking lot summary sections

Closes #78, closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)