### PR TITLE
fix: use canonical APP_BASE_URL for auth and portal links (#173)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,29 @@
+# Local development environment variables
+#
+# Copy this file to `.dev.vars` and fill in the secret values for your
+# machine. `.dev.vars` is gitignored — never commit real secrets.
+#
+# Wrangler loads `.dev.vars` automatically when running `wrangler pages dev`
+# and `astro dev` (via the platformProxy adapter config).
+
+# ---------- Canonical URLs ----------
+# Used to build outbound auth, portal, and webhook callback links. In dev
+# we point at localhost so magic links and email previews open the right
+# environment. See src/lib/config/app-url.ts and issue #173.
+APP_BASE_URL="http://localhost:4321"
+PORTAL_BASE_URL="http://localhost:4321"
+
+# ---------- Secrets (set with: wrangler secret put <NAME>) ----------
+# These are documented for reference. Actual values must come from the
+# team vault — never commit real keys.
+RESEND_API_KEY=""
+ANTHROPIC_API_KEY=""
+SIGNWELL_API_KEY=""
+SIGNWELL_WEBHOOK_SECRET=""
+STRIPE_API_KEY=""
+STRIPE_WEBHOOK_SECRET=""
+LEAD_INGEST_API_KEY=""
+GOOGLE_PLACES_API_KEY=""
+OUTSCRAPER_API_KEY=""
+SERPAPI_API_KEY=""
+PROXYCURL_API_KEY=""

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,6 +14,20 @@ type CfEnv = {
   DB: D1Database
   STORAGE: R2Bucket
   SESSIONS: KVNamespace
+  /**
+   * Canonical absolute URL for the marketing/admin app, e.g.
+   * `https://smd.services`. Used to build outbound auth, portal,
+   * and webhook callback links — never derive from request host.
+   * See `src/lib/config/app-url.ts` and GitHub issue #173.
+   */
+  APP_BASE_URL?: string
+  /**
+   * Canonical absolute URL for the client portal, e.g.
+   * `https://portal.smd.services`. Optional — falls back to
+   * `APP_BASE_URL` when unset (the portal is the same Pages
+   * deployment served under a subdomain rewrite).
+   */
+  PORTAL_BASE_URL?: string
   RESEND_API_KEY?: string
   ANTHROPIC_API_KEY?: string
   SIGNWELL_API_KEY?: string

--- a/src/lib/config/app-url.ts
+++ b/src/lib/config/app-url.ts
@@ -1,0 +1,105 @@
+/**
+ * Canonical application URL helpers.
+ *
+ * All outbound auth and portal links (magic links, invitation emails,
+ * follow-up emails, invoice notifications, signature webhook callbacks)
+ * MUST be built from `APP_BASE_URL` rather than the inbound request's
+ * host/protocol. Trusting the request is unsafe: if the edge does not
+ * tightly canonicalize Host/Origin, an attacker can poison generated
+ * links by sending a request with a spoofed Host header.
+ *
+ * Production deploys MUST set `APP_BASE_URL` (e.g. `https://smd.services`).
+ * The portal subdomain is served by the same Pages project, so we derive
+ * the portal base from `PORTAL_BASE_URL` if set, otherwise we fall back
+ * to `APP_BASE_URL`. Both come from environment, never from request.
+ *
+ * Tracking: GitHub issue #173.
+ */
+
+/**
+ * Minimal env shape — only the URL config we need. Accepting a structural
+ * type keeps callers (Astro endpoints, webhook handlers, Workers) decoupled
+ * from the full `CfEnv` declaration in `src/env.d.ts`.
+ */
+export interface AppUrlEnv {
+  APP_BASE_URL?: string
+  PORTAL_BASE_URL?: string
+}
+
+/**
+ * Read and normalize `APP_BASE_URL` from environment. Trims whitespace and
+ * strips any trailing slash so callers can safely concatenate paths.
+ *
+ * Returns `null` if the value is missing or blank. Use `requireAppBaseUrl`
+ * when you need a hard guarantee.
+ */
+export function getAppBaseUrl(env: AppUrlEnv): string | null {
+  const raw = env.APP_BASE_URL
+  if (!raw || typeof raw !== 'string') return null
+  const trimmed = raw.trim().replace(/\/+$/, '')
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Read and normalize `PORTAL_BASE_URL`. Falls back to `APP_BASE_URL` when
+ * unset, since the portal is served by the same Pages project under a
+ * subdomain rewrite (see `src/middleware.ts`).
+ */
+export function getPortalBaseUrl(env: AppUrlEnv): string | null {
+  const raw = env.PORTAL_BASE_URL
+  if (raw && typeof raw === 'string') {
+    const trimmed = raw.trim().replace(/\/+$/, '')
+    if (trimmed.length > 0) return trimmed
+  }
+  return getAppBaseUrl(env)
+}
+
+/**
+ * Strict variant of `getAppBaseUrl`. Throws when the canonical URL is not
+ * configured. Use this in code paths that send outbound emails or webhook
+ * callbacks — failing loudly is preferable to silently emitting links built
+ * from a request host.
+ */
+export function requireAppBaseUrl(env: AppUrlEnv): string {
+  const base = getAppBaseUrl(env)
+  if (!base) {
+    throw new Error(
+      'APP_BASE_URL is not configured. Set APP_BASE_URL in wrangler env (e.g. https://smd.services) before sending outbound links.'
+    )
+  }
+  return base
+}
+
+/**
+ * Strict variant of `getPortalBaseUrl`. Throws when neither `PORTAL_BASE_URL`
+ * nor `APP_BASE_URL` is configured.
+ */
+export function requirePortalBaseUrl(env: AppUrlEnv): string {
+  const base = getPortalBaseUrl(env)
+  if (!base) {
+    throw new Error(
+      'PORTAL_BASE_URL (or APP_BASE_URL fallback) is not configured. Set it in wrangler env before sending portal links.'
+    )
+  }
+  return base
+}
+
+/**
+ * Build an absolute URL on the canonical app origin. Handles leading-slash
+ * normalization so callers can pass either `/foo` or `foo`.
+ */
+export function buildAppUrl(env: AppUrlEnv, path: string): string {
+  const base = requireAppBaseUrl(env)
+  const normalized = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalized}`
+}
+
+/**
+ * Build an absolute URL on the canonical portal origin. Defaults to the
+ * portal root (`/portal`) when no path is supplied.
+ */
+export function buildPortalUrl(env: AppUrlEnv, path: string = '/portal'): string {
+  const base = requirePortalBaseUrl(env)
+  const normalized = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalized}`
+}

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Config module — re-exports for convenience.
+ */
+
+export {
+  getAppBaseUrl,
+  getPortalBaseUrl,
+  requireAppBaseUrl,
+  requirePortalBaseUrl,
+  buildAppUrl,
+  buildPortalUrl,
+} from './app-url'
+export type { AppUrlEnv } from './app-url'

--- a/src/pages/api/admin/follow-ups/[id].ts
+++ b/src/pages/api/admin/follow-ups/[id].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro'
+import { buildPortalUrl } from '../../../../lib/config/app-url'
 import { getFollowUp, completeFollowUp, skipFollowUp } from '../../../../lib/db/follow-ups'
 import { getFollowUpTemplate } from '../../../../lib/email/follow-up-templates'
 import type { FollowUpEmailData } from '../../../../lib/email/follow-up-templates'
@@ -26,7 +27,7 @@ interface ContactRow {
  *
  * Protected by auth middleware (requires admin role).
  */
-export const POST: APIRoute = async ({ request, locals, redirect, params, url }) => {
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
   const session = locals.session
   if (!session || session.role !== 'admin') {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -93,9 +94,9 @@ export const POST: APIRoute = async ({ request, locals, redirect, params, url })
         return redirect('/admin/follow-ups?error=no_template', 302)
       }
 
-      // Build portal URL
-      const baseUrl = `${url.protocol}//${url.host}`
-      const portalUrl = `${baseUrl}/portal`
+      // Build portal URL from the canonical PORTAL_BASE_URL (falls back to
+      // APP_BASE_URL). Never derive from request host — see issue #173.
+      const portalUrl = buildPortalUrl(env)
 
       const emailData: FollowUpEmailData = {
         clientName: contact.name,

--- a/src/pages/api/admin/invoices/[id].ts
+++ b/src/pages/api/admin/invoices/[id].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro'
+import { buildPortalUrl } from '../../../../lib/config/app-url'
 import { getInvoice, updateInvoice, updateInvoiceStatus } from '../../../../lib/db/invoices'
 import type { InvoiceStatus } from '../../../../lib/db/invoices'
 import {
@@ -123,7 +124,9 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       if (clientEmail) {
         try {
           const formattedAmount = `$${existing.amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-          const portalUrl = new URL('/portal/invoices', request.url).toString()
+          // Build portal URL from canonical PORTAL_BASE_URL (falls back to
+          // APP_BASE_URL). Never derive from request host — see issue #173.
+          const portalUrl = buildPortalUrl(env, '/portal/invoices')
 
           await sendEmail(env.RESEND_API_KEY, {
             to: clientEmail,

--- a/src/pages/api/admin/quotes/[id]/sign.ts
+++ b/src/pages/api/admin/quotes/[id]/sign.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro'
+import { buildAppUrl } from '../../../../../lib/config/app-url'
 import { getQuote } from '../../../../../lib/db/quotes'
 import { getEntity } from '../../../../../lib/db/entities'
 import { listContacts } from '../../../../../lib/db/contacts'
@@ -26,7 +27,7 @@ import type { SignWellCreateDocumentRequest } from '../../../../../lib/signwell/
  *
  * Protected by auth middleware (requires admin role).
  */
-export const POST: APIRoute = async ({ locals, redirect, params, url }) => {
+export const POST: APIRoute = async ({ locals, redirect, params }) => {
   const session = locals.session
   if (!session || session.role !== 'admin') {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -106,8 +107,9 @@ export const POST: APIRoute = async ({ locals, redirect, params, url }) => {
       )
     }
 
-    // 4. Build the webhook callback URL
-    const callbackUrl = new URL('/api/webhooks/signwell', url.origin).toString()
+    // 4. Build the webhook callback URL from the canonical APP_BASE_URL.
+    // Never derive from request host — see issue #173.
+    const callbackUrl = buildAppUrl(env, '/api/webhooks/signwell')
 
     // 5. Create signature request in SignWell
     const signerId = crypto.randomUUID()

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createMagicLink } from '../../../lib/auth/magic-link'
+import { requireAppBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, portalInvitationEmailHtml } from '../../../lib/email/templates'
 
@@ -27,7 +28,7 @@ interface UserRow {
  * If email is provided, updates the user's email before sending.
  * This supports the OQ-010 flow where admin corrects a bounced email.
  */
-export const POST: APIRoute = async ({ request, locals, url }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   // Verify admin session (middleware already checks /admin/* routes,
   // but this is under /api/admin/* so we verify explicitly)
   const session = locals.session
@@ -78,8 +79,9 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
     // Create magic link
     const token = await createMagicLink(env.DB, targetEmail)
 
-    // Build verification URL
-    const baseUrl = `${url.protocol}//${url.host}`
+    // Build verification URL from the canonical APP_BASE_URL.
+    // Never derive from request host — see issue #173.
+    const baseUrl = requireAppBaseUrl(env)
     const magicLinkUrl = buildMagicLinkUrl(baseUrl, token)
 
     // Send invitation email

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createMagicLink } from '../../../lib/auth/magic-link'
+import { requireAppBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, magicLinkEmailHtml } from '../../../lib/email/templates'
 
@@ -24,7 +25,7 @@ interface UserRow {
  * Security: Always returns the same response whether or not the email
  * exists, to prevent email enumeration.
  */
-export const POST: APIRoute = async ({ request, locals, redirect, url }) => {
+export const POST: APIRoute = async ({ request, locals, redirect }) => {
   try {
     const formData = await request.formData()
     const email = formData.get('email')
@@ -50,8 +51,9 @@ export const POST: APIRoute = async ({ request, locals, redirect, url }) => {
     // Create magic link token
     const token = await createMagicLink(env.DB, normalizedEmail)
 
-    // Build the verification URL
-    const baseUrl = `${url.protocol}//${url.host}`
+    // Build the verification URL from the canonical APP_BASE_URL.
+    // Never derive from request host — see issue #173.
+    const baseUrl = requireAppBaseUrl(env)
     const magicLinkUrl = buildMagicLinkUrl(baseUrl, token)
 
     // Send the email

--- a/tests/canonical-app-url.test.ts
+++ b/tests/canonical-app-url.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  getAppBaseUrl,
+  getPortalBaseUrl,
+  requireAppBaseUrl,
+  requirePortalBaseUrl,
+  buildAppUrl,
+  buildPortalUrl,
+} from '../src/lib/config/app-url'
+
+/**
+ * Issue #173: Outbound auth and portal links must be built from a canonical
+ * APP_BASE_URL env var, never from request-derived host/protocol values.
+ *
+ * These tests cover:
+ *   1. The helper module behavior (parsing, normalization, strict guards).
+ *   2. File-content guards proving the affected endpoints use the helper
+ *      and no longer reach into `url.protocol` / `url.host` / `request.url`
+ *      to construct outbound links.
+ *   3. Env declarations and wrangler config document the new vars.
+ */
+
+describe('canonical app-url helper: getAppBaseUrl', () => {
+  it('returns the trimmed value when set', () => {
+    expect(getAppBaseUrl({ APP_BASE_URL: 'https://smd.services' })).toBe('https://smd.services')
+  })
+
+  it('strips trailing slashes', () => {
+    expect(getAppBaseUrl({ APP_BASE_URL: 'https://smd.services/' })).toBe('https://smd.services')
+    expect(getAppBaseUrl({ APP_BASE_URL: 'https://smd.services///' })).toBe('https://smd.services')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(getAppBaseUrl({ APP_BASE_URL: '  https://smd.services  ' })).toBe('https://smd.services')
+  })
+
+  it('returns null when env var is missing', () => {
+    expect(getAppBaseUrl({})).toBeNull()
+  })
+
+  it('returns null when env var is blank', () => {
+    expect(getAppBaseUrl({ APP_BASE_URL: '' })).toBeNull()
+    expect(getAppBaseUrl({ APP_BASE_URL: '   ' })).toBeNull()
+  })
+})
+
+describe('canonical app-url helper: getPortalBaseUrl', () => {
+  it('returns PORTAL_BASE_URL when set', () => {
+    expect(
+      getPortalBaseUrl({
+        APP_BASE_URL: 'https://smd.services',
+        PORTAL_BASE_URL: 'https://portal.smd.services',
+      })
+    ).toBe('https://portal.smd.services')
+  })
+
+  it('falls back to APP_BASE_URL when PORTAL_BASE_URL is unset', () => {
+    expect(getPortalBaseUrl({ APP_BASE_URL: 'https://smd.services' })).toBe('https://smd.services')
+  })
+
+  it('falls back to APP_BASE_URL when PORTAL_BASE_URL is blank', () => {
+    expect(
+      getPortalBaseUrl({
+        APP_BASE_URL: 'https://smd.services',
+        PORTAL_BASE_URL: '   ',
+      })
+    ).toBe('https://smd.services')
+  })
+
+  it('returns null when neither is set', () => {
+    expect(getPortalBaseUrl({})).toBeNull()
+  })
+})
+
+describe('canonical app-url helper: strict guards', () => {
+  it('requireAppBaseUrl throws a descriptive error when missing', () => {
+    expect(() => requireAppBaseUrl({})).toThrow(/APP_BASE_URL is not configured/)
+  })
+
+  it('requireAppBaseUrl returns the value when set', () => {
+    expect(requireAppBaseUrl({ APP_BASE_URL: 'https://smd.services' })).toBe('https://smd.services')
+  })
+
+  it('requirePortalBaseUrl throws when neither var is set', () => {
+    expect(() => requirePortalBaseUrl({})).toThrow(/PORTAL_BASE_URL/)
+  })
+
+  it('requirePortalBaseUrl honors APP_BASE_URL fallback', () => {
+    expect(requirePortalBaseUrl({ APP_BASE_URL: 'https://smd.services' })).toBe(
+      'https://smd.services'
+    )
+  })
+})
+
+describe('canonical app-url helper: URL builders', () => {
+  const env = {
+    APP_BASE_URL: 'https://smd.services',
+    PORTAL_BASE_URL: 'https://portal.smd.services',
+  }
+
+  it('buildAppUrl prepends the base origin', () => {
+    expect(buildAppUrl(env, '/api/webhooks/signwell')).toBe(
+      'https://smd.services/api/webhooks/signwell'
+    )
+  })
+
+  it('buildAppUrl handles paths without a leading slash', () => {
+    expect(buildAppUrl(env, 'api/webhooks/signwell')).toBe(
+      'https://smd.services/api/webhooks/signwell'
+    )
+  })
+
+  it('buildPortalUrl defaults to /portal when no path is supplied', () => {
+    expect(buildPortalUrl(env)).toBe('https://portal.smd.services/portal')
+  })
+
+  it('buildPortalUrl honors a custom path', () => {
+    expect(buildPortalUrl(env, '/portal/invoices')).toBe(
+      'https://portal.smd.services/portal/invoices'
+    )
+  })
+
+  it('buildPortalUrl falls back to APP_BASE_URL when PORTAL_BASE_URL is unset', () => {
+    expect(buildPortalUrl({ APP_BASE_URL: 'https://smd.services' }, '/portal')).toBe(
+      'https://smd.services/portal'
+    )
+  })
+
+  it('buildAppUrl throws when APP_BASE_URL is missing', () => {
+    expect(() => buildAppUrl({}, '/foo')).toThrow(/APP_BASE_URL/)
+  })
+
+  it('buildPortalUrl throws when neither base URL is set', () => {
+    expect(() => buildPortalUrl({}, '/portal')).toThrow(/PORTAL_BASE_URL/)
+  })
+})
+
+describe('canonical app-url: magic-link endpoint uses canonical helper', () => {
+  const path = resolve('src/pages/api/auth/magic-link.ts')
+
+  it('imports requireAppBaseUrl from the config helper', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
+    expect(source).toContain('requireAppBaseUrl')
+  })
+
+  it('does not derive base URL from request host/protocol', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).not.toContain('url.protocol')
+    expect(source).not.toContain('url.host')
+    expect(source).not.toMatch(/new URL\([^)]*request\.url/)
+  })
+
+  it('still passes a canonical baseUrl into buildMagicLinkUrl', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).toContain('buildMagicLinkUrl(baseUrl, token)')
+  })
+})
+
+describe('canonical app-url: resend-invitation endpoint uses canonical helper', () => {
+  const path = resolve('src/pages/api/admin/resend-invitation.ts')
+
+  it('imports requireAppBaseUrl from the config helper', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
+    expect(source).toContain('requireAppBaseUrl')
+  })
+
+  it('does not derive base URL from request host/protocol', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).not.toContain('url.protocol')
+    expect(source).not.toContain('url.host')
+    expect(source).not.toMatch(/new URL\([^)]*request\.url/)
+  })
+})
+
+describe('canonical app-url: follow-ups endpoint uses canonical helper', () => {
+  const path = resolve('src/pages/api/admin/follow-ups/[id].ts')
+
+  it('imports buildPortalUrl from the config helper', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
+    expect(source).toContain('buildPortalUrl')
+  })
+
+  it('does not derive base URL from request host/protocol', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).not.toContain('url.protocol')
+    expect(source).not.toContain('url.host')
+    expect(source).not.toMatch(/new URL\([^)]*request\.url/)
+  })
+})
+
+describe('canonical app-url: invoices endpoint uses canonical helper', () => {
+  const path = resolve('src/pages/api/admin/invoices/[id].ts')
+
+  it('imports buildPortalUrl from the config helper', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
+    expect(source).toContain('buildPortalUrl')
+  })
+
+  it('does not derive portal URL from request.url', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).not.toMatch(/new URL\([^)]*request\.url/)
+  })
+})
+
+describe('canonical app-url: signwell signature endpoint uses canonical helper', () => {
+  const path = resolve('src/pages/api/admin/quotes/[id]/sign.ts')
+
+  it('imports buildAppUrl from the config helper', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
+    expect(source).toContain('buildAppUrl')
+  })
+
+  it('does not derive callback URL from url.origin or request.url', () => {
+    const source = readFileSync(path, 'utf-8')
+    expect(source).not.toContain('url.origin')
+    expect(source).not.toMatch(/new URL\([^)]*request\.url/)
+  })
+})
+
+describe('canonical app-url: env declarations', () => {
+  it('CfEnv declares APP_BASE_URL', () => {
+    const source = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(source).toContain('APP_BASE_URL')
+  })
+
+  it('CfEnv declares PORTAL_BASE_URL', () => {
+    const source = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(source).toContain('PORTAL_BASE_URL')
+  })
+
+  it('wrangler.toml declares APP_BASE_URL under [vars]', () => {
+    const source = readFileSync(resolve('wrangler.toml'), 'utf-8')
+    expect(source).toContain('[vars]')
+    expect(source).toContain('APP_BASE_URL')
+  })
+
+  it('wrangler.toml declares PORTAL_BASE_URL', () => {
+    const source = readFileSync(resolve('wrangler.toml'), 'utf-8')
+    expect(source).toContain('PORTAL_BASE_URL')
+  })
+
+  it('.dev.vars.example documents APP_BASE_URL for local dev', () => {
+    const source = readFileSync(resolve('.dev.vars.example'), 'utf-8')
+    expect(source).toContain('APP_BASE_URL')
+    expect(source).toContain('PORTAL_BASE_URL')
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,15 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
+# ---------- Public env vars ----------
+# Canonical origin for outbound auth, portal, and webhook callback URLs.
+# All email links and webhook callbacks are built from APP_BASE_URL — never
+# from the inbound request host (see src/lib/config/app-url.ts and issue #173).
+# PORTAL_BASE_URL is optional; when unset it falls back to APP_BASE_URL.
+[vars]
+APP_BASE_URL = "https://smd.services"
+PORTAL_BASE_URL = "https://portal.smd.services"
+
 # ---------- D1 (structured data) ----------
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

Closes #173.

Outbound auth, portal, and webhook callback URLs were being built from request-derived host/protocol values (`url.protocol`, `url.host`, `request.url`, `url.origin`). Without strict edge canonicalization of `Host`/`Origin` headers, an attacker can poison generated links by sending a request with a spoofed `Host`, redirecting recipients to attacker-controlled domains.

This PR introduces a canonical `APP_BASE_URL` env var (with an optional `PORTAL_BASE_URL` for the portal subdomain) and a small helper module that normalizes the value and fails loudly when missing. All affected endpoints now build outbound links from the canonical env, never from the request.

## Canonical env vars

- **`APP_BASE_URL`** — required. The marketing/admin origin (e.g. `https://smd.services`). Used for magic-link verification URLs and the SignWell webhook callback.
- **`PORTAL_BASE_URL`** — optional. The portal origin (e.g. `https://portal.smd.services`). Falls back to `APP_BASE_URL` when unset, since the portal is the same Pages deployment served under a subdomain rewrite (see `src/middleware.ts`).

## Files changed

**New helper module**
- `src/lib/config/app-url.ts` — `getAppBaseUrl`, `getPortalBaseUrl`, `requireAppBaseUrl`, `requirePortalBaseUrl`, `buildAppUrl`, `buildPortalUrl`. Trims, strips trailing slashes, throws a descriptive error in production code paths if missing.
- `src/lib/config/index.ts` — barrel re-export.

**Endpoints fixed (the three flagged in #173 plus two more with the same root cause)**
- `src/pages/api/auth/magic-link.ts` — magic-link verification URL now uses `requireAppBaseUrl(env)`.
- `src/pages/api/admin/resend-invitation.ts` — invitation magic-link URL now uses `requireAppBaseUrl(env)`.
- `src/pages/api/admin/follow-ups/[id].ts` — follow-up portal URL now uses `buildPortalUrl(env)`.
- `src/pages/api/admin/invoices/[id].ts` — invoice notification portal URL now uses `buildPortalUrl(env, '/portal/invoices')` instead of `new URL('/portal/invoices', request.url)`.
- `src/pages/api/admin/quotes/[id]/sign.ts` — SignWell webhook callback now uses `buildAppUrl(env, '/api/webhooks/signwell')` instead of `new URL('/api/webhooks/signwell', url.origin)`. Same root cause: a webhook callback URL must be canonical or an attacker can redirect signature callbacks to their host.

**Env / config**
- `src/env.d.ts` — declares `APP_BASE_URL` and `PORTAL_BASE_URL` on `CfEnv` with documentation comments.
- `wrangler.toml` — declares both under `[vars]` with production values (`https://smd.services`, `https://portal.smd.services`). These are not secrets — they're public origins.
- `.dev.vars.example` — new file documenting local-dev values (`http://localhost:4321`) and the existing API-key secret names. Gitignored `.dev.vars` is the actual local file.

**Tests**
- `tests/canonical-app-url.test.ts` — 36 new tests covering:
  - Helper behavior: trimming, trailing-slash stripping, fallback semantics, strict-guard error messages, URL builders, and missing-env failure modes.
  - File-content guards for each of the 5 affected endpoints proving they import the canonical helper and no longer reference `url.protocol`, `url.host`, `url.origin`, or `new URL(..., request.url)` for outbound link construction.
  - Env-declaration guards for `src/env.d.ts`, `wrangler.toml`, and `.dev.vars.example`.

## Production misconfiguration safety

The acceptance criteria asks for production misconfig to be detected early. The `requireAppBaseUrl` / `requirePortalBaseUrl` helpers throw a descriptive `Error` the first time they're called without the env var set:

```
APP_BASE_URL is not configured. Set APP_BASE_URL in wrangler env (e.g. https://smd.services) before sending outbound links.
```

In practice, `wrangler.toml` now ships `APP_BASE_URL = "https://smd.services"` as a `[vars]` default, so production deploys are configured by default. If a future deploy clobbers it, the next outbound-email request fails fast with a clear error rather than emitting a poisoned link.

## Deploy-time configuration

- **No new secrets** — `APP_BASE_URL` and `PORTAL_BASE_URL` are public-origin strings, not credentials. They live in `wrangler.toml` `[vars]` and ship with the repo.
- **Cloudflare Pages dashboard** — if Pages has env-var overrides set for the `production` environment, confirm they don't unset `APP_BASE_URL`/`PORTAL_BASE_URL`. The `[vars]` defaults will apply otherwise.
- **Local dev** — copy `.dev.vars.example` to `.dev.vars` (gitignored) for localhost overrides. Without `.dev.vars`, the `wrangler.toml` `[vars]` apply, which means dev magic links will point at `https://smd.services` rather than localhost. Recommend developers set up `.dev.vars` before testing email flows locally.

## Out of scope (noted, not fixed)

- `src/lib/webhooks/signwell-handler.ts:209` hardcodes `'SMD Services <noreply@smd.services>'` as the email sender. Not a URL bug, but the inconsistency with `src/lib/email/resend.ts` (which uses `team@smd.services`) is worth a follow-up.
- `src/layouts/Base.astro` hardcodes `https://smd.services` for canonical/og-image URLs. This is correct for SEO (canonical URL must be the production origin), so left as-is.
- `src/pages/api/booking/intake.ts:121` hardcodes `https://smd.services/admin/entities/...` in an internal admin notification email. Internal-only and points at the canonical admin host, but could be tidied to use `buildAppUrl` in a follow-up.

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, build, all 875 tests including the 36 new ones).
- [x] All 5 affected endpoints type-check after dropping `url` from the destructured `APIRoute` context.
- [x] New tests prove the affected endpoints no longer reference `url.protocol` / `url.host` / `url.origin` / `request.url` for link construction.
- [ ] Manual smoke test in preview deploy: trigger magic-link flow, confirm email contains `https://smd.services/auth/verify?token=...` (or the configured `APP_BASE_URL`), not the preview URL.
- [ ] Manual smoke test in preview deploy: trigger SignWell signature request, confirm the SignWell document's `callback_url` points at the canonical origin.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>