### PR TITLE
fix: use shared Nav component on all public pages

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,12 +2,18 @@
 export const prerender = true
 
 import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
 ---
 
 <Base title="Page Not Found | SMD Services">
+  <Nav />
   <main class="mx-auto max-w-4xl px-4 py-16 text-center">
-    <h1 class="text-3xl font-bold text-gray-900">Page not found</h1>
-    <p class="mt-4 text-lg text-gray-600">The page you're looking for doesn't exist.</p>
-    <a href="/" class="mt-8 inline-block text-blue-800 hover:underline">Back to home</a>
+    <h1 class="text-3xl font-bold text-slate-900">Page not found</h1>
+    <p class="mt-4 text-lg text-slate-600">The page you're looking for doesn't exist.</p>
+    <a href="/" class="mt-8 inline-block text-sm font-medium text-primary hover:text-primary/80">
+      Back to home
+    </a>
   </main>
+  <Footer />
 </Base>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -2,6 +2,7 @@
 export const prerender = true
 
 import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 ---
 
@@ -9,17 +10,8 @@ import Footer from '../components/Footer.astro'
   title="Let's Talk | SMD Services"
   description="Schedule a conversation about your business. We'll learn how things run, understand what you're trying to accomplish, and share how we can help."
 >
+  <Nav />
   <main>
-    <!-- Header -->
-    <header class="sticky top-0 z-50 border-b border-slate-100 bg-white">
-      <div class="mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-6">
-        <a href="/" class="text-lg font-bold tracking-tight text-slate-900">SMD Services</a>
-        <a href="/" class="text-sm text-slate-500 transition hover:text-slate-700">
-          &larr; Back to home
-        </a>
-      </div>
-    </header>
-
     <!-- Booking Section -->
     <section class="bg-slate-50 px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">

--- a/src/pages/book/thanks.astro
+++ b/src/pages/book/thanks.astro
@@ -2,6 +2,7 @@
 export const prerender = false
 
 import Base from '../../layouts/Base.astro'
+import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import { ENTITY_VERTICALS } from '../../lib/db/entities'
 ---
@@ -10,17 +11,8 @@ import { ENTITY_VERTICALS } from '../../lib/db/entities'
   title="You're All Set | SMD Services"
   description="Thanks for booking. Help us prepare for your call by telling us a bit about your business."
 >
+  <Nav />
   <main>
-    <!-- Header -->
-    <header class="sticky top-0 z-50 border-b border-slate-100 bg-white">
-      <div class="mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-6">
-        <a href="/" class="text-lg font-bold tracking-tight text-slate-900">SMD Services</a>
-        <a href="/" class="text-sm text-slate-500 transition hover:text-slate-700">
-          &larr; Back to home
-        </a>
-      </div>
-    </header>
-
     <!-- Confirmation + Intake -->
     <section class="bg-slate-50 px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">


### PR DESCRIPTION
## Summary
- Replace inline custom headers on `/book` and `/book/thanks` with the shared `<Nav />` component
- Add `<Nav />` and `<Footer />` to the 404 page (previously had neither)
- All public pages now use the same navigation: logo linking home, Contact text link, Book a Call button

## Test plan
- [ ] `npm run verify` passes
- [ ] `/book` page shows standard nav with Contact + Book a Call
- [ ] `/book/thanks` page shows standard nav
- [ ] 404 page shows standard nav and footer
- [ ] No "← Back to home" standalone links remain in navigation headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)