### PR TITLE
feat: add Stripe invoicing integration with dev-mode stubs (#76)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -18,6 +18,8 @@ type CfEnv = {
   ANTHROPIC_API_KEY?: string
   SIGNWELL_API_KEY?: string
   SIGNWELL_WEBHOOK_SECRET?: string
+  STRIPE_API_KEY?: string
+  STRIPE_WEBHOOK_SECRET?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>

--- a/src/lib/db/invoices.ts
+++ b/src/lib/db/invoices.ts
@@ -1,0 +1,322 @@
+/**
+ * Invoice data access layer.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
+ *
+ * Business rules:
+ * - Deposit invoice: 50% at signing, auto-created by SignWell webhook (Decision #14)
+ * - Completion invoice: remaining balance at engagement completion
+ * - Milestone invoices: for 40+ hour engagements (3-milestone billing)
+ * - Assessment invoice: standalone paid assessment
+ * - Retainer invoice: monthly post-delivery support
+ * - Status machine enforced at application layer
+ * - Client sees total project price only, never hourly breakdown (Decision #16)
+ */
+
+export interface Invoice {
+  id: string
+  org_id: string
+  engagement_id: string | null
+  client_id: string
+  type: string
+  amount: number
+  description: string | null
+  status: string
+  stripe_invoice_id: string | null
+  stripe_hosted_url: string | null
+  due_date: string | null
+  sent_at: string | null
+  paid_at: string | null
+  payment_method: string | null
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type InvoiceType = 'deposit' | 'completion' | 'milestone' | 'assessment' | 'retainer'
+
+export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'void'
+
+export const INVOICE_STATUSES: { value: InvoiceStatus; label: string }[] = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'sent', label: 'Sent' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'overdue', label: 'Overdue' },
+  { value: 'void', label: 'Void' },
+]
+
+/**
+ * Valid status transitions enforced at the application layer.
+ *
+ * draft    -> sent | void
+ * sent     -> paid | overdue | void
+ * overdue  -> paid | void
+ * paid     -> (terminal)
+ * void     -> (terminal)
+ */
+export const VALID_TRANSITIONS: Record<InvoiceStatus, InvoiceStatus[]> = {
+  draft: ['sent', 'void'],
+  sent: ['paid', 'overdue', 'void'],
+  overdue: ['paid', 'void'],
+  paid: [],
+  void: [],
+}
+
+export interface CreateInvoiceData {
+  client_id: string
+  engagement_id?: string | null
+  type: InvoiceType
+  amount: number
+  description?: string | null
+  due_date?: string | null
+  notes?: string | null
+}
+
+export interface UpdateInvoiceData {
+  amount?: number
+  description?: string | null
+  due_date?: string | null
+  notes?: string | null
+  stripe_invoice_id?: string | null
+  stripe_hosted_url?: string | null
+}
+
+export interface InvoiceFilters {
+  clientId?: string
+  engagementId?: string
+  status?: InvoiceStatus
+}
+
+/**
+ * List invoices for an organization, optionally filtered by client, engagement, or status.
+ */
+export async function listInvoices(
+  db: D1Database,
+  orgId: string,
+  filters?: InvoiceFilters
+): Promise<Invoice[]> {
+  const conditions: string[] = ['org_id = ?']
+  const params: (string | number)[] = [orgId]
+
+  if (filters?.clientId) {
+    conditions.push('client_id = ?')
+    params.push(filters.clientId)
+  }
+
+  if (filters?.engagementId) {
+    conditions.push('engagement_id = ?')
+    params.push(filters.engagementId)
+  }
+
+  if (filters?.status) {
+    conditions.push('status = ?')
+    params.push(filters.status)
+  }
+
+  const where = conditions.join(' AND ')
+  const sql = `SELECT * FROM invoices WHERE ${where} ORDER BY created_at DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<Invoice>()
+  return result.results
+}
+
+/**
+ * Get a single invoice by ID, scoped to an organization.
+ */
+export async function getInvoice(
+  db: D1Database,
+  orgId: string,
+  invoiceId: string
+): Promise<Invoice | null> {
+  const result = await db
+    .prepare('SELECT * FROM invoices WHERE id = ? AND org_id = ?')
+    .bind(invoiceId, orgId)
+    .first<Invoice>()
+
+  return result ?? null
+}
+
+/**
+ * Create a new invoice. Returns the created invoice record.
+ */
+export async function createInvoice(
+  db: D1Database,
+  orgId: string,
+  data: CreateInvoiceData
+): Promise<Invoice> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  await db
+    .prepare(
+      `INSERT INTO invoices (id, org_id, client_id, engagement_id, type, amount, description, status, due_date, notes, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      data.client_id,
+      data.engagement_id ?? null,
+      data.type,
+      data.amount,
+      data.description ?? null,
+      data.due_date ?? null,
+      data.notes ?? null,
+      now,
+      now
+    )
+    .run()
+
+  const invoice = await getInvoice(db, orgId, id)
+  if (!invoice) {
+    throw new Error('Failed to retrieve created invoice')
+  }
+  return invoice
+}
+
+/**
+ * Update an existing invoice. Returns the updated invoice record.
+ * Only draft invoices should be updated (caller enforces this).
+ */
+export async function updateInvoice(
+  db: D1Database,
+  orgId: string,
+  invoiceId: string,
+  data: UpdateInvoiceData
+): Promise<Invoice | null> {
+  const existing = await getInvoice(db, orgId, invoiceId)
+  if (!existing) {
+    return null
+  }
+
+  const fields: string[] = []
+  const params: (string | number | null)[] = []
+
+  if (data.amount !== undefined) {
+    fields.push('amount = ?')
+    params.push(data.amount)
+  }
+
+  if (data.description !== undefined) {
+    fields.push('description = ?')
+    params.push(data.description)
+  }
+
+  if (data.due_date !== undefined) {
+    fields.push('due_date = ?')
+    params.push(data.due_date)
+  }
+
+  if (data.notes !== undefined) {
+    fields.push('notes = ?')
+    params.push(data.notes)
+  }
+
+  if (data.stripe_invoice_id !== undefined) {
+    fields.push('stripe_invoice_id = ?')
+    params.push(data.stripe_invoice_id)
+  }
+
+  if (data.stripe_hosted_url !== undefined) {
+    fields.push('stripe_hosted_url = ?')
+    params.push(data.stripe_hosted_url)
+  }
+
+  if (fields.length === 0) {
+    return existing
+  }
+
+  fields.push("updated_at = datetime('now')")
+
+  const sql = `UPDATE invoices SET ${fields.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(invoiceId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getInvoice(db, orgId, invoiceId)
+}
+
+/**
+ * Transition invoice status with validation.
+ * Returns the updated record or null if the invoice was not found.
+ * Throws if the transition is invalid.
+ *
+ * Side effects:
+ * - Any -> paid: sets paid_at to now
+ * - draft -> sent: sets sent_at to now
+ */
+export async function updateInvoiceStatus(
+  db: D1Database,
+  orgId: string,
+  invoiceId: string,
+  newStatus: InvoiceStatus
+): Promise<Invoice | null> {
+  const existing = await getInvoice(db, orgId, invoiceId)
+  if (!existing) {
+    return null
+  }
+
+  const currentStatus = existing.status as InvoiceStatus
+  const validNext = VALID_TRANSITIONS[currentStatus] ?? []
+
+  if (!validNext.includes(newStatus)) {
+    throw new Error(
+      `Invalid status transition: ${currentStatus} -> ${newStatus}. Valid transitions: ${validNext.join(', ') || 'none (terminal state)'}`
+    )
+  }
+
+  const updates: string[] = ['status = ?']
+  const params: (string | number | null)[] = [newStatus]
+
+  if (newStatus === 'paid' && !existing.paid_at) {
+    updates.push('paid_at = ?')
+    params.push(new Date().toISOString())
+  }
+
+  if (newStatus === 'sent' && !existing.sent_at) {
+    updates.push('sent_at = ?')
+    params.push(new Date().toISOString())
+  }
+
+  updates.push("updated_at = datetime('now')")
+
+  const sql = `UPDATE invoices SET ${updates.join(', ')} WHERE id = ? AND org_id = ?`
+  params.push(invoiceId, orgId)
+
+  await db
+    .prepare(sql)
+    .bind(...params)
+    .run()
+
+  return getInvoice(db, orgId, invoiceId)
+}
+
+/**
+ * Portal-facing statuses visible to clients.
+ * Draft and void invoices are internal-only.
+ */
+const PORTAL_VISIBLE_STATUSES = ['sent', 'paid', 'overdue'] as const
+
+/**
+ * List invoices for a specific client (portal access).
+ *
+ * Scoped by client_id (NOT org_id) — portal users access via their client_id.
+ * Only returns invoices visible to clients (sent, paid, overdue).
+ */
+export async function listInvoicesForClient(db: D1Database, clientId: string): Promise<Invoice[]> {
+  const placeholders = PORTAL_VISIBLE_STATUSES.map(() => '?').join(', ')
+  const sql = `SELECT * FROM invoices WHERE client_id = ? AND status IN (${placeholders}) ORDER BY created_at DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(clientId, ...PORTAL_VISIBLE_STATUSES)
+    .all<Invoice>()
+  return result.results
+}

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -103,6 +103,92 @@ export function quoteSentEmailHtml(clientName: string, portalUrl: string): strin
 /**
  * Email sent when an admin first sends a quote to a client (portal invitation).
  */
