### PR TITLE
feat(lifecycle): add re_engagement_tasks migration

### DIFF
--- a/migrations/0014_re_engagement_tasks.sql
+++ b/migrations/0014_re_engagement_tasks.sql
@@ -1,0 +1,18 @@
+-- Re-engagement tasks — surfaced by the follow-up processor when entities
+-- in terminal stages (delivered, ongoing, lost) become candidates for
+-- re-engagement based on elapsed time and prior engagement history.
+--
+-- Read by the operator dashboard's re-engagement card.
+-- Written by the follow-up processor's re-engagement surfacing handler.
+
+CREATE TABLE re_engagement_tasks (
+  id            TEXT PRIMARY KEY,
+  entity_id     TEXT NOT NULL REFERENCES entities(id),
+  reason        TEXT NOT NULL,
+  surfaced_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  acted_on      TEXT,
+  dismissed_at  TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_re_engagement_tasks_entity ON re_engagement_tasks(entity_id);


### PR DESCRIPTION
## Summary
- Migration 0014: creates `re_engagement_tasks` table with entity FK, reason, surfaced_at, acted_on, dismissed_at timestamps
- Used by the follow-up processor's re-engagement surfacing handler and the operator dashboard's re-engagement card
- Part of Entity Lifecycle System epic #234 (Phase 2b)

Closes #257

## Test plan
- [ ] Verify passes (0 errors, 29 test files, 957 tests)
- [ ] Migration creates table and index cleanly against current D1 schema
- [ ] FK to entities(id) is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)