### PR TITLE
feat: intake form — append context on repeat submits + email notification

### DIFF
--- a/src/pages/api/booking/intake.ts
+++ b/src/pages/api/booking/intake.ts
@@ -3,7 +3,10 @@ import { findOrCreateEntity } from '../../../lib/db/entities'
 import { appendContext } from '../../../lib/db/context'
 import { createContact } from '../../../lib/db/contacts'
 import { createAssessment } from '../../../lib/db/assessments'
+import { sendEmail } from '../../../lib/email/resend'
 import { ORG_ID } from '../../../lib/constants'
+
+const NOTIFY_EMAIL = 'team@smd.services'
 
 /**
  * POST /api/booking/intake
@@ -51,25 +54,15 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const howHeard = trimString(body.how_heard)
 
   try {
-    // Dedup: check if a contact with this email already exists
-    const existing = await env.DB.prepare(
-      'SELECT id, entity_id FROM contacts WHERE org_id = ? AND email = ? LIMIT 1'
-    )
-      .bind(ORG_ID, email)
-      .first<{ id: string; entity_id: string }>()
-
-    if (existing) {
-      return jsonResponse(200, { ok: true, client_id: existing.entity_id })
-    }
-
-    // Find or create entity record
+    // Find or create entity record (dedup is by business name slug)
     const { entity } = await findOrCreateEntity(env.DB, ORG_ID, {
       name: businessName,
       stage: 'prospect',
       source_pipeline: 'website_booking',
     })
 
-    // Append intake data as context
+    // Append intake data as context — every submission gets recorded,
+    // even from repeat submitters, so we don't lose new information.
     const intakeParts: string[] = []
     if (vertical) intakeParts.push(`Vertical: ${vertical}`)
     if (employeeCount) intakeParts.push(`Employees: ${employeeCount}`)
@@ -84,6 +77,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
         content: intakeParts.join('\n'),
         source: 'website_booking',
         metadata: {
+          name,
+          email,
           vertical,
           employee_count: employeeCount,
           years_in_business: yearsInBusiness,
@@ -93,20 +88,56 @@ export const POST: APIRoute = async ({ request, locals }) => {
       })
     }
 
-    // Create contact record
-    await createContact(env.DB, ORG_ID, entity.id, {
-      name,
-      email,
-    })
+    // Create contact only if one with this email doesn't already exist
+    // for this entity. Repeat submissions update context but don't duplicate
+    // contact rows.
+    const existingContact = await env.DB.prepare(
+      'SELECT id FROM contacts WHERE org_id = ? AND email = ? LIMIT 1'
+    )
+      .bind(ORG_ID, email)
+      .first<{ id: string }>()
+
+    if (!existingContact) {
+      await createContact(env.DB, ORG_ID, entity.id, { name, email })
+    }
 
     // Create assessment record (status defaults to 'scheduled')
     await createAssessment(env.DB, ORG_ID, entity.id, {})
+
+    // Notify the team — fire and forget, don't block the response
+    try {
+      const escapedName = escapeHtml(name)
+      const escapedEmail = escapeHtml(email)
+      const escapedBusiness = escapeHtml(businessName)
+      const detailLines = intakeParts.map((line) => `<p>${escapeHtml(line)}</p>`).join('')
+
+      await sendEmail(env.RESEND_API_KEY, {
+        to: NOTIFY_EMAIL,
+        reply_to: email,
+        subject: `New booking intake: ${businessName}`,
+        html:
+          `<p><strong>${escapedName}</strong> &lt;${escapedEmail}&gt; from <strong>${escapedBusiness}</strong> just booked a call and submitted the intake form.</p>` +
+          `<hr>${detailLines}` +
+          `<hr><p><a href="https://smd.services/admin/entities/${entity.id}">View in admin →</a></p>`,
+      })
+    } catch (emailErr) {
+      // Email failure should not block the response
+      console.error('[api/booking/intake] Notification email error:', emailErr)
+    }
 
     return jsonResponse(201, { ok: true, client_id: entity.id })
   } catch (err) {
     console.error('[api/booking/intake] Error:', err)
     return jsonResponse(500, { error: 'Internal server error' })
   }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 function trimString(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- Repeat submissions to `/api/booking/intake` no longer silently dropped. Previously the API returned early with 200 OK if a contact with the same email already existed, losing any new info from follow-up submissions
- Now the context entry is always written; only the contact INSERT is skipped when the email already exists for the entity
- Send notification email to `team@smd.services` on every successful submission, including all intake details and a deep link to the admin entity page
- Notification email failure is non-blocking (logs and continues)

## Test plan
- [ ] `npm run verify` passes
- [ ] After deploy, submitting the intake form sends a notification email to team@smd.services
- [ ] Submitting twice with the same email creates two context entries on the entity (no duplicate contact rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)