### PR TITLE
feat(lifecycle): wire handoff cadence + entity stage transition (#241)

### DIFF
--- a/src/lib/db/engagements.ts
+++ b/src/lib/db/engagements.ts
@@ -5,6 +5,9 @@
  * Primary keys use crypto.randomUUID() (ULID-like uniqueness for D1).
  */
 
+import { scheduleEngagementCadence } from '../follow-ups/scheduler'
+import { transitionStage } from './entities'
+
 export interface Engagement {
   id: string
   org_id: string
@@ -263,7 +266,8 @@ export async function updateEngagementStatus(
   const updates: string[] = ['status = ?', "updated_at = datetime('now')"]
   const params: (string | number | null)[] = [newStatus]
 
-  // When transitioning to handoff, auto-set handoff_date and safety_net_end
+  // When transitioning to handoff, auto-set handoff_date and safety_net_end,
+  // schedule the engagement follow-up cadence, and transition entity to delivered.
   if (newStatus === 'handoff') {
     const handoffDate = new Date()
     const safetyNetEnd = new Date(handoffDate)
@@ -273,6 +277,18 @@ export async function updateEngagementStatus(
     params.push(handoffDate.toISOString())
     updates.push('safety_net_end = ?')
     params.push(safetyNetEnd.toISOString())
+
+    // Schedule handoff follow-up cadence (referral_ask, review_request, safety_net_checkin, feedback_30day)
+    await scheduleEngagementCadence(
+      db,
+      orgId,
+      engagementId,
+      existing.entity_id,
+      handoffDate.toISOString()
+    )
+
+    // Transition entity stage to delivered
+    await transitionStage(db, orgId, existing.entity_id, 'delivered', 'Engagement entered handoff')
   }
 
   // When transitioning to completed, auto-set actual_end

--- a/tests/engagements.test.ts
+++ b/tests/engagements.test.ts
@@ -117,6 +117,45 @@ describe('engagements: data access layer', () => {
   })
 })
 
+describe('engagements: handoff wiring', () => {
+  const source = () => readFileSync(resolve('src/lib/db/engagements.ts'), 'utf-8')
+
+  it('imports scheduleEngagementCadence from scheduler', () => {
+    expect(source()).toContain(
+      "import { scheduleEngagementCadence } from '../follow-ups/scheduler'"
+    )
+  })
+
+  it('imports transitionStage from entities', () => {
+    expect(source()).toContain("import { transitionStage } from './entities'")
+  })
+
+  it('calls scheduleEngagementCadence on handoff transition', () => {
+    const code = source()
+    expect(code).toContain('scheduleEngagementCadence(')
+    expect(code).toContain('existing.entity_id')
+  })
+
+  it('passes correct args to scheduleEngagementCadence: db, orgId, engagementId, entityId, handoffDate', () => {
+    const code = source()
+    expect(code).toContain(
+      'scheduleEngagementCadence(\n      db,\n      orgId,\n      engagementId,\n      existing.entity_id,\n      handoffDate.toISOString()\n    )'
+    )
+  })
+
+  it('calls transitionStage to delivered on handoff', () => {
+    const code = source()
+    expect(code).toContain("transitionStage(db, orgId, existing.entity_id, 'delivered'")
+  })
+
+  it('safety_net_end is set to handoff_date + 14 days on handoff', () => {
+    const code = source()
+    expect(code).toContain("newStatus === 'handoff'")
+    expect(code).toContain('safety_net_end')
+    expect(code).toContain('getDate() + 14')
+  })
+})
+
 describe('engagements: API routes', () => {
   it('create endpoint exists at src/pages/api/admin/engagements/index.ts', () => {
     expect(existsSync(resolve('src/pages/api/admin/engagements/index.ts'))).toBe(true)


### PR DESCRIPTION
## Summary
- Wires handoff cadence and entity stage transition for engagement completion
- Replaces #266 (rebased onto current main)

## Test plan
- [x] `npm run verify` passes (995 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)