### PR TITLE
feat: switch pipeline workers to entity-context ingestion

### DIFF
--- a/workers/job-monitor/src/index.ts
+++ b/workers/job-monitor/src/index.ts
@@ -11,7 +11,9 @@
  */
 
 import { ORG_ID } from '../../../src/lib/constants.js'
-import { computeDedupKey, createLeadSignal } from '../../../src/lib/db/lead-signals.js'
+import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
+import { appendContext } from '../../../src/lib/db/context.js'
+import { computeSlug } from '../../../src/lib/entities/slug.js'
 import { searchJobs, JOB_QUERIES } from './serpapi.js'
 import { qualifyJob, derivePainScore } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -71,11 +73,9 @@ async function run(env: Env): Promise<RunSummary> {
 
   for (const { job, query } of uniqueJobs) {
     try {
-      const dedupKey = computeDedupKey(job.company_name, null, job.location)
-      const existing = await env.DB.prepare(
-        "SELECT 1 FROM lead_signals WHERE org_id = ? AND dedup_key = ? AND source_pipeline = 'job_monitor'"
-      )
-        .bind(ORG_ID, dedupKey)
+      const slug = computeSlug(job.company_name, job.location)
+      const existing = await env.DB.prepare('SELECT 1 FROM entities WHERE org_id = ? AND slug = ?')
+        .bind(ORG_ID, slug)
         .first()
 
       if (existing) continue
@@ -96,29 +96,49 @@ async function run(env: Env): Promise<RunSummary> {
 
       summary.qualified++
 
-      const result = await createLeadSignal(env.DB, ORG_ID, {
-        business_name: qualification.company,
-        category: null,
+      // Find or create entity
+      const { entity } = await findOrCreateEntity(env.DB, ORG_ID, {
+        name: qualification.company,
         area: job.location,
         source_pipeline: 'job_monitor',
-        pain_score: derivePainScore(qualification),
-        top_problems: qualification.problems_signaled,
-        evidence_summary: qualification.evidence,
-        outreach_angle: qualification.outreach_angle,
-        source_metadata: {
-          job_hash: job.job_id,
-          job_url: job.apply_options?.[0]?.link ?? null,
-          job_title: job.title,
-          query_term: query,
-          confidence: qualification.confidence,
-          company_size_estimate: qualification.company_size_estimate,
-        },
-        date_found: new Date().toISOString().split('T')[0],
       })
 
-      if (result.status === 'created') {
-        summary.written++
+      // Build context content
+      const contentParts: string[] = []
+      if (qualification.evidence) contentParts.push(qualification.evidence)
+      if (qualification.outreach_angle) {
+        contentParts.push(`**Outreach angle:** ${qualification.outreach_angle}`)
       }
+      const content = contentParts.join('\n\n') || 'Signal from job_monitor.'
+
+      // Build metadata
+      const dateFound = new Date().toISOString().split('T')[0]
+      const painScore = derivePainScore(qualification)
+      const metadata: Record<string, unknown> = {
+        job_hash: job.job_id,
+        job_url: job.apply_options?.[0]?.link ?? null,
+        job_title: job.title,
+        query_term: query,
+        confidence: qualification.confidence,
+        company_size_estimate: qualification.company_size_estimate,
+        ...(painScore != null ? { pain_score: painScore } : {}),
+        ...(qualification.problems_signaled
+          ? { top_problems: qualification.problems_signaled }
+          : {}),
+        ...(qualification.outreach_angle ? { outreach_angle: qualification.outreach_angle } : {}),
+        date_found: dateFound,
+      }
+
+      // Append context
+      await appendContext(env.DB, ORG_ID, {
+        entity_id: entity.id,
+        type: 'signal',
+        content,
+        source: 'job_monitor',
+        metadata,
+      })
+
+      summary.written++
     } catch (err) {
       summary.errors++
       const msg = err instanceof Error ? err.message : String(err)

--- a/workers/new-business/src/index.ts
+++ b/workers/new-business/src/index.ts
@@ -12,7 +12,9 @@
  */
 
 import { ORG_ID } from '../../../src/lib/constants.js'
-import { computeDedupKey, createLeadSignal } from '../../../src/lib/db/lead-signals.js'
+import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
+import { appendContext } from '../../../src/lib/db/context.js'
+import { computeSlug } from '../../../src/lib/entities/slug.js'
 import { fetchAllPermits } from './soda.js'
 import { qualifyNewBusiness } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -42,11 +44,9 @@ async function run(env: Env): Promise<RunSummary> {
 
   for (const permit of permits) {
     try {
-      const dedupKey = computeDedupKey(permit.business_name, null, permit.address)
-      const existing = await env.DB.prepare(
-        "SELECT 1 FROM lead_signals WHERE org_id = ? AND dedup_key = ? AND source_pipeline = 'new_business'"
-      )
-        .bind(ORG_ID, dedupKey)
+      const slug = computeSlug(permit.business_name, permit.address)
+      const existing = await env.DB.prepare('SELECT 1 FROM entities WHERE org_id = ? AND slug = ?')
+        .bind(ORG_ID, slug)
         .first()
 
       if (existing) continue
@@ -67,31 +67,47 @@ async function run(env: Env): Promise<RunSummary> {
 
       summary.qualified++
 
-      const result = await createLeadSignal(env.DB, ORG_ID, {
-        business_name: qualification.business_name,
-        category: null,
+      // Find or create entity
+      const { entity } = await findOrCreateEntity(env.DB, ORG_ID, {
+        name: qualification.business_name,
         area: qualification.area,
         source_pipeline: 'new_business',
-        pain_score: null,
-        top_problems: null,
-        evidence_summary: `${qualification.entity_type} — ${qualification.source}. ${qualification.notes}`,
-        outreach_angle: qualification.outreach_angle,
-        source_metadata: {
-          permit_number: permit.permit_number ?? null,
-          permit_type: permit.permit_type ?? null,
-          entity_type: qualification.entity_type,
-          filing_date: permit.filing_date,
-          source: qualification.source,
-          vertical_match: qualification.vertical_match,
-          size_estimate: qualification.size_estimate,
-          outreach_timing: qualification.outreach_timing,
-        },
-        date_found: new Date().toISOString().split('T')[0],
       })
 
-      if (result.status === 'created') {
-        summary.written++
+      // Build context content
+      const evidenceSummary = `${qualification.entity_type} — ${qualification.source}. ${qualification.notes}`
+      const contentParts: string[] = []
+      if (evidenceSummary) contentParts.push(evidenceSummary)
+      if (qualification.outreach_angle) {
+        contentParts.push(`**Outreach angle:** ${qualification.outreach_angle}`)
       }
+      const content = contentParts.join('\n\n') || 'Signal from new_business.'
+
+      // Build metadata
+      const dateFound = new Date().toISOString().split('T')[0]
+      const metadata: Record<string, unknown> = {
+        permit_number: permit.permit_number ?? null,
+        permit_type: permit.permit_type ?? null,
+        entity_type: qualification.entity_type,
+        filing_date: permit.filing_date,
+        source: qualification.source,
+        vertical_match: qualification.vertical_match,
+        size_estimate: qualification.size_estimate,
+        outreach_timing: qualification.outreach_timing,
+        ...(qualification.outreach_angle ? { outreach_angle: qualification.outreach_angle } : {}),
+        date_found: dateFound,
+      }
+
+      // Append context
+      await appendContext(env.DB, ORG_ID, {
+        entity_id: entity.id,
+        type: 'signal',
+        content,
+        source: 'new_business',
+        metadata,
+      })
+
+      summary.written++
     } catch (err) {
       summary.errors++
       const msg = err instanceof Error ? err.message : String(err)

--- a/workers/review-mining/src/index.ts
+++ b/workers/review-mining/src/index.ts
@@ -12,7 +12,9 @@
  */
 
 import { ORG_ID } from '../../../src/lib/constants.js'
-import { computeDedupKey, createLeadSignal } from '../../../src/lib/db/lead-signals.js'
+import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
+import { appendContext } from '../../../src/lib/db/context.js'
+import { computeSlug } from '../../../src/lib/entities/slug.js'
 import { discoverBusinesses, fetchReviews, DISCOVERY_QUERIES } from './outscraper.js'
 import { scoreReviews } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -97,11 +99,9 @@ async function run(env: Env): Promise<RunSummary> {
   // Phase 3: Score each business
   for (const business of businessesWithReviews) {
     try {
-      const dedupKey = computeDedupKey(business.name, business.category, business.area)
-      const existing = await env.DB.prepare(
-        "SELECT 1 FROM lead_signals WHERE org_id = ? AND dedup_key = ? AND source_pipeline = 'review_mining'"
-      )
-        .bind(ORG_ID, dedupKey)
+      const slug = computeSlug(business.name, business.area)
+      const existing = await env.DB.prepare('SELECT 1 FROM entities WHERE org_id = ? AND slug = ?')
+        .bind(ORG_ID, slug)
         .first()
 
       if (existing) continue
@@ -122,29 +122,47 @@ async function run(env: Env): Promise<RunSummary> {
 
       summary.qualified++
 
-      const result = await createLeadSignal(env.DB, ORG_ID, {
-        business_name: scoring.business_name,
-        phone: null,
-        website: null,
-        category: business.category,
+      // Find or create entity
+      const { entity } = await findOrCreateEntity(env.DB, ORG_ID, {
+        name: scoring.business_name,
         area: business.area,
         source_pipeline: 'review_mining',
-        pain_score: scoring.pain_score,
-        top_problems: scoring.top_problems,
-        evidence_summary: scoring.signals.map((s) => `${s.problem_id}: "${s.quote}"`).join(' | '),
-        outreach_angle: scoring.outreach_angle,
-        source_metadata: {
-          place_id: scoring.place_id,
-          google_rating: business.rating,
-          review_count: business.total_reviews,
-          signals_count: scoring.signals.length,
-        },
-        date_found: new Date().toISOString().split('T')[0],
       })
 
-      if (result.status === 'created') {
-        summary.written++
+      // Build context content
+      const evidenceSummary = scoring.signals
+        .map((s) => `${s.problem_id}: "${s.quote}"`)
+        .join(' | ')
+      const contentParts: string[] = []
+      if (evidenceSummary) contentParts.push(evidenceSummary)
+      if (scoring.outreach_angle) {
+        contentParts.push(`**Outreach angle:** ${scoring.outreach_angle}`)
       }
+      const content = contentParts.join('\n\n') || 'Signal from review_mining.'
+
+      // Build metadata
+      const dateFound = new Date().toISOString().split('T')[0]
+      const metadata: Record<string, unknown> = {
+        place_id: scoring.place_id,
+        google_rating: business.rating,
+        review_count: business.total_reviews,
+        signals_count: scoring.signals.length,
+        ...(scoring.pain_score != null ? { pain_score: scoring.pain_score } : {}),
+        ...(scoring.top_problems ? { top_problems: scoring.top_problems } : {}),
+        ...(scoring.outreach_angle ? { outreach_angle: scoring.outreach_angle } : {}),
+        date_found: dateFound,
+      }
+
+      // Append context
+      await appendContext(env.DB, ORG_ID, {
+        entity_id: entity.id,
+        type: 'signal',
+        content,
+        source: 'review_mining',
+        metadata,
+      })
+
+      summary.written++
     } catch (err) {
       summary.errors++
       const msg = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary
- **All 3 pipeline Workers updated**: job-monitor, new-business, review-mining now use `findOrCreateEntity()` + `appendContext()` instead of `createLeadSignal()`
- **Dedup via slug**: Workers check `entities` table by slug instead of `lead_signals` by dedup_key — fixes PIRTEK-style duplicate issues
- **Same payload, new destination**: Pipeline qualification logic unchanged; only the final write step changes

## Test plan
- [x] `npm run verify` passes (0 errors, 1113 tests)
- [x] Worker imports resolve correctly against shared DAL
- [x] Dedup queries target `entities` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)