### PR TITLE
feat: portal quote view + signing flow (#75)

### DIFF
--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -277,6 +277,50 @@ export async function updateQuote(
  * - draft -> sent: sets sent_at and expires_at (sent_at + 5 days)
  * - sent -> accepted: sets accepted_at
  */
+/**
+ * Portal-facing statuses visible to clients.
+ * Draft and superseded quotes are internal-only.
+ */
+const PORTAL_VISIBLE_STATUSES = ['sent', 'accepted', 'declined', 'expired'] as const
+
+/**
+ * List quotes for a specific client (portal access).
+ *
+ * Scoped by client_id (NOT org_id) — portal users access via their client_id.
+ * Only returns quotes visible to clients (sent, accepted, declined, expired).
+ */
+export async function listQuotesForClient(db: D1Database, clientId: string): Promise<Quote[]> {
+  const placeholders = PORTAL_VISIBLE_STATUSES.map(() => '?').join(', ')
+  const sql = `SELECT * FROM quotes WHERE client_id = ? AND status IN (${placeholders}) ORDER BY updated_at DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(clientId, ...PORTAL_VISIBLE_STATUSES)
+    .all<Quote>()
+  return result.results
+}
+
+/**
+ * Get a single quote for a client (portal access).
+ *
+ * Scoped by client_id (NOT org_id) — same status filter as list.
+ */
+export async function getQuoteForClient(
+  db: D1Database,
+  clientId: string,
+  quoteId: string
+): Promise<Quote | null> {
+  const placeholders = PORTAL_VISIBLE_STATUSES.map(() => '?').join(', ')
+  const sql = `SELECT * FROM quotes WHERE id = ? AND client_id = ? AND status IN (${placeholders})`
+
+  const result = await db
+    .prepare(sql)
+    .bind(quoteId, clientId, ...PORTAL_VISIBLE_STATUSES)
+    .first<Quote>()
+
+  return result ?? null
+}
+
 export async function updateQuoteStatus(
   db: D1Database,
   orgId: string,

--- a/src/lib/portal/session.ts
+++ b/src/lib/portal/session.ts
@@ -1,0 +1,50 @@
+/**
+ * Portal session helpers.
+ *
+ * Resolves the client record for an authenticated portal user.
+ * Portal users are linked to clients via users.client_id.
+ */
+
+import type { Client } from '../db/clients'
+
+interface UserRow {
+  id: string
+  org_id: string
+  email: string
+  name: string
+  role: string
+  client_id: string | null
+}
+
+/**
+ * Resolve the client record for the current portal session.
+ *
+ * Looks up the user by session.userId to get client_id,
+ * then fetches the client record.
+ *
+ * Returns null if the user or client is not found.
+ */
+export async function getPortalClient(
+  db: D1Database,
+  userId: string
+): Promise<{ user: UserRow; client: Client } | null> {
+  const user = await db
+    .prepare(`SELECT * FROM users WHERE id = ? AND role = 'client'`)
+    .bind(userId)
+    .first<UserRow>()
+
+  if (!user || !user.client_id) {
+    return null
+  }
+
+  const client = await db
+    .prepare('SELECT * FROM clients WHERE id = ?')
+    .bind(user.client_id)
+    .first<Client>()
+
+  if (!client) {
+    return null
+  }
+
+  return { user, client }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,10 +5,11 @@ import { parseSessionToken, validateSession, renewSession } from './lib/auth/ses
  * Astro middleware — handles auth for protected routes.
  *
  * Route protection:
- *   /admin/*      → requires role='admin', redirects to /auth/login
- *   /api/admin/*  → requires role='admin', returns 401 JSON
- *   /portal/*     → requires role='client', redirects to /auth/portal-login
- *   /auth/*       → public (login pages)
+ *   /admin/*       → requires role='admin', redirects to /auth/login
+ *   /api/admin/*   → requires role='admin', returns 401 JSON
+ *   /portal/*      → requires role='client', redirects to /auth/portal-login
+ *   /api/portal/*  → requires role='client', returns 401 JSON
+ *   /auth/*        → public (login pages)
  *   everything else → public
  *
  * On valid session: renews expiration (sliding window) and attaches session to locals.
@@ -23,7 +24,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const isAdminRoute = pathname.startsWith('/admin')
   const isAdminApiRoute = pathname.startsWith('/api/admin')
   const isPortalRoute = pathname.startsWith('/portal')
-  const isProtectedRoute = isAdminRoute || isAdminApiRoute || isPortalRoute
+  const isPortalApiRoute = pathname.startsWith('/api/portal')
+  const isProtectedRoute = isAdminRoute || isAdminApiRoute || isPortalRoute || isPortalApiRoute
 
   if (!isProtectedRoute) {
     return next()
@@ -34,7 +36,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const token = parseSessionToken(cookieHeader)
 
   if (!token) {
-    if (isAdminApiRoute) {
+    if (isAdminApiRoute || isPortalApiRoute) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401,
         headers: { 'Content-Type': 'application/json' },
@@ -51,7 +53,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const sessionData = await validateSession(env.DB, env.SESSIONS, token)
 
   if (!sessionData) {
-    if (isAdminApiRoute) {
+    if (isAdminApiRoute || isPortalApiRoute) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401,
         headers: { 'Content-Type': 'application/json' },
@@ -66,7 +68,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Role-based access control
   const requiredRole = isAdminRoute || isAdminApiRoute ? 'admin' : 'client'
   if (sessionData.role !== requiredRole) {
-    if (isAdminApiRoute) {
+    if (isAdminApiRoute || isPortalApiRoute) {
       return new Response(JSON.stringify({ error: 'Forbidden' }), {
         status: 403,
         headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/portal/quotes/[id]/sow.ts
+++ b/src/pages/api/portal/quotes/[id]/sow.ts
@@ -1,0 +1,73 @@
+import type { APIRoute } from 'astro'
+import { getPortalClient } from '../../../../../lib/portal/session'
+import { getQuoteForClient } from '../../../../../lib/db/quotes'
+import { getPdf } from '../../../../../lib/storage/r2'
+
+/**
+ * GET /api/portal/quotes/:id/sow
+ *
+ * Streams the SOW PDF from R2 for the authenticated portal client.
+ *
+ * Protected by auth middleware (requires client role).
+ * Scoped to client_id (not org_id) — portal access pattern.
+ */
+export const GET: APIRoute = async ({ locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'client') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const quoteId = params.id
+  if (!quoteId) {
+    return new Response(JSON.stringify({ error: 'Quote ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  // Resolve client from session
+  const portalData = await getPortalClient(env.DB, session.userId)
+  if (!portalData) {
+    return new Response(JSON.stringify({ error: 'Client not found' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Get quote scoped to this client
+  const quote = await getQuoteForClient(env.DB, portalData.client.id, quoteId)
+  if (!quote) {
+    return new Response(JSON.stringify({ error: 'Quote not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  if (!quote.sow_path) {
+    return new Response(JSON.stringify({ error: 'SOW not available' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Stream PDF from R2
+  const object = await getPdf(env.STORAGE, quote.sow_path)
+  if (!object) {
+    return new Response(JSON.stringify({ error: 'SOW file not found in storage' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="SMD-Services-SOW.pdf"`,
+    },
+  })
+}

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -1,14 +1,115 @@
 ---
 import '../../styles/global.css'
