### PR TITLE
fix(signwell): use pdfplumber-measured coordinates from Forme PDF

### DIFF
--- a/src/lib/pdf/signing-layout.ts
+++ b/src/lib/pdf/signing-layout.ts
@@ -100,7 +100,7 @@ export const SIGNING_PAGE = {
   /** CLIENT signature field (left column) */
   clientSignature: {
     x: PAGE_MARGINS.left,
-    y: 200,
+    y: 205, // Measured: CLIENT label bottom at 204.5pt from page top
     width: 200,
     height: 50,
   },
@@ -108,7 +108,7 @@ export const SIGNING_PAGE = {
   /** CLIENT date field (left column, below signature) */
   clientDate: {
     x: PAGE_MARGINS.left,
-    y: 293,
+    y: 300, // Measured: "Date: ___" text top at 302.1pt from page top
     width: 120,
     height: 20,
   },
@@ -116,7 +116,7 @@ export const SIGNING_PAGE = {
   /** SMD SERVICES signature field (right column) — reserved for future use */
   smdSignature: {
     x: PAGE_MARGINS.left + COLUMN_WIDTH + COLUMN_GAP,
-    y: 200,
+    y: 205,
     width: 200,
     height: 50,
   },
@@ -124,7 +124,7 @@ export const SIGNING_PAGE = {
   /** SMD SERVICES date field (right column) — reserved for future use */
   smdDate: {
     x: PAGE_MARGINS.left + COLUMN_WIDTH + COLUMN_GAP,
-    y: 293,
+    y: 300,
     width: 120,
     height: 20,
   },


### PR DESCRIPTION
## Summary

- Updates signing field coordinates in `signing-layout.ts` with values measured from the actual Forme-rendered production PDF using pdfplumber
- Signature field: y=200 → 205 (CLIENT label bottom measured at 204.5pt)
- Date field: y=293 → 300 ("Date: ___" text measured at 302.1pt)

Follows up #327 (dedicated signing page). The initial values from the pdf-lib reference simulation were ~5-9pt off from the actual Forme WASM output due to font metric differences (Helvetica vs Inter/Plus Jakarta Sans).

## Test plan

- [x] `signing-fields.test.ts` — all 13 tests pass
- [x] Coordinates measured from actual production Forme PDF via pdfplumber
- [ ] SignWell `test_mode` visual verification after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)