### PR TITLE
fix(db): add missing entity_id column to contacts table

### DIFF
--- a/migrations/0013_contacts_add_entity_id.sql
+++ b/migrations/0013_contacts_add_entity_id.sql
@@ -1,0 +1,10 @@
+-- Add entity_id to contacts table.
+--
+-- Migration 0010 dropped client_id from contacts and added entity_id to
+-- assessments, quotes, engagements, invoices, and follow_ups — but missed
+-- contacts. The DAL (src/lib/db/contacts.ts) and the SignWell webhook
+-- handler both reference contacts.entity_id, causing silent failures.
+
+ALTER TABLE contacts ADD COLUMN entity_id TEXT REFERENCES entities(id);
+
+CREATE INDEX idx_contacts_entity_id ON contacts(org_id, entity_id);


### PR DESCRIPTION
## Summary
- Migration 0010 dropped `client_id` from contacts and added `entity_id` to 5 other tables — but missed `contacts`
- The DAL (`src/lib/db/contacts.ts`) and SignWell webhook handler both query `contacts.entity_id`, causing silent failures
- Adds migration 0013 with the missing column + index

## Test plan
- [ ] Verify migration applies cleanly on D1
- [ ] Verify `createContact()` succeeds with entity_id
- [ ] Verify `listContacts()` returns results filtered by entity_id
- [ ] Verify SignWell handler `getClientPrimaryEmail()` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)