### PR TITLE
feat(signwell): text tags for auto field placement via pdf-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "globals": "^15.0.0",
         "husky": "^9.1.0",
         "lint-staged": "^15.4.0",
+        "pdf-lib": "^1.17.1",
         "prettier": "^3.4.0",
         "prettier-plugin-astro": "^0.14.1",
         "tailwindcss": "^4.2.2",
@@ -2313,6 +2314,26 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -7749,6 +7770,13 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7852,6 +7880,26 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "globals": "^15.0.0",
     "husky": "^9.1.0",
     "lint-staged": "^15.4.0",
+    "pdf-lib": "^1.17.1",
     "prettier": "^3.4.0",
     "prettier-plugin-astro": "^0.14.1",
     "tailwindcss": "^4.2.2",

--- a/src/lib/pdf/inject-signing-tags.ts
+++ b/src/lib/pdf/inject-signing-tags.ts
@@ -1,0 +1,74 @@
+/**
+ * Inject SignWell text tags into a Forme-rendered PDF.
+ *
+ * Forme's WASM renderer does not write text to PDF content streams,
+ * so SignWell's text tag scanner can't find tags embedded in JSX templates.
+ * pdf-lib writes standard PDF text operations (BT/Tf/Tj/ET) that ARE
+ * in the content stream. This module bridges the two.
+ *
+ * ## How it works
+ *
+ * 1. renderSow() generates the visual PDF via Forme
+ * 2. This function post-processes the PDF via pdf-lib to add hidden text tags
+ * 3. SignWell scans the PDF, finds the tags, and auto-places interactive fields
+ *
+ * ## Text tag syntax
+ *
+ * SignWell text tags use `{{type:signer:required:label:prefill:api_id:width:height}}`.
+ * Empty fields must use a space (not empty string) — `::::` breaks detection,
+ * but `: : :` works. This was validated via PoC testing.
+ *
+ * @see https://developers.signwell.com/reference/adding-text-tags
+ * @see https://developers.signwell.com/reference/text-tag-options
+ */
+
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib'
+import { SIGNING_PAGE, PAGE_SIZE } from './signing-layout'
+
+/**
+ * Inject SignWell text tags into a Forme-rendered SOW PDF.
+ *
+ * Adds hidden signature and date text tags at the measured signing positions
+ * on the dedicated signing page (page 3). SignWell auto-detects these tags
+ * when `text_tags: true` is set in the API request.
+ *
+ * @param pdfBytes - Raw PDF bytes from Forme's renderDocument()
+ * @returns Modified PDF bytes with text tags injected
+ */
+export async function injectSigningTags(pdfBytes: Uint8Array): Promise<Uint8Array> {
+  const doc = await PDFDocument.load(pdfBytes)
+  const signingPage = doc.getPage(SIGNING_PAGE.pageNumber - 1) // 0-indexed
+  const font = await doc.embedFont(StandardFonts.Helvetica)
+
+  // Tag text color: white (invisible on white background).
+  // SignWell's field widget covers the tag position, so even if visible
+  // the signer never sees the raw tag text.
+  const tagColor = rgb(1, 1, 1)
+
+  // Signature tag — placed at the empty signing space below "CLIENT" label.
+  // Spaces for skipped fields (label, prefill) — empty colons break SignWell's parser.
+  signingPage.drawText(
+    `{{signature:1:y: : :client_signature:${SIGNING_PAGE.sigFieldWidth}:${SIGNING_PAGE.sigFieldHeight}}}`,
+    {
+      x: SIGNING_PAGE.tagInjection.signature.x,
+      y: PAGE_SIZE.height - SIGNING_PAGE.tagInjection.signature.y,
+      size: 6,
+      font,
+      color: tagColor,
+    }
+  )
+
+  // Date tag — placed at the "Date: ___" position below contact name/title.
+  signingPage.drawText(
+    `{{date:1:y: : :client_date:${SIGNING_PAGE.dateFieldWidth}:${SIGNING_PAGE.dateFieldHeight}}}`,
+    {
+      x: SIGNING_PAGE.tagInjection.date.x,
+      y: PAGE_SIZE.height - SIGNING_PAGE.tagInjection.date.y,
+      size: 6,
+      font,
+      color: tagColor,
+    }
+  )
+
+  return new Uint8Array(await doc.save())
+}

--- a/src/lib/pdf/render.ts
+++ b/src/lib/pdf/render.ts
@@ -19,6 +19,7 @@ import { SOWTemplate } from './sow-template'
 import type { SOWTemplateProps } from './sow-template'
 import { ScorecardReportTemplate } from './scorecard-template'
 import type { ScorecardReportProps } from './scorecard-template'
