### PR TITLE
feat(booking): wire booking emails to Resend

### DIFF
--- a/src/lib/email/booking-emails.ts
+++ b/src/lib/email/booking-emails.ts
@@ -1,0 +1,136 @@
+/**
+ * Booking email send functions.
+ *
+ * Composes HTML from the booking templates in `./templates.ts` and sends
+ * via Resend using the shared `sendEmail` helper. Each function returns
+ * the Resend message ID on success.
+ *
+ * All functions are fire-and-forget safe — callers should try/catch and
+ * log failures without blocking the booking flow.
+ */
+
+import { sendEmail } from './resend.js'
+import type { SendResult, EmailAttachment } from './resend.js'
+import {
+  bookingConfirmationEmailHtml,
+  bookingRescheduledEmailHtml,
+  bookingCancelledEmailHtml,
+  bookingAdminNotificationEmailHtml,
+} from './templates.js'
+import type {
+  BookingConfirmationEmailInput,
+  BookingRescheduledEmailInput,
+  BookingCancelledEmailInput,
+  BookingAdminNotificationInput,
+} from './templates.js'
+
+const NOTIFY_EMAIL = 'team@smd.services'
+
+// ---------------------------------------------------------------------------
+// Confirmation (sent to guest after successful reserve)
+// ---------------------------------------------------------------------------
+
+export interface SendBookingConfirmationInput extends BookingConfirmationEmailInput {
+  guestEmail: string
+  /** Base64-encoded ICS content, or null if ICS generation failed. */
+  icsAttachment: EmailAttachment | null
+}
+
+export async function sendBookingConfirmation(
+  apiKey: string | undefined,
+  input: SendBookingConfirmationInput
+): Promise<SendResult> {
+  const html = bookingConfirmationEmailHtml(input)
+  const attachments: EmailAttachment[] = []
+  if (input.icsAttachment) {
+    attachments.push(input.icsAttachment)
+  }
+
+  return sendEmail(apiKey, {
+    to: input.guestEmail,
+    subject: `Confirmed: ${input.meetingLabel} with SMD Services`,
+    html,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Reschedule (sent to guest after successful reschedule)
+// ---------------------------------------------------------------------------
+
+export interface SendBookingRescheduleInput extends BookingRescheduledEmailInput {
+  guestEmail: string
+  /** Base64-encoded ICS content, or null if ICS generation failed. */
+  icsAttachment: EmailAttachment | null
+}
+
+export async function sendBookingReschedule(
+  apiKey: string | undefined,
+  input: SendBookingRescheduleInput
+): Promise<SendResult> {
+  const html = bookingRescheduledEmailHtml(input)
+  const attachments: EmailAttachment[] = []
+  if (input.icsAttachment) {
+    attachments.push(input.icsAttachment)
+  }
+
+  return sendEmail(apiKey, {
+    to: input.guestEmail,
+    subject: `Rescheduled: ${input.meetingLabel} with SMD Services`,
+    html,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Cancellation (sent to guest after cancellation)
+// ---------------------------------------------------------------------------
+
+export interface SendBookingCancellationInput extends BookingCancelledEmailInput {
+  guestEmail: string
+  /** Base64-encoded ICS CANCEL content, or null if ICS generation failed. */
+  icsAttachment: EmailAttachment | null
+}
+
+export async function sendBookingCancellation(
+  apiKey: string | undefined,
+  input: SendBookingCancellationInput
+): Promise<SendResult> {
+  const html = bookingCancelledEmailHtml(input)
+  const attachments: EmailAttachment[] = []
+  if (input.icsAttachment) {
+    attachments.push(input.icsAttachment)
+  }
+
+  return sendEmail(apiKey, {
+    to: input.guestEmail,
+    subject: 'Cancelled: Assessment call with SMD Services',
+    html,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Admin notification (sent to team on every new booking)
+// ---------------------------------------------------------------------------
+
+export interface SendBookingAdminNotificationInput extends BookingAdminNotificationInput {
+  /** Reply-to address (the guest's email). */
+  replyTo: string
+  /** Formatted slot label for the subject line. */
+  subjectSlotLabel: string
+}
+
+export async function sendBookingAdminNotification(
+  apiKey: string | undefined,
+  input: SendBookingAdminNotificationInput
+): Promise<SendResult> {
+  const html = bookingAdminNotificationEmailHtml(input)
+
+  return sendEmail(apiKey, {
+    to: NOTIFY_EMAIL,
+    reply_to: input.replyTo,
+    subject: `New booking: ${input.businessName} — ${input.subjectSlotLabel}`,
+    html,
+  })
+}

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -5,3 +5,15 @@
 export { sendEmail } from './resend'
 export type { EmailPayload, SendResult } from './resend'
 export { buildMagicLinkUrl, magicLinkEmailHtml, portalInvitationEmailHtml } from './templates'
+export {
+  sendBookingConfirmation,
+  sendBookingReschedule,
+  sendBookingCancellation,
+  sendBookingAdminNotification,
+} from './booking-emails'
+export type {
+  SendBookingConfirmationInput,
+  SendBookingRescheduleInput,
+  SendBookingCancellationInput,
+  SendBookingAdminNotificationInput,
+} from './booking-emails'


### PR DESCRIPTION
## Summary

Adds `src/lib/email/booking-emails.ts` with four concrete send functions that compose booking HTML templates with the Resend API client (#223):

- **`sendBookingConfirmation`** — sends confirmation email with ICS calendar attachment to guest after successful reserve
- **`sendBookingReschedule`** — sends rescheduled confirmation with updated ICS attachment
- **`sendBookingCancellation`** — sends cancellation notice with ICS CANCEL attachment
- **`sendBookingAdminNotification`** — notifies team@smd.services of new bookings with reply-to set to guest email

Each function calls the existing HTML template from `templates.ts` and sends via the shared `sendEmail` helper in `resend.ts`. All functions accept an optional ICS attachment and return the Resend message ID.

Updates `src/lib/email/index.ts` to re-export all functions and types.

## Test plan
- [ ] Verify `npm run verify` passes (typecheck, lint, format, build, tests)
- [ ] Verify confirmation email includes ICS attachment when provided
- [ ] Verify cancellation email subject line is correct
- [ ] Verify admin notification sets reply-to to guest email
- [ ] Integration test: call `sendBookingConfirmation` with no API key, confirm dev-mode log output

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)