### PR TITLE
feat: portal docs/progress + follow-up cadence (#80, #81)

### DIFF
--- a/src/lib/db/follow-ups.ts
+++ b/src/lib/db/follow-ups.ts
@@ -1,0 +1,240 @@
+/**
+ * Follow-up data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ *
+ * Follow-ups track scheduled outreach at key moments:
+ * - Proposal cadence: 3-touch over 7 days (Decision #19)
+ * - Review request: 2 days post-handoff (Decision #26)
+ * - Referral ask: at handoff (Decision #23)
+ * - Safety net check-in: 7 days post-handoff
+ * - Feedback survey: 30 days post-handoff (Decision #29)
+ */
+
+export interface FollowUp {
+  id: string
+  org_id: string
+  client_id: string
+  engagement_id: string | null
+  quote_id: string | null
+  type: string
+  scheduled_for: string
+  completed_at: string | null
+  status: string
+  notes: string | null
+  created_at: string
+}
+
+export type FollowUpType =
+  | 'proposal_day2'
+  | 'proposal_day5'
+  | 'proposal_day7'
+  | 'review_request'
+  | 'referral_ask'
+  | 'safety_net_checkin'
+  | 'feedback_30day'
+
+export type FollowUpStatus = 'scheduled' | 'completed' | 'skipped'
+
+export const FOLLOW_UP_TYPES: { value: FollowUpType; label: string }[] = [
+  { value: 'proposal_day2', label: 'Proposal - Day 2' },
+  { value: 'proposal_day5', label: 'Proposal - Day 5' },
+  { value: 'proposal_day7', label: 'Proposal - Day 7' },
+  { value: 'review_request', label: 'Review Request' },
+  { value: 'referral_ask', label: 'Referral Ask' },
+  { value: 'safety_net_checkin', label: 'Safety Net Check-in' },
+  { value: 'feedback_30day', label: '30-Day Feedback' },
+]
+
+export interface FollowUpFilters {
+  status?: FollowUpStatus
+  type?: FollowUpType
+  upcoming?: boolean
+  overdue?: boolean
+}
+
+export interface CreateFollowUpData {
+  client_id: string
+  engagement_id?: string | null
+  quote_id?: string | null
+  type: FollowUpType
+  scheduled_for: string
+  notes?: string | null
+}
+
+/**
+ * List follow-ups for an organization with optional filters.
+ */
+export async function listFollowUps(
+  db: D1Database,
+  orgId: string,
+  filters?: FollowUpFilters
+): Promise<FollowUp[]> {
+  const conditions: string[] = ['org_id = ?']
+  const params: (string | number)[] = [orgId]
+
+  if (filters?.status) {
+    conditions.push('status = ?')
+    params.push(filters.status)
+  }
+
+  if (filters?.type) {
+    conditions.push('type = ?')
+    params.push(filters.type)
+  }
+
+  if (filters?.upcoming) {
+    conditions.push("scheduled_for >= datetime('now')")
+    conditions.push("status = 'scheduled'")
+  }
+
+  if (filters?.overdue) {
+    conditions.push("scheduled_for < datetime('now')")
+    conditions.push("status = 'scheduled'")
+  }
+
+  const where = conditions.join(' AND ')
+  const sql = `SELECT * FROM follow_ups WHERE ${where} ORDER BY scheduled_for ASC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<FollowUp>()
+  return result.results
+}
+
+/**
+ * Get a single follow-up by ID, scoped to an organization.
+ */
+export async function getFollowUp(
+  db: D1Database,
+  orgId: string,
+  id: string
+): Promise<FollowUp | null> {
+  const result = await db
+    .prepare('SELECT * FROM follow_ups WHERE id = ? AND org_id = ?')
+    .bind(id, orgId)
+    .first<FollowUp>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new follow-up. Returns the created record.
+ */
+export async function createFollowUp(
+  db: D1Database,
+  orgId: string,
+  data: CreateFollowUpData
+): Promise<FollowUp> {
+  const id = crypto.randomUUID()
+
+  await db
+    .prepare(
+      `INSERT INTO follow_ups (id, org_id, client_id, engagement_id, quote_id, type, scheduled_for, status, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'scheduled', ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      data.client_id,
+      data.engagement_id ?? null,
+      data.quote_id ?? null,
+      data.type,
+      data.scheduled_for,
+      data.notes ?? null
+    )
+    .run()
+
+  const followUp = await getFollowUp(db, orgId, id)
+  if (!followUp) {
+    throw new Error('Failed to retrieve created follow-up')
+  }
+  return followUp
+}
+
+/**
+ * Mark a follow-up as completed with optional notes.
+ */
+export async function completeFollowUp(
+  db: D1Database,
+  orgId: string,
+  id: string,
+  notes?: string | null
+): Promise<FollowUp | null> {
+  const existing = await getFollowUp(db, orgId, id)
+  if (!existing) {
+    return null
+  }
+
+  const params: (string | null)[] = [new Date().toISOString()]
+  let sql = `UPDATE follow_ups SET status = 'completed', completed_at = ?`
+
+  if (notes !== undefined) {
+    sql += ', notes = ?'
+    params.push(notes ?? null)
+  }
+
+  sql += ' WHERE id = ? AND org_id = ?'
+  params.push(id, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getFollowUp(db, orgId, id)
+}
+
+/**
+ * Mark a follow-up as skipped with optional notes.
+ */
+export async function skipFollowUp(
+  db: D1Database,
+  orgId: string,
+  id: string,
+  notes?: string | null
+): Promise<FollowUp | null> {
+  const existing = await getFollowUp(db, orgId, id)
+  if (!existing) {
+    return null
+  }
+
+  const params: (string | null)[] = []
+  let sql = `UPDATE follow_ups SET status = 'skipped'`
+
+  if (notes !== undefined) {
+    sql += ', notes = ?'
+    params.push(notes ?? null)
+  }
+
+  sql += ' WHERE id = ? AND org_id = ?'
+  params.push(id, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getFollowUp(db, orgId, id)
+}
+
+/**
+ * Bulk create follow-ups for scheduling a cadence.
+ * Returns the array of created follow-ups.
+ */
+export async function bulkCreateFollowUps(
+  db: D1Database,
+  orgId: string,
+  followUps: CreateFollowUpData[]
+): Promise<FollowUp[]> {
+  const created: FollowUp[] = []
+
+  for (const data of followUps) {
+    const followUp = await createFollowUp(db, orgId, data)
+    created.push(followUp)
+  }
+
+  return created
+}

--- a/src/lib/email/follow-up-templates.ts
+++ b/src/lib/email/follow-up-templates.ts
@@ -1,0 +1,280 @@
+/**
+ * Email templates for follow-up cadence emails.
+ *
+ * All templates use "we" voice per Decision #20.
+ * Templates produce self-contained HTML emails with inline styles.
+ * No external CSS or image dependencies.
+ */
+
+export interface FollowUpEmailData {
+  clientName: string
+  businessName: string
+  portalUrl: string
+}
+
+export interface FollowUpEmail {
+  subject: string
+  html: string
+}
+
+/**
+ * Shared email wrapper for consistent styling.
+ */
+function emailWrapper(body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 24px;text-align:center;">SMD Services</h1>
+${body}
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Proposal Day 2 — Confirm receipt. Short, no pressure.
+ * Per Decision #19: "We sent over the scope yesterday — wanted to make sure it landed."
+ */
+export function proposalDay2Email(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        We sent over the scope for ${data.businessName} recently and wanted to make sure it landed. You can review it anytime in your portal.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        No rush — just let us know if you have any questions.
+      </p>
+      <div style="text-align:center;">
+        <a href="${data.portalUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 32px;border-radius:6px;">
+          View Your Proposal
+        </a>
+      </div>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        If you have any questions, reply directly to this email.
+      </p>`
+
+  return {
+    subject: `Following up on your proposal — ${data.businessName}`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * Proposal Day 5 — Value add. One specific observation from the call.
+ * Per Decision #19: Shows the team was already working the problem.
+ */
+export function proposalDay5Email(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        We've been thinking about what we discussed during our conversation about ${data.businessName}. The challenges you described are common at your stage of growth, and we're confident the plan we outlined will make a real difference.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Your proposal is still available in your portal. We'd love to get started whenever the timing works for you.
+      </p>
+      <div style="text-align:center;">
+        <a href="${data.portalUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 32px;border-radius:6px;">
+          Review Proposal
+        </a>
+      </div>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        If you have any questions, reply directly to this email.
+      </p>`
+
+  return {
+    subject: `Thinking about ${data.businessName}`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * Proposal Day 7 — Soft deadline. Offer to reschedule. No pressure.
+ * Per Decision #19: Reference slot hold, clean yes or reschedule.
+ */
+export function proposalDay7Email(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        We wanted to check in one more time about the proposal for ${data.businessName}. We've been holding a slot in our schedule, and we want to make sure we're being respectful of your time.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        If the timing isn't right, no problem at all — just let us know and we can revisit down the road. If you're ready to move forward, we're here to get started.
+      </p>
+      <div style="text-align:center;">
+        <a href="${data.portalUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 32px;border-radius:6px;">
+          View Proposal
+        </a>
+      </div>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        Reply to this email anytime — we're happy to chat.
+      </p>`
+
+  return {
+    subject: `Checking in — ${data.businessName} proposal`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * Review request — 2 days post-handoff.
+ * Per Decision #26: Google review link + LinkedIn, framed as easy and appreciated.
+ */
+export function reviewRequestEmail(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        We really enjoyed working with you and the team at ${data.businessName}. Now that things are up and running, we'd genuinely appreciate it if you could leave us a quick review.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        Either a Google review or a LinkedIn recommendation works great — whichever is easier for you. It means a lot to a small team like ours.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Your portal is always available if you need to reference anything from the engagement.
+      </p>
+      <div style="text-align:center;">
+        <a href="${data.portalUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 32px;border-radius:6px;">
+          Visit Your Portal
+        </a>
+      </div>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        Thank you for trusting us with ${data.businessName}.
+      </p>`
+
+  return {
+    subject: `It was great working with ${data.businessName}`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * Referral ask — at handoff.
+ * Per Decision #23: Explicit ask, no formal incentive. Easy introduction.
+ */
+export function referralAskEmail(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        Now that we've wrapped up the engagement for ${data.businessName}, we wanted to say thanks for being great to work with.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        If you know another business owner dealing with the same kind of operational growing pains, we'd genuinely appreciate the introduction. We make it easy for them — it starts with a conversation, no commitment.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Just reply to this email with their name and we'll take it from there.
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        Thank you for choosing SMD Services.
+      </p>`
+
+  return {
+    subject: `Know someone who could use the same help?`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * Safety net check-in — handoff + 7 days.
+ * Quick check that everything is holding up in real-world use.
+ */
+export function safetyNetCheckinEmail(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        We wanted to check in and see how things are going at ${data.businessName} since we wrapped up. Has the team settled into the new workflows?
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        If anything needs adjusting or questions have come up, we're still here — that's what the support window is for. Reply to this email or reach out anytime.
+      </p>
+      <div style="text-align:center;">
+        <a href="${data.portalUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 32px;border-radius:6px;">
+          Visit Your Portal
+        </a>
+      </div>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        We're here if you need us.
+      </p>`
+
+  return {
+    subject: `How's everything going at ${data.businessName}?`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * 30-day feedback survey — handoff + 30 days.
+ * Per Decision #29: 4 questions, question 4 doubles as referral prompt.
+ */
+export function feedback30DayEmail(data: FollowUpEmailData): FollowUpEmail {
+  const body = `      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${data.clientName ? ` ${data.clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        It's been about a month since we wrapped up at ${data.businessName}, and we'd love to hear how things are going. A few quick questions:
+      </p>
+      <ol style="font-size:15px;color:#334155;margin:0 0 16px;padding-left:20px;">
+        <li style="margin-bottom:8px;">Are the solutions we built still being used day-to-day?</li>
+        <li style="margin-bottom:8px;">What's the most noticeable change in how your team operates?</li>
+        <li style="margin-bottom:8px;">Any friction points that came up after we left?</li>
+        <li style="margin-bottom:8px;">Would you refer us to another business owner? If so, who comes to mind?</li>
+      </ol>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Just reply to this email — a few sentences is all we need. Your feedback helps us get better, and we genuinely appreciate it.
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
+        Thank you for working with SMD Services.
+      </p>`
+
+  return {
+    subject: `30-day check-in — how's ${data.businessName} doing?`,
+    html: emailWrapper(body),
+  }
+}
+
+/**
+ * Get the email template function for a given follow-up type.
+ */
+export function getFollowUpTemplate(
+  type: string
+): ((data: FollowUpEmailData) => FollowUpEmail) | null {
+  const templates: Record<string, (data: FollowUpEmailData) => FollowUpEmail> = {
+    proposal_day2: proposalDay2Email,
+    proposal_day5: proposalDay5Email,
+    proposal_day7: proposalDay7Email,
+    review_request: reviewRequestEmail,
+    referral_ask: referralAskEmail,
+    safety_net_checkin: safetyNetCheckinEmail,
+    feedback_30day: feedback30DayEmail,
+  }
+
+  return templates[type] ?? null
+}

--- a/src/lib/follow-ups/scheduler.ts
+++ b/src/lib/follow-ups/scheduler.ts
@@ -1,0 +1,104 @@
+/**
+ * Follow-up cadence scheduler.
+ *
+ * Schedules follow-up sequences at the right moments:
+ * - Proposal cadence: Day 2, Day 5, Day 7 after quote sent (Decision #19)
+ * - Engagement cadence: review request, referral ask, safety net, feedback (Decisions #23, #26, #29)
+ */
+
+import { bulkCreateFollowUps } from '../db/follow-ups'
+import type { CreateFollowUpData } from '../db/follow-ups'
+
+/**
+ * Add days to an ISO date string, returning a new ISO date string.
+ */
+function addDays(isoDate: string, days: number): string {
+  const date = new Date(isoDate)
+  date.setDate(date.getDate() + days)
+  return date.toISOString()
+}
+
+/**
+ * Schedule the 3-touch proposal follow-up cadence.
+ *
+ * Per Decision #19:
+ * - Day 2: Confirm receipt
+ * - Day 5: Value add
+ * - Day 7: Soft deadline
+ */
+export async function scheduleProposalCadence(
+  db: D1Database,
+  orgId: string,
+  quoteId: string,
+  clientId: string,
+  sentAt: string
+): Promise<void> {
+  const followUps: CreateFollowUpData[] = [
+    {
+      client_id: clientId,
+      quote_id: quoteId,
+      type: 'proposal_day2',
+      scheduled_for: addDays(sentAt, 2),
+    },
+    {
+      client_id: clientId,
+      quote_id: quoteId,
+      type: 'proposal_day5',
+      scheduled_for: addDays(sentAt, 5),
+    },
+    {
+      client_id: clientId,
+      quote_id: quoteId,
+      type: 'proposal_day7',
+      scheduled_for: addDays(sentAt, 7),
+    },
+  ]
+
+  await bulkCreateFollowUps(db, orgId, followUps)
+}
+
+/**
+ * Schedule the engagement follow-up cadence.
+ *
+ * Per Decisions #23, #26, #29:
+ * - At handoff: referral ask
+ * - Handoff + 2 days: review request
+ * - Handoff + 7 days: safety net check-in
+ * - Handoff + 30 days: feedback survey
+ */
+export async function scheduleEngagementCadence(
+  db: D1Database,
+  orgId: string,
+  engagementId: string,
+  clientId: string,
+  handoffDate: string
+): Promise<void> {
+  const followUps: CreateFollowUpData[] = [
+    {
+      client_id: clientId,
+      engagement_id: engagementId,
+      type: 'referral_ask',
+      scheduled_for: handoffDate,
+    },
+    {
+      client_id: clientId,
+      engagement_id: engagementId,
+      type: 'review_request',
+      scheduled_for: addDays(handoffDate, 2),
+    },
+    {
+      client_id: clientId,
+      engagement_id: engagementId,
+      type: 'safety_net_checkin',
+      scheduled_for: addDays(handoffDate, 7),
+    },
+    {
+      client_id: clientId,
+      engagement_id: engagementId,
+      type: 'feedback_30day',
+      scheduled_for: addDays(handoffDate, 30),
+    },
+  ]
+
+  await bulkCreateFollowUps(db, orgId, followUps)
+}

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -123,3 +123,33 @@ export function getPdfUrl(orgId: string, quoteId: string): string {
 export async function getPdf(r2: R2Bucket, key: string): Promise<R2ObjectBody | null> {
   return r2.get(key)
 }
+
+// ---------------------------------------------------------------------------
+// Document listing and streaming helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * List all R2 objects under a given prefix.
+ *
+ * Used to enumerate documents for a client engagement:
+ *   {orgId}/engagements/{engId}/docs/*
+ *
+ * @param r2 - The R2 bucket binding
+ * @param prefix - The key prefix to list under
+ * @returns Array of R2Object metadata
+ */
+export async function listDocuments(r2: R2Bucket, prefix: string): Promise<R2Object[]> {
+  const listed = await r2.list({ prefix })
+  return listed.objects
+}
+
+/**
+ * Get an R2 object for streaming download.
+ *
+ * @param r2 - The R2 bucket binding
+ * @param key - The R2 key of the document
+ * @returns The R2ObjectBody for streaming, or null if not found
+ */
+export async function streamDocument(r2: R2Bucket, key: string): Promise<R2ObjectBody | null> {
+  return r2.get(key)
+}

--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -1,0 +1,287 @@
+---
+import '../../../styles/global.css'
+import { listFollowUps, FOLLOW_UP_TYPES } from '../../../lib/db/follow-ups'
+import type { FollowUp, FollowUpType } from '../../../lib/db/follow-ups'
+
+/**
+ * Admin follow-up dashboard — view and manage follow-up cadences.
+ *
+ * Three sections: Upcoming, Overdue, Completed.
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Get filter from URL params
+const filterType = Astro.url.searchParams.get('type') ?? ''
+const activeTab = Astro.url.searchParams.get('tab') ?? 'upcoming'
+
+// Fetch follow-ups in parallel
+const [upcoming, overdue, completed] = await Promise.all([
+  listFollowUps(env.DB, session.orgId, {
+    upcoming: true,
+    ...(filterType ? { type: filterType as FollowUpType } : {}),
+  }),
+  listFollowUps(env.DB, session.orgId, {
+    overdue: true,
+    ...(filterType ? { type: filterType as FollowUpType } : {}),
+  }),
+  listFollowUps(env.DB, session.orgId, {
+    status: 'completed',
+    ...(filterType ? { type: filterType as FollowUpType } : {}),
+  }),
+])
+
+// Look up client names for follow-ups
+const allFollowUps = [...upcoming, ...overdue, ...completed]
+const clientIds = [...new Set(allFollowUps.map((f) => f.client_id))]
+
+interface ClientRow {
+  id: string
+  business_name: string
+}
+
+const clientMap: Record<string, string> = {}
+for (const id of clientIds) {
+  const client = await env.DB.prepare(
+    'SELECT id, business_name FROM clients WHERE id = ? AND org_id = ?'
+  )
+    .bind(id, session.orgId)
+    .first<ClientRow>()
+  if (client) {
+    clientMap[id] = client.business_name
+  }
+}
+
+// Helpers
+function getTypeLabel(type: string): string {
+  return FOLLOW_UP_TYPES.find((t) => t.value === type)?.label ?? type
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function daysUntil(iso: string): number {
+  const target = new Date(iso)
+  const now = new Date()
+  const diff = target.getTime() - now.getTime()
+  return Math.ceil(diff / (1000 * 60 * 60 * 24))
+}
+
+function daysLabel(iso: string): string {
+  const days = daysUntil(iso)
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Tomorrow'
+  if (days > 1) return `In ${days} days`
+  if (days === -1) return '1 day overdue'
+  return `${Math.abs(days)} days overdue`
+}
+
+const success = Astro.url.searchParams.get('saved')
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Follow-ups — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Follow-ups</span>
+      </nav>
+
+      {
+        success && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Follow-up updated successfully.
+          </div>
+        )
+      }
+
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-xl font-semibold text-slate-900">Follow-ups</h2>
+
+        {/* Type filter */}
+        <form method="GET" class="flex items-center gap-2">
+          <input type="hidden" name="tab" value={activeTab} />
+          <select
+            name="type"
+            class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+            onchange="this.form.submit()"
+          >
+            <option value="">All types</option>
+            {
+              FOLLOW_UP_TYPES.map((t) => (
+                <option value={t.value} selected={filterType === t.value}>
+                  {t.label}
+                </option>
+              ))
+            }
+          </select>
+        </form>
+      </div>
+
+      {/* Tabs */}
+      <div class="flex gap-1 mb-6 border-b border-slate-200">
+        <a
+          href={`/admin/follow-ups?tab=upcoming${filterType ? `&type=${filterType}` : ''}`}
+          class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'upcoming'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-slate-500 hover:text-slate-700'
+          }`}
+        >
+          Upcoming ({upcoming.length})
+        </a>
+        <a
+          href={`/admin/follow-ups?tab=overdue${filterType ? `&type=${filterType}` : ''}`}
+          class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'overdue'
+              ? 'border-red-500 text-red-600'
+              : 'border-transparent text-slate-500 hover:text-slate-700'
+          }`}
+        >
+          Overdue ({overdue.length})
+        </a>
+        <a
+          href={`/admin/follow-ups?tab=completed${filterType ? `&type=${filterType}` : ''}`}
+          class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'completed'
+              ? 'border-green-500 text-green-600'
+              : 'border-transparent text-slate-500 hover:text-slate-700'
+          }`}
+        >
+          Completed ({completed.length})
+        </a>
+      </div>
+
+      {/* Follow-up list */}
+      {
+        (() => {
+          const items =
+            activeTab === 'overdue' ? overdue : activeTab === 'completed' ? completed : upcoming
+          if (items.length === 0) {
+            return (
+              <div class="bg-white rounded-lg border border-slate-200 p-6">
+                <p class="text-slate-500 text-sm">
+                  {activeTab === 'upcoming' && 'No upcoming follow-ups.'}
+                  {activeTab === 'overdue' && 'No overdue follow-ups.'}
+                  {activeTab === 'completed' && 'No completed follow-ups.'}
+                </p>
+              </div>
+            )
+          }
+          return (
+            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {items.map((f: FollowUp) => (
+                <div class="px-6 py-4">
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2 mb-1">
+                        <span class="text-sm font-medium text-slate-900">
+                          {clientMap[f.client_id] ?? 'Unknown'}
+                        </span>
+                        <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">
+                          {getTypeLabel(f.type)}
+                        </span>
+                      </div>
+                      <div class="flex items-center gap-3 text-xs text-slate-400">
+                        <span>{formatDate(f.scheduled_for)}</span>
+                        {f.status === 'scheduled' && (
+                          <span
+                            class={
+                              daysUntil(f.scheduled_for) < 0
+                                ? 'text-red-500 font-medium'
+                                : 'text-slate-500'
+                            }
+                          >
+                            {daysLabel(f.scheduled_for)}
+                          </span>
+                        )}
+                        {f.completed_at && <span>Completed: {formatDate(f.completed_at)}</span>}
+                      </div>
+                      {f.notes && <p class="text-xs text-slate-500 mt-1">{f.notes}</p>}
+                    </div>
+
+                    {f.status === 'scheduled' && (
+                      <div class="flex items-center gap-2 shrink-0">
+                        <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
+                          <input type="hidden" name="action" value="send_email" />
+                          <button
+                            type="submit"
+                            class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                          >
+                            Send Email
+                          </button>
+                        </form>
+                        <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
+                          <input type="hidden" name="action" value="complete" />
+                          <button
+                            type="submit"
+                            class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-md hover:bg-green-100 transition-colors"
+                          >
+                            Mark Complete
+                          </button>
+                        </form>
+                        <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
+                          <input type="hidden" name="action" value="skip" />
+                          <button
+                            type="submit"
+                            class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                          >
+                            Skip
+                          </button>
+                        </form>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )
+        })()
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,14 +1,25 @@
 ---
 import '../../styles/global.css'
+import { listFollowUps } from '../../lib/db/follow-ups'
 
 /**
- * Admin dashboard placeholder — protected by auth middleware.
+ * Admin dashboard — protected by auth middleware.
  *
  * If you're seeing this page, the session is valid.
  * Session data is available via Astro.locals.session.
  */
 
 const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Fetch follow-up counts for dashboard card
+const [upcomingFollowUps, overdueFollowUps] = await Promise.all([
+  listFollowUps(env.DB, session.orgId, { upcoming: true }),
+  listFollowUps(env.DB, session.orgId, { overdue: true }),
+])
+
+const upcomingCount = upcomingFollowUps.length
+const overdueCount = overdueFollowUps.length
 ---
 
 <!doctype html>
@@ -60,6 +71,39 @@ const session = Astro.locals.session!
           <p class="text-sm text-slate-500 mt-1">
             Manage your client pipeline — create, edit, and track clients through the engagement
             lifecycle.
+          </p>
+        </a>
+
+        <a
+          href="/admin/follow-ups"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <div class="flex items-center justify-between">
+            <h3
+              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+            >
+              Follow-ups
+            </h3>
+            <div class="flex items-center gap-2">
+              {
+                overdueCount > 0 && (
+                  <span class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded-full font-medium">
+                    {overdueCount} overdue
+                  </span>
+                )
+              }
+              {
+                upcomingCount > 0 && (
+                  <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
+                    {upcomingCount} upcoming
+                  </span>
+                )
+              }
+            </div>
+          </div>
+          <p class="text-sm text-slate-500 mt-1">
+            Manage follow-up cadences — proposal follow-ups, review requests, referral asks, and
+            feedback surveys.
           </p>
         </a>
       </div>

--- a/src/pages/api/admin/follow-ups/[id].ts
+++ b/src/pages/api/admin/follow-ups/[id].ts
@@ -1,0 +1,131 @@
+import type { APIRoute } from 'astro'
+import { getFollowUp, completeFollowUp, skipFollowUp } from '../../../../lib/db/follow-ups'
+import { getFollowUpTemplate } from '../../../../lib/email/follow-up-templates'
+import type { FollowUpEmailData } from '../../../../lib/email/follow-up-templates'
+import { sendEmail } from '../../../../lib/email/resend'
+
+interface ClientRow {
+  id: string
+  business_name: string
+}
+
+interface ContactRow {
+  name: string
+  email: string | null
+}
+
+/**
+ * POST /api/admin/follow-ups/:id
+ *
+ * Manages follow-up actions: complete, skip, or send email.
+ *
+ * Actions:
+ * - action=complete: mark follow-up as completed (with optional notes)
+ * - action=skip: mark follow-up as skipped (with optional notes)
+ * - action=send_email: send the follow-up email via Resend, then mark completed
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params, url }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const followUpId = params.id
+  if (!followUpId) {
+    return new Response(JSON.stringify({ error: 'Follow-up ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const followUp = await getFollowUp(env.DB, session.orgId, followUpId)
+    if (!followUp) {
+      return redirect('/admin/follow-ups?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const action = formData.get('action')
+    const notes = formData.get('notes')
+    const notesStr = notes && typeof notes === 'string' ? notes.trim() || null : null
+
+    if (action === 'complete') {
+      await completeFollowUp(env.DB, session.orgId, followUpId, notesStr)
+      return redirect('/admin/follow-ups?saved=1', 302)
+    }
+
+    if (action === 'skip') {
+      await skipFollowUp(env.DB, session.orgId, followUpId, notesStr)
+      return redirect('/admin/follow-ups?saved=1', 302)
+    }
+
+    if (action === 'send_email') {
+      // Look up client info
+      const client = await env.DB.prepare(
+        'SELECT id, business_name FROM clients WHERE id = ? AND org_id = ?'
+      )
+        .bind(followUp.client_id, session.orgId)
+        .first<ClientRow>()
+
+      if (!client) {
+        return redirect('/admin/follow-ups?error=client_not_found', 302)
+      }
+
+      // Look up primary contact email
+      const contact = await env.DB.prepare(
+        'SELECT name, email FROM contacts WHERE client_id = ? AND org_id = ? LIMIT 1'
+      )
+        .bind(followUp.client_id, session.orgId)
+        .first<ContactRow>()
+
+      if (!contact?.email) {
+        return redirect('/admin/follow-ups?error=no_contact_email', 302)
+      }
+
+      // Get the template for this follow-up type
+      const templateFn = getFollowUpTemplate(followUp.type)
+      if (!templateFn) {
+        return redirect('/admin/follow-ups?error=no_template', 302)
+      }
+
+      // Build portal URL
+      const baseUrl = `${url.protocol}//${url.host}`
+      const portalUrl = `${baseUrl}/portal`
+
+      const emailData: FollowUpEmailData = {
+        clientName: contact.name,
+        businessName: client.business_name,
+        portalUrl,
+      }
+
+      const { subject, html } = templateFn(emailData)
+
+      const result = await sendEmail(env.RESEND_API_KEY, {
+        to: contact.email,
+        subject,
+        html,
+      })
+
+      if (!result.success) {
+        console.error(`[follow-ups] Email send failed: ${result.error}`)
+        return redirect('/admin/follow-ups?error=email_failed', 302)
+      }
+
+      // Mark as completed after successful send
+      await completeFollowUp(env.DB, session.orgId, followUpId, `Email sent: ${result.id}`)
+      return redirect('/admin/follow-ups?saved=1', 302)
+    }
+
+    return redirect('/admin/follow-ups?error=invalid_action', 302)
+  } catch (err) {
+    console.error('[api/admin/follow-ups/[id]] Error:', err)
+    return redirect('/admin/follow-ups?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -6,6 +6,7 @@ import { listContacts } from '../../../../lib/db/contacts'
 import { uploadPdf } from '../../../../lib/storage/r2'
 import { renderSow } from '../../../../lib/pdf/render'
 import type { SOWTemplateProps } from '../../../../lib/pdf/sow-template'
+import { scheduleProposalCadence } from '../../../../lib/follow-ups/scheduler'
 
 /**
  * POST /api/admin/quotes/:id
@@ -146,6 +147,15 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
           `/admin/clients/${existing.client_id}/quotes/${quoteId}?error=invalid_transition`,
           302
         )
+      }
+
+      // Schedule proposal follow-up cadence (Decision #19: Day 2, Day 5, Day 7)
+      try {
+        const sentAt = new Date().toISOString()
+        await scheduleProposalCadence(env.DB, session.orgId, quoteId, existing.client_id, sentAt)
+      } catch (err) {
+        // Non-blocking — log but don't fail the send action
+        console.error('[api/admin/quotes/[id]] Follow-up scheduling error:', err)
       }
 
       return redirect(`/admin/clients/${existing.client_id}/quotes/${quoteId}?saved=1`, 302)

--- a/src/pages/api/portal/documents/[...key].ts
+++ b/src/pages/api/portal/documents/[...key].ts
@@ -1,0 +1,132 @@
+import type { APIRoute } from 'astro'
+import { streamDocument } from '../../../../lib/storage/r2'
+import { listEngagements } from '../../../../lib/db/engagements'
+
+/**
+ * GET /api/portal/documents/:key
+ *
+ * Streams a document from R2 for portal clients.
+ * Uses a catch-all route to capture the full R2 key path.
+ *
+ * Security:
+ * - Requires valid client session (middleware ensures role=client)
+ * - Verifies the R2 key belongs to this client's org/engagement
+ * - Prevents path traversal by checking key prefix
+ *
+ * Content-Disposition:
+ * - PDFs: inline (view in browser)
+ * - Everything else: attachment (download)
+ */
+
+interface UserRow {
+  id: string
+  client_id: string | null
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.csv': 'text/csv',
+  '.txt': 'text/plain',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+}
+
+function getContentType(key: string): string {
+  const ext = key.substring(key.lastIndexOf('.')).toLowerCase()
+  return CONTENT_TYPES[ext] ?? 'application/octet-stream'
+}
+
+export const GET: APIRoute = async ({ locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'client') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const key = params.key
+  if (!key) {
+    return new Response(JSON.stringify({ error: 'Document key required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  // Look up client_id from users table
+  const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
+    .bind(session.userId)
+    .first<UserRow>()
+
+  if (!user?.client_id) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Path traversal protection: key must start with org prefix
+  if (!key.startsWith(`${session.orgId}/`)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Reject path traversal attempts
+  if (key.includes('..') || key.includes('//')) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Verify the key belongs to this client's engagement
+  const engagements = await listEngagements(env.DB, session.orgId, user.client_id)
+  const engagementIds = engagements.map((e) => e.id)
+  const quoteIds = engagements.map((e) => e.quote_id)
+
+  // Check if key matches engagement docs path or SOW PDF path
+  const isEngagementDoc = engagementIds.some((id) =>
+    key.startsWith(`${session.orgId}/engagements/${id}/`)
+  )
+  const isQuoteDoc = quoteIds.some((qid) => key.startsWith(`${session.orgId}/quotes/${qid}/`))
+
+  if (!isEngagementDoc && !isQuoteDoc) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Stream the document from R2
+  const object = await streamDocument(env.STORAGE, key)
+  if (!object) {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const contentType = getContentType(key)
+  const filename = key.split('/').pop() ?? 'document'
+  const isPdf = contentType === 'application/pdf'
+  const disposition = isPdf
+    ? `inline; filename="${filename}"`
+    : `attachment; filename="${filename}"`
+
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': contentType,
+      'Content-Disposition': disposition,
+      'Cache-Control': 'private, max-age=3600',
+    },
+  })
+}

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -1,0 +1,171 @@
+---
+import '../../../styles/global.css'
+import { listEngagements } from '../../../lib/db/engagements'
+import { listDocuments } from '../../../lib/storage/r2'
+
+/**
+ * Client portal — document library page.
+ *
+ * Lists all R2 documents under the client's engagement path,
+ * plus the SOW PDF from the accepted quote.
+ * Protected by auth middleware (role=client).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Look up client_id from the users table
+interface UserRow {
+  id: string
+  client_id: string | null
+}
+
+const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
+  .bind(session.userId)
+  .first<UserRow>()
+
+const clientId = user?.client_id
+
+interface DocumentEntry {
+  name: string
+  key: string
+  uploaded: string
+  isPdf: boolean
+}
+
+const documents: DocumentEntry[] = []
+let engagement = null
+
+if (clientId) {
+  // Get active engagement (or most recent one)
+  const engagements = await listEngagements(env.DB, session.orgId, clientId)
+  engagement =
+    engagements.find((e) => e.status !== 'completed' && e.status !== 'cancelled') ??
+    engagements[0] ??
+    null
+
+  if (engagement) {
+    // List engagement documents from R2
+    const prefix = `${session.orgId}/engagements/${engagement.id}/docs/`
+    const r2Objects = await listDocuments(env.STORAGE, prefix)
+
+    for (const obj of r2Objects) {
+      const name = obj.key.split('/').pop() ?? obj.key
+      documents.push({
+        name,
+        key: obj.key,
+        uploaded: obj.uploaded.toISOString(),
+        isPdf: name.toLowerCase().endsWith('.pdf'),
+      })
+    }
+
+    // Include SOW PDF from the quote if available
+    if (engagement.quote_id) {
+      interface QuoteRow {
+        sow_path: string | null
+      }
+
+      const quote = await env.DB.prepare('SELECT sow_path FROM quotes WHERE id = ? AND org_id = ?')
+        .bind(engagement.quote_id, session.orgId)
+        .first<QuoteRow>()
+
+      if (quote?.sow_path) {
+        documents.unshift({
+          name: 'Statement of Work (SOW)',
+          key: quote.sow_path,
+          uploaded: engagement.created_at,
+          isPdf: true,
+        })
+      }
+    }
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Documents — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/portal"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/portal" class="hover:text-primary transition-colors">Portal</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Documents</span>
+      </nav>
+
+      <h2 class="text-xl font-semibold text-slate-900 mb-6">Documents</h2>
+
+      {
+        documents.length === 0 ? (
+          <div class="bg-white rounded-lg border border-slate-200 p-6">
+            <p class="text-slate-600">Documents will appear here as your engagement progresses.</p>
+          </div>
+        ) : (
+          <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+            {documents.map((doc) => (
+              <div class="flex items-center justify-between px-6 py-4">
+                <div class="flex items-center gap-3 min-w-0">
+                  <span class={`text-lg ${doc.isPdf ? 'text-red-500' : 'text-slate-400'}`}>
+                    {doc.isPdf ? '&#128196;' : '&#128462;'}
+                  </span>
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-slate-900 truncate">{doc.name}</p>
+                    <p class="text-xs text-slate-400">{formatDate(doc.uploaded)}</p>
+                  </div>
+                </div>
+                <a
+                  href={`/api/portal/documents/${doc.key}`}
+                  class="text-sm text-primary hover:text-primary/80 font-medium transition-colors shrink-0 ml-4"
+                >
+                  {doc.isPdf ? 'View' : 'Download'}
+                </a>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -1,0 +1,198 @@
+---
+import '../../../styles/global.css'
+import { listEngagements } from '../../../lib/db/engagements'
+import { listMilestones } from '../../../lib/db/milestones'
+import type { Milestone } from '../../../lib/db/milestones'
+
+/**
+ * Client portal — engagement progress page.
+ *
+ * Shows the client's active engagement with milestone progress,
+ * scope summary, and timeline. Protected by auth middleware (role=client).
+ *
+ * Looks up the user's client_id via the users table to scope data.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Look up client_id from the users table
+interface UserRow {
+  id: string
+  client_id: string | null
+}
+
+const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
+  .bind(session.userId)
+  .first<UserRow>()
+
+const clientId = user?.client_id
+
+let engagement = null
+let milestones: Milestone[] = []
+
+if (clientId) {
+  // Get active engagement (not completed or cancelled)
+  const engagements = await listEngagements(env.DB, session.orgId, clientId)
+  engagement = engagements.find((e) => e.status !== 'completed' && e.status !== 'cancelled') ?? null
+
+  if (engagement) {
+    milestones = await listMilestones(env.DB, engagement.id)
+  }
+}
+
+// Status indicator helpers
+const statusIcon: Record<string, { color: string; icon: string; label: string }> = {
+  pending: { color: 'text-slate-400 bg-slate-100', icon: '&#9675;', label: 'Pending' },
+  in_progress: { color: 'text-blue-600 bg-blue-50', icon: '&#8635;', label: 'In Progress' },
+  completed: { color: 'text-green-600 bg-green-50', icon: '&#10003;', label: 'Completed' },
+  skipped: { color: 'text-slate-400 bg-slate-50', icon: '&#8212;', label: 'Skipped' },
+}
+
+const engagementStatusLabel: Record<string, string> = {
+  scheduled: 'Scheduled',
+  active: 'Active',
+  handoff: 'Handoff',
+  safety_net: 'Support Window',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return 'TBD'
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Engagement Progress — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/portal"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/portal" class="hover:text-primary transition-colors">Portal</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Engagement</span>
+      </nav>
+
+      <h2 class="text-xl font-semibold text-slate-900 mb-6">Engagement Progress</h2>
+
+      {
+        !engagement ? (
+          <div class="bg-white rounded-lg border border-slate-200 p-6">
+            <p class="text-slate-600">
+              No active engagement. When your engagement begins, progress will appear here.
+            </p>
+          </div>
+        ) : (
+          <div class="space-y-6">
+            {/* Status and Timeline */}
+            <div class="bg-white rounded-lg border border-slate-200 p-6">
+              <div class="flex items-center justify-between mb-4">
+                <h3 class="text-base font-semibold text-slate-900">Overview</h3>
+                <span class="text-sm font-medium text-blue-700 bg-blue-50 px-3 py-1 rounded-full">
+                  {engagementStatusLabel[engagement.status] ?? engagement.status}
+                </span>
+              </div>
+
+              {engagement.scope_summary && (
+                <p class="text-sm text-slate-600 mb-4">{engagement.scope_summary}</p>
+              )}
+
+              <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+                <div>
+                  <span class="text-slate-500">Started</span>
+                  <p class="font-medium text-slate-900">{formatDate(engagement.start_date)}</p>
+                </div>
+                <div>
+                  <span class="text-slate-500">Estimated Completion</span>
+                  <p class="font-medium text-slate-900">{formatDate(engagement.estimated_end)}</p>
+                </div>
+                <div>
+                  <span class="text-slate-500">Current Phase</span>
+                  <p class="font-medium text-slate-900">
+                    {engagementStatusLabel[engagement.status] ?? engagement.status}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Milestones */}
+            <div class="bg-white rounded-lg border border-slate-200 p-6">
+              <h3 class="text-base font-semibold text-slate-900 mb-4">Milestones</h3>
+
+              {milestones.length === 0 ? (
+                <p class="text-sm text-slate-500">
+                  Milestones will appear here as your engagement progresses.
+                </p>
+              ) : (
+                <div class="space-y-3">
+                  {milestones.map((m) => {
+                    const indicator = statusIcon[m.status] ?? statusIcon.pending
+                    return (
+                      <div class="flex items-start gap-3 py-2">
+                        <span
+                          class={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-medium shrink-0 mt-0.5 ${indicator.color}`}
+                          set:html={indicator.icon}
+                        />
+                        <div class="flex-1 min-w-0">
+                          <p class="text-sm font-medium text-slate-900">{m.name}</p>
+                          {m.description && (
+                            <p class="text-sm text-slate-500 mt-0.5">{m.description}</p>
+                          )}
+                          <div class="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                            <span>{indicator.label}</span>
+                            {m.due_date && <span>Due: {formatDate(m.due_date)}</span>}
+                            {m.completed_at && <span>Completed: {formatDate(m.completed_at)}</span>}
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -300,6 +300,37 @@ const engagementStatusColors: Record<string, string> = {
             )
           }
         </div>
+
+        <!-- Engagement & Documents Quick Links -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
+          <a
+            href="/portal/engagement"
+            class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+          >
+            <h3
+              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+            >
+              Engagement Progress
+            </h3>
+            <p class="text-sm text-slate-500 mt-1">
+              View your engagement milestones, timeline, and current status.
+            </p>
+          </a>
+
+          <a
+            href="/portal/documents"
+            class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+          >
+            <h3
+              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+            >
+              Documents
+            </h3>
+            <p class="text-sm text-slate-500 mt-1">
+              Access your statement of work, deliverables, and other engagement documents.
+            </p>
+          </a>
+        </div>
       </div>
     </main>
   </body>

--- a/tests/follow-ups.test.ts
+++ b/tests/follow-ups.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('follow-ups: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/follow-ups.ts'), 'utf-8')
+
+  it('follow-ups.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/follow-ups.ts'))).toBe(true)
+  })
+
+  it('exports listFollowUps function', () => {
+    expect(source()).toContain('export async function listFollowUps')
+  })
+
+  it('exports getFollowUp function', () => {
+    expect(source()).toContain('export async function getFollowUp')
+  })
+
+  it('exports createFollowUp function', () => {
+    expect(source()).toContain('export async function createFollowUp')
+  })
+
+  it('exports completeFollowUp function', () => {
+    expect(source()).toContain('export async function completeFollowUp')
+  })
+
+  it('exports skipFollowUp function', () => {
+    expect(source()).toContain('export async function skipFollowUp')
+  })
+
+  it('exports bulkCreateFollowUps function', () => {
+    expect(source()).toContain('export async function bulkCreateFollowUps')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('scopes all queries to org_id', () => {
+    const code = source()
+    expect(code).toContain("'org_id = ?'")
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('defines all follow-up types', () => {
+    const code = source()
+    expect(code).toContain("'proposal_day2'")
+    expect(code).toContain("'proposal_day5'")
+    expect(code).toContain("'proposal_day7'")
+    expect(code).toContain("'review_request'")
+    expect(code).toContain("'referral_ask'")
+    expect(code).toContain("'safety_net_checkin'")
+    expect(code).toContain("'feedback_30day'")
+  })
+
+  it('exports FOLLOW_UP_TYPES constant', () => {
+    expect(source()).toContain('export const FOLLOW_UP_TYPES')
+  })
+
+  it('supports status filter in listFollowUps', () => {
+    const code = source()
+    expect(code).toContain("'status = ?'")
+  })
+
+  it('supports type filter in listFollowUps', () => {
+    const code = source()
+    expect(code).toContain("'type = ?'")
+  })
+
+  it('supports upcoming filter in listFollowUps', () => {
+    const code = source()
+    expect(code).toContain("scheduled_for >= datetime('now')")
+    expect(code).toContain('upcoming')
+  })
+
+  it('supports overdue filter in listFollowUps', () => {
+    const code = source()
+    expect(code).toContain("scheduled_for < datetime('now')")
+    expect(code).toContain('overdue')
+  })
+
+  it('completeFollowUp sets completed_at', () => {
+    const code = source()
+    expect(code).toContain("'completed'")
+    expect(code).toContain('completed_at')
+  })
+
+  it('skipFollowUp sets status to skipped', () => {
+    const code = source()
+    expect(code).toContain("'skipped'")
+  })
+})
+
+describe('follow-ups: scheduler', () => {
+  const source = () => readFileSync(resolve('src/lib/follow-ups/scheduler.ts'), 'utf-8')
+
+  it('scheduler.ts exists', () => {
+    expect(existsSync(resolve('src/lib/follow-ups/scheduler.ts'))).toBe(true)
+  })
+
+  it('exports scheduleProposalCadence function', () => {
+    expect(source()).toContain('export async function scheduleProposalCadence')
+  })
+
+  it('exports scheduleEngagementCadence function', () => {
+    expect(source()).toContain('export async function scheduleEngagementCadence')
+  })
+
+  it('proposal cadence creates 3 follow-ups', () => {
+    const code = source()
+    expect(code).toContain('proposal_day2')
+    expect(code).toContain('proposal_day5')
+    expect(code).toContain('proposal_day7')
+  })
+
+  it('proposal cadence uses correct intervals: day 2, 5, 7', () => {
+    const code = source()
+    expect(code).toContain('addDays(sentAt, 2)')
+    expect(code).toContain('addDays(sentAt, 5)')
+    expect(code).toContain('addDays(sentAt, 7)')
+  })
+
+  it('engagement cadence creates 4 follow-ups', () => {
+    const code = source()
+    expect(code).toContain('referral_ask')
+    expect(code).toContain('review_request')
+    expect(code).toContain('safety_net_checkin')
+    expect(code).toContain('feedback_30day')
+  })
+
+  it('engagement cadence uses correct intervals', () => {
+    const code = source()
+    // referral_ask at handoff (no addDays)
+    expect(code).toContain('scheduled_for: handoffDate')
+    // review_request at handoff+2
+    expect(code).toContain('addDays(handoffDate, 2)')
+    // safety_net_checkin at handoff+7
+    expect(code).toContain('addDays(handoffDate, 7)')
+    // feedback_30day at handoff+30
+    expect(code).toContain('addDays(handoffDate, 30)')
+  })
+
+  it('uses bulkCreateFollowUps for batch creation', () => {
+    expect(source()).toContain('bulkCreateFollowUps')
+  })
+
+  it('references Decision #19 for proposal cadence', () => {
+    expect(source()).toContain('Decision #19')
+  })
+
+  it('references Decisions #23, #26, #29 for engagement cadence', () => {
+    const code = source()
+    expect(code).toContain('Decision')
+  })
+})
+
+describe('follow-ups: email templates', () => {
+  const source = () => readFileSync(resolve('src/lib/email/follow-up-templates.ts'), 'utf-8')
+
+  it('follow-up-templates.ts exists', () => {
+    expect(existsSync(resolve('src/lib/email/follow-up-templates.ts'))).toBe(true)
+  })
+
+  it('exports proposalDay2Email template', () => {
+    expect(source()).toContain('export function proposalDay2Email')
+  })
+
+  it('exports proposalDay5Email template', () => {
+    expect(source()).toContain('export function proposalDay5Email')
+  })
+
+  it('exports proposalDay7Email template', () => {
+    expect(source()).toContain('export function proposalDay7Email')
+  })
+
+  it('exports reviewRequestEmail template', () => {
+    expect(source()).toContain('export function reviewRequestEmail')
+  })
+
+  it('exports referralAskEmail template', () => {
+    expect(source()).toContain('export function referralAskEmail')
+  })
+
+  it('exports safetyNetCheckinEmail template', () => {
+    expect(source()).toContain('export function safetyNetCheckinEmail')
+  })
+
+  it('exports feedback30DayEmail template', () => {
+    expect(source()).toContain('export function feedback30DayEmail')
+  })
+
+  it('exports getFollowUpTemplate dispatcher', () => {
+    expect(source()).toContain('export function getFollowUpTemplate')
+  })
+
+  it('all templates return subject and html', () => {
+    const code = source()
+    // Each template function returns { subject, html }
+    expect(code.match(/subject:/g)?.length).toBeGreaterThanOrEqual(7)
+    expect(code.match(/html: emailWrapper/g)?.length).toBeGreaterThanOrEqual(6)
+  })
+
+  it('uses "we" voice (Decision #20)', () => {
+    const code = source()
+    // Should contain "we" language
+    expect(code).toContain('We sent over')
+    expect(code).toContain("We've been thinking")
+    expect(code).toContain("we'd genuinely appreciate")
+    // Should NOT contain "I" language
+    expect(code).not.toContain('I sent')
+    expect(code).not.toContain('I wanted')
+  })
+
+  it('templates take clientName, businessName, portalUrl', () => {
+    const code = source()
+    expect(code).toContain('clientName')
+    expect(code).toContain('businessName')
+    expect(code).toContain('portalUrl')
+  })
+
+  it('getFollowUpTemplate maps all 7 types', () => {
+    const code = source()
+    expect(code).toContain('proposal_day2: proposalDay2Email')
+    expect(code).toContain('proposal_day5: proposalDay5Email')
+    expect(code).toContain('proposal_day7: proposalDay7Email')
+    expect(code).toContain('review_request: reviewRequestEmail')
+    expect(code).toContain('referral_ask: referralAskEmail')
+    expect(code).toContain('safety_net_checkin: safetyNetCheckinEmail')
+    expect(code).toContain('feedback_30day: feedback30DayEmail')
+  })
+})
+
+describe('follow-ups: dashboard page', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/follow-ups/index.astro'), 'utf-8')
+
+  it('dashboard page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/follow-ups/index.astro'))).toBe(true)
+  })
+
+  it('loads follow-ups via listFollowUps', () => {
+    expect(source()).toContain('listFollowUps')
+  })
+
+  it('has upcoming, overdue, and completed sections', () => {
+    const code = source()
+    expect(code).toContain('upcoming')
+    expect(code).toContain('overdue')
+    expect(code).toContain('completed')
+  })
+
+  it('displays client name for each follow-up', () => {
+    const code = source()
+    expect(code).toContain('clientMap')
+    expect(code).toContain('business_name')
+  })
+
+  it('displays follow-up type label', () => {
+    expect(source()).toContain('getTypeLabel')
+  })
+
+  it('displays scheduled date and days until/overdue', () => {
+    const code = source()
+    expect(code).toContain('scheduled_for')
+    expect(code).toContain('daysLabel')
+  })
+
+  it('has Mark Complete action', () => {
+    const code = source()
+    expect(code).toContain('Mark Complete')
+    expect(code).toContain('value="complete"')
+  })
+
+  it('has Skip action', () => {
+    const code = source()
+    expect(code).toContain('Skip')
+    expect(code).toContain('value="skip"')
+  })
+
+  it('has Send Email action', () => {
+    const code = source()
+    expect(code).toContain('Send Email')
+    expect(code).toContain('value="send_email"')
+  })
+
+  it('supports filter by type', () => {
+    const code = source()
+    expect(code).toContain('FOLLOW_UP_TYPES')
+    expect(code).toContain('filterType')
+  })
+
+  it('actions post to follow-ups API', () => {
+    expect(source()).toContain('/api/admin/follow-ups/')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('follow-ups: API route', () => {
+  const source = () => readFileSync(resolve('src/pages/api/admin/follow-ups/[id].ts'), 'utf-8')
+
+  it('API route exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/follow-ups/[id].ts'))).toBe(true)
+  })
+
+  it('handles complete action', () => {
+    const code = source()
+    expect(code).toContain("action === 'complete'")
+    expect(code).toContain('completeFollowUp')
+  })
+
+  it('handles skip action', () => {
+    const code = source()
+    expect(code).toContain("action === 'skip'")
+    expect(code).toContain('skipFollowUp')
+  })
+
+  it('handles send_email action', () => {
+    const code = source()
+    expect(code).toContain("action === 'send_email'")
+    expect(code).toContain('sendEmail')
+  })
+
+  it('uses getFollowUpTemplate for email content', () => {
+    expect(source()).toContain('getFollowUpTemplate')
+  })
+
+  it('verifies admin session', () => {
+    expect(source()).toContain("session.role !== 'admin'")
+  })
+
+  it('scopes follow-up lookup to org', () => {
+    expect(source()).toContain('session.orgId')
+  })
+
+  it('marks follow-up completed after email send', () => {
+    const code = source()
+    // After send_email, should call completeFollowUp
+    expect(code).toContain('completeFollowUp')
+  })
+})
+
+describe('follow-ups: integration with quotes', () => {
+  const source = () => readFileSync(resolve('src/pages/api/admin/quotes/[id].ts'), 'utf-8')
+
+  it('quote send action imports scheduleProposalCadence', () => {
+    expect(source()).toContain('scheduleProposalCadence')
+  })
+
+  it('quote send action calls scheduleProposalCadence after status update', () => {
+    const code = source()
+    // Should call scheduleProposalCadence in the send action block
+    expect(code).toContain('scheduleProposalCadence(env.DB')
+  })
+})
+
+describe('follow-ups: admin dashboard integration', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/index.astro'), 'utf-8')
+
+  it('admin dashboard imports listFollowUps', () => {
+    expect(source()).toContain('listFollowUps')
+  })
+
+  it('admin dashboard shows follow-ups card', () => {
+    const code = source()
+    expect(code).toContain('Follow-ups')
+    expect(code).toContain('/admin/follow-ups')
+  })
+
+  it('admin dashboard shows upcoming and overdue counts', () => {
+    const code = source()
+    expect(code).toContain('upcomingCount')
+    expect(code).toContain('overdueCount')
+  })
+})

--- a/tests/portal-docs.test.ts
+++ b/tests/portal-docs.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('portal: engagement progress page', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/engagement/index.astro'), 'utf-8')
+
+  it('engagement progress page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/engagement/index.astro'))).toBe(true)
+  })
+
+  it('loads engagement data via listEngagements', () => {
+    expect(source()).toContain('listEngagements')
+  })
+
+  it('loads milestones via listMilestones', () => {
+    expect(source()).toContain('listMilestones')
+  })
+
+  it('looks up client_id from users table', () => {
+    const code = source()
+    expect(code).toContain('client_id')
+    expect(code).toContain('users')
+    expect(code).toContain('session.userId')
+  })
+
+  it('filters out completed and cancelled engagements', () => {
+    const code = source()
+    expect(code).toContain("'completed'")
+    expect(code).toContain("'cancelled'")
+  })
+
+  it('shows milestone status indicators for all states', () => {
+    const code = source()
+    expect(code).toContain('pending')
+    expect(code).toContain('in_progress')
+    expect(code).toContain('completed')
+    expect(code).toContain('skipped')
+  })
+
+  it('displays scope summary', () => {
+    expect(source()).toContain('scope_summary')
+  })
+
+  it('displays timeline information', () => {
+    const code = source()
+    expect(code).toContain('start_date')
+    expect(code).toContain('estimated_end')
+  })
+
+  it('shows empty state when no active engagement', () => {
+    expect(source()).toContain('No active engagement')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('portal: documents page', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/documents/index.astro'), 'utf-8')
+
+  it('documents page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/documents/index.astro'))).toBe(true)
+  })
+
+  it('lists R2 documents via listDocuments', () => {
+    expect(source()).toContain('listDocuments')
+  })
+
+  it('includes SOW PDF from quote', () => {
+    const code = source()
+    expect(code).toContain('sow_path')
+    expect(code).toContain('Statement of Work')
+  })
+
+  it('scopes document listing to org/engagement prefix', () => {
+    const code = source()
+    expect(code).toContain('session.orgId')
+    expect(code).toContain('engagement.id')
+    expect(code).toContain('/docs/')
+  })
+
+  it('shows empty state when no documents', () => {
+    expect(source()).toContain('Documents will appear here as your engagement progresses')
+  })
+
+  it('provides download links to document API', () => {
+    expect(source()).toContain('/api/portal/documents/')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+})
+
+describe('portal: document download route', () => {
+  const source = () => readFileSync(resolve('src/pages/api/portal/documents/[...key].ts'), 'utf-8')
+
+  it('document download route exists', () => {
+    expect(existsSync(resolve('src/pages/api/portal/documents/[...key].ts'))).toBe(true)
+  })
+
+  it('verifies portal session', () => {
+    const code = source()
+    expect(code).toContain("session.role !== 'client'")
+    expect(code).toContain('Unauthorized')
+  })
+
+  it('prevents path traversal with .. check', () => {
+    const code = source()
+    expect(code).toContain("'..'")
+    expect(code).toContain("'//'")
+    expect(code).toContain('Forbidden')
+  })
+
+  it('verifies key starts with org prefix', () => {
+    const code = source()
+    expect(code).toContain('session.orgId')
+    expect(code).toContain('startsWith')
+  })
+
+  it('verifies key belongs to client engagement or quote', () => {
+    const code = source()
+    expect(code).toContain('isEngagementDoc')
+    expect(code).toContain('isQuoteDoc')
+    expect(code).toContain('listEngagements')
+  })
+
+  it('streams document from R2', () => {
+    expect(source()).toContain('streamDocument')
+  })
+
+  it('sets Content-Disposition inline for PDFs', () => {
+    const code = source()
+    expect(code).toContain('inline')
+    expect(code).toContain('attachment')
+    expect(code).toContain('Content-Disposition')
+  })
+
+  it('sets Content-Type based on file extension', () => {
+    const code = source()
+    expect(code).toContain('Content-Type')
+    expect(code).toContain('application/pdf')
+    expect(code).toContain('application/octet-stream')
+  })
+})
+
+describe('R2 helpers: listDocuments and streamDocument', () => {
+  const source = () => readFileSync(resolve('src/lib/storage/r2.ts'), 'utf-8')
+
+  it('exports listDocuments function', () => {
+    expect(source()).toContain('export async function listDocuments')
+  })
+
+  it('exports streamDocument function', () => {
+    expect(source()).toContain('export async function streamDocument')
+  })
+
+  it('listDocuments uses prefix parameter', () => {
+    const code = source()
+    expect(code).toContain('prefix')
+    expect(code).toContain('r2.list')
+  })
+
+  it('streamDocument returns R2 object', () => {
+    const code = source()
+    expect(code).toContain('r2.get')
+  })
+})


### PR DESCRIPTION
## Summary

- **Portal engagement progress** (`/portal/engagement`) — shows active engagement with milestone tracking (pending/in-progress/completed/skipped indicators), scope summary, and timeline
- **Portal document library** (`/portal/documents`) — lists R2 documents under the client's engagement path + SOW PDF, with secure streaming download via `/api/portal/documents/[...key]` with path traversal protection
- **Follow-up cadence automation** — data layer, scheduler, 7 email templates ("we" voice per Decision #20), admin dashboard with upcoming/overdue/completed tabs, filter by type, and send/complete/skip actions
- **Integration** — quote send action auto-schedules proposal cadence (Day 2/5/7 per Decision #19), admin dashboard shows follow-up counts

## New files (10)
- `src/lib/db/follow-ups.ts` — follow-up data access layer (CRUD, bulk create, status transitions)
- `src/lib/follow-ups/scheduler.ts` — `scheduleProposalCadence()` and `scheduleEngagementCadence()`
- `src/lib/email/follow-up-templates.ts` — 7 templates + dispatcher for all follow-up types
- `src/pages/portal/engagement/index.astro` — client-facing engagement progress
- `src/pages/portal/documents/index.astro` — client-facing document library
- `src/pages/api/portal/documents/[...key].ts` — secure R2 document streaming
- `src/pages/admin/follow-ups/index.astro` — admin follow-up dashboard
- `src/pages/api/admin/follow-ups/[id].ts` — follow-up actions API
- `tests/portal-docs.test.ts` — 29 tests for portal pages
- `tests/follow-ups.test.ts` — 66 tests for follow-up system

## Modified files (4)
- `src/lib/storage/r2.ts` — added `listDocuments()` and `streamDocument()` helpers
- `src/pages/api/admin/quotes/[id].ts` — calls `scheduleProposalCadence()` after quote send
- `src/pages/admin/index.astro` — added Follow-ups card with upcoming/overdue counts
- `src/pages/portal/index.astro` — added Engagement Progress and Documents navigation cards

## Test plan
- [ ] 722 tests pass (95 new + 627 existing), 2 pre-existing build-output failures from `@formepdf/core`
- [ ] Portal engagement page shows milestone progress for authenticated client
- [ ] Portal documents page lists R2 docs + SOW PDF
- [ ] Document download prevents path traversal (rejects `..`, `//`, wrong org prefix)
- [ ] Follow-up data layer creates/completes/skips with org scoping
- [ ] Proposal cadence schedules 3 follow-ups at Day 2, 5, 7
- [ ] Engagement cadence schedules 4 follow-ups at correct offsets
- [ ] All 7 email templates use "we" voice, return subject + html
- [ ] Admin dashboard shows follow-up counts and links to dashboard
- [ ] Follow-up API route handles complete, skip, and send_email actions

Closes #80, closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)