### PR TITLE
feat(lifecycle): quote builder UI + SOW PDF generation (#72)

### DIFF
--- a/migrations/0013_add_sow_generated_at.sql
+++ b/migrations/0013_add_sow_generated_at.sql
@@ -1,0 +1,8 @@
+-- Migration 0013: Add sow_generated_at to quotes table
+--
+-- Supports OQ-006 (stale PDF warning): when the quote is modified after the
+-- last PDF generation, the UI shows a warning banner prompting re-generation.
+--
+-- The column is nullable because most quotes have never had a PDF generated.
+
+ALTER TABLE quotes ADD COLUMN sow_generated_at TEXT;

--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -31,6 +31,7 @@ export interface Quote {
   sow_path: string | null
   signed_sow_path: string | null
   signwell_doc_id: string | null
+  sow_generated_at: string | null
   created_at: string
   updated_at: string
 }
@@ -84,6 +85,7 @@ export interface UpdateQuoteData {
   rate?: number
   depositPct?: number
   sow_path?: string | null
+  sow_generated_at?: string | null
 }
 
 /**
@@ -219,6 +221,11 @@ export async function updateQuote(
   if (data.sow_path !== undefined) {
     fields.push('sow_path = ?')
     params.push(data.sow_path)
+  }
+
+  if (data.sow_generated_at !== undefined) {
+    fields.push('sow_generated_at = ?')
+    params.push(data.sow_generated_at)
   }
 
   // Recalculate totals if line items or rate changed

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -798,7 +798,10 @@ function confidenceColor(confidence: string): string {
             </summary>
             <div class="px-6 pb-4 divide-y divide-slate-100">
               {quotes.map((q) => (
-                <div class="py-2 flex items-center gap-2">
+                <a
+                  href={`/admin/entities/${entity.id}/quotes/${q.id}`}
+                  class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
+                >
                   <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(q.status)}`}>
                     {q.status}
                   </span>
@@ -807,7 +810,7 @@ function confidenceColor(confidence: string): string {
                   </span>
                   <span class="text-xs text-slate-400">{q.total_hours} hrs</span>
                   <span class="text-xs text-slate-400">v{q.version}</span>
-                </div>
+                </a>
               ))}
             </div>
           </details>

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -1,0 +1,675 @@
+---
+import '../../../../../styles/global.css'
+import { getEntity } from '../../../../../lib/db/entities'
+import { getQuote, QUOTE_STATUSES, VALID_TRANSITIONS } from '../../../../../lib/db/quotes'
+import type { LineItem, QuoteStatus } from '../../../../../lib/db/quotes'
+
+/**
+ * Quote builder — admin page for editing line items, generating SOW PDFs,
+ * and managing quote status transitions.
+ *
+ * Business rules:
+ * - Client never sees hourly rate or per-item pricing (Decision #16)
+ * - 5-day expiration from when quote is sent (Decision #18)
+ * - Soft warning at 3+ line items (OQ-005)
+ * - Stale PDF warning if quote modified after last generation (OQ-006)
+ * - No hourly breakdown in SOW PDF (UX-003)
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+
+const session = Astro.locals.session!
+const env = Astro.locals.runtime.env
+const entityId = Astro.params.id!
+const quoteId = Astro.params.quoteId!
+
+const [entity, quote] = await Promise.all([
+  getEntity(env.DB, session.orgId, entityId),
+  getQuote(env.DB, session.orgId, quoteId),
+])
+
+if (!entity) return Astro.redirect('/admin/entities?error=not_found')
+if (!quote) return Astro.redirect(`/admin/entities/${entityId}?error=not_found`)
+
+const lineItems: LineItem[] = JSON.parse(quote.line_items)
+const status = quote.status as QuoteStatus
+const validTransitions = VALID_TRANSITIONS[status] ?? []
+const isDraft = status === 'draft'
+const isTerminal = validTransitions.length === 0
+
+// Stale PDF detection (OQ-006)
+const hasSow = !!quote.sow_path
+const sowGeneratedAt = quote.sow_generated_at ? new Date(quote.sow_generated_at) : null
+const updatedAt = new Date(quote.updated_at)
+const isSowStale = hasSow && sowGeneratedAt && updatedAt > sowGeneratedAt
+
+// Expiration
+const expiresAt = quote.expires_at ? new Date(quote.expires_at) : null
+const isExpired = expiresAt && expiresAt < new Date()
+
+// Payment structure
+const isThreeMilestone = quote.total_hours >= 40
+const depositPct = quote.deposit_pct
+
+// URL params
+const saved = Astro.url.searchParams.get('saved')
+const error = Astro.url.searchParams.get('error')
+
+function statusBadgeClass(s: string): string {
+  const map: Record<string, string> = {
+    draft: 'bg-slate-100 text-slate-600',
+    sent: 'bg-blue-100 text-blue-700',
+    accepted: 'bg-green-100 text-green-700',
+    declined: 'bg-red-100 text-red-700',
+    expired: 'bg-slate-100 text-slate-500',
+    superseded: 'bg-slate-100 text-slate-400',
+  }
+  return map[s] ?? 'bg-slate-100 text-slate-600'
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatCurrency(amount: number): string {
+  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Quote — {entity.name} — SMD Services</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <header class="bg-white border-b border-slate-200">
+      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-4 py-8">
+      <nav class="text-sm text-slate-500 mb-4">
+        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
+        <span class="mx-1">/</span>
+        <a
+          href={`/admin/entities?stage=${entity.stage}`}
+          class="hover:text-primary transition-colors">Entities</a
+        >
+        <span class="mx-1">/</span>
+        <a href={`/admin/entities/${entityId}`} class="hover:text-primary transition-colors"
+          >{entity.name}</a
+        >
+        <span class="mx-1">/</span>
+        <span class="text-slate-900">Quote</span>
+      </nav>
+
+      {
+        saved && (
+          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+            Quote saved.
+          </div>
+        )
+      }
+      {
+        error && (
+          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+            {error === 'invalid_transition'
+              ? 'Invalid status transition.'
+              : error === 'no_sow'
+                ? 'Generate a SOW PDF first.'
+                : error === 'already_sent'
+                  ? 'SOW already sent for signature.'
+                  : error === 'no_contact_email'
+                    ? 'No contact email found. Add a contact with email first.'
+                    : error === 'client_not_found'
+                      ? 'Client not found.'
+                      : decodeURIComponent(error)}
+          </div>
+        )
+      }
+
+      {/* Stale PDF warning (OQ-006) */}
+      {
+        isSowStale && (
+          <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-lg mb-4">
+            The quote has been modified since the last SOW PDF was generated. Re-generate the PDF
+            before sending.
+          </div>
+        )
+      }
+
+      {/* Header */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <div class="flex items-center gap-3 mb-2">
+              <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(status)}`}>
+                {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
+              </span>
+            </div>
+            <div class="flex items-center gap-4 text-sm text-slate-500">
+              <span>Created {formatDate(quote.created_at)}</span>
+              {
+                expiresAt && (
+                  <span class={isExpired ? 'text-red-600 font-medium' : ''}>
+                    {isExpired ? 'Expired' : 'Expires'} {formatDate(quote.expires_at!)}
+                  </span>
+                )
+              }
+              <span>Rate: {formatCurrency(quote.rate)}/hr</span>
+              <span>v{quote.version}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Line Item Editor */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-semibold text-slate-900">Line Items</h3>
+          <div id="line-item-warning" class="hidden text-sm text-amber-600 font-medium">
+            Consider keeping scope focused — 3+ line items may indicate too broad an engagement
+            (OQ-005)
+          </div>
+        </div>
+
+        <div id="line-items-container">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-slate-200">
+                <th class="text-left py-2 px-2 text-slate-500 font-medium w-8">#</th>
+                <th class="text-left py-2 px-2 text-slate-500 font-medium w-48">Problem</th>
+                <th class="text-left py-2 px-2 text-slate-500 font-medium">Description</th>
+                <th class="text-right py-2 px-2 text-slate-500 font-medium w-24">Est. Hours</th>
+                {isDraft && <th class="py-2 px-2 w-10" />}
+              </tr>
+            </thead>
+            <tbody id="line-items-body">
+              {
+                lineItems.map((item, index) => (
+                  <tr class="border-b border-slate-100 line-item-row" data-index={index}>
+                    <td class="py-2 px-2 text-slate-400 row-number">{index + 1}</td>
+                    <td class="py-2 px-2">
+                      {isDraft ? (
+                        <input
+                          type="text"
+                          class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem"
+                          value={item.problem}
+                          placeholder="e.g., Scheduling chaos"
+                        />
+                      ) : (
+                        <span class="text-slate-700">{item.problem}</span>
+                      )}
+                    </td>
+                    <td class="py-2 px-2">
+                      {isDraft ? (
+                        <input
+                          type="text"
+                          class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-description"
+                          value={item.description}
+                          placeholder="What we'll deliver"
+                        />
+                      ) : (
+                        <span class="text-slate-700">{item.description}</span>
+                      )}
+                    </td>
+                    <td class="py-2 px-2 text-right">
+                      {isDraft ? (
+                        <input
+                          type="number"
+                          class="w-20 border border-slate-200 rounded px-2 py-1 text-sm text-right item-hours"
+                          value={item.estimated_hours}
+                          min="0.5"
+                          step="0.5"
+                        />
+                      ) : (
+                        <span class="text-slate-700">{item.estimated_hours}</span>
+                      )}
+                    </td>
+                    {isDraft && (
+                      <td class="py-2 px-2 text-center">
+                        <button
+                          type="button"
+                          class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn"
+                          title="Remove"
+                        >
+                          &times;
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
+
+          {
+            isDraft && (
+              <button
+                type="button"
+                id="add-line-item-btn"
+                class="mt-3 text-sm text-primary hover:text-primary-hover transition-colors font-medium"
+              >
+                + Add line item
+              </button>
+            )
+          }
+        </div>
+
+        {/* Totals */}
+        <div class="mt-4 pt-4 border-t border-slate-200 flex justify-end">
+          <div class="text-right space-y-1">
+            <div class="text-sm text-slate-500">
+              Total hours: <span id="total-hours" class="font-medium text-slate-900"
+                >{quote.total_hours}</span
+              >
+            </div>
+            <div class="text-lg font-semibold text-slate-900">
+              Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Payment Structure */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <h3 class="text-lg font-semibold text-slate-900 mb-4">Payment Structure</h3>
+
+        <div class="space-y-3">
+          <div class="flex items-center gap-4">
+            <label class="text-sm text-slate-600 w-36">Deposit percentage:</label>
+            {
+              isDraft ? (
+                <select
+                  id="deposit-pct-select"
+                  class="border border-slate-200 rounded px-2 py-1 text-sm"
+                >
+                  <option value="0.5" selected={depositPct === 0.5}>
+                    50%
+                  </option>
+                  <option value="0.4" selected={depositPct === 0.4}>
+                    40%
+                  </option>
+                </select>
+              ) : (
+                <span class="text-sm text-slate-900">{Math.round(depositPct * 100)}%</span>
+              )
+            }
+          </div>
+
+          {
+            isThreeMilestone && (
+              <div class="text-sm text-amber-600 bg-amber-50 border border-amber-200 px-3 py-2 rounded">
+                40+ hour engagement — 3-milestone payment applies (40% deposit, 30% mid-engagement,
+                30% completion)
+              </div>
+            )
+          }
+
+          <div class="text-sm text-slate-600 space-y-1">
+            <div class="flex justify-between max-w-xs">
+              <span>Deposit:</span>
+              <span id="deposit-amount" class="font-medium text-slate-900">
+                {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
+              </span>
+            </div>
+            {
+              isThreeMilestone ? (
+                <>
+                  <div class="flex justify-between max-w-xs">
+                    <span>Mid-engagement milestone:</span>
+                    <span class="font-medium text-slate-900">
+                      {formatCurrency(quote.total_price * 0.3)}
+                    </span>
+                  </div>
+                  <div class="flex justify-between max-w-xs">
+                    <span>Completion:</span>
+                    <span class="font-medium text-slate-900">
+                      {formatCurrency(quote.total_price * 0.3)}
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <div class="flex justify-between max-w-xs">
+                  <span>Completion:</span>
+                  <span id="completion-amount" class="font-medium text-slate-900">
+                    {formatCurrency(quote.total_price * (1 - depositPct))}
+                  </span>
+                </div>
+              )
+            }
+          </div>
+        </div>
+      </div>
+
+      {/* SOW PDF Status */}
+      {
+        hasSow && (
+          <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+            <h3 class="text-lg font-semibold text-slate-900 mb-2">SOW PDF</h3>
+            <div class="text-sm text-slate-600 space-y-1">
+              <div>
+                Generated: {sowGeneratedAt ? formatDate(quote.sow_generated_at!) : 'Unknown'}
+              </div>
+              {quote.signwell_doc_id && (
+                <div class="text-green-700">Sent for signature via SignWell</div>
+              )}
+            </div>
+          </div>
+        )
+      }
+
+      {/* Actions */}
+      <div class="bg-white rounded-lg border border-slate-200 p-6">
+        <h3 class="text-lg font-semibold text-slate-900 mb-4">Actions</h3>
+        <div class="flex flex-wrap gap-3">
+          {/* Save Draft */}
+          {
+            isDraft && (
+              <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="save-form">
+                <input type="hidden" name="action" value="update" />
+                <input
+                  type="hidden"
+                  name="line_items"
+                  id="save-line-items"
+                  value={JSON.stringify(lineItems)}
+                />
+                <input
+                  type="hidden"
+                  name="deposit_pct"
+                  id="save-deposit-pct"
+                  value={String(depositPct)}
+                />
+                <button
+                  type="submit"
+                  class="px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors text-sm font-medium"
+                >
+                  Save Draft
+                </button>
+              </form>
+            )
+          }
+
+          {/* Generate SOW PDF */}
+          {
+            isDraft && (
+              <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="generate-pdf-form">
+                <input type="hidden" name="action" value="generate-pdf" />
+                <button
+                  type="submit"
+                  class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors text-sm font-medium"
+                  id="generate-pdf-btn"
+                >
+                  {hasSow ? 'Re-generate SOW PDF' : 'Generate SOW PDF'}
+                </button>
+              </form>
+            )
+          }
+
+          {/* Send via SignWell */}
+          {
+            (isDraft || status === 'sent') && hasSow && !quote.signwell_doc_id && (
+              <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
+                <button
+                  type="submit"
+                  class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors text-sm font-medium"
+                  id="sign-btn"
+                >
+                  Send via SignWell
+                </button>
+              </form>
+            )
+          }
+
+          {/* Send (mark as sent without SignWell) */}
+          {
+            isDraft && hasSow && (
+              <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+                <input type="hidden" name="action" value="send" />
+                <button
+                  type="submit"
+                  class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors text-sm font-medium"
+                >
+                  Mark as Sent
+                </button>
+              </form>
+            )
+          }
+
+          {/* Decline */}
+          {
+            validTransitions.includes('declined') && (
+              <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+                <input type="hidden" name="action" value="decline" />
+                <button
+                  type="submit"
+                  class="px-4 py-2 bg-slate-100 text-slate-600 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
+                >
+                  Decline
+                </button>
+              </form>
+            )
+          }
+
+          {/* Mark Expired */}
+          {
+            validTransitions.includes('expired') && (
+              <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+                <input type="hidden" name="action" value="expire" />
+                <button
+                  type="submit"
+                  class="px-4 py-2 bg-slate-100 text-slate-500 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
+                >
+                  Mark Expired
+                </button>
+              </form>
+            )
+          }
+        </div>
+
+        {
+          isTerminal && (
+            <p class="mt-3 text-sm text-slate-500">
+              This quote is in a terminal state ({status}) and cannot be modified.
+            </p>
+          )
+        }
+      </div>
+    </main>
+
+    <script define:vars={{ lineItems, isDraft, rate: quote.rate }}>
+      if (!isDraft) {
+        // Read-only mode — no interactive behavior needed
+      } else {
+        const body = document.getElementById('line-items-body')
+        const addBtn = document.getElementById('add-line-item-btn')
+        const warning = document.getElementById('line-item-warning')
+        const totalHoursEl = document.getElementById('total-hours')
+        const totalPriceEl = document.getElementById('total-price')
+        const depositAmountEl = document.getElementById('deposit-amount')
+        const completionAmountEl = document.getElementById('completion-amount')
+        const depositSelect = document.getElementById('deposit-pct-select')
+        const saveLineItemsInput = document.getElementById('save-line-items')
+        const saveDepositPctInput = document.getElementById('save-deposit-pct')
+        const generatePdfBtn = document.getElementById('generate-pdf-btn')
+        const signBtn = document.getElementById('sign-btn')
+
+        function getLineItems() {
+          const rows = body.querySelectorAll('.line-item-row')
+          const items = []
+          rows.forEach((row) => {
+            const problem = row.querySelector('.item-problem')?.value ?? ''
+            const description = row.querySelector('.item-description')?.value ?? ''
+            const hours = parseFloat(row.querySelector('.item-hours')?.value ?? '0')
+            if (problem.trim() || description.trim()) {
+              items.push({
+                problem: problem.trim(),
+                description: description.trim(),
+                estimated_hours: isNaN(hours) ? 0 : hours,
+              })
+            }
+          })
+          return items
+        }
+
+        function recalculate() {
+          const items = getLineItems()
+          const totalHours = items.reduce((sum, item) => sum + item.estimated_hours, 0)
+          const totalPrice = totalHours * rate
+          const depositPct = parseFloat(depositSelect?.value ?? '0.5')
+
+          if (totalHoursEl) totalHoursEl.textContent = String(totalHours)
+          if (totalPriceEl) {
+            totalPriceEl.textContent =
+              '$' +
+              totalPrice.toLocaleString('en-US', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              })
+          }
+
+          const depositAmount = totalPrice * depositPct
+          const completionAmount = totalPrice * (1 - depositPct)
+          if (depositAmountEl) {
+            depositAmountEl.textContent =
+              '$' +
+              depositAmount.toLocaleString('en-US', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              })
+          }
+          if (completionAmountEl) {
+            completionAmountEl.textContent =
+              '$' +
+              completionAmount.toLocaleString('en-US', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              })
+          }
+
+          // OQ-005: soft warning at 3+ line items
+          if (warning) {
+            warning.classList.toggle('hidden', items.length < 3)
+          }
+
+          // Update hidden form fields
+          if (saveLineItemsInput) saveLineItemsInput.value = JSON.stringify(items)
+          if (saveDepositPctInput) saveDepositPctInput.value = String(depositPct)
+
+          renumberRows()
+        }
+
+        function renumberRows() {
+          const rows = body.querySelectorAll('.line-item-row')
+          rows.forEach((row, i) => {
+            const num = row.querySelector('.row-number')
+            if (num) num.textContent = String(i + 1)
+            row.setAttribute('data-index', String(i))
+          })
+        }
+
+        function addRow() {
+          const index = body.querySelectorAll('.line-item-row').length
+          const tr = document.createElement('tr')
+          tr.className = 'border-b border-slate-100 line-item-row'
+          tr.setAttribute('data-index', String(index))
+          tr.innerHTML = `
+            <td class="py-2 px-2 text-slate-400 row-number">${index + 1}</td>
+            <td class="py-2 px-2">
+              <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
+            </td>
+            <td class="py-2 px-2">
+              <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
+            </td>
+            <td class="py-2 px-2 text-right">
+              <input type="number" class="w-20 border border-slate-200 rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
+            </td>
+            <td class="py-2 px-2 text-center">
+              <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
+            </td>
+          `
+          body.appendChild(tr)
+          recalculate()
+        }
+
+        if (addBtn) addBtn.addEventListener('click', addRow)
+
+        // Event delegation for remove buttons and input changes
+        body.addEventListener('click', (e) => {
+          if (e.target.classList.contains('remove-item-btn')) {
+            const row = e.target.closest('.line-item-row')
+            if (row && body.querySelectorAll('.line-item-row').length > 1) {
+              row.remove()
+              recalculate()
+            }
+          }
+        })
+
+        body.addEventListener('input', recalculate)
+        if (depositSelect) depositSelect.addEventListener('change', recalculate)
+
+        // Before form submit, sync line items to hidden field
+        const saveForm = document.getElementById('save-form')
+        if (saveForm) {
+          saveForm.addEventListener('submit', () => {
+            recalculate()
+          })
+        }
+
+        // Disable buttons on submit to prevent double-clicks
+        const generatePdfForm = document.getElementById('generate-pdf-form')
+        if (generatePdfForm && generatePdfBtn) {
+          generatePdfForm.addEventListener('submit', () => {
+            generatePdfBtn.disabled = true
+            generatePdfBtn.textContent = 'Generating...'
+          })
+        }
+
+        const signForm = document.getElementById('sign-form')
+        if (signForm && signBtn) {
+          signForm.addEventListener('submit', () => {
+            signBtn.disabled = true
+            signBtn.textContent = 'Sending...'
+          })
+        }
+
+        // Initial state check for OQ-005
+        if (warning && lineItems.length >= 3) {
+          warning.classList.remove('hidden')
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -131,7 +131,10 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
 
       const pdf = await renderSow(templateProps)
       const sowPath = await uploadPdf(env.STORAGE, session.orgId, quoteId, pdf)
-      await updateQuote(env.DB, session.orgId, quoteId, { sow_path: sowPath })
+      await updateQuote(env.DB, session.orgId, quoteId, {
+        sow_path: sowPath,
+        sow_generated_at: new Date().toISOString(),
+      })
 
       return redirect(`/admin/entities/${existing.entity_id}/quotes/${quoteId}?saved=1`, 302)
     }
@@ -157,6 +160,34 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
         console.error('[api/admin/quotes/[id]] Follow-up scheduling error:', err)
       }
 
+      return redirect(`/admin/entities/${existing.entity_id}/quotes/${quoteId}?saved=1`, 302)
+    }
+
+    // ----- ACTION: decline -----
+    if (action === 'decline') {
+      try {
+        await updateQuoteStatus(env.DB, session.orgId, quoteId, 'declined' as QuoteStatus)
+      } catch (err) {
+        console.error('[api/admin/quotes/[id]] Decline error:', err)
+        return redirect(
+          `/admin/entities/${existing.entity_id}/quotes/${quoteId}?error=invalid_transition`,
+          302
+        )
+      }
+      return redirect(`/admin/entities/${existing.entity_id}/quotes/${quoteId}?saved=1`, 302)
+    }
+
+    // ----- ACTION: expire -----
+    if (action === 'expire') {
+      try {
+        await updateQuoteStatus(env.DB, session.orgId, quoteId, 'expired' as QuoteStatus)
+      } catch (err) {
+        console.error('[api/admin/quotes/[id]] Expire error:', err)
+        return redirect(
+          `/admin/entities/${existing.entity_id}/quotes/${quoteId}?error=invalid_transition`,
+          302
+        )
+      }
       return redirect(`/admin/entities/${existing.entity_id}/quotes/${quoteId}?saved=1`, 302)
     }
 


### PR DESCRIPTION
## Summary

- Add admin quote builder page at `/admin/entities/:id/quotes/:quoteId` with full line item editor, payment structure, SOW PDF generation, and status transition actions
- Add migration 0013 for `sow_generated_at` column to support stale PDF detection (OQ-006)
- Add decline and expire status transition actions to the quotes API endpoint
- Link quotes in entity detail page to the new quote builder

## Business Rules Enforced

- **Decision #16**: Client never sees hourly rate or per-item pricing — admin-only display
- **Decision #18**: 5-day quote expiration
- **OQ-005**: Soft warning at 3+ line items
- **OQ-006**: Stale PDF warning if quote modified after last generation
- **UX-003**: No hourly breakdown in client-facing documents

## Files Changed

- `migrations/0013_add_sow_generated_at.sql` — new column for stale PDF tracking
- `src/lib/db/quotes.ts` — `sow_generated_at` field in Quote interface and UpdateQuoteData
- `src/pages/admin/entities/[id]/quotes/[quoteId].astro` — **new** quote builder page
- `src/pages/admin/entities/[id].astro` — quotes now link to builder
- `src/pages/api/admin/quotes/[id].ts` — decline/expire actions, sow_generated_at on PDF gen

## Test plan

- [ ] Navigate to an entity with a draft quote, click the quote to open the builder
- [ ] Edit line items (add, remove), verify totals recalculate
- [ ] Verify OQ-005 warning appears at 3+ line items
- [ ] Save draft, verify data persists on reload
- [ ] Generate SOW PDF, verify `sow_generated_at` is set
- [ ] Edit quote after PDF generation, verify stale PDF warning (OQ-006)
- [ ] Test status transitions: send, decline, expire
- [ ] Verify SOW PDF contains no hourly rates or per-item hours (Decision #16)
- [ ] Run `npm run verify` — 936 tests pass

Closes #72