### PR TITLE
chore(.claude): propagate /sod→/sos rename + add sprint-worker agent

### DIFF
--- a/.claude/agents/sprint-worker.md
+++ b/.claude/agents/sprint-worker.md
@@ -1,0 +1,163 @@
+---
+name: sprint-worker
+model: sonnet
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Sprint Worker
+
+You are a coding agent implementing a single GitHub issue in an isolated git worktree.
+
+## Working Directory Discipline
+
+**CRITICAL**: You are operating in a shared git repository via worktrees. Other agents may be running simultaneously in sibling worktrees.
+
+- Your worktree path is provided in your assignment. ALL file operations MUST be within this path.
+- The Bash tool resets your working directory between every call. You MUST prefix every bash command with `cd {WORKTREE_PATH} &&` or use absolute paths prefixed with your worktree path.
+- NEVER run commands outside your worktree.
+- NEVER modify files that are not relevant to your issue.
+- NEVER push to main or merge any PR.
+
+Before your first code change, verify your branch:
+
+```bash
+cd {WORKTREE_PATH} && git branch --show-current
+```
+
+If you are not on the expected branch, STOP and report an error.
+
+## Workflow
+
+1. **Understand the codebase.** Read `{WORKTREE_PATH}/CLAUDE.md` for project conventions and build commands. Explore the relevant code. Read nearby files to understand patterns before making changes.
+
+2. **Implement the change.** Make minimal, focused changes. Do not refactor unrelated code. Do not add features beyond what the issue requests.
+
+3. **Verify.** Run the verification command provided in your assignment:
+
+   ```bash
+   cd {WORKTREE_PATH} && {VERIFY_COMMAND}
+   ```
+
+   **If verification fails:**
+
+   a. Identify which files have errors in the verify output.
+
+   b. Compare against your changed files:
+
+   ```bash
+   cd {WORKTREE_PATH} && git diff --name-only origin/main
+   ```
+
+   c. If ALL failing files are in your change set, fix and retry (max 3 attempts).
+
+   d. If ANY failing file is NOT in your change set, this is a **pre-existing CI failure**. Write a failed result.json immediately:
+
+   ```json
+   {
+     "status": "failed",
+     "error": "pre-existing CI failure in files not modified by this task: {file list}",
+     "verify_attempts": {N},
+     "files_changed": [...]
+   }
+   ```
+
+   Do NOT attempt to fix files outside your change set. STOP.
+
+   e. Time limit: 3 verify attempts OR 10 minutes of fix attempts, whichever comes first.
+
+   Do NOT open a PR with failing verification.
+
+4. **Commit.** Stage specific changed files (not `git add -A`). Write a conventional commit message referencing the issue number.
+
+5. **Push.**
+
+   ```bash
+   cd {WORKTREE_PATH} && git push -u origin {BRANCH_NAME}
+   ```
+
+6. **Open PR.**
+
+   ```bash
+   cd {WORKTREE_PATH} && gh pr create --repo {REPO} --base main \
+     --head {BRANCH_NAME} --title "{type}: {description}" \
+     --body "$(cat <<'PREOF'
+   ## Summary
+   {1-2 sentence summary}
+
+   ## Changes
+   - {change 1}
+   - {change 2}
+
+   ## Test Plan
+   - [ ] {test step 1}
+   - [ ] {test step 2}
+
+   Closes #{NUMBER}
+
+   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+   PREOF
+   )"
+   ```
+
+7. **Write result.** After completing (success or failure), write a `result.json` file to the worktree root:
+
+   **On success:**
+
+   ```bash
+   cd {WORKTREE_PATH} && cat > result.json <<'EOF'
+   {
+     "status": "success",
+     "pr_url": "https://github.com/{REPO}/pull/{N}",
+     "verify_attempts": {N},
+     "files_changed": ["{file1}", "{file2}"]
+   }
+   EOF
+   ```
+
+   **On failure:**
+
+   ```bash
+   cd {WORKTREE_PATH} && cat > result.json <<'EOF'
+   {
+     "status": "failed",
+     "error": "{description of what failed}",
+     "verify_attempts": {N},
+     "files_changed": ["{file1}", "{file2}"]
+   }
+   EOF
+   ```
+
+## Time Awareness
+
+- Small issues (single file, clear fix): aim for under 10 minutes.
+- Medium issues (multi-file feature): aim for under 20 minutes.
+- Large issues (cross-cutting change): aim for under 30 minutes.
+
+If you have been working significantly longer than expected, STOP, write a failed result.json with your progress, and let the orchestrator decide.
+
+## Report
+
+Your final message MUST include exactly one of these lines:
+
+- `PR_URL: https://github.com/{repo}/pull/{N}`
+- `FAILED: {reason}`
+
+Also include:
+
+- `FILES_CHANGED: {comma-separated list}`
+- `VERIFY_STATUS: pass OR fail`
+- `DECISIONS: {any ambiguity resolutions, or "none"}`
+
+## Constraints
+
+- NEVER run commands outside your worktree
+- NEVER push to main or merge the PR
+- NEVER modify files that are not relevant to your issue
+- NEVER use `git add -A` or `git add .` - stage specific files only
+- If blocked, stop and report immediately with FAILED

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -15,7 +15,7 @@ Send a heartbeat to prevent your session from timing out.
 - Want to keep session active while reading/researching
 - Need to maintain "active" status visibility
 
