### PR TITLE
fix: scorecard UX polish — progress bar, question tone, skip option

### DIFF
--- a/src/lib/scorecard/questions.ts
+++ b/src/lib/scorecard/questions.ts
@@ -124,8 +124,8 @@ export const CONTEXT_QUESTIONS: ContextQuestion[] = [
 // ---------------------------------------------------------------------------
 
 export interface QuestionOption {
-  key: 'a' | 'b' | 'c' | 'd'
-  score: 0 | 1 | 2 | 3
+  key: 'a' | 'b' | 'c' | 'd' | 'skip'
+  score: 0 | 1 | 2 | 3 | -1
   text: string
 }
 
@@ -199,12 +199,12 @@ export const QUESTIONS: ScoredQuestion[] = [
   {
     id: 'q5',
     dimension: 'lead_leakage',
-    text: 'If I asked you how many leads came in last month and how many became customers, could you tell me?',
+    text: 'How well do you know your lead numbers (how many came in last month, how many converted)?',
     options: [
-      { key: 'a', score: 0, text: "Honestly, no — I don't track that" },
+      { key: 'a', score: 0, text: "I don't track that" },
       { key: 'b', score: 1, text: "I could guess, but I don't have real numbers" },
-      { key: 'c', score: 2, text: 'I have a rough idea from email/calls but nothing centralized' },
-      { key: 'd', score: 3, text: 'Yes — I can pull that up and tell you our close rate' },
+      { key: 'c', score: 2, text: 'I have a rough idea but nothing centralized' },
+      { key: 'd', score: 3, text: 'I can pull up our numbers and close rate anytime' },
     ],
   },
   {
@@ -265,12 +265,12 @@ export const QUESTIONS: ScoredQuestion[] = [
   {
     id: 'q9',
     dimension: 'financial_blindness',
-    text: 'Could you tell me right now which of your services or jobs are most profitable?',
+    text: 'How well do you know which services or jobs are most profitable?',
     options: [
       { key: 'a', score: 0, text: 'Not really — revenue comes in and bills go out' },
       { key: 'b', score: 1, text: "I have a sense, but I've never run the numbers" },
       { key: 'c', score: 2, text: 'I know broadly, but the details are fuzzy' },
-      { key: 'd', score: 3, text: 'Yes — I track profitability by service/job type' },
+      { key: 'd', score: 3, text: 'I track profitability by service or job type' },
     ],
   },
 
@@ -347,7 +347,7 @@ export const QUESTIONS: ScoredQuestion[] = [
   {
     id: 'q15',
     dimension: 'manual_communication',
-    text: 'If a customer from 6 months ago called right now, could your team pull up their full history?',
+    text: "How easy is it for your team to pull up a past customer's full history?",
     options: [
       { key: 'a', score: 0, text: "We'd have to piece it together from texts, emails, and memory" },
       { key: 'b', score: 1, text: 'I could probably find it, but nobody else could' },
@@ -355,7 +355,7 @@ export const QUESTIONS: ScoredQuestion[] = [
       {
         key: 'd',
         score: 3,
-        text: 'Yes — their full history is in one place anyone on the team can access',
+        text: 'Full history is in one place anyone on the team can access',
       },
     ],
   },

--- a/src/lib/scorecard/scoring.ts
+++ b/src/lib/scorecard/scoring.ts
@@ -59,18 +59,32 @@ export function getThreshold(scaled: number): ScoreThreshold {
 export function computeDimensionScores(answers: Record<string, number>): DimensionScore[] {
   return DIMENSIONS.map((dim) => {
     const dimQuestions = QUESTIONS.filter((q) => q.dimension === dim.id)
-    const raw = dimQuestions.reduce((sum, q) => sum + (answers[q.id] ?? 0), 0)
-    const scaled = SCALED_SCORES[raw] ?? 0
-    const threshold = getThreshold(scaled)
+    const answered = dimQuestions.filter((q) => (answers[q.id] ?? -1) >= 0)
+    const raw = answered.reduce((sum, q) => sum + (answers[q.id] ?? 0), 0)
+
+    // Scale based on answered questions only (skipped = -1 are excluded)
+    let scaled: number
+    if (answered.length === 0) {
+      scaled = -1 // entire dimension skipped
+    } else if (answered.length === dimQuestions.length) {
+      scaled = SCALED_SCORES[raw] ?? 0
+    } else {
+      // Extrapolate: avg per answered question, projected to full dimension
+      const avgPerQuestion = raw / answered.length
+      const extrapolatedRaw = Math.round(avgPerQuestion * dimQuestions.length)
+      scaled = SCALED_SCORES[extrapolatedRaw] ?? 0
+    }
+
+    const threshold = getThreshold(Math.max(scaled, 0))
 
     return {
       id: dim.id,
       label: dim.label,
       raw,
-      scaled,
+      scaled: Math.max(scaled, 0),
       scoreLabel: threshold.label,
-      displayLabel: threshold.displayLabel,
-      color: threshold.color,
+      displayLabel: scaled === -1 ? 'Skipped' : threshold.displayLabel,
+      color: scaled === -1 ? '#94a3b8' : threshold.color,
     }
   })
 }
@@ -80,9 +94,10 @@ export function computeDimensionScores(answers: Record<string, number>): Dimensi
 // ---------------------------------------------------------------------------
 
 export function computeOverallScore(dimensions: DimensionScore[]): number {
-  if (dimensions.length === 0) return 0
-  const sum = dimensions.reduce((total, d) => total + d.scaled, 0)
-  return Math.round(sum / dimensions.length)
+  const scored = dimensions.filter((d) => d.displayLabel !== 'Skipped')
+  if (scored.length === 0) return 0
+  const sum = scored.reduce((total, d) => total + d.scaled, 0)
+  return Math.round(sum / scored.length)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pages/api/scorecard/submit.ts
+++ b/src/pages/api/scorecard/submit.ts
@@ -69,7 +69,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const questionIds = QUESTIONS.map((q) => q.id)
   for (const qid of questionIds) {
     const val = answers[qid]
-    if (typeof val !== 'number' || val < 0 || val > 3) {
+    if (typeof val !== 'number' || val < -1 || val > 3) {
       return jsonResponse(400, { error: `Invalid or missing answer for ${qid}` })
     }
   }

--- a/src/pages/scorecard.astro
+++ b/src/pages/scorecard.astro
@@ -68,12 +68,19 @@ for (const [i, q] of QUESTIONS.entries()) {
   <Nav />
 
   <!-- Progress bar (hidden on landing and results) -->
-  <div id="progress-bar" class="fixed left-0 top-16 z-50 hidden h-1 w-full bg-slate-200">
-    <div id="progress-fill" class="h-1 bg-primary transition-all duration-300" style="width: 0%">
+  <div id="progress-wrapper" class="fixed left-0 top-16 z-50 hidden w-full">
+    <div id="progress-bar" class="h-1.5 w-full bg-slate-200">
+      <div
+        id="progress-fill"
+        class="h-1.5 bg-primary transition-all duration-300"
+        style="width: 0%"
+      >
+      </div>
     </div>
-  </div>
-  <div id="progress-bar-text" class="fixed left-0 top-[68px] z-50 hidden w-full">
-    <p id="progress-text" class="px-6 pt-1 text-right text-sm text-slate-400"></p>
+    <div class="mx-auto flex max-w-2xl items-center justify-between px-6 pt-2">
+      <p id="progress-text" class="text-sm font-medium text-slate-500"></p>
+      <p id="progress-pct" class="text-sm text-slate-400"></p>
+    </div>
   </div>
 
   <!-- ============================================================ -->
@@ -144,7 +151,7 @@ for (const [i, q] of QUESTIONS.entries()) {
   <!-- QUIZ -->
   <!-- ============================================================ -->
   <section id="quiz" class="hidden">
-    <div class="mx-auto max-w-2xl px-6 pb-24 pt-16">
+    <div class="mx-auto max-w-2xl px-6 pb-24 pt-20">
       {
         steps.map((step) => (
           <div data-step={step.num} class="hidden">
@@ -165,6 +172,14 @@ for (const [i, q] of QUESTIONS.entries()) {
                   {opt.text}
                 </button>
               ))}
+              {step.type === 'scored' && (
+                <button
+                  data-answer="-1"
+                  class="block w-full cursor-pointer rounded-lg border border-dashed border-slate-200 px-5 py-3 text-left text-sm text-slate-400 transition-colors hover:bg-slate-50"
+                >
+                  Doesn't apply to my business
+                </button>
+              )}
             </div>
           </div>
         ))

--- a/src/scripts/scorecard.ts
+++ b/src/scripts/scorecard.ts
@@ -136,17 +136,19 @@ function goToStep(step: number) {
   // Hide all question steps
   document.querySelectorAll('[data-step]').forEach((el) => el.classList.add('hidden'))
 
-  const progressBar = document.getElementById('progress-fill')
+  const progressWrapper = document.getElementById('progress-wrapper')
+  const progressFill = document.getElementById('progress-fill')
   const progressText = document.getElementById('progress-text')
+  const progressPct = document.getElementById('progress-pct')
   const quizNav = document.getElementById('quiz-nav')
 
   if (step === 0) {
     document.getElementById('landing')?.classList.remove('hidden')
-    progressBar?.parentElement?.classList.add('hidden')
+    progressWrapper?.classList.add('hidden')
     quizNav?.classList.add('hidden')
   } else if (step >= 1 && step <= TOTAL_STEPS) {
     document.getElementById('quiz')?.classList.remove('hidden')
-    progressBar?.parentElement?.classList.remove('hidden')
+    progressWrapper?.classList.remove('hidden')
     quizNav?.classList.remove('hidden')
 
     const stepEl = document.querySelector(`[data-step="${step}"]`)
@@ -154,8 +156,9 @@ function goToStep(step: number) {
 
     // Update progress
     const pct = Math.round((step / TOTAL_STEPS) * 100)
-    if (progressBar) progressBar.style.width = `${pct}%`
+    if (progressFill) progressFill.style.width = `${pct}%`
     if (progressText) progressText.textContent = `Question ${step} of ${TOTAL_STEPS}`
+    if (progressPct) progressPct.textContent = `${pct}%`
 
     // Update Next button state
     updateNextButton(step)
@@ -165,12 +168,13 @@ function goToStep(step: number) {
     if (backBtn) backBtn.classList.toggle('invisible', step === 1)
   } else if (step === 22) {
     document.getElementById('email-gate')?.classList.remove('hidden')
-    if (progressBar) progressBar.style.width = '100%'
-    if (progressText) progressText.textContent = `${TOTAL_STEPS} of ${TOTAL_STEPS}`
+    if (progressFill) progressFill.style.width = '100%'
+    if (progressText) progressText.textContent = 'Done!'
+    if (progressPct) progressPct.textContent = '100%'
     quizNav?.classList.add('hidden')
   } else if (step === 23) {
     document.getElementById('results')?.classList.remove('hidden')
-    progressBar?.parentElement?.classList.add('hidden')
+    progressWrapper?.classList.add('hidden')
     quizNav?.classList.add('hidden')
   }
 
@@ -237,28 +241,41 @@ function computeClientScores(): {
 } {
   const dimensions: DimensionResult[] = data.dimensions.map((dim) => {
     const dimQuestions = data.questions.filter((q) => q.dimension === dim.id)
-    const raw = dimQuestions.reduce((sum, q) => sum + ((answers[q.id] as number) ?? 0), 0)
-    const scaled = data.scaledScores[raw] ?? 0
+    const answered = dimQuestions.filter((q) => ((answers[q.id] as number) ?? -1) >= 0)
+    const raw = answered.reduce((sum, q) => sum + ((answers[q.id] as number) ?? 0), 0)
+
+    let scaled: number
+    if (answered.length === 0) {
+      scaled = -1
+    } else if (answered.length === dimQuestions.length) {
+      scaled = data.scaledScores[raw] ?? 0
+    } else {
+      const avgPerQuestion = raw / answered.length
+      const extrapolatedRaw = Math.round(avgPerQuestion * dimQuestions.length)
+      scaled = data.scaledScores[extrapolatedRaw] ?? 0
+    }
+
+    const effectiveScaled = Math.max(scaled, 0)
     const threshold =
-      data.scoreThresholds.find((t) => scaled >= t.min && scaled <= t.max) ||
+      data.scoreThresholds.find((t) => effectiveScaled >= t.min && effectiveScaled <= t.max) ||
       data.scoreThresholds[0]
-    const description = data.descriptions[dim.id]?.[threshold.label as keyof Description] ?? ''
+    const description =
+      scaled === -1 ? '' : (data.descriptions[dim.id]?.[threshold.label as keyof Description] ?? '')
 
     return {
       id: dim.id,
       label: dim.label,
-      scaled,
+      scaled: effectiveScaled,
       scoreLabel: threshold.label,
-      displayLabel: threshold.displayLabel,
-      color: threshold.color,
+      displayLabel: scaled === -1 ? 'Skipped' : threshold.displayLabel,
+      color: scaled === -1 ? '#94a3b8' : threshold.color,
       description,
     }
   })
 
+  const scored = dimensions.filter((d) => d.displayLabel !== 'Skipped')
   const overall =
-    dimensions.length > 0
-      ? Math.round(dimensions.reduce((s, d) => s + d.scaled, 0) / dimensions.length)
-      : 0
+    scored.length > 0 ? Math.round(scored.reduce((s, d) => s + d.scaled, 0) / scored.length) : 0
 
   const overallThreshold =
     data.scoreThresholds.find((t) => overall >= t.min && overall <= t.max) ||

--- a/tests/scorecard-scoring.test.ts
+++ b/tests/scorecard-scoring.test.ts
@@ -79,6 +79,34 @@ describe('computeDimensionScores', () => {
     expect(ownerDim.scaled).toBe(33)
     expect(ownerDim.scoreLabel).toBe('room_to_grow')
   })
+
+  it('handles skipped questions (-1) by extrapolating', () => {
+    const answers: Record<string, number> = {}
+    // Owner bottleneck: q1=2, q2=2, q3=skipped → avg 2, extrapolated raw 6 → scaled 67
+    answers['q1'] = 2
+    answers['q2'] = 2
+    answers['q3'] = -1
+    for (const q of QUESTIONS) {
+      if (!(q.id in answers)) answers[q.id] = 2
+    }
+    const dims = computeDimensionScores(answers)
+    const ownerDim = dims.find((d) => d.id === 'owner_bottleneck')!
+    expect(ownerDim.scaled).toBe(67) // extrapolated from 2 answered questions
+  })
+
+  it('marks fully-skipped dimension as Skipped', () => {
+    const answers: Record<string, number> = {}
+    answers['q1'] = -1
+    answers['q2'] = -1
+    answers['q3'] = -1
+    for (const q of QUESTIONS) {
+      if (!(q.id in answers)) answers[q.id] = 2
+    }
+    const dims = computeDimensionScores(answers)
+    const ownerDim = dims.find((d) => d.id === 'owner_bottleneck')!
+    expect(ownerDim.displayLabel).toBe('Skipped')
+    expect(ownerDim.scaled).toBe(0)
+  })
 })
 
 describe('computeOverallScore', () => {


### PR DESCRIPTION
## Summary

- Progress bar now shows "Question 4 of 21" + percentage, thicker (h-1.5) and clearly visible during the quiz
- Rewrote Q5, Q9, Q15 from conversational ("If I asked you...") to direct survey phrasing
- Added "Doesn't apply to my business" skip option on all 18 scored questions
- Skipped answers (-1) excluded from scoring — extrapolates from answered questions in the same dimension

## Test plan

- [x] `npm run verify` passes (839 tests, 0 errors)
- [ ] Progress bar visible and updating through all 21 steps
- [ ] "Doesn't apply" option appears on scored questions but not context questions
- [ ] Skipping all 3 questions in a dimension shows "Skipped" in results
- [ ] Skipping 1 of 3 extrapolates correctly from the other 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)