### PR TITLE
feat(lifecycle): booking entity enrichment handler (#254)

### DIFF
--- a/tests/booking-enrichment.test.ts
+++ b/tests/booking-enrichment.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const handlerSrc = readFileSync(
+  resolve('workers/follow-up-processor/src/handlers/booking-enrichment.ts'),
+  'utf-8'
+)
+const indexSrc = readFileSync(resolve('workers/follow-up-processor/src/index.ts'), 'utf-8')
+const wranglerToml = readFileSync(resolve('workers/follow-up-processor/wrangler.toml'), 'utf-8')
+
+describe('booking-enrichment handler', () => {
+  describe('entity selection query', () => {
+    it('filters by source_pipeline = website_booking', () => {
+      expect(handlerSrc).toContain("source_pipeline = 'website_booking'")
+    })
+
+    it('filters by stage = assessing', () => {
+      expect(handlerSrc).toContain("stage = 'assessing'")
+    })
+
+    it('excludes entities that already have enrichment context', () => {
+      expect(handlerSrc).toContain('NOT EXISTS')
+      expect(handlerSrc).toContain("c.type = 'enrichment'")
+    })
+
+    it('limits batch size to prevent runaway processing', () => {
+      expect(handlerSrc).toContain('BATCH_LIMIT')
+      expect(handlerSrc).toContain('LIMIT ?')
+    })
+
+    it('processes oldest entities first', () => {
+      expect(handlerSrc).toContain('ORDER BY e.created_at ASC')
+    })
+  })
+
+  describe('enrichment modules', () => {
+    it('runs Google Places lookup', () => {
+      expect(handlerSrc).toContain('lookupGooglePlaces')
+      expect(handlerSrc).toContain("source: 'google_places'")
+    })
+
+    it('runs website analysis', () => {
+      expect(handlerSrc).toContain('analyzeWebsite')
+      expect(handlerSrc).toContain("source: 'website_analysis'")
+    })
+
+    it('runs Outscraper lookup', () => {
+      expect(handlerSrc).toContain('lookupOutscraper')
+      expect(handlerSrc).toContain("source: 'outscraper'")
+    })
+
+    it('runs ACC filing lookup', () => {
+      expect(handlerSrc).toContain('lookupAcc')
+      expect(handlerSrc).toContain("source: 'acc_filing'")
+    })
+
+    it('runs ROC license check for trades verticals', () => {
+      expect(handlerSrc).toContain('lookupRoc')
+      expect(handlerSrc).toContain("source: 'roc_license'")
+      expect(handlerSrc).toContain("entity.vertical === 'home_services'")
+      expect(handlerSrc).toContain("entity.vertical === 'contractor_trades'")
+    })
+
+    it('runs review pattern analysis', () => {
+      expect(handlerSrc).toContain('analyzeReviewPatterns')
+      expect(handlerSrc).toContain("source: 'review_analysis'")
+    })
+
+    it('runs competitor benchmarking', () => {
+      expect(handlerSrc).toContain('benchmarkCompetitors')
+      expect(handlerSrc).toContain("source: 'competitors'")
+    })
+
+    it('runs news/press search', () => {
+      expect(handlerSrc).toContain('searchNews')
+      expect(handlerSrc).toContain("source: 'news_search'")
+    })
+  })
+
+  describe('does NOT generate outreach draft', () => {
+    it('does not import outreach generation', () => {
+      expect(handlerSrc).not.toContain('generateOutreachDraft')
+    })
+
+    it('does not write outreach_draft context entries', () => {
+      expect(handlerSrc).not.toContain("type: 'outreach_draft'")
+    })
+  })
+
+  describe('error isolation', () => {
+    it('wraps each enrichment module in try/catch', () => {
+      const catchCount = (handlerSrc.match(/\} catch \(err\)/g) || []).length
+      expect(catchCount).toBeGreaterThanOrEqual(8)
+    })
+
+    it('logs errors with entity context', () => {
+      expect(handlerSrc).toContain('[booking-enrichment]')
+      expect(handlerSrc).toContain('console.error')
+    })
+  })
+
+  describe('context entries', () => {
+    it('writes all enrichment context entries with type enrichment', () => {
+      const contextCalls = handlerSrc.match(/type: 'enrichment'/g) || []
+      expect(contextCalls.length).toBeGreaterThanOrEqual(8)
+    })
+
+    it('uses ORG_ID constant for org scoping', () => {
+      expect(handlerSrc).toContain('ORG_ID')
+      expect(handlerSrc).toContain("from '../../../../src/lib/constants.js'")
+    })
+  })
+})
+
+describe('Worker index wiring', () => {
+  it('imports the booking-enrichment handler', () => {
+    expect(indexSrc).toContain("from './handlers/booking-enrichment.js'")
+  })
+
+  it('runs booking-enrichment before health-check', () => {
+    const enrichmentPos = indexSrc.indexOf('booking-enrichment')
+    const healthCheckPos = indexSrc.indexOf('health-check', enrichmentPos)
+    expect(enrichmentPos).toBeLessThan(healthCheckPos)
+  })
+
+  it('passes full env to booking-enrichment (not just DB)', () => {
+    expect(indexSrc).toContain('runBookingEnrichment(env)')
+  })
+
+  it('declares enrichment API key bindings in Env interface', () => {
+    expect(indexSrc).toContain('GOOGLE_PLACES_API_KEY')
+    expect(indexSrc).toContain('ANTHROPIC_API_KEY')
+    expect(indexSrc).toContain('OUTSCRAPER_API_KEY')
+    expect(indexSrc).toContain('SERPAPI_API_KEY')
+  })
+})
+
+describe('Worker wrangler.toml', () => {
+  it('documents enrichment secrets', () => {
+    expect(wranglerToml).toContain('GOOGLE_PLACES_API_KEY')
+    expect(wranglerToml).toContain('ANTHROPIC_API_KEY')
+    expect(wranglerToml).toContain('OUTSCRAPER_API_KEY')
+    expect(wranglerToml).toContain('SERPAPI_API_KEY')
+  })
+})

