### PR TITLE
feat(lifecycle): operator dashboard — single pane of glass (#262)

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,48 +1,85 @@
 ---
 import '../../styles/global.css'
 import { listFollowUps } from '../../lib/db/follow-ups'
-import { getPipelineConversion } from '../../lib/db/analytics'
+import {
+  getPipelineConversion,
+  getRevenueReport,
+  getEngagementHealth,
+  getFollowUpCompliance,
+} from '../../lib/db/analytics'
 import { listEngagements } from '../../lib/db/engagements'
-import { countEntitiesByStage } from '../../lib/db/entities'
+import { listAssessments } from '../../lib/db/assessments'
+import { listEntities } from '../../lib/db/entities'
+import { listInvoices } from '../../lib/db/invoices'
+import { getIntegration } from '../../lib/db/integrations'
 
 /**
- * Admin dashboard — protected by auth middleware.
+ * Operator dashboard — single pane of glass.
  *
- * If you're seeing this page, the session is valid.
- * Session data is available via Astro.locals.session.
+ * Five server-rendered cards. No dynamic JS. Fast load.
  */
 
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
+const now = new Date()
+const todayStr = now.toISOString().split('T')[0]
 
-// Fetch follow-up counts and analytics data in parallel
-const [upcomingFollowUps, overdueFollowUps, pipeline, allEngagements, newSignalCount] =
-  await Promise.all([
-    listFollowUps(env.DB, session.orgId, { upcoming: true }),
-    listFollowUps(env.DB, session.orgId, { overdue: true }),
-    getPipelineConversion(env.DB, session.orgId),
-    listEngagements(env.DB, session.orgId),
-    countEntitiesByStage(env.DB, session.orgId, 'signal'),
-  ])
+// Parallel queries — everything the dashboard needs in one Promise.all
+const [
+  overdueFollowUps,
+  upcomingFollowUps,
+  pipeline,
+  revenue,
+  health,
+  compliance,
+  allEngagements,
+  allAssessments,
+  outstandingInvoices,
+  signals,
+  googleIntegration,
+] = await Promise.all([
+  listFollowUps(env.DB, session.orgId, { overdue: true }),
+  listFollowUps(env.DB, session.orgId, { upcoming: true }),
+  getPipelineConversion(env.DB, session.orgId),
+  getRevenueReport(env.DB, session.orgId),
+  getEngagementHealth(env.DB, session.orgId),
+  getFollowUpCompliance(env.DB, session.orgId),
+  listEngagements(env.DB, session.orgId),
+  listAssessments(env.DB, session.orgId),
+  listInvoices(env.DB, session.orgId, { status: 'sent' }),
+  listEntities(env.DB, session.orgId, { stage: 'signal' }),
+  getIntegration(env.DB, session.orgId, 'google'),
+])
 
-const upcomingCount = upcomingFollowUps.length
+// Today's work
+const todayAssessments = allAssessments.filter((a) => {
+  return a.status === 'scheduled' && a.scheduled_at?.startsWith(todayStr)
+})
 const overdueCount = overdueFollowUps.length
+const signalCount = signals.length
 
-// Dashboard metrics
-const totalClients =
-  pipeline.prospect +
-  pipeline.assessing +
-  pipeline.proposing +
-  pipeline.engaged +
-  pipeline.delivered +
-  pipeline.lost
+// Pipeline
+const pipelineStages = [
+  { label: 'Signals', count: signalCount, stage: 'signal', color: 'amber' },
+  { label: 'Prospects', count: pipeline.prospect, stage: 'prospect', color: 'blue' },
+  { label: 'Assessing', count: pipeline.assessing, stage: 'assessing', color: 'indigo' },
+  { label: 'Proposing', count: pipeline.proposing, stage: 'proposing', color: 'purple' },
+  { label: 'Engaged', count: pipeline.engaged, stage: 'engaged', color: 'green' },
+  { label: 'Delivered', count: pipeline.delivered, stage: 'delivered', color: 'teal' },
+]
+const totalPipeline = pipelineStages.reduce((sum, s) => sum + s.count, 0)
+
+// Engagements
 const activeEngagements = allEngagements.filter(
-  (e) => e.status === 'active' || e.status === 'handoff' || e.status === 'safety_net'
-).length
-const pipelineConversionRate =
-  totalClients > 0
-    ? Math.round(((pipeline.engaged + pipeline.delivered) / totalClients) * 1000) / 10
-    : 0
+  (e) => e.status === 'active' || e.status === 'scheduled' || e.status === 'handoff'
+)
+
+// Revenue
+const outstandingTotal = outstandingInvoices.reduce((sum, inv) => sum + (inv.amount ?? 0), 0)
+
+// System health
+const hasGoogleCalendar = !!googleIntegration
+const hasStripe = !!env.STRIPE_API_KEY
 ---
 
 <!doctype html>
