### PR TITLE
fix: scope resend-invitation queries to org_id (#172)

### DIFF
--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -51,9 +51,12 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
 
     const env = locals.runtime.env
 
-    // Look up the client user
-    const user = await env.DB.prepare(`SELECT * FROM users WHERE id = ? AND role = 'client'`)
-      .bind(userId)
+    // Look up the client user — scoped to the admin's org to prevent
+    // cross-tenant access (issue #172).
+    const user = await env.DB.prepare(
+      `SELECT * FROM users WHERE id = ? AND org_id = ? AND role = 'client'`
+    )
+      .bind(userId, session.orgId)
       .first<UserRow>()
 
     if (!user) {
@@ -68,9 +71,24 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
     if (newEmail && typeof newEmail === 'string') {
       const normalizedEmail = newEmail.toLowerCase().trim()
       if (normalizedEmail !== user.email) {
-        await env.DB.prepare(`UPDATE users SET email = ? WHERE id = ?`)
-          .bind(normalizedEmail, userId)
+        // Update is org-scoped as a defense-in-depth measure even though the
+        // preceding SELECT already gates on org_id.
+        const updateResult = await env.DB.prepare(
+          `UPDATE users SET email = ? WHERE id = ? AND org_id = ?`
+        )
+          .bind(normalizedEmail, userId, session.orgId)
           .run()
+
+        // D1 returns meta.changes for affected row count. If zero, the row
+        // disappeared between the SELECT and UPDATE (or somehow slipped org
+        // scoping) — fail closed rather than send an invitation we can't trust.
+        if (!updateResult.meta || updateResult.meta.changes === 0) {
+          return new Response(JSON.stringify({ error: 'Client user not found' }), {
+            status: 404,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+
         targetEmail = normalizedEmail
       }
     }


### PR DESCRIPTION
## Summary

Fixes a cross-tenant authorization weakness in `POST /api/admin/resend-invitation`. The endpoint looked up and updated client users by `id` only, with no `org_id` constraint. An admin with a known `userId` from another org could:

- Read that user's record (the SELECT returned any user across orgs).
- Overwrite that user's email via the optional `email` body parameter.
- Trigger an invitation email to an attacker-controlled address for a user in a different tenant.

Both queries are now scoped to `session.orgId`, matching the convention used across the rest of the admin API surface (e.g. `entities`, `quotes`, `engagements`, `invoices`, `assessments`, `follow-ups`).

## Files changed

- `src/pages/api/admin/resend-invitation.ts`

## How the fix works

1. The lookup query now binds `session.orgId`:
   ```sql
   SELECT * FROM users WHERE id = ? AND org_id = ? AND role = 'client'
   ```
   A user belonging to a different org returns `null`, producing the existing `404 Client user not found` response.

2. The optional email update query now also binds `session.orgId`:
   ```sql
   UPDATE users SET email = ? WHERE id = ? AND org_id = ?
   ```
   This is defense-in-depth — the preceding org-scoped SELECT already gates access — but it ensures the write itself can never cross tenants.

3. The UPDATE result is now inspected via `meta.changes`. If zero rows were affected (e.g. the row vanished between the SELECT and UPDATE), the request fails closed with `404` rather than proceeding to send an invitation against state we cannot trust.

## Acceptance criteria

- [x] Endpoint only reads/updates client users in the authenticated admin's org.
- [x] Existing same-org behavior remains intact (same input shape, same success/error responses).
- [x] Lookup and write are both org-scoped.
- [x] Affected row count is validated; missing/cross-org rows return 404.

## Tests

No tests previously covered this endpoint (the existing `tests/magic-link.test.ts` only exercises the magic-link library). Per task scope, no new test infrastructure was added in this PR. A follow-up issue should add a route-level regression test that asserts cross-org `userId` access returns 404 — this would require introducing an HTTP-level test harness for `/api/admin/*` endpoints, which does not exist in the repo today.

`npm run verify` passes locally:
- typecheck: 0 errors
- lint: 0 errors (3 pre-existing warnings in `workers/*` unrelated to this change)
- format: clean
- build: succeeds
- test: 839/839 pass

## Follow-up concerns

None of the other admin endpoints surveyed (`entities`, `quotes`, `engagements`, `invoices`, `assessments`, `follow-ups`, `time-entries`) appear to have the same bug — they all route through helper functions that take `session.orgId` as a parameter. `resend-invitation.ts` was an outlier because it issues raw SQL inline. Recommend a follow-up issue to add a route-level test harness so future inline-SQL endpoints can be regression-tested for cross-org access.

Closes #172

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>