### PR TITLE
feat: entity admin UI — unified list and detail pages

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,0 +1,633 @@
+---
+import '../../../styles/global.css'
+import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
+import type { Entity, EntityStage } from '../../../lib/db/entities'
+import { listContext, CONTEXT_TYPES } from '../../../lib/db/context'
+import type { ContextEntry } from '../../../lib/db/context'
+import { listContacts } from '../../../lib/db/contacts'
+import { listAssessments } from '../../../lib/db/assessments'
+import { listEngagements } from '../../../lib/db/engagements'
+import { listQuotes } from '../../../lib/db/quotes'
+import { listInvoices } from '../../../lib/db/invoices'
+
+/**
+ * Entity detail — unified view of a single business across its lifecycle.
+ * Context timeline is the centerpiece; operational data in collapsible panels.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const entityId = Astro.params.id!
+
+const entity = await getEntity(env.DB, session.orgId, entityId)
+if (!entity) return Astro.redirect('/admin/entities?error=not_found')
+
+const [contextEntries, contacts, assessments, engagements, quotes, invoices] = await Promise.all([
+  listContext(env.DB, entityId),
+  listContacts(env.DB, session.orgId, entityId),
+  listAssessments(env.DB, session.orgId, entityId),
+  listEngagements(env.DB, session.orgId, entityId),
+  listQuotes(env.DB, session.orgId, entityId),
+  listInvoices(env.DB, session.orgId, { entityId }),
+])
+
+// Reverse for newest-first display
+const timelineEntries = [...contextEntries].reverse()
+
+// Filter by type from URL
+const typeFilter = Astro.url.searchParams.get('type') ?? ''
+const filteredEntries = typeFilter
+  ? timelineEntries.filter((e) => e.type === typeFilter)
+  : timelineEntries
+
+// Count by type for filter buttons
+const typeCounts: Record<string, number> = {}
+for (const e of contextEntries) {
+  typeCounts[e.type] = (typeCounts[e.type] ?? 0) + 1
+}
+
+const promoted = Astro.url.searchParams.get('promoted')
+const noteAdded = Astro.url.searchParams.get('note_added')
+const stageUpdated = Astro.url.searchParams.get('stage_updated')
+const error = Astro.url.searchParams.get('error')
+
+// Stage transitions
+const TRANSITIONS: Record<string, { label: string; stage: EntityStage; style: string }[]> = {
+  signal: [
+    { label: 'Promote', stage: 'prospect', style: 'bg-primary text-white hover:bg-primary/90' },
+    { label: 'Dismiss', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+  ],
+  prospect: [
+    {
+      label: 'Book Assessment',
+      stage: 'assessing',
+      style: 'bg-purple-600 text-white hover:bg-purple-700',
+    },
+    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+  ],
+  assessing: [
+    {
+      label: 'Send Proposal',
+      stage: 'proposing',
+      style: 'bg-indigo-600 text-white hover:bg-indigo-700',
+    },
+    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+  ],
+  proposing: [
+    { label: 'Engaged', stage: 'engaged', style: 'bg-green-600 text-white hover:bg-green-700' },
+    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+  ],
+  engaged: [
+    {
+      label: 'Delivered',
+      stage: 'delivered',
+      style: 'bg-emerald-600 text-white hover:bg-emerald-700',
+    },
+  ],
+  delivered: [
+    { label: 'Ongoing', stage: 'ongoing', style: 'bg-teal-600 text-white hover:bg-teal-700' },
+    {
+      label: 'Re-engage',
+      stage: 'prospect',
+      style: 'bg-blue-600 text-white hover:bg-blue-700',
+    },
+  ],
+  ongoing: [
+    {
+      label: 'Re-engage',
+      stage: 'prospect',
+      style: 'bg-blue-600 text-white hover:bg-blue-700',
+    },
+    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+  ],
+  lost: [
+    {
+      label: 'Re-engage',
+      stage: 'prospect',
+      style: 'bg-blue-600 text-white hover:bg-blue-700',
+    },
+  ],
+}
+
+function contextTypeBadge(type: string): string {
+  const map: Record<string, string> = {
+    signal: 'bg-amber-100 text-amber-700',
+    enrichment: 'bg-cyan-100 text-cyan-700',
+    note: 'bg-slate-100 text-slate-600',
+    transcript: 'bg-purple-100 text-purple-700',
+    extraction: 'bg-indigo-100 text-indigo-700',
+    outreach_draft: 'bg-blue-100 text-blue-700',
+    engagement_log: 'bg-green-100 text-green-700',
+    follow_up_result: 'bg-teal-100 text-teal-700',
+    feedback: 'bg-emerald-100 text-emerald-700',
+    parking_lot: 'bg-orange-100 text-orange-700',
+    stage_change: 'bg-slate-50 text-slate-500',
+    intake: 'bg-pink-100 text-pink-700',
+  }
+  return map[type] ?? 'bg-slate-100 text-slate-600'
+}
+
+function stageBadgeClass(stage: string): string {
+  const map: Record<string, string> = {
+    signal: 'bg-amber-100 text-amber-700',
+    prospect: 'bg-blue-100 text-blue-700',
+    assessing: 'bg-purple-100 text-purple-700',
+    proposing: 'bg-indigo-100 text-indigo-700',
+    engaged: 'bg-green-100 text-green-700',
+    delivered: 'bg-emerald-100 text-emerald-700',
+    ongoing: 'bg-teal-100 text-teal-700',
+    lost: 'bg-slate-100 text-slate-500',
+  }
+  return map[stage] ?? 'bg-slate-100 text-slate-500'
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function statusBadgeClass(status: string): string {
+  const map: Record<string, string> = {
+    scheduled: 'bg-blue-100 text-blue-700',
+    active: 'bg-green-100 text-green-700',
+    completed: 'bg-emerald-100 text-emerald-700',
+    handoff: 'bg-teal-100 text-teal-700',
+    safety_net: 'bg-amber-100 text-amber-700',
+    cancelled: 'bg-slate-100 text-slate-500',
+    draft: 'bg-slate-100 text-slate-600',
+    sent: 'bg-blue-100 text-blue-700',
+    accepted: 'bg-green-100 text-green-700',
+    declined: 'bg-red-100 text-red-700',
+    expired: 'bg-slate-100 text-slate-500',
+    paid: 'bg-green-100 text-green-700',
+    overdue: 'bg-red-100 text-red-700',
+    void: 'bg-slate-100 text-slate-400',
+    disqualified: 'bg-red-100 text-red-600',
+    converted: 'bg-green-100 text-green-700',
+  }
+  return map[status] ?? 'bg-slate-100 text-slate-600'
+}
+
+function parseMetadata(json: string | null): Record<string, unknown> | null {
+  if (!json) return null
+  try {
+    return JSON.parse(json)
+  } catch {
+    return null
+  }
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>{entity.name} — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <a
+          href={`/admin/entities?stage=${entity.stage}`}
+          class="hover:text-primary transition-colors">Entities</a
+        >
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">{entity.name}</span>
+      </nav>
+
+      {
+        promoted && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Entity promoted to prospect.
+          </div>
+        )
+      }
+      {
+        noteAdded && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Note added.
+          </div>
+        )
+      }
+      {
+        stageUpdated && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Stage updated.
+          </div>
+        )
+      }
+      {
+        error && (
+          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+            {decodeURIComponent(error)}
+          </div>
+        )
+      }
+
+      {/* Entity Summary */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <div class="flex items-center gap-3 mb-2">
+              <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+              <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
+                {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
+              </span>
+              {
+                entity.tier && (
+                  <span
+                    class={`text-xs px-2 py-0.5 rounded ${
+                      entity.tier === 'hot'
+                        ? 'bg-red-100 text-red-700'
+                        : entity.tier === 'warm'
+                          ? 'bg-amber-100 text-amber-700'
+                          : entity.tier === 'cool'
+                            ? 'bg-blue-100 text-blue-700'
+                            : 'bg-slate-100 text-slate-500'
+                    }`}
+                  >
+                    {entity.tier}
+                  </span>
+                )
+              }
+            </div>
+
+            <div class="flex items-center gap-4 text-sm text-slate-500 mb-2 flex-wrap">
+              {
+                entity.pain_score && (
+                  <span>
+                    Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
+                  </span>
+                )
+              }
+              {
+                entity.vertical && (
+                  <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>
+                )
+              }
+              {entity.area && <span>{entity.area}</span>}
+              {entity.employee_count && <span>~{entity.employee_count} employees</span>}
+            </div>
+
+            <div class="flex items-center gap-3 text-xs text-slate-400">
+              {
+                entity.source_pipeline && (
+                  <span>Source: {entity.source_pipeline.replace(/_/g, ' ')}</span>
+                )
+              }
+              <span>Created {formatDate(entity.created_at)}</span>
+              {entity.phone && <span>{entity.phone}</span>}
+              {
+                entity.website && (
+                  <a
+                    href={
+                      entity.website.startsWith('http')
+                        ? entity.website
+                        : `https://${entity.website}`
+                    }
+                    target="_blank"
+                    class="text-blue-500 hover:underline"
+                  >
+                    {entity.website}
+                  </a>
+                )
+              }
+            </div>
+
+            {
+              entity.next_action && (
+                <div class="mt-3 bg-amber-50 border border-amber-200 px-3 py-2 rounded text-sm">
+                  <span class="font-medium text-amber-800">Next:</span>
+                  <span class="text-amber-700">
+                    {entity.next_action}
+                    {entity.next_action_at && ` — ${formatDate(entity.next_action_at)}`}
+                  </span>
+                </div>
+              )
+            }
+          </div>
+
+          {/* Stage transition buttons */}
+          <div class="flex items-center gap-2 shrink-0">
+            {
+              TRANSITIONS[entity.stage]?.map((t) => (
+                <form method="POST" action={`/api/admin/entities/${entity.id}/stage`}>
+                  <input type="hidden" name="stage" value={t.stage} />
+                  <input type="hidden" name="reason" value={`${t.label} by admin.`} />
+                  <button
+                    type="submit"
+                    class={`text-xs px-3 py-1.5 rounded-md transition-colors ${t.style}`}
+                  >
+                    {t.label}
+                  </button>
+                </form>
+              ))
+            }
+          </div>
+        </div>
+      </div>
+
+      {/* Add Note */}
+      <div class="bg-white rounded-lg border border-slate-200 p-4 mb-6">
+        <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-3">
+          <input type="hidden" name="type" value="note" />
+          <textarea
+            name="content"
+            placeholder="Add a note..."
+            rows="2"
+            class="flex-1 text-sm border border-slate-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          ></textarea>
+          <button
+            type="submit"
+            class="self-end text-sm bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors"
+          >
+            Add Note
+          </button>
+        </form>
+      </div>
+
+      {/* Context Timeline */}
+      <div class="mb-6">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-base font-semibold text-slate-900">
+            Context Timeline
+            <span class="text-sm font-normal text-slate-400">({contextEntries.length})</span>
+          </h3>
+        </div>
+
+        {/* Type filter pills */}
+        <div class="flex gap-1 mb-4 flex-wrap">
+          <a
+            href={`/admin/entities/${entity.id}`}
+            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'}`}
+          >
+            All ({contextEntries.length})
+          </a>
+          {
+            Object.entries(typeCounts).map(([type, count]) => (
+              <a
+                href={`/admin/entities/${entity.id}?type=${type}`}
+                class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-slate-900 text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
+              >
+                {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
+              </a>
+            ))
+          }
+        </div>
+
+        {/* Timeline entries */}
+        {
+          filteredEntries.length === 0 ? (
+            <div class="bg-white rounded-lg border border-slate-200 p-4">
+              <p class="text-slate-500 text-sm">No context entries yet.</p>
+            </div>
+          ) : (
+            <div class="space-y-3">
+              {filteredEntries.map((entry: ContextEntry) => {
+                const meta = parseMetadata(entry.metadata)
+                const problems = meta?.top_problems as string[] | undefined
+                return (
+                  <div class="bg-white rounded-lg border border-slate-200 px-4 py-3">
+                    <div class="flex items-center gap-2 mb-1.5">
+                      <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
+                        {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
+                      </span>
+                      <span class="text-xs text-slate-400">{entry.source}</span>
+                      <span class="text-xs text-slate-400">{formatDateTime(entry.created_at)}</span>
+                      {entry.type === 'signal' && meta?.pain_score && (
+                        <span class="text-xs font-semibold text-red-600">
+                          Pain: {String(meta.pain_score)}/10
+                        </span>
+                      )}
+                    </div>
+
+                    {problems && problems.length > 0 && (
+                      <div class="flex gap-1 mb-1.5">
+                        {problems.map((p: string) => (
+                          <span class="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded">
+                            {p.replace(/_/g, ' ')}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <details class="group">
+                      <summary class="text-sm text-slate-700 cursor-pointer line-clamp-3 group-open:line-clamp-none whitespace-pre-wrap">
+                        {entry.content}
+                      </summary>
+                    </details>
+                  </div>
+                )
+              })}
+            </div>
+          )
+        }
+      </div>
+
+      {/* Related Data Panels */}
+      {
+        contacts.length > 0 && (
+          <details class="bg-white rounded-lg border border-slate-200 mb-4" open>
+            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+              Contacts ({contacts.length})
+            </summary>
+            <div class="px-6 pb-4 divide-y divide-slate-100">
+              {contacts.map((c) => (
+                <div class="py-2 flex items-center justify-between">
+                  <div>
+                    <span class="text-sm font-medium text-slate-900">{c.name}</span>
+                    {c.role && (
+                      <span class="text-xs bg-slate-100 text-slate-500 px-1.5 py-0.5 rounded ml-2">
+                        {c.role}
+                      </span>
+                    )}
+                  </div>
+                  <div class="text-xs text-slate-400 flex gap-3">
+                    {c.email && <span>{c.email}</span>}
+                    {c.phone && <span>{c.phone}</span>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        assessments.length > 0 && (
+          <details class="bg-white rounded-lg border border-slate-200 mb-4">
+            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+              Assessments ({assessments.length})
+            </summary>
+            <div class="px-6 pb-4 divide-y divide-slate-100">
+              {assessments.map((a) => (
+                <div class="py-2 flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(a.status)}`}>
+                      {a.status}
+                    </span>
+                    {a.scheduled_at && (
+                      <span class="text-sm text-slate-700">{formatDate(a.scheduled_at)}</span>
+                    )}
+                    {a.duration_minutes && (
+                      <span class="text-xs text-slate-400">{a.duration_minutes} min</span>
+                    )}
+                  </div>
+                  <a
+                    href={`/admin/clients/${entity.id}/assessments/${a.id}`}
+                    class="text-xs text-primary hover:underline"
+                  >
+                    View
+                  </a>
+                </div>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        engagements.length > 0 && (
+          <details class="bg-white rounded-lg border border-slate-200 mb-4">
+            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+              Engagements ({engagements.length})
+            </summary>
+            <div class="px-6 pb-4 divide-y divide-slate-100">
+              {engagements.map((e) => (
+                <div class="py-2 flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(e.status)}`}>
+                      {e.status}
+                    </span>
+                    {e.start_date && (
+                      <span class="text-sm text-slate-700">{formatDate(e.start_date)}</span>
+                    )}
+                    {e.estimated_hours && (
+                      <span class="text-xs text-slate-400">
+                        {e.actual_hours}/{e.estimated_hours} hrs
+                      </span>
+                    )}
+                  </div>
+                  <a
+                    href={`/admin/clients/${entity.id}/engagements/${e.id}`}
+                    class="text-xs text-primary hover:underline"
+                  >
+                    View
+                  </a>
+                </div>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        quotes.length > 0 && (
+          <details class="bg-white rounded-lg border border-slate-200 mb-4">
+            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+              Quotes ({quotes.length})
+            </summary>
+            <div class="px-6 pb-4 divide-y divide-slate-100">
+              {quotes.map((q) => (
+                <div class="py-2 flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(q.status)}`}>
+                      {q.status}
+                    </span>
+                    <span class="text-sm font-medium text-slate-700">
+                      ${q.total_price.toLocaleString()}
+                    </span>
+                    <span class="text-xs text-slate-400">{q.total_hours} hrs</span>
+                    <span class="text-xs text-slate-400">v{q.version}</span>
+                  </div>
+                  <a
+                    href={`/admin/clients/${entity.id}/quotes/${q.id}`}
+                    class="text-xs text-primary hover:underline"
+                  >
+                    View
+                  </a>
+                </div>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        invoices.length > 0 && (
+          <details class="bg-white rounded-lg border border-slate-200 mb-4">
+            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+              Invoices ({invoices.length})
+            </summary>
+            <div class="px-6 pb-4 divide-y divide-slate-100">
+              {invoices.map((inv) => (
+                <div class="py-2 flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(inv.status)}`}>
+                      {inv.status}
+                    </span>
+                    <span class="text-sm font-medium text-slate-700">
+                      ${inv.amount.toLocaleString()}
+                    </span>
+                    <span class="text-xs text-slate-400">{inv.type}</span>
+                    {inv.due_date && (
+                      <span class="text-xs text-slate-400">Due {formatDate(inv.due_date)}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -1,0 +1,317 @@
+---
+import '../../../styles/global.css'
+import { listEntities, countEntitiesByStage, ENTITY_STAGES } from '../../../lib/db/entities'
+import type { Entity, EntityStage } from '../../../lib/db/entities'
+import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
+import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
+
+/**
+ * Entity list — unified view of all businesses across their lifecycle.
+ * Replaces the separate Lead Inbox and Clients list.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+
+const filterStage = (Astro.url.searchParams.get('stage') ?? 'signal') as EntityStage
+const filterPipeline = Astro.url.searchParams.get('pipeline') ?? ''
+
+const entities = await listEntities(env.DB, session.orgId, {
+  stage: filterStage,
+  ...(filterPipeline ? { source_pipeline: filterPipeline } : {}),
+})
+
+const signalCount = await countEntitiesByStage(env.DB, session.orgId, 'signal')
+
+const promoted = Astro.url.searchParams.get('promoted')
+const dismissed = Astro.url.searchParams.get('dismissed')
+const error = Astro.url.searchParams.get('error')
+
+const LEAD_PIPELINES = [
+  { value: 'review_mining', label: 'Review Mining' },
+  { value: 'job_monitor', label: 'Job Monitor' },
+  { value: 'new_business', label: 'New Business' },
+  { value: 'social_listening', label: 'Social Listening' },
+]
+
+function pipelineBadgeClass(pipeline: string): string {
+  switch (pipeline) {
+    case 'review_mining':
+      return 'bg-amber-100 text-amber-700'
+    case 'job_monitor':
+      return 'bg-blue-100 text-blue-700'
+    case 'new_business':
+      return 'bg-green-100 text-green-700'
+    case 'social_listening':
+      return 'bg-purple-100 text-purple-700'
+    default:
+      return 'bg-slate-100 text-slate-600'
+  }
+}
+
+function tierBadgeClass(tier: string | null): string {
+  switch (tier) {
+    case 'hot':
+      return 'bg-red-100 text-red-700'
+    case 'warm':
+      return 'bg-amber-100 text-amber-700'
+    case 'cool':
+      return 'bg-blue-100 text-blue-700'
+    case 'cold':
+      return 'bg-slate-100 text-slate-500'
+    default:
+      return ''
+  }
+}
+
+function painScoreClass(score: number | null): string {
+  if (!score) return 'text-slate-400'
+  if (score >= 8) return 'text-red-600 font-bold'
+  if (score >= 6) return 'text-amber-600 font-semibold'
+  return 'text-slate-500'
+}
+
+function stageBadgeClass(stage: string): string {
+  switch (stage) {
+    case 'signal':
+      return 'border-amber-500 text-amber-600'
+    case 'prospect':
+      return 'border-blue-500 text-blue-600'
+    case 'assessing':
+      return 'border-purple-500 text-purple-600'
+    case 'proposing':
+      return 'border-indigo-500 text-indigo-600'
+    case 'engaged':
+      return 'border-green-500 text-green-600'
+    case 'delivered':
+      return 'border-emerald-500 text-emerald-600'
+    case 'ongoing':
+      return 'border-teal-500 text-teal-600'
+    case 'lost':
+      return 'border-slate-400 text-slate-500'
+    default:
+      return 'border-slate-300 text-slate-500'
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Entities — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Entities</span>
+      </nav>
+
+      {
+        promoted && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Entity promoted to prospect.
+          </div>
+        )
+      }
+      {
+        dismissed && (
+          <div class="bg-slate-50 border border-slate-200 text-slate-600 text-sm px-4 py-3 rounded-lg mb-4">
+            Entity dismissed.
+          </div>
+        )
+      }
+      {
+        error && (
+          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+            {error}
+          </div>
+        )
+      }
+
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-xl font-semibold text-slate-900">Entities</h2>
+        <form method="GET" class="flex items-center gap-2">
+          <input type="hidden" name="stage" value={filterStage} />
+          <select
+            name="pipeline"
+            class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+            onchange="this.form.submit()"
+          >
+            <option value="">All pipelines</option>
+            {
+              LEAD_PIPELINES.map((p) => (
+                <option value={p.value} selected={filterPipeline === p.value}>
+                  {p.label}
+                </option>
+              ))
+            }
+          </select>
+        </form>
+      </div>
+
+      {/* Stage tabs */}
+      <div class="flex gap-1 mb-6 border-b border-slate-200 overflow-x-auto">
+        {
+          ENTITY_STAGES.map((s) => (
+            <a
+              href={`/admin/entities?stage=${s.value}${filterPipeline ? `&pipeline=${filterPipeline}` : ''}`}
+              class={`px-3 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                filterStage === s.value
+                  ? stageBadgeClass(s.value) + ' border-current'
+                  : 'border-transparent text-slate-500 hover:text-slate-700'
+              }`}
+            >
+              {s.label}
+              {s.value === 'signal' && signalCount > 0 && (
+                <span class="ml-1 text-xs bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded-full">
+                  {signalCount}
+                </span>
+              )}
+            </a>
+          ))
+        }
+      </div>
+
+      {/* Entity list */}
+      {
+        entities.length === 0 ? (
+          <div class="bg-white rounded-lg border border-slate-200 p-6">
+            <p class="text-slate-500 text-sm">
+              No entities at the <strong>{filterStage}</strong> stage.
+            </p>
+          </div>
+        ) : (
+          <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+            {entities.map((e: Entity) => (
+              <div class="px-6 py-4">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2 mb-1 flex-wrap">
+                      <a
+                        href={`/admin/entities/${e.id}`}
+                        class="text-sm font-medium text-slate-900 hover:text-primary transition-colors"
+                      >
+                        {e.name}
+                      </a>
+                      {e.source_pipeline && (
+                        <span
+                          class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
+                        >
+                          {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
+                        </span>
+                      )}
+                      {e.pain_score && (
+                        <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
+                          Pain: {e.pain_score}/10
+                        </span>
+                      )}
+                      {e.tier && (
+                        <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
+                          {e.tier}
+                        </span>
+                      )}
+                    </div>
+
+                    {e.summary && (
+                      <p class="text-xs text-slate-600 mb-1 line-clamp-2">{e.summary}</p>
+                    )}
+
+                    {e.next_action && (
+                      <p class="text-xs text-amber-600 mb-1">
+                        <span class="font-medium">Next:</span> {e.next_action}
+                        {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
+                      </p>
+                    )}
+
+                    <div class="flex items-center gap-3 text-xs text-slate-400 mt-1">
+                      <span>{formatDate(e.created_at)}</span>
+                      {e.area && <span>{e.area}</span>}
+                      {e.vertical && (
+                        <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>
+                      )}
+                      {e.employee_count && <span>~{e.employee_count} employees</span>}
+                    </div>
+                  </div>
+
+                  <div class="flex items-center gap-2 shrink-0">
+                    {e.stage === 'signal' ? (
+                      <>
+                        <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
+                          <button
+                            type="submit"
+                            class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                          >
+                            Promote
+                          </button>
+                        </form>
+                        <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
+                          <button
+                            type="submit"
+                            class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                          >
+                            Dismiss
+                          </button>
+                        </form>
+                      </>
+                    ) : (
+                      <a
+                        href={`/admin/entities/${e.id}`}
+                        class="text-xs bg-slate-50 text-slate-700 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                      >
+                        View
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -3,7 +3,7 @@ import '../../styles/global.css'
 import { listFollowUps } from '../../lib/db/follow-ups'
 import { getPipelineConversion } from '../../lib/db/analytics'
 import { listEngagements } from '../../lib/db/engagements'
-import { countNewSignals } from '../../lib/db/lead-signals'
+import { countEntitiesByStage } from '../../lib/db/entities'
 
 /**
  * Admin dashboard — protected by auth middleware.
@@ -22,7 +22,7 @@ const [upcomingFollowUps, overdueFollowUps, pipeline, allEngagements, newSignalC
     listFollowUps(env.DB, session.orgId, { overdue: true }),
     getPipelineConversion(env.DB, session.orgId),
     listEngagements(env.DB, session.orgId),
-    countNewSignals(env.DB, session.orgId),
+    countEntitiesByStage(env.DB, session.orgId, 'signal'),
   ])
 
 const upcomingCount = upcomingFollowUps.length
@@ -83,42 +83,33 @@ const pipelineConversionRate =
       <h2 class="text-xl font-semibold text-slate-900 mb-4">Dashboard</h2>
       <div class="grid gap-4">
         <a
-          href="/admin/clients"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <h3
-            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-          >
-            Clients
-          </h3>
-          <p class="text-sm text-slate-500 mt-1">
-            Manage your client pipeline — create, edit, and track clients through the engagement
-            lifecycle.
-          </p>
-        </a>
-
-        <a
-          href="/admin/leads"
+          href="/admin/entities"
           class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
         >
           <div class="flex items-center justify-between">
             <h3
               class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
             >
-              Lead Inbox
+              Entities
             </h3>
             <div class="flex items-center gap-2">
               {
                 newSignalCount > 0 && (
                   <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full font-medium">
-                    {newSignalCount} new
+                    {newSignalCount} signals
                   </span>
                 )
               }
+              <span
+                class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full font-medium"
+              >
+                {totalClients} total
+              </span>
             </div>
           </div>
           <p class="text-sm text-slate-500 mt-1">
-            Review and triage lead signals from automated pipelines — promote to clients or dismiss.
+            Every business in one place — from pipeline signals through active engagements and
+            repeat clients. Triage, promote, and track the full lifecycle.
           </p>
         </a>
 

--- a/tests/clients.test.ts
+++ b/tests/clients.test.ts
@@ -312,9 +312,9 @@ describe('clients: detail/edit page', () => {
 })
 
 describe('clients: admin dashboard integration', () => {
-  it('admin dashboard links to clients page', () => {
+  it('admin dashboard links to entities page', () => {
     const code = readFileSync(resolve('src/pages/admin/index.astro'), 'utf-8')
-    expect(code).toContain('/admin/clients')
-    expect(code).toContain('Clients')
+    expect(code).toContain('/admin/entities')
+    expect(code).toContain('Entities')
   })
 })


### PR DESCRIPTION
## Summary
- **Entity list page** (`/admin/entities/`): 8 stage tabs, tier/pain sorting, pipeline filter, one-click promote/dismiss for signals, view link for all other stages
- **Entity detail page** (`/admin/entities/[id]`): context timeline with type filter pills, stage transition buttons, add-note form, collapsible panels for contacts/assessments/engagements/quotes/invoices
- **Dashboard updated**: single "Entities" card replaces separate Clients + Lead Inbox links

## Test plan
- [x] `npm run verify` passes (0 errors, 1113 tests)
- [x] Entity list renders with stage tabs and signal count badge
- [x] Entity detail shows context timeline and stage transitions
- [x] Dashboard links to `/admin/entities`

🤖 Generated with [Claude Code](https://claude.com/claude-code)