+/**
+ * Email sent when an invoice is sent to a client via the portal.
+ * Links them to the portal to view and pay the invoice.
+ */
+export function invoiceSentEmailHtml(
+  clientName: string,
+  amount: string,
+  portalUrl: string
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;text-align:center;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${clientName ? ` ${clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Your invoice from SMD Services for ${amount} is ready. Sign in to your portal to view the details and make a payment.
+      </p>
+
+      <a href="${portalUrl}"
+         style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                font-size:14px;font-weight:600;text-decoration:none;
+                padding:12px 32px;border-radius:6px;">
+        View Invoice
+      </a>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        If you have any questions, reply directly to this email.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Email sent when a payment is received for an invoice.
+ */
+export function paymentConfirmationEmailHtml(clientName: string, amount: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;text-align:center;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${clientName ? ` ${clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        We've received your payment of ${amount}. Thank you!
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        If you have any questions about your engagement, our team is here to help.
+      </p>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        If you have any questions, reply directly to this email.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Email sent when an admin first sends a quote to a client (portal invitation).
+ */
 export function portalInvitationEmailHtml(clientName: string, magicLinkUrl: string): string {
   return `<!DOCTYPE html>
 <html lang="en">

--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -1,0 +1,299 @@
+/**
+ * Stripe API client for invoice operations.
+ *
+ * Uses raw fetch against https://api.stripe.com/v1/ (no SDK).
+ * Stripe API uses form-encoded bodies for most endpoints.
+ *
+ * DEV-MODE PATTERN: When apiKey is undefined, logs the request and
+ * returns a mock response. Follows the same pattern as
+ * src/lib/email/resend.ts handles missing RESEND_API_KEY.
+ */
+
+import type { StripeCreateInvoiceParams, StripeInvoice, StripeInvoiceResult } from './types'
+
+const STRIPE_API_BASE = 'https://api.stripe.com/v1'
+
+/**
+ * Create a Stripe invoice with line items, then return the result.
+ *
+ * Stripe invoice creation is a multi-step process:
+ * 1. Create or find a customer by email
+ * 2. Create a draft invoice for that customer
+ * 3. Add line items (invoice items) to the invoice
+ *
+ * If apiKey is undefined: dev-mode stub.
+ */
+export async function createStripeInvoice(
+  apiKey: string | undefined,
+  params: StripeCreateInvoiceParams
+): Promise<StripeInvoiceResult> {
+  const totalCents = params.line_items.reduce((sum, item) => sum + item.amount * item.quantity, 0)
+  const totalDollars = (totalCents / 100).toFixed(2)
+
+  if (!apiKey) {
+    const devId = 'dev_inv_' + crypto.randomUUID()
+    console.log(`[DEV] Stripe: would create invoice for $${totalDollars}`)
+    console.log(`[DEV] Stripe: customer_email=${params.customer_email}`)
+    console.log(`[DEV] Stripe: line_items=${params.line_items.length}`)
+    return { id: devId, hosted_invoice_url: '#dev-mode', status: 'draft' }
+  }
+
+  // Step 1: Create or find customer by email
+  const customerSearchBody = new URLSearchParams()
+  customerSearchBody.append('email', params.customer_email)
+  customerSearchBody.append('limit', '1')
+
+  const customerSearchRes = await fetch(
+    `${STRIPE_API_BASE}/customers/search?query=email:'${encodeURIComponent(params.customer_email)}'`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    }
+  )
+
+  let customerId: string
+
+  if (customerSearchRes.ok) {
+    const searchData = (await customerSearchRes.json()) as { data: { id: string }[] }
+    if (searchData.data.length > 0) {
+      customerId = searchData.data[0].id
+    } else {
+      // Create customer
+      const createCustomerBody = new URLSearchParams()
+      createCustomerBody.append('email', params.customer_email)
+      const createRes = await fetch(`${STRIPE_API_BASE}/customers`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: createCustomerBody.toString(),
+      })
+      if (!createRes.ok) {
+        const errBody = await createRes.text()
+        throw new Error(`Stripe customer creation failed ${createRes.status}: ${errBody}`)
+      }
+      const customerData = (await createRes.json()) as { id: string }
+      customerId = customerData.id
+    }
+  } else {
+    // Fallback: just create a new customer
+    const createCustomerBody = new URLSearchParams()
+    createCustomerBody.append('email', params.customer_email)
+    const createRes = await fetch(`${STRIPE_API_BASE}/customers`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: createCustomerBody.toString(),
+    })
+    if (!createRes.ok) {
+      const errBody = await createRes.text()
+      throw new Error(`Stripe customer creation failed ${createRes.status}: ${errBody}`)
+    }
+    const customerData = (await createRes.json()) as { id: string }
+    customerId = customerData.id
+  }
+
+  // Step 2: Create draft invoice
+  const invoiceBody = new URLSearchParams()
+  invoiceBody.append('customer', customerId)
+  invoiceBody.append('collection_method', params.collection_method ?? 'send_invoice')
+  invoiceBody.append('days_until_due', String(params.days_until_due ?? 15))
+
+  if (params.description) {
+    invoiceBody.append('description', params.description)
+  }
+
+  if (params.metadata) {
+    for (const [key, value] of Object.entries(params.metadata)) {
+      invoiceBody.append(`metadata[${key}]`, value)
+    }
+  }
+
+  if (params.payment_settings?.payment_method_types) {
+    for (const methodType of params.payment_settings.payment_method_types) {
+      invoiceBody.append('payment_settings[payment_method_types][]', methodType)
+    }
+  }
+
+  const invoiceRes = await fetch(`${STRIPE_API_BASE}/invoices`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: invoiceBody.toString(),
+  })
+
+  if (!invoiceRes.ok) {
+    const errBody = await invoiceRes.text()
+    throw new Error(`Stripe invoice creation failed ${invoiceRes.status}: ${errBody}`)
+  }
+
+  const invoice = (await invoiceRes.json()) as StripeInvoice
+
+  // Step 3: Add line items (invoice items)
+  for (const item of params.line_items) {
+    const itemBody = new URLSearchParams()
+    itemBody.append('customer', customerId)
+    itemBody.append('invoice', invoice.id)
+    itemBody.append('amount', String(item.amount))
+    itemBody.append('currency', item.currency)
+    itemBody.append('description', item.description)
+    itemBody.append('quantity', String(item.quantity))
+
+    const itemRes = await fetch(`${STRIPE_API_BASE}/invoiceitems`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: itemBody.toString(),
+    })
+
+    if (!itemRes.ok) {
+      const errBody = await itemRes.text()
+      throw new Error(`Stripe invoice item creation failed ${itemRes.status}: ${errBody}`)
+    }
+  }
+
+  return {
+    id: invoice.id,
+    hosted_invoice_url: invoice.hosted_invoice_url,
+    status: invoice.status,
+  }
+}
+
+/**
+ * Finalize and send a Stripe invoice.
+ *
+ * Two-step process:
+ * 1. POST /invoices/:id/finalize — locks the invoice
+ * 2. POST /invoices/:id/send — sends the hosted invoice email
+ *
+ * If apiKey is undefined: dev-mode stub.
+ */
+export async function sendStripeInvoice(
+  apiKey: string | undefined,
+  invoiceId: string
+): Promise<StripeInvoiceResult> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would send invoice ${invoiceId}`)
+    return {
+      id: invoiceId,
+      hosted_invoice_url: '#dev-mode',
+      status: 'open',
+    }
+  }
+
+  // Finalize
+  const finalizeRes = await fetch(`${STRIPE_API_BASE}/invoices/${invoiceId}/finalize`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  })
+
+  if (!finalizeRes.ok) {
+    const errBody = await finalizeRes.text()
+    throw new Error(`Stripe invoice finalize failed ${finalizeRes.status}: ${errBody}`)
+  }
+
+  // Send
+  const sendRes = await fetch(`${STRIPE_API_BASE}/invoices/${invoiceId}/send`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  })
+
+  if (!sendRes.ok) {
+    const errBody = await sendRes.text()
+    throw new Error(`Stripe invoice send failed ${sendRes.status}: ${errBody}`)
+  }
+
+  const invoice = (await sendRes.json()) as StripeInvoice
+
+  return {
+    id: invoice.id,
+    hosted_invoice_url: invoice.hosted_invoice_url,
+    status: invoice.status,
+  }
+}
+
+/**
+ * Void a Stripe invoice.
+ *
+ * If apiKey is undefined: dev-mode stub.
+ */
+export async function voidStripeInvoice(
+  apiKey: string | undefined,
+  invoiceId: string
+): Promise<StripeInvoiceResult> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would void invoice ${invoiceId}`)
+    return { id: invoiceId, hosted_invoice_url: null, status: 'void' }
+  }
+
+  const res = await fetch(`${STRIPE_API_BASE}/invoices/${invoiceId}/void`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  })
+
+  if (!res.ok) {
+    const errBody = await res.text()
+    throw new Error(`Stripe invoice void failed ${res.status}: ${errBody}`)
+  }
+
+  const invoice = (await res.json()) as StripeInvoice
+
+  return {
+    id: invoice.id,
+    hosted_invoice_url: invoice.hosted_invoice_url,
+    status: invoice.status,
+  }
+}
+
+/**
+ * Get a Stripe invoice by ID.
+ *
+ * If apiKey is undefined: dev-mode stub.
+ */
+export async function getStripeInvoice(
+  apiKey: string | undefined,
+  invoiceId: string
+): Promise<StripeInvoiceResult> {
+  if (!apiKey) {
+    console.log(`[DEV] Stripe: would get invoice ${invoiceId}`)
+    return { id: invoiceId, hosted_invoice_url: '#dev-mode', status: 'draft' }
+  }
+
+  const res = await fetch(`${STRIPE_API_BASE}/invoices/${invoiceId}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  })
+
+  if (!res.ok) {
+    const errBody = await res.text()
+    throw new Error(`Stripe invoice get failed ${res.status}: ${errBody}`)
+  }
+
+  const invoice = (await res.json()) as StripeInvoice
+
+  return {
+    id: invoice.id,
+    hosted_invoice_url: invoice.hosted_invoice_url,
+    status: invoice.status,
+  }
+}

--- a/src/lib/stripe/types.ts
+++ b/src/lib/stripe/types.ts
@@ -1,0 +1,107 @@
+/**
+ * TypeScript types for the Stripe Invoice API.
+ *
+ * Based on the Stripe API v1 documentation.
+ * These types cover the subset of the API used by the SMD Services portal:
+ * invoice creation, finalization, sending, voiding, and webhook events.
+ *
+ * Stripe uses snake_case for all API fields.
+ */
+
+/**
+ * Line item for a Stripe invoice.
+ */
+export interface StripeInvoiceLineItem {
+  /** Price amount in cents */
+  amount: number
+  /** Currency code (e.g. 'usd') */
+  currency: string
+  /** Description shown on the invoice */
+  description: string
+  /** Quantity (default 1) */
+  quantity: number
+}
+
+/**
+ * Parameters for creating a Stripe invoice.
+ */
+export interface StripeCreateInvoiceParams {
+  /** Customer email — Stripe creates/reuses a customer record */
+  customer_email: string
+  /** Description shown on the invoice */
+  description?: string
+  /** Line items to include */
+  line_items: StripeInvoiceLineItem[]
+  /** Days until due (default 15) */
+  days_until_due?: number
+  /** Collection method: 'send_invoice' sends email, 'charge_automatically' charges on file */
+  collection_method?: 'send_invoice' | 'charge_automatically'
+  /** Metadata key-value pairs */
+  metadata?: Record<string, string>
+  /** Payment settings */
+  payment_settings?: {
+    /** Default payment method types to enable */
+    payment_method_types?: string[]
+  }
+}
+
+/**
+ * Stripe invoice object returned by the API (relevant fields).
+ */
+export interface StripeInvoice {
+  id: string
+  object: 'invoice'
+  status: 'draft' | 'open' | 'paid' | 'uncollectible' | 'void'
+  /** Amount due in cents */
+  amount_due: number
+  /** Amount paid in cents */
+  amount_paid: number
+  /** Currency code */
+  currency: string
+  /** Customer ID */
+  customer: string
+  /** Customer email */
+  customer_email: string | null
+  /** Description */
+  description: string | null
+  /** URL for hosted invoice payment page */
+  hosted_invoice_url: string | null
+  /** PDF URL for the invoice */
+  invoice_pdf: string | null
+  /** Collection method */
+  collection_method: string
+  /** Unix timestamp when paid */
+  status_transitions: {
+    paid_at: number | null
+    finalized_at: number | null
+    voided_at: number | null
+  }
+  /** Metadata */
+  metadata: Record<string, string>
+  /** Unix timestamp */
+  created: number
+  /** Due date as Unix timestamp */
+  due_date: number | null
+}
+
+/**
+ * Stripe webhook event envelope.
+ */
+export interface StripeWebhookEvent {
+  id: string
+  object: 'event'
+  type: string
+  data: {
+    object: StripeInvoice
+  }
+  created: number
+}
+
+/**
+ * Simplified result returned by the Stripe client (both real and dev-mode).
+ */
+export interface StripeInvoiceResult {
+  id: string
+  hosted_invoice_url: string | null
+  status: string
+}

