### PR TITLE
feat: add post-booking intake form and enrich lead promote action

### DIFF
--- a/src/pages/admin/clients/new.astro
+++ b/src/pages/admin/clients/new.astro
@@ -26,6 +26,8 @@ const fromSignal = url.searchParams.get('from_signal') || ''
 const prefillName = url.searchParams.get('business_name') || ''
 const prefillSource = url.searchParams.get('source') || ''
 const prefillNotes = url.searchParams.get('notes') || ''
+const prefillVertical = url.searchParams.get('vertical') || ''
+const prefillEmployeeCount = url.searchParams.get('employee_count') || ''
 ---
 
 <!doctype html>
@@ -126,7 +128,13 @@ const prefillNotes = url.searchParams.get('notes') || ''
             class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
           >
             <option value="">Select a vertical</option>
-            {CLIENT_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
+            {
+              CLIENT_VERTICALS.map((v) => (
+                <option value={v.value} selected={prefillVertical === v.value}>
+                  {v.label}
+                </option>
+              ))
+            }
           </select>
         </div>
 
@@ -140,6 +148,7 @@ const prefillNotes = url.searchParams.get('notes') || ''
             id="employee_count"
             name="employee_count"
             min="1"
+            value={prefillEmployeeCount}
             class="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
             placeholder="e.g. 15"
           />
@@ -247,14 +256,29 @@ const prefillNotes = url.searchParams.get('notes') || ''
       const buyBoxWarning = document.getElementById('buy-box-warning') as HTMLElement
 
       if (employeeInput && buyBoxWarning) {
-        employeeInput.addEventListener('input', () => {
+        function checkBuyBox() {
           const val = parseInt(employeeInput.value, 10)
           if (!isNaN(val) && (val < 10 || val > 25)) {
             buyBoxWarning.classList.remove('hidden')
           } else {
             buyBoxWarning.classList.add('hidden')
           }
-        })
+        }
+        // Check on load (handles pre-filled values from promote)
+        checkBuyBox()
+        employeeInput.addEventListener('input', checkBuyBox)
+      }
+
+      // Auto-resize notes textarea to fit content
+      const notesTextarea = document.getElementById('notes') as HTMLTextAreaElement
+      if (notesTextarea) {
+        notesTextarea.style.overflowY = 'hidden'
+        function autoResizeNotes() {
+          notesTextarea.style.height = 'auto'
+          notesTextarea.style.height = notesTextarea.scrollHeight + 'px'
+        }
+        autoResizeNotes()
+        notesTextarea.addEventListener('input', autoResizeNotes)
       }
     </script>
   </body>

--- a/src/pages/admin/leads/index.astro
+++ b/src/pages/admin/leads/index.astro
@@ -81,6 +81,52 @@ function formatDate(iso: string): string {
   })
 }
 