+import { injectSigningTags } from './inject-signing-tags'
 import formeWasm from '@formepdf/core/pkg/forme_bg.wasm'
 
 /**
@@ -45,7 +46,10 @@ function ensureWasm(): Promise<void> {
 export async function renderSow(props: SOWTemplateProps): Promise<Uint8Array> {
   await ensureWasm()
   const pdf = await renderDocument(SOWTemplate(props))
-  return pdf
+  // Post-process: inject SignWell text tags for auto field detection.
+  // Forme's WASM renderer doesn't write text to PDF content streams,
+  // so we use pdf-lib to add tags that SignWell's scanner can find.
+  return injectSigningTags(pdf)
 }
 
 /**

--- a/src/lib/pdf/signing-layout.ts
+++ b/src/lib/pdf/signing-layout.ts
@@ -5,31 +5,21 @@
  * and are consumed in two places:
  *
  *   1. The Forme template (sow-template.tsx) — positions the signing block
- *   2. The SignWell field config (field-config.ts) — places interactive fields
+ *   2. The text tag injection (inject-signing-tags.ts) — places SignWell tags
  *
- * CRITICAL: If you change these values, the template and the SignWell fields
+ * CRITICAL: If you change these values, the template and the text tags
  * move together. That is the entire point of this module.
  *
- * ## How coordinates were measured
+ * ## How tag positions were measured
  *
- * The y-values below were measured from an actual rendered PDF, NOT calculated
- * from font metrics. Procedure:
+ * The y-values below were measured from the actual Forme-rendered PDF using
+ * pdfplumber (not calculated from font metrics):
  *
- *   1. Generate a test SOW via renderSow() or the admin UI
- *   2. Open the PDF in Preview > Tools > Show Inspector (or any PDF coordinate tool)
- *   3. Hover over the top-left corner of the signing space on page 3
- *   4. Read the y-coordinate (Preview uses bottom-left origin — convert to
- *      top-left by subtracting from PAGE_HEIGHT)
- *   5. Update the values below
+ *   python3: pdfplumber.open("sow.pdf").pages[2].extract_words()
+ *   CLIENT label bottom: y=204.5pt from page top
+ *   Date text top:       y=302.1pt from page top
  *
  * Re-measure whenever the signing page layout changes.
- *
- * ## SignWell coordinate system
- *
- * Based on empirical testing:
- * - Origin: top-left of each page (0,0 = top-left corner)
- * - Units: PDF points (1/72 inch)
- * - Pages: 1-indexed (page 1 = first page)
  *
  * @see docs/templates/sow-template.md — Section 5.4 (signing page layout)
  */
