### PR TITLE
fix: drop client_id indexes before dropping columns in migration 0010

### DIFF
--- a/migrations/0010_rename_client_id_to_entity_id.sql
+++ b/migrations/0010_rename_client_id_to_entity_id.sql
@@ -14,6 +14,13 @@
 --
 -- Tables are empty for the affected columns — verified before migration.
 -- ALTER TABLE DROP COLUMN requires SQLite 3.35.0+ (D1 supports this).
+-- Indexes on client_id must be dropped first or the DROP COLUMN fails.
+
+DROP INDEX IF EXISTS idx_contacts_client_id;
+DROP INDEX IF EXISTS idx_assessments_client_id;
+DROP INDEX IF EXISTS idx_quotes_client_id;
+DROP INDEX IF EXISTS idx_engagements_client_id;
+DROP INDEX IF EXISTS idx_invoices_client_id;
 
 ALTER TABLE contacts DROP COLUMN client_id;
 ALTER TABLE contacts DROP COLUMN notes;


### PR DESCRIPTION
## Summary
- Migration 0010 failed: SQLite validates dependent indexes after DROP COLUMN and raised "no such column: client_id"
- Fix: drop the client_id indexes first, then drop the columns

## Test plan
- [ ] `npm run verify` passes
- [ ] D1 migration applies successfully on deploy
- [ ] Intake form submits successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)