### PR TITLE
feat: lead signal ingestion pipeline and admin triage UI

### DIFF
--- a/migrations/0007_create_lead_signals.sql
+++ b/migrations/0007_create_lead_signals.sql
@@ -1,0 +1,70 @@
+-- Lead signals — pre-client intelligence from automated pipelines.
+--
+-- Each row is a single qualified signal from one pipeline.
+-- A business can have multiple signals (one per pipeline that finds it).
+-- Signals start unlinked (client_id NULL) and get promoted during admin triage.
+--
+-- source_pipeline values:
+--   review_mining   — Pipeline 1: Google/Yelp review pain scoring
+--   job_monitor     — Pipeline 2: Job posting qualification
+--   new_business    — Pipeline 3: ACC/ADOR/permit detection
+--   social_listening — Pipeline 4: Reddit/alerts (reserved, not yet implemented)
+--
+-- top_problems: JSON array of ProblemId strings
+--   e.g. ["owner_bottleneck", "scheduling_chaos"]
+--
+-- source_metadata: JSON bag of pipeline-specific data
+--   review_mining:    { "place_id": "...", "google_rating": 3.2, "review_count": 45 }
+--   job_monitor:      { "job_hash": "...", "job_url": "...", "job_title": "..." }
+--   new_business:     { "permit_number": "...", "entity_type": "LLC", "filing_date": "..." }
+--   social_listening: { "post_id": "...", "platform": "reddit", "post_url": "..." }
+--
+-- Dedup: UNIQUE(org_id, dedup_key, source_pipeline) prevents duplicate signals
+-- from the same pipeline. Cross-pipeline duplicates are allowed (same business,
+-- different pipeline) and linked via dedup_key matching at ingestion time.
+
+CREATE TABLE lead_signals (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  client_id       TEXT REFERENCES clients(id),
+
+  -- Business identity
+  business_name   TEXT NOT NULL,
+  phone           TEXT,
+  website         TEXT,
+  category        TEXT,
+  area            TEXT,
+
+  -- Pipeline source
+  source_pipeline TEXT NOT NULL CHECK (source_pipeline IN (
+    'review_mining', 'job_monitor', 'new_business', 'social_listening'
+  )),
+
+  -- Scoring
+  pain_score      INTEGER CHECK (pain_score BETWEEN 1 AND 10),
+  top_problems    TEXT,
+  evidence_summary TEXT,
+  outreach_angle  TEXT,
+
+  -- Pipeline-specific metadata
+  source_metadata TEXT,
+
+  -- Triage workflow
+  triage_status   TEXT NOT NULL DEFAULT 'new' CHECK (triage_status IN (
+    'new', 'reviewed', 'promoted', 'dismissed'
+  )),
+  triage_notes    TEXT,
+  triaged_at      TEXT,
+
+  -- Dedup key: lowercase business_name|category|area
+  dedup_key       TEXT NOT NULL,
+
+  date_found      TEXT NOT NULL,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+
+  UNIQUE(org_id, dedup_key, source_pipeline)
+);
+
+CREATE INDEX idx_lead_signals_org_triage ON lead_signals(org_id, triage_status);
+CREATE INDEX idx_lead_signals_org_pipeline ON lead_signals(org_id, source_pipeline);
+CREATE INDEX idx_lead_signals_client ON lead_signals(client_id);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -20,6 +20,7 @@ type CfEnv = {
   SIGNWELL_WEBHOOK_SECRET?: string
   STRIPE_API_KEY?: string
   STRIPE_WEBHOOK_SECRET?: string
+  LEAD_INGEST_API_KEY?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>

--- a/src/lib/auth/api-key.ts
+++ b/src/lib/auth/api-key.ts
@@ -1,0 +1,22 @@
+/**
+ * API key validation for machine-to-machine endpoints.
+ *
+ * Uses constant-time comparison to prevent timing attacks.
+ * Matches the pattern used in webhook handlers (signwell.ts, stripe.ts).
+ */
+export function validateApiKey(request: Request, expectedKey: string | undefined): boolean {
+  const header = request.headers.get('Authorization')
+  if (!header?.startsWith('Bearer ')) return false
+
+  const provided = header.slice(7)
+  const expected = expectedKey ?? ''
+
+  if (!expected || provided.length !== expected.length) return false
+
+  let mismatch = 0
+  for (let i = 0; i < provided.length; i++) {
+    mismatch |= provided.charCodeAt(i) ^ expected.charCodeAt(i)
+  }
+
+  return mismatch === 0
+}

--- a/src/lib/db/lead-signals.ts
+++ b/src/lib/db/lead-signals.ts
@@ -1,0 +1,280 @@
+/**
+ * Lead signal data access layer.
+ *
+ * Lead signals are pre-client intelligence surfaced by automated pipelines.
+ * They sit in a triage inbox until the admin promotes them to client records
+ * or dismisses them.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ * Dedup is enforced atomically via UNIQUE(org_id, dedup_key, source_pipeline).
+ */
+
+// Re-export types from lead-gen schemas for convenience
+export type { PipelineId } from '../../lead-gen/schemas/lead-scoring-schema.js'
+
+export interface LeadSignal {
+  id: string
+  org_id: string
+  client_id: string | null
+  business_name: string
+  phone: string | null
+  website: string | null
+  category: string | null
+  area: string | null
+  source_pipeline: string
+  pain_score: number | null
+  top_problems: string | null
+  evidence_summary: string | null
+  outreach_angle: string | null
+  source_metadata: string | null
+  triage_status: string
+  triage_notes: string | null
+  triaged_at: string | null
+  dedup_key: string
+  date_found: string
+  created_at: string
+}
+
+export type TriageStatus = 'new' | 'reviewed' | 'promoted' | 'dismissed'
+
+export const TRIAGE_STATUSES: { value: TriageStatus; label: string }[] = [
+  { value: 'new', label: 'New' },
+  { value: 'reviewed', label: 'Reviewed' },
+  { value: 'promoted', label: 'Promoted' },
+  { value: 'dismissed', label: 'Dismissed' },
+]
+
+const ALLOWED_PIPELINES = ['review_mining', 'job_monitor', 'new_business', 'social_listening']
+
+export interface CreateLeadSignalData {
+  business_name: string
+  phone?: string | null
+  website?: string | null
+  category?: string | null
+  area?: string | null
+  source_pipeline: string
+  pain_score?: number | null
+  top_problems?: string[] | null
+  evidence_summary?: string | null
+  outreach_angle?: string | null
+  source_metadata?: Record<string, unknown> | null
+  date_found: string
+}
+
+export interface LeadSignalFilters {
+  triage_status?: string
+  source_pipeline?: string
+}
+
+export type CreateResult =
+  | { status: 'created'; id: string; cross_match: boolean }
+  | { status: 'duplicate'; existing_id: string }
+
+// ---------------------------------------------------------------------------
+// Dedup key computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a normalized dedup key from business identity fields.
+ * Lowercase + whitespace collapse only — no suffix stripping to avoid false positives.
+ */
+export function computeDedupKey(
+  businessName: string,
+  category: string | null,
+  area: string | null
+): string {
+  const name = businessName.toLowerCase().replace(/\s+/g, ' ').trim()
+  const cat = (category || '').toLowerCase().trim()
+  const loc = (area || '').toLowerCase().trim()
+  return `${name}|${cat}|${loc}`
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a lead signal with atomic dedup.
+ *
+ * Uses INSERT ... ON CONFLICT DO NOTHING to avoid TOCTOU races.
+ * If the same business was found by a different pipeline and is already linked
+ * to a client, the new signal is auto-linked to the same client.
+ */
+export async function createLeadSignal(
+  db: D1Database,
+  orgId: string,
+  data: CreateLeadSignalData
+): Promise<CreateResult> {
+  if (!ALLOWED_PIPELINES.includes(data.source_pipeline)) {
+    throw new Error(`Invalid source_pipeline: ${data.source_pipeline}`)
+  }
+
+  const id = crypto.randomUUID()
+  const dedupKey = computeDedupKey(data.business_name, data.category ?? null, data.area ?? null)
+
+  // Check for cross-pipeline match (same dedup key, different pipeline)
+  const crossMatch = await db
+    .prepare(
+      'SELECT id, client_id FROM lead_signals WHERE org_id = ? AND dedup_key = ? AND source_pipeline != ?'
+    )
+    .bind(orgId, dedupKey, data.source_pipeline)
+    .first<{ id: string; client_id: string | null }>()
+
+  const clientId = crossMatch?.client_id ?? null
+
+  // Atomic insert with conflict handling
+  const result = await db
+    .prepare(
+      `INSERT INTO lead_signals (
+        id, org_id, client_id, business_name, phone, website, category, area,
+        source_pipeline, pain_score, top_problems, evidence_summary, outreach_angle,
+        source_metadata, triage_status, dedup_key, date_found
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'new', ?, ?)
+      ON CONFLICT(org_id, dedup_key, source_pipeline) DO NOTHING`
+    )
+    .bind(
+      id,
+      orgId,
+      clientId,
+      data.business_name,
+      data.phone ?? null,
+      data.website ?? null,
+      data.category ?? null,
+      data.area ?? null,
+      data.source_pipeline,
+      data.pain_score ?? null,
+      data.top_problems ? JSON.stringify(data.top_problems) : null,
+      data.evidence_summary ?? null,
+      data.outreach_angle ?? null,
+      data.source_metadata ? JSON.stringify(data.source_metadata) : null,
+      dedupKey,
+      data.date_found
+    )
+    .run()
+
+  // If no rows changed, it was a conflict (duplicate)
+  if (!result.meta.changed_db) {
+    const existing = await db
+      .prepare(
+        'SELECT id FROM lead_signals WHERE org_id = ? AND dedup_key = ? AND source_pipeline = ?'
+      )
+      .bind(orgId, dedupKey, data.source_pipeline)
+      .first<{ id: string }>()
+
+    return { status: 'duplicate', existing_id: existing?.id ?? '' }
+  }
+
+  return { status: 'created', id, cross_match: !!crossMatch }
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+/**
+ * List lead signals for an organization with optional filters.
+ */
+export async function listLeadSignals(
+  db: D1Database,
+  orgId: string,
+  filters?: LeadSignalFilters
+): Promise<LeadSignal[]> {
+  const conditions: string[] = ['org_id = ?']
+  const params: (string | number)[] = [orgId]
+
+  if (filters?.triage_status) {
+    conditions.push('triage_status = ?')
+    params.push(filters.triage_status)
+  }
+
+  if (filters?.source_pipeline) {
+    conditions.push('source_pipeline = ?')
+    params.push(filters.source_pipeline)
+  }
+
+  const where = conditions.join(' AND ')
+  const sql = `SELECT * FROM lead_signals WHERE ${where} ORDER BY pain_score DESC, date_found DESC`
+
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<LeadSignal>()
+  return result.results
+}
+
+/**
+ * Get a single lead signal by ID, scoped to an organization.
+ */
+export async function getLeadSignal(
+  db: D1Database,
+  orgId: string,
+  signalId: string
+): Promise<LeadSignal | null> {
+  const result = await db
+    .prepare('SELECT * FROM lead_signals WHERE id = ? AND org_id = ?')
+    .bind(signalId, orgId)
+    .first<LeadSignal>()
+
+  return result ?? null
+}
+
+/**
+ * Count signals with triage_status = 'new' for dashboard badge.
+ */
+export async function countNewSignals(db: D1Database, orgId: string): Promise<number> {
+  const result = await db
+    .prepare(
+      "SELECT COUNT(*) as count FROM lead_signals WHERE org_id = ? AND triage_status = 'new'"
+    )
+    .bind(orgId)
+    .first<{ count: number }>()
+
+  return result?.count ?? 0
+}
+
+// ---------------------------------------------------------------------------
+// Triage actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the triage status of a signal (dismiss, mark reviewed, etc.).
+ */
+export async function updateTriageStatus(
+  db: D1Database,
+  orgId: string,
+  signalId: string,
+  status: TriageStatus,
+  notes?: string | null
+): Promise<boolean> {
+  const result = await db
+    .prepare(
+      `UPDATE lead_signals
+       SET triage_status = ?, triage_notes = ?, triaged_at = datetime('now')
+       WHERE id = ? AND org_id = ?`
+    )
+    .bind(status, notes ?? null, signalId, orgId)
+    .run()
+
+  return (result.meta.changed_db ?? false) as boolean
+}
+
+/**
+ * Link a signal to an existing client and mark as promoted.
+ */
+export async function linkToClient(
+  db: D1Database,
+  orgId: string,
+  signalId: string,
+  clientId: string
+): Promise<boolean> {
+  const result = await db
+    .prepare(
+      `UPDATE lead_signals
+       SET client_id = ?, triage_status = 'promoted', triaged_at = datetime('now')
+       WHERE id = ? AND org_id = ?`
+    )
+    .bind(clientId, signalId, orgId)
+    .run()
+
+  return (result.meta.changed_db ?? false) as boolean
+}

--- a/src/pages/admin/clients/new.astro
+++ b/src/pages/admin/clients/new.astro
@@ -20,6 +20,12 @@ const errorMessages: Record<string, string> = {
 }
 
 const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurred.') : ''
+
+// Pre-fill from lead signal promote action
+const fromSignal = url.searchParams.get('from_signal') || ''
+const prefillName = url.searchParams.get('business_name') || ''
+const prefillSource = url.searchParams.get('source') || ''
+const prefillNotes = url.searchParams.get('notes') || ''
 ---
 
 <!doctype html>
@@ -71,6 +77,14 @@ const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurr
       <h1 class="text-2xl font-bold text-slate-900 mb-6">Add Client</h1>
 
       {
+        fromSignal && (
+          <div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-700">
+            Creating from lead signal — review and complete the details.
+          </div>
+        )
+      }
+
+      {
         errorMessage && (
           <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
             {errorMessage}
@@ -83,6 +97,8 @@ const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurr
         action="/api/admin/clients"
         class="bg-white rounded-lg border border-slate-200 p-6 space-y-6"
       >
+        {fromSignal && <input type="hidden" name="from_signal" value={fromSignal} />}
+
         <!-- Business Name -->
         <div>
           <label for="business_name" class="block text-sm font-medium text-slate-700 mb-1">
@@ -93,6 +109,7 @@ const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurr
             id="business_name"
             name="business_name"
             required
+            value={prefillName}
             class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
             placeholder="e.g. Phoenix Plumbing Co."
           />
@@ -156,6 +173,7 @@ const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurr
             id="source"
             name="source"
             required
+            value={prefillSource}
             class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
             placeholder="e.g. BNI, Chamber, Referral, Website"
           />
@@ -201,7 +219,8 @@ const errorMessage = errorParam ? (errorMessages[errorParam] ?? 'An error occurr
             name="notes"
             rows="3"
             class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
-            placeholder="Any additional context..."></textarea>
+            placeholder="Any additional context...">{prefillNotes}</textarea
+          >
         </div>
 
         <!-- Actions -->

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -3,6 +3,7 @@ import '../../styles/global.css'
 import { listFollowUps } from '../../lib/db/follow-ups'
 import { getPipelineConversion } from '../../lib/db/analytics'
 import { listEngagements } from '../../lib/db/engagements'
+import { countNewSignals } from '../../lib/db/lead-signals'
 
 /**
  * Admin dashboard — protected by auth middleware.
@@ -15,12 +16,14 @@ const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
 // Fetch follow-up counts and analytics data in parallel
-const [upcomingFollowUps, overdueFollowUps, pipeline, allEngagements] = await Promise.all([
-  listFollowUps(env.DB, session.orgId, { upcoming: true }),
-  listFollowUps(env.DB, session.orgId, { overdue: true }),
-  getPipelineConversion(env.DB, session.orgId),
-  listEngagements(env.DB, session.orgId),
-])
+const [upcomingFollowUps, overdueFollowUps, pipeline, allEngagements, newSignalCount] =
+  await Promise.all([
+    listFollowUps(env.DB, session.orgId, { upcoming: true }),
+    listFollowUps(env.DB, session.orgId, { overdue: true }),
+    getPipelineConversion(env.DB, session.orgId),
+    listEngagements(env.DB, session.orgId),
+    countNewSignals(env.DB, session.orgId),
+  ])
 
 const upcomingCount = upcomingFollowUps.length
 const overdueCount = overdueFollowUps.length
@@ -91,6 +94,31 @@ const pipelineConversionRate =
           <p class="text-sm text-slate-500 mt-1">
             Manage your client pipeline — create, edit, and track clients through the engagement
             lifecycle.
+          </p>
+        </a>
+
+        <a
+          href="/admin/leads"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <div class="flex items-center justify-between">
+            <h3
+              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+            >
+              Lead Inbox
+            </h3>
+            <div class="flex items-center gap-2">
+              {
+                newSignalCount > 0 && (
+                  <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full font-medium">
+                    {newSignalCount} new
+                  </span>
+                )
+              }
+            </div>
+          </div>
+          <p class="text-sm text-slate-500 mt-1">
+            Review and triage lead signals from automated pipelines — promote to clients or dismiss.
           </p>
         </a>
 

--- a/src/pages/admin/leads/index.astro
+++ b/src/pages/admin/leads/index.astro
@@ -1,0 +1,291 @@
+---
+import '../../../styles/global.css'
+import { listLeadSignals, TRIAGE_STATUSES } from '../../../lib/db/lead-signals'
+import type { LeadSignal, TriageStatus } from '../../../lib/db/lead-signals'
+import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
+import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
+import { PROBLEM_LABELS } from '../../../portal/assessments/extraction-schema'
+import type { ProblemId } from '../../../portal/assessments/extraction-schema'
+
+/**
+ * Lead Inbox — triage incoming signals from automated pipelines.
+ *
+ * Signals are sorted by pain score (highest first), then date found.
+ * Actions: Promote (pre-fill new client form), Link (to existing client), Dismiss.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+// Filters from URL params
+const filterStatus = (Astro.url.searchParams.get('status') ?? 'new') as TriageStatus
+const filterPipeline = Astro.url.searchParams.get('pipeline') ?? ''
+
+const signals = await listLeadSignals(env.DB, session.orgId, {
+  triage_status: filterStatus,
+  ...(filterPipeline ? { source_pipeline: filterPipeline } : {}),
+})
+
+const success = Astro.url.searchParams.get('saved')
+const dismissed = Astro.url.searchParams.get('dismissed')
+
+// Pipeline display labels (only the 4 lead pipelines)
+const LEAD_PIPELINES: { value: string; label: string }[] = [
+  { value: 'review_mining', label: 'Review Mining' },
+  { value: 'job_monitor', label: 'Job Monitor' },
+  { value: 'new_business', label: 'New Business' },
+  { value: 'social_listening', label: 'Social Listening' },
+]
+
+// Pipeline badge colors
+function pipelineBadgeClass(pipeline: string): string {
+  switch (pipeline) {
+    case 'review_mining':
+      return 'bg-amber-100 text-amber-700'
+    case 'job_monitor':
+      return 'bg-blue-100 text-blue-700'
+    case 'new_business':
+      return 'bg-green-100 text-green-700'
+    case 'social_listening':
+      return 'bg-purple-100 text-purple-700'
+    default:
+      return 'bg-slate-100 text-slate-600'
+  }
+}
+
+// Pain score color
+function painScoreClass(score: number | null): string {
+  if (!score) return 'text-slate-400'
+  if (score >= 8) return 'text-red-600 font-bold'
+  if (score >= 6) return 'text-amber-600 font-semibold'
+  return 'text-slate-500'
+}
+
+// Parse top_problems JSON
+function parseProblems(json: string | null): string[] {
+  if (!json) return []
+  try {
+    return JSON.parse(json) as string[]
+  } catch {
+    return []
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+// Build promote URL with query params for pre-filling the client form
+function promoteUrl(signal: LeadSignal): string {
+  const params = new URLSearchParams()
+  params.set('from_signal', signal.id)
+  params.set('business_name', signal.business_name)
+
+  const pipelineLabel =
+    PIPELINE_LABELS[signal.source_pipeline as PipelineId] ?? signal.source_pipeline
+  params.set('source', pipelineLabel)
+
+  // Combine evidence + outreach angle into notes
+  const noteParts: string[] = []
+  if (signal.evidence_summary) noteParts.push(`Evidence: ${signal.evidence_summary}`)
+  if (signal.outreach_angle) noteParts.push(`Outreach angle: ${signal.outreach_angle}`)
+  if (noteParts.length > 0) params.set('notes', noteParts.join('\n\n'))
+
+  return `/admin/clients/new?${params.toString()}`
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Lead Inbox — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Lead Inbox</span>
+      </nav>
+
+      {
+        success && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Signal linked to client successfully.
+          </div>
+        )
+      }
+      {
+        dismissed && (
+          <div class="bg-slate-50 border border-slate-200 text-slate-600 text-sm px-4 py-3 rounded-lg mb-4">
+            Signal dismissed.
+          </div>
+        )
+      }
+
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-xl font-semibold text-slate-900">Lead Inbox</h2>
+
+        <form method="GET" class="flex items-center gap-2">
+          <input type="hidden" name="status" value={filterStatus} />
+          <select
+            name="pipeline"
+            class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+            onchange="this.form.submit()"
+          >
+            <option value="">All pipelines</option>
+            {
+              LEAD_PIPELINES.map((p) => (
+                <option value={p.value} selected={filterPipeline === p.value}>
+                  {p.label}
+                </option>
+              ))
+            }
+          </select>
+        </form>
+      </div>
+
+      {/* Status tabs */}
+      <div class="flex gap-1 mb-6 border-b border-slate-200">
+        {
+          TRIAGE_STATUSES.map((s) => (
+            <a
+              href={`/admin/leads?status=${s.value}${filterPipeline ? `&pipeline=${filterPipeline}` : ''}`}
+              class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                filterStatus === s.value
+                  ? s.value === 'new'
+                    ? 'border-primary text-primary'
+                    : s.value === 'dismissed'
+                      ? 'border-slate-400 text-slate-600'
+                      : s.value === 'promoted'
+                        ? 'border-green-500 text-green-600'
+                        : 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-slate-500 hover:text-slate-700'
+              }`}
+            >
+              {s.label}
+            </a>
+          ))
+        }
+      </div>
+
+      {/* Signal list */}
+      {
+        signals.length === 0 ? (
+          <div class="bg-white rounded-lg border border-slate-200 p-6">
+            <p class="text-slate-500 text-sm">
+              {filterStatus === 'new' && 'No new signals to review.'}
+              {filterStatus === 'reviewed' && 'No reviewed signals.'}
+              {filterStatus === 'promoted' && 'No promoted signals.'}
+              {filterStatus === 'dismissed' && 'No dismissed signals.'}
+            </p>
+          </div>
+        ) : (
+          <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+            {signals.map((s: LeadSignal) => {
+              const problems = parseProblems(s.top_problems)
+              return (
+                <div class="px-6 py-4">
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2 mb-1">
+                        <span class="text-sm font-medium text-slate-900">{s.business_name}</span>
+                        <span
+                          class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(s.source_pipeline)}`}
+                        >
+                          {PIPELINE_LABELS[s.source_pipeline as PipelineId] ?? s.source_pipeline}
+                        </span>
+                        {s.pain_score && (
+                          <span class={`text-xs ${painScoreClass(s.pain_score)}`}>
+                            Pain: {s.pain_score}/10
+                          </span>
+                        )}
+                      </div>
+
+                      {problems.length > 0 && (
+                        <div class="flex gap-1 mb-1">
+                          {problems.map((p) => (
+                            <span class="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded">
+                              {PROBLEM_LABELS[p as ProblemId] ?? p}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+
+                      {s.evidence_summary && (
+                        <p class="text-xs text-slate-500 mt-1 line-clamp-2">{s.evidence_summary}</p>
+                      )}
+
+                      <div class="flex items-center gap-3 text-xs text-slate-400 mt-1.5">
+                        <span>{formatDate(s.date_found)}</span>
+                        {s.area && <span>{s.area}</span>}
+                        {s.category && <span>{s.category}</span>}
+                      </div>
+                    </div>
+
+                    {s.triage_status === 'new' && (
+                      <div class="flex items-center gap-2 shrink-0">
+                        <a
+                          href={promoteUrl(s)}
+                          class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                        >
+                          Promote
+                        </a>
+                        <form method="POST" action={`/api/admin/leads/${s.id}/dismiss`}>
+                          <button
+                            type="submit"
+                            class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                          >
+                            Dismiss
+                          </button>
+                        </form>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/api/admin/clients/index.ts
+++ b/src/pages/api/admin/clients/index.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createClient } from '../../../../lib/db/clients'
+import { linkToClient } from '../../../../lib/db/lead-signals'
 
 /**
  * POST /api/admin/clients
@@ -72,6 +73,12 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       status: status && typeof status === 'string' && status.trim() ? status.trim() : 'prospect',
       notes: notes && typeof notes === 'string' && notes.trim() ? notes.trim() : null,
     })
+
+    // Link lead signal if this client was promoted from one
+    const fromSignal = formData.get('from_signal')
+    if (fromSignal && typeof fromSignal === 'string' && fromSignal.trim()) {
+      await linkToClient(env.DB, session.orgId, fromSignal.trim(), client.id)
+    }
 
     return redirect(`/admin/clients/${client.id}`, 302)
   } catch (err) {

--- a/src/pages/api/admin/leads/[id]/dismiss.ts
+++ b/src/pages/api/admin/leads/[id]/dismiss.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro'
+import { updateTriageStatus } from '../../../../../lib/db/lead-signals'
+
+/**
+ * POST /api/admin/leads/[id]/dismiss
+ *
+ * Dismiss a lead signal with optional notes.
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const signalId = params.id
+  if (!signalId) {
+    return redirect('/admin/leads?error=missing', 302)
+  }
+
+  try {
+    const formData = await request.formData()
+    const notes = formData.get('notes')
+    const notesStr = notes && typeof notes === 'string' && notes.trim() ? notes.trim() : null
+
+    const env = locals.runtime.env
+    await updateTriageStatus(env.DB, session.orgId, signalId, 'dismissed', notesStr)
+
+    return redirect('/admin/leads?dismissed=1', 302)
+  } catch (err) {
+    console.error('[api/admin/leads/dismiss] Error:', err)
+    return redirect('/admin/leads?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/leads/[id]/link.ts
+++ b/src/pages/api/admin/leads/[id]/link.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from 'astro'
+import { linkToClient } from '../../../../../lib/db/lead-signals'
+
+/**
+ * POST /api/admin/leads/[id]/link
+ *
+ * Link a lead signal to an existing client record.
+ * Sets triage_status to 'promoted' and associates the client_id.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const signalId = params.id
+  if (!signalId) {
+    return redirect('/admin/leads?error=missing', 302)
+  }
+
+  try {
+    const formData = await request.formData()
+    const clientId = formData.get('client_id')
+
+    if (!clientId || typeof clientId !== 'string' || !clientId.trim()) {
+      return redirect('/admin/leads?error=missing', 302)
+    }
+
+    const env = locals.runtime.env
+    await linkToClient(env.DB, session.orgId, signalId, clientId.trim())
+
+    return redirect('/admin/leads?saved=1', 302)
+  } catch (err) {
+    console.error('[api/admin/leads/link] Error:', err)
+    return redirect('/admin/leads?error=server', 302)
+  }
+}

--- a/src/pages/api/ingest/leads.ts
+++ b/src/pages/api/ingest/leads.ts
@@ -1,0 +1,118 @@
+import type { APIRoute } from 'astro'
+import { validateApiKey } from '../../../lib/auth/api-key'
+import { createLeadSignal } from '../../../lib/db/lead-signals'
+
+/**
+ * POST /api/ingest/leads
+ *
+ * Ingest endpoint for Make.com lead generation pipelines.
+ * Accepts qualified lead signals and writes them to D1.
+ *
+ * Auth: Bearer token (LEAD_INGEST_API_KEY), not session cookies.
+ * This route is outside /api/admin/*, so middleware passes it through.
+ *
+ * Dedup: Atomic via UNIQUE(org_id, dedup_key, source_pipeline).
+ * Same pipeline + same business = duplicate (200).
+ * Different pipeline + same business = cross-match (201, auto-linked if prior signal has client_id).
+ */
+
+const ORG_ID = '01JQFK0000SMDSERVICES000'
+const MAX_BODY_SIZE = 10 * 1024 // 10KB
+
+const ALLOWED_PIPELINES = ['review_mining', 'job_monitor', 'new_business', 'social_listening']
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  // Reject oversized payloads
+  const contentLength = request.headers.get('content-length')
+  if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
+    return jsonResponse(413, { error: 'Payload too large' })
+  }
+
+  // Validate API key
+  const env = locals.runtime.env
+  if (!validateApiKey(request, env.LEAD_INGEST_API_KEY)) {
+    return jsonResponse(401, { error: 'Unauthorized' })
+  }
+
+  // Parse body
+  let body: Record<string, unknown>
+  try {
+    const text = await request.text()
+    if (text.length > MAX_BODY_SIZE) {
+      return jsonResponse(413, { error: 'Payload too large' })
+    }
+    body = JSON.parse(text)
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON' })
+  }
+
+  // Validate required fields
+  const errors: string[] = []
+
+  const businessName = typeof body.business_name === 'string' ? body.business_name.trim() : ''
+  if (!businessName) errors.push('business_name is required')
+
+  const sourcePipeline = typeof body.source_pipeline === 'string' ? body.source_pipeline : ''
+  if (!sourcePipeline) {
+    errors.push('source_pipeline is required')
+  } else if (!ALLOWED_PIPELINES.includes(sourcePipeline)) {
+    errors.push(`source_pipeline must be one of: ${ALLOWED_PIPELINES.join(', ')}`)
+  }
+
+  const dateFound = typeof body.date_found === 'string' ? body.date_found : ''
+  if (!dateFound) errors.push('date_found is required')
+
+  if (errors.length > 0) {
+    return jsonResponse(400, { error: 'Validation failed', details: errors })
+  }
+
+  // Validate optional fields
+  const painScore =
+    typeof body.pain_score === 'number' && body.pain_score >= 1 && body.pain_score <= 10
+      ? body.pain_score
+      : null
+
+  const topProblems = Array.isArray(body.top_problems)
+    ? body.top_problems.filter((p): p is string => typeof p === 'string')
+    : null
+
+  try {
+    const result = await createLeadSignal(env.DB, ORG_ID, {
+      business_name: businessName,
+      phone: stringOrNull(body.phone),
+      website: stringOrNull(body.website),
+      category: stringOrNull(body.category),
+      area: stringOrNull(body.area),
+      source_pipeline: sourcePipeline,
+      pain_score: painScore,
+      top_problems: topProblems,
+      evidence_summary: stringOrNull(body.evidence_summary),
+      outreach_angle: stringOrNull(body.outreach_angle),
+      source_metadata:
+        body.source_metadata && typeof body.source_metadata === 'object'
+          ? (body.source_metadata as Record<string, unknown>)
+          : null,
+      date_found: dateFound,
+    })
+
+    if (result.status === 'duplicate') {
+      return jsonResponse(200, result)
+    }
+
+    return jsonResponse(201, result)
+  } catch (err) {
+    console.error('[api/ingest/leads] Error:', err)
+    return jsonResponse(500, { error: 'Internal server error' })
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## Summary
- Replaces Google Sheets as the landing zone for automated lead generation pipelines
- New `lead_signals` table with atomic dedup (UNIQUE constraint + INSERT ON CONFLICT)
- `POST /api/ingest/leads` endpoint with bearer token auth for Make.com pipelines
- Admin Lead Inbox page at `/admin/leads` with pain score display, pipeline badges, promote/dismiss actions
- Promote pre-fills the existing new client form and links the signal back on creation
- Dashboard card with new signal count badge

## Test plan
- [ ] Run migration against local D1: `wrangler d1 execute ss-console-db --local --file=migrations/0007_create_lead_signals.sql`
- [ ] Test ingest endpoint with curl (create, duplicate, cross-pipeline match)
- [ ] Verify Lead Inbox renders at `/admin/leads` with filters
- [ ] Test promote flow: signal → pre-filled client form → client created → signal linked
- [ ] Test dismiss flow
- [ ] Set `LEAD_INGEST_API_KEY` secret and update Make.com scenarios post-merge
- [ ] `npm run verify` passes (typecheck, lint, build, 1122 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)