### PR TITLE
fix(booking): extend lookahead from 14 days to 60 days

### DIFF
--- a/src/lib/booking/config.ts
+++ b/src/lib/booking/config.ts
@@ -61,7 +61,7 @@ export const BOOKING_CONFIG: BookingConfig = {
   slot_minutes: 30,
   buffer_minutes: 15,
   min_notice_minutes: 24 * 60,
-  max_lookahead_days: 14,
+  max_lookahead_days: 60,
   weekly_schedule: {
     sun: [],
     mon: [{ start: '09:00', end: '16:00' }],

--- a/src/pages/api/booking/slots.ts
+++ b/src/pages/api/booking/slots.ts
@@ -14,7 +14,7 @@ const FALLBACK_EMAIL = 'scott@smd.services'
 /**
  * GET /api/booking/slots
  *
- * Public endpoint — returns available booking slots for the next 14 days.
+ * Public endpoint — returns available booking slots for the configured lookahead window.
  * No rate limiting (public availability is uninteresting to scrape and
  * rate-limiting punishes legitimate users behind shared NAT).
  *


### PR DESCRIPTION
## Summary
- Extended `max_lookahead_days` from 14 to 60 in booking config so the monthly calendar grid shows available slots across the full visible range
- Updated API endpoint doc comment to reference configured lookahead window instead of hardcoded "14 days"

## Test plan
- [ ] `npm run verify` passes
- [ ] Visit `/book` — calendar shows available dates beyond 2 weeks
- [ ] Forward navigation arrows work through multiple months

🤖 Generated with [Claude Code](https://claude.com/claude-code)