### PR TITLE
fix(pdf): bundle Forme WASM for Cloudflare Workers runtime

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../.astro/types.d.ts" />
 
+/** WASM module imports — handled by Cloudflare adapter at build time */
+declare module '*.wasm' {
+  const module: WebAssembly.Module
+  export default module
+}
+
 /**
  * Cloudflare bindings available via Astro.locals.runtime.env
  *

--- a/src/lib/pdf/render.ts
+++ b/src/lib/pdf/render.ts
@@ -3,15 +3,38 @@
  *
  * Provides a single entry point for generating SOW PDFs from typed props.
  *
+ * Cloudflare Workers can't fetch() WASM at runtime — the binary must be
+ * imported at build time. We import forme_bg.wasm explicitly and pass
+ * the compiled module to init() before any render call. The Astro
+ * Cloudflare adapter (cloudflareModules) emits the WASM as a build
+ * asset and produces a WebAssembly.Module reference.
+ *
  * @see docs/spikes/forme-wasm-pdf.md — Forme spike results
  * @see src/lib/pdf/sow-template.tsx — SOW template component
  */
 
 import { renderDocument } from '@formepdf/core'
+import { init } from '@formepdf/core/browser'
 import { SOWTemplate } from './sow-template'
 import type { SOWTemplateProps } from './sow-template'
 import { ScorecardReportTemplate } from './scorecard-template'
 import type { ScorecardReportProps } from './scorecard-template'
+import formeWasm from '@formepdf/core/pkg/forme_bg.wasm'
+
+/**
+ * Ensure the Forme WASM module is initialized before rendering.
+ * Memoizes the init promise; resets on failure so the next call retries.
+ */
+let wasmReady: Promise<void> | null = null
+function ensureWasm(): Promise<void> {
+  if (!wasmReady) {
+    wasmReady = init(formeWasm).catch((err) => {
+      wasmReady = null
+      throw err
+    })
+  }
+  return wasmReady
+}
 
 /**
  * Render a Statement of Work PDF from quote/client/contact data.
@@ -20,6 +43,7 @@ import type { ScorecardReportProps } from './scorecard-template'
  * @returns PDF binary as Uint8Array — suitable for R2 storage or HTTP response
  */
 export async function renderSow(props: SOWTemplateProps): Promise<Uint8Array> {
+  await ensureWasm()
   const pdf = await renderDocument(SOWTemplate(props))
   return pdf
 }
@@ -31,6 +55,7 @@ export async function renderSow(props: SOWTemplateProps): Promise<Uint8Array> {
  * @returns PDF binary as Uint8Array — suitable for email attachment
  */
 export async function renderScorecardReport(props: ScorecardReportProps): Promise<Uint8Array> {
+  await ensureWasm()
   const pdf = await renderDocument(ScorecardReportTemplate(props))
   return pdf
 }


### PR DESCRIPTION
## Summary
- Forme's wasm-pack glue code loads WASM via `fetch()` at runtime, which fails in Cloudflare Workers (no filesystem). Import the WASM binary explicitly and pass to `init()` before rendering.
- Adds `ensureWasm()` with retry-on-failure to both `renderSow` and `renderScorecardReport`
- WASM file now appears in build output: `dist/_worker.js/forme_bg.*.wasm`

Closes #320

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run build` — WASM file in `dist/_worker.js/`
- [x] `npm run verify` — 996/996 pass
- [ ] Deploy and click "Generate SOW PDF" on Desert Bloom quote

🤖 Generated with [Claude Code](https://claude.com/claude-code)