@@ -56,16 +93,24 @@ const pipelineConversionRate =
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>Admin — SMD Services</title>
+    <title>Dashboard — SMD Services</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
         <div class="flex items-center gap-3">
           <h1 class="text-lg font-bold text-slate-900">SMD Services</h1>
           <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
         </div>
         <div class="flex items-center gap-4">
+          <a href="/admin/entities" class="text-sm text-slate-600 hover:text-slate-900">Entities</a>
+          <a href="/admin/follow-ups" class="text-sm text-slate-600 hover:text-slate-900"
+            >Follow-ups</a
+          >
+          <a href="/admin/analytics" class="text-sm text-slate-600 hover:text-slate-900"
+            >Analytics</a
+          >
+          <span class="text-sm text-slate-400">|</span>
           <span class="text-sm text-slate-600">{session.email}</span>
           <form method="POST" action="/api/auth/logout">
             <button
@@ -79,110 +124,311 @@ const pipelineConversionRate =
       </div>
     </header>
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <h2 class="text-xl font-semibold text-slate-900 mb-4">Dashboard</h2>
-      <div class="grid gap-4">
-        <a
-          href="/admin/entities"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <div class="flex items-center justify-between">
-            <h3
-              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
+    <main class="max-w-6xl mx-auto px-4 py-8 space-y-6">
+      <!-- Card 1: Today's Work -->
+      <section class="bg-white rounded-lg border border-slate-200 p-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">Today's Work</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <a
+            href="/admin/entities?stage=signal"
+            class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors"
+          >
+            <div
+              class:list={[
+                'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+                signalCount > 0 ? 'bg-amber-100 text-amber-700' : 'bg-slate-100 text-slate-400',
+              ]}
             >
-              Entities
-            </h3>
-            <div class="flex items-center gap-2">
-              {
-                newSignalCount > 0 && (
-                  <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full font-medium">
-                    {newSignalCount} signals
-                  </span>
-                )
-              }
-              <span
-                class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full font-medium"
+              {signalCount}
+            </div>
+            <div>
+              <div class="text-sm font-medium text-slate-900">Signals to triage</div>
+              <div class="text-xs text-slate-500">Promote or dismiss</div>
+            </div>
+          </a>
+
+          <div class="flex items-center gap-3 p-3 rounded-lg">
+            <div
+              class:list={[
+                'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+                todayAssessments.length > 0
+                  ? 'bg-indigo-100 text-indigo-700'
+                  : 'bg-slate-100 text-slate-400',
+              ]}
+            >
+              {todayAssessments.length}
+            </div>
+            <div>
+              <div class="text-sm font-medium text-slate-900">Assessments today</div>
+              <div class="text-xs text-slate-500">
+                {
+                  todayAssessments.length > 0
+                    ? todayAssessments
+                        .map((a) => {
+                          const time = a.scheduled_at
+                            ? new Date(a.scheduled_at).toLocaleTimeString('en-US', {
+                                hour: 'numeric',
+                                minute: '2-digit',
+                              })
+                            : ''
+                          return time
+                        })
+                        .join(', ')
+                    : 'None scheduled'
+                }
+              </div>
+            </div>
+          </div>
+
+          <a
+            href="/admin/follow-ups?filter=overdue"
+            class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors"
+          >
+            <div
+              class:list={[
+                'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+                overdueCount > 0 ? 'bg-red-100 text-red-700' : 'bg-slate-100 text-slate-400',
+              ]}
+            >
+              {overdueCount}
+            </div>
+            <div>
+              <div class="text-sm font-medium text-slate-900">Overdue follow-ups</div>
+              <div class="text-xs text-slate-500">
+                {overdueCount > 0 ? 'Needs attention' : 'All clear'}
+              </div>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <!-- Card 2: Pipeline State -->
+      <section class="bg-white rounded-lg border border-slate-200 p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-base font-semibold text-slate-900">Pipeline</h2>
+          <a href="/admin/entities" class="text-xs text-slate-500 hover:text-slate-700"
+            >{totalPipeline} total</a
+          >
+        </div>
+
+        <!-- Funnel bar -->
+        {
+          totalPipeline > 0 && (
+            <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-slate-100">
+              {pipelineStages.map((s) =>
+                s.count > 0 ? (
+                  <div
+                    class:list={[
+                      s.color === 'amber' && 'bg-amber-400',
+                      s.color === 'blue' && 'bg-blue-400',
+                      s.color === 'indigo' && 'bg-indigo-400',
+                      s.color === 'purple' && 'bg-purple-400',
+                      s.color === 'green' && 'bg-green-400',
+                      s.color === 'teal' && 'bg-teal-400',
+                    ]}
+                    style={`width: ${(s.count / totalPipeline) * 100}%`}
+                    title={`${s.label}: ${s.count}`}
+                  />
+                ) : null
+              )}
+            </div>
+          )
+        }
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
+          {
+            pipelineStages.map((s) => (
+              <a
+                href={`/admin/entities?stage=${s.stage}`}
+                class="text-center p-2 rounded-lg hover:bg-slate-50 transition-colors"
               >
-                {totalClients} total
+                <div
+                  class:list={[
+                    'text-2xl font-bold',
+                    s.count > 0 ? 'text-slate-900' : 'text-slate-300',
+                  ]}
+                >
+                  {s.count}
+                </div>
+                <div class="text-xs text-slate-500">{s.label}</div>
+              </a>
+            ))
+          }
+        </div>
+
+        {
+          pipeline.lost > 0 && (
+            <div class="mt-3 pt-3 border-t border-slate-100 text-center">
+              <a
+                href="/admin/entities?stage=lost"
+                class="text-xs text-slate-400 hover:text-slate-600"
+              >
+                {pipeline.lost} lost
+              </a>
+            </div>
+          )
+        }
+      </section>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- Card 3: Revenue -->
+        <section class="bg-white rounded-lg border border-slate-200 p-6">
+          <h2 class="text-base font-semibold text-slate-900 mb-4">Revenue</h2>
+          <div class="space-y-3">
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Invoiced</span>
+              <span class="text-lg font-semibold text-slate-900">
+                ${revenue.total_invoiced.toLocaleString('en-US', { minimumFractionDigits: 0 })}
               </span>
             </div>
