### PR TITLE
fix(admin): intelligence brief whitespace + follow-up entity resolution

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -592,11 +592,14 @@ function confidenceColor(confidence: string): string {
 
             {/* Zone 3: Intelligence Brief */}
             <div class="border-t border-slate-100 pt-4 mb-4">
-              <details open>
+              <details>
                 <summary class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-3 cursor-pointer">
                   Intelligence Brief
                 </summary>
-                <div class="prose-sm" set:html={renderSimpleMarkdown(dossierBrief!.content)} />
+                <div
+                  class="max-h-[50vh] overflow-y-auto"
+                  set:html={renderSimpleMarkdown(dossierBrief!.content)}
+                />
               </details>
             </div>
 

--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -43,12 +43,16 @@ interface EntityRow {
 }
 
 const clientMap: Record<string, string> = {}
-for (const id of clientIds) {
-  const entity = await env.DB.prepare('SELECT id, name FROM entities WHERE id = ? AND org_id = ?')
-    .bind(id, session.orgId)
-    .first<EntityRow>()
-  if (entity) {
-    clientMap[id] = entity.name
+const validIds = clientIds.filter(Boolean).slice(0, 500)
+if (validIds.length > 0) {
+  const placeholders = validIds.map(() => '?').join(', ')
+  const rows = await env.DB.prepare(
+    `SELECT id, name FROM entities WHERE id IN (${placeholders}) AND org_id = ?`
+  )
+    .bind(...validIds, session.orgId)
+    .all<EntityRow>()
+  for (const row of rows.results) {
+    clientMap[row.id] = row.name
   }
 }
 
@@ -217,8 +221,10 @@ const success = Astro.url.searchParams.get('saved')
                   <div class="flex items-start justify-between gap-4">
                     <div class="min-w-0 flex-1">
                       <div class="flex items-center gap-2 mb-1">
-                        <span class="text-sm font-medium text-slate-900">
-                          {clientMap[f.entity_id] ?? 'Unknown'}
+                        <span
+                          class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-slate-900' : 'italic text-slate-400'}`}
+                        >
+                          {f.entity_id ? (clientMap[f.entity_id] ?? 'Missing entity') : 'Unlinked'}
                         </span>
                         <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">
                           {getTypeLabel(f.type)}

--- a/tests/follow-ups.test.ts
+++ b/tests/follow-ups.test.ts
@@ -258,7 +258,7 @@ describe('follow-ups: dashboard page', () => {
   it('displays client name for each follow-up', () => {
     const code = source()
     expect(code).toContain('clientMap')
-    expect(code).toContain('entity.name')
+    expect(code).toContain('row.name')
   })
 
   it('displays follow-up type label', () => {


### PR DESCRIPTION
## Summary
- Remove dead `prose-sm` class and add `max-h-[50vh] overflow-y-auto` to intelligence brief, preventing it from pushing Context Timeline off-screen. Collapse by default.
- Replace N+1 entity lookups in follow-ups with batch `IN (...)` query (capped at 500 for D1 safety)
- Show diagnostic fallback ("Missing entity" / "Unlinked") instead of opaque "Unknown" for orphaned follow-ups

## Test plan
- [ ] `npm run verify` passes (995/995 tests)
- [ ] Entity detail page: intelligence brief starts collapsed, expands with scroll cap, Context Timeline visible without excessive scrolling
- [ ] Follow-ups page: entity names resolve; orphaned records show italic "Missing entity" not "Unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)