### PR TITLE
fix(signwell): correct document creation API schema

### DIFF
--- a/src/lib/signwell/types.ts
+++ b/src/lib/signwell/types.ts
@@ -39,24 +39,29 @@ export interface SignWellField {
 export interface SignWellCreateDocumentRequest {
   /** Display name for the document in SignWell */
   name: string
-  /** Base64-encoded file content */
-  file_base64?: string
-  /** Public URL to the file (alternative to file_base64) */
-  file_url?: string
-  /** Original filename */
-  original_filename?: string
-  /** Signer details */
-  signers: {
+  /** Document files — each with file_base64 or file_url */
+  files: {
+    file_base64?: string
+    file_url?: string
+    name?: string
+  }[]
+  /** Recipients (signers) */
+  recipients: {
     id: string
     name: string
     email: string
   }[]
   /** Webhook callback URL for completion events */
   callback_url?: string
-  /** Field placements for signature blocks */
-  fields: (SignWellField & { signer_id: string })[]
+  /**
+   * Field placements — 2D array: outer = per file, inner = fields.
+   * Each field uses recipient_id to link to a recipient.
+   */
+  fields: (SignWellField & { recipient_id: string })[][]
   /** Whether to send the signing request via email immediately */
   draft?: boolean
+  /** Enable test mode (no real signatures) */
+  test_mode?: boolean
   /** Custom message to include in the signing email */
   custom_requester_name?: string
   custom_requester_email?: string

--- a/src/pages/api/admin/quotes/[id]/sign.ts
+++ b/src/pages/api/admin/quotes/[id]/sign.ts
@@ -116,9 +116,8 @@ export const POST: APIRoute = async ({ locals, redirect, params }) => {
 
     const signRequest: SignWellCreateDocumentRequest = {
       name: `SOW — ${entity.name}`,
-      file_base64: pdfBase64,
-      original_filename: 'sow.pdf',
-      signers: [
+      files: [{ file_base64: pdfBase64, name: 'sow.pdf' }],
+      recipients: [
         {
           id: signerId,
           name: primaryContact.name,
@@ -127,28 +126,30 @@ export const POST: APIRoute = async ({ locals, redirect, params }) => {
       ],
       callback_url: callbackUrl,
       fields: [
-        {
-          type: 'signature',
-          required: true,
-          page: 1,
-          x: 72,
-          y: 680,
-          width: 200,
-          height: 40,
-          signer_id: signerId,
-          api_id: 'client_signature',
-        },
-        {
-          type: 'date',
-          required: true,
-          page: 1,
-          x: 72,
-          y: 730,
-          width: 120,
-          height: 20,
-          signer_id: signerId,
-          api_id: 'client_date',
-        },
+        [
+          {
+            type: 'signature',
+            required: true,
+            page: 1,
+            x: 72,
+            y: 680,
+            width: 200,
+            height: 40,
+            recipient_id: signerId,
+            api_id: 'client_signature',
+          },
+          {
+            type: 'date',
+            required: true,
+            page: 1,
+            x: 72,
+            y: 730,
+            width: 120,
+            height: 20,
+            recipient_id: signerId,
+            api_id: 'client_date',
+          },
+        ],
       ],
       draft: false,
       custom_requester_name: 'SMD Services',
@@ -184,7 +185,11 @@ export const POST: APIRoute = async ({ locals, redirect, params }) => {
 
     return redirect(`/admin/entities/${quote.entity_id}/quotes/${quoteId}?saved=1`, 302)
   } catch (err) {
-    console.error('[api/admin/quotes/[id]/sign] Error:', err)
-    return redirect('/admin/entities?error=server', 302)
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[api/admin/quotes/[id]/sign] Error:', msg, err instanceof Error ? err.stack : '')
+    return redirect(
+      `/admin/entities?error=server&detail=${encodeURIComponent(msg.slice(0, 200))}`,
+      302
+    )
   }
 }

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -30,9 +30,9 @@ describe('signwell: types', () => {
     expect(code).toContain('file_base64')
   })
 
-  it('SignWellCreateDocumentRequest includes signers array', () => {
+  it('SignWellCreateDocumentRequest includes recipients array', () => {
     const code = source()
-    expect(code).toContain('signers')
+    expect(code).toContain('recipients')
   })
 
   it('SignWellCreateDocumentRequest includes callback_url for webhooks', () => {
@@ -353,10 +353,10 @@ describe('signwell: send-for-signature route', () => {
     expect(code).toContain('primaryContact')
   })
 
-  it('calls createSignatureRequest with signer and field placements', () => {
+  it('calls createSignatureRequest with recipients and field placements', () => {
     const code = source()
     expect(code).toContain('createSignatureRequest')
-    expect(code).toContain('signers')
+    expect(code).toContain('recipients')
     expect(code).toContain('fields')
   })
 


### PR DESCRIPTION
## Summary
- SignWell API uses `recipients` not `signers`, `files[]` not top-level `file_base64`, `recipient_id` not `signer_id`, and `fields` as a 2D array
- Updated `SignWellCreateDocumentRequest` type to match actual API
- Updated sign route to build correct request payload
- Added error detail to sign route redirects for easier debugging

Part of #320 — sprint review found three production issues in the SignWell integration

## Test plan
- [x] `npm run verify` — 0 errors, 996 tests pass
- [ ] Deploy and click "Send via SignWell" on Desert Bloom quote

🤖 Generated with [Claude Code](https://claude.com/claude-code)