-          </div>
-          <p class="text-sm text-slate-500 mt-1">
-            Every business in one place — from pipeline signals through active engagements and
-            repeat clients. Triage, promote, and track the full lifecycle.
-          </p>
-        </a>
-
-        <a
-          href="/admin/follow-ups"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <div class="flex items-center justify-between">
-            <h3
-              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-            >
-              Follow-ups
-            </h3>
-            <div class="flex items-center gap-2">
-              {
-                overdueCount > 0 && (
-                  <span class="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded-full font-medium">
-                    {overdueCount} overdue
-                  </span>
-                )
-              }
-              {
-                upcomingCount > 0 && (
-                  <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
-                    {upcomingCount} upcoming
-                  </span>
-                )
-              }
-            </div>
-          </div>
-          <p class="text-sm text-slate-500 mt-1">
-            Manage follow-up cadences — proposal follow-ups, review requests, referral asks, and
-            feedback surveys.
-          </p>
-        </a>
-
-        <a
-          href="/admin/analytics"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <div class="flex items-center justify-between">
-            <h3
-              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-            >
-              Analytics
-            </h3>
-            <div class="flex items-center gap-2">
-              <span
-                class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full font-medium"
-              >
-                {totalClients} clients
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Paid</span>
+              <span class="text-lg font-semibold text-green-600">
+                ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
               </span>