--- a/src/lib/webhooks/stripe-handler.ts
+++ b/src/lib/webhooks/stripe-handler.ts
@@ -1,0 +1,218 @@
+/**
+ * Stripe webhook handler — two-phase pattern.
+ *
+ * Follows the architecture from docs/spikes/d1-batch-api.md EXACTLY:
+ *
+ * Phase 1 — Atomic D1 Batch (all-or-nothing):
+ *   invoice.paid:
+ *     1. Update invoice status to 'paid', set paid_at
+ *     2. If deposit invoice: update engagement status to 'active', set start_date
+ *   invoice.payment_failed:
+ *     1. Log the failure (keep invoice status as sent)
+ *
+ * Phase 2 — Best-effort side effects:
+ *   1. Send payment confirmation email via Resend
+ *
+ * Returns 200 after Phase 1 succeeds, even if Phase 2 fails.
+ */
+
+import type { StripeWebhookEvent } from '../stripe/types'
+import { sendEmail } from '../email/resend'
+import { paymentConfirmationEmailHtml } from '../email/templates'
+
+/**
+ * Look up an invoice by its Stripe invoice ID.
+ * Not scoped to org_id because webhooks don't carry org context —
+ * the stripe_invoice_id is globally unique.
+ */
+async function getInvoiceByStripeId(
+  db: D1Database,
+  stripeInvoiceId: string
+): Promise<{
+  id: string
+  org_id: string
+  client_id: string
+  engagement_id: string | null
+  type: string
+  amount: number
+  status: string
+} | null> {
+  const result = await db
+    .prepare(
+      'SELECT id, org_id, client_id, engagement_id, type, amount, status FROM invoices WHERE stripe_invoice_id = ?'
+    )
+    .bind(stripeInvoiceId)
+    .first<{
+      id: string
+      org_id: string
+      client_id: string
+      engagement_id: string | null
+      type: string
+      amount: number
+      status: string
+    }>()
+
+  return result ?? null
+}
+
+/**
+ * Look up the primary contact email for a client.
+ */
+async function getClientPrimaryEmail(
+  db: D1Database,
+  orgId: string,
+  clientId: string
+): Promise<string | null> {
+  const contact = await db
+    .prepare(
+      'SELECT email FROM contacts WHERE org_id = ? AND client_id = ? AND email IS NOT NULL ORDER BY created_at ASC LIMIT 1'
+    )
+    .bind(orgId, clientId)
+    .first<{ email: string }>()
+
+  return contact?.email ?? null
+}
+
+/**
+ * Look up the business name for a client.
+ */
+async function getClientBusinessName(
+  db: D1Database,
+  orgId: string,
+  clientId: string
+): Promise<string> {
+  const client = await db
+    .prepare('SELECT business_name FROM clients WHERE id = ? AND org_id = ?')
+    .bind(clientId, orgId)
+    .first<{ business_name: string }>()
+
+  return client?.business_name ?? 'there'
+}
+
+/**
+ * Handle the invoice.paid webhook event from Stripe.
+ *
+ * @param db - D1 database binding
+ * @param resendApiKey - Resend API key for sending confirmation emails (optional)
+ * @param event - The parsed Stripe webhook event
+ * @returns Response to send back to Stripe (200 or 500)
+ */
+export async function handleInvoicePaid(
+  db: D1Database,
+  resendApiKey: string | undefined,
+  event: StripeWebhookEvent
+): Promise<Response> {
+  const stripeInvoiceId = event.data.object.id
+  const now = new Date().toISOString()
+
+  // --- Pre-batch reads (outside transaction) ---
+
+  // 1. Look up invoice by Stripe invoice ID
+  const invoice = await getInvoiceByStripeId(db, stripeInvoiceId)
+  if (!invoice) {
+    console.log(`[stripe-handler] Unknown Stripe invoice: ${stripeInvoiceId}`)
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // 2. Idempotency guard — if already paid, skip processing
+  if (invoice.status === 'paid') {
+    console.log(`[stripe-handler] Invoice ${invoice.id} already paid, skipping`)
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Phase 1: Atomic D1 batch ---
+
+  try {
+    const batchStatements: D1PreparedStatement[] = [
+      // 1. Update invoice status to 'paid'
+      db
+        .prepare(
+          `UPDATE invoices SET status = 'paid', paid_at = ?, payment_method = 'stripe', updated_at = ?
+         WHERE id = ? AND org_id = ?`
+        )
+        .bind(now, now, invoice.id, invoice.org_id),
+    ]
+
+    // 2. If this is a deposit invoice, activate the engagement
+    if (invoice.type === 'deposit' && invoice.engagement_id) {
+      batchStatements.push(
+        db
+          .prepare(
+            `UPDATE engagements SET status = 'active', start_date = ?, updated_at = ?
+           WHERE id = ? AND org_id = ? AND status = 'scheduled'`
+          )
+          .bind(now, now, invoice.engagement_id, invoice.org_id)
+      )
+    }
+
+    await db.batch(batchStatements)
+  } catch (err) {
+    // Batch failed — all changes rolled back. Safe to let the webhook retry.
+    console.error('[stripe-handler] Phase 1 batch failed:', err)
+    return new Response(JSON.stringify({ error: 'INTERNAL_ERROR' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Phase 2: Side effects (best-effort) ---
+
+  try {
+    const clientEmail = await getClientPrimaryEmail(db, invoice.org_id, invoice.client_id)
+    if (clientEmail) {
+      const clientName = await getClientBusinessName(db, invoice.org_id, invoice.client_id)
+      const formattedAmount = `$${invoice.amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+
+      await sendEmail(resendApiKey, {
+        to: clientEmail,
+        subject: 'Payment received — thank you',
+        html: paymentConfirmationEmailHtml(clientName, formattedAmount),
+      })
+    }
+  } catch (err) {
+    console.error('[stripe-handler] Failed to send payment confirmation email:', err)
+    // Non-fatal: admin can send manually
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Handle the invoice.payment_failed webhook event from Stripe.
+ *
+ * We log the failure but do not change invoice status — it remains as 'sent'.
+ * The admin dashboard will show the invoice is still outstanding.
+ */
+export async function handleInvoicePaymentFailed(
+  db: D1Database,
+  event: StripeWebhookEvent
+): Promise<Response> {
+  const stripeInvoiceId = event.data.object.id
+
+  const invoice = await getInvoiceByStripeId(db, stripeInvoiceId)
+  if (!invoice) {
+    console.log(`[stripe-handler] Unknown Stripe invoice (payment_failed): ${stripeInvoiceId}`)
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  console.error(
+    `[stripe-handler] Payment failed for invoice ${invoice.id} (Stripe: ${stripeInvoiceId}), amount: $${invoice.amount}`
+  )
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/admin/clients/[id]/engagements/[engId].astro
+++ b/src/pages/admin/clients/[id]/engagements/[engId].astro
@@ -814,6 +814,19 @@ const showSafetyNet = engagement.status === 'handoff' || engagement.status === '
         </div>
       </div>
 
+      <!-- Invoices Section -->
+      <div class="mt-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">Invoices</h2>
+          <a
+            href={`/admin/clients/${client.id}/engagements/${engagement.id}/invoices`}
+            class="text-sm text-primary hover:text-primary-hover font-medium transition-colors"
+          >
+            Manage Invoices
+          </a>
+        </div>
+      </div>
+
       <!-- Parking Lot Section -->
       <div class="mt-8">
         <div class="flex items-center justify-between mb-4">

--- a/src/pages/admin/clients/[id]/engagements/[engId]/invoices.astro
+++ b/src/pages/admin/clients/[id]/engagements/[engId]/invoices.astro
@@ -1,0 +1,431 @@
+---
+import '../../../../../../styles/global.css'
+import { getClient } from '../../../../../../lib/db/clients'
+import { getEngagement } from '../../../../../../lib/db/engagements'
+import { listInvoices, INVOICE_STATUSES } from '../../../../../../lib/db/invoices'
+
+/**
+ * Invoice list per engagement — admin page.
+ *
+ * Lists invoices with type, amount, status badge, Stripe link, and dates.
+ * Provides actions to create, send, void, and manually mark paid.
+ *
+ * Protected by auth middleware (session guaranteed).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const { id: clientId, engId: engagementId } = Astro.params
+
+if (!clientId || !engagementId) {
+  return Astro.redirect('/admin/clients')
+}
+
+const client = await getClient(env.DB, session.orgId, clientId)
+if (!client) {
+  return Astro.redirect('/admin/clients?error=not_found')
+}
+
+const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+if (!engagement) {
+  return Astro.redirect(`/admin/clients/${clientId}?error=engagement_not_found`)
+}
+
+const invoices = await listInvoices(env.DB, session.orgId, {
+  engagementId,
+})
+
+const url = Astro.url
+const saved = url.searchParams.get('saved') === '1'
+const created = url.searchParams.get('created') === '1'
+const errorParam = url.searchParams.get('error') || ''
+
+const errorMessages: Record<string, string> = {
+  server: 'Something went wrong. Please try again.',
+  missing: 'Required fields are missing.',
+  not_found: 'Invoice not found.',
+  invalid_transition: 'That status transition is not allowed.',
+  invalid_type: 'Invalid invoice type.',
+  invalid_amount: 'Amount must be a positive number.',
+}
+
+const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Status badge colors
+const statusColorMap: Record<string, string> = {
+  draft: 'bg-slate-100 text-slate-600',
+  sent: 'bg-blue-100 text-blue-800',
+  paid: 'bg-green-100 text-green-800',
+  overdue: 'bg-red-100 text-red-800',
+  void: 'bg-slate-100 text-slate-400',
+}
+
+// Type label map
+const typeLabels: Record<string, string> = {
+  deposit: 'Deposit',
+  completion: 'Completion',
+  milestone: 'Milestone',
+  assessment: 'Assessment',
+  retainer: 'Retainer',
+}
+
+// Invoice total
+const totalInvoiced = invoices.reduce(
+  (sum, inv) => sum + (inv.status !== 'void' ? inv.amount : 0),
+  0
+)
+const totalPaid = invoices.reduce((sum, inv) => sum + (inv.status === 'paid' ? inv.amount : 0), 0)
+const totalOutstanding = invoices.reduce(
+  (sum, inv) => sum + (inv.status === 'sent' || inv.status === 'overdue' ? inv.amount : 0),
+  0
+)
+
+function formatCurrency(amount: number): string {
+  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '--'
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Invoices — {client.business_name} — SMD Services Admin</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a href="/admin" class="text-lg font-bold text-slate-900 hover:text-slate-700"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Breadcrumb -->
+      <nav class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-slate-500">
+          <li><a href="/admin/clients" class="hover:text-slate-700">Clients</a></li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a href={`/admin/clients/${client.id}`} class="hover:text-slate-700"
+              >{client.business_name}</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li>
+            <a
+              href={`/admin/clients/${client.id}/engagements/${engagement.id}`}
+              class="hover:text-slate-700">Engagement</a
+            >
+          </li>
+          <li class="text-slate-300">/</li>
+          <li class="text-slate-900 font-medium">Invoices</li>
+        </ol>
+      </nav>
+
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-slate-900">
+          Invoices
+          <span class="text-sm font-normal text-slate-400 ml-1">({invoices.length})</span>
+        </h1>
+      </div>
+
+      {
+        saved && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Invoice updated successfully.
+          </div>
+        )
+      }
+
+      {
+        created && (
+          <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+            Invoice created successfully.
+          </div>
+        )
+      }
+
+      {
+        errorMessage && (
+          <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )
+      }
+
+      <!-- Summary cards -->
+      <div class="grid grid-cols-3 gap-4 mb-6">
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <p class="text-xs text-slate-500">Total Invoiced</p>
+          <p class="text-lg font-semibold text-slate-900">{formatCurrency(totalInvoiced)}</p>
+        </div>
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <p class="text-xs text-slate-500">Paid</p>
+          <p class="text-lg font-semibold text-green-600">{formatCurrency(totalPaid)}</p>
+        </div>
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <p class="text-xs text-slate-500">Outstanding</p>
+          <p
+            class:list={[
+              'text-lg font-semibold',
+              totalOutstanding > 0 ? 'text-amber-600' : 'text-slate-900',
+            ]}
+          >
+            {formatCurrency(totalOutstanding)}
+          </p>
+        </div>
+      </div>
+
+      <!-- Invoice list -->
+      {
+        invoices.length > 0 ? (
+          <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+            {invoices.map((inv) => (
+              <div class="px-4 py-3">
+                <div class="flex items-center justify-between">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                      <p class="text-sm font-medium text-slate-900">
+                        {typeLabels[inv.type] ?? inv.type}
+                      </p>
+                      <span
+                        class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusColorMap[inv.status] ?? 'bg-slate-100 text-slate-600'}`}
+                      >
+                        {INVOICE_STATUSES.find((s) => s.value === inv.status)?.label ?? inv.status}
+                      </span>
+                    </div>
+                    <div class="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                      <span class="text-sm font-semibold text-slate-700">
+                        {formatCurrency(inv.amount)}
+                      </span>
+                      <span>Created: {formatDate(inv.created_at)}</span>
+                      {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
+                      {inv.paid_at && <span>Paid: {formatDate(inv.paid_at)}</span>}
+                      {inv.stripe_hosted_url && inv.stripe_hosted_url !== '#dev-mode' && (
+                        <a
+                          href={inv.stripe_hosted_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="text-primary hover:text-primary-hover"
+                        >
+                          Stripe
+                        </a>
+                      )}
+                    </div>
+                    {inv.description && (
+                      <p class="text-xs text-slate-500 mt-1">{inv.description}</p>
+                    )}
+                    {inv.notes && <p class="text-xs text-slate-400 mt-0.5 italic">{inv.notes}</p>}
+                  </div>
+                  <div class="flex items-center gap-1 flex-shrink-0 ml-2">
+                    {/* Send button — draft invoices only */}
+                    {inv.status === 'draft' && (
+                      <form method="POST" action={`/api/admin/invoices/${inv.id}`} class="inline">
+                        <input type="hidden" name="action" value="send" />
+                        <input
+                          type="hidden"
+                          name="redirect_url"
+                          value={`/admin/clients/${clientId}/engagements/${engagementId}/invoices`}
+                        />
+                        <button
+                          type="submit"
+                          class="px-3 py-1.5 rounded text-xs font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                        >
+                          Send
+                        </button>
+                      </form>
+                    )}
+                    {/* Void button — draft or sent invoices */}
+                    {(inv.status === 'draft' || inv.status === 'sent') && (
+                      <form
+                        method="POST"
+                        action={`/api/admin/invoices/${inv.id}`}
+                        class="inline"
+                        onsubmit="return confirm('Void this invoice? This cannot be undone.')"
+                      >
+                        <input type="hidden" name="action" value="void" />
+                        <input
+                          type="hidden"
+                          name="redirect_url"
+                          value={`/admin/clients/${clientId}/engagements/${engagementId}/invoices`}
+                        />
+                        <button
+                          type="submit"
+                          class="px-3 py-1.5 rounded text-xs font-medium bg-red-50 text-red-600 hover:bg-red-100 transition-colors"
+                        >
+                          Void
+                        </button>
+                      </form>
+                    )}
+                    {/* Mark Paid button — sent or overdue invoices (manual override for offline payments) */}
+                    {(inv.status === 'sent' || inv.status === 'overdue') && (
+                      <form method="POST" action={`/api/admin/invoices/${inv.id}`} class="inline">
+                        <input type="hidden" name="action" value="mark_paid" />
+                        <input
+                          type="hidden"
+                          name="redirect_url"
+                          value={`/admin/clients/${clientId}/engagements/${engagementId}/invoices`}
+                        />
+                        <button
+                          type="submit"
+                          class="px-3 py-1.5 rounded text-xs font-medium bg-green-50 text-green-700 hover:bg-green-100 transition-colors"
+                        >
+                          Mark Paid
+                        </button>
+                      </form>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div class="bg-white rounded-lg border border-slate-200 border-dashed p-6 text-center">
+            <p class="text-sm text-slate-400 mb-2">No invoices yet.</p>
+          </div>
+        )
+      }
+
+      <!-- Create Invoice Form -->
+      <div class="mt-6 bg-white rounded-lg border border-slate-200 p-6">
+        <h3 class="text-sm font-medium text-slate-700 mb-3">Create Invoice</h3>
+        <form method="POST" action="/api/admin/invoices" class="space-y-4">
+          <input type="hidden" name="engagement_id" value={engagement.id} />
+          <input type="hidden" name="client_id" value={client.id} />
+          <input
+            type="hidden"
+            name="redirect_url"
+            value={`/admin/clients/${clientId}/engagements/${engagementId}/invoices`}
+          />
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="invoice_type" class="block text-sm font-medium text-slate-700 mb-1">
+                Type <span class="text-red-500">*</span>
+              </label>
+              <select
+                id="invoice_type"
+                name="type"
+                required
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              >
+                <option value="deposit">Deposit</option>
+                <option value="completion">Completion</option>
+                <option value="milestone">Milestone</option>
+                <option value="assessment">Assessment</option>
+                <option value="retainer">Retainer</option>
+              </select>
+            </div>
+            <div>
+              <label for="invoice_amount" class="block text-sm font-medium text-slate-700 mb-1">
+                Amount ($) <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                id="invoice_amount"
+                name="amount"
+                step="0.01"
+                min="0.01"
+                required
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="0.00"
+              />
+            </div>
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="invoice_due_date" class="block text-sm font-medium text-slate-700 mb-1">
+                Due Date
+              </label>
+              <input
+                type="date"
+                id="invoice_due_date"
+                name="due_date"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label
+                for="invoice_description"
+                class="block text-sm font-medium text-slate-700 mb-1"
+              >
+                Description
+              </label>
+              <input
+                type="text"
+                id="invoice_description"
+                name="description"
+                class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="Brief description..."
+              />
+            </div>
+          </div>
+
+          <div>
+            <label for="invoice_notes" class="block text-sm font-medium text-slate-700 mb-1">
+              Notes (internal)
+            </label>
+            <input
+              type="text"
+              id="invoice_notes"
+              name="notes"
+              class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+              placeholder="Internal notes..."
+            />
+          </div>
+
+          <div class="flex justify-end">
+            <button
+              type="submit"
+              class="bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+            >
+              Create Invoice
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <!-- Back link -->
+      <div class="mt-6">
+        <a
+          href={`/admin/clients/${client.id}/engagements/${engagement.id}`}
+          class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+        >
+          Back to Engagement
+        </a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/api/admin/invoices/[id].ts
+++ b/src/pages/api/admin/invoices/[id].ts
@@ -1,0 +1,219 @@
+import type { APIRoute } from 'astro'
+import { getInvoice, updateInvoice, updateInvoiceStatus } from '../../../../lib/db/invoices'
+import type { InvoiceStatus } from '../../../../lib/db/invoices'
+import {
+  createStripeInvoice,
+  sendStripeInvoice,
+  voidStripeInvoice,
+} from '../../../../lib/stripe/client'
+import { sendEmail } from '../../../../lib/email/resend'
+import { invoiceSentEmailHtml } from '../../../../lib/email/templates'
+
+/**
+ * POST /api/admin/invoices/:id
+ *
+ * Performs actions on an existing invoice:
+ * - action=send: Creates invoice in Stripe, sends it, updates local status
+ * - action=void: Voids the invoice (Stripe + local)
+ * - action=mark_paid: Manual override for offline payments (OQ-008)
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const invoiceId = params.id
+  if (!invoiceId) {
+    return new Response(JSON.stringify({ error: 'Invoice ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const existing = await getInvoice(env.DB, session.orgId, invoiceId)
+    if (!existing) {
+      return redirect('/admin/clients?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const action = formData.get('action')
+    const redirectUrl = formData.get('redirect_url')
+    const target = typeof redirectUrl === 'string' ? redirectUrl : '/admin/clients'
+
+    // ----- ACTION: send -----
+    if (action === 'send') {
+      if (existing.status !== 'draft') {
+        return redirect(`${target}?error=invalid_transition`, 302)
+      }
+
+      // Look up client email for Stripe
+      const contact = await env.DB.prepare(
+        'SELECT email FROM contacts WHERE org_id = ? AND client_id = ? AND email IS NOT NULL ORDER BY created_at ASC LIMIT 1'
+      )
+        .bind(session.orgId, existing.client_id)
+        .first<{ email: string }>()
+
+      const clientEmail = contact?.email
+
+      // Look up client business name
+      const clientRow = await env.DB.prepare(
+        'SELECT business_name FROM clients WHERE id = ? AND org_id = ?'
+      )
+        .bind(existing.client_id, session.orgId)
+        .first<{ business_name: string }>()
+
+      const clientName = clientRow?.business_name ?? 'there'
+
+      try {
+        // Create in Stripe (or dev-mode stub)
+        const stripeResult = await createStripeInvoice(env.STRIPE_API_KEY, {
+          customer_email: clientEmail ?? 'placeholder@example.com',
+          description: existing.description ?? `Invoice from SMD Services`,
+          line_items: [
+            {
+              amount: Math.round(existing.amount * 100), // Convert dollars to cents
+              currency: 'usd',
+              description: existing.description ?? `SMD Services — ${existing.type} invoice`,
+              quantity: 1,
+            },
+          ],
+          days_until_due: 15,
+          collection_method: 'send_invoice',
+          metadata: {
+            invoice_id: existing.id,
+            org_id: session.orgId,
+            type: existing.type,
+          },
+          payment_settings: {
+            payment_method_types: ['ach_debit', 'card'],
+          },
+        })
+
+        // Send the Stripe invoice (finalize + email)
+        const sentResult = await sendStripeInvoice(env.STRIPE_API_KEY, stripeResult.id)
+
+        // Update local invoice with Stripe details and transition to sent
+        await updateInvoice(env.DB, session.orgId, invoiceId, {
+          stripe_invoice_id: stripeResult.id,
+          stripe_hosted_url: sentResult.hosted_invoice_url,
+        })
+        await updateInvoiceStatus(env.DB, session.orgId, invoiceId, 'sent' as InvoiceStatus)
+      } catch (err) {
+        console.error('[api/admin/invoices/[id]] Stripe send error:', err)
+        // Still transition to sent locally even if Stripe fails
+        // Admin can see the invoice needs attention (no stripe link)
+        try {
+          await updateInvoiceStatus(env.DB, session.orgId, invoiceId, 'sent' as InvoiceStatus)
+        } catch (statusErr) {
+          console.error('[api/admin/invoices/[id]] Status update also failed:', statusErr)
+          return redirect(`${target}?error=server`, 302)
+        }
+      }
+
+      // Best-effort: send notification email to client
+      if (clientEmail) {
+        try {
+          const formattedAmount = `$${existing.amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+          const portalUrl = new URL('/portal/invoices', request.url).toString()
+
+          await sendEmail(env.RESEND_API_KEY, {
+            to: clientEmail,
+            subject: 'Your invoice from SMD Services is ready',
+            html: invoiceSentEmailHtml(clientName, formattedAmount, portalUrl),
+          })
+        } catch (err) {
+          console.error('[api/admin/invoices/[id]] Email send error:', err)
+          // Non-fatal
+        }
+      }
+
+      return redirect(`${target}?saved=1`, 302)
+    }
+
+    // ----- ACTION: void -----
+    if (action === 'void') {
+      if (existing.status !== 'draft' && existing.status !== 'sent') {
+        return redirect(`${target}?error=invalid_transition`, 302)
+      }
+
+      // Void in Stripe if it exists there
+      if (existing.stripe_invoice_id) {
+        try {
+          await voidStripeInvoice(env.STRIPE_API_KEY, existing.stripe_invoice_id)
+        } catch (err) {
+          console.error('[api/admin/invoices/[id]] Stripe void error:', err)
+          // Continue voiding locally even if Stripe fails
+        }
+      }
+
+      try {
+        await updateInvoiceStatus(env.DB, session.orgId, invoiceId, 'void' as InvoiceStatus)
+      } catch (err) {
+        console.error('[api/admin/invoices/[id]] Void status error:', err)
+        return redirect(`${target}?error=invalid_transition`, 302)
+      }
+
+      return redirect(`${target}?saved=1`, 302)
+    }
+
+    // ----- ACTION: mark_paid (manual override for offline payments, OQ-008) -----
+    if (action === 'mark_paid') {
+      if (existing.status !== 'sent' && existing.status !== 'overdue') {
+        return redirect(`${target}?error=invalid_transition`, 302)
+      }
+
+      const notes = formData.get('notes')
+      if (notes && typeof notes === 'string' && notes.trim()) {
+        await updateInvoice(env.DB, session.orgId, invoiceId, {
+          notes: notes.trim(),
+        })
+      }
+
+      try {
+        // Update payment method to indicate manual/offline
+        await env.DB.prepare(
+          `UPDATE invoices SET payment_method = 'manual', updated_at = datetime('now') WHERE id = ? AND org_id = ?`
+        )
+          .bind(invoiceId, session.orgId)
+          .run()
+
+        await updateInvoiceStatus(env.DB, session.orgId, invoiceId, 'paid' as InvoiceStatus)
+      } catch (err) {
+        console.error('[api/admin/invoices/[id]] Mark paid error:', err)
+        return redirect(`${target}?error=invalid_transition`, 302)
+      }
+
+      // If this is a deposit, activate the engagement
+      if (existing.type === 'deposit' && existing.engagement_id) {
+        try {
+          const now = new Date().toISOString()
+          await env.DB.prepare(
+            `UPDATE engagements SET status = 'active', start_date = ?, updated_at = ?
+           WHERE id = ? AND org_id = ? AND status = 'scheduled'`
+          )
+            .bind(now, now, existing.engagement_id, session.orgId)
+            .run()
+        } catch (err) {
+          console.error('[api/admin/invoices/[id]] Engagement activation error:', err)
+          // Non-fatal: admin can activate manually
+        }
+      }
+
+      return redirect(`${target}?saved=1`, 302)
+    }
+
+    return redirect(`${target}?error=missing`, 302)
+  } catch (err) {
+    console.error('[api/admin/invoices/[id]] Action error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/invoices/index.ts
+++ b/src/pages/api/admin/invoices/index.ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from 'astro'
+import { createInvoice } from '../../../../lib/db/invoices'
+import type { InvoiceType } from '../../../../lib/db/invoices'
+
+const VALID_TYPES: InvoiceType[] = ['deposit', 'completion', 'milestone', 'assessment', 'retainer']
+
+/**
+ * POST /api/admin/invoices
+ *
+ * Creates a new invoice from form data.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const formData = await request.formData()
+
+    const clientId = formData.get('client_id')
+    const engagementId = formData.get('engagement_id')
+    const type = formData.get('type')
+    const amountStr = formData.get('amount')
+    const description = formData.get('description')
+    const dueDate = formData.get('due_date')
+    const notes = formData.get('notes')
+    const redirectUrl = formData.get('redirect_url')
+
+    if (
+      !clientId ||
+      typeof clientId !== 'string' ||
+      !type ||
+      typeof type !== 'string' ||
+      !amountStr ||
+      typeof amountStr !== 'string'
+    ) {
+      const target = typeof redirectUrl === 'string' ? redirectUrl : '/admin/clients'
+      return redirect(`${target}?error=missing`, 302)
+    }
+
+    if (!VALID_TYPES.includes(type as InvoiceType)) {
+      const target = typeof redirectUrl === 'string' ? redirectUrl : '/admin/clients'
+      return redirect(`${target}?error=invalid_type`, 302)
+    }
+
+    const amount = parseFloat(amountStr)
+    if (isNaN(amount) || amount <= 0) {
+      const target = typeof redirectUrl === 'string' ? redirectUrl : '/admin/clients'
+      return redirect(`${target}?error=invalid_amount`, 302)
+    }
+
+    await createInvoice(env.DB, session.orgId, {
+      client_id: clientId,
+      engagement_id: typeof engagementId === 'string' && engagementId.trim() ? engagementId : null,
+      type: type as InvoiceType,
+      amount,
+      description:
+        typeof description === 'string' && description.trim() ? description.trim() : null,
+      due_date: typeof dueDate === 'string' && dueDate.trim() ? dueDate.trim() : null,
+      notes: typeof notes === 'string' && notes.trim() ? notes.trim() : null,
+    })
+
+    const target = typeof redirectUrl === 'string' ? redirectUrl : '/admin/clients'
+    return redirect(`${target}?created=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/invoices] Create error:', err)
+    return redirect('/admin/clients?error=server', 302)
+  }
+}

--- a/src/pages/api/webhooks/stripe.ts
+++ b/src/pages/api/webhooks/stripe.ts
@@ -1,0 +1,146 @@
+import type { APIRoute } from 'astro'
+import type { StripeWebhookEvent } from '../../../lib/stripe/types'
+import { handleInvoicePaid, handleInvoicePaymentFailed } from '../../../lib/webhooks/stripe-handler'
+
+/**
+ * POST /api/webhooks/stripe
+ *
+ * Receives webhook callbacks from Stripe when invoice events occur.
+ *
+ * This is an unauthenticated endpoint — Stripe webhooks do not carry
+ * session tokens. Security is enforced via Stripe-Signature header
+ * verification using the STRIPE_WEBHOOK_SECRET.
+ *
+ * Only processes `invoice.paid` and `invoice.payment_failed` events.
+ * All other events are acknowledged with 200 but not acted upon.
+ */
+export const POST: APIRoute = async ({ request, locals }) => {
+  const env = locals.runtime.env
+
+  const webhookSecret = env.STRIPE_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[webhook/stripe] STRIPE_WEBHOOK_SECRET not configured')
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Signature verification ---
+  const rawBody = await request.text()
+  const signatureHeader = request.headers.get('stripe-signature') ?? ''
+
+  const isValid = await verifyStripeSignature(rawBody, signatureHeader, webhookSecret)
+  if (!isValid) {
+    console.error('[webhook/stripe] Invalid webhook signature')
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Parse payload ---
+  let event: StripeWebhookEvent
+  try {
+    event = JSON.parse(rawBody) as StripeWebhookEvent
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Dispatch by event type ---
+  if (event.type === 'invoice.paid') {
+    return handleInvoicePaid(env.DB, env.RESEND_API_KEY, event)
+  }
+
+  if (event.type === 'invoice.payment_failed') {
+    return handleInvoicePaymentFailed(env.DB, event)
+  }
+
+  // Acknowledge all other events without processing
+  return new Response(JSON.stringify({ ok: true, event: event.type }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Verify the Stripe webhook signature.
+ *
+ * Stripe uses a timestamp + HMAC-SHA256 signature scheme:
+ * - Header format: `t=<timestamp>,v1=<signature>`
+ * - Signed payload: `<timestamp>.<rawBody>`
+ * - Signature: HMAC-SHA256(webhook_secret, signed_payload)
+ *
+ * Also validates that the timestamp is not too old (5 minute tolerance)
+ * to prevent replay attacks.
+ *
+ * Uses the Web Crypto API (available in Cloudflare Workers).
+ */
+async function verifyStripeSignature(
+  body: string,
+  signatureHeader: string,
+  secret: string
+): Promise<boolean> {
+  if (!signatureHeader) {
+    return false
+  }
+
+  // Parse the header into components
+  const elements: Record<string, string> = {}
+  for (const part of signatureHeader.split(',')) {
+    const [key, value] = part.split('=', 2)
+    if (key && value) {
+      elements[key.trim()] = value.trim()
+    }
+  }
+
+  const timestamp = elements['t']
+  const signature = elements['v1']
+
+  if (!timestamp || !signature) {
+    return false
+  }
+
+  // Check timestamp tolerance (5 minutes)
+  const timestampSeconds = parseInt(timestamp, 10)
+  if (isNaN(timestampSeconds)) {
+    return false
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  if (Math.abs(nowSeconds - timestampSeconds) > 300) {
+    return false
+  }
+
+  // Compute expected signature
+  const signedPayload = `${timestamp}.${body}`
+  const encoder = new TextEncoder()
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(signedPayload))
+  const expectedSignature = Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  // Constant-time comparison to prevent timing attacks
+  if (expectedSignature.length !== signature.length) {
+    return false
+  }
+
+  let mismatch = 0
+  for (let i = 0; i < expectedSignature.length; i++) {
+    mismatch |= expectedSignature.charCodeAt(i) ^ signature.charCodeAt(i)
+  }
+
+  return mismatch === 0
+}

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -330,6 +330,20 @@ const engagementStatusColors: Record<string, string> = {
               Access your statement of work, deliverables, and other engagement documents.
             </p>
           </a>
+
+          <a
+            href="/portal/invoices"
+            class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+          >
+            <h3
+              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+            >
+              Invoices
+            </h3>
+            <p class="text-sm text-slate-500 mt-1">
+              View invoices and make payments for your engagement.
+            </p>
+          </a>
         </div>
       </div>
     </main>

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -1,0 +1,181 @@
+---
+import '../../../styles/global.css'
+import { listInvoicesForClient, INVOICE_STATUSES } from '../../../lib/db/invoices'
+
+/**
+ * Client portal — invoices page.
+ *
+ * Shows the client's invoices with status, amount, and payment links.
+ * Protected by auth middleware (role=client).
+ *
+ * Looks up the user's client_id via the users table to scope data.
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Look up client_id from the users table
+interface UserRow {
+  id: string
+  client_id: string | null
+}
+
+const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
+  .bind(session.userId)
+  .first<UserRow>()
+
+const clientId = user?.client_id
+
+let invoices: Awaited<ReturnType<typeof listInvoicesForClient>> = []
+
+if (clientId) {
+  invoices = await listInvoicesForClient(env.DB, clientId)
+}
+
+// Status badge colors for portal-visible statuses
+const statusColorMap: Record<string, string> = {
+  sent: 'bg-blue-100 text-blue-800',
+  paid: 'bg-green-100 text-green-800',
+  overdue: 'bg-red-100 text-red-800',
+}
+
+// Type label map
+const typeLabels: Record<string, string> = {
+  deposit: 'Deposit',
+  completion: 'Completion',
+  milestone: 'Milestone',
+  assessment: 'Assessment',
+  retainer: 'Retainer',
+}
+
+function formatCurrency(amount: number): string {
+  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '--'
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Invoices — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/portal"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/portal" class="hover:text-primary transition-colors">Portal</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Invoices</span>
+      </nav>
+
+      <h2 class="text-xl font-semibold text-slate-900 mb-6">Invoices</h2>
+
+      {
+        invoices.length === 0 ? (
+          <div class="bg-white rounded-lg border border-slate-200 p-6">
+            <p class="text-slate-600">
+              No invoices yet. When invoices are created for your engagement, they will appear here.
+            </p>
+          </div>
+        ) : (
+          <div class="space-y-3">
+            {invoices.map((inv) => (
+              <div class="bg-white rounded-lg border border-slate-200 p-4">
+                <div class="flex items-center justify-between">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 mb-1">
+                      <p class="text-sm font-medium text-slate-900">
+                        {typeLabels[inv.type] ?? inv.type}
+                      </p>
+                      <span
+                        class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusColorMap[inv.status] ?? 'bg-slate-100 text-slate-600'}`}
+                      >
+                        {INVOICE_STATUSES.find((s) => s.value === inv.status)?.label ?? inv.status}
+                      </span>
+                    </div>
+                    <p class="text-lg font-semibold text-slate-900">{formatCurrency(inv.amount)}</p>
+                    <div class="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                      {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
+                      {inv.paid_at && (
+                        <span class="text-green-600">Paid: {formatDate(inv.paid_at)}</span>
+                      )}
+                    </div>
+                    {inv.description && (
+                      <p class="text-sm text-slate-500 mt-2">{inv.description}</p>
+                    )}
+                  </div>
+                  <div class="flex-shrink-0 ml-4">
+                    {/* Pay Now link for unpaid invoices with Stripe URL */}
+                    {inv.status !== 'paid' &&
+                      inv.stripe_hosted_url &&
+                      inv.stripe_hosted_url !== '#dev-mode' && (
+                        <a
+                          href={inv.stripe_hosted_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="inline-block bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+                        >
+                          Pay Now
+                        </a>
+                      )}
+                    {/* Show dev-mode indicator when Stripe not configured */}
+                    {inv.status !== 'paid' && inv.stripe_hosted_url === '#dev-mode' && (
+                      <span class="inline-block bg-slate-100 text-slate-500 px-3 py-2 rounded-lg text-xs font-medium">
+                        Payment link pending
+                      </span>
+                    )}
+                    {/* Paid indicator */}
+                    {inv.status === 'paid' && (
+                      <span class="inline-block bg-green-50 text-green-700 px-3 py-2 rounded-lg text-xs font-medium">
+                        Paid
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -1,0 +1,710 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('invoices: data layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/invoices.ts'), 'utf-8')
+
+  it('invoices.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/invoices.ts'))).toBe(true)
+  })
+
+  it('exports Invoice interface', () => {
+    expect(source()).toContain('export interface Invoice')
+  })
+
+  it('exports CreateInvoiceData interface', () => {
+    expect(source()).toContain('export interface CreateInvoiceData')
+  })
+
+  it('exports UpdateInvoiceData interface', () => {
+    expect(source()).toContain('export interface UpdateInvoiceData')
+  })
+
+  it('exports InvoiceType with all 5 types', () => {
+    const code = source()
+    expect(code).toContain('export type InvoiceType')
+    expect(code).toContain("'deposit'")
+    expect(code).toContain("'completion'")
+    expect(code).toContain("'milestone'")
+    expect(code).toContain("'assessment'")
+    expect(code).toContain("'retainer'")
+  })
+
+  it('exports InvoiceStatus with all 5 statuses', () => {
+    const code = source()
+    expect(code).toContain('export type InvoiceStatus')
+    expect(code).toContain("'draft'")
+    expect(code).toContain("'sent'")
+    expect(code).toContain("'paid'")
+    expect(code).toContain("'overdue'")
+    expect(code).toContain("'void'")
+  })
+
+  it('exports INVOICE_STATUSES constant with labels', () => {
+    const code = source()
+    expect(code).toContain('export const INVOICE_STATUSES')
+    expect(code).toContain("label: 'Draft'")
+    expect(code).toContain("label: 'Sent'")
+    expect(code).toContain("label: 'Paid'")
+    expect(code).toContain("label: 'Overdue'")
+    expect(code).toContain("label: 'Void'")
+  })
+
+  it('exports VALID_TRANSITIONS with correct status machine', () => {
+    const code = source()
+    expect(code).toContain('export const VALID_TRANSITIONS')
+    // draft -> sent, void
+    expect(code).toContain("draft: ['sent', 'void']")
+    // sent -> paid, overdue, void
+    expect(code).toContain("sent: ['paid', 'overdue', 'void']")
+    // overdue -> paid, void
+    expect(code).toContain("overdue: ['paid', 'void']")
+    // paid -> terminal
+    expect(code).toContain('paid: []')
+    // void -> terminal
+    expect(code).toContain('void: []')
+  })
+
+  it('exports listInvoices function with org scoping', () => {
+    const code = source()
+    expect(code).toContain('export async function listInvoices')
+    expect(code).toContain('org_id = ?')
+  })
+
+  it('listInvoices supports optional filters (client, engagement, status)', () => {
+    const code = source()
+    expect(code).toContain('filters?.clientId')
+    expect(code).toContain('filters?.engagementId')
+    expect(code).toContain('filters?.status')
+  })
+
+  it('exports getInvoice function with org scoping', () => {
+    const code = source()
+    expect(code).toContain('export async function getInvoice')
+    expect(code).toContain('WHERE id = ? AND org_id = ?')
+  })
+
+  it('exports createInvoice function with UUID generation', () => {
+    const code = source()
+    expect(code).toContain('export async function createInvoice')
+    expect(code).toContain('crypto.randomUUID()')
+  })
+
+  it('exports updateInvoice function', () => {
+    expect(source()).toContain('export async function updateInvoice')
+  })
+
+  it('exports updateInvoiceStatus function with status validation', () => {
+    const code = source()
+    expect(code).toContain('export async function updateInvoiceStatus')
+    expect(code).toContain('VALID_TRANSITIONS')
+    expect(code).toContain('Invalid status transition')
+  })
+
+  it('updateInvoiceStatus sets paid_at on payment', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'paid'")
+    expect(code).toContain('paid_at')
+  })
+
+  it('updateInvoiceStatus sets sent_at on send', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'sent'")
+    expect(code).toContain('sent_at')
+  })
+
+  it('exports listInvoicesForClient for portal access', () => {
+    const code = source()
+    expect(code).toContain('export async function listInvoicesForClient')
+    expect(code).toContain('client_id = ?')
+  })
+
+  it('portal-visible statuses exclude draft and void', () => {
+    const code = source()
+    expect(code).toContain('PORTAL_VISIBLE_STATUSES')
+    expect(code).toContain("'sent'")
+    expect(code).toContain("'paid'")
+    expect(code).toContain("'overdue'")
+  })
+
+  it('uses parameterized queries with .bind()', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    // No template literal injection in SQL
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+})
+
+describe('invoices: stripe types', () => {
+  const source = () => readFileSync(resolve('src/lib/stripe/types.ts'), 'utf-8')
+
+  it('types.ts exists', () => {
+    expect(existsSync(resolve('src/lib/stripe/types.ts'))).toBe(true)
+  })
+
+  it('exports StripeInvoiceLineItem type', () => {
+    expect(source()).toContain('export interface StripeInvoiceLineItem')
+  })
+
+  it('exports StripeCreateInvoiceParams type', () => {
+    expect(source()).toContain('export interface StripeCreateInvoiceParams')
+  })
+
+  it('exports StripeInvoice type', () => {
+    expect(source()).toContain('export interface StripeInvoice')
+  })
+
+  it('exports StripeWebhookEvent type', () => {
+    expect(source()).toContain('export interface StripeWebhookEvent')
+  })
+
+  it('exports StripeInvoiceResult type', () => {
+    expect(source()).toContain('export interface StripeInvoiceResult')
+  })
+
+  it('StripeCreateInvoiceParams includes customer_email', () => {
+    expect(source()).toContain('customer_email')
+  })
+
+  it('StripeCreateInvoiceParams includes line_items', () => {
+    expect(source()).toContain('line_items')
+  })
+
+  it('StripeCreateInvoiceParams includes collection_method', () => {
+    expect(source()).toContain('collection_method')
+  })
+
+  it('StripeCreateInvoiceParams supports payment_method_types', () => {
+    expect(source()).toContain('payment_method_types')
+  })
+
+  it('StripeInvoice includes hosted_invoice_url', () => {
+    expect(source()).toContain('hosted_invoice_url')
+  })
+
+  it('StripeWebhookEvent includes data.object (StripeInvoice)', () => {
+    const code = source()
+    expect(code).toContain('data:')
+    expect(code).toContain('object: StripeInvoice')
+  })
+})
+
+describe('invoices: stripe client', () => {
+  const source = () => readFileSync(resolve('src/lib/stripe/client.ts'), 'utf-8')
+
+  it('client.ts exists', () => {
+    expect(existsSync(resolve('src/lib/stripe/client.ts'))).toBe(true)
+  })
+
+  it('exports createStripeInvoice function', () => {
+    expect(source()).toContain('export async function createStripeInvoice')
+  })
+
+  it('exports sendStripeInvoice function', () => {
+    expect(source()).toContain('export async function sendStripeInvoice')
+  })
+
+  it('exports voidStripeInvoice function', () => {
+    expect(source()).toContain('export async function voidStripeInvoice')
+  })
+
+  it('exports getStripeInvoice function', () => {
+    expect(source()).toContain('export async function getStripeInvoice')
+  })
+
+  it('uses correct Stripe API base URL', () => {
+    expect(source()).toContain('https://api.stripe.com/v1')
+  })
+
+  it('dev-mode: returns mock when no API key for createStripeInvoice', () => {
+    const code = source()
+    expect(code).toContain("'dev_inv_' + crypto.randomUUID()")
+    expect(code).toContain("'#dev-mode'")
+  })
+
+  it('dev-mode: logs request details', () => {
+    const code = source()
+    expect(code).toContain('[DEV] Stripe: would create invoice')
+  })
+
+  it('dev-mode: sendStripeInvoice returns mock when no API key', () => {
+    const code = source()
+    expect(code).toContain('[DEV] Stripe: would send invoice')
+  })
+
+  it('dev-mode: voidStripeInvoice returns mock when no API key', () => {
+    const code = source()
+    expect(code).toContain('[DEV] Stripe: would void invoice')
+  })
+
+  it('dev-mode: getStripeInvoice returns mock when no API key', () => {
+    const code = source()
+    expect(code).toContain('[DEV] Stripe: would get invoice')
+  })
+
+  it('uses form-encoded bodies (not JSON) for Stripe API', () => {
+    const code = source()
+    expect(code).toContain("'Content-Type': 'application/x-www-form-urlencoded'")
+    expect(code).toContain('URLSearchParams')
+  })
+
+  it('uses Bearer token auth', () => {
+    expect(source()).toContain('Authorization: `Bearer ${apiKey}`')
+  })
+
+  it('sendStripeInvoice calls finalize then send', () => {
+    const code = source()
+    expect(code).toContain('/finalize')
+    expect(code).toContain('/send')
+  })
+
+  it('voidStripeInvoice calls POST /invoices/:id/void', () => {
+    expect(source()).toContain('/void')
+  })
+
+  it('uses raw fetch — no SDK dependency', () => {
+    const code = source()
+    expect(code).toContain('await fetch(')
+    expect(code).not.toContain("from 'stripe'")
+    expect(code).not.toContain('import Stripe')
+  })
+})
+
+describe('invoices: stripe webhook handler', () => {
+  const source = () => readFileSync(resolve('src/lib/webhooks/stripe-handler.ts'), 'utf-8')
+
+  it('stripe-handler.ts exists', () => {
+    expect(existsSync(resolve('src/lib/webhooks/stripe-handler.ts'))).toBe(true)
+  })
+
+  it('exports handleInvoicePaid function', () => {
+    expect(source()).toContain('export async function handleInvoicePaid')
+  })
+
+  it('exports handleInvoicePaymentFailed function', () => {
+    expect(source()).toContain('export async function handleInvoicePaymentFailed')
+  })
+
+  it('looks up invoice by stripe_invoice_id', () => {
+    const code = source()
+    expect(code).toContain('stripe_invoice_id')
+    expect(code).toContain('getInvoiceByStripeId')
+  })
+
+  it('implements idempotency check — returns early if already paid', () => {
+    const code = source()
+    expect(code).toContain("invoice.status === 'paid'")
+    expect(code).toContain('already paid, skipping')
+  })
+
+  it('uses db.batch() for atomic multi-table writes (two-phase pattern)', () => {
+    expect(source()).toContain('await db.batch(')
+  })
+
+  it('Phase 1: updates invoice status to paid with paid_at', () => {
+    const code = source()
+    expect(code).toContain("status = 'paid'")
+    expect(code).toContain('paid_at')
+  })
+
+  it('Phase 1: activates engagement for deposit invoices', () => {
+    const code = source()
+    expect(code).toContain("invoice.type === 'deposit'")
+    expect(code).toContain("status = 'active'")
+    expect(code).toContain('start_date')
+  })
+
+  it('returns 500 on Phase 1 batch failure', () => {
+    const code = source()
+    expect(code).toContain('Phase 1 batch failed')
+    expect(code).toContain('status: 500')
+  })
+
+  it('Phase 2: sends payment confirmation email (best-effort)', () => {
+    const code = source()
+    expect(code).toContain('sendEmail')
+    expect(code).toContain('paymentConfirmationEmailHtml')
+  })
+
+  it('returns 200 for unknown Stripe invoice (non-retryable)', () => {
+    const code = source()
+    expect(code).toContain('Unknown Stripe invoice')
+    const unknownBlock = code.substring(
+      code.indexOf('Unknown Stripe invoice'),
+      code.indexOf('Unknown Stripe invoice') + 200
+    )
+    expect(unknownBlock).toContain('status: 200')
+  })
+
+  it('handleInvoicePaymentFailed logs failure but does not change status', () => {
+    const code = source()
+    expect(code).toContain('Payment failed for invoice')
+    // Should not contain UPDATE invoices in the payment_failed handler
+    const paymentFailedFn = code.substring(code.indexOf('handleInvoicePaymentFailed'))
+    expect(paymentFailedFn).not.toContain('UPDATE invoices SET status')
+  })
+
+  it('uses parameterized queries with .bind()', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+})
+
+describe('invoices: stripe webhook route', () => {
+  const source = () => readFileSync(resolve('src/pages/api/webhooks/stripe.ts'), 'utf-8')
+
+  it('stripe.ts webhook route exists', () => {
+    expect(existsSync(resolve('src/pages/api/webhooks/stripe.ts'))).toBe(true)
+  })
+
+  it('exports POST handler', () => {
+    expect(source()).toContain('export const POST')
+  })
+
+  it('implements Stripe signature verification', () => {
+    const code = source()
+    expect(code).toContain('verifyStripeSignature')
+    expect(code).toContain('HMAC')
+    expect(code).toContain('SHA-256')
+  })
+
+  it('reads signature from stripe-signature header', () => {
+    expect(source()).toContain('stripe-signature')
+  })
+
+  it('parses Stripe signature format (t=timestamp,v1=signature)', () => {
+    const code = source()
+    expect(code).toContain("elements['t']")
+    expect(code).toContain("elements['v1']")
+  })
+
+  it('validates timestamp tolerance to prevent replay attacks', () => {
+    const code = source()
+    expect(code).toContain('300') // 5 minute tolerance
+    expect(code).toContain('timestampSeconds')
+  })
+
+  it('returns 401 for invalid signatures', () => {
+    const code = source()
+    expect(code).toContain('Invalid signature')
+    expect(code).toContain('status: 401')
+  })
+
+  it('checks for STRIPE_WEBHOOK_SECRET configuration', () => {
+    expect(source()).toContain('STRIPE_WEBHOOK_SECRET')
+  })
+
+  it('dispatches invoice.paid events to handler', () => {
+    const code = source()
+    expect(code).toContain("event.type === 'invoice.paid'")
+    expect(code).toContain('handleInvoicePaid')
+  })
+
+  it('dispatches invoice.payment_failed events to handler', () => {
+    const code = source()
+    expect(code).toContain("event.type === 'invoice.payment_failed'")
+    expect(code).toContain('handleInvoicePaymentFailed')
+  })
+
+  it('acknowledges unhandled events with 200', () => {
+    const code = source()
+    expect(code).toContain('event.type')
+    expect(code).toContain('status: 200')
+  })
+
+  it('uses constant-time comparison for signature check', () => {
+    const code = source()
+    expect(code).toContain('mismatch |=')
+    expect(code).toContain('charCodeAt')
+  })
+
+  it('does NOT use auth middleware (webhooks are unauthenticated)', () => {
+    const code = source()
+    expect(code).not.toContain("session.role !== 'admin'")
+    expect(code).not.toContain('locals.session')
+  })
+
+  it('parses raw body for both signature verification and JSON parsing', () => {
+    const code = source()
+    expect(code).toContain('request.text()')
+    expect(code).toContain('JSON.parse(rawBody)')
+  })
+})
+
+describe('invoices: portal view', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/invoices/index.astro'), 'utf-8')
+
+  it('portal invoice page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/invoices/index.astro'))).toBe(true)
+  })
+
+  it('uses listInvoicesForClient for client-scoped access', () => {
+    expect(source()).toContain('listInvoicesForClient')
+  })
+
+  it('looks up client_id from user session', () => {
+    const code = source()
+    expect(code).toContain('client_id')
+    expect(code).toContain('session.userId')
+  })
+
+  it('displays invoice amount', () => {
+    expect(source()).toContain('formatCurrency')
+  })
+
+  it('displays invoice status badges', () => {
+    expect(source()).toContain('statusColorMap')
+  })
+
+  it('provides Pay Now link opening Stripe hosted URL in new tab', () => {
+    const code = source()
+    expect(code).toContain('Pay Now')
+    expect(code).toContain('stripe_hosted_url')
+    expect(code).toContain('target="_blank"')
+  })
+
+  it('shows paid date for paid invoices', () => {
+    const code = source()
+    expect(code).toContain('paid_at')
+    expect(code).toContain('Paid')
+  })
+
+  it('handles empty state when no invoices exist', () => {
+    expect(source()).toContain('No invoices yet')
+  })
+})
+
+describe('invoices: admin pages', () => {
+  const source = () =>
+    readFileSync(
+      resolve('src/pages/admin/clients/[id]/engagements/[engId]/invoices.astro'),
+      'utf-8'
+    )
+
+  it('admin invoice list page exists', () => {
+    expect(
+      existsSync(resolve('src/pages/admin/clients/[id]/engagements/[engId]/invoices.astro'))
+    ).toBe(true)
+  })
+
+  it('lists invoices with type labels', () => {
+    const code = source()
+    expect(code).toContain('typeLabels')
+    expect(code).toContain('Deposit')
+    expect(code).toContain('Completion')
+    expect(code).toContain('Milestone')
+  })
+
+  it('shows invoice amount and status badge', () => {
+    const code = source()
+    expect(code).toContain('formatCurrency')
+    expect(code).toContain('statusColorMap')
+  })
+
+  it('includes Create Invoice form with type selector', () => {
+    const code = source()
+    expect(code).toContain('Create Invoice')
+    expect(code).toContain('invoice_type')
+    expect(code).toContain('invoice_amount')
+  })
+
+  it('includes Send button for draft invoices', () => {
+    const code = source()
+    expect(code).toContain('action" value="send"')
+    expect(code).toContain("inv.status === 'draft'")
+  })
+
+  it('includes Void button for draft/sent invoices', () => {
+    const code = source()
+    expect(code).toContain('action" value="void"')
+  })
+
+  it('includes Mark Paid button for sent/overdue invoices (OQ-008)', () => {
+    const code = source()
+    expect(code).toContain('action" value="mark_paid"')
+    expect(code).toContain('Mark Paid')
+  })
+
+  it('shows Stripe link when available', () => {
+    const code = source()
+    expect(code).toContain('stripe_hosted_url')
+    expect(code).toContain('Stripe')
+  })
+
+  it('shows summary cards (total, paid, outstanding)', () => {
+    const code = source()
+    expect(code).toContain('Total Invoiced')
+    expect(code).toContain('totalPaid')
+    expect(code).toContain('totalOutstanding')
+  })
+})
+
+describe('invoices: admin API routes', () => {
+  it('POST /api/admin/invoices/index.ts exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/invoices/index.ts'))).toBe(true)
+  })
+
+  it('POST /api/admin/invoices/[id].ts exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/invoices/[id].ts'))).toBe(true)
+  })
+
+  describe('create route (index.ts)', () => {
+    const source = () => readFileSync(resolve('src/pages/api/admin/invoices/index.ts'), 'utf-8')
+
+    it('exports POST handler', () => {
+      expect(source()).toContain('export const POST')
+    })
+
+    it('verifies admin session', () => {
+      expect(source()).toContain("session.role !== 'admin'")
+    })
+
+    it('validates invoice type', () => {
+      expect(source()).toContain('VALID_TYPES')
+    })
+
+    it('validates amount is positive', () => {
+      expect(source()).toContain('amount <= 0')
+    })
+
+    it('calls createInvoice from data layer', () => {
+      expect(source()).toContain('createInvoice')
+    })
+  })
+
+  describe('action route ([id].ts)', () => {
+    const source = () => readFileSync(resolve('src/pages/api/admin/invoices/[id].ts'), 'utf-8')
+
+    it('exports POST handler', () => {
+      expect(source()).toContain('export const POST')
+    })
+
+    it('verifies admin session', () => {
+      expect(source()).toContain("session.role !== 'admin'")
+    })
+
+    it('handles send action — creates in Stripe and sends', () => {
+      const code = source()
+      expect(code).toContain("action === 'send'")
+      expect(code).toContain('createStripeInvoice')
+      expect(code).toContain('sendStripeInvoice')
+    })
+
+    it('handles void action — voids in Stripe and locally', () => {
+      const code = source()
+      expect(code).toContain("action === 'void'")
+      expect(code).toContain('voidStripeInvoice')
+      expect(code).toContain('updateInvoiceStatus')
+    })
+
+    it('handles mark_paid action — manual override for offline payments', () => {
+      const code = source()
+      expect(code).toContain("action === 'mark_paid'")
+      expect(code).toContain("payment_method = 'manual'")
+    })
+
+    it('mark_paid activates engagement for deposit invoices', () => {
+      const code = source()
+      expect(code).toContain("existing.type === 'deposit'")
+      expect(code).toContain("status = 'active'")
+    })
+
+    it('sends notification email when invoice is sent', () => {
+      const code = source()
+      expect(code).toContain('invoiceSentEmailHtml')
+      expect(code).toContain('sendEmail')
+    })
+  })
+})
+
+describe('invoices: email templates', () => {
+  const source = () => readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
+
+  it('exports invoiceSentEmailHtml function', () => {
+    expect(source()).toContain('export function invoiceSentEmailHtml')
+  })
+
+  it('invoiceSentEmailHtml includes clientName, amount, and portalUrl parameters', () => {
+    const code = source()
+    expect(code).toContain('invoiceSentEmailHtml(')
+    expect(code).toContain('clientName: string')
+    expect(code).toContain('amount: string')
+    expect(code).toContain('portalUrl: string')
+  })
+
+  it('invoiceSentEmailHtml mentions invoice is ready', () => {
+    expect(source()).toContain('invoice from SMD Services')
+  })
+
+  it('exports paymentConfirmationEmailHtml function', () => {
+    expect(source()).toContain('export function paymentConfirmationEmailHtml')
+  })
+
+  it('paymentConfirmationEmailHtml includes clientName and amount parameters', () => {
+    const code = source()
+    expect(code).toContain('paymentConfirmationEmailHtml(clientName: string, amount: string)')
+  })
+
+  it('paymentConfirmationEmailHtml confirms payment received', () => {
+    expect(source()).toContain('received your payment')
+  })
+})
+
+describe('invoices: env.d.ts bindings', () => {
+  const source = () => readFileSync(resolve('src/env.d.ts'), 'utf-8')
+
+  it('declares STRIPE_API_KEY in CfEnv', () => {
+    expect(source()).toContain('STRIPE_API_KEY')
+  })
+
+  it('declares STRIPE_WEBHOOK_SECRET in CfEnv', () => {
+    expect(source()).toContain('STRIPE_WEBHOOK_SECRET')
+  })
+
+  it('Stripe bindings are optional (using ?)', () => {
+    const code = source()
+    expect(code).toContain('STRIPE_API_KEY?: string')
+    expect(code).toContain('STRIPE_WEBHOOK_SECRET?: string')
+  })
+})
+
+describe('invoices: engagement detail integration', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/clients/[id]/engagements/[engId].astro'), 'utf-8')
+
+  it('engagement detail page has Invoices section with link', () => {
+    const code = source()
+    expect(code).toContain('Manage Invoices')
+    expect(code).toContain('/invoices')
+  })
+})
+
+describe('invoices: portal dashboard integration', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
+
+  it('portal dashboard has Invoices quick link', () => {
+    const code = source()
+    expect(code).toContain('/portal/invoices')
+    expect(code).toContain('Invoices')
+  })
+})
+
+describe('invoices: signwell handler creates deposit invoice', () => {
+  const source = () => readFileSync(resolve('src/lib/webhooks/signwell-handler.ts'), 'utf-8')
+
+  it('signwell handler creates deposit invoice in batch', () => {
+    const code = source()
+    expect(code).toContain('INSERT INTO invoices')
+    expect(code).toContain("'deposit'")
+    expect(code).toContain("'draft'")
+  })
+
+  it('deposit invoice uses raw SQL in batch (atomicity requirement)', () => {
+    const code = source()
+    // The batch must use raw SQL, not the data layer function, for atomicity
+    expect(code).toContain('db.batch([')
+    expect(code).toContain('INSERT INTO invoices')
+  })
+})


