### PR TITLE
fix(dashboard): use 'google_calendar' provider name in Automations card

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -50,7 +50,7 @@ const [
   listAssessments(env.DB, session.orgId),
   listInvoices(env.DB, session.orgId, { status: 'sent' }),
   listEntities(env.DB, session.orgId, { stage: 'signal' }),
-  getIntegration(env.DB, session.orgId, 'google', { includeInactive: true }),
+  getIntegration(env.DB, session.orgId, 'google_calendar', { includeInactive: true }),
   env.DB.prepare(
     `SELECT source_pipeline, MAX(created_at) as last_signal
      FROM entities


### PR DESCRIPTION
## Summary
- Fix provider name mismatch: dashboard queried `'google'` but integration is stored as `'google_calendar'`
- This caused the Automations card to always show "Not connected" even after completing the OAuth flow
- One-line fix — every other file in the codebase already uses `'google_calendar'`

## Test plan
- [ ] `npm run verify` passes
- [ ] After connecting Google Calendar, Automations card shows green dot + account email

🤖 Generated with [Claude Code](https://claude.com/claude-code)