+import { getPortalClient } from '../../lib/portal/session'
+import { listQuotesForClient } from '../../lib/db/quotes'
+import type { Quote } from '../../lib/db/quotes'
 
 /**
  * Client portal dashboard — protected by auth middleware (role=client).
  *
- * If you're seeing this page, the session is valid and the user has client role.
- * Session data is available via Astro.locals.session.
+ * Shows:
+ * - Welcome message with client business name
+ * - Active engagement status (if any)
+ * - Pending quotes requiring action
+ * - Recent activity feed
+ * - Quick links to sections
  */
 
 const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Resolve client from session
+const portalData = await getPortalClient(env.DB, session.userId)
+if (!portalData) {
+  return Astro.redirect('/auth/portal-login?error=no_account')
+}
+
+const { client } = portalData
+
+// Load quotes for this client
+const quotes = await listQuotesForClient(env.DB, client.id)
+const pendingQuotes = quotes.filter((q: Quote) => q.status === 'sent')
+
+// Load active engagement (if any)
+interface EngagementRow {
+  id: string
+  status: string
+  scope_summary: string | null
+  start_date: string | null
+  estimated_end: string | null
+}
+
+interface MilestoneRow {
+  id: string
+  name: string
+  status: string
+  sort_order: number
+}
+
+const activeEngagement = await env.DB.prepare(
+  `SELECT id, status, scope_summary, start_date, estimated_end FROM engagements WHERE client_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net') ORDER BY created_at DESC LIMIT 1`
+)
+  .bind(client.id)
+  .first<EngagementRow>()
+
+// Load milestones for active engagement
+let currentMilestone: MilestoneRow | null = null
+if (activeEngagement) {
+  currentMilestone =
+    (await env.DB.prepare(
+      `SELECT id, name, status, sort_order FROM milestones WHERE engagement_id = ? AND status IN ('pending', 'in_progress') ORDER BY sort_order ASC LIMIT 1`
+    )
+      .bind(activeEngagement.id)
+      .first<MilestoneRow>()) ?? null
+}
+
+// Build recent activity
+interface ActivityItem {
+  description: string
+  date: string
+  type: 'quote' | 'engagement'
+}
+
+const recentActivity: ActivityItem[] = []
+for (const q of quotes.slice(0, 5)) {
+  if (q.sent_at) {
+    recentActivity.push({
+      description: 'Proposal sent',
+      date: q.sent_at,
+      type: 'quote',
+    })
+  }
+  if (q.accepted_at) {
+    recentActivity.push({
+      description: 'Proposal signed',
+      date: q.accepted_at,
+      type: 'quote',
+    })
+  }
+}
+recentActivity.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
+// Helpers
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+
+const engagementStatusLabels: Record<string, string> = {
+  scheduled: 'Scheduled',
+  active: 'In Progress',
+  handoff: 'Handoff',
+  safety_net: 'Support',
+}
+
+const engagementStatusColors: Record<string, string> = {
+  scheduled: 'bg-slate-100 text-slate-600',
+  active: 'bg-blue-100 text-blue-800',
+  handoff: 'bg-amber-100 text-amber-800',
+  safety_net: 'bg-green-100 text-green-800',
+}
 ---
 
 <!doctype html>
@@ -32,7 +133,7 @@ const session = Astro.locals.session!
           <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
         </div>
         <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
+          <span class="text-sm text-slate-600 hidden sm:inline">{session.email}</span>
           <form method="POST" action="/api/auth/logout">
             <button
               type="submit"
