### PR TITLE
fix: exclude /api/auth from portal subdomain rewriting

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
     isPortalSubdomain &&
     !pathname.startsWith('/portal') &&
     !pathname.startsWith('/api/portal') &&
-    !pathname.startsWith('/auth')
+    !pathname.startsWith('/auth') &&
+    !pathname.startsWith('/api/auth')
   ) {
     // Rewrite the URL to the /portal path prefix
     const portalPath = pathname === '/' ? '/portal' : `/portal${pathname}`


### PR DESCRIPTION
## Summary
- Portal sign-in form POSTs to `/api/auth/magic-link`, but the middleware's subdomain rewriter was catching this path on `portal.smd.services` and rewriting it to `/portal/api/auth/magic-link` (nonexistent route)
- This caused a blank screen after submitting the sign-in form and no magic link email was ever sent
- Added `/api/auth` to the subdomain rewrite exclusion list in middleware

## Test plan
- [ ] `npm run verify` passes (1,122 tests)
- [ ] On `portal.smd.services`, enter email and submit — should redirect to login page with "Check your email" message
- [ ] Magic link email should arrive via Resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)