### PR DESCRIPTION
## Summary

- **Data layer** (`src/lib/db/invoices.ts`): Full CRUD with status machine (draft -> sent -> paid/overdue -> void), org-scoped admin queries, client-scoped portal queries
- **Stripe API client** (`src/lib/stripe/client.ts`): Raw `fetch` against `api.stripe.com/v1` with form-encoded bodies. Dev-mode stubs log and return mocks when `STRIPE_API_KEY` is undefined (API key blocked on 2FA recovery)
- **Stripe webhook handler** (`src/lib/webhooks/stripe-handler.ts`): Two-phase pattern matching SignWell handler. Phase 1: atomic D1 batch (update invoice + activate engagement for deposits). Phase 2: best-effort payment confirmation email
- **Webhook route** (`src/pages/api/webhooks/stripe.ts`): Stripe-Signature header verification with timestamp tolerance, dispatches `invoice.paid` and `invoice.payment_failed` events
- **Admin pages**: Invoice list per engagement with summary cards, create/send/void/mark-paid actions, Stripe link display
- **Portal view** (`src/pages/portal/invoices/index.astro`): Client-scoped invoice list with Pay Now link to Stripe hosted URL
- **Email templates**: `invoiceSentEmailHtml` and `paymentConfirmationEmailHtml` added to existing templates file
- **Integration**: Invoices section added to admin engagement detail page; Invoices quick link added to portal dashboard
- **118 new tests** covering data layer, Stripe client dev-mode, webhook handler, admin pages, portal view, email templates, and env bindings. All 1072 tests passing.

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, build, 1072 tests)
- [ ] Manual: Create invoice via admin UI, verify draft status
- [ ] Manual: Send invoice (dev-mode), verify status transitions and mock Stripe response logged
- [ ] Manual: Void invoice, verify status transition
- [ ] Manual: Mark paid (manual override), verify engagement activation for deposit type
- [ ] Manual: Portal invoice list shows only sent/paid/overdue (not draft/void)
- [ ] Future: End-to-end test with real Stripe API key when 2FA is recovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)