### PR TITLE
docs: add Sun Tzu framework for client engagements

### DIFF
--- a/docs/strategy/sun-tzu-framework.md
+++ b/docs/strategy/sun-tzu-framework.md
@@ -1,0 +1,719 @@
+# Sun Tzu Framework for Client Engagements
+
+**SMD Services | Strategic Framework Document**
+
+---
+
+## Overview
+
+The Art of War is a 5th-century BC Chinese military treatise attributed to Sun Tzu. Its core insight: war is a serious matter to be studied, not a contest of bravery, and the best victory is the one won before the fighting starts.
+
+This document applies Sun Tzu's principles to SMD Services client engagements across three frameworks:
+
+1. **Strategic Framework** — Mapping the 13 chapters to engagement phases and principles
+2. **Assessment Call Lens** — Using Sun Tzu as a mental model for discovery conversations
+3. **Positioning Refinement** — Applying terrain thinking to vertical and channel selection
+
+---
+
+## Core Principles
+
+- **Win without fighting.** "To subdue the enemy without fighting is the acme of skill." The best proposal is the one the client has already sold themselves on.
+- **Know yourself and know your enemy.** Self-knowledge matters as much as intelligence on the client.
+- **All warfare is based on deception.** Shape perception. The assessment call appears diagnostic but is strategic.
+- **Speed and timing.** Prolonged engagements drain both parties. Move fast, strike at weakness.
+- **Terrain and positioning.** Whoever occupies the field first and waits is fresh. Choose where to fight.
+- **Formlessness.** "Water shapes its course according to the ground." Adapt to each client.
+
+---
+
+## The 13 Chapters
+
+| Chapter | Title | Core Teaching |
+|---------|-------|---------------|
+| 1 | Laying Plans | Five factors decide war: moral law, heaven, earth, commander, doctrine |
+| 2 | Waging War | The economic cost of war; why long wars ruin states |
+| 3 | Attack by Stratagem | Winning whole rather than destroying; the won-without-fighting ideal |
+| 4 | Tactical Dispositions | Make yourself invincible first, then wait for the enemy's mistake |
+| 5 | Energy | Direct vs. indirect force (zheng and qi); combining ordinary with surprising |
+| 6 | Weak Points and Strong | Strike where the enemy is unprepared; be where they are not |
+| 7 | Maneuvering | Turning the devious into the direct; converting disadvantage to advantage |
+| 8 | Variation in Tactics | Adapt; some roads are not to be followed, some orders not to be obeyed |
+| 9 | The Army on the March | Reading terrain and signs; interpreting enemy behavior |
+| 10 | Terrain | Six types of ground and how to fight on each |
+| 11 | The Nine Situations | Psychology of soldiers in different positions; "death ground" forces commitment |
+| 12 | The Attack by Fire | Using fire as a weapon; only fight when there's something to gain |
+| 13 | The Use of Spies | Intelligence is the cheapest investment with the highest return |
+
+---
+
+# Framework 1: Strategic Framework
+
+## Mapping the 13 Chapters to Engagement Principles
+
+Sun Tzu's 13 chapters don't map 1:1 to engagement phases — they're *principles* that inform how you operate across phases.
+
+---
+
+### Chapter 1: Laying Plans — The Five Factors
+
+**Sun Tzu:** War is decided by five factors — moral law, heaven, earth, commander, doctrine.
+
+| Factor | Military | Consulting Translation |
+|--------|----------|------------------------|
+| **Moral Law** | Troops believe in the cause | Does the owner believe operational improvement is *their* problem to solve? |
+| **Heaven** | Timing, seasons | Is this the right moment? Post-crisis recovery? Pre-growth scaling? |
+| **Earth** | Terrain | The business itself — industry, size, complexity, existing tools |
+| **Commander** | Leadership quality | Owner decisiveness, willingness to change, presence of internal champion |
+| **Doctrine** | Training, discipline | Your methodology — the 6 problems framework, delivery phases, tools rubric |
+
+**Maps to:** Layer 1 (Buy Box), Decision #4 (Disqualification), Decision #5 (Ideal Client Profile)
+
+**Insight:** Before any engagement, assess all five factors. The assessment call isn't just about identifying problems — it's evaluating whether the *conditions for victory* exist.
+
+---
+
+### Chapter 2: Waging War — The Economic Cost
+
+**Sun Tzu:** "There is no instance of a country having benefited from prolonged warfare."
+
+**In consulting:** Prolonged engagements drain both parties. The client's attention fades. The consultant's margin erodes.
+
+**Maps to:**
+- Decision #14 (Payment terms — 50/50 structure)
+- Decision #10 (Scope boundaries — 5 hard exclusions)
+- Decision #11 (Scope creep protocol — parking lot)
+- The entire fixed-price model
+
+**Insight:** The decision stack embodies this principle. Scope-based pricing with clear boundaries IS the answer to prolonged warfare.
+
+---
+
+### Chapter 3: Attack by Stratagem — Win Without Fighting
+
+**Sun Tzu:** "To subdue the enemy without fighting is the acme of skill."
+
+**In consulting:** The best proposal is the one the client has already sold themselves on.
+
+**Maps to:**
+- The entire assessment call design
+- Decision #15 (ROI Anchor Math — owner does the math)
+- Decision #18 (48-hour proposal turnaround)
+
+**Insight:** The assessment call IS the battle. If you're "closing" on a proposal call, you've already lost the strategic war. Decision #15 is Sun Tzu in pure form: "Owner does the math. We ask the questions."
+
+---
+
+### Chapter 4: Tactical Dispositions — Invincibility First
+
+**Sun Tzu:** "The good fighters of old first put themselves beyond the possibility of defeat, and then waited for an opportunity."
+
+**In consulting:** Build the machine before you turn it on.
+
+**Maps to:**
+- Week 1-3 deliverables queue — all 11 artifacts built before first live client
+- Tool evaluation framework ready (Decision #9)
+- SOW template ready (Deliverable #35)
+
+**Insight:** Don't pursue that first warm lead before the machine is built. An improvised assessment damages credibility.
+
+---
+
+### Chapter 5: Energy — Direct and Indirect Force
+
+**Sun Tzu:** "In battle, there are not more than two methods of attack — the direct and the indirect."
+
+- **Zheng (正):** Direct, ordinary force. The expected attack.
+- **Qi (奇):** Indirect, surprising force. The unexpected.
+
+| Phase | Direct (Zheng) | Indirect (Qi) |
+|-------|----------------|---------------|
+| **Pipeline** | Networking events, outreach | Accountant partnerships — solving *their* problem |
+| **Assessment** | "Tell me about your operations" | ROI anchor questions — appears diagnostic, actually economic |
+| **Proposal** | "Here's what we'll do" | The 48-hour turnaround itself — speed signals competence |
+| **Delivery** | Tool configuration | Champion orientation on Day 1 — building internal advocacy |
+| **Handoff** | Training session | The referral ask — feels like appreciation, functions as pipeline |
+
+**Insight:** The accountant partnership (Decision #22) is pure qi. You're not selling "operations consulting." You're offering to make their difficult clients easier to work with.
+
+---
+
+### Chapter 6: Weak Points and Strong
+
+**Sun Tzu:** "You may advance and be absolutely irresistible, if you make for the enemy's weak points."
+
+**In consulting:** Find the 2-3 acute problems and attack there. Don't spray across all six.
+
+**Maps to:**
+- The 6 Universal Problems framework
+- Decision #3 (Vertical-specific pain clusters)
+- Assessment call prioritization
+
+**Insight:** The 6 problems are a map of weak points. The assessment call identifies which 2-3 are *acute*. The others may exist but aren't worth attacking.
+
+---
+
+### Chapter 7: Maneuvering — Turning Disadvantage to Advantage
+
+**Sun Tzu:** "The difficulty of maneuvering consists in turning the devious into the direct, and misfortune into gain."
+
+**In consulting:** Every "no" contains a potential "yes."
+
+| Negative Outcome | Conversion Path |
+|------------------|-----------------|
+| Scope creep request | Parking lot → pre-handoff review → follow-on proposal |
+| Disqualified prospect (books behind) | Bookkeeper referral → reciprocal partnership |
+| No internal champion | Owner-as-champion with bounded tasks → smaller scope |
+| Post-handoff question out of scope | Retainer conversation opener |
+
+**Insight:** The parking lot protocol (Decision #11) is the clearest example. A scope creep request is a problem. Logging it and reviewing at pre-handoff turns it into follow-on revenue.
+
+---
+
+### Chapter 8: Variation in Tactics — Roads Not Followed
+
+**Sun Tzu:** "There are roads which must not be followed, armies which must not be attacked."
+
+**In consulting:** Some clients should not be taken. Some problems should not be solved. Some deals should not be chased.
+
+**Maps to:**
+- Decision #4 (Hard disqualifiers — automatic no)
+- Decision #6 (Financial visibility prerequisite)
+- Decision #19 (Follow-up cadence — after Day 7, mark dead)
+
+**Insight:** The follow-up cadence embodies this most clearly. Day 7 with no response → mark dead. No drip sequence. The mental bandwidth is freed.
+
+---
+
+### Chapter 9: The Army on the March — Reading Signs
+
+**Sun Tzu:** "When envoys are sent with compliments in their mouths, it is a sign that the enemy wishes for a truce."
+
+**In consulting:** Read the signals during the assessment. The client tells you more than they know.
+
+| Good Signal | Bad Signal |
+|-------------|------------|
+| "I know something has to change" | "My accountant told me to call you" |
+| "I've been meaning to fix this for months" | "I'm not sure what you do exactly" |
+| "I make the decisions here" | "I'll need to run this by my partner" |
+| Specific frustration with examples | Vague dissatisfaction |
+| "I just need someone to tell me what to do" | Blame language ("my employees don't...") |
+
+**Insight:** The assessment call is intelligence gathering. But not just for problems — for *readiness signals*.
+
+---
+
+### Chapter 10: Terrain — Six Types of Ground
+
+**Sun Tzu describes six terrains.** In consulting, terrain = vertical + distribution channel.
+
+| Terrain Type | Definition | Examples |
+|--------------|------------|----------|
+| **Accessible** | Easy entry, high competition | Chamber events, LinkedIn, pest control |
+| **Entangling** | Easy in, hard out | Marketing agencies, landscaping |
+| **Narrow Pass** | Gatekeeper-controlled | Accountant partnerships, ACCA, ASCPA |
+| **Precipitous Heights** | Defensible, high ground | BNI seat, specialized positioning |
+| **Temporizing** | No first-mover advantage | Consultants (competitors, not clients) |
+| **Positions at Distance** | Expensive to reach | Cold email, financial advisors |
+
+**Insight:** Don't fight on accessible ground if you can occupy a narrow pass. Accountant partnerships and vertical associations are narrow passes. Hold those.
+
+---
+
+### Chapter 11: The Nine Situations — Death Ground
+
+**Sun Tzu:** "Throw your soldiers into positions whence there is no escape, and they will prefer death to flight."
+
+**In consulting:** Create conditions where decision becomes easier than indecision.
+
+**Maps to:**
+- Decision #19 (Follow-up cadence — Day 7 soft deadline with sprint slot hold)
+- Decision #18 (SOW includes tentative start date with 5-day confirmation deadline)
+
+**Insight:** The sprint slot hold is manufactured death ground. The prospect faces: confirm and proceed, or lose the slot. That's not pressure — it's clarity.
+
+---
+
+### Chapter 12: Attack by Fire — Only Fight When There's Something to Gain
+
+**Sun Tzu:** "No ruler should put troops into the field merely to gratify his own spleen."
+
+**In consulting:** Don't take engagements that don't serve the business.
+
+**Maps to:**
+- Decision #13 (Paid assessment — $250 creates a qualification filter)
+- Decision #19 (Mark dead after Day 7)
+
+**Insight:** Every engagement has a cost. The $250 assessment fee (post-launch) ensures the prospect is serious. The "mark dead" rule prevents chasing with no gain.
+
+---
+
+### Chapter 13: The Use of Spies — Intelligence
+
+**Sun Tzu:** "What enables the wise sovereign to strike and conquer is foreknowledge."
+
+**In consulting:** Know more than the client knows about themselves.
+
+**Maps to:**
+- Decision #17 (MacWhisper transcription)
+- Assessment call structure
+- Decision #29 (Day 30 feedback survey)
+- Decision #30 (Case study from survey data)
+
+**Insight:** The assessment call is intelligence gathering under the guise of diagnosis. Day 30 surveys are delayed intelligence. Case studies are intelligence derivatives.
+
+---
+
+## Strategic Framework Summary
+
+| Chapter | Principle | Consulting Application | Key Decision |
+|---------|-----------|------------------------|--------------|
+| 1 | Five factors | Qualification = conditions for victory | #4, #5 |
+| 2 | Economic cost | Bounded scope, fixed price, clear endings | #10, #14 |
+| 3 | Win without fighting | Assessment call sells before proposal | #15, #18 |
+| 4 | Invincibility first | Build deliverables before first client | Week 1-3 |
+| 5 | Direct + indirect | Accountant partnership, ROI questions | #22, #15 |
+| 6 | Weak points | 6 problems framework, 2-3 focus | #3 |
+| 7 | Maneuvering | Parking lot, disqualify referrals | #11, #22 |
+| 8 | Roads not followed | Hard disqualifiers, mark dead | #4, #19 |
+| 9 | Read signs | Budget proxies, behavioral signals | #4 |
+| 10 | Terrain | Vertical + channel tactics | #3, #21 |
+| 11 | Death ground | Sprint slot hold, deadline | #18, #19 |
+| 12 | Fight for gain | Paid assessment, strategic value | #13 |
+| 13 | Intelligence | MacWhisper, Day 30 survey | #17, #29 |
+
+---
+
+# Framework 2: Assessment Call Lens
+
+## Sun Tzu as Mental Model for Discovery
+
+The assessment call is where the engagement is won or lost. Everything before it is positioning. Everything after it is execution. The call itself is the decisive battle.
+
+**The strategic truth:** The call appears diagnostic but is actually positioning. The client thinks they're being analyzed. They're being sold — without ever feeling sold to.
+
+---
+
+## The Dual Nature of the Assessment Call
+
+| Surface Layer (What Client Sees) | Strategic Layer (What You're Doing) |
+|----------------------------------|-------------------------------------|
+| "Tell me about your business" | Qualifying against the five factors |
+| "Walk me through a typical day" | Mapping weak points (the 6 problems) |
+| "How many leads slip through?" | Getting them to say the ROI number |
+| "Who would own this after?" | Identifying the champion / soft disqualifying |
+| "Sounds like X is the biggest pain" | Positioning your scope for the proposal |
+| "We'll send over a solution in a couple days" | Creating momentum toward close |
+
+---
+
+## Pre-Call: Laying Plans
+
+**Before the call starts, you've already begun the campaign.**
+
+### Intelligence Gathering
+- LinkedIn: Owner's background, years in business, employee count
+- Google: Reviews, location, single vs. multi-site
+- Referral source context: What did the accountant/BNI contact say?
+
+### Hypothesis Formation
+
+| Vertical + Size | Hypothesize... |
+|-----------------|----------------|
+| Home services, 10-15 employees | Scheduling chaos, lead leakage |
+| Home services, 20+ employees | Employee retention, owner bottleneck |
+| Professional services, small firm | Owner bottleneck, manual communication |
+| Professional services, growing firm | Pipeline leakage, financial blindness |
+
+**The hypothesis is not the answer.** The call will confirm, refute, or redirect.
+
+### Pre-Call Checklist
+- [ ] MacWhisper running
+- [ ] Hypothesis noted
+- [ ] Referral context reviewed
+- [ ] Disqualifier signals to watch for
+
+---
+
+## Opening: Establishing Moral Law (3-5 min)
+
+**What you're assessing:**
+- **Moral Law:** Does the owner believe this is *their* problem to solve?
+- **Commander:** Is this the decision-maker?
+
+**Opening Questions:**
+
+| Question | What You're Really Asking |
+|----------|---------------------------|
+| "What made you want to have this conversation?" | Are they in pain, or just curious? |
+| "What's been tried before?" | Are they burned? What's the competitive landscape? |
+| "If we solve this, what does that unlock for you?" | Do they have a vision, or just a complaint? |
+
+---
+
+## Discovery: Reading Terrain (15-20 min)
+
+**The Core Technique: "Show Me How"**
+
+Don't ask "Do you have a scheduling problem?" Instead: "Walk me through what happens when a new lead comes in."
+
+Then follow the thread:
+- "And then what happens?"
+- "Who does that?"
+- "How long does that usually take?"
+- "What happens when [person] is busy or out?"
+
+**The 6 Problems as Terrain Features:**
+
+| Problem | Terrain Signals |
+|---------|-----------------|
+| Owner bottleneck | "I have to approve..." / "They wait for me to..." |
+| Lead leakage | No CRM / "We use a spreadsheet" / "Sometimes they slip through" |
+| Financial blindness | Hesitation about margins / "My bookkeeper handles that" |
+| Scheduling chaos | "Double-bookings happen" / "Customers complain about wait times" |
+| Manual communication | "I text each customer" / "No templates" |
+| Employee retention | "I've lost three people this year" / "Training takes forever" |
+
+---
+
+## ROI Anchoring: Win Without Fighting (5-10 min)
+
+**The Principle:** Owner does the math. You ask the questions.
+
+| Problem | ROI Anchor Question |
+|---------|---------------------|
+| Owner bottleneck | "How many hours a week on things only you can approve?" + "What's your time worth?" |
+| Lead leakage | "How many leads slip through in a month?" + "What's the average job worth?" |
+| Scheduling chaos | "How many missed appointments in a month?" + "What does each one cost?" |
+| Manual communication | "How much of your evening is spent texting customers?" (pain framing) |
+| Financial blindness | "When's the last time you knew if you were profitable?" (peace of mind) |
+| Employee retention | "How many people lost this year?" + "What does replacement cost?" |
+
+**The Critical Moment:**
+
+When the owner says "That's probably $1,500 a month I'm losing" — **PAUSE**. Let it land.
+
+Your response: "Yeah. That adds up."
+
+**They subdued themselves.** The fight is already won.
+
+---
+
+## Champion Identification (3 min)
+
+**The Question:** "Who on your team would own this after we finish?"
+
+| Response | Signal |
+|----------|--------|
+| Immediate name with confidence | Champion exists, good sign |
+| "Probably [name], but they're busy" | Champion exists but may resist |
+| "I guess it would be me" | No champion — bound the scope |
+| Long pause, no clear answer | Red flag |
+
+---
+
+## Qualification Check (2-3 min)
+
+**Hard Disqualifiers — End Gracefully:**
+1. Not speaking to the decision-maker
+2. Scope exceeds single engagement
+3. No tech baseline
+
+**Soft Disqualifiers — Probe:**
+1. No internal champion
+2. Books 3+ months behind
+3. Diagnosis without intent to change
+
+---
+
+## The Close: Creating Momentum (2 min)
+
+**The Language:**
+
+> "Based on what we've talked through today, we can see a clear path to fixing [X, Y, and Z]. We'll design the solution and send you a scope and price within a couple of days. Sound good?"
+
+**What you're NOT doing:**
+- Quoting a price on the call
+- Asking for the sale
+- Creating artificial urgency
+
+**Post-Call:** Transcript → extraction → capture doc (same day). Solution design → proposal (within 48 hours). **Speed is the signal.**
+
+---
+
+## The Assessor's Internal Monologue
+
+Throughout the call, hold two tracks:
+
+**Track 1: Surface (What You Say)**
+- Curious, open questions
+- Active listening, reflecting back
+- No judgment, no pitching
+
+**Track 2: Strategic (What You Think)**
+- Which of the 6 problems are acute?
+- Is moral law present?
+- Who is the commander?
+- What's the terrain?
+- Are any roads not to be followed?
+- What's the qi move?
+
+**The client only sees Track 1. Track 2 runs silently.**
+
+---
+
+## Assessment Call Phases Summary
+
+| Phase | Duration | Sun Tzu Chapter | Strategic Objective |
+|-------|----------|-----------------|---------------------|
+| Pre-Call | Before | Ch. 1: Laying Plans | Hypothesis, intelligence |
+| Opening | 3-5 min | Ch. 1: Moral Law | Conditions for victory |
+| Discovery | 15-20 min | Ch. 9-10: Terrain | Map operation, find weak points |
+| Prioritization | 5 min | Ch. 6: Weak Points | Focus on 2-3 acute problems |
+| ROI Anchoring | 5-10 min | Ch. 3: Win Without Fighting | Owner says the number |
+| Champion ID | 3 min | Ch. 1: Commander | Identify post-delivery owner |
+| Qualification | 2-3 min | Ch. 8: Variation | Confirm no roads not followed |
+| Close | 2 min | Ch. 11: Death Ground | Create momentum |
+
+**Total: 35-45 minutes.** Any longer and you're losing energy.
+
+---
+
+## Traps and How to Avoid Them
+
+| Trap | What It Looks Like | The Fix |
+|------|---------------------|---------|
+| Pitching too early | Explaining services before understanding problems | Discovery comes first. Always. |
+| Accepting every problem | "Yes, we can fix that too" | Prioritize ruthlessly. "These three first." |
+| Doing their math | "So that's $1,500/month" | Ask the question. Let them calculate. |
+| Ignoring disqualifiers | Proceeding despite clear signals | End gracefully. |
+| Talking past the close | Continuing after "sounds good" | Shut up. Set next step. End call. |
+| No champion probe | Assuming someone will own it | Ask explicitly. |
+
+---
+
+# Framework 3: Positioning Refinement
+
+## Terrain Thinking for Vertical Selection
+
+Sun Tzu's terrain chapters describe how ground shapes strategy. Some terrain favors attack. Some favors defense. Some should be avoided. The general who understands terrain chooses where to fight.
+
+In consulting, terrain = market segments. Verticals, sub-verticals, channels, and positioning.
+
+---
+
+## Sun Tzu's Six Types of Ground
+
+| Terrain | Military Definition | Market Translation |
+|---------|---------------------|-------------------|
+| **Accessible** | Both sides can reach easily | Crowded market, low barriers, easy competition |
+| **Entangling** | Easy to enter, hard to exit | Verticals with high switching costs |
+| **Temporizing** | Neither side gains by moving first | No first-mover advantage |
+| **Narrow Passes** | Whoever holds the pass controls movement | Gatekeeper relationships |
+| **Precipitous Heights** | High ground — occupy first and wait | Positioning with clear differentiation |
+| **Positions at Distance** | Hard to reach, costly to engage | Markets requiring significant investment |
+
+**Strategic insight:** Don't fight on accessible ground if you can occupy a narrow pass.
+
+---
+
+## Home Services Sub-Verticals
+
+| Sub-Vertical | Terrain Type | Recommendation |
+|--------------|--------------|----------------|
+| **HVAC** | Narrow Pass | **Primary** — ACCA gatekeeper, seasonal urgency, 10-25 range common |
+| **Pool Services** | Narrow Pass | **Secondary** — Phoenix-specific, recurring model, scheduling pain acute |
+| **Electrical** | Precipitous Heights | **Tertiary** — Licensing = quality filter, higher job value |
+| Pest Control | Accessible | **Avoid** — Thin margins, commodity market |
+| Landscaping | Entangling | **Defer** — Contractor-heavy, structural turnover issues |
+| Roofing/Solar | Positions at Distance | **Defer** — Different engagement model needed |
+
+---
+
+## Professional Services Sub-Verticals
+
+| Sub-Vertical | Terrain Type | Recommendation |
+|--------------|--------------|----------------|
+| **Accountants** | Narrow Pass | **Primary** — Referral gatekeepers, dual value (client + partner) |
+| **Attorneys** | Precipitous Heights | **Secondary** — Professional networks, higher fee tolerance |
+| Insurance Agents | Accessible | **Avoid** — Often solo, commoditized |
+| Financial Advisors | Positions at Distance | **Defer** — Compliance complexity |
+| Marketing Agencies | Entangling | **Avoid** — High ego, hard to satisfy |
+| Consultants | Temporizing | **Avoid** — Competitors, not clients |
+
+---
+
+## Channel Selection as Terrain
+
+| Channel | Terrain Type | Priority |
+|---------|--------------|----------|
+| **Accountant Partnerships** | Narrow Pass | 1 — Control referral flow |
+| **BNI Chapters** | Precipitous Heights | 2 — Once you hold the seat, defensible |
+| **Vertical Associations (ACCA, ASCPA)** | Narrow Pass | 3 — Industry-specific credibility |
+| Chamber Events | Accessible | 4 — Volume, not quality |
+| LinkedIn | Accessible | 5 — Supplement only |
+| Cold Email | Positions at Distance | **Avoid** — Low conversion |
+
+---
+
+## The Precipitous Height: SMD Services Positioning
+
+> "We help Phoenix businesses with 10-25 employees clean up operations — fixed price, clear scope, we do it with you."
+
+**Why this is defensible:**
+
+| Positioning Element | Why It's Defensible |
+|--------------------|---------------------|
+| 10-25 employees | Below: owners DIY. Above: they hire COO. Middle is underserved. |
+| Operations cleanup | Nobody does scoped implementation. Coaches advise. IT configures. We do both. |
+| Fixed project price | Competitors bill hourly or sell retainers. Fixed price is clarity. |
+| Phoenix metro only | Geographic specificity = credibility. |
+| Collaborative | "We figure it out together" vs. "We audit and tell you." |
+
+**Who can't compete here:**
+- Enterprise consultants: Too expensive, wrong size
+- Managed IT: Technical only
+- Business coaches: No implementation
+- Bookkeepers: Financial only
+- Fractional COOs: Too expensive for this size
+- VAs: No strategic capability
+
+---
+
+## Market Entry: Campaign Phases
+
+### Phase 1: Beachhead (Weeks 1-8)
+
+**Objective:** First 3 engagements, first 2 case studies
+
+| Week | Action |
+|------|--------|
+| 1 | Accountant outreach (10 contacts) |
+| 1-2 | Chamber membership |
+| 2 | ACCA Arizona membership |
+| 2-3 | BNI chapter application |
+| 3-4 | First assessment calls |
+| 4-6 | First engagement signed |
+
+**Success Signal:** 1 closed engagement by Week 6, pipeline of 3+ assessments.
+
+---
+
+### Phase 2: Consolidation (Weeks 8-16)
+
+**Objective:** Referral flywheel started, BNI established
+
+| Week | Action |
+|------|--------|
+| Ongoing | BNI weekly attendance |
+| 8-10 | First engagement delivered |
+| 10-12 | First case study published |
+| 10-14 | Second engagement signed |
+| 12-16 | ACCA speaking slot requested |
+
+**Success Signal:** 2 assessments/week without cold outreach, 1+ referral received.
+
+---
+
+### Phase 3: Expansion (Weeks 16-24)
+
+**Objective:** Add Pool Services, Attorneys
+
+| Week | Action |
+|------|--------|
+| 16 | IPSSA Arizona contact |
+| 16-20 | State Bar small firm event |
+| 18-22 | First Pool Services assessment |
+| 20-24 | First Attorney assessment |
+
+**Success Signal:** Closed engagement in each new sub-vertical.
+
+---
+
+### Phase 4: Defense (Weeks 24+)
+
+**Objective:** Hold territory, increase rates
+
+| When | Action |
+|------|--------|
+| After 5 engagements | Rate increase ($150 → $175) |
+| After 3 follow-on requests | Retainer model defined |
+| Ongoing | Reject off-vertical inquiries or price at premium |
+
+**Success Signal:** Close rate > 40%, 50%+ pipeline from referrals.
+
+---
+
+## Terrain Decision Framework
+
+When evaluating any new opportunity, ask:
+
+1. **What type of terrain is this?**
+   - Prefer: Narrow pass, precipitous heights
+   - Avoid: Accessible, entangling, positions at distance
+
+2. **Who else is on this ground?**
+   - Direct competitors?
+   - Adjacent competitors?
+   - No one? (Opportunity or warning)
+
+3. **What are the natural advantages?**
+   - Phoenix-specific?
+   - Referral network density?
+   - Problem acuteness?
+
+4. **What's the cost of engagement?**
+   - Time to first client
+   - Ongoing commitment
+   - Investment required
+
+5. **Does this support or distract?**
+   - Reinforcing current terrain
+   - Expanding to adjacent terrain
+   - Distracting from held positions
+
+**Default:** Hold current terrain unless new position is clearly superior.
+
+---
+
+## Roads Not Followed
+
+| Sub-Vertical/Channel | Terrain Type | Why Not |
+|---------------------|--------------|---------|
+| Pest Control | Accessible | Thin margins, commodity |
+| Landscaping | Entangling | Structural turnover |
+| Insurance Agents | Accessible | Solo operators |
+| Marketing Agencies | Entangling | Ego, hard to satisfy |
+| Financial Advisors | Positions at Distance | Compliance complexity |
+| Cold Email | Positions at Distance | Low conversion |
+
+---
+
+# Conclusion
+
+## The Core Insight
+
+Sun Tzu isn't about fighting harder — it's about fighting smarter. Choosing the right terrain, gathering intelligence before engagement, and winning before the battle starts.
+
+For SMD Services, that means:
+
+1. **The assessment call is the decisive engagement** — win there
+2. **Accountant partnerships and HVAC are the narrow passes** — hold those
+3. **Every "no" is a potential maneuver** — parking lot, referral, follow-on
+4. **Build the machine before turning it on** — deliverables before clients
+5. **Mark dead and move on** — don't chase, don't drain resources on unfavorable ground
+
+---
+
+## Related Issues
+
+See GitHub issues #183-210 for actionable items derived from this framework.
+
+## References
+
+- Decision Stack: `docs/adr/decision-stack.md`
+- Sun Tzu, *The Art of War* (5th century BC)
+
+---
+
+*SMD Services | Strategic Framework | Confidential*


### PR DESCRIPTION
## Summary

Comprehensive strategic framework applying Art of War principles to SMD Services client engagements.

**Three Frameworks:**
1. **Strategic Framework** - Maps all 13 chapters to engagement phases and Decision Stack
2. **Assessment Call Lens** - Mental model for discovery conversations with phase timing
3. **Positioning Refinement** - Terrain thinking for vertical and channel selection

**Key Additions:**
- Chapter-by-chapter mapping to consulting principles
- Assessment call phase breakdown (35-45 min structure)
- Sub-vertical prioritization (HVAC primary, Pool Services secondary)
- Channel terrain analysis (accountant partnerships as narrow pass)
- Phase 1-4 campaign timeline with success signals
- Decision framework for evaluating new opportunities
- "Roads Not Followed" documentation

## Related Issues

Creates backlog for 28 actionable items: #183-210

## Test plan

- [ ] Document renders correctly in GitHub
- [ ] All Decision Stack references are accurate
- [ ] Links to related issues are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)