### PR TITLE
fix: align footer links with nav design pattern

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,12 +1,17 @@
 <footer class="border-t border-slate-200 bg-slate-50 py-12">
-  <div class="mx-auto flex w-full max-w-5xl flex-col items-center justify-between px-6 md:flex-row">
-    <div class="mb-6 md:mb-0">
+  <div
+    class="mx-auto flex w-full max-w-5xl flex-col items-center justify-between gap-6 px-6 md:flex-row"
+  >
+    <div>
       <div class="text-sm font-semibold text-slate-800">SMD Services</div>
       <p class="mt-1 text-sm text-slate-500">&copy; 2026 SMDurgan, LLC. Phoenix, Arizona.</p>
     </div>
-    <div class="flex items-center gap-6">
-      <a class="text-sm font-medium text-slate-600 hover:text-slate-900" href="/contact">Contact</a>
-      <a class="text-sm font-medium text-slate-900 underline" href="/book">Book a Call</a>
-    </div>
+    <nav class="flex items-center gap-6">
+      <a class="text-sm text-slate-500 hover:text-slate-900" href="/contact">Contact</a>
+      <a
+        class="rounded bg-primary px-5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-80"
+        href="/book">Book a Call</a
+      >
+    </nav>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Replace mismatched footer links (plain text + underline) with the same pattern used in the nav: text link for Contact, primary button for Book a Call
- Wrap footer links in a `<nav>` element for semantics
- Consistent hover states and sizing across nav and footer

## Test plan
- [ ] `npm run verify` passes
- [ ] Footer "Book a Call" renders as a blue button matching the nav
- [ ] Footer "Contact" renders as a subtle text link matching the nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)