### PR TITLE
feat: enrichment Tiers 3-4 — deep intelligence + dossier generation

### DIFF
--- a/src/lib/enrichment/competitors.ts
+++ b/src/lib/enrichment/competitors.ts
@@ -1,0 +1,115 @@
+/**
+ * Local competitor benchmarking via Google Places.
+ * Searches for businesses in the same vertical and area, compares metrics.
+ */
+
+const PLACES_API_URL = 'https://places.googleapis.com/v1/places:searchText'
+
+export interface CompetitorBenchmark {
+  competitors: Array<{
+    name: string
+    rating: number
+    review_count: number
+  }>
+  entity_rank_by_reviews: number | null
+  entity_rank_by_rating: number | null
+  total_competitors: number
+  summary: string
+}
+
+const VERTICAL_QUERIES: Record<string, string> = {
+  home_services: 'home services contractor',
+  professional_services: 'professional services firm',
+  contractor_trades: 'contractor',
+  retail_salon: 'salon spa',
+  restaurant_food: 'restaurant',
+}
+
+export async function benchmarkCompetitors(
+  entityName: string,
+  vertical: string | null,
+  area: string | null,
+  entityRating: number | null,
+  entityReviewCount: number | null,
+  apiKey: string
+): Promise<CompetitorBenchmark | null> {
+  const verticalQuery = (vertical && VERTICAL_QUERIES[vertical]) || 'business'
+  const locationQuery = area || 'Phoenix, AZ'
+  const query = `${verticalQuery} ${locationQuery}`
+
+  try {
+    const response = await fetch(PLACES_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask': 'places.displayName,places.rating,places.userRatingCount',
+      },
+      body: JSON.stringify({
+        textQuery: query,
+        locationBias: {
+          circle: {
+            center: { latitude: 33.4484, longitude: -112.074 },
+            radius: 25000,
+          },
+        },
+        maxResultCount: 10,
+      }),
+    })
+
+    if (!response.ok) return null
+
+    const data = (await response.json()) as {
+      places?: Array<{
+        displayName?: { text: string }
+        rating?: number
+        userRatingCount?: number
+      }>
+    }
+
+    const competitors = (data.places ?? [])
+      .filter((p) => p.displayName?.text?.toLowerCase() !== entityName.toLowerCase())
+      .map((p) => ({
+        name: p.displayName?.text ?? '',
+        rating: p.rating ?? 0,
+        review_count: p.userRatingCount ?? 0,
+      }))
+      .slice(0, 5)
+
+    if (competitors.length === 0) return null
+
+    // Rank entity among competitors
+    let rankByReviews: number | null = null
+    let rankByRating: number | null = null
+
+    if (entityReviewCount != null) {
+      const allByReviews = [...competitors.map((c) => c.review_count), entityReviewCount].sort(
+        (a, b) => b - a
+      )
+      rankByReviews = allByReviews.indexOf(entityReviewCount) + 1
+    }
+
+    if (entityRating != null) {
+      const allByRating = [...competitors.map((c) => c.rating), entityRating].sort((a, b) => b - a)
+      rankByRating = allByRating.indexOf(entityRating) + 1
+    }
+
+    const avgRating = competitors.reduce((sum, c) => sum + c.rating, 0) / competitors.length
+    const avgReviews = competitors.reduce((sum, c) => sum + c.review_count, 0) / competitors.length
+
+    const parts: string[] = []
+    if (rankByRating) parts.push(`Ranked #${rankByRating} of ${competitors.length + 1} by rating`)
+    if (rankByReviews) parts.push(`#${rankByReviews} by review count`)
+    parts.push(`Local avg: ${avgRating.toFixed(1)} stars, ${Math.round(avgReviews)} reviews`)
+
+    return {
+      competitors,
+      entity_rank_by_reviews: rankByReviews,
+      entity_rank_by_rating: rankByRating,
+      total_competitors: competitors.length,
+      summary: parts.join('. ') + '.',
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/enrichment/deep-website.ts
+++ b/src/lib/enrichment/deep-website.ts
@@ -1,0 +1,192 @@
+/**
+ * Deep website analysis using Claude Sonnet for comprehensive business intelligence.
+ * Fetches homepage + discoverable subpages, extracts detailed profile.
+ */
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 2048
+
+const DEEP_ANALYSIS_PROMPT = `You are analyzing a small business website for comprehensive intelligence. Extract ALL available information. Return ONLY valid JSON:
+
+{
+  "owner_profile": {
+    "name": "string or null",
+    "title": "string or null",
+    "background": "string or null — bio, education, career history mentioned"
+  },
+  "team": {
+    "size_estimate": "number or null",
+    "named_employees": ["array of {name, role} objects"],
+    "departments_visible": ["array of department names"]
+  },
+  "business_profile": {
+    "founding_year": "number or null",
+    "services": ["array of services"],
+    "service_areas": ["array of geographic areas served"],
+    "certifications": ["array of certifications/licenses mentioned"],
+    "awards": ["array of awards/recognition"],
+    "partnerships": ["array of partner/affiliate mentions"]
+  },
+  "customer_signals": {
+    "testimonials_count": "number",
+    "case_studies_visible": "boolean",
+    "portfolio_visible": "boolean",
+    "pricing_visible": "boolean"
+  },
+  "digital_maturity": {
+    "score": "1-10 integer",
+    "reasoning": "1 sentence explanation",
+    "online_booking": "boolean",
+    "chat_widget": "boolean",
+    "blog_active": "boolean — true if blog has posts within last 6 months",
+    "ssl": "boolean",
+    "mobile_friendly": "boolean"
+  },
+  "contact_info": {
+    "email": "string or null",
+    "phone": "string or null",
+    "address": "string or null",
+    "social_media": {"facebook": "url or null", "instagram": "url or null", "linkedin": "url or null"}
+  }
+}`
+
+export interface DeepWebsiteAnalysis {
+  owner_profile: { name: string | null; title: string | null; background: string | null }
+  team: {
+    size_estimate: number | null
+    named_employees: Array<{ name: string; role: string }>
+    departments_visible: string[]
+  }
+  business_profile: {
+    founding_year: number | null
+    services: string[]
+    service_areas: string[]
+    certifications: string[]
+    awards: string[]
+    partnerships: string[]
+  }
+  customer_signals: {
+    testimonials_count: number
+    case_studies_visible: boolean
+    portfolio_visible: boolean
+    pricing_visible: boolean
+  }
+  digital_maturity: {
+    score: number
+    reasoning: string
+    online_booking: boolean
+    chat_widget: boolean
+    blog_active: boolean
+    ssl: boolean
+    mobile_friendly: boolean
+  }
+  contact_info: {
+    email: string | null
+    phone: string | null
+    address: string | null
+    social_media: { facebook: string | null; instagram: string | null; linkedin: string | null }
+  }
+  pages_analyzed: string[]
+}
+
+export async function deepWebsiteAnalysis(
+  websiteUrl: string,
+  anthropicKey: string
+): Promise<DeepWebsiteAnalysis | null> {
+  const baseUrl = websiteUrl.startsWith('http') ? websiteUrl : `https://${websiteUrl}`
+  const pages: { url: string; html: string }[] = []
+
+  // Fetch homepage first
+  const homepage = await safeFetch(baseUrl)
+  if (!homepage) return null
+  pages.push({ url: baseUrl, html: homepage })
+
+  // Discover and fetch subpages
+  const subpaths = [
+    '/about',
+    '/about-us',
+    '/our-team',
+    '/team',
+    '/staff',
+    '/services',
+    '/contact',
+    '/contact-us',
+    '/careers',
+    '/jobs',
+    '/testimonials',
+    '/reviews',
+    '/blog',
+    '/portfolio',
+    '/gallery',
+  ]
+
+  for (const path of subpaths) {
+    if (pages.length >= 8) break // Cap at 8 pages to manage tokens
+    const html = await safeFetch(`${baseUrl}${path}`)
+    if (html && html.length > 500) {
+      pages.push({ url: `${baseUrl}${path}`, html })
+    }
+  }
+
+  // Clean and combine
+  const combined = pages.map((p) => `=== ${p.url} ===\n${cleanHtml(p.html)}`).join('\n\n')
+  const truncated = combined.slice(0, 50_000) // Larger budget for Sonnet
+
+  try {
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': anthropicKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: DEEP_ANALYSIS_PROMPT,
+        messages: [{ role: 'user', content: `Analyze this business website:\n\n${truncated}` }],
+      }),
+    })
+
+    if (!response.ok) return null
+
+    const result = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>
+    }
+    let text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+    if (!text) return null
+    if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+
+    const parsed = JSON.parse(text)
+    return { ...parsed, pages_analyzed: pages.map((p) => p.url) }
+  } catch {
+    return null
+  }
+}
+
+async function safeFetch(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; SMDBot/1.0)' },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!response.ok) return null
+    const ct = response.headers.get('content-type') ?? ''
+    if (!ct.includes('text/html')) return null
+    return await response.text()
+  } catch {
+    return null
+  }
+}
+
+function cleanHtml(html: string): string {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/src/lib/enrichment/dossier.ts
+++ b/src/lib/enrichment/dossier.ts
@@ -1,0 +1,84 @@
+/**
+ * Intelligence brief (dossier) generation using Claude Sonnet.
+ * Synthesizes all accumulated context into a structured 2-3 page assessment.
+ */
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 4096
+
+const DOSSIER_PROMPT = `You are generating a comprehensive intelligence brief for a consulting team (SMD Services) that sells operations cleanup engagements to Phoenix-area small businesses. Use "we" voice.
+
+Generate a structured dossier in markdown format with these sections:
+
+## Business Overview
+- Name, vertical, location, estimated size, founding year
+- Growth trajectory (growing/stable/declining, with evidence)
+- Competitive position (vs. local peers)
+
+## Owner / Decision-Maker Profile
+- Name, role, management style (inferred from review responses, hiring patterns)
+- Likely concerns and priorities
+- Communication preference (responsive to digital, prefers phone, etc.)
+
+## Technology & Operations Assessment
+- Current tools detected (and what's missing)
+- Digital maturity score with reasoning
+- Key operational gaps mapped to the 6 universal SMB problems:
+  1. Owner bottleneck
+  2. Lead leakage
+  3. Financial blindness
+  4. Scheduling chaos
+  5. Manual communication
+  6. Team invisibility
+
+## Engagement Opportunity
+- Top 2-3 problems we can address (with confidence level and evidence)
+- Estimated engagement complexity (low/medium/high)
+- Recommended approach and talking points for the assessment call
+- Potential objections and responses
+
+## Conversation Starters
+- 3-4 specific, evidence-based opening lines for the assessment call
+- Reference specific things we know about their business
+- Collaborative tone — objectives over problems
+
+Keep it concise but thorough. 800-1200 words.`
+
+export async function generateDossier(
+  assembledContext: string,
+  entityName: string,
+  anthropicKey: string
+): Promise<string | null> {
+  try {
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': anthropicKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: DOSSIER_PROMPT,
+        messages: [
+          {
+            role: 'user',
+            content: `Generate an intelligence brief for: ${entityName}\n\nAll available intelligence:\n\n${assembledContext}`,
+          },
+        ],
+      }),
+    })
+
+    if (!response.ok) return null
+
+    const result = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>
+    }
+    return result?.content?.find((b) => b.type === 'text')?.text?.trim() ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/lib/enrichment/linkedin.ts
+++ b/src/lib/enrichment/linkedin.ts
@@ -1,0 +1,57 @@
+/**
+ * LinkedIn intelligence via Proxycurl API.
+ * Looks up company by name, returns employee count, industry, specialties.
+ * Low cost per lookup via Proxycurl.
+ */
+
+const PROXYCURL_API_URL = 'https://nubela.co/proxycurl/api/linkedin/company/resolve'
+
+export interface LinkedInEnrichment {
+  linkedin_url: string
+  company_name: string
+  employee_count: number | null
+  industry: string | null
+  description: string | null
+}
+
+export async function lookupLinkedIn(
+  companyName: string,
+  location: string | null,
+  apiKey: string
+): Promise<LinkedInEnrichment | null> {
+  try {
+    const params = new URLSearchParams({
+      company_name: companyName,
+      company_location: location ?? 'Phoenix, Arizona',
+    })
+
+    const response = await fetch(`${PROXYCURL_API_URL}?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) return null
+
+    const data = (await response.json()) as {
+      url?: string
+      name?: string
+      company_size?: number[]
+      industry?: string
+      description?: string
+    }
+
+    if (!data.url) return null
+
+    return {
+      linkedin_url: data.url,
+      company_name: data.name ?? companyName,
+      employee_count: data.company_size
+        ? Math.round((data.company_size[0] + (data.company_size[1] ?? data.company_size[0])) / 2)
+        : null,
+      industry: data.industry ?? null,
+      description: data.description ?? null,
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/enrichment/news.ts
+++ b/src/lib/enrichment/news.ts
@@ -1,0 +1,93 @@
+/**
+ * News/press search via SerpAPI Google Search + Claude Haiku extraction.
+ */
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const HAIKU_MODEL = 'claude-haiku-4-5-20251001'
+
+export interface NewsEnrichment {
+  mentions: Array<{
+    title: string
+    source: string
+    snippet: string
+  }>
+  summary: string
+}
+
+export async function searchNews(
+  entityName: string,
+  area: string | null,
+  serpApiKey: string,
+  anthropicKey: string
+): Promise<NewsEnrichment | null> {
+  const query = `"${entityName}" ${area ?? 'Phoenix AZ'}`
+
+  try {
+    // SerpAPI Google Search
+    const params = new URLSearchParams({
+      engine: 'google',
+      q: query,
+      location: 'Phoenix, Arizona, United States',
+      num: '5',
+      api_key: serpApiKey,
+    })
+
+    const response = await fetch(`https://serpapi.com/search?${params.toString()}`)
+    if (!response.ok) return null
+
+    const data = (await response.json()) as {
+      organic_results?: Array<{
+        title?: string
+        source?: string
+        snippet?: string
+        link?: string
+      }>
+    }
+
+    const results = data.organic_results ?? []
+    if (results.length === 0) return null
+
+    const mentions = results
+      .filter((r) => r.title && r.snippet)
+      .map((r) => ({
+        title: r.title!,
+        source: r.source ?? new URL(r.link ?? '').hostname,
+        snippet: r.snippet!,
+      }))
+
+    if (mentions.length === 0) return null
+
+    // Claude Haiku to summarize relevance
+    const summaryResponse = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': anthropicKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: HAIKU_MODEL,
+        max_tokens: 256,
+        messages: [
+          {
+            role: 'user',
+            content: `Summarize what these search results reveal about "${entityName}" in 1-2 sentences. Focus on awards, community involvement, growth signals, or reputation. If results are irrelevant (wrong business, ads), say "No relevant mentions found."\n\n${mentions.map((m) => `${m.title}: ${m.snippet}`).join('\n')}`,
+          },
+        ],
+      }),
+    })
+
+    let summary = 'Search results found but not summarized.'
+    if (summaryResponse.ok) {
+      const summaryResult = (await summaryResponse.json()) as {
+        content?: Array<{ type: string; text?: string }>
+      }
+      summary = summaryResult?.content?.find((b) => b.type === 'text')?.text?.trim() ?? summary
+    }
+
+    return { mentions, summary }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/enrichment/review-analysis.ts
+++ b/src/lib/enrichment/review-analysis.ts
@@ -1,0 +1,67 @@
+/**
+ * Review response pattern analysis.
+ * Reads existing signal context for review evidence, analyzes owner engagement patterns.
+ */
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MODEL = 'claude-haiku-4-5-20251001'
+const MAX_TOKENS = 512
+
+const ANALYSIS_PROMPT = `Analyze these business review signals for owner engagement patterns. Return ONLY valid JSON:
+{
+  "response_pattern": "responsive | sporadic | unresponsive | unknown",
+  "engagement_level": "high | medium | low | unknown",
+  "owner_accessible": true/false,
+  "insights": "1-2 sentence summary of what review patterns reveal about the owner's management style"
+}`
+
+export interface ReviewAnalysis {
+  response_pattern: string
+  engagement_level: string
+  owner_accessible: boolean
+  insights: string
+}
+
+export async function analyzeReviewPatterns(
+  signalContent: string,
+  anthropicKey: string
+): Promise<ReviewAnalysis | null> {
+  try {
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': anthropicKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: ANALYSIS_PROMPT,
+        messages: [{ role: 'user', content: `Review signals:\n\n${signalContent}` }],
+      }),
+    })
+
+    if (!response.ok) return null
+
+    const result = (await response.json()) as { content?: Array<{ type: string; text?: string }> }
+    const text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+    if (!text) return null
+
+    let jsonText = text
+    if (jsonText.startsWith('```')) {
+      jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+    }
+
+    const parsed = JSON.parse(jsonText)
+    return {
+      response_pattern: parsed.response_pattern ?? 'unknown',
+      engagement_level: parsed.engagement_level ?? 'unknown',
+      owner_accessible: parsed.owner_accessible ?? false,
+      insights: parsed.insights ?? '',
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/enrichment/review-synthesis.ts
+++ b/src/lib/enrichment/review-synthesis.ts
@@ -1,0 +1,66 @@
+/**
+ * Cross-platform review synthesis using Claude Sonnet.
+ * Reads existing signal and enrichment context, produces unified analysis.
+ */
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 1024
+
+export interface ReviewSynthesis {
+  unified_rating: number | null
+  total_reviews_across_platforms: number
+  sentiment_trend: 'improving' | 'stable' | 'declining' | 'insufficient_data'
+  top_themes: string[]
+  operational_problems: Array<{ problem: string; confidence: string; evidence: string }>
+  customer_sentiment: string
+}
+
+export async function synthesizeReviews(
+  contextEntries: string,
+  anthropicKey: string
+): Promise<ReviewSynthesis | null> {
+  try {
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': anthropicKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: `Synthesize all review data for this business across platforms. Map operational issues to these 6 problems: owner_bottleneck, lead_leakage, financial_blindness, scheduling_chaos, manual_communication, team_invisibility. Return ONLY valid JSON:
+{
+  "unified_rating": "number 1-5 or null",
+  "total_reviews_across_platforms": "number",
+  "sentiment_trend": "improving | stable | declining | insufficient_data",
+  "top_themes": ["array of 3-5 recurring themes"],
+  "operational_problems": [{"problem": "problem_id", "confidence": "high|medium|low", "evidence": "brief quote or pattern"}],
+  "customer_sentiment": "1-2 sentence overall assessment"
+}`,
+        messages: [
+          {
+            role: 'user',
+            content: `All available review and enrichment data:\n\n${contextEntries}`,
+          },
+        ],
+      }),
+    })
+
+    if (!response.ok) return null
+
+    const result = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>
+    }
+    let text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+    if (!text) return null
+    if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -51,7 +51,19 @@ for (const e of contextEntries) {
 const promoted = Astro.url.searchParams.get('promoted')
 const noteAdded = Astro.url.searchParams.get('note_added')
 const stageUpdated = Astro.url.searchParams.get('stage_updated')
+const dossierGenerated = Astro.url.searchParams.get('dossier')
 const error = Astro.url.searchParams.get('error')
+
+// Dossier available for prospect stage and beyond (not signal or lost)
+const dossierStages: string[] = [
+  'prospect',
+  'assessing',
+  'proposing',
+  'engaged',
+  'delivered',
+  'ongoing',
+]
+const showDossierButton = dossierStages.includes(entity.stage)
 
 // Stage transitions
 const TRANSITIONS: Record<string, { label: string; stage: EntityStage; style: string }[]> = {
@@ -265,6 +277,13 @@ function parseMetadata(json: string | null): Record<string, unknown> | null {
         )
       }
       {
+        dossierGenerated && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Intelligence dossier generated. See enrichment entries in the timeline below.
+          </div>
+        )
+      }
+      {
         error && (
           <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
             {decodeURIComponent(error)}
@@ -370,6 +389,18 @@ function parseMetadata(json: string | null): Record<string, unknown> | null {
                   </button>
                 </form>
               ))
+            }
+            {
+              showDossierButton && (
+                <form method="POST" action={`/api/admin/entities/${entity.id}/dossier`}>
+                  <button
+                    type="submit"
+                    class="text-xs px-3 py-1.5 rounded-md transition-colors bg-cyan-600 text-white hover:bg-cyan-700"
+                  >
+                    Generate Dossier
+                  </button>
+                </form>
+              )
             }
           </div>
         </div>

--- a/src/pages/api/admin/entities/[id]/dossier.ts
+++ b/src/pages/api/admin/entities/[id]/dossier.ts
@@ -1,0 +1,147 @@
+import type { APIRoute } from 'astro'
+import { getEntity } from '../../../../../lib/db/entities'
+import { appendContext, assembleEntityContext } from '../../../../../lib/db/context'
+import { deepWebsiteAnalysis } from '../../../../../lib/enrichment/deep-website'
+import type { DeepWebsiteAnalysis } from '../../../../../lib/enrichment/deep-website'
+import { synthesizeReviews } from '../../../../../lib/enrichment/review-synthesis'
+import { lookupLinkedIn } from '../../../../../lib/enrichment/linkedin'
+import { generateDossier } from '../../../../../lib/enrichment/dossier'
+
+/**
+ * POST /api/admin/entities/[id]/dossier
+ *
+ * Generate a deep intelligence dossier for an entity.
+ * Runs Tier 4 enrichment modules then synthesizes into a brief.
+ */
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) return redirect('/admin/entities?error=missing', 302)
+
+  try {
+    const env = locals.runtime.env
+    const entity = await getEntity(env.DB, session.orgId, entityId)
+    if (!entity) return redirect('/admin/entities?error=not_found', 302)
+
+    const anthropicKey = env.ANTHROPIC_API_KEY as string | undefined
+    if (!anthropicKey) {
+      return redirect(`/admin/entities/${entityId}?error=no_api_key`, 302)
+    }
+
+    // Module 11: Deep website analysis (if website available)
+    if (entity.website) {
+      try {
+        const deepAnalysis = await deepWebsiteAnalysis(entity.website, anthropicKey)
+        if (deepAnalysis) {
+          await appendContext(env.DB, session.orgId, {
+            entity_id: entityId,
+            type: 'enrichment',
+            content: formatDeepWebsite(deepAnalysis),
+            source: 'deep_website',
+            metadata: deepAnalysis as unknown as Record<string, unknown>,
+          })
+        }
+      } catch (err) {
+        console.error('[dossier] Deep website analysis failed:', err)
+      }
+    }
+
+    // Module 12: Cross-platform review synthesis
+    try {
+      const allContext = await assembleEntityContext(env.DB, entityId, {
+        maxBytes: 20_000,
+        typeFilter: ['signal', 'enrichment'],
+      })
+      if (allContext) {
+        const synthesis = await synthesizeReviews(allContext, anthropicKey)
+        if (synthesis) {
+          await appendContext(env.DB, session.orgId, {
+            entity_id: entityId,
+            type: 'enrichment',
+            content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}. Themes: ${synthesis.top_themes.join(', ')}. Problems: ${synthesis.operational_problems.map((p) => `${p.problem} (${p.confidence})`).join(', ')}.`,
+            source: 'review_synthesis',
+            metadata: synthesis as unknown as Record<string, unknown>,
+          })
+        }
+      }
+    } catch (err) {
+      console.error('[dossier] Review synthesis failed:', err)
+    }
+
+    // Module 13: LinkedIn (if API key available)
+    if (env.PROXYCURL_API_KEY) {
+      try {
+        const linkedin = await lookupLinkedIn(
+          entity.name,
+          entity.area,
+          env.PROXYCURL_API_KEY as string
+        )
+        if (linkedin) {
+          await appendContext(env.DB, session.orgId, {
+            entity_id: entityId,
+            type: 'enrichment',
+            content: `LinkedIn: ${linkedin.company_name}. ${linkedin.employee_count ? `~${linkedin.employee_count} employees.` : ''} ${linkedin.industry ? `Industry: ${linkedin.industry}.` : ''} ${linkedin.description ? linkedin.description.slice(0, 200) : ''}`,
+            source: 'linkedin',
+            metadata: linkedin as unknown as Record<string, unknown>,
+          })
+        }
+      } catch (err) {
+        console.error('[dossier] LinkedIn lookup failed:', err)
+      }
+    }
+
+    // Module 14: Generate the intelligence brief
+    const fullContext = await assembleEntityContext(env.DB, entityId, { maxBytes: 32_000 })
+    if (fullContext) {
+      const brief = await generateDossier(fullContext, entity.name, anthropicKey)
+      if (brief) {
+        await appendContext(env.DB, session.orgId, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: brief,
+          source: 'intelligence_brief',
+          metadata: { model: 'claude-sonnet-4-20250514', trigger: 'dossier' },
+        })
+      }
+    }
+
+    return redirect(`/admin/entities/${entityId}?dossier=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/entities/dossier] Error:', err)
+    return redirect(`/admin/entities/${entityId}?error=dossier_failed`, 302)
+  }
+}
+
+function formatDeepWebsite(analysis: DeepWebsiteAnalysis): string {
+  const parts: string[] = ['Deep website analysis:']
+  if (analysis.owner_profile.name)
+    parts.push(`Owner: ${analysis.owner_profile.name} (${analysis.owner_profile.title ?? 'owner'})`)
+  if (analysis.owner_profile.background)
+    parts.push(`Background: ${analysis.owner_profile.background}`)
+  if (analysis.team.size_estimate) parts.push(`Team: ~${analysis.team.size_estimate} people`)
+  if (analysis.team.named_employees.length > 0)
+    parts.push(
+      `Named staff: ${analysis.team.named_employees.map((e) => `${e.name} (${e.role})`).join(', ')}`
+    )
+  if (analysis.business_profile.services.length > 0)
+    parts.push(`Services: ${analysis.business_profile.services.join(', ')}`)
+  if (analysis.business_profile.certifications.length > 0)
+    parts.push(`Certifications: ${analysis.business_profile.certifications.join(', ')}`)
+  if (analysis.business_profile.awards.length > 0)
+    parts.push(`Awards: ${analysis.business_profile.awards.join(', ')}`)
+  parts.push(
+    `Digital maturity: ${analysis.digital_maturity.score}/10 — ${analysis.digital_maturity.reasoning}`
+  )
+  parts.push(
+    `Online booking: ${analysis.digital_maturity.online_booking ? 'Yes' : 'No'}, Chat: ${analysis.digital_maturity.chat_widget ? 'Yes' : 'No'}, Blog active: ${analysis.digital_maturity.blog_active ? 'Yes' : 'No'}`
+  )
+  if (analysis.contact_info.email) parts.push(`Email: ${analysis.contact_info.email}`)
+  return parts.join('\n')
+}

--- a/src/pages/api/admin/entities/[id]/promote.ts
+++ b/src/pages/api/admin/entities/[id]/promote.ts
@@ -8,6 +8,9 @@ import { analyzeWebsite } from '../../../../../lib/enrichment/website-analyzer'
 import { lookupYelp } from '../../../../../lib/enrichment/yelp'
 import { lookupAcc } from '../../../../../lib/enrichment/acc'
 import { lookupRoc } from '../../../../../lib/enrichment/roc'
+import { analyzeReviewPatterns } from '../../../../../lib/enrichment/review-analysis'
+import { benchmarkCompetitors } from '../../../../../lib/enrichment/competitors'
+import { searchNews } from '../../../../../lib/enrichment/news'
 
 /**
  * POST /api/admin/entities/[id]/promote
@@ -198,11 +201,94 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
       }
     }
 
+    // --- Tier 3: Deeper intelligence ---
+
+    // 3a. Review response analysis
+    if (env.ANTHROPIC_API_KEY) {
+      try {
+        const signalContext = await assembleEntityContext(env.DB, entityId, {
+          maxBytes: 8_000,
+          typeFilter: ['signal'],
+        })
+        if (signalContext) {
+          const reviewAnalysis = await analyzeReviewPatterns(
+            signalContext,
+            env.ANTHROPIC_API_KEY as string
+          )
+          if (reviewAnalysis) {
+            await appendContext(env.DB, session.orgId, {
+              entity_id: entityId,
+              type: 'enrichment',
+              content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''} ${reviewAnalysis.insights}`,
+              source: 'review_analysis',
+              metadata: reviewAnalysis as unknown as Record<string, unknown>,
+            })
+            enrichmentResults.push('review_analysis')
+          }
+        }
+      } catch (err) {
+        console.error('[promote] Review analysis failed:', err)
+      }
+    }
+
+    // 3b. Competitor benchmarking
+    if (env.GOOGLE_PLACES_API_KEY) {
+      try {
+        const benchmark = await benchmarkCompetitors(
+          entity.name,
+          entity.vertical,
+          entity.area,
+          entity.pain_score,
+          null,
+          env.GOOGLE_PLACES_API_KEY as string
+        )
+        if (benchmark) {
+          await appendContext(env.DB, session.orgId, {
+            entity_id: entityId,
+            type: 'enrichment',
+            content: `Competitor benchmarking: ${benchmark.summary} Top competitors: ${benchmark.competitors.map((c) => `${c.name} (${c.rating}★, ${c.review_count} reviews)`).join(', ')}.`,
+            source: 'competitors',
+            metadata: benchmark as unknown as Record<string, unknown>,
+          })
+          enrichmentResults.push('competitors')
+        }
+      } catch (err) {
+        console.error('[promote] Competitor benchmarking failed:', err)
+      }
+    }
+
+    // 3c. News/press search
+    if (env.SERPAPI_API_KEY && env.ANTHROPIC_API_KEY) {
+      try {
+        const news = await searchNews(
+          entity.name,
+          entity.area,
+          env.SERPAPI_API_KEY as string,
+          env.ANTHROPIC_API_KEY as string
+        )
+        if (news) {
+          await appendContext(env.DB, session.orgId, {
+            entity_id: entityId,
+            type: 'enrichment',
+            content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
+            source: 'news_search',
+            metadata: {
+              mentions: news.mentions,
+              summary: news.summary,
+            },
+          })
+          enrichmentResults.push('news_search')
+        }
+      } catch (err) {
+        console.error('[promote] News search failed:', err)
+      }
+    }
+
     console.log(
       `[promote] Enrichment complete for ${entity.name}: ${enrichmentResults.join(', ') || 'none'}`
     )
 
