### PR TITLE
fix: link SMD Services logo text to homepage

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,7 @@
     class="mx-auto flex w-full max-w-5xl flex-col items-center justify-between gap-6 px-6 md:flex-row"
   >
     <div>
-      <div class="text-sm font-semibold text-slate-800">SMD Services</div>
+      <a href="/" class="text-sm font-semibold text-slate-800">SMD Services</a>
       <p class="mt-1 text-sm text-slate-500">&copy; 2026 SMDurgan, LLC. Phoenix, Arizona.</p>
     </div>
     <nav class="flex items-center gap-6">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,6 @@
 <header class="sticky top-0 z-50 border-b border-slate-100 bg-white">
   <div class="mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-6">
-    <div class="text-lg font-bold tracking-tight text-slate-900">SMD Services</div>
+    <a href="/" class="text-lg font-bold tracking-tight text-slate-900">SMD Services</a>
     <div class="flex items-center gap-5">
       <a class="text-sm font-medium text-slate-600 hover:text-slate-900" href="/contact">Contact</a>
       <a


### PR DESCRIPTION
## Summary
- Change nav "SMD Services" from `<div>` to `<a href="/">` so it links home
- Same change in footer for consistency

## Test plan
- [ ] `npm run verify` passes
- [ ] Click "SMD Services" in nav from `/contact` — navigates to `/`
- [ ] Click "SMD Services" in footer — navigates to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)