### PR TITLE
fix: add migration to rename client_id → entity_id in 6 tables

### DIFF
--- a/migrations/0010_rename_client_id_to_entity_id.sql
+++ b/migrations/0010_rename_client_id_to_entity_id.sql
@@ -1,0 +1,14 @@
+-- Rename client_id → entity_id in all tables that reference entities.
+--
+-- The entity-context architecture (migration 0008) introduced the `entities`
+-- table to replace `clients`. Application code was updated to use `entity_id`
+-- but the column rename in existing tables was never migrated.
+--
+-- SQLite 3.25.0+ supports ALTER TABLE ... RENAME COLUMN.
+
+ALTER TABLE contacts RENAME COLUMN client_id TO entity_id;
+ALTER TABLE assessments RENAME COLUMN client_id TO entity_id;
+ALTER TABLE quotes RENAME COLUMN client_id TO entity_id;
+ALTER TABLE engagements RENAME COLUMN client_id TO entity_id;
+ALTER TABLE invoices RENAME COLUMN client_id TO entity_id;
+ALTER TABLE follow_ups RENAME COLUMN client_id TO entity_id;


### PR DESCRIPTION
## Summary
- Root cause of intake form 500 error: the `contacts` and `assessments` tables still have `client_id` columns from migration 0001, but application code references `entity_id` (refactored in the entity-context architecture)
- Adds migration 0010 to rename `client_id` → `entity_id` in: contacts, assessments, quotes, engagements, invoices, follow_ups
- **Note:** `D1_MIGRATIONS_ENABLED` repo variable is not set — migration must be applied manually after merge: `npx wrangler d1 migrations apply ss-console-db --remote`

## Test plan
- [ ] `npm run verify` passes
- [ ] After applying migration, `/book/thanks` intake form submits successfully
- [ ] Scorecard form still submits successfully
- [ ] Admin entity pages still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)