### PR TITLE
feat: Operations Health Scorecard (#147)

### DIFF
--- a/src/pages/scorecard.astro
+++ b/src/pages/scorecard.astro
@@ -65,22 +65,6 @@ for (const [i, q] of QUESTIONS.entries()) {
 ---
 
 <Base title={pageTitle} description={pageDescription}>
-  <Fragment slot="head">
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
-      rel="stylesheet"
-    />
-    <style is:inline>
-      .material-symbols-outlined {
-        font-variation-settings:
-          'FILL' 0,
-          'wght' 400,
-          'GRAD' 0,
-          'opsz' 24;
-        vertical-align: middle;
-      }
-    </style>
-  </Fragment>
   <Nav />
 
   <!-- Progress bar (hidden on landing and results) -->


### PR DESCRIPTION
## Summary

- Full interactive operations health scorecard at `/scorecard` — 21-question quiz (3 context + 18 scored across 6 dimensions) with instant results and PDF report delivery
- Feeds qualified leads into entity pipeline with pain scoring, auto-staging, and vertical tracking via `source_pipeline: 'website_scorecard'`
- D1 migration adds `'scorecard'` to context type CHECK constraint; Resend email extended with attachment support for PDF delivery

## What's included

**Data modules** (`src/lib/scorecard/`): Question bank, scoring logic (pure functions), dimension descriptions per score range

**API** (`POST /api/scorecard/submit`): Validates answers, computes scores, creates entity + contact + context, generates Forme PDF, sends email with attachment. Honeypot + timing bot protection.

**Page** (`/scorecard`): Single-page experience with 4 states (landing, quiz, email gate, results) managed by typed client-side script. Server renders all 21 question steps; JS handles navigation, selection, scoring, and results DOM construction.

**PDF** (`src/lib/pdf/scorecard-template.tsx`): 2-page Forme report — overall score, dimension bars, opportunities, per-dimension detail, CTA

**Homepage CTA**: Scorecard link added before FinalCta section

**Tests**: 15 unit tests covering scoring logic, pain score inversion, auto-stage thresholds, edge cases

## Deferred

- `GET /api/scorecard/report/[id]` — PDF re-download endpoint (v2)
- Vertical-specific question weights (v2)

## Test plan

- [ ] Visit `/scorecard` — landing renders with hero, trust signals, 6 dimension cards
- [ ] Click through all 21 questions — progress bar updates, back/next works
- [ ] Submit email gate — results render instantly with score, dimension bars, opportunities
- [ ] Check dev console for PDF/email log (dev mode)
- [ ] Verify entity created in D1 with correct `source_pipeline`, `pain_score`, `vertical`
- [ ] Test honeypot: fill hidden field, verify silent 200
- [ ] Test retake: same email submits twice, new context entry appended, no duplicate contact
- [ ] Run `npm run verify` — all 836 tests pass, 0 typecheck errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)