-    // 3. Generate outreach draft (best-effort, uses enriched context)
+    // 4. Generate outreach draft (best-effort, uses enriched context)
     try {
       if (env.ANTHROPIC_API_KEY) {
         const context = await assembleEntityContext(env.DB, entityId, { maxBytes: 16_000 })

--- a/workers/job-monitor/src/alert.ts
+++ b/workers/job-monitor/src/alert.ts
@@ -11,6 +11,7 @@ export interface RunSummary {
   written: number
   errors: number
   errorDetails: string[]
+  existingAppended: number
 }
 
 /**
@@ -23,6 +24,7 @@ export async function sendFailureAlert(summary: RunSummary, resendApiKey: string
     `Queries run: ${summary.queries}`,
     `Total results: ${summary.totalResults}`,
     `New jobs (not deduped): ${summary.newJobs}`,
+    `Existing entities seen again: ${summary.existingAppended}`,
     `Qualified: ${summary.qualified}`,
     `Disqualified: ${summary.disqualified}`,
     `Written to D1: ${summary.written}`,

--- a/workers/job-monitor/src/index.ts
+++ b/workers/job-monitor/src/index.ts
@@ -37,6 +37,7 @@ async function run(env: Env): Promise<RunSummary> {
     written: 0,
     errors: 0,
     errorDetails: [],
+    existingAppended: 0,
   }
 
   const allJobs: Array<{ job: SerpApiJob; query: string }> = []
@@ -78,7 +79,11 @@ async function run(env: Env): Promise<RunSummary> {
         .bind(ORG_ID, slug)
         .first()
 
-      if (existing) continue
+      if (existing) {
+        // Track repeat postings from known entities (full signal append in future iteration)
+        summary.existingAppended++
+        continue
+      }
 
       summary.newJobs++
 
@@ -148,8 +153,9 @@ async function run(env: Env): Promise<RunSummary> {
   }
 
   console.log(
-    `Run complete: ${summary.newJobs} new, ${summary.qualified} qualified, ` +
-      `${summary.disqualified} disqualified, ${summary.written} written, ${summary.errors} errors`
+    `Run complete: ${summary.newJobs} new, ${summary.existingAppended} existing, ` +
+      `${summary.qualified} qualified, ${summary.disqualified} disqualified, ` +
+      `${summary.written} written, ${summary.errors} errors`
   )
 
   return summary


### PR DESCRIPTION
## Summary
- **Tier 3** (runs on promote): review response analysis (Haiku), competitor benchmarking (Google Places), news/press search (SerpAPI + Haiku), job posting history tracking
- **Tier 4** (on-demand): deep website analysis (Sonnet, 8 pages), cross-platform review synthesis, LinkedIn intelligence (Proxycurl), 800-1200 word intelligence brief with conversation starters
- **UI**: "Generate Dossier" button on entity detail page for prospect+ stages
- **14 enrichment modules total** across all tiers, all with graceful failure

## Test plan
- [x] `npm run verify` passes (0 errors, 1113 tests)
- [x] All enrichment modules return null on failure (no API keys = silent skip)
- [x] Dossier endpoint generates enrichment context entries + intelligence brief
- [x] No dollar amounts in src/ (content policy compliance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)