+// Valid verticals for pre-fill validation
+const VALID_VERTICALS = new Set([
+  'home_services',
+  'professional_services',
+  'contractor_trades',
+  'retail_salon',
+  'restaurant',
+  'other',
+])
+
+// Extract vertical and size estimate from source_metadata JSON.
+// Vertical lives in source_metadata.vertical_match (new_business pipeline only).
+// Size lives in source_metadata.size_estimate or .company_size_estimate depending on pipeline.
+// signal.category is NOT a valid vertical — review_mining stores Google Places display names there.
+function parseSourceMetadata(metadata: string | null): {
+  vertical: string | null
+  employeeCount: number | null
+} {
+  if (!metadata) return { vertical: null, employeeCount: null }
+  try {
+    const data = JSON.parse(metadata)
+
+    // Vertical: only trust vertical_match from new_business pipeline
+    const rawVertical: unknown = data.vertical_match
+    const vertical =
+      typeof rawVertical === 'string' && VALID_VERTICALS.has(rawVertical) ? rawVertical : null
+
+    // Size: try both field names
+    const rawSize: unknown = data.company_size_estimate ?? data.size_estimate
+    let employeeCount: number | null = null
+    if (typeof rawSize === 'string' && rawSize !== 'unknown') {
+      const rangeMatch = rawSize.match(/^(\d+)\s*-\s*(\d+)$/)
+      if (rangeMatch) {
+        employeeCount = Math.round((parseInt(rangeMatch[1], 10) + parseInt(rangeMatch[2], 10)) / 2)
+      } else {
+        const num = parseInt(rawSize, 10)
+        if (!isNaN(num)) employeeCount = num
+      }
+    }
+
+    return { vertical, employeeCount }
+  } catch {
+    return { vertical: null, employeeCount: null }
+  }
+}
+
 // Build promote URL with query params for pre-filling the client form
 function promoteUrl(signal: LeadSignal): string {
   const params = new URLSearchParams()
@@ -96,6 +142,11 @@ function promoteUrl(signal: LeadSignal): string {
   if (signal.evidence_summary) noteParts.push(`Evidence: ${signal.evidence_summary}`)
   if (signal.outreach_angle) noteParts.push(`Outreach angle: ${signal.outreach_angle}`)
   if (noteParts.length > 0) params.set('notes', noteParts.join('\n\n'))
+
+  // Extract enrichment data from source_metadata
+  const { vertical, employeeCount } = parseSourceMetadata(signal.source_metadata)
+  if (vertical) params.set('vertical', vertical)
+  if (employeeCount !== null) params.set('employee_count', String(employeeCount))
 
   return `/admin/clients/new?${params.toString()}`
 }

--- a/src/pages/api/booking/intake.ts
+++ b/src/pages/api/booking/intake.ts
@@ -1,0 +1,107 @@
+import type { APIRoute } from 'astro'
+import { createClient } from '../../../lib/db/clients'
+import { createContact } from '../../../lib/db/contacts'
+import { createAssessment } from '../../../lib/db/assessments'
+import { ORG_ID } from '../../../lib/constants'
+
+/**
+ * POST /api/booking/intake
+ *
+ * Public endpoint for the post-booking intake form. Creates a client,
+ * contact, and scheduled assessment from prospect-submitted data.
+ *
+ * Security:
+ * - Honeypot field rejects bot submissions silently
+ * - Email dedup prevents double-submit from creating duplicate records
+ * - No auth required (prospect-facing)
+ */
+export const POST: APIRoute = async ({ request, locals }) => {
+  const env = locals.runtime.env
+
+  // Parse JSON body
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON' })
+  }
+
+  // Honeypot check — bots fill this hidden field, humans don't
+  if (typeof body.website_url === 'string' && body.website_url.trim() !== '') {
+    return jsonResponse(200, { ok: true })
+  }
+
+  // Validate required fields
+  const name = trimString(body.name)
+  const email = trimString(body.email)
+  const businessName = trimString(body.business_name)
+
+  if (!name || !email || !businessName) {
+    return jsonResponse(400, { error: 'name, email, and business_name are required' })
+  }
+
+  // Optional fields
+  const vertical = trimString(body.vertical) || null
+  const employeeCount =
+    typeof body.employee_count === 'string' ? parseInt(body.employee_count, 10) || null : null
+  const yearsInBusiness =
+    typeof body.years_in_business === 'string' ? parseInt(body.years_in_business, 10) || null : null
+  const biggestChallenge = trimString(body.biggest_challenge)
+  const howHeard = trimString(body.how_heard)
+
+  try {
+    // Dedup: check if a contact with this email already exists
+    const existing = await env.DB.prepare(
+      'SELECT id, client_id FROM contacts WHERE org_id = ? AND email = ? LIMIT 1'
+    )
+      .bind(ORG_ID, email)
+      .first<{ id: string; client_id: string }>()
+
+    if (existing) {
+      return jsonResponse(200, { ok: true, client_id: existing.client_id })
+    }
+
+    // Build notes from intake answers
+    const noteParts: string[] = []
+    if (biggestChallenge) noteParts.push(`What they're trying to accomplish: ${biggestChallenge}`)
+    if (howHeard) noteParts.push(`How they found us: ${howHeard}`)
+    const notes = noteParts.length > 0 ? noteParts.join('\n\n') : null
+
+    // Create client record
+    const client = await createClient(env.DB, ORG_ID, {
+      business_name: businessName,
+      vertical,
+      employee_count: employeeCount,
+      years_in_business: yearsInBusiness,
+      source: 'Website Booking',
+      notes,
+    })
+
+    // Create contact record
+    await createContact(env.DB, ORG_ID, client.id, {
+      name,
+      email,
+    })
+
+    // Create assessment record (status defaults to 'scheduled')
+    await createAssessment(env.DB, ORG_ID, client.id, {
+      notes: notes ? `Booked via website.\n\n${notes}` : 'Booked via website.',
+    })
+
+    return jsonResponse(201, { ok: true, client_id: client.id })
+  } catch (err) {
+    console.error('[api/booking/intake] Error:', err)
+    return jsonResponse(500, { error: 'Internal server error' })
+  }
+}
+
+function trimString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -40,6 +40,18 @@ import Footer from '../components/Footer.astro'
           >
           </div>
         </div>
+        <p
+          id="booked-fallback"
+          class="mx-auto mt-6 hidden max-w-3xl text-center text-sm text-slate-500"
+        >
+          Already booked?
+          <a
+            href="/book/thanks"
+            class="font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            Tell us a bit about your business &rarr;
+          </a>
+        </p>
       </div>
     </section>
 
@@ -132,4 +144,19 @@ import Footer from '../components/Footer.astro'
   </main>
   <Footer />
   <script is:inline src="https://assets.calendly.com/assets/external/widget.js" async></script>
+  <script is:inline>
+    // Detect Calendly booking completion and redirect to intake form
+    window.addEventListener('message', function (e) {
+      if (e.data && e.data.event === 'calendly.event_scheduled') {
+        window.location.href = '/book/thanks'
+      }
+    })
+    // Show fallback link after widget loads (in case message event doesn't fire)
+    window.addEventListener('load', function () {
+      setTimeout(function () {
+        const fallback = document.getElementById('booked-fallback')
+        if (fallback) fallback.classList.remove('hidden')
+      }, 3000)
+    })
+  </script>
 </Base>

--- a/src/pages/book/thanks.astro
+++ b/src/pages/book/thanks.astro
@@ -1,0 +1,261 @@
+---
+export const prerender = false
+
+import Base from '../../layouts/Base.astro'
+import Footer from '../../components/Footer.astro'
+import { CLIENT_VERTICALS } from '../../lib/db/clients'
+---
+
+<Base
+  title="You're All Set — SMD Services"
+  description="Thanks for booking. Help us prepare for your call by telling us a bit about your business."
+>
+  <main>
+    <!-- Header -->
+    <header class="sticky top-0 z-50 border-b border-slate-100 bg-white">
+      <div class="mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-6">
+        <a href="/" class="text-lg font-bold tracking-tight text-slate-900">SMD Services</a>
+        <a href="/" class="text-sm text-slate-500 transition hover:text-slate-700">
+          &larr; Back to home
+        </a>
+      </div>
+    </header>
+
+    <!-- Confirmation + Intake -->
+    <section class="bg-slate-50 px-6 py-16 sm:py-24">
+      <div class="mx-auto max-w-2xl">
+        <!-- Thank you -->
+        <div class="text-center">
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+            <svg
+              class="h-8 w-8 text-green-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="2"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
+            </svg>
+          </div>
+          <h1 class="mt-6 text-3xl font-bold tracking-tight text-slate-900">You're all set</h1>
+          <p class="mt-3 text-lg text-slate-600">
+            We'll see you on the call. In the meantime, a few quick questions to help us prepare.
+          </p>
+        </div>
+
+        <!-- Intake form -->
+        <div id="intake-form-container" class="mt-12 rounded-xl bg-white p-8 shadow-sm">
+          <h2 class="text-xl font-bold text-slate-900">Help us prepare for your call</h2>
+          <p class="mt-2 text-sm text-slate-500">
+            The more we understand up front, the more useful the conversation will be.
+          </p>
+
+          <form id="intake-form" class="mt-8 space-y-6">
+            <!-- Honeypot — hidden from humans, bots fill it in -->
+            <div class="absolute -left-[9999px]" aria-hidden="true">
+              <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
+            </div>
+
+            <!-- Name + Email -->
+            <div class="grid gap-6 sm:grid-cols-2">
+              <div>
+                <label for="name" class="block text-sm font-medium text-slate-700">
+                  Your name <span class="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  required
+                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                  placeholder="e.g. Maria Garcia"
+                />
+              </div>
+              <div>
+                <label for="email" class="block text-sm font-medium text-slate-700">
+                  Email <span class="text-red-500">*</span>
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  required
+                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                  placeholder="maria@example.com"
+                />
+              </div>
+            </div>
+
+            <!-- Business name -->
+            <div>
+              <label for="business_name" class="block text-sm font-medium text-slate-700">
+                Business name <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                id="business_name"
+                name="business_name"
+                required
+                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="e.g. Phoenix Plumbing Co."
+              />
+            </div>
+
+            <!-- Vertical + Employee count -->
+            <div class="grid gap-6 sm:grid-cols-2">
+              <div>
+                <label for="vertical" class="block text-sm font-medium text-slate-700">
+                  What kind of business?
+                </label>
+                <select
+                  id="vertical"
+                  name="vertical"
+                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                >
+                  <option value="">Select one</option>
+                  {CLIENT_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <label for="employee_count" class="block text-sm font-medium text-slate-700">
+                  How many employees?
+                </label>
+                <input
+                  type="number"
+                  id="employee_count"
+                  name="employee_count"
+                  min="1"
+                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                  placeholder="e.g. 15"
+                />
+              </div>
+            </div>
+
+            <!-- Years in business -->
+            <div class="sm:w-1/2">
+              <label for="years_in_business" class="block text-sm font-medium text-slate-700">
+                Years in business
+              </label>
+              <input
+                type="number"
+                id="years_in_business"
+                name="years_in_business"
+                min="0"
+                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="e.g. 8"
+              />
+            </div>
+
+            <!-- Biggest challenge / objective -->
+            <div>
+              <label for="biggest_challenge" class="block text-sm font-medium text-slate-700">
+                What are you trying to accomplish?
+              </label>
+              <p class="mt-0.5 text-xs text-slate-400">
+                What would make the biggest difference in how your business runs day to day?
+              </p>
+              <textarea
+                id="biggest_challenge"
+                name="biggest_challenge"
+                rows="3"
+                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="e.g. I want to stop being the bottleneck for every decision..."
+              ></textarea>
+            </div>
+
+            <!-- How they found us -->
+            <div>
+              <label for="how_heard" class="block text-sm font-medium text-slate-700">
+                How did you find us?
+              </label>
+              <input
+                type="text"
+                id="how_heard"
+                name="how_heard"
+                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                placeholder="e.g. Google, referral from my accountant, BNI..."
+              />
+            </div>
+
+            <!-- Error message -->
+            <div id="error-message" class="hidden rounded-lg bg-red-50 p-3 text-sm text-red-700">
+              Something went wrong. Please try again.
+            </div>
+
+            <!-- Submit -->
+            <button
+              id="submit-btn"
+              type="submit"
+              class="w-full rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary/90"
+            >
+              Send
+            </button>
+          </form>
+        </div>
+
+        <!-- Success state (hidden by default) -->
+        <div id="success-message" class="mt-12 hidden text-center">
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+            <svg
+              class="h-8 w-8 text-green-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="2"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
+            </svg>
+          </div>
+          <h2 class="mt-6 text-2xl font-bold text-slate-900">Thanks for sharing</h2>
+          <p class="mt-3 text-lg text-slate-600">
+            We'll review this before your call so we can make the most of our time together.
+          </p>
+          <a
+            href="/"
+            class="mt-8 inline-block text-sm font-medium text-primary transition-colors hover:text-primary/80"
+          >
+            &larr; Back to home
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+
+  <script is:inline>
+    const form = document.getElementById('intake-form')
+    const submitBtn = document.getElementById('submit-btn')
+    const errorMsg = document.getElementById('error-message')
+    const formContainer = document.getElementById('intake-form-container')
+    const successMsg = document.getElementById('success-message')
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault()
+      submitBtn.disabled = true
+      submitBtn.textContent = 'Sending...'
+      errorMsg.classList.add('hidden')
+
+      const formData = new FormData(form)
+      const data = {}
+      formData.forEach(function (value, key) {
+        data[key] = value
+      })
+
+      fetch('/api/booking/intake', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+        .then(function (res) {
+          if (!res.ok) throw new Error('Failed')
+          formContainer.classList.add('hidden')
+          successMsg.classList.remove('hidden')
+        })
+        .catch(function () {
+          errorMsg.classList.remove('hidden')
+          submitBtn.disabled = false
+          submitBtn.textContent = 'Send'
+        })
+    })
+  </script>
+</Base>


### PR DESCRIPTION
## Summary
- Add `/book/thanks` intake form that captures prospect info (name, email, business, vertical, employee count, objectives) after Calendly booking, with honeypot bot protection and email dedup
- Enrich lead inbox Promote action to pre-fill vertical (from `source_metadata.vertical_match`) and employee count (from size estimates) on the new client form
- Auto-resize notes textarea to fit pre-filled content; fire buy-box warning on page load for pre-filled employee counts
- Add Calendly `event_scheduled` listener on `/book` to auto-redirect after booking, plus "Already booked?" fallback link

## Test plan
- [ ] `npm run verify` passes
- [ ] Promote a lead signal from new_business pipeline → vertical dropdown and employee count pre-fill correctly on new client form
- [ ] Promote a lead signal from review_mining pipeline → vertical stays on "Select a vertical" (no bad mapping)
- [ ] Notes textarea auto-resizes to fit multi-line pre-filled content
- [ ] Visit `/book/thanks` directly → form renders, submit creates client + contact + assessment in D1
- [ ] POST `/api/booking/intake` with duplicate email → returns existing client_id, no duplicate records
- [ ] POST with honeypot field filled → returns 200 OK silently, no records created
- [ ] Calendly booking on `/book` triggers redirect to `/book/thanks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)