+            </div>
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Outstanding</span>
+              <span
+                class:list={[
+                  'text-lg font-semibold',
+                  outstandingTotal > 0 ? 'text-amber-600' : 'text-slate-400',
+                ]}
+              >
+                ${outstandingTotal.toLocaleString('en-US', { minimumFractionDigits: 0 })}
+              </span>
+            </div>
+
+            <div class="pt-3 border-t border-slate-100">
+              <div class="flex justify-between items-baseline">
+                <span class="text-sm text-slate-500">Active engagements</span>
+                <span class="text-sm font-medium text-slate-900">{activeEngagements.length}</span>
+              </div>
               {
-                activeEngagements > 0 && (
-                  <span class="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full font-medium">
-                    {activeEngagements} active
-                  </span>
-                )
-              }
-              {
-                pipelineConversionRate > 0 && (
-                  <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
-                    {pipelineConversionRate}% conversion
-                  </span>
+                health.avg_days_to_completion > 0 && (
+                  <div class="flex justify-between items-baseline mt-1">
+                    <span class="text-sm text-slate-500">Avg completion</span>
+                    <span class="text-sm font-medium text-slate-900">
+                      {health.avg_days_to_completion} days
+                    </span>
+                  </div>
                 )
               }
             </div>
           </div>
-          <p class="text-sm text-slate-500 mt-1">
-            Pipeline funnel, quote accuracy, revenue, engagement health, and follow-up compliance.
-          </p>
-        </a>
+        </section>
+
+        <!-- Card 4: Follow-up Health -->
+        <section class="bg-white rounded-lg border border-slate-200 p-6">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-base font-semibold text-slate-900">Follow-up Health</h2>
+            <a href="/admin/follow-ups" class="text-xs text-slate-500 hover:text-slate-700"
+              >View all</a
+            >
+          </div>
+          <div class="space-y-3">
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">On-time rate</span>
+              <span
+                class:list={[
+                  'text-lg font-semibold',
+                  compliance.compliance_pct >= 80
+                    ? 'text-green-600'
+                    : compliance.compliance_pct >= 50
+                      ? 'text-amber-600'
+                      : 'text-red-600',
+                ]}
+              >
+                {compliance.compliance_pct}%
+              </span>
+            </div>
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Sent on time</span>
+              <span class="text-sm font-medium text-slate-900">{compliance.completed_on_time}</span>
+            </div>
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Sent late</span>
+              <span
+                class:list={[
+                  'text-sm font-medium',
+                  compliance.completed_late > 0 ? 'text-amber-600' : 'text-slate-900',
+                ]}
+              >
+                {compliance.completed_late}
+              </span>
+            </div>
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Missed</span>
+              <span
+                class:list={[
+                  'text-sm font-medium',
+                  compliance.missed > 0 ? 'text-red-600' : 'text-slate-900',
+                ]}
+              >
+                {compliance.missed}
+              </span>
+            </div>
+
+            <div class="pt-3 border-t border-slate-100">
+              <div class="flex justify-between items-baseline">
+                <span class="text-sm text-slate-500">Upcoming</span>
+                <span class="text-sm font-medium text-slate-900"
+                  >{upcomingFollowUps.length} scheduled</span
+                >
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
+
+      <!-- Card 5: System Health -->
+      <section class="bg-white rounded-lg border border-slate-200 p-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">System Health</h2>
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div class="flex items-center gap-2">
+            <div
+              class:list={[
+                'w-2 h-2 rounded-full',
+                hasGoogleCalendar ? 'bg-green-500' : 'bg-slate-300',
+              ]}
+            >
+            </div>
+            <span class="text-sm text-slate-600">
+              Google Calendar
+              <span class="text-xs text-slate-400">
+                {hasGoogleCalendar ? 'connected' : 'not connected'}
+              </span>
+            </span>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <div class:list={['w-2 h-2 rounded-full', hasStripe ? 'bg-green-500' : 'bg-slate-300']}>
+            </div>
+            <span class="text-sm text-slate-600">
+              Stripe
+              <span class="text-xs text-slate-400">
+                {hasStripe ? 'configured' : 'not configured'}
+              </span>
+            </span>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <div class="w-2 h-2 rounded-full bg-slate-300"></div>
+            <span class="text-sm text-slate-600">
+              Follow-up processor
+              <span class="text-xs text-slate-400">not deployed</span>
+            </span>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <div class="w-2 h-2 rounded-full bg-slate-300"></div>
+            <span class="text-sm text-slate-600">
+              Lead-gen Workers
+              <span class="text-xs text-slate-400">not deployed</span>
+            </span>
+          </div>
+        </div>
+      </section>
     </main>
   </body>
 </html>

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -293,15 +293,15 @@ describe('analytics: admin dashboard integration', () => {
     expect(code).toContain('/admin/analytics')
   })
 
-  it('admin dashboard shows total clients metric', () => {
-    expect(source()).toContain('totalClients')
+  it('admin dashboard shows pipeline total metric', () => {
+    expect(source()).toContain('totalPipeline')
   })
 
   it('admin dashboard shows active engagements metric', () => {
     expect(source()).toContain('activeEngagements')
   })
 
-  it('admin dashboard shows pipeline conversion rate', () => {
-    expect(source()).toContain('pipelineConversionRate')
+  it('admin dashboard shows revenue report', () => {
+    expect(source()).toContain('getRevenueReport')
   })
 })

--- a/tests/follow-ups.test.ts
+++ b/tests/follow-ups.test.ts
@@ -375,9 +375,9 @@ describe('follow-ups: admin dashboard integration', () => {
     expect(code).toContain('/admin/follow-ups')
   })
 
-  it('admin dashboard shows upcoming and overdue counts', () => {
+  it('admin dashboard shows upcoming and overdue follow-ups', () => {
     const code = source()
-    expect(code).toContain('upcomingCount')
-    expect(code).toContain('overdueCount')
+    expect(code).toContain('upcomingFollowUps')
+    expect(code).toContain('overdueFollowUps')
   })
 })


### PR DESCRIPTION
## Summary
- Rebuilt `/admin` as a 5-card operator dashboard
- Today's work: signals to triage, assessments scheduled today, overdue follow-ups
- Pipeline funnel with visual bar chart and stage counts
- Revenue: invoiced/paid/outstanding + active engagements + avg completion time
- Follow-up compliance: on-time rate, sent on time, late, missed
- System health: Google Calendar, Stripe, follow-up processor, lead-gen Workers

## Test plan
- [x] `npm run verify` passes (995 tests)
- [ ] Visual review of dashboard layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)