### PR TITLE
fix(deploy): replace BOOKING_CACHE KV namespace placeholder with real ID

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -48,7 +48,7 @@ id = "4570dcc1e154476f889bc9fcfc28b2b9"
 # Create with: npx wrangler kv:namespace create BOOKING_CACHE
 [[kv_namespaces]]
 binding = "BOOKING_CACHE"
-id = "REPLACE_ME_AFTER_CREATION"
+id = "daf6a3220f8f42f28f3da7e82f663088"
 
 # ---------- Secrets (set via wrangler secret put) ----------
 # All secrets are set per-project. Workers have their own copies.


### PR DESCRIPTION
## Summary
- Replace `REPLACE_ME_AFTER_CREATION` placeholder in wrangler.toml with actual KV namespace ID `daf6a3220f8f42f28f3da7e82f663088`
- This has been blocking **every production deploy** since the booking feature was added
- Unblocks the Phase 2a operator dashboard and all pending fixes from reaching production

## Test plan
- [ ] `npm run verify` passes
- [ ] Deploy workflow succeeds after merge (no more "Invalid KV namespace ID" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)