### PR TITLE
fix(auth): request openid+email scopes for Google OAuth

### DIFF
--- a/src/pages/api/auth/google/connect.ts
+++ b/src/pages/api/auth/google/connect.ts
@@ -10,12 +10,16 @@ import { requireAppBaseUrl } from '../../../../lib/config/app-url.js'
  * to Google's OAuth consent screen.
  *
  * Scopes requested:
+ * - openid + email (required so the callback can fetch the connecting
+ *   user's email from the userinfo endpoint to populate the integration)
  * - calendar.events (create/update/delete events)
  * - calendar.freebusy (slot availability queries)
  */
 
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
 const SCOPES = [
+  'openid',
+  'email',
   'https://www.googleapis.com/auth/calendar.events',
   'https://www.googleapis.com/auth/calendar.freebusy',
 ].join(' ')


### PR DESCRIPTION
## Summary
- OAuth connect flow failed at the callback with `userinfo_failed` (see screenshot)
- Root cause: `connect.ts` only requested `calendar.events` + `calendar.freebusy`, neither of which grants access to Google's userinfo endpoint
- Adding `openid` + `email` scopes lets the callback fetch `account_email` and write the integrations row

## Root cause
`src/pages/api/auth/google/callback.ts:77` fetches `https://www.googleapis.com/oauth2/v2/userinfo` with the access token to populate `integration.account_email`. Without `openid`/`email`/`userinfo.email` in the scope set, Google returns 403 and the callback redirects to `/admin/settings/google-connect?error=userinfo_failed`, leaving the `integrations` table empty.

## Test plan
- [x] `npm run verify` — typecheck, format, lint, build, 995 tests pass
- [ ] Merge + wait for Pages deploy
- [ ] Retry connect at https://smd.services/admin/settings/google-connect
- [ ] Confirm green "Connected" banner with account email
- [ ] Confirm `integrations` row with `status='active'` in D1
- [ ] Confirm Automations card on dashboard turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)