### PR TITLE
feat(lifecycle): assessment detail page + completion form (#235)

### DIFF
--- a/migrations/0013_assessment_live_notes.sql
+++ b/migrations/0013_assessment_live_notes.sql
@@ -1,0 +1,6 @@
+-- Add live_notes column to assessments table.
+--
+-- Stores auto-saved notes from the assessment detail page during
+-- the live call. Pre-filled from booking notes if present.
+
+ALTER TABLE assessments ADD COLUMN live_notes TEXT;

--- a/src/lib/db/assessments.ts
+++ b/src/lib/db/assessments.ts
@@ -14,6 +14,7 @@ export interface Assessment {
   duration_minutes: number | null
   transcript_path: string | null
   extraction: string | null
+  live_notes: string | null
   status: string
   created_at: string
 }
@@ -64,6 +65,7 @@ export interface UpdateAssessmentData {
   duration_minutes?: number | null
   transcript_path?: string | null
   extraction?: string | null
+  live_notes?: string | null
 }
 
 /**
@@ -175,6 +177,11 @@ export async function updateAssessment(
   if (data.extraction !== undefined) {
     fields.push('extraction = ?')
     params.push(data.extraction)
+  }
+
+  if (data.live_notes !== undefined) {
+    fields.push('live_notes = ?')
+    params.push(data.live_notes)
   }
 
   if (fields.length === 0) {

--- a/src/pages/admin/assessments/[id].astro
+++ b/src/pages/admin/assessments/[id].astro
@@ -1,0 +1,562 @@
+---
+import '../../../styles/global.css'
+import { getAssessment } from '../../../lib/db/assessments'
+import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
+import { listContext } from '../../../lib/db/context'
+
+/**
+ * Assessment detail page — used during the live assessment call.
+ *
+ * Shows entity info, schedule details, live notes textarea (auto-saves),
+ * and a collapsible completion form for post-call processing.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const assessmentId = Astro.params.id!
+
+const assessment = await getAssessment(env.DB, session.orgId, assessmentId)
+if (!assessment) return Astro.redirect('/admin/entities?error=not_found')
+
+const entity = await getEntity(env.DB, session.orgId, assessment.entity_id)
+if (!entity) return Astro.redirect('/admin/entities?error=entity_not_found')
+
+// Load schedule sidecar
+interface AssessmentSchedule {
+  slot_start_utc: string
+  slot_end_utc: string
+  timezone: string
+  guest_timezone: string | null
+  guest_name: string
+  guest_email: string
+  google_meet_url: string | null
+  google_event_link: string | null
+}
+
+const schedule = await env.DB.prepare(
+  'SELECT * FROM assessment_schedule WHERE assessment_id = ? AND org_id = ?'
+)
+  .bind(assessmentId, session.orgId)
+  .first<AssessmentSchedule>()
+
+// Load entity context timeline
+const contextEntries = await listContext(env.DB, entity.id)
+const timelineEntries = [...contextEntries].reverse()
+
+// Load booking notes from intake context (if any)
+const intakeEntry = contextEntries.find((e) => e.type === 'intake')
+const bookingNotes = intakeEntry?.content ?? ''
+
+// Pre-fill live notes from existing data or booking notes
+const liveNotesValue = assessment.live_notes ?? bookingNotes
+
+const error = Astro.url.searchParams.get('error')
+const saved = Astro.url.searchParams.get('saved')
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'America/Phoenix',
+  })
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function stageBadgeClass(stage: string): string {
+  const map: Record<string, string> = {
+    signal: 'bg-amber-100 text-amber-700',
+    prospect: 'bg-blue-100 text-blue-700',
+    assessing: 'bg-purple-100 text-purple-700',
+    proposing: 'bg-indigo-100 text-indigo-700',
+    engaged: 'bg-green-100 text-green-700',
+    delivered: 'bg-emerald-100 text-emerald-700',
+    ongoing: 'bg-teal-100 text-teal-700',
+    lost: 'bg-slate-100 text-slate-500',
+  }
+  return map[stage] ?? 'bg-slate-100 text-slate-500'
+}
+
+function tierBadgeClass(tier: string): string {
+  const map: Record<string, string> = {
+    hot: 'bg-red-100 text-red-700',
+    warm: 'bg-amber-100 text-amber-700',
+    cool: 'bg-blue-100 text-blue-700',
+    cold: 'bg-slate-100 text-slate-500',
+  }
+  return map[tier] ?? 'bg-slate-100 text-slate-500'
+}
+
+function contextTypeBadge(type: string): string {
+  const map: Record<string, string> = {
+    signal: 'bg-amber-100 text-amber-700',
+    enrichment: 'bg-cyan-100 text-cyan-700',
+    note: 'bg-slate-100 text-slate-600',
+    transcript: 'bg-purple-100 text-purple-700',
+    extraction: 'bg-indigo-100 text-indigo-700',
+    outreach_draft: 'bg-blue-100 text-blue-700',
+    engagement_log: 'bg-green-100 text-green-700',
+    follow_up_result: 'bg-teal-100 text-teal-700',
+    feedback: 'bg-emerald-100 text-emerald-700',
+    parking_lot: 'bg-orange-100 text-orange-700',
+    stage_change: 'bg-slate-50 text-slate-500',
+    intake: 'bg-pink-100 text-pink-700',
+    scorecard: 'bg-violet-100 text-violet-700',
+  }
+  return map[type] ?? 'bg-slate-100 text-slate-600'
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Assessment: {entity.name} — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <a href={`/admin/entities/${entity.id}`} class="hover:text-primary transition-colors"
+          >{entity.name}</a
+        >
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Assessment</span>
+      </nav>
+
+      {
+        error && (
+          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+            {decodeURIComponent(error)}
+          </div>
+        )
+      }
+      {
+        saved && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Changes saved.
+          </div>
+        )
+      }
+
+      {/* Entity + Assessment Info */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <div class="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <div class="flex items-center gap-3 mb-2">
+              <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+              <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
+                {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
+              </span>
+              {
+                entity.tier && (
+                  <span class={`text-xs px-2 py-0.5 rounded ${tierBadgeClass(entity.tier)}`}>
+                    {entity.tier}
+                  </span>
+                )
+              }
+            </div>
+
+            <div class="flex items-center gap-4 text-sm text-slate-500 flex-wrap">
+              {
+                entity.pain_score != null && (
+                  <span>
+                    Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
+                  </span>
+                )
+              }
+              {
+                entity.vertical && (
+                  <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>
+                )
+              }
+              {entity.area && <span>{entity.area}</span>}
+            </div>
+          </div>
+          <span
+            class={`text-xs px-2 py-0.5 rounded ${assessment.status === 'scheduled' ? 'bg-blue-100 text-blue-700' : assessment.status === 'completed' ? 'bg-green-100 text-green-700' : 'bg-slate-100 text-slate-500'}`}
+          >
+            {assessment.status}
+          </span>
+        </div>
+
+        {/* Schedule details */}
+        {
+          schedule && (
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+              <div>
+                <span class="text-slate-500">Scheduled:</span>
+                <span class="ml-1 text-slate-900 font-medium">
+                  {formatDateTime(schedule.slot_start_utc)}
+                </span>
+                <span class="text-slate-400 ml-1">({schedule.timezone})</span>
+              </div>
+              <div>
+                <span class="text-slate-500">Contact:</span>
+                <span class="ml-1 text-slate-900">{schedule.guest_name}</span>
+                <a
+                  href={`mailto:${schedule.guest_email}`}
+                  class="ml-1 text-blue-600 hover:underline"
+                >
+                  {schedule.guest_email}
+                </a>
+              </div>
+              {schedule.google_meet_url && (
+                <div>
+                  <a
+                    href={schedule.google_meet_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 transition-colors"
+                  >
+                    Join Google Meet
+                  </a>
+                </div>
+              )}
+              {schedule.google_event_link && (
+                <div>
+                  <a
+                    href={schedule.google_event_link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:underline"
+                  >
+                    View Calendar Event
+                  </a>
+                </div>
+              )}
+            </div>
+          )
+        }
+        {
+          !schedule && assessment.scheduled_at && (
+            <div class="text-sm text-slate-500">
+              Scheduled: {formatDateTime(assessment.scheduled_at)}
+            </div>
+          )
+        }
+      </div>
+
+      {/* Live Notes */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-base font-semibold text-slate-900">Live Notes</h3>
+          <span id="save-status" class="text-xs text-slate-400">Saved</span>
+        </div>
+        <textarea
+          id="live-notes"
+          rows="10"
+          class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
+          placeholder="Take notes during the call...">{liveNotesValue}</textarea
+        >
+      </div>
+
+      {/* Complete Assessment Form (collapsible) */}
+      <div class="bg-white rounded-lg border border-slate-200 mb-6">
+        <button
+          type="button"
+          id="toggle-complete"
+          class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-slate-50 transition-colors"
+        >
+          <h3 class="text-base font-semibold text-slate-900">Complete Assessment</h3>
+          <svg
+            id="toggle-icon"
+            class="w-5 h-5 text-slate-400 transition-transform"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"
+            ></path>
+          </svg>
+        </button>
+
+        <div id="complete-form" class="hidden px-6 pb-6 border-t border-slate-100">
+          <form
+            method="POST"
+            action={`/api/admin/assessments/${assessmentId}/complete`}
+            enctype="multipart/form-data"
+            class="space-y-6 pt-4"
+          >
+            {/* Problems identified */}
+            <div>
+              <label class="block text-sm font-medium text-slate-700 mb-2"
+                >Problems Identified</label
+              >
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+                <label class="flex items-center gap-2 text-sm text-slate-700">
+                  <input type="checkbox" name="owner_bottleneck" class="rounded border-slate-300" />
+                  Owner bottleneck
+                </label>
+                <label class="flex items-center gap-2 text-sm text-slate-700">
+                  <input type="checkbox" name="lead_leakage" class="rounded border-slate-300" />
+                  Lead leakage
+                </label>
+                <label class="flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="checkbox"
+                    name="financial_blindness"
+                    class="rounded border-slate-300"
+                  />
+                  Financial blindness
+                </label>
+                <label class="flex items-center gap-2 text-sm text-slate-700">
+                  <input type="checkbox" name="scheduling_chaos" class="rounded border-slate-300" />
+                  Scheduling chaos
+                </label>
+                <label class="flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="checkbox"
+                    name="manual_communication"
+                    class="rounded border-slate-300"
+                  />
+                  Manual communication
+                </label>
+                <label class="flex items-center gap-2 text-sm text-slate-700">
+                  <input
+                    type="checkbox"
+                    name="employee_retention"
+                    class="rounded border-slate-300"
+                  />
+                  Employee retention
+                </label>
+              </div>
+              <div class="mt-2">
+                <input
+                  type="text"
+                  name="other_problem"
+                  placeholder="Other (describe)"
+                  class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                />
+              </div>
+            </div>
+
+            {/* Disqualifiers */}
+            <div class="border border-slate-200 rounded-lg p-4">
+              <label class="flex items-center gap-2 text-sm text-slate-700 mb-2">
+                <input
+                  type="checkbox"
+                  name="disqualified"
+                  id="disqualified-check"
+                  class="rounded border-slate-300"
+                />
+                <span class="font-medium">Disqualified</span>
+              </label>
+              <input
+                type="text"
+                name="disqualify_reason"
+                id="disqualify-reason"
+                placeholder="Reason for disqualification"
+                class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:opacity-50 disabled:bg-slate-50"
+                disabled
+              />
+            </div>
+
+            {/* Duration */}
+            <div>
+              <label for="duration_minutes" class="block text-sm font-medium text-slate-700 mb-1"
+                >Duration (minutes)</label
+              >
+              <input
+                type="number"
+                name="duration_minutes"
+                id="duration_minutes"
+                min="1"
+                max="300"
+                placeholder="30"
+                class="w-32 text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              />
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label for="complete-notes" class="block text-sm font-medium text-slate-700 mb-1"
+                >Notes</label
+              >
+              <textarea
+                name="notes"
+                id="complete-notes"
+                rows="4"
+                class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                placeholder="Assessment notes..."></textarea>
+            </div>
+
+            {/* Transcript upload */}
+            <div>
+              <label for="transcript" class="block text-sm font-medium text-slate-700 mb-1"
+                >Transcript (optional)</label
+              >
+              <input
+                type="file"
+                name="transcript"
+                id="transcript"
+                accept=".txt,.md,.pdf,.doc,.docx"
+                class="text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200"
+              />
+            </div>
+
+            {/* Submit */}
+            <div class="flex items-center gap-3 pt-2">
+              <button
+                type="submit"
+                class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-lg hover:bg-green-700 transition-colors font-medium"
+              >
+                Complete & Draft Proposal
+              </button>
+              <span class="text-xs text-slate-400"
+                >Creates a draft quote and transitions to proposing stage</span
+              >
+            </div>
+          </form>
+        </div>
+      </div>
+
+      {/* Entity Context Timeline */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6">
+        <h3 class="text-base font-semibold text-slate-900 mb-4">
+          Entity Context Timeline
+          <span class="text-sm font-normal text-slate-400 ml-1"
+            >({contextEntries.length} entries)</span
+          >
+        </h3>
+
+        {
+          timelineEntries.length === 0 && (
+            <p class="text-sm text-slate-400">No context entries yet.</p>
+          )
+        }
+
+        <div class="space-y-3">
+          {
+            timelineEntries.map((entry) => (
+              <div class="border border-slate-100 rounded-lg p-3">
+                <div class="flex items-center gap-2 mb-1">
+                  <span class={`text-xs px-1.5 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
+                    {entry.type.replace(/_/g, ' ')}
+                  </span>
+                  <span class="text-xs text-slate-400">{entry.source}</span>
+                  <span class="text-xs text-slate-300 ml-auto">{formatDate(entry.created_at)}</span>
+                </div>
+                <div class="text-sm text-slate-700 whitespace-pre-wrap break-words">
+                  {entry.content.length > 500 ? entry.content.slice(0, 500) + '...' : entry.content}
+                </div>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </main>
+
+    <script define:vars={{ assessmentId }}>
+      // Live notes auto-save
+      const textarea = document.getElementById('live-notes')
+      const saveStatus = document.getElementById('save-status')
+      let saveTimer = null
+      let lastSaved = textarea?.value ?? ''
+
+      async function saveLiveNotes() {
+        const value = textarea?.value ?? ''
+        if (value === lastSaved) return
+
+        saveStatus.textContent = 'Saving...'
+        try {
+          const res = await fetch(`/api/admin/assessments/${assessmentId}/live-notes`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ live_notes: value }),
+          })
+          if (res.ok) {
+            lastSaved = value
+            saveStatus.textContent = 'Saved'
+          } else {
+            saveStatus.textContent = 'Save failed'
+          }
+        } catch {
+          saveStatus.textContent = 'Save failed'
+        }
+      }
+
+      textarea?.addEventListener('input', () => {
+        saveStatus.textContent = 'Unsaved changes'
+        clearTimeout(saveTimer)
+        saveTimer = setTimeout(saveLiveNotes, 10000) // 10 second auto-save
+      })
+
+      // Save on blur (tab away)
+      textarea?.addEventListener('blur', () => {
+        clearTimeout(saveTimer)
+        saveLiveNotes()
+      })
+
+      // Toggle complete form
+      const toggleBtn = document.getElementById('toggle-complete')
+      const completeForm = document.getElementById('complete-form')
+      const toggleIcon = document.getElementById('toggle-icon')
+
+      toggleBtn?.addEventListener('click', () => {
+        completeForm?.classList.toggle('hidden')
+        toggleIcon?.classList.toggle('rotate-180')
+      })
+
+      // Disqualifier checkbox controls reason input
+      const dqCheck = document.getElementById('disqualified-check')
+      const dqReason = document.getElementById('disqualify-reason')
+
+      dqCheck?.addEventListener('change', () => {
+        dqReason.disabled = !dqCheck.checked
+        if (!dqCheck.checked) dqReason.value = ''
+      })
+
+      // Pre-fill completion notes from live notes
+      const completeNotes = document.getElementById('complete-notes')
+      toggleBtn?.addEventListener('click', () => {
+        if (completeNotes && !completeNotes.value && textarea?.value) {
+          completeNotes.value = textarea.value
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/src/pages/api/admin/assessments/[id]/complete.ts
+++ b/src/pages/api/admin/assessments/[id]/complete.ts
@@ -1,0 +1,176 @@
+import type { APIRoute } from 'astro'
+import {
+  getAssessment,
+  updateAssessment,
+  updateAssessmentStatus,
+} from '../../../../../lib/db/assessments'
+import { getEntity, transitionStage } from '../../../../../lib/db/entities'
+import { appendContext } from '../../../../../lib/db/context'
+import { createQuote, type LineItem } from '../../../../../lib/db/quotes'
+import { uploadTranscript } from '../../../../../lib/storage/r2'
+
+/** Default hourly rate at launch (per Decision Stack). */
+const DEFAULT_RATE = 150
+
+/**
+ * POST /api/admin/assessments/:id/complete
+ *
+ * Completes an assessment: builds extraction JSON, transitions status,
+ * appends context, creates a draft quote, and redirects to the new quote.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const assessmentId = params.id
+  if (!assessmentId) {
+    return new Response(JSON.stringify({ error: 'Assessment ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const assessment = await getAssessment(env.DB, session.orgId, assessmentId)
+    if (!assessment) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    const entity = await getEntity(env.DB, session.orgId, assessment.entity_id)
+    if (!entity) {
+      return redirect('/admin/entities?error=entity_not_found', 302)
+    }
+
+    const formData = await request.formData()
+
+    // 1. Build extraction JSON from form data
+    const problemKeys = [
+      'owner_bottleneck',
+      'lead_leakage',
+      'financial_blindness',
+      'scheduling_chaos',
+      'manual_communication',
+      'employee_retention',
+    ]
+    const problems: string[] = []
+    for (const key of problemKeys) {
+      if (formData.get(key) === 'on') {
+        problems.push(key)
+      }
+    }
+    const otherProblem = formData.get('other_problem')
+    if (otherProblem && typeof otherProblem === 'string' && otherProblem.trim()) {
+      problems.push(`other: ${otherProblem.trim()}`)
+    }
+
+    const disqualified = formData.get('disqualified') === 'on'
+    const disqualifyReason = formData.get('disqualify_reason')
+    const durationStr = formData.get('duration_minutes')
+    const duration =
+      durationStr && typeof durationStr === 'string' ? parseInt(durationStr, 10) || null : null
+    const notes = formData.get('notes')
+    const notesStr = notes && typeof notes === 'string' ? notes.trim() : ''
+
+    const extraction = {
+      problems,
+      disqualified,
+      disqualify_reason:
+        disqualified && disqualifyReason && typeof disqualifyReason === 'string'
+          ? disqualifyReason.trim()
+          : null,
+      duration_minutes: duration,
+      notes: notesStr,
+      completed_at: new Date().toISOString(),
+    }
+
+    // Handle transcript upload if provided
+    let transcriptPath: string | undefined
+    const transcriptFile = formData.get('transcript')
+    if (transcriptFile && transcriptFile instanceof File && transcriptFile.size > 0) {
+      transcriptPath = await uploadTranscript(
+        env.STORAGE,
+        session.orgId,
+        assessmentId,
+        transcriptFile
+      )
+    }
+
+    // 2. Update assessment status to completed (auto-sets completed_at)
+    await updateAssessmentStatus(env.DB, session.orgId, assessmentId, 'completed')
+
+    // 3. Write extraction JSON and duration to assessment
+    await updateAssessment(env.DB, session.orgId, assessmentId, {
+      extraction: JSON.stringify(extraction),
+      duration_minutes: duration,
+      ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
+    })
+
+    // 4. Append extraction context entry on the entity
+    await appendContext(env.DB, session.orgId, {
+      entity_id: entity.id,
+      type: 'extraction',
+      content: JSON.stringify(extraction, null, 2),
+      source: 'assessment_completion',
+      source_ref: assessmentId,
+    })
+
+    // If disqualified, transition to lost and redirect back
+    if (disqualified) {
+      try {
+        await updateAssessmentStatus(env.DB, session.orgId, assessmentId, 'disqualified')
+        await transitionStage(
+          env.DB,
+          session.orgId,
+          entity.id,
+          'lost',
+          `Disqualified during assessment: ${extraction.disqualify_reason ?? 'No reason provided'}`
+        )
+      } catch {
+        // Stage transition may fail if already in lost state
+      }
+      return redirect(`/admin/entities/${entity.id}?assessment_completed=1`, 302)
+    }
+
+    // 5. Transition entity stage to proposing
+    try {
+      await transitionStage(env.DB, session.orgId, entity.id, 'proposing', 'Assessment completed.')
+    } catch {
+      // May fail if already proposing or further along
+    }
+
+    // 6. Generate quote line items (best-effort, #236 not yet built)
+    let lineItems: LineItem[] = []
+    try {
+      // generateQuoteLineItems is #236 -- not yet implemented.
+      // When it ships, import and call it here:
+      // const { generateQuoteLineItems } = await import('../../../../../lib/claude/quote-lines')
+      // lineItems = await generateQuoteLineItems(extraction, entityContext)
+      lineItems = []
+    } catch {
+      lineItems = []
+    }
+
+    // 7. Create draft quote with pre-filled line items
+    const quote = await createQuote(env.DB, session.orgId, {
+      entityId: entity.id,
+      assessmentId,
+      lineItems,
+      rate: DEFAULT_RATE,
+    })
+
+    // 8. Redirect to quote builder
+    return redirect(`/admin/entities/${entity.id}?quote_created=${quote.id}`, 302)
+  } catch (err) {
+    console.error('[api/admin/assessments/[id]/complete] Error:', err)
+    return redirect('/admin/entities?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/assessments/[id]/live-notes.ts
+++ b/src/pages/api/admin/assessments/[id]/live-notes.ts
@@ -1,0 +1,54 @@
+import type { APIRoute } from 'astro'
+import { getAssessment, updateAssessment } from '../../../../../lib/db/assessments'
+
+/**
+ * PUT /api/admin/assessments/:id/live-notes
+ *
+ * Auto-saves live notes for an assessment during the call.
+ * Accepts JSON body: { live_notes: string }
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+export const PUT: APIRoute = async ({ request, locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return jsonResponse(401, { error: 'Unauthorized' })
+  }
+
+  const assessmentId = params.id
+  if (!assessmentId) {
+    return jsonResponse(400, { error: 'Assessment ID required' })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const body = (await request.json()) as Record<string, unknown>
+    const liveNotes = body.live_notes
+
+    if (typeof liveNotes !== 'string') {
+      return jsonResponse(400, { error: 'live_notes must be a string' })
+    }
+
+    const existing = await getAssessment(env.DB, session.orgId, assessmentId)
+    if (!existing) {
+      return jsonResponse(404, { error: 'Assessment not found' })
+    }
+
+    await updateAssessment(env.DB, session.orgId, assessmentId, {
+      live_notes: liveNotes,
+    })
+
+    return jsonResponse(200, { ok: true })
+  } catch (err) {
+    console.error('[api/admin/assessments/[id]/live-notes] Error:', err)
+    return jsonResponse(500, { error: 'Internal server error' })
+  }
+}
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## Summary

- Add admin assessment detail page (`/admin/assessments/[id]`) with entity info, assessment schedule sidecar (Google Meet link, contact details, timezone), and live notes textarea with 10-second auto-save
- Add collapsible completion form with the 6 universal SMB problems checkboxes, disqualifier handling, duration, notes, and transcript upload
- Add POST `/api/admin/assessments/[id]/complete` endpoint that builds extraction JSON, transitions assessment to completed, appends extraction context on the entity, transitions entity stage to proposing, and creates a draft quote
- Add PUT `/api/admin/assessments/[id]/live-notes` endpoint for auto-saving notes during the call
- Add migration 0013 to add `live_notes` column to assessments table
- Update Assessment DAL interface and `updateAssessment` to support `live_notes`

## What This Enables

This is the admin's primary tool during a live assessment call. The page surfaces all entity context, the Google Meet link, and provides a notepad. After the call, the admin fills the completion form, which creates a draft quote and moves the entity into the proposing stage -- enabling the next step in the lifecycle (#236 quote line item generation).

## Test plan

- [ ] Verify migration 0013 applies cleanly on local D1
- [ ] Navigate to `/admin/assessments/{id}` for a scheduled assessment
- [ ] Verify entity info, stage badge, schedule details, and Meet link display correctly
- [ ] Type in live notes textarea, wait 10s, verify auto-save via network tab
- [ ] Expand completion form, check problems, fill duration/notes, submit
- [ ] Verify assessment status transitions to completed
- [ ] Verify entity stage transitions to proposing
- [ ] Verify draft quote is created
- [ ] Test disqualifier flow: check disqualified, verify entity transitions to lost
- [ ] Verify `npm run verify` passes (0 errors, 936 tests)

Closes #235