### PR TITLE
feat: portal business intelligence views (#82)

### DIFF
--- a/src/lib/db/analytics.ts
+++ b/src/lib/db/analytics.ts
@@ -1,0 +1,337 @@
+/**
+ * Analytics query layer for business intelligence views.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * All queries are scoped to org_id for multi-tenancy.
+ * All functions handle empty data gracefully (no division by zero, sensible defaults).
+ */
+
+// ── Pipeline Conversion ─────────────────────────────────────────────
+export interface PipelineConversion {
+  prospect: number
+  assessed: number
+  quoted: number
+  active: number
+  completed: number
+  dead: number
+}
+
+/**
+ * Count clients at each pipeline stage.
+ */
+export async function getPipelineConversion(
+  db: D1Database,
+  orgId: string
+): Promise<PipelineConversion> {
+  const result = await db
+    .prepare(
+      `SELECT status, COUNT(*) as count
+       FROM clients
+       WHERE org_id = ?
+       GROUP BY status`
+    )
+    .bind(orgId)
+    .all<{ status: string; count: number }>()
+
+  const counts: PipelineConversion = {
+    prospect: 0,
+    assessed: 0,
+    quoted: 0,
+    active: 0,
+    completed: 0,
+    dead: 0,
+  }
+
+  for (const row of result.results) {
+    if (row.status in counts) {
+      counts[row.status as keyof PipelineConversion] = row.count
+    }
+  }
+
+  return counts
+}
+
+// ── Quote Accuracy ──────────────────────────────────────────────────
+export interface QuoteAccuracyRow {
+  engagement_id: string
+  client_name: string
+  estimated_hours: number
+  actual_hours: number
+  accuracy_pct: number
+}
+
+/**
+ * Compare estimated vs actual hours for completed engagements.
+ * accuracy_pct = (actual_hours / estimated_hours) * 100
+ * Only includes completed engagements with non-null estimated_hours.
+ */
+export async function getQuoteAccuracy(db: D1Database, orgId: string): Promise<QuoteAccuracyRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT
+         e.id AS engagement_id,
+         c.business_name AS client_name,
+         e.estimated_hours,
+         e.actual_hours
+       FROM engagements e
+       JOIN clients c ON c.id = e.client_id AND c.org_id = ?
+       WHERE e.org_id = ?
+         AND e.status = 'completed'
+         AND e.estimated_hours IS NOT NULL
+         AND e.estimated_hours > 0
+       ORDER BY e.actual_end DESC`
+    )
+    .bind(orgId, orgId)
+    .all<{
+      engagement_id: string
+      client_name: string
+      estimated_hours: number
+      actual_hours: number
+    }>()
+
+  return result.results.map((row) => ({
+    engagement_id: row.engagement_id,
+    client_name: row.client_name,
+    estimated_hours: row.estimated_hours,
+    actual_hours: row.actual_hours,
+    accuracy_pct:
+      row.estimated_hours > 0
+        ? Math.round((row.actual_hours / row.estimated_hours) * 1000) / 10
+        : 0,
+  }))
+}
+
+// ── Revenue Report ──────────────────────────────────────────────────
+export interface RevenueReport {
+  total_revenue: number
+  total_invoiced: number
+  total_paid: number
+  by_month: Array<{ month: string; amount: number }>
+  by_vertical: Array<{ vertical: string; amount: number }>
+}
+
+/**
+ * Aggregate revenue from invoices.
+ * total_revenue = sum of all invoice amounts (any status except void)
+ * total_invoiced = sum of sent + paid + overdue
+ * total_paid = sum of paid
+ * by_month = paid invoices grouped by month (from paid_at)
+ * by_vertical = paid invoices grouped by client vertical
+ */
+export async function getRevenueReport(
+  db: D1Database,
+  orgId: string,
+  _period?: string
+): Promise<RevenueReport> {
+  // Total revenue (all non-void invoices)
+  const totalsResult = await db
+    .prepare(
+      `SELECT
+         COALESCE(SUM(CASE WHEN status != 'void' THEN amount ELSE 0 END), 0) AS total_revenue,
+         COALESCE(SUM(CASE WHEN status IN ('sent', 'paid', 'overdue') THEN amount ELSE 0 END), 0) AS total_invoiced,
+         COALESCE(SUM(CASE WHEN status = 'paid' THEN amount ELSE 0 END), 0) AS total_paid
+       FROM invoices
+       WHERE org_id = ?`
+    )
+    .bind(orgId)
+    .first<{ total_revenue: number; total_invoiced: number; total_paid: number }>()
+
+  // Paid invoices by month (using paid_at)
+  const byMonthResult = await db
+    .prepare(
+      `SELECT
+         substr(paid_at, 1, 7) AS month,
+         SUM(amount) AS amount
+       FROM invoices
+       WHERE org_id = ?
+         AND status = 'paid'
+         AND paid_at IS NOT NULL
+       GROUP BY substr(paid_at, 1, 7)
+       ORDER BY month ASC`
+    )
+    .bind(orgId)
+    .all<{ month: string; amount: number }>()
+
+  // Paid invoices by client vertical
+  const byVerticalResult = await db
+    .prepare(
+      `SELECT
+         COALESCE(c.vertical, 'unknown') AS vertical,
+         SUM(i.amount) AS amount
+       FROM invoices i
+       JOIN clients c ON c.id = i.client_id AND c.org_id = ?
+       WHERE i.org_id = ?
+         AND i.status = 'paid'
+       GROUP BY c.vertical
+       ORDER BY amount DESC`
+    )
+    .bind(orgId, orgId)
+    .all<{ vertical: string; amount: number }>()
+
+  return {
+    total_revenue: totalsResult?.total_revenue ?? 0,
+    total_invoiced: totalsResult?.total_invoiced ?? 0,
+    total_paid: totalsResult?.total_paid ?? 0,
+    by_month: byMonthResult.results,
+    by_vertical: byVerticalResult.results,
+  }
+}
+
+// ── Engagement Health ───────────────────────────────────────────────
+export interface EngagementHealth {
+  avg_days_to_completion: number
+  avg_parking_lot_items: number
+  total_engagements: number
+  on_time_pct: number
+}
+
+/**
+ * Engagement health metrics from completed engagements.
+ * avg_days_to_completion = avg(julianday(actual_end) - julianday(start_date))
+ * avg_parking_lot_items = avg count of parking lot items per engagement
+ * on_time_pct = percentage of completed engagements where actual_end <= estimated_end
+ */
+export async function getEngagementHealth(
+  db: D1Database,
+  orgId: string
+): Promise<EngagementHealth> {
+  // Core metrics from completed engagements
+  const metricsResult = await db
+    .prepare(
+      `SELECT
+         COUNT(*) AS total_engagements,
+         COALESCE(AVG(
+           CASE
+             WHEN actual_end IS NOT NULL AND start_date IS NOT NULL
+             THEN julianday(actual_end) - julianday(start_date)
+             ELSE NULL
+           END
+         ), 0) AS avg_days_to_completion,
+         COALESCE(SUM(
+           CASE
+             WHEN actual_end IS NOT NULL AND estimated_end IS NOT NULL
+                  AND actual_end <= estimated_end
+             THEN 1
+             ELSE 0
+           END
+         ), 0) AS on_time_count,
+         COALESCE(SUM(
+           CASE
+             WHEN actual_end IS NOT NULL AND estimated_end IS NOT NULL
+             THEN 1
+             ELSE 0
+           END
+         ), 0) AS has_both_dates_count
+       FROM engagements
+       WHERE org_id = ?
+         AND status = 'completed'`
+    )
+    .bind(orgId)
+    .first<{
+      total_engagements: number
+      avg_days_to_completion: number
+      on_time_count: number
+      has_both_dates_count: number
+    }>()
+
+  // Average parking lot items per completed engagement
+  const parkingLotResult = await db
+    .prepare(
+      `SELECT
+         COALESCE(AVG(pl_count), 0) AS avg_parking_lot_items
+       FROM (
+         SELECT e.id, COUNT(p.id) AS pl_count
+         FROM engagements e
+         LEFT JOIN parking_lot p ON p.engagement_id = e.id
+         WHERE e.org_id = ?
+           AND e.status = 'completed'
+         GROUP BY e.id
+       )`
+    )
+    .bind(orgId)
+    .first<{ avg_parking_lot_items: number }>()
+
+  const totalEngagements = metricsResult?.total_engagements ?? 0
+  const hasBothDatesCount = metricsResult?.has_both_dates_count ?? 0
+  const onTimeCount = metricsResult?.on_time_count ?? 0
+
+  return {
+    avg_days_to_completion: Math.round((metricsResult?.avg_days_to_completion ?? 0) * 10) / 10,
+    avg_parking_lot_items: Math.round((parkingLotResult?.avg_parking_lot_items ?? 0) * 10) / 10,
+    total_engagements: totalEngagements,
+    on_time_pct:
+      hasBothDatesCount > 0 ? Math.round((onTimeCount / hasBothDatesCount) * 1000) / 10 : 0,
+  }
+}
+
+// ── Follow-up Compliance ────────────────────────────────────────────
+export interface FollowUpCompliance {
+  total: number
+  completed_on_time: number
+  completed_late: number
+  missed: number
+  compliance_pct: number
+}
+
+/**
+ * Follow-up compliance metrics.
+ * completed_on_time = completed where completed_at <= scheduled_for
+ * completed_late = completed where completed_at > scheduled_for
+ * missed = status = 'scheduled' and scheduled_for < now (past due, never completed)
+ * compliance_pct = completed_on_time / total * 100
+ */
+export async function getFollowUpCompliance(
+  db: D1Database,
+  orgId: string
+): Promise<FollowUpCompliance> {
+  const result = await db
+    .prepare(
+      `SELECT
+         COUNT(*) AS total,
+         COALESCE(SUM(
+           CASE
+             WHEN status = 'completed' AND completed_at IS NOT NULL
+                  AND completed_at <= scheduled_for
+             THEN 1
+             ELSE 0
+           END
+         ), 0) AS completed_on_time,
+         COALESCE(SUM(
+           CASE
+             WHEN status = 'completed' AND completed_at IS NOT NULL
+                  AND completed_at > scheduled_for
+             THEN 1
+             ELSE 0
+           END
+         ), 0) AS completed_late,
+         COALESCE(SUM(
+           CASE
+             WHEN status = 'scheduled' AND scheduled_for < datetime('now')
+             THEN 1
+             ELSE 0
+           END
+         ), 0) AS missed
+       FROM follow_ups
+       WHERE org_id = ?`
+    )
+    .bind(orgId)
+    .first<{
+      total: number
+      completed_on_time: number
+      completed_late: number
+      missed: number
+    }>()
+
+  const total = result?.total ?? 0
+  const completedOnTime = result?.completed_on_time ?? 0
+  const completedLate = result?.completed_late ?? 0
+  const missed = result?.missed ?? 0
+
+  return {
+    total,
+    completed_on_time: completedOnTime,
+    completed_late: completedLate,
+    missed,
+    compliance_pct: total > 0 ? Math.round((completedOnTime / total) * 1000) / 10 : 0,
+  }
+}

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -1,0 +1,439 @@
+---
+import '../../../styles/global.css'
+import {
+  getPipelineConversion,
+  getQuoteAccuracy,
+  getRevenueReport,
+  getEngagementHealth,
+  getFollowUpCompliance,
+} from '../../../lib/db/analytics'
+import { CLIENT_VERTICALS } from '../../../lib/db/clients'
+
+/**
+ * Admin analytics dashboard — business intelligence views.
+ *
+ * All data is rendered server-side. No JavaScript charting libraries.
+ * Charts use Tailwind width classes for horizontal bar rendering.
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Fetch all analytics data in parallel
+const [pipeline, quoteAccuracy, revenue, health, compliance] = await Promise.all([
+  getPipelineConversion(env.DB, session.orgId),
+  getQuoteAccuracy(env.DB, session.orgId),
+  getRevenueReport(env.DB, session.orgId),
+  getEngagementHealth(env.DB, session.orgId),
+  getFollowUpCompliance(env.DB, session.orgId),
+])
+
+// ── Pipeline helpers ─────────────────────────────────────────────
+const pipelineStages = [
+  { key: 'prospect' as const, label: 'Prospect', color: 'bg-slate-400' },
+  { key: 'assessed' as const, label: 'Assessed', color: 'bg-blue-500' },
+  { key: 'quoted' as const, label: 'Quoted', color: 'bg-amber-500' },
+  { key: 'active' as const, label: 'Active', color: 'bg-green-500' },
+  { key: 'completed' as const, label: 'Completed', color: 'bg-emerald-600' },
+  { key: 'dead' as const, label: 'Dead', color: 'bg-red-500' },
+]
+
+const maxPipelineCount = Math.max(...pipelineStages.map((s) => pipeline[s.key]), 1)
+const totalClients = Object.values(pipeline).reduce((a, b) => a + b, 0)
+
+function pipelineBarWidth(count: number): string {
+  if (count === 0) return '0%'
+  const pct = Math.max((count / maxPipelineCount) * 100, 4) // min 4% for visibility
+  return `${pct}%`
+}
+
+// ── Quote accuracy helpers ──────────────────────────────────────
+function accuracyColor(pct: number): string {
+  const variance = Math.abs(pct - 100)
+  if (variance <= 20) return 'text-green-700 bg-green-50'
+  if (variance <= 40) return 'text-amber-700 bg-amber-50'
+  return 'text-red-700 bg-red-50'
+}
+
+const avgAccuracy =
+  quoteAccuracy.length > 0
+    ? Math.round(
+        (quoteAccuracy.reduce((sum, r) => sum + r.accuracy_pct, 0) / quoteAccuracy.length) * 10
+      ) / 10
+    : 0
+
+// ── Revenue helpers ─────────────────────────────────────────────
+const maxMonthlyAmount = Math.max(...revenue.by_month.map((m) => m.amount), 1)
+const outstanding = revenue.total_invoiced - revenue.total_paid
+
+function revenueBarWidth(amount: number): string {
+  if (amount === 0) return '0%'
+  const pct = Math.max((amount / maxMonthlyAmount) * 100, 4)
+  return `${pct}%`
+}
+
+function formatCurrency(amount: number): string {
+  return amount.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+function getVerticalLabel(value: string): string {
+  return CLIENT_VERTICALS.find((v) => v.value === value)?.label ?? value
+}
+
+function formatMonthLabel(yyyymm: string): string {
+  const [year, month] = yyyymm.split('-')
+  const date = new Date(Number(year), Number(month) - 1)
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short' })
+}
+
+// ── Compliance helpers ──────────────────────────────────────────
+function complianceBarWidth(pct: number): string {
+  return `${Math.max(pct, 2)}%`
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Analytics — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Analytics</span>
+      </nav>
+
+      <h2 class="text-xl font-semibold text-slate-900 mb-6">Analytics</h2>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* ── Pipeline Funnel ──────────────────────────────── */}
+        <div class="bg-white rounded-lg border border-slate-200 p-6">
+          <h3 class="text-base font-semibold text-slate-900 mb-4">Pipeline Funnel</h3>
+          {
+            totalClients === 0 ? (
+              <p class="text-sm text-slate-500">No clients yet.</p>
+            ) : (
+              <div class="space-y-3">
+                {pipelineStages.map((stage) => (
+                  <div class="flex items-center gap-3">
+                    <span class="text-sm text-slate-600 w-24 shrink-0">{stage.label}</span>
+                    <div class="flex-1 bg-slate-100 rounded-full h-6 overflow-hidden">
+                      <div
+                        class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
+                        style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
+                      >
+                        {pipeline[stage.key] > 0 && (
+                          <span class="text-xs font-medium text-white">
+                            {pipeline[stage.key].toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {pipeline[stage.key] === 0 && (
+                      <span class="text-xs text-slate-400 w-6 text-right">0</span>
+                    )}
+                  </div>
+                ))}
+                <p class="text-xs text-slate-400 mt-2 pt-2 border-t border-slate-100">
+                  Total clients: {totalClients.toLocaleString()}
+                </p>
+              </div>
+            )
+          }
+        </div>
+
+        {/* ── Engagement Health ────────────────────────────── */}
+        <div class="bg-white rounded-lg border border-slate-200 p-6">
+          <h3 class="text-base font-semibold text-slate-900 mb-4">Engagement Health</h3>
+          {
+            health.total_engagements === 0 ? (
+              <p class="text-sm text-slate-500">No completed engagements yet.</p>
+            ) : (
+              <div class="space-y-4">
+                <div class="grid grid-cols-2 gap-4">
+                  <div>
+                    <p class="text-2xl font-bold text-slate-900">
+                      {health.avg_days_to_completion.toLocaleString()}
+                    </p>
+                    <p class="text-xs text-slate-500">Avg days to completion</p>
+                  </div>
+                  <div>
+                    <p class="text-2xl font-bold text-slate-900">
+                      {health.total_engagements.toLocaleString()}
+                    </p>
+                    <p class="text-xs text-slate-500">Completed engagements</p>
+                  </div>
+                  <div>
+                    <p class="text-2xl font-bold text-slate-900">
+                      {health.avg_parking_lot_items.toLocaleString()}
+                    </p>
+                    <p class="text-xs text-slate-500">Avg parking lot items</p>
+                  </div>
+                  <div>
+                    <p class="text-2xl font-bold text-slate-900">{health.on_time_pct}%</p>
+                    <p class="text-xs text-slate-500">On-time completion</p>
+                  </div>
+                </div>
+                <div>
+                  <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+                    <span>On-time rate</span>
+                    <span>{health.on_time_pct}%</span>
+                  </div>
+                  <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
+                    <div
+                      class="h-full rounded-full bg-emerald-500"
+                      style={`width: ${complianceBarWidth(health.on_time_pct)}`}
+                    />
+                  </div>
+                </div>
+              </div>
+            )
+          }
+        </div>
+
+        {/* ── Revenue Summary ─────────────────────────────── */}
+        <div class="bg-white rounded-lg border border-slate-200 p-6">
+          <h3 class="text-base font-semibold text-slate-900 mb-4">Revenue Summary</h3>
+          {
+            revenue.total_revenue === 0 ? (
+              <p class="text-sm text-slate-500">No invoices yet.</p>
+            ) : (
+              <div class="space-y-4">
+                <div class="grid grid-cols-3 gap-4">
+                  <div>
+                    <p class="text-lg font-bold text-slate-900">
+                      {formatCurrency(revenue.total_invoiced)}
+                    </p>
+                    <p class="text-xs text-slate-500">Total invoiced</p>
+                  </div>
+                  <div>
+                    <p class="text-lg font-bold text-green-700">
+                      {formatCurrency(revenue.total_paid)}
+                    </p>
+                    <p class="text-xs text-slate-500">Total paid</p>
+                  </div>
+                  <div>
+                    <p class="text-lg font-bold text-amber-700">{formatCurrency(outstanding)}</p>
+                    <p class="text-xs text-slate-500">Outstanding</p>
+                  </div>
+                </div>
+
+                {revenue.by_month.length > 0 && (
+                  <div>
+                    <h4 class="text-sm font-medium text-slate-700 mb-2">Monthly Revenue</h4>
+                    <div class="space-y-2">
+                      {revenue.by_month.map((m) => (
+                        <div class="flex items-center gap-3">
+                          <span class="text-xs text-slate-600 w-20 shrink-0">
+                            {formatMonthLabel(m.month)}
+                          </span>
+                          <div class="flex-1 bg-slate-100 rounded-full h-5 overflow-hidden">
+                            <div
+                              class="h-full rounded-full bg-green-500 flex items-center justify-end pr-2"
+                              style={`width: ${revenueBarWidth(m.amount)}`}
+                            >
+                              {m.amount > 0 && (
+                                <span class="text-xs font-medium text-white">
+                                  {formatCurrency(m.amount)}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {revenue.by_vertical.length > 0 && (
+                  <div>
+                    <h4 class="text-sm font-medium text-slate-700 mb-2">Revenue by Vertical</h4>
+                    <div class="space-y-1">
+                      {revenue.by_vertical.map((v) => (
+                        <div class="flex items-center justify-between text-sm">
+                          <span class="text-slate-600">{getVerticalLabel(v.vertical)}</span>
+                          <span class="font-medium text-slate-900">{formatCurrency(v.amount)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          }
+        </div>
+
+        {/* ── Follow-up Compliance ────────────────────────── */}
+        <div class="bg-white rounded-lg border border-slate-200 p-6">
+          <h3 class="text-base font-semibold text-slate-900 mb-4">Follow-up Compliance</h3>
+          {
+            compliance.total === 0 ? (
+              <p class="text-sm text-slate-500">No follow-ups yet.</p>
+            ) : (
+              <div class="space-y-4">
+                <div class="text-center">
+                  <p class="text-4xl font-bold text-slate-900">{compliance.compliance_pct}%</p>
+                  <p class="text-sm text-slate-500">Compliance rate</p>
+                </div>
+                <div class="grid grid-cols-3 gap-4 text-center">
+                  <div>
+                    <p class="text-lg font-bold text-green-700">
+                      {compliance.completed_on_time.toLocaleString()}
+                    </p>
+                    <p class="text-xs text-slate-500">On time</p>
+                  </div>
+                  <div>
+                    <p class="text-lg font-bold text-amber-700">
+                      {compliance.completed_late.toLocaleString()}
+                    </p>
+                    <p class="text-xs text-slate-500">Late</p>
+                  </div>
+                  <div>
+                    <p class="text-lg font-bold text-red-700">
+                      {compliance.missed.toLocaleString()}
+                    </p>
+                    <p class="text-xs text-slate-500">Missed</p>
+                  </div>
+                </div>
+                <div>
+                  <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+                    <span>Compliance</span>
+                    <span>{compliance.compliance_pct}%</span>
+                  </div>
+                  <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
+                    <div
+                      class="h-full rounded-full bg-green-500"
+                      style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
+                    />
+                  </div>
+                </div>
+                <p class="text-xs text-slate-400 pt-2 border-t border-slate-100">
+                  Total follow-ups: {compliance.total.toLocaleString()}
+                </p>
+              </div>
+            )
+          }
+        </div>
+
+        {/* ── Quote Accuracy ──────────────────────────────── */}
+        <div class="bg-white rounded-lg border border-slate-200 p-6 md:col-span-2">
+          <h3 class="text-base font-semibold text-slate-900 mb-4">Quote Accuracy</h3>
+          {
+            quoteAccuracy.length === 0 ? (
+              <p class="text-sm text-slate-500">No completed engagements yet.</p>
+            ) : (
+              <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                  <thead>
+                    <tr class="text-left text-xs text-slate-500 border-b border-slate-200">
+                      <th class="pb-2 font-medium">Client</th>
+                      <th class="pb-2 font-medium text-right">Estimated</th>
+                      <th class="pb-2 font-medium text-right">Actual</th>
+                      <th class="pb-2 font-medium text-right">Variance</th>
+                      <th class="pb-2 font-medium text-right">Accuracy</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100">
+                    {quoteAccuracy.map((row) => {
+                      const variance = row.actual_hours - row.estimated_hours
+                      const varianceStr =
+                        variance > 0
+                          ? `+${variance.toLocaleString()}h`
+                          : `${variance.toLocaleString()}h`
+                      return (
+                        <tr>
+                          <td class="py-2 text-slate-900">{row.client_name}</td>
+                          <td class="py-2 text-right text-slate-600">
+                            {row.estimated_hours.toLocaleString()}h
+                          </td>
+                          <td class="py-2 text-right text-slate-600">
+                            {row.actual_hours.toLocaleString()}h
+                          </td>
+                          <td class="py-2 text-right text-slate-600">{varianceStr}</td>
+                          <td class="py-2 text-right">
+                            <span
+                              class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(row.accuracy_pct)}`}
+                            >
+                              {row.accuracy_pct}%
+                            </span>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                  <tfoot>
+                    <tr class="border-t border-slate-200 font-medium">
+                      <td class="py-2 text-slate-900">Average</td>
+                      <td class="py-2 text-right text-slate-600">
+                        {Math.round(
+                          quoteAccuracy.reduce((s, r) => s + r.estimated_hours, 0) /
+                            quoteAccuracy.length
+                        ).toLocaleString()}
+                        h
+                      </td>
+                      <td class="py-2 text-right text-slate-600">
+                        {Math.round(
+                          quoteAccuracy.reduce((s, r) => s + r.actual_hours, 0) /
+                            quoteAccuracy.length
+                        ).toLocaleString()}
+                        h
+                      </td>
+                      <td class="py-2" />
+                      <td class="py-2 text-right">
+                        <span
+                          class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(avgAccuracy)}`}
+                        >
+                          {avgAccuracy}%
+                        </span>
+                      </td>
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            )
+          }
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,6 +1,8 @@
 ---
 import '../../styles/global.css'
 import { listFollowUps } from '../../lib/db/follow-ups'
+import { getPipelineConversion } from '../../lib/db/analytics'
+import { listEngagements } from '../../lib/db/engagements'
 
 /**
  * Admin dashboard — protected by auth middleware.
@@ -12,14 +14,32 @@ import { listFollowUps } from '../../lib/db/follow-ups'
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
-// Fetch follow-up counts for dashboard card
-const [upcomingFollowUps, overdueFollowUps] = await Promise.all([
+// Fetch follow-up counts and analytics data in parallel
+const [upcomingFollowUps, overdueFollowUps, pipeline, allEngagements] = await Promise.all([
   listFollowUps(env.DB, session.orgId, { upcoming: true }),
   listFollowUps(env.DB, session.orgId, { overdue: true }),
+  getPipelineConversion(env.DB, session.orgId),
+  listEngagements(env.DB, session.orgId),
 ])
 
 const upcomingCount = upcomingFollowUps.length
 const overdueCount = overdueFollowUps.length
+
+// Dashboard metrics
+const totalClients =
+  pipeline.prospect +
+  pipeline.assessed +
+  pipeline.quoted +
+  pipeline.active +
+  pipeline.completed +
+  pipeline.dead
+const activeEngagements = allEngagements.filter(
+  (e) => e.status === 'active' || e.status === 'handoff' || e.status === 'safety_net'
+).length
+const pipelineConversionRate =
+  totalClients > 0
+    ? Math.round(((pipeline.active + pipeline.completed) / totalClients) * 1000) / 10
+    : 0
 ---
 
 <!doctype html>
@@ -104,6 +124,43 @@ const overdueCount = overdueFollowUps.length
           <p class="text-sm text-slate-500 mt-1">
             Manage follow-up cadences — proposal follow-ups, review requests, referral asks, and
             feedback surveys.
+          </p>
+        </a>
+
+        <a
+          href="/admin/analytics"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <div class="flex items-center justify-between">
+            <h3
+              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+            >
+              Analytics
+            </h3>
+            <div class="flex items-center gap-2">
+              <span
+                class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full font-medium"
+              >
+                {totalClients} clients
+              </span>
+              {
+                activeEngagements > 0 && (
+                  <span class="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full font-medium">
+                    {activeEngagements} active
+                  </span>
+                )
+              }
+              {
+                pipelineConversionRate > 0 && (
+                  <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
+                    {pipelineConversionRate}% conversion
+                  </span>
+                )
+              }
+            </div>
+          </div>
+          <p class="text-sm text-slate-500 mt-1">
+            Pipeline funnel, quote accuracy, revenue, engagement health, and follow-up compliance.
           </p>
         </a>
       </div>

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('analytics: query layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/analytics.ts'), 'utf-8')
+
+  it('analytics.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/analytics.ts'))).toBe(true)
+  })
+
+  it('exports getPipelineConversion function', () => {
+    expect(source()).toContain('export async function getPipelineConversion')
+  })
+
+  it('exports getQuoteAccuracy function', () => {
+    expect(source()).toContain('export async function getQuoteAccuracy')
+  })
+
+  it('exports getRevenueReport function', () => {
+    expect(source()).toContain('export async function getRevenueReport')
+  })
+
+  it('exports getEngagementHealth function', () => {
+    expect(source()).toContain('export async function getEngagementHealth')
+  })
+
+  it('exports getFollowUpCompliance function', () => {
+    expect(source()).toContain('export async function getFollowUpCompliance')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // Should not use template literals in SQL strings
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('scopes getPipelineConversion to org_id', () => {
+    const code = source()
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('scopes getQuoteAccuracy to org_id', () => {
+    const code = source()
+    // Both the engagements and clients tables should be scoped
+    const quoteAccuracySection = code.slice(
+      code.indexOf('getQuoteAccuracy'),
+      code.indexOf('getRevenueReport')
+    )
+    expect(quoteAccuracySection).toContain('org_id')
+  })
+
+  it('scopes getRevenueReport to org_id', () => {
+    const code = source()
+    const revenueSection = code.slice(
+      code.indexOf('getRevenueReport'),
+      code.indexOf('getEngagementHealth')
+    )
+    expect(revenueSection).toContain('org_id = ?')
+  })
+
+  it('scopes getEngagementHealth to org_id', () => {
+    const code = source()
+    const healthSection = code.slice(
+      code.indexOf('getEngagementHealth'),
+      code.indexOf('getFollowUpCompliance')
+    )
+    expect(healthSection).toContain('org_id = ?')
+  })
+
+  it('scopes getFollowUpCompliance to org_id', () => {
+    const code = source()
+    const complianceSection = code.slice(code.indexOf('getFollowUpCompliance'))
+    expect(complianceSection).toContain('org_id = ?')
+  })
+
+  it('getPipelineConversion counts by client status', () => {
+    const code = source()
+    expect(code).toContain('GROUP BY status')
+    expect(code).toContain('FROM clients')
+  })
+
+  it('getQuoteAccuracy joins engagements with clients', () => {
+    const code = source()
+    expect(code).toContain('FROM engagements')
+    expect(code).toContain('JOIN clients')
+  })
+
+  it('getQuoteAccuracy only includes completed engagements', () => {
+    const code = source()
+    const section = code.slice(code.indexOf('getQuoteAccuracy'), code.indexOf('getRevenueReport'))
+    expect(section).toContain("status = 'completed'")
+  })
+
+  it('getQuoteAccuracy calculates accuracy percentage', () => {
+    expect(source()).toContain('accuracy_pct')
+  })
+
+  it('getRevenueReport aggregates from invoices table', () => {
+    expect(source()).toContain('FROM invoices')
+  })
+
+  it('getRevenueReport groups by month using substr of paid_at', () => {
+    const code = source()
+    expect(code).toContain('substr(paid_at')
+    expect(code).toContain('GROUP BY')
+  })
+
+  it('getRevenueReport groups by client vertical', () => {
+    const code = source()
+    expect(code).toContain('c.vertical')
+    expect(code).toContain('JOIN clients')
+  })
+
+  it('getEngagementHealth calculates average days to completion', () => {
+    const code = source()
+    expect(code).toContain('julianday(actual_end)')
+    expect(code).toContain('julianday(start_date)')
+  })
+
+  it('getEngagementHealth calculates on-time percentage', () => {
+    const code = source()
+    expect(code).toContain('actual_end <= estimated_end')
+  })
+
+  it('getEngagementHealth includes parking lot item average', () => {
+    const code = source()
+    expect(code).toContain('parking_lot')
+    expect(code).toContain('avg_parking_lot_items')
+  })
+
+  it('getFollowUpCompliance categorizes on-time, late, and missed', () => {
+    const code = source()
+    expect(code).toContain('completed_on_time')
+    expect(code).toContain('completed_late')
+    expect(code).toContain('missed')
+  })
+
+  it('getFollowUpCompliance uses completed_at vs scheduled_for for timing', () => {
+    const code = source()
+    expect(code).toContain('completed_at <= scheduled_for')
+    expect(code).toContain('completed_at > scheduled_for')
+  })
+
+  it('getFollowUpCompliance detects missed as scheduled and past due', () => {
+    const code = source()
+    expect(code).toContain("status = 'scheduled'")
+    expect(code).toContain("scheduled_for < datetime('now')")
+  })
+
+  it('handles division by zero safely', () => {
+    const code = source()
+    // Multiple guards against division by zero
+    expect(code).toContain('> 0')
+  })
+
+  it('exports result type interfaces', () => {
+    const code = source()
+    expect(code).toContain('export interface PipelineConversion')
+    expect(code).toContain('export interface QuoteAccuracyRow')
+    expect(code).toContain('export interface RevenueReport')
+    expect(code).toContain('export interface EngagementHealth')
+    expect(code).toContain('export interface FollowUpCompliance')
+  })
+})
+
+describe('analytics: dashboard page', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/analytics/index.astro'), 'utf-8')
+
+  it('dashboard page exists', () => {
+    expect(existsSync(resolve('src/pages/admin/analytics/index.astro'))).toBe(true)
+  })
+
+  it('imports all 5 analytics functions', () => {
+    const code = source()
+    expect(code).toContain('getPipelineConversion')
+    expect(code).toContain('getQuoteAccuracy')
+    expect(code).toContain('getRevenueReport')
+    expect(code).toContain('getEngagementHealth')
+    expect(code).toContain('getFollowUpCompliance')
+  })
+
+  it('does not import any JavaScript charting library', () => {
+    const code = source()
+    expect(code).not.toContain('chart.js')
+    expect(code).not.toContain('d3')
+    expect(code).not.toContain('recharts')
+    expect(code).not.toContain('plotly')
+    expect(code).not.toContain('apexcharts')
+    expect(code).not.toContain('echarts')
+  })
+
+  it('renders pipeline funnel section', () => {
+    const code = source()
+    expect(code).toContain('Pipeline Funnel')
+  })
+
+  it('renders quote accuracy table', () => {
+    const code = source()
+    expect(code).toContain('Quote Accuracy')
+    expect(code).toContain('Estimated')
+    expect(code).toContain('Actual')
+    expect(code).toContain('Variance')
+    expect(code).toContain('Accuracy')
+  })
+
+  it('renders revenue summary section', () => {
+    const code = source()
+    expect(code).toContain('Revenue Summary')
+    expect(code).toContain('Total invoiced')
+    expect(code).toContain('Total paid')
+    expect(code).toContain('Outstanding')
+  })
+
+  it('renders engagement health section', () => {
+    const code = source()
+    expect(code).toContain('Engagement Health')
+    expect(code).toContain('Avg days to completion')
+    expect(code).toContain('Avg parking lot items')
+  })
+
+  it('renders follow-up compliance section', () => {
+    const code = source()
+    expect(code).toContain('Follow-up Compliance')
+    expect(code).toContain('Compliance rate')
+    expect(code).toContain('On time')
+    expect(code).toContain('Late')
+    expect(code).toContain('Missed')
+  })
+
+  it('has empty state for no clients', () => {
+    expect(source()).toContain('No clients yet')
+  })
+
+  it('has empty state for no completed engagements', () => {
+    expect(source()).toContain('No completed engagements yet')
+  })
+
+  it('has empty state for no invoices', () => {
+    expect(source()).toContain('No invoices yet')
+  })
+
+  it('has empty state for no follow-ups', () => {
+    expect(source()).toContain('No follow-ups yet')
+  })
+
+  it('has breadcrumb navigation', () => {
+    const code = source()
+    expect(code).toContain('/admin')
+    expect(code).toContain('Dashboard')
+    expect(code).toContain('Analytics')
+  })
+
+  it('is not indexed by search engines', () => {
+    expect(source()).toContain('noindex')
+  })
+
+  it('uses responsive grid layout', () => {
+    const code = source()
+    expect(code).toContain('grid-cols-1')
+    expect(code).toContain('md:grid-cols-2')
+  })
+
+  it('color-codes quote accuracy within 20%, 20-40%, and >40%', () => {
+    const code = source()
+    expect(code).toContain('text-green-700')
+    expect(code).toContain('text-amber-700')
+    expect(code).toContain('text-red-700')
+  })
+
+  it('color-codes pipeline stages', () => {
+    const code = source()
+    expect(code).toContain('bg-slate-400') // prospect
+    expect(code).toContain('bg-blue-500') // assessed
+    expect(code).toContain('bg-amber-500') // quoted
+    expect(code).toContain('bg-green-500') // active
+    expect(code).toContain('bg-emerald-600') // completed
+    expect(code).toContain('bg-red-500') // dead
+  })
+})
+
+describe('analytics: admin dashboard integration', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/index.astro'), 'utf-8')
+
+  it('admin dashboard imports getPipelineConversion', () => {
+    expect(source()).toContain('getPipelineConversion')
+  })
+
+  it('admin dashboard shows Analytics card', () => {
+    const code = source()
+    expect(code).toContain('Analytics')
+    expect(code).toContain('/admin/analytics')
+  })
+
+  it('admin dashboard shows total clients metric', () => {
+    expect(source()).toContain('totalClients')
+  })
+
+  it('admin dashboard shows active engagements metric', () => {
+    expect(source()).toContain('activeEngagements')
+  })
+
+  it('admin dashboard shows pipeline conversion rate', () => {
+    expect(source()).toContain('pipelineConversionRate')
+  })
+})


### PR DESCRIPTION
## Summary
- Add analytics query layer (`src/lib/db/analytics.ts`) with 5 parameterized, org-scoped aggregate functions: pipeline conversion, quote accuracy, revenue report, engagement health, and follow-up compliance
- Add HTML/CSS-only admin analytics dashboard at `/admin/analytics` with pipeline funnel bars, quote accuracy table with color-coded variance, revenue summary with monthly bars and vertical breakdown, engagement health metrics, and follow-up compliance rate
- Integrate analytics card with key metrics (total clients, active engagements, pipeline conversion rate) into the main admin dashboard

## Test plan
- [x] All 49 new tests in `tests/analytics.test.ts` pass
- [x] All 1001 existing tests continue to pass (2 pre-existing build-output failures unrelated)
- [x] Lint clean
- [x] Format clean
- [x] Typecheck passes (2 pre-existing formepdf type errors unrelated)
- [ ] Verify analytics page renders at `/admin/analytics` with test data
- [ ] Verify empty states display correctly with no data
- [ ] Verify responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)