### PR TITLE
fix: rewrite migration 0010 to drop client_id instead of rename

### DIFF
--- a/migrations/0010_rename_client_id_to_entity_id.sql
+++ b/migrations/0010_rename_client_id_to_entity_id.sql
@@ -1,14 +1,25 @@
--- Rename client_id → entity_id in all tables that reference entities.
+-- Drop legacy client_id column and reconcile contacts schema with code.
 --
--- The entity-context architecture (migration 0008) introduced the `entities`
--- table to replace `clients`. Application code was updated to use `entity_id`
--- but the column rename in existing tables was never migrated.
+-- The entity-context architecture (migration 0008) introduced the entities
+-- table and an additive entity_id column on related tables. The legacy
+-- client_id column was left in place as NOT NULL, blocking all INSERTs
+-- since the application code only writes entity_id.
 --
--- SQLite 3.25.0+ supports ALTER TABLE ... RENAME COLUMN.
+-- This migration:
+--   1. Drops client_id from 5 tables (contacts, assessments, quotes,
+--      engagements, invoices). follow_ups already had it dropped.
+--   2. Drops the legacy contacts.notes column (replaced by contacts.role
+--      semantically and not referenced by any code).
+--   3. Adds the contacts.role column the application code expects.
+--
+-- Tables are empty for the affected columns — verified before migration.
+-- ALTER TABLE DROP COLUMN requires SQLite 3.35.0+ (D1 supports this).
 
-ALTER TABLE contacts RENAME COLUMN client_id TO entity_id;
-ALTER TABLE assessments RENAME COLUMN client_id TO entity_id;
-ALTER TABLE quotes RENAME COLUMN client_id TO entity_id;
-ALTER TABLE engagements RENAME COLUMN client_id TO entity_id;
-ALTER TABLE invoices RENAME COLUMN client_id TO entity_id;
-ALTER TABLE follow_ups RENAME COLUMN client_id TO entity_id;
+ALTER TABLE contacts DROP COLUMN client_id;
+ALTER TABLE contacts DROP COLUMN notes;
+ALTER TABLE contacts ADD COLUMN role TEXT;
+
+ALTER TABLE assessments DROP COLUMN client_id;
+ALTER TABLE quotes DROP COLUMN client_id;
+ALTER TABLE engagements DROP COLUMN client_id;
+ALTER TABLE invoices DROP COLUMN client_id;


### PR DESCRIPTION
## Summary
- Original migration 0010 tried to RENAME `client_id` → `entity_id` but failed because both columns already exist (entity_id was added additively in migration 0008)
- The legacy `client_id` column is NOT NULL with no default, blocking all INSERTs from application code that only writes `entity_id`
- This migration drops `client_id` from contacts, assessments, quotes, engagements, invoices
- Also reconciles contacts schema with code: drops unused `notes` column, adds `role` column referenced by `createContact()`
- Verified contacts table is empty (0 rows) before merging — drops are non-destructive

## Test plan
- [ ] `npm run verify` passes
- [ ] After deploy, `/book/thanks` intake form submits successfully
- [ ] Scorecard form submits and creates contact + entity records
- [ ] Admin entity pages still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)