--- a/workers/follow-up-processor/src/handlers/booking-enrichment.ts
+++ b/workers/follow-up-processor/src/handlers/booking-enrichment.ts
@@ -1,0 +1,348 @@
+/**
+ * Booking entity enrichment handler.
+ *
+ * Runs enrichment on entities that booked via the public /book page.
+ * Public booking skips enrichment to avoid 10-30s latency on the booking
+ * page, so this handler catches them up asynchronously.
+ *
+ * Selection criteria:
+ *   - source_pipeline = 'website_booking'
+ *   - stage = 'assessing'
+ *   - No 'enrichment' context entries yet
+ *
+ * Runs the same enrichment modules as the admin promote endpoint
+ * (src/pages/api/admin/entities/[id]/promote.ts) but does NOT generate
+ * an outreach draft — the entity already has a booked assessment call.
+ *
+ * Each enrichment module is independent — failures don't block others
+ * or the overall handler.
+ */
+
+import { ORG_ID } from '../../../../src/lib/constants.js'
+import { getEntity, updateEntity } from '../../../../src/lib/db/entities.js'
+import { appendContext, assembleEntityContext } from '../../../../src/lib/db/context.js'
+import { lookupGooglePlaces } from '../../../../src/lib/enrichment/google-places.js'
+import { analyzeWebsite } from '../../../../src/lib/enrichment/website-analyzer.js'
+import { lookupOutscraper } from '../../../../src/lib/enrichment/outscraper.js'
+import { lookupAcc } from '../../../../src/lib/enrichment/acc.js'
+import { lookupRoc } from '../../../../src/lib/enrichment/roc.js'
+import { analyzeReviewPatterns } from '../../../../src/lib/enrichment/review-analysis.js'
+import { benchmarkCompetitors } from '../../../../src/lib/enrichment/competitors.js'
+import { searchNews } from '../../../../src/lib/enrichment/news.js'
+
+export interface BookingEnrichmentEnv {
+  DB: D1Database
+  GOOGLE_PLACES_API_KEY?: string
+  ANTHROPIC_API_KEY?: string
+  OUTSCRAPER_API_KEY?: string
+  SERPAPI_API_KEY?: string
+}
+
+const BATCH_LIMIT = 5
+
+/**
+ * Find booking entities that need enrichment and run all modules.
+ * Returns a summary string for the handler result log.
+ */
+export async function runBookingEnrichment(env: BookingEnrichmentEnv): Promise<string> {
+  const candidates = await env.DB.prepare(
+    `SELECT e.id FROM entities e
+       WHERE e.org_id = ?
+         AND e.source_pipeline = 'website_booking'
+         AND e.stage = 'assessing'
+         AND NOT EXISTS (
+           SELECT 1 FROM context c
+           WHERE c.entity_id = e.id AND c.type = 'enrichment'
+         )
+       ORDER BY e.created_at ASC
+       LIMIT ?`
+  )
+    .bind(ORG_ID, BATCH_LIMIT)
+    .all<{ id: string }>()
+
+  if (candidates.results.length === 0) {
+    return 'no candidates'
+  }
+
+  const results: string[] = []
+
+  for (const row of candidates.results) {
+    const entityResult = await enrichEntity(env, row.id)
+    results.push(`${row.id.slice(0, 8)}:${entityResult}`)
+  }
+
+  return `enriched ${candidates.results.length} — ${results.join(', ')}`
+}
+
+async function enrichEntity(env: BookingEnrichmentEnv, entityId: string): Promise<string> {
+  const entity = await getEntity(env.DB, ORG_ID, entityId)
+  if (!entity) return 'not_found'
+
+  const modules: string[] = []
+
+  // --- Tier 1: Contact discovery ---
+
+  // Google Places (if missing phone or website)
+  if ((!entity.phone || !entity.website) && env.GOOGLE_PLACES_API_KEY) {
+    try {
+      const places = await lookupGooglePlaces(entity.name, entity.area, env.GOOGLE_PLACES_API_KEY)
+      if (places) {
+        await updateEntity(env.DB, ORG_ID, entityId, {
+          phone: places.phone ?? entity.phone ?? undefined,
+          website: places.website ?? entity.website ?? undefined,
+        })
+        const phonePart = places.phone ? `Phone: ${places.phone}` : 'No phone found'
+        const webPart = places.website ? `Website: ${places.website}` : 'No website found'
+        const ratingPart = `Rating: ${places.rating ?? 'N/A'} (${places.reviewCount ?? 0} reviews)`
+        const statusPart = `Status: ${places.businessStatus ?? 'unknown'}`
+        await appendContext(env.DB, ORG_ID, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: `Google Places: ${phonePart}. ${webPart}. ${ratingPart}. ${statusPart}.`,
+          source: 'google_places',
+          metadata: places as unknown as Record<string, unknown>,
+        })
+        modules.push('google_places')
+        const refreshed = await getEntity(env.DB, ORG_ID, entityId)
+        if (refreshed) Object.assign(entity, refreshed)
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] Google Places failed for ${entityId}:`, err)
+    }
+  }
+
+  // Website analysis + tech stack
+  if (entity.website && env.ANTHROPIC_API_KEY) {
+    try {
+      const analysis = await analyzeWebsite(entity.website, env.ANTHROPIC_API_KEY)
+      if (analysis) {
+        const techTools = [
+          ...analysis.tech_stack.scheduling,
+          ...analysis.tech_stack.crm,
+          ...analysis.tech_stack.reviews,
+          ...analysis.tech_stack.payments,
+          ...analysis.tech_stack.communication,
+        ]
+        const missingTools: string[] = []
+        if (analysis.tech_stack.scheduling.length === 0) missingTools.push('No scheduling tool')
+        if (analysis.tech_stack.crm.length === 0) missingTools.push('No CRM')
+        if (analysis.tech_stack.reviews.length === 0) missingTools.push('No review management')
+
+        const contentParts = [
+          `Website analysis (${analysis.pages_analyzed.length} pages):`,
+          analysis.owner_name ? `Owner/Founder: ${analysis.owner_name}` : null,
+          analysis.team_size ? `Team size: ~${analysis.team_size} people` : null,
+          analysis.founding_year ? `Founded: ${analysis.founding_year}` : null,
+          analysis.contact_email ? `Email: ${analysis.contact_email}` : null,
+          analysis.services.length > 0 ? `Services: ${analysis.services.join(', ')}` : null,
+          `Site quality: ${analysis.quality}`,
+          techTools.length > 0
+            ? `Tools detected: ${techTools.join(', ')}`
+            : 'No business tools detected on website',
+          missingTools.length > 0 ? `Gaps: ${missingTools.join(', ')}` : null,
+          `Platform: ${analysis.tech_stack.platform.join(', ') || 'Custom/unknown'}`,
+        ].filter(Boolean)
+
+        await appendContext(env.DB, ORG_ID, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: contentParts.join('\n'),
+          source: 'website_analysis',
+          metadata: {
+            owner_name: analysis.owner_name,
+            team_size: analysis.team_size,
+            employee_count: analysis.team_size,
+            founding_year: analysis.founding_year,
+            contact_email: analysis.contact_email,
+            services: analysis.services,
+            quality: analysis.quality,
+            tech_stack: analysis.tech_stack,
+            pages_analyzed: analysis.pages_analyzed,
+          },
+        })
+        modules.push('website_analysis')
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] Website analysis failed for ${entityId}:`, err)
+    }
+  }
+
+  // Outscraper full business profile
+  if (env.OUTSCRAPER_API_KEY) {
+    try {
+      const osc = await lookupOutscraper(entity.name, entity.area, env.OUTSCRAPER_API_KEY)
+      if (osc) {
+        await updateEntity(env.DB, ORG_ID, entityId, {
+          phone: osc.phone ?? entity.phone ?? undefined,
+          website: osc.website ?? entity.website ?? undefined,
+        })
+        if (osc.website && !entity.website) {
+          const refreshed = await getEntity(env.DB, ORG_ID, entityId)
+          if (refreshed) Object.assign(entity, refreshed)
+        }
+
+        const contentParts = [
+          'Outscraper business profile:',
+          osc.owner_name ? `Owner: ${osc.owner_name}` : null,
+          osc.emails.length > 0 ? `Email: ${osc.emails.join(', ')}` : null,
+          osc.phone ? `Phone: ${osc.phone}` : null,
+          osc.working_hours ? `Hours: ${osc.working_hours}` : null,
+          osc.verified ? 'Google listing: Verified' : 'Google listing: Unverified',
+          osc.rating != null ? `Rating: ${osc.rating} (${osc.review_count ?? 0} reviews)` : null,
+          osc.booking_link ? 'Online booking: Yes' : 'Online booking: Not detected',
+          osc.facebook ? `Facebook: ${osc.facebook}` : null,
+          osc.instagram ? `Instagram: ${osc.instagram}` : null,
+          osc.linkedin ? `LinkedIn: ${osc.linkedin}` : null,
+          osc.website_generator ? `Platform: ${osc.website_generator}` : null,
+          osc.has_facebook_pixel ? 'Has Facebook Pixel' : null,
+          osc.has_google_tag_manager ? 'Has Google Tag Manager' : null,
+          osc.about ? `About: ${osc.about}` : null,
+        ].filter(Boolean)
+
+        await appendContext(env.DB, ORG_ID, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: contentParts.join('\n'),
+          source: 'outscraper',
+          metadata: osc as unknown as Record<string, unknown>,
+        })
+        modules.push('outscraper')
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] Outscraper failed for ${entityId}:`, err)
+    }
+  }
+
+  // --- Tier 2: Public records ---
+
+  // ACC filing
+  try {
+    const acc = await lookupAcc(entity.name)
+    if (acc) {
+      const filing = `${acc.entity_name} (${acc.entity_type ?? 'unknown type'})`
+      const filed = `Filed: ${acc.filing_date ?? 'unknown'}`
+      const status = `Status: ${acc.status ?? 'unknown'}`
+      const agent = `Registered agent: ${acc.registered_agent ?? 'not found'}`
+      await appendContext(env.DB, ORG_ID, {
+        entity_id: entityId,
+        type: 'enrichment',
+        content: `ACC Filing: ${filing}. ${filed}. ${status}. ${agent}.`,
+        source: 'acc_filing',
+        metadata: acc as unknown as Record<string, unknown>,
+      })
+      modules.push('acc_filing')
+    }
+  } catch (err) {
+    console.error(`[booking-enrichment] ACC lookup failed for ${entityId}:`, err)
+  }
+
+  // ROC license (trades only)
+  if (entity.vertical === 'home_services' || entity.vertical === 'contractor_trades') {
+    try {
+      const roc = await lookupRoc(entity.name)
+      if (roc) {
+        const license = `${roc.license_number ?? 'N/A'} (${roc.classification ?? 'unknown classification'})`
+        const rocStatus = `Status: ${roc.status ?? 'unknown'}`
+        const complaints = `Complaints: ${roc.complaint_count ?? 'N/A'}`
+        await appendContext(env.DB, ORG_ID, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: `ROC License: ${license}. ${rocStatus}. ${complaints}.`,
+          source: 'roc_license',
+          metadata: roc as unknown as Record<string, unknown>,
+        })
+        modules.push('roc_license')
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] ROC lookup failed for ${entityId}:`, err)
+    }
+  }
+
+  // --- Tier 3: Deeper intelligence ---
+
+  // Review response analysis
+  if (env.ANTHROPIC_API_KEY) {
+    try {
+      const signalContext = await assembleEntityContext(env.DB, entityId, {
+        maxBytes: 8_000,
+        typeFilter: ['signal'],
+      })
+      if (signalContext) {
+        const reviewAnalysis = await analyzeReviewPatterns(signalContext, env.ANTHROPIC_API_KEY)
+        if (reviewAnalysis) {
+          const accessible = reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''
+          await appendContext(env.DB, ORG_ID, {
+            entity_id: entityId,
+            type: 'enrichment',
+            content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${accessible} ${reviewAnalysis.insights}`,
+            source: 'review_analysis',
+            metadata: reviewAnalysis as unknown as Record<string, unknown>,
+          })
+          modules.push('review_analysis')
+        }
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] Review analysis failed for ${entityId}:`, err)
+    }
+  }
+
+  // Competitor benchmarking
+  if (env.GOOGLE_PLACES_API_KEY) {
+    try {
+      const benchmark = await benchmarkCompetitors(
+        entity.name,
+        entity.vertical,
+        entity.area,
+        entity.pain_score,
+        null,
+        env.GOOGLE_PLACES_API_KEY
+      )
+      if (benchmark) {
+        const competitorList = benchmark.competitors
+          .map((c) => `${c.name} (${c.rating}★, ${c.review_count} reviews)`)
+          .join(', ')
+        await appendContext(env.DB, ORG_ID, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: `Competitor benchmarking: ${benchmark.summary} Top competitors: ${competitorList}.`,
+          source: 'competitors',
+          metadata: benchmark as unknown as Record<string, unknown>,
+        })
+        modules.push('competitors')
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] Competitor benchmarking failed for ${entityId}:`, err)
+    }
+  }
+
+  // News/press search
+  if (env.SERPAPI_API_KEY && env.ANTHROPIC_API_KEY) {
+    try {
+      const news = await searchNews(
+        entity.name,
+        entity.area,
+        env.SERPAPI_API_KEY,
+        env.ANTHROPIC_API_KEY
+      )
+      if (news) {
+        await appendContext(env.DB, ORG_ID, {
+          entity_id: entityId,
+          type: 'enrichment',
+          content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
+          source: 'news_search',
+          metadata: {
+            mentions: news.mentions,
+            summary: news.summary,
+          },
+        })
+        modules.push('news_search')
+      }
+    } catch (err) {
+      console.error(`[booking-enrichment] News search failed for ${entityId}:`, err)
+    }
+  }
+
+  console.log(`[booking-enrichment] ${entity.name}: ${modules.join(', ') || 'none'}`)
+
+  return modules.length > 0 ? modules.join('+') : 'no_data'
+}

--- a/workers/follow-up-processor/src/index.ts
+++ b/workers/follow-up-processor/src/index.ts
@@ -7,6 +7,7 @@
  *
  * Schedule: Hourly at :00 UTC
  * Handlers:
+ *   - booking-enrichment: enrich booking entities that skipped inline enrichment
  *   - booking-cleanup: prune expired holds and OAuth states
  *   - health-check: write heartbeat row for deploy monitoring
  *
@@ -15,14 +16,18 @@
  *   - Invoice overdue escalation
  *   - Re-engagement surfacing
  *   - Safety net auto-completion
- *   - Booking entity enrichment
  */
 
+import { runBookingEnrichment } from './handlers/booking-enrichment.js'
 import { runBookingCleanup } from './handlers/booking-cleanup.js'
 import { runHealthCheck } from './handlers/health-check.js'
 
 export interface Env {
   DB: D1Database
+  GOOGLE_PLACES_API_KEY?: string
+  ANTHROPIC_API_KEY?: string
+  OUTSCRAPER_API_KEY?: string
+  SERPAPI_API_KEY?: string
 }
 
 interface HandlerResult {
@@ -50,6 +55,7 @@ async function run(env: Env): Promise<HandlerResult[]> {
 
   // Run handlers sequentially — order matters for health-check (it records
   // the full run duration, so it goes last).
+  results.push(await runHandler('booking-enrichment', () => runBookingEnrichment(env)))
   results.push(await runHandler('booking-cleanup', () => runBookingCleanup(env.DB)))
   results.push(await runHandler('health-check', () => runHealthCheck(env.DB, results)))
 
@@ -74,7 +80,6 @@ export default {
     const url = new URL(request.url)
 
     if (url.pathname === '/health') {
-      // Quick liveness check — just confirm the Worker responds
       const latest = await env.DB.prepare(
         `SELECT ran_at, summary FROM worker_heartbeats
          WHERE worker_name = 'follow-up-processor'

--- a/workers/follow-up-processor/wrangler.toml
+++ b/workers/follow-up-processor/wrangler.toml
@@ -12,3 +12,14 @@ database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 # Hourly cron — all lifecycle background automation runs here
 [triggers]
 crons = ["0 * * * *"]
+
+# ---------- Secrets (set via wrangler secret put) ----------
+# Required by the booking-enrichment handler for entity enrichment modules.
+# These are the same secrets used by the Pages project's promote endpoint.
+#
+# GOOGLE_PLACES_API_KEY   — Google Places Text Search (enrichment)
+# ANTHROPIC_API_KEY       — Claude API (website analysis, review analysis)
+# OUTSCRAPER_API_KEY      — Outscraper business profile enrichment
+# SERPAPI_API_KEY          — SerpAPI Google Search (news/press enrichment)
+#
+# Set with: npx wrangler secret put SECRET_NAME --config workers/follow-up-processor/wrangler.toml


### PR DESCRIPTION
## Summary

- Adds `booking-enrichment` handler to the follow-up processor Worker
- Asynchronously enriches entities that booked via the public `/book` page, where enrichment is skipped to avoid 10-30s latency
- Selects entities matching `source_pipeline='website_booking'`, `stage='assessing'`, with no existing `enrichment` context entries
- Runs all 8 enrichment modules from the promote endpoint: Google Places, website analysis, Outscraper, ACC filing, ROC license (trades), review analysis, competitor benchmarking, news/press search
- Does NOT generate outreach drafts — these entities already have a booked assessment call
- Each module is independently try/caught so failures don't block others
- Batch limit of 5 entities per cron run to stay within Worker CPU limits
- Expanded Worker `Env` interface with enrichment API key bindings
- Updated `wrangler.toml` with secret documentation

## Files changed

- `workers/follow-up-processor/src/handlers/booking-enrichment.ts` — new handler
- `workers/follow-up-processor/src/index.ts` — wired handler, expanded Env
- `workers/follow-up-processor/wrangler.toml` — secret docs
- `tests/booking-enrichment.test.ts` — 24 tests

## Test plan

- [x] All 936 tests pass including 24 new booking-enrichment tests
- [x] `npm run verify` clean (0 errors)
- [ ] After scaffold PR #267 merges, rebase onto main

Closes #254