### PR TITLE
fix: rewrite About section with authentic founder background

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -12,16 +12,15 @@
       />
       <div class="space-y-6 border-l-4 border-primary pl-6">
         <p class="text-lg leading-relaxed text-slate-600">
-          Scott Durgan started SMD Services in Phoenix because he kept seeing the same thing:
-          growing businesses stuck running on memory, gut feel, and the owner's phone. He'd spent
-          years in operations, tech, and strategy, and noticed that what most of these businesses
-          needed wasn't a report or a deck. They needed someone to actually build the thing and hand
-          it off.
+          Scott Durgan spent 20 years building enterprise software and leading product teams. He's a
+          creative technologist who listens first and gets how the pieces fit together. He started
+          SMD Services because he wanted to put that experience to use for people who need it.
         </p>
         <p class="text-lg leading-relaxed text-slate-600">
-          That's what we do. We work with small businesses across the Phoenix metro (Scottsdale,
-          Chandler, Tempe, Mesa, Gilbert, the East Valley) that are past the startup phase but not
-          big enough to hire a full-time operations person. If that sounds like you, we should talk.
+          We work with small businesses across the Phoenix metro (Scottsdale, Chandler, Tempe, Mesa,
+          Gilbert, the East Valley) that are past the startup phase but not big enough for a
+          dedicated operations person. You know where you're trying to go. You just can't get to
+          everything while running the business. That's what we're here for.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace generic consultant origin story with Scott's real background: 20 years enterprise software and product teams, creative technologist
- Reframe value proposition around the owner's vision ("You know where you're trying to go") rather than diagnosing problems
- Align with guide persona and tone standards

## Test plan
- [ ] `npm run verify` passes
- [ ] About section renders correctly on homepage
- [ ] Copy reads naturally, no AI phrasing markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)