### PR TITLE
feat(lifecycle): add retainers table migration

### DIFF
--- a/migrations/0015_retainers.sql
+++ b/migrations/0015_retainers.sql
@@ -1,0 +1,33 @@
+-- Retainers — post-delivery recurring service agreements.
+--
+-- Created when an engagement completes and the client opts into ongoing
+-- support. Linked to entity and optionally to the originating engagement.
+-- The follow-up processor's billing handler reads next_billing_date to
+-- generate monthly invoices.
+--
+-- Part of Entity Lifecycle System epic #234 (Phase 2b — retainer).
+
+CREATE TABLE retainers (
+  id                  TEXT PRIMARY KEY,
+  org_id              TEXT NOT NULL REFERENCES organizations(id),
+  entity_id           TEXT NOT NULL REFERENCES entities(id),
+  engagement_id       TEXT REFERENCES engagements(id),
+  monthly_rate        REAL NOT NULL,
+  included_hours      REAL,
+  scope_description   TEXT,
+  terms               TEXT,
+  cancellation_policy TEXT,
+  start_date          TEXT NOT NULL,
+  end_date            TEXT,
+  status              TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active', 'paused', 'cancelled'
+                      )),
+  last_billed_at      TEXT,
+  next_billing_date   TEXT NOT NULL,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_retainers_entity ON retainers(entity_id);
+CREATE INDEX idx_retainers_status ON retainers(status);
+CREATE INDEX idx_retainers_next_billing ON retainers(next_billing_date);


### PR DESCRIPTION
## Summary
- Migration 0015: creates `retainers` table for post-delivery recurring service agreements
- Columns: monthly_rate, included_hours, scope_description, terms, cancellation_policy, billing dates, status (active/paused/cancelled)
- FKs to organizations, entities, and optionally engagements
- Indexes on entity_id, status, and next_billing_date for follow-up processor billing queries
- Part of Entity Lifecycle System epic #234 (Phase 2b — retainer)

Closes #258

## Test plan
- [ ] Verify passes (0 errors, 28 test files, 936 tests)
- [ ] Migration creates table and indexes cleanly against current D1 schema
- [ ] FKs to organizations, entities, engagements are valid
- [ ] CHECK constraint on status enforces active/paused/cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)