### PR TITLE
fix: portal subdomain routing for portal.smd.services

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,20 @@ import { parseSessionToken, validateSession, renewSession } from './lib/auth/ses
  */
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url
+  const hostname = context.url.hostname
+
+  // Subdomain routing: portal.smd.services rewrites to /portal/* paths
+  const isPortalSubdomain = hostname.startsWith('portal.')
+  if (
+    isPortalSubdomain &&
+    !pathname.startsWith('/portal') &&
+    !pathname.startsWith('/api/portal') &&
+    !pathname.startsWith('/auth')
+  ) {
+    // Rewrite the URL to the /portal path prefix
+    const portalPath = pathname === '/' ? '/portal' : `/portal${pathname}`
+    return context.rewrite(new Request(new URL(portalPath, context.url), context.request))
+  }
 
   // Initialize session as null for all routes
   context.locals.session = null
@@ -23,7 +37,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Determine route type
   const isAdminRoute = pathname.startsWith('/admin')
   const isAdminApiRoute = pathname.startsWith('/api/admin')
-  const isPortalRoute = pathname.startsWith('/portal')
+  const isPortalRoute = pathname.startsWith('/portal') || isPortalSubdomain
   const isPortalApiRoute = pathname.startsWith('/api/portal')
   const isProtectedRoute = isAdminRoute || isAdminApiRoute || isPortalRoute || isPortalApiRoute
 


### PR DESCRIPTION
## Summary
- Middleware now detects `portal.smd.services` hostname and rewrites requests to `/portal/*` paths
- `portal.smd.services/` → `/portal` (dashboard)
- `portal.smd.services/quotes` → `/portal/quotes`
- Auth and API routes pass through unchanged

## Test plan
- [x] `npm run verify` passes
- [ ] `portal.smd.services` serves portal dashboard, not marketing homepage
- [ ] `smd.services` still serves marketing homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)