### PR TITLE
feat(booking): admin UI audit for cancelled assessment status

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -5,7 +5,12 @@ import type { EntityStage } from '../../../lib/db/entities'
 import { listContext, CONTEXT_TYPES } from '../../../lib/db/context'
 import type { ContextEntry } from '../../../lib/db/context'
 import { listContacts } from '../../../lib/db/contacts'
-import { listAssessments } from '../../../lib/db/assessments'
+import {
+  listAssessments,
+  ASSESSMENT_STATUSES,
+  VALID_TRANSITIONS as ASSESSMENT_TRANSITIONS,
+} from '../../../lib/db/assessments'
+import type { AssessmentStatus } from '../../../lib/db/assessments'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listQuotes } from '../../../lib/db/quotes'
 import { listInvoices } from '../../../lib/db/invoices'
@@ -193,6 +198,10 @@ function statusBadgeClass(status: string): string {
     converted: 'bg-green-100 text-green-700',
   }
   return map[status] ?? 'bg-slate-100 text-slate-600'
+}
+
+function assessmentStatusLabel(status: string): string {
+  return ASSESSMENT_STATUSES.find((s) => s.value === status)?.label ?? status
 }
 
 function parseMetadata(json: string | null): Record<string, unknown> | null {
@@ -745,19 +754,38 @@ function confidenceColor(confidence: string): string {
               Assessments ({assessments.length})
             </summary>
             <div class="px-6 pb-4 divide-y divide-slate-100">
-              {assessments.map((a) => (
-                <div class="py-2 flex items-center gap-2">
-                  <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(a.status)}`}>
-                    {a.status}
-                  </span>
-                  {a.scheduled_at && (
-                    <span class="text-sm text-slate-700">{formatDate(a.scheduled_at)}</span>
-                  )}
-                  {a.duration_minutes && (
-                    <span class="text-xs text-slate-400">{a.duration_minutes} min</span>
-                  )}
-                </div>
-              ))}
+              {assessments.map((a) => {
+                const validNext = ASSESSMENT_TRANSITIONS[a.status as AssessmentStatus] ?? []
+                return (
+                  <div class="py-2 flex items-center gap-2 flex-wrap">
+                    <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(a.status)}`}>
+                      {assessmentStatusLabel(a.status)}
+                    </span>
+                    {a.scheduled_at && (
+                      <span class="text-sm text-slate-700">{formatDate(a.scheduled_at)}</span>
+                    )}
+                    {a.duration_minutes && (
+                      <span class="text-xs text-slate-400">{a.duration_minutes} min</span>
+                    )}
+                    {validNext.length > 0 && (
+                      <div class="ml-auto flex items-center gap-1">
+                        {validNext.map((next: string) => (
+                          <form method="POST" action={`/api/admin/assessments/${a.id}`}>
+                            <input type="hidden" name="action" value="transition_status" />
+                            <input type="hidden" name="new_status" value={next} />
+                            <button
+                              type="submit"
+                              class={`text-xs px-2 py-0.5 rounded transition-colors ${statusBadgeClass(next)} hover:opacity-80`}
+                            >
+                              {assessmentStatusLabel(next)}
+                            </button>
+                          </form>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </details>
         )

--- a/tests/assessments.test.ts
+++ b/tests/assessments.test.ts
@@ -51,12 +51,18 @@ describe('assessments: data access layer', () => {
     expect(code).toContain("'entity_id = ?'")
   })
 
-  it('defines all valid assessment statuses', () => {
+  it('defines all valid assessment statuses including cancelled', () => {
     const code = source()
     expect(code).toContain("'scheduled'")
     expect(code).toContain("'completed'")
     expect(code).toContain("'disqualified'")
     expect(code).toContain("'converted'")
+    expect(code).toContain("'cancelled'")
+  })
+
+  it('ASSESSMENT_STATUSES includes cancelled with Cancelled label', () => {
+    const code = source()
+    expect(code).toContain("{ value: 'cancelled', label: 'Cancelled' }")
   })
 
   it('exports ASSESSMENT_STATUSES constant', () => {
@@ -212,5 +218,60 @@ describe('assessments: API routes', () => {
     )
     expect(code).toContain('Content-Disposition')
     expect(code).toContain('attachment')
+  })
+})
+
+describe('assessments: admin UI cancelled status audit', () => {
+  const entityDetailSource = () =>
+    readFileSync(resolve('src/pages/admin/entities/[id].astro'), 'utf-8')
+
+  it('entity detail page imports ASSESSMENT_STATUSES', () => {
+    expect(entityDetailSource()).toContain('ASSESSMENT_STATUSES')
+  })
+
+  it('entity detail page imports VALID_TRANSITIONS as ASSESSMENT_TRANSITIONS', () => {
+    expect(entityDetailSource()).toContain('VALID_TRANSITIONS as ASSESSMENT_TRANSITIONS')
+  })
+
+  it('entity detail page imports AssessmentStatus type', () => {
+    expect(entityDetailSource()).toContain('AssessmentStatus')
+  })
+
+  it('status badge helper includes cancelled with neutral gray styling', () => {
+    const code = entityDetailSource()
+    expect(code).toContain("cancelled: 'bg-slate-100 text-slate-500'")
+  })
+
+  it('assessmentStatusLabel helper maps status to ASSESSMENT_STATUSES labels', () => {
+    const code = entityDetailSource()
+    expect(code).toContain('function assessmentStatusLabel')
+    expect(code).toContain('ASSESSMENT_STATUSES.find')
+  })
+
+  it('assessment list renders labels via assessmentStatusLabel, not raw status', () => {
+    const code = entityDetailSource()
+    expect(code).toContain('{assessmentStatusLabel(a.status)}')
+  })
+
+  it('assessment transition UI reads from ASSESSMENT_TRANSITIONS (not hardcoded)', () => {
+    const code = entityDetailSource()
+    expect(code).toContain('ASSESSMENT_TRANSITIONS[a.status as AssessmentStatus]')
+  })
+
+  it('terminal statuses (cancelled, disqualified, converted) show no transition buttons', () => {
+    const code = entityDetailSource()
+    expect(code).toContain('validNext.length > 0')
+  })
+
+  it('transition buttons post to assessments API with transition_status action', () => {
+    const code = entityDetailSource()
+    expect(code).toContain('value="transition_status"')
+    expect(code).toContain('name="new_status"')
+    expect(code).toContain('/api/admin/assessments/')
+  })
+
+  it('transition buttons reuse statusBadgeClass for consistent styling', () => {
+    const code = entityDetailSource()
+    expect(code).toContain('statusBadgeClass(next)')
   })
 })


### PR DESCRIPTION
## Summary

Closes #227

Audits the admin UI entity detail page to properly handle the `cancelled` assessment status added in migration 0011. Before this PR, assessment status was rendered as a raw lowercase string with no transition controls.

- **Import assessment constants**: `ASSESSMENT_STATUSES`, `VALID_TRANSITIONS`, `AssessmentStatus` type now imported from the assessments DAL
- **Status labels**: New `assessmentStatusLabel()` helper maps status codes to proper display labels (e.g., "Cancelled" not "cancelled") via `ASSESSMENT_STATUSES`
- **Status transition UI**: Assessment rows now show transition buttons derived from `VALID_TRANSITIONS` — terminal statuses (cancelled, disqualified, converted) show no buttons
- **Badge styling**: `cancelled` already had neutral gray (`bg-slate-100 text-slate-500`) in the existing `statusBadgeClass()` helper; transition buttons reuse the same helper for consistency
- **12 new tests**: 2 DAL tests (cancelled in status enum, cancelled label), 10 admin UI audit tests (imports, helper function, label rendering, transition UI, terminal state handling, API action format)

### Audit scope

| Surface | Status |
|---------|--------|
| Status badges / labels | Handled — `statusBadgeClass` + `assessmentStatusLabel` |
| Status transition UI | Added — reads from `VALID_TRANSITIONS`, not hardcoded |
| Terminal state handling | Verified — cancelled/disqualified/converted show no transitions |
| Dashboard widgets | No assessment metrics exist on dashboard — N/A |
| CSV exports | No assessment export exists — N/A |
| Status filter dropdowns | No assessment filter UI exists — N/A |
| Portal pages | No assessment status rendered in portal — N/A |

## Test plan

- [x] `npm run verify` passes (947 tests, 0 type errors, formatting clean)
- [x] 49 assessment tests pass (up from 37)
- [x] All existing tests unaffected
- [x] Transition buttons only appear for non-terminal statuses
- [x] Cancelled badge uses neutral gray (not red)


🤖 Generated with [Claude Code](https://claude.com/claude-code)