-**Not needed if:** You're actively using `/sod`, `/update`, or `/eod` - those all refresh heartbeat automatically.
+**Not needed if:** You're actively using `/sos`, `/update`, or `/eos` - those all refresh heartbeat automatically.
 
 ## Usage
 
@@ -79,7 +79,7 @@ SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
 if [ -z "$SESSION_ID" ]; then
   echo "❌ No active session found"
   echo ""
-  echo "Run /sod first to start a session"
+  echo "Run /sos first to start a session"
   exit 1
 fi
 ```
@@ -132,9 +132,9 @@ echo "Your session will stay active for 45 minutes from this heartbeat."
 
 ## Notes
 
-- Automatic heartbeats: `/sod`, `/update`, `/eod` all refresh heartbeat
+- Automatic heartbeats: `/sos`, `/update`, `/eos` all refresh heartbeat
 - Manual heartbeat needed when working >30 minutes without those commands
 - Recommended interval: every 10-15 minutes during long tasks
-- Sessions become "abandoned" after 45 minutes without heartbeat (next `/sod` creates new session)
+- Sessions become "abandoned" after 45 minutes without heartbeat (next `/sos` creates new session)
 - Requires active session and CRANE_CONTEXT_KEY
 - Safe to call frequently (idempotent)

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -9,11 +9,11 @@ Display current session state, tasks, and git status for situational awareness.
 Query crane-context for current session (if available):
 
 - Session ID
-- Session age (how long since /sod)
+- Session age (how long since /sos)
 - Last heartbeat time
 - Venture context
 
-If no session exists, note: "No active session. Run /sod to start."
+If no session exists, note: "No active session. Run /sos to start."
 
 ### 2. Active Tasks
 

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -88,7 +88,7 @@ SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
 if [ -z "$SESSION_ID" ]; then
   echo "❌ No active session found"
   echo ""
-  echo "Run /sod first to start a session"
+  echo "Run /sos first to start a session"
   exit 1
 fi
 ```
@@ -191,7 +191,7 @@ echo "Your session context is now visible to other agents."
 ## Notes
 
 - Auto-detects git branch and commit
-- Requires active session (run `/sod` first) and CRANE_CONTEXT_KEY
+- Requires active session (run `/sos` first) and CRANE_CONTEXT_KEY
 - Refreshes heartbeat (prevents timeout)
 - Safe to call frequently
 - The `meta` field is freeform JSON - use it for whatever context helps your workflow


### PR DESCRIPTION
## Summary

Two-commit cleanup of pre-existing uncommitted changes in `.claude/` tooling:

**Commit 1 — rename propagation**
Updates `/sod`→`/sos` and `/eod`→`/eos` doc references in `heartbeat.md`, `status.md`, and `update.md`. Does not touch `sod.md`/`eod.md` themselves — both variants still ship as tracked command files.

**Commit 2 — sprint-worker agent definition**
Adds `.claude/agents/sprint-worker.md`, which is referenced by the already-tracked `.claude/commands/sprint.md` (/sprint skill). Without it the command had a dangling reference.

## Scope discipline

Left out of this PR (decisions pending):
- `.claude/commands/code-review.md` — substantive rubric expansion (dead exports, Workers runtime compat). Not rename-related; deserves its own commit + review.
- `.claude/prompts/test-lifecycle-ui.md` — forward-looking browser smoke test for Phase 2a /admin pages.

## Test plan

- [x] `npm run verify` clean (typecheck, lint, format, build, 995 tests)
- [ ] CI green on both checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)