### PR TITLE
fix: collapse intake form success state to single confirmation

### DIFF
--- a/src/pages/book/thanks.astro
+++ b/src/pages/book/thanks.astro
@@ -17,7 +17,7 @@ import { ENTITY_VERTICALS } from '../../lib/db/entities'
     <section class="bg-slate-50 px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Thank you -->
-        <div class="text-center">
+        <div id="thank-you" class="text-center">
           <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
             <svg
               class="h-8 w-8 text-green-600"
@@ -208,30 +208,11 @@ import { ENTITY_VERTICALS } from '../../lib/db/entities'
           </form>
         </div>
 
-        <!-- Success state (hidden by default) -->
-        <div id="success-message" class="mt-12 hidden text-center">
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
-            <svg
-              class="h-8 w-8 text-green-600"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-              stroke="currentColor"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
-            </svg>
-          </div>
-          <h2 class="mt-6 text-2xl font-bold text-slate-900">Thanks for sharing</h2>
-          <p class="mt-3 text-lg text-slate-600">
-            We'll review this before your call so we can make the most of our time together.
-          </p>
-          <a
-            href="/"
-            class="mt-8 inline-block text-sm font-medium text-primary transition-colors hover:text-primary/80"
-          >
-            &larr; Back to home
-          </a>
-        </div>
+        <!-- Success state (replaces form on submit; hides original "thank you" too) -->
+        <p id="success-message" class="mt-6 hidden text-center text-lg text-slate-600">
+          Thanks for sharing. We'll review this before your call so we can make the most of our time
+          together.
+        </p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- Removes duplicated success state on `/book/thanks` — was stacking two checkmark+heading sections
- Replaces redundant "Thanks for sharing" block (with its own checkmark and standalone Back to home link) with a simple confirmation paragraph that appears below the existing "You're all set" header
- Removes the standalone "Back to home" link since the nav is right there

## Test plan
- [ ] `npm run verify` passes
- [ ] After form submit, only one confirmation header is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)