@@ -74,30 +64,34 @@ export const SIGNING_PAGE = {
   columnWidth: COLUMN_WIDTH,
 
   // ---------------------------------------------------------------------------
-  // SignWell field coordinates
+  // Text tag injection positions (top-left origin, PDF points)
   //
-  // Initial values derived from the page 3 layout, which has ZERO variable
-  // content — every element is fixed-length static text. This makes the
-  // y-positions deterministic regardless of SOW content on pages 1-2.
-  //
-  // Layout (from page top):
-  //   54pt  top margin
-  //  ~28pt  NEXT STEPS heading (12pt font + 12pt marginBottom + padding/border)
-  //  ~52pt  preamble text (2 lines × 14pt + 24pt marginBottom)
-  //  ~28pt  AGREEMENT heading (same as NEXT STEPS)
-  //  ~44pt  agreement text (2 lines × 14pt + 16pt marginBottom)
-  //  ~12pt  "CLIENT" label (9pt font + spacing)
-  //   = ~218pt cumulative — signing space starts here
-  //  60pt   empty signing space (signingSpaceHeight)
-  //   5pt   divider + margin
-  //  ~24pt  contact name + optional title
-  //  ~16pt  date field area
-  //
-  // IMPORTANT: These values MUST be verified against the actual rendered PDF
-  // before production use. See "How coordinates were measured" above.
+  // These are the positions where pdf-lib injects SignWell text tags.
+  // Measured from the actual Forme-rendered PDF via pdfplumber.
   // ---------------------------------------------------------------------------
 
-  /** CLIENT signature field (left column) */
+  /** Where to inject text tags (top-left origin, converted to bottom-left by inject-signing-tags.ts) */
+  tagInjection: {
+    /** Signature tag position: below CLIENT label, in the 60pt signing space */
+    signature: { x: PAGE_MARGINS.left, y: 215 },
+    /** Date tag position: at the "Date: ___" text area */
+    date: { x: PAGE_MARGINS.left, y: 305 },
+  },
+
+  /** SignWell field dimensions (specified in text tag options) */
+  sigFieldWidth: 200,
+  sigFieldHeight: 50,
+  dateFieldWidth: 120,
+  dateFieldHeight: 20,
+
+  // ---------------------------------------------------------------------------
+  // Coordinate-based fallback (kept per critique recommendation)
+  //
+  // If text tags fail, sign.ts can fall back to explicit field coordinates.
+  // These are the same measured positions used for tag injection.
+  // ---------------------------------------------------------------------------
+
+  /** CLIENT signature field (left column) — fallback coordinates */
   clientSignature: {
     x: PAGE_MARGINS.left,
     y: 205, // Measured: CLIENT label bottom at 204.5pt from page top
@@ -105,7 +99,7 @@ export const SIGNING_PAGE = {
     height: 50,
   },
 
-  /** CLIENT date field (left column, below signature) */
+  /** CLIENT date field (left column) — fallback coordinates */
   clientDate: {
     x: PAGE_MARGINS.left,
     y: 300, // Measured: "Date: ___" text top at 302.1pt from page top

--- a/src/pages/api/admin/quotes/[id]/sign.ts
+++ b/src/pages/api/admin/quotes/[id]/sign.ts
@@ -6,7 +6,7 @@ import { listContacts } from '../../../../../lib/db/contacts'
 import { getPdf } from '../../../../../lib/storage/r2'
 import { createSignatureRequest } from '../../../../../lib/signwell/client'
 import type { SignWellCreateDocumentRequest } from '../../../../../lib/signwell/types'
-import { getSowSigningFields } from '../../../../../lib/signwell/field-config'
+import { getSowSigningFields } from '../../../../../lib/signwell/field-config' // coordinate fallback
 
 /**
  * POST /api/admin/quotes/:id/sign
@@ -115,10 +115,8 @@ export const POST: APIRoute = async ({ locals, redirect, params }) => {
     // 5. Create signature request in SignWell
     const signerId = crypto.randomUUID()
 
-    // Field coordinates come from signing-layout.ts (measured from rendered PDF).
-    // See src/lib/pdf/signing-layout.ts for measurement methodology.
-    const signingFields = getSowSigningFields()
-
+    // Text tags are embedded in the PDF by inject-signing-tags.ts (called during renderSow).
+    // SignWell auto-detects fields from these tags — no manual coordinates needed.
     const signRequest: SignWellCreateDocumentRequest = {
       name: `SOW — ${entity.name}`,
       files: [{ file_base64: pdfBase64, name: 'sow.pdf' }],
@@ -130,22 +128,7 @@ export const POST: APIRoute = async ({ locals, redirect, params }) => {
         },
       ],
       callback_url: callbackUrl,
-      fields: [
-        [
-          {
-            ...signingFields.signature,
-            required: true,
-            recipient_id: signerId,
-            api_id: 'client_signature',
-          },
-          {
-            ...signingFields.date,
-            required: true,
-            recipient_id: signerId,
-            api_id: 'client_date',
-          },
-        ],
-      ],
+      text_tags: true,
       draft: false,
       custom_requester_name: 'SMD Services',
       subject: `SOW for Signature — ${entity.name}`,
@@ -153,6 +136,49 @@ export const POST: APIRoute = async ({ locals, redirect, params }) => {
     }
 
     const signwellDoc = await createSignatureRequest(apiKey, signRequest)
+
+    // Verify text tags were detected. If not, fall back to coordinate-based placement.
+    const detectedFields = (
+      (signwellDoc as unknown as { fields?: unknown[][] }).fields || []
+    ).flat()
+    if (detectedFields.length === 0) {
+      console.warn(
+        '[api/admin/quotes/[id]/sign] Text tags not detected — falling back to coordinates'
+      )
+      const fallbackFields = getSowSigningFields()
+      // Re-create with explicit field coordinates
+      const fallbackRequest: SignWellCreateDocumentRequest = {
+        ...signRequest,
+        text_tags: undefined,
+        fields: [
+          [
+            {
+              ...fallbackFields.signature,
+              required: true,
+              recipient_id: signerId,
+              api_id: 'client_signature',
+            },
+            {
+              ...fallbackFields.date,
+              required: true,
+              recipient_id: signerId,
+              api_id: 'client_date',
+            },
+          ],
+        ],
+      }
+      // Delete the fieldless document first
+      try {
+        await fetch(`https://www.signwell.com/api/v1/documents/${signwellDoc.id}`, {
+          method: 'DELETE',
+          headers: { 'X-Api-Key': apiKey },
+        })
+      } catch {
+        // Best effort cleanup
+      }
+      const fallbackDoc = await createSignatureRequest(apiKey, fallbackRequest)
+      Object.assign(signwellDoc, fallbackDoc)
+    }
 
     // 6. Update quote with signwell_doc_id
     const now = new Date().toISOString()

--- a/tests/inject-signing-tags.test.ts
+++ b/tests/inject-signing-tags.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('inject-signing-tags: module', () => {
+  it('inject-signing-tags.ts exists', () => {
+    expect(existsSync(resolve('src/lib/pdf/inject-signing-tags.ts'))).toBe(true)
+  })
+
+  it('exports injectSigningTags function', () => {
+    const code = readFileSync(resolve('src/lib/pdf/inject-signing-tags.ts'), 'utf-8')
+    expect(code).toContain('export async function injectSigningTags')
+  })
+
+  it('uses pdf-lib to inject text tags', () => {
+    const code = readFileSync(resolve('src/lib/pdf/inject-signing-tags.ts'), 'utf-8')
+    expect(code).toContain("from 'pdf-lib'")
+    expect(code).toContain('drawText')
+    expect(code).toContain('{{signature:1:y:')
+    expect(code).toContain('{{date:1:y:')
+  })
+
+  it('uses spaces for empty tag fields (not empty colons)', () => {
+    const code = readFileSync(resolve('src/lib/pdf/inject-signing-tags.ts'), 'utf-8')
+    // Empty colons (::::) break SignWell's parser. Must use spaces (: : :).
+    // Check only the drawText calls, not JSDoc comments.
+    const drawCalls = code.split('\n').filter((l) => l.includes('drawText') || l.includes('{{'))
+    const tagLines = drawCalls.join('\n')
+    expect(tagLines).not.toContain('::::')
+    expect(tagLines).toContain(': : :')
+  })
+
+  it('imports layout constants from signing-layout', () => {
+    const code = readFileSync(resolve('src/lib/pdf/inject-signing-tags.ts'), 'utf-8')
+    expect(code).toContain('SIGNING_PAGE')
+    expect(code).toContain('PAGE_SIZE')
+  })
+})
+
+describe('inject-signing-tags: render.ts integration', () => {
+  it('render.ts imports and calls injectSigningTags', () => {
+    const code = readFileSync(resolve('src/lib/pdf/render.ts'), 'utf-8')
+    expect(code).toContain('injectSigningTags')
+    expect(code).toContain("from './inject-signing-tags'")
+  })
+
+  it('renderSow calls injectSigningTags after Forme render', () => {
+    const code = readFileSync(resolve('src/lib/pdf/render.ts'), 'utf-8')
+    // The function should call renderDocument then injectSigningTags
+    const renderIdx = code.indexOf('renderDocument')
+    const injectIdx = code.indexOf('injectSigningTags(pdf)')
+    expect(renderIdx).toBeGreaterThan(-1)
+    expect(injectIdx).toBeGreaterThan(renderIdx)
+  })
+})

--- a/tests/signwell.test.ts
+++ b/tests/signwell.test.ts
@@ -360,11 +360,12 @@ describe('signwell: send-for-signature route', () => {
     expect(code).toContain('fields')
   })
 
-  it('uses field config for signing page coordinates', () => {
+  it('uses text_tags for auto field detection with coordinate fallback', () => {
     const code = source()
-    expect(code).toContain('getSowSigningFields')
+    expect(code).toContain('text_tags: true')
     expect(code).toContain('client_signature')
     expect(code).toContain('client_date')
+    expect(code).toContain('getSowSigningFields') // fallback
   })
 
   it('sets callback_url for webhook', () => {


### PR DESCRIPTION
## Summary

- Replaces coordinate-based SignWell field placement with **text tags** — SignWell's built-in mechanism for auto-detecting signing fields from PDF content
- Forme renders the visual PDF, then **pdf-lib** post-processes to inject hidden text tags at the signing positions on page 3
- SignWell scans the PDF content stream and auto-places fields — no `fields` array, no coordinate math, no coordinate system ambiguity
- Includes **coordinate-based fallback** — if text tag detection returns zero fields, falls back to explicit coordinates per critique recommendation

## Key finding from PoC

SignWell's text tag parser requires **spaces** (not empty strings) for skipped options:
- `{{signature:1:y: : :client_signature:200:50}}` — **works**
- `{{signature:1:y::::client_signature:200:50}}` — **silently fails** (0 fields)

This was the reason PR #326's text tag attempt failed — the empty colons, not the content stream issue.

## Validation

- PoC sent a tagged Forme PDF to SignWell with `text_tags: true`
- SignWell detected both fields (signature + date) on page 3
- Opened the signing URL and visually verified correct field placement
- Screenshot shows signature field in the CLIENT signing space and date field at the Date placeholder

## Test plan

- [x] 1022 tests pass, 0 errors
- [x] New `inject-signing-tags.test.ts` — verifies tag injection module
- [x] Updated `signwell.test.ts` — verifies text_tags usage with coordinate fallback
- [x] PoC validated end-to-end: Forme → pdf-lib → SignWell → correct fields
- [ ] After merge: regenerate Desert Bloom SOW and send to SignWell via admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)