### PR TITLE
fix(signwell): align webhook verification with actual SignWell API

### DIFF
--- a/src/lib/signwell/types.ts
+++ b/src/lib/signwell/types.ts
@@ -82,15 +82,42 @@ export interface SignWellDocument {
 /**
  * Webhook payload sent by SignWell when a document event occurs.
  *
- * The primary event we handle is `document_completed`.
+ * SignWell wraps event metadata (type, timestamp, HMAC hash) in an
+ * `event` object and the document data in `data.object`.
+ *
+ * Ref: https://developers.signwell.com/reference/event-data
  */
 export interface SignWellWebhookPayload {
-  event: 'document_completed' | 'document_expired' | 'document_cancelled'
+  event: {
+    type:
+      | 'document_completed'
+      | 'document_expired'
+      | 'document_cancelled'
+      | 'document_created'
+      | 'document_sent'
+      | 'document_viewed'
+      | 'document_signed'
+      | 'document_declined'
+      | 'document_bounced'
+      | 'document_error'
+      | 'document_in_progress'
+      | 'document_recipients_updated'
+    /** Unix timestamp of the event */
+    time: number
+    /** HMAC-SHA256 hex digest for verification (key = webhook ID) */
+    hash: string
+    /** Present on view/sign/decline events */
+    related_signer?: { email: string; name: string }
+  }
   data: {
-    id: string
-    name: string
-    status: string
-    signers: SignWellSigner[]
-    completed_at: string | null
+    /** Full document object (matches GET /documents/:id response) */
+    object: {
+      id: string
+      name: string
+      status: string
+      signers?: SignWellSigner[]
+      completed_at: string | null
+    }
+    account_id: string
   }
 }

--- a/src/lib/webhooks/signwell-handler.test.ts
+++ b/src/lib/webhooks/signwell-handler.test.ts
@@ -62,20 +62,27 @@ const LINE_ITEMS: LineItem[] = [
 
 function makePayload(): SignWellWebhookPayload {
   return {
-    event: 'document_completed',
+    event: {
+      type: 'document_completed',
+      time: Math.floor(Date.now() / 1000),
+      hash: 'test-hash',
+    },
     data: {
-      id: SIGNWELL_DOC_ID,
-      name: 'SOW - Test Business',
-      status: 'completed',
-      signers: [
-        {
-          id: 's1',
-          name: 'Test Owner',
-          email: 'owner@test.com',
-          signed_at: new Date().toISOString(),
-        },
-      ],
-      completed_at: new Date().toISOString(),
+      object: {
+        id: SIGNWELL_DOC_ID,
+        name: 'SOW - Test Business',
+        status: 'completed',
+        signers: [
+          {
+            id: 's1',
+            name: 'Test Owner',
+            email: 'owner@test.com',
+            signed_at: new Date().toISOString(),
+          },
+        ],
+        completed_at: new Date().toISOString(),
+      },
+      account_id: 'test-account',
     },
   }
 }

--- a/src/lib/webhooks/signwell-handler.ts
+++ b/src/lib/webhooks/signwell-handler.ts
@@ -84,7 +84,7 @@ export async function handleDocumentCompleted(
   stripeApiKey: string | undefined,
   payload: SignWellWebhookPayload
 ): Promise<Response> {
-  const documentId = payload.data.id
+  const documentId = payload.data.object.id
   const now = new Date().toISOString()
 
   // --- Pre-batch reads (outside transaction) ---

--- a/src/pages/api/webhooks/signwell.ts
+++ b/src/pages/api/webhooks/signwell.ts
@@ -8,12 +8,25 @@ import { handleDocumentCompleted } from '../../../lib/webhooks/signwell-handler'
  * Receives webhook callbacks from SignWell when document events occur.
  *
  * This is an unauthenticated endpoint — SignWell webhooks do not carry
- * session tokens. Security is enforced via HMAC-SHA256 signature verification
- * using the SIGNWELL_WEBHOOK_SECRET.
+ * session tokens. Security is enforced via HMAC-SHA256 hash verification
+ * using the webhook ID (stored as SIGNWELL_WEBHOOK_SECRET).
+ *
+ * Unlike Stripe (which puts the signature in an HTTP header), SignWell
+ * includes the hash inside the JSON body at `event.hash`. This means we
+ * must parse the body before we can verify it. To maintain defense in
+ * depth, we extract ONLY the three verification fields (type, time, hash)
+ * before verification and do not log, dispatch, or act on any payload
+ * data until the hash check passes.
+ *
+ * Ref: https://developers.signwell.com/reference/event-hash-verification
  *
  * Only processes `document_completed` events. All other events are
  * acknowledged with 200 but not acted upon.
  */
+
+/** Maximum age (in seconds) for a webhook timestamp to be considered fresh. */
+const MAX_WEBHOOK_AGE_SECONDS = 300
+
 export const POST: APIRoute = async ({ request, locals }) => {
   const env = locals.runtime.env
 
@@ -26,22 +39,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
     })
   }
 
-  // --- Signature verification ---
-  const rawBody = await request.text()
-  const signature = request.headers.get('x-signwell-signature') ?? ''
-
-  const isValid = await verifySignature(rawBody, signature, webhookSecret)
-  if (!isValid) {
-    console.error('[webhook/signwell] Invalid webhook signature')
-    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
-
-  // --- Parse payload ---
+  // --- Parse body (required — SignWell puts the hash inside the JSON) ---
   let payload: SignWellWebhookPayload
   try {
+    const rawBody = await request.text()
     payload = JSON.parse(rawBody) as SignWellWebhookPayload
   } catch {
     return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
@@ -50,8 +51,40 @@ export const POST: APIRoute = async ({ request, locals }) => {
     })
   }
 
+  // --- Extract verification fields only (no logging/dispatch yet) ---
+  const eventType = payload.event?.type
+  const eventTime = payload.event?.time
+  const eventHash = payload.event?.hash
+
+  if (!eventType || eventTime == null || !eventHash) {
+    return new Response(JSON.stringify({ error: 'Missing event fields' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- HMAC-SHA256 verification ---
+  const isValid = await verifyEventHash(eventType, eventTime, eventHash, webhookSecret)
+  if (!isValid) {
+    console.error('[webhook/signwell] Invalid event hash')
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Timestamp freshness check (replay protection) ---
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  if (nowSeconds - eventTime > MAX_WEBHOOK_AGE_SECONDS) {
+    console.error(`[webhook/signwell] Stale webhook: event.time ${eventTime}, now ${nowSeconds}`)
+    return new Response(JSON.stringify({ error: 'Stale webhook' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
   // --- Dispatch by event type ---
-  if (payload.event === 'document_completed') {
+  if (payload.event.type === 'document_completed') {
     const apiKey = env.SIGNWELL_API_KEY
     if (!apiKey) {
       console.error('[webhook/signwell] SIGNWELL_API_KEY not configured')
@@ -72,26 +105,34 @@ export const POST: APIRoute = async ({ request, locals }) => {
   }
 
   // Acknowledge all other events without processing
-  return new Response(JSON.stringify({ ok: true, event: payload.event }), {
+  return new Response(JSON.stringify({ ok: true, event: payload.event.type }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   })
 }
 
 /**
- * Verify the HMAC-SHA256 signature of the webhook payload.
+ * Verify the HMAC-SHA256 event hash from a SignWell webhook.
  *
- * SignWell signs the raw request body with the webhook secret using
- * HMAC-SHA256 and sends the hex-encoded digest in the
- * x-signwell-signature header.
+ * SignWell signs the string "{event_type}@{event_time}" using the
+ * webhook ID as the HMAC key and includes the hex digest in the
+ * payload at `event.hash`.
+ *
+ * Ref: https://developers.signwell.com/reference/event-hash-verification
  *
  * Uses the Web Crypto API (available in Cloudflare Workers).
  */
-async function verifySignature(body: string, signature: string, secret: string): Promise<boolean> {
-  if (!signature) {
+async function verifyEventHash(
+  type: string,
+  time: number,
+  hash: string,
+  secret: string
+): Promise<boolean> {
+  if (!hash) {
     return false
   }
 
+  const data = `${type}@${time}`
   const encoder = new TextEncoder()
   const key = await crypto.subtle.importKey(
     'raw',
@@ -101,19 +142,19 @@ async function verifySignature(body: string, signature: string, secret: string):
     ['sign']
   )
 
-  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(body))
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(data))
   const digest = Array.from(new Uint8Array(mac))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
 
   // Constant-time comparison to prevent timing attacks
-  if (digest.length !== signature.length) {
+  if (digest.length !== hash.length) {
     return false
   }
 
   let mismatch = 0
   for (let i = 0; i < digest.length; i++) {
-    mismatch |= digest.charCodeAt(i) ^ signature.charCodeAt(i)
+    mismatch |= digest.charCodeAt(i) ^ hash.charCodeAt(i)
   }
 
   return mismatch === 0

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -244,15 +244,15 @@ describe('signwell: webhook route', () => {
     expect(source()).toContain('export const POST')
   })
 
-  it('implements HMAC-SHA256 signature verification', () => {
+  it('implements HMAC-SHA256 event hash verification', () => {
     const code = source()
-    expect(code).toContain('verifySignature')
+    expect(code).toContain('verifyEventHash')
     expect(code).toContain('HMAC')
     expect(code).toContain('SHA-256')
   })
 
-  it('reads signature from x-signwell-signature header', () => {
-    expect(source()).toContain('x-signwell-signature')
+  it('verifies hash from event.hash in payload body', () => {
+    expect(source()).toContain('event.hash')
   })
 
   it('returns 401 for invalid signatures', () => {
@@ -271,20 +271,27 @@ describe('signwell: webhook route', () => {
 
   it('dispatches document_completed events to handler', () => {
     const code = source()
-    expect(code).toContain("payload.event === 'document_completed'")
+    expect(code).toContain("payload.event.type === 'document_completed'")
     expect(code).toContain('handleDocumentCompleted')
   })
 
   it('acknowledges non-completed events with 200', () => {
     const code = source()
-    expect(code).toContain('payload.event')
+    expect(code).toContain('payload.event.type')
     expect(code).toContain('status: 200')
   })
 
-  it('uses constant-time comparison for signature check', () => {
+  it('uses constant-time comparison for hash check', () => {
     const code = source()
     expect(code).toContain('mismatch |=')
     expect(code).toContain('charCodeAt')
+  })
+
+  it('implements timestamp freshness check for replay protection', () => {
+    const code = source()
+    expect(code).toContain('event.time')
+    expect(code).toContain('MAX_WEBHOOK_AGE_SECONDS')
+    expect(code).toContain('Stale webhook')
   })
 
   it('does NOT use auth middleware (webhooks are unauthenticated)', () => {


### PR DESCRIPTION
## Summary
- Rewrites SignWell webhook HMAC verification to match their actual [Event Hash Verification](https://developers.signwell.com/reference/event-hash-verification) spec: hash is in the JSON body at `event.hash` (not an HTTP header), HMAC signs `"{type}@{time}"` (not the full body), and the webhook ID is the signing key
- Updates `SignWellWebhookPayload` type to match the real nested payload structure (`event.type`/`event.time`/`event.hash` + `data.object`)
- Adds 5-minute timestamp freshness check for replay protection (matches Stripe handler pattern)
- Fixes handler field access (`payload.data.object.id`)

Closes #303 (partial — webhook verification + types; secret storage is a post-merge step)

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 996/996 pass (72 signwell tests)
- [x] `npm run verify` — full CI green
- [ ] After merge: store webhook ID as `SIGNWELL_WEBHOOK_SECRET` in Cloudflare Pages, Infisical, Bitwarden
- [ ] Send test document via SignWell to verify end-to-end webhook flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)