@@ -45,12 +146,160 @@ const session = Astro.locals.session!
       </div>
     </header>
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <h2 class="text-xl font-semibold text-slate-900 mb-4">Welcome</h2>
-      <div class="bg-white rounded-lg border border-slate-200 p-6">
-        <p class="text-slate-600">
-          Your client portal is ready. Proposals, project updates, and documents will appear here.
-        </p>
+    <main class="max-w-5xl mx-auto px-4 py-6 sm:py-8">
+      <!-- Welcome -->
+      <h2 class="text-xl sm:text-2xl font-bold text-slate-900 mb-1">
+        Welcome, {client.business_name}
+      </h2>
+      <p class="text-sm text-slate-500 mb-6">Your client portal for SMD Services</p>
+
+      <!-- Pending Quotes Alert -->
+      {
+        pendingQuotes.length > 0 && (
+          <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+              <div class="flex-1">
+                <p class="text-sm font-medium text-blue-900">
+                  {pendingQuotes.length === 1
+                    ? 'You have a proposal ready for review'
+                    : `You have ${pendingQuotes.length} proposals ready for review`}
+                </p>
+                <p class="text-xs text-blue-700 mt-0.5">Review the scope and sign to get started</p>
+              </div>
+              <a
+                href="/portal/quotes"
+                class="inline-flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors min-h-[44px]"
+              >
+                Review Proposals
+              </a>
+            </div>
+          </div>
+        )
+      }
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Main Column -->
+        <div class="lg:col-span-2 space-y-6">
+          <!-- Active Engagement -->
+          {
+            activeEngagement && (
+              <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
+                <div class="flex items-center gap-3 mb-4">
+                  <h3 class="text-base font-semibold text-slate-900">Current Engagement</h3>
+                  <span
+                    class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${engagementStatusColors[activeEngagement.status] ?? 'bg-slate-100 text-slate-600'}`}
+                  >
+                    {engagementStatusLabels[activeEngagement.status] ?? activeEngagement.status}
+                  </span>
+                </div>
+                {activeEngagement.scope_summary && (
+                  <p class="text-sm text-slate-600 mb-3">{activeEngagement.scope_summary}</p>
+                )}
+                {currentMilestone && (
+                  <div class="p-3 bg-slate-50 rounded-lg">
+                    <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">
+                      Current Milestone
+                    </p>
+                    <p class="text-sm font-medium text-slate-900">{currentMilestone.name}</p>
+                  </div>
+                )}
+                {activeEngagement.estimated_end && (
+                  <p class="text-xs text-slate-400 mt-3">
+                    Estimated completion: {formatDate(activeEngagement.estimated_end)}
+                  </p>
+                )}
+              </div>
+            )
+          }
+
+          <!-- Recent Activity -->
+          <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
+            <h3 class="text-base font-semibold text-slate-900 mb-4">Recent Activity</h3>
+            {
+              recentActivity.length > 0 ? (
+                <ul class="space-y-3">
+                  {recentActivity.slice(0, 5).map((activity) => (
+                    <li class="flex items-start gap-3">
+                      <div
+                        class={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${activity.type === 'quote' ? 'bg-blue-400' : 'bg-green-400'}`}
+                      />
+                      <div>
+                        <p class="text-sm text-slate-700">{activity.description}</p>
+                        <p class="text-xs text-slate-400">{formatDate(activity.date)}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p class="text-sm text-slate-500">No recent activity to show.</p>
+              )
+            }
+          </div>
+        </div>
+
+        <!-- Sidebar -->
+        <div class="space-y-6">
+          <!-- Quick Links -->
+          <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
+            <h3 class="text-base font-semibold text-slate-900 mb-4">Quick Links</h3>
+            <nav class="space-y-2">
+              <a
+                href="/portal/quotes"
+                class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors min-h-[44px]"
+              >
+                <svg
+                  class="w-5 h-5 text-slate-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  ></path>
+                </svg>
+                <div>
+                  <p class="text-sm font-medium text-slate-900">Proposals</p>
+                  <p class="text-xs text-slate-500">View and sign proposals</p>
+                </div>
+                {
+                  pendingQuotes.length > 0 && (
+                    <span class="ml-auto bg-blue-100 text-blue-800 text-xs font-medium px-2 py-0.5 rounded-full">
+                      {pendingQuotes.length}
+                    </span>
+                  )
+                }
+              </a>
+            </nav>
+          </div>
+
+          <!-- Quotes Summary -->
+          {
+            quotes.length > 0 && (
+              <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
+                <h3 class="text-base font-semibold text-slate-900 mb-3">Proposal Summary</h3>
+                <div class="space-y-2 text-sm">
+                  {pendingQuotes.length > 0 && (
+                    <div class="flex justify-between">
+                      <span class="text-slate-500">Pending review</span>
+                      <span class="font-medium text-blue-600">{pendingQuotes.length}</span>
+                    </div>
+                  )}
+                  {quotes.filter((q: Quote) => q.status === 'accepted').length > 0 && (
+                    <div class="flex justify-between">
+                      <span class="text-slate-500">Accepted</span>
+                      <span class="font-medium text-green-600">
+                        {quotes.filter((q: Quote) => q.status === 'accepted').length}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          }
+        </div>
       </div>
     </main>
   </body>

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -1,0 +1,408 @@
+---
+import '../../../styles/global.css'
+import { getPortalClient } from '../../../lib/portal/session'
+import { getQuoteForClient } from '../../../lib/db/quotes'
+import type { LineItem } from '../../../lib/db/quotes'
+import { PROBLEM_LABELS } from '../../../portal/assessments/extraction-schema'
+import type { ProblemId } from '../../../portal/assessments/extraction-schema'
+
+/**
+ * Portal quote detail — shows scope, project price, payment terms, signing.
+ *
+ * CRITICAL: No hourly breakdown, no per-item pricing (Decision #16).
+ * Client sees total project price only, never hours or rates.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: quoteId } = Astro.params
+
+if (!quoteId) {
+  return Astro.redirect('/portal/quotes')
+}
+
+// Resolve client from session
+const portalData = await getPortalClient(env.DB, session.userId)
+if (!portalData) {
+  return Astro.redirect('/auth/portal-login?error=no_account')
+}
+
+const { client } = portalData
+
+// Get quote scoped to this client
+const quote = await getQuoteForClient(env.DB, client.id, quoteId)
+if (!quote) {
+  return Astro.redirect('/portal/quotes')
+}
+
+const lineItems: LineItem[] = JSON.parse(quote.line_items)
+
+// Helpers
+const formatCurrency = (amount: number) =>
+  `$${amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+const getProblemLabel = (problem: string) => PROBLEM_LABELS[problem as ProblemId] ?? problem
+
+const statusColorMap: Record<string, string> = {
+  sent: 'bg-blue-100 text-blue-800',
+  accepted: 'bg-green-100 text-green-800',
+  declined: 'bg-red-100 text-red-800',
+  expired: 'bg-amber-100 text-amber-800',
+}
+
+const statusLabelMap: Record<string, string> = {
+  sent: 'Pending Review',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  expired: 'Expired',
+}
+
+// Payment terms calculation
+const depositAmount = quote.deposit_amount ?? quote.total_price * quote.deposit_pct
+const balanceAmount = quote.total_price - depositAmount
+const depositPctDisplay = Math.round(quote.deposit_pct * 100)
+const balancePctDisplay = 100 - depositPctDisplay
+
+// Determine if 3-milestone payment (40+ hours — Decision #14)
+const isThreeMilestone = quote.total_hours >= 40
+
+// Expiration
+let expirationText = ''
+if (quote.status === 'sent' && quote.expires_at) {
+  const diffMs = new Date(quote.expires_at).getTime() - Date.now()
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+  expirationText =
+    diffDays > 0 ? `Expires in ${diffDays} day${diffDays !== 1 ? 's' : ''}` : 'Expired'
+}
+
+// SignWell signing
+const hasSignWell = !!quote.signwell_doc_id
+const hasSow = !!quote.sow_path
+const isSent = quote.status === 'sent'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Proposal — Portal — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/portal" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600 hidden sm:inline">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-6 sm:py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/portal" class="hover:text-slate-700">Dashboard</a></li>
+          <li class="text-slate-300">/</li>
+          <li><a href="/portal/quotes" class="hover:text-slate-700">Proposals</a></li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Proposal Details</li>
+        </ol>
+      </nav>
+
+      <!-- Header -->
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-6">
+        <div class="flex-1">
+          <div class="flex items-center gap-3 mb-1">
+            <h1 class="text-xl sm:text-2xl font-bold text-slate-900">Your Proposal</h1>
+            <span
+              class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColorMap[quote.status] ?? 'bg-slate-100 text-slate-600'}`}
+            >
+              {statusLabelMap[quote.status] ?? quote.status}
+            </span>
+          </div>
+          {
+            expirationText && (
+              <p
+                class={`text-sm ${expirationText === 'Expired' ? 'text-red-500' : 'text-amber-500'}`}
+              >
+                {expirationText}
+              </p>
+            )
+          }
+        </div>
+      </div>
+
+      <!-- Scope Table -->
+      <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6 mb-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">Scope of Work</h2>
+
+        <div class="space-y-4">
+          {
+            lineItems.map((item, index) => (
+              <div class="pb-4 border-b border-slate-100 last:border-0 last:pb-0">
+                <div class="flex items-start gap-3">
+                  <span class="flex-shrink-0 w-6 h-6 bg-slate-100 rounded-full flex items-center justify-center text-xs font-medium text-slate-500">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <p class="text-sm font-medium text-slate-900">
+                      {getProblemLabel(item.problem)}
+                    </p>
+                    {item.description && (
+                      <p class="text-sm text-slate-600 mt-1">{item.description}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+
+      <!-- Project Price -->
+      <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6 mb-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">Investment</h2>
+
+        <div class="mb-4 pb-4 border-b border-slate-200">
+          <p class="text-sm text-slate-500 mb-1">Project Price</p>
+          <p class="text-2xl sm:text-3xl font-bold text-slate-900">
+            {formatCurrency(quote.total_price)}
+          </p>
+        </div>
+
+        <h3 class="text-sm font-medium text-slate-700 mb-3">Payment Terms</h3>
+
+        {
+          isThreeMilestone ? (
+            <div class="space-y-2 text-sm">
+              <div class="flex justify-between p-3 bg-slate-50 rounded-lg">
+                <span class="text-slate-600">Deposit at signing</span>
+                <span class="font-medium text-slate-900">{formatCurrency(depositAmount)}</span>
+              </div>
+              <div class="flex justify-between p-3 bg-slate-50 rounded-lg">
+                <span class="text-slate-600">Milestone payments</span>
+                <span class="font-medium text-slate-900">{formatCurrency(balanceAmount)}</span>
+              </div>
+              <p class="text-xs text-slate-400 mt-2">
+                Milestone payments are billed as project phases are completed.
+              </p>
+            </div>
+          ) : (
+            <div class="space-y-2 text-sm">
+              <div class="flex justify-between p-3 bg-slate-50 rounded-lg">
+                <span class="text-slate-600">Deposit at signing ({depositPctDisplay}%)</span>
+                <span class="font-medium text-slate-900">{formatCurrency(depositAmount)}</span>
+              </div>
+              <div class="flex justify-between p-3 bg-slate-50 rounded-lg">
+                <span class="text-slate-600">Balance at completion ({balancePctDisplay}%)</span>
+                <span class="font-medium text-slate-900">{formatCurrency(balanceAmount)}</span>
+              </div>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- SOW Download -->
+      {
+        hasSow && (
+          <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6 mb-6">
+            <h2 class="text-base font-semibold text-slate-900 mb-3">Statement of Work</h2>
+            <p class="text-sm text-slate-600 mb-4">
+              Download the full Statement of Work for your records.
+            </p>
+            <a
+              href={`/api/portal/quotes/${quote.id}/sow`}
+              class="inline-flex items-center gap-2 px-4 py-2.5 bg-slate-100 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-200 transition-colors min-h-[44px]"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+              </svg>
+              Download SOW (PDF)
+            </a>
+          </div>
+        )
+      }
+
+      <!-- Signing Section -->
+      {
+        isSent && (
+          <div
+            class="bg-white rounded-lg border border-blue-200 p-5 sm:p-6 mb-6"
+            id="signing-section"
+          >
+            <h2 class="text-base font-semibold text-slate-900 mb-3">Review & Sign</h2>
+
+            {hasSignWell ? (
+              <div>
+                <p class="text-sm text-slate-600 mb-4">
+                  Review the statement of work below and sign to get started.
+                </p>
+                <div
+                  class="rounded-lg border border-slate-200 overflow-hidden"
+                  style="min-height: 600px;"
+                >
+                  <iframe
+                    src={`https://app.signwell.com/sign/${quote.signwell_doc_id}`}
+                    class="w-full border-0"
+                    style="min-height: 600px;"
+                    title="Sign Statement of Work"
+                    allow="clipboard-write"
+                  />
+                </div>
+              </div>
+            ) : (
+              <div class="text-center py-8">
+                <svg
+                  class="w-12 h-12 text-slate-300 mx-auto mb-3"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <p class="text-slate-600 font-medium">Your proposal is being prepared</p>
+                <p class="text-sm text-slate-400 mt-1">
+                  The signing document is being finalized. You will receive an email when it is
+                  ready.
+                </p>
+              </div>
+            )}
+          </div>
+        )
+      }
+
+      <!-- Accepted Confirmation -->
+      {
+        quote.status === 'accepted' && (
+          <div class="bg-green-50 border border-green-200 rounded-lg p-5 sm:p-6 mb-6">
+            <div class="flex items-start gap-3">
+              <svg
+                class="w-6 h-6 text-green-600 flex-shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div>
+                <p class="font-medium text-green-900">Proposal accepted</p>
+                {quote.accepted_at && (
+                  <p class="text-sm text-green-700 mt-1">
+                    Signed on {formatDate(quote.accepted_at)}
+                  </p>
+                )}
+                <p class="text-sm text-green-700 mt-1">
+                  Our team will be in touch to schedule the kickoff.
+                </p>
+              </div>
+            </div>
+          </div>
+        )
+      }
+
+      <!-- Declined / Expired States -->
+      {
+        quote.status === 'declined' && (
+          <div class="bg-slate-50 border border-slate-200 rounded-lg p-5 sm:p-6 mb-6">
+            <p class="text-sm text-slate-600">
+              This proposal was declined. If you would like to discuss a revised proposal, please
+              reach out to our team.
+            </p>
+          </div>
+        )
+      }
+
+      {
+        quote.status === 'expired' && (
+          <div class="bg-amber-50 border border-amber-200 rounded-lg p-5 sm:p-6 mb-6">
+            <p class="text-sm text-amber-800">
+              This proposal has expired. Please reach out to our team if you would like to discuss a
+              new proposal.
+            </p>
+          </div>
+        )
+      }
+
+      <!-- Timeline -->
+      <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6 mb-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">Timeline</h2>
+        <div class="space-y-3 text-sm">
+          {
+            quote.sent_at && (
+              <div class="flex justify-between">
+                <span class="text-slate-500">Proposal sent</span>
+                <span class="text-slate-900">{formatDate(quote.sent_at)}</span>
+              </div>
+            )
+          }
+          {
+            quote.expires_at && quote.status === 'sent' && (
+              <div class="flex justify-between">
+                <span class="text-slate-500">Expires</span>
+                <span class={expirationText === 'Expired' ? 'text-red-500' : 'text-slate-900'}>
+                  {formatDate(quote.expires_at)}
+                </span>
+              </div>
+            )
+          }
+          {
+            quote.accepted_at && (
+              <div class="flex justify-between">
+                <span class="text-slate-500">Signed</span>
+                <span class="text-green-600 font-medium">{formatDate(quote.accepted_at)}</span>
+              </div>
+            )
+          }
+        </div>
+      </div>
+
+      <!-- Back link -->
+      <div class="pt-2">
+        <a
+          href="/portal/quotes"
+          class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+        >
+          Back to Proposals
+        </a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -1,0 +1,176 @@
+---
+import '../../../styles/global.css'
+import { getPortalClient } from '../../../lib/portal/session'
+import { listQuotesForClient } from '../../../lib/db/quotes'
+
+/**
+ * Portal quote list — shows all quotes visible to this client.
+ *
+ * Statuses shown: sent, accepted, declined, expired.
+ * "Review & Sign" CTA for quotes with status = 'sent'.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Resolve client from session
+const portalData = await getPortalClient(env.DB, session.userId)
+if (!portalData) {
+  return Astro.redirect('/auth/portal-login?error=no_account')
+}
+
+const { client } = portalData
+const quotes = await listQuotesForClient(env.DB, client.id)
+
+// Helpers
+const formatCurrency = (amount: number) =>
+  `$${amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+const statusColorMap: Record<string, string> = {
+  sent: 'bg-blue-100 text-blue-800',
+  accepted: 'bg-green-100 text-green-800',
+  declined: 'bg-red-100 text-red-800',
+  expired: 'bg-amber-100 text-amber-800',
+}
+
+const statusLabelMap: Record<string, string> = {
+  sent: 'Pending Review',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  expired: 'Expired',
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Proposals — Portal — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/portal" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600 hidden sm:inline">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-6 sm:py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/portal" class="hover:text-slate-700">Dashboard</a></li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Proposals</li>
+        </ol>
+      </nav>
+
+      <h2 class="text-xl sm:text-2xl font-bold text-slate-900 mb-6">Your Proposals</h2>
+
+      {
+        quotes.length === 0 ? (
+          <div class="bg-white rounded-lg border border-slate-200 p-8 text-center">
+            <svg
+              class="w-12 h-12 text-slate-300 mx-auto mb-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+            <p class="text-slate-600 font-medium">No proposals yet</p>
+            <p class="text-sm text-slate-400 mt-1">
+              Proposals will appear here once they are ready for review.
+            </p>
+          </div>
+        ) : (
+          <div class="space-y-4">
+            {quotes.map((quote) => (
+              <a
+                href={`/portal/quotes/${quote.id}`}
+                class="block bg-white rounded-lg border border-slate-200 p-5 sm:p-6 hover:border-slate-300 hover:shadow-sm transition-all"
+              >
+                <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 mb-1">
+                      <span
+                        class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColorMap[quote.status] ?? 'bg-slate-100 text-slate-600'}`}
+                      >
+                        {statusLabelMap[quote.status] ?? quote.status}
+                      </span>
+                      {quote.status === 'sent' && quote.expires_at && (
+                        <span class="text-xs text-amber-600">
+                          {(() => {
+                            const diffMs = new Date(quote.expires_at).getTime() - Date.now()
+                            const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+                            return diffDays > 0
+                              ? `Expires in ${diffDays} day${diffDays !== 1 ? 's' : ''}`
+                              : 'Expired'
+                          })()}
+                        </span>
+                      )}
+                    </div>
+                    <p class="text-sm text-slate-500">
+                      {quote.sent_at
+                        ? `Sent ${formatDate(quote.sent_at)}`
+                        : `Created ${formatDate(quote.created_at)}`}
+                    </p>
+                  </div>
+
+                  <div class="flex items-center gap-4">
+                    <div class="text-right">
+                      <p class="text-lg font-bold text-slate-900">
+                        {formatCurrency(quote.total_price)}
+                      </p>
+                      <p class="text-xs text-slate-400">Project price</p>
+                    </div>
+
+                    {quote.status === 'sent' ? (
+                      <span class="inline-flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
+                        Review &amp; Sign
+                      </span>
+                    ) : (
+                      <span class="inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-600 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
+                        View Details
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('portal quotes: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/quotes.ts'), 'utf-8')
+
+  it('exports listQuotesForClient function', () => {
+    expect(source()).toContain('export async function listQuotesForClient')
+  })
+
+  it('exports getQuoteForClient function', () => {
+    expect(source()).toContain('export async function getQuoteForClient')
+  })
+
+  it('listQuotesForClient scopes by client_id (not org_id)', () => {
+    const code = source()
+    // Should use client_id = ? without org_id in the portal function
+    expect(code).toContain('SELECT * FROM quotes WHERE client_id = ?')
+  })
+
+  it('getQuoteForClient scopes by client_id and quote_id (not org_id)', () => {
+    const code = source()
+    expect(code).toContain('SELECT * FROM quotes WHERE id = ? AND client_id = ?')
+  })
+
+  it('portal queries filter to visible statuses only (sent, accepted, declined, expired)', () => {
+    const code = source()
+    expect(code).toContain("'sent', 'accepted', 'declined', 'expired'")
+    // Draft and superseded should not be visible
+    expect(code).toContain('PORTAL_VISIBLE_STATUSES')
+  })
+
+  it('portal functions do not use org_id parameter', () => {
+    const code = source()
+    // Extract just the listQuotesForClient function signature
+    const listMatch = code.match(/export async function listQuotesForClient\([^)]+\)/)
+    expect(listMatch).toBeTruthy()
+    expect(listMatch![0]).not.toContain('orgId')
+
+    // Extract just the getQuoteForClient function signature
+    const getMatch = code.match(/export async function getQuoteForClient\([^)]+\)/)
+    expect(getMatch).toBeTruthy()
+    expect(getMatch![0]).not.toContain('orgId')
+  })
+})
+
+describe('portal quotes: session helper', () => {
+  it('portal session helper exists at src/lib/portal/session.ts', () => {
+    expect(existsSync(resolve('src/lib/portal/session.ts'))).toBe(true)
+  })
+
+  it('exports getPortalClient function', () => {
+    const code = readFileSync(resolve('src/lib/portal/session.ts'), 'utf-8')
+    expect(code).toContain('export async function getPortalClient')
+  })
+
+  it('resolves client via users.client_id', () => {
+    const code = readFileSync(resolve('src/lib/portal/session.ts'), 'utf-8')
+    expect(code).toContain('client_id')
+    expect(code).toContain("role = 'client'")
+  })
+})
+
+describe('portal quotes: dashboard', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+
+  it('portal dashboard exists', () => {
+    expect(existsSync(resolve('src/pages/portal/index.astro'))).toBe(true)
+  })
+
+  it('shows client business name', () => {
+    expect(source()).toContain('client.business_name')
+  })
+
+  it('shows pending quotes section', () => {
+    const code = source()
+    expect(code).toContain('pendingQuotes')
+    expect(code).toContain('proposal')
+  })
+
+  it('loads quotes via listQuotesForClient', () => {
+    expect(source()).toContain('listQuotesForClient')
+  })
+
+  it('resolves client via getPortalClient', () => {
+    expect(source()).toContain('getPortalClient')
+  })
+
+  it('shows active engagement status', () => {
+    const code = source()
+    expect(code).toContain('activeEngagement')
+    expect(code).toContain('Current Engagement')
+  })
+
+  it('shows current milestone', () => {
+    expect(source()).toContain('currentMilestone')
+  })
+
+  it('shows recent activity feed', () => {
+    expect(source()).toContain('recentActivity')
+    expect(source()).toContain('Recent Activity')
+  })
+
+  it('has quick links to quotes section', () => {
+    expect(source()).toContain('/portal/quotes')
+  })
+
+  it('has mobile viewport meta tag', () => {
+    expect(source()).toContain('width=device-width, initial-scale=1.0')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+
+  it('does not expose hourly rates', () => {
+    const code = source()
+    expect(code).not.toContain('rate')
+    expect(code).not.toContain('/hr')
+    expect(code).not.toContain('hourly')
+  })
+})
+
+describe('portal quotes: quote list page', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/quotes/index.astro'), 'utf-8')
+
+  it('quote list page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/quotes/index.astro'))).toBe(true)
+  })
+
+  it('loads quotes via listQuotesForClient', () => {
+    expect(source()).toContain('listQuotesForClient')
+  })
+
+  it('resolves client via getPortalClient', () => {
+    expect(source()).toContain('getPortalClient')
+  })
+
+  it('displays status badges', () => {
+    const code = source()
+    expect(code).toContain('statusColorMap')
+    expect(code).toContain('bg-blue-100')
+    expect(code).toContain('bg-green-100')
+    expect(code).toContain('bg-red-100')
+    expect(code).toContain('bg-amber-100')
+  })
+
+  it('displays total price for each quote', () => {
+    expect(source()).toContain('quote.total_price')
+  })
+
+  it('displays date sent', () => {
+    expect(source()).toContain('quote.sent_at')
+  })
+
+  it('shows Review & Sign CTA for sent quotes', () => {
+    const code = source()
+    expect(code).toContain('Review')
+    expect(code).toContain('Sign')
+    expect(code).toContain("quote.status === 'sent'")
+  })
+
+  it('links to detail page', () => {
+    expect(source()).toContain('/portal/quotes/${quote.id}')
+  })
+
+  it('has mobile viewport meta tag', () => {
+    expect(source()).toContain('width=device-width, initial-scale=1.0')
+  })
+
+  it('does not expose hourly rates', () => {
+    const code = source()
+    expect(code).not.toContain('.rate')
+    expect(code).not.toContain('/hr')
+    expect(code).not.toContain('hourly')
+    expect(code).not.toContain('total_hours')
+    expect(code).not.toContain('estimated_hours')
+  })
+
+  it('does not expose per-item pricing', () => {
+    const code = source()
+    expect(code).not.toContain('item.estimated_hours')
+    expect(code).not.toContain('per item')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('portal quotes: quote detail page', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/quotes/[id].astro'), 'utf-8')
+
+  it('quote detail page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/quotes/[id].astro'))).toBe(true)
+  })
+
+  it('loads quote via getQuoteForClient', () => {
+    expect(source()).toContain('getQuoteForClient')
+  })
+
+  it('resolves client via getPortalClient', () => {
+    expect(source()).toContain('getPortalClient')
+  })
+
+  it('displays scope with problem descriptions only', () => {
+    const code = source()
+    expect(code).toContain('lineItems')
+    expect(code).toContain('getProblemLabel')
+    expect(code).toContain('item.description')
+  })
+
+  it('does NOT show hours column in scope table', () => {
+    const code = source()
+    // The scope section should not reference hours
+    expect(code).not.toMatch(/item\.estimated_hours/)
+    // Should not have a Hours column header in the scope section
+    expect(code).not.toContain('>Hours<')
+  })
+
+  it('does NOT show hourly rate', () => {
+    const code = source()
+    // Extract HTML template (after the closing --- frontmatter delimiter)
+    const parts = code.split('---')
+    const htmlTemplate = parts.slice(2).join('---')
+    expect(htmlTemplate).not.toContain('quote.rate')
+    expect(htmlTemplate).not.toContain('/hr')
+    expect(htmlTemplate).not.toContain('hourly')
+    expect(htmlTemplate).not.toContain('Rate')
+  })
+
+  it('does NOT show total_hours to client', () => {
+    const code = source()
+    // total_hours is used internally for 3-milestone calculation but not displayed
+    expect(code).not.toContain('>total_hours<')
+    expect(code).not.toContain('Total Hours')
+  })
+
+  it('displays total project price', () => {
+    expect(source()).toContain('quote.total_price')
+  })
+
+  it('displays payment terms with deposit and balance', () => {
+    const code = source()
+    expect(code).toContain('depositAmount')
+    expect(code).toContain('balanceAmount')
+    expect(code).toContain('Payment Terms')
+  })
+
+  it('handles 3-milestone payment for 40+ hour engagements', () => {
+    const code = source()
+    expect(code).toContain('isThreeMilestone')
+    expect(code).toContain('total_hours >= 40')
+  })
+
+  it('includes SOW PDF download link', () => {
+    const code = source()
+    expect(code).toContain('/api/portal/quotes/')
+    expect(code).toContain('/sow')
+    expect(code).toContain('Download SOW')
+  })
+
+  it('shows signing iframe when signwell_doc_id exists', () => {
+    const code = source()
+    expect(code).toContain('signwell_doc_id')
+    expect(code).toContain('iframe')
+    expect(code).toContain('signwell.com')
+  })
+
+  it('shows "proposal is being prepared" when no signwell_doc_id (UX-004)', () => {
+    expect(source()).toContain('Your proposal is being prepared')
+  })
+
+  it('shows Review & Sign section for sent quotes', () => {
+    const code = source()
+    expect(code).toContain('Review & Sign')
+    expect(code).toContain('isSent')
+  })
+
+  it('shows accepted confirmation state', () => {
+    const code = source()
+    expect(code).toContain('Proposal accepted')
+    expect(code).toContain("quote.status === 'accepted'")
+  })
+
+  it('shows declined and expired states', () => {
+    const code = source()
+    expect(code).toContain("quote.status === 'declined'")
+    expect(code).toContain("quote.status === 'expired'")
+  })
+
+  it('has mobile viewport meta tag', () => {
+    expect(source()).toContain('width=device-width, initial-scale=1.0')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('portal quotes: SOW download API route', () => {
+  it('SOW download route exists at src/pages/api/portal/quotes/[id]/sow.ts', () => {
+    expect(existsSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'))).toBe(true)
+  })
+
+  it('verifies portal session (client role)', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain("session.role !== 'client'")
+  })
+
+  it('scopes quote to client via getQuoteForClient', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain('getQuoteForClient')
+    expect(code).toContain('getPortalClient')
+  })
+
+  it('verifies sow_path exists', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain('sow_path')
+  })
+
+  it('streams PDF with correct Content-Type', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain("'Content-Type': 'application/pdf'")
+  })
+
+  it('sets Content-Disposition for download', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain('Content-Disposition')
+    expect(code).toContain('attachment')
+  })
+
+  it('returns 401 on unauthorized', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain('401')
+  })
+
+  it('returns 404 when quote not found', () => {
+    const code = readFileSync(resolve('src/pages/api/portal/quotes/[id]/sow.ts'), 'utf-8')
+    expect(code).toContain('404')
+  })
+})
+
+describe('portal quotes: middleware handles /api/portal/* routes', () => {
+  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('middleware detects portal API routes', () => {
+    expect(source()).toContain("pathname.startsWith('/api/portal')")
+  })
+
+  it('portal API routes return 401 JSON on auth failure (not redirect)', () => {
+    const code = source()
+    // isPortalApiRoute should lead to JSON 401 response
+    expect(code).toContain('isPortalApiRoute')
+  })
+
+  it('portal API routes included in protected route check', () => {
+    const code = source()
+    expect(code).toContain('isPortalApiRoute')
+    expect(code).toContain('isProtectedRoute')
+  })
+})


### PR DESCRIPTION
## Summary

- **Portal data access:** Added `listQuotesForClient` and `getQuoteForClient` to the quotes data layer, scoped by `client_id` (not `org_id`) with visibility filter (sent, accepted, declined, expired only)
- **Portal dashboard:** Replaced placeholder with real dashboard showing client business name, active engagement with current milestone, pending quotes alert, recent activity feed, and quick links
- **Quote list page:** `/portal/quotes` with status badges, total project price, date sent, and "Review & Sign" CTA for pending quotes
- **Quote detail page:** `/portal/quotes/[id]` with scope table (problem descriptions only, no hours/rates per Decision #16), total project price, payment terms (deposit + balance or 3-milestone), SOW PDF download, and SignWell iframe signing or "being prepared" state (UX-004)
- **SOW download API:** `GET /api/portal/quotes/:id/sow` streams PDF from R2 with proper content headers
- **Middleware update:** `/api/portal/*` routes now return 401 JSON on auth failure (not redirect) and enforce `role='client'`
- **62 new tests** covering data access, page structure, security (no rate/hours leakage), and middleware behavior
- **Mobile-first design** with responsive Tailwind classes, 44px touch targets, and clean client-friendly layout

## Test plan

- [ ] Verify `npm run test` passes (689 pass, 2 pre-existing failures from build-output guard)
- [ ] Verify `npm run typecheck` shows only pre-existing formepdf errors
- [ ] Verify `npm run lint` and `npm run format:check` pass clean
- [ ] Confirm portal quote detail page does NOT show hourly rates, hours per item, or total hours
- [ ] Confirm portal pages scope data by `client_id` only (no `org_id` leakage)
- [ ] Confirm SOW download route returns 401 for unauthenticated requests
- [ ] Verify mobile layout at 375px width for all portal pages

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)