### PR TITLE
Editorial pass: remove AI patterns from marketing copy

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -12,16 +12,16 @@
       />
       <div class="space-y-6 border-l-4 border-primary pl-6">
         <p class="text-lg leading-relaxed text-slate-600">
-          SMD Services was founded by Scott Durgan in Phoenix. After years working across
-          operations, technology, and business strategy, Scott started SMD with a simple premise:
-          most consultants hand you a report — we build the solution and train your team to run it.
+          Scott Durgan started SMD Services in Phoenix because he kept seeing the same thing:
+          growing businesses stuck running on memory, gut feel, and the owner's phone. He'd spent
+          years in operations, tech, and strategy, and noticed that what most of these businesses
+          needed wasn't a report or a deck. They needed someone to actually build the thing and hand
+          it off.
         </p>
         <p class="text-lg leading-relaxed text-slate-600">
-          We work with small businesses across the Valley — Scottsdale, Chandler, Tempe, Mesa,
-          Gilbert, and the East Valley — that have hit that in-between stage: too big for the owner
-          to run everything alone, not big enough for a full-time operations hire. We start by
-          understanding where you're trying to go, figure out what's in the way, and build the right
-          solution to get you there.
+          That's what we do. We work with small businesses across the Phoenix metro (Scottsdale,
+          Chandler, Tempe, Mesa, Gilbert, the East Valley) that are past the startup phase but not
+          big enough to hire a full-time operations person. If that sounds like you, we should talk.
         </p>
       </div>
     </div>

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -7,7 +7,7 @@ import CtaButton from './CtaButton.astro'
     <h2 class="text-3xl font-bold text-white">Let's Talk About Your Business</h2>
     <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-400">
       We'll ask how things run, what you're trying to accomplish, and where things get in the way.
-      You'll walk away with clarity — whether we work together or not.
+      You'll walk away with clarity, whether we work together or not.
     </p>
     <div class="mt-10">
       <CtaButton variant="outline-white" href="/book">Book a Call</CtaButton>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -10,7 +10,7 @@ import CtaButton from './CtaButton.astro'
       Your Business Is Growing. How You Run It Should Too.
     </h1>
     <p class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-slate-600">
-      You know where you're headed. We work alongside you to figure out what needs to change — and
+      You know where you're headed. We work alongside you to figure out what needs to change and
       build the right solution together.
     </p>
     <CtaButton href="/book">Book a Call</CtaButton>

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -3,7 +3,7 @@ const steps = [
   {
     title: 'Learn Your Business',
     description:
-      "We start with a conversation. What are you trying to accomplish? Where do things get stuck? We listen until we understand your business — not just the frustrations, but what you're actually trying to achieve.",
+      "We start with a conversation. What are you trying to accomplish? Where do things get stuck? We listen until we understand your business. Not just the frustrations, but what you're actually trying to achieve.",
   },
   {
     title: 'Build It Out',

--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -4,7 +4,7 @@ const schema = {
   '@type': 'LocalBusiness',
   name: 'SMD Services',
   description:
-    'Operations consulting for Phoenix-area small businesses. We work alongside growing businesses to figure out what needs to change and build the right solution together.',
+    'Operations consulting for Phoenix-area small businesses. We work with growing businesses to figure out what needs to change and get it done.',
   url: 'https://smd.services',
   email: 'scott@smd.services',
   address: {

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-4xl text-center">
     <h2 class="mb-4 text-3xl font-bold md:text-4xl">Scoped to Your Business</h2>
     <p class="mx-auto mb-16 max-w-2xl text-lg text-slate-400">
-      Every business is different. We quote a fixed price after we understand yours — no hourly
+      Every business is different. We quote a fixed price after we understand yours. No hourly
       billing, no open-ended retainers, no surprises.
     </p>
 
@@ -15,12 +15,14 @@
       </div>
       <div>
         <h3 class="mb-2 text-xl font-bold">Quote</h3>
-        <p class="text-slate-400">Fixed price based on what we find — before you commit.</p>
+        <p class="text-slate-400">
+          Fixed price based on what we find. You see it before you commit.
+        </p>
       </div>
       <div>
         <h3 class="mb-2 text-xl font-bold">Deliver</h3>
         <p class="text-slate-400">
-          Implementation, training, and handoff — all scoped to your objectives.
+          Implementation, training, and handoff. All scoped to your objectives.
         </p>
       </div>
     </div>
@@ -30,9 +32,9 @@
       <ul class="space-y-4">
         {
           [
-            'Fixed price — you know the total cost before work starts',
+            'Fixed price. You know the total cost before work starts',
             'Scoped to your specific objectives, not a vague retainer',
-            'Simple terms — we walk you through everything upfront',
+            'Simple terms. We walk you through everything upfront',
             'No commitment until after the first conversation',
           ].map((item) => (
             <li class="flex items-center gap-3">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -9,7 +9,7 @@ interface Props {
 
 const {
   title,
-  description = 'SMD Services — Operations consulting for Phoenix-area small businesses. We work alongside growing businesses to figure out what needs to change and build the right solution together.',
+  description = 'Operations consulting for Phoenix-area small businesses. We work with growing businesses to figure out what needs to change and get it done.',
 } = Astro.props
 
 const canonicalUrl = new URL(Astro.url.pathname, 'https://smd.services')

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,7 +4,7 @@ export const prerender = true
 import Base from '../layouts/Base.astro'
 ---
 
-<Base title="Page Not Found — SMD Services">
+<Base title="Page Not Found | SMD Services">
   <main class="mx-auto max-w-4xl px-4 py-16 text-center">
     <h1 class="text-3xl font-bold text-gray-900">Page not found</h1>
     <p class="mt-4 text-lg text-gray-600">The page you're looking for doesn't exist.</p>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro'
 ---
 
 <Base
-  title="Let's Talk — SMD Services"
+  title="Let's Talk | SMD Services"
   description="Schedule a conversation about your business. We'll learn how things run, understand what you're trying to accomplish, and share how we can help."
 >
   <main>
@@ -83,7 +83,7 @@ import Footer from '../components/Footer.astro'
             <h3 class="mt-4 font-bold text-slate-900">We figure out what matters most</h3>
             <p class="mt-2 text-sm text-slate-600">
               Together we identify what would make the biggest difference for where you're trying to
-              go — and why those things matter most right now.
+              go, and why those things matter most right now.
             </p>
           </div>
           <div class="text-center">
@@ -119,7 +119,7 @@ import Footer from '../components/Footer.astro'
             <dt class="font-semibold text-slate-900">Do I need to prepare anything?</dt>
             <dd class="mt-2 text-slate-600">
               Just be ready to talk honestly about how things work. We'll ask questions. The less
-              polished, the better — the real version of how things run is what helps us figure out
+              polished, the better. The real version of how things run is what helps us figure out
               the right path forward.
             </dd>
           </div>
@@ -127,7 +127,7 @@ import Footer from '../components/Footer.astro'
             <dt class="font-semibold text-slate-900">What happens after the call?</dt>
             <dd class="mt-2 text-slate-600">
               If it makes sense to work together, you get a proposal. Fixed price, clear scope, no
-              surprises. If not, we'll tell you that too — no pressure either way.
+              surprises. If not, we'll tell you that too. No pressure either way.
             </dd>
           </div>
           <div>

--- a/src/pages/book/thanks.astro
+++ b/src/pages/book/thanks.astro
@@ -7,7 +7,7 @@ import { CLIENT_VERTICALS } from '../../lib/db/clients'
 ---
 
 <Base
-  title="You're All Set — SMD Services"
+  title="You're All Set | SMD Services"
   description="Thanks for booking. Help us prepare for your call by telling us a bit about your business."
 >
   <main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 ---
 
-<Base title="SMD Services — Operations Consulting for Phoenix Small Businesses">
+<Base title="SMD Services | Operations Consulting for Phoenix Small Businesses">
   <Nav />
   <main>
     <Hero />


### PR DESCRIPTION
## Summary

- **About section fully rewritten** to sound human-written. Irregular rhythm, conversational voice, no polished parallel structures.
- **All em dashes removed** from marketing copy (components, pages, meta descriptions). Replaced with periods, commas, or rewrites.
- **Page titles** use `|` separator instead of em dash.
- **Meta/OG descriptions** rewritten to be shorter and less AI-sounding.

## Before/After (About section)

**Before:** "SMD Services was founded by Scott Durgan in Phoenix. After years working across operations, technology, and business strategy, Scott started SMD with a simple premise: most consultants hand you a report — we build the solution and train your team to run it."

**After:** "Scott Durgan started SMD Services in Phoenix because he kept seeing the same thing: growing businesses stuck running on memory, gut feel, and the owner's phone. He'd spent years in operations, tech, and strategy, and noticed that what most of these businesses needed wasn't a report or a deck. They needed someone to actually build the thing and hand it off."

## Test plan

- [ ] Visual review of About section copy
- [ ] Grep for em dashes in marketing components (should be zero)
- [ ] `npm run verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)