### PR TITLE
fix(booking): replace Google Meet with static Zoom link

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -62,6 +62,8 @@ type CfEnv = {
   BOOKING_ENCRYPTION_KEY?: string
   /** Cloudflare Turnstile secret key (paired with PUBLIC_TURNSTILE_SITE_KEY). */
   TURNSTILE_SECRET_KEY?: string
+  /** Static video call URL for booking events (e.g. Zoom personal meeting link). */
+  MEETING_URL?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>

--- a/src/lib/booking/config.ts
+++ b/src/lib/booking/config.ts
@@ -49,6 +49,8 @@ export interface BookingConfig {
    * for this many hours after their assessment slot before the token expires.
    */
   manage_token_ttl_hours_after_slot: number
+  /** Static video call URL used for all booking events. */
+  meeting_url: string
 }
 
 export const BOOKING_CONFIG: BookingConfig = {
@@ -75,4 +77,5 @@ export const BOOKING_CONFIG: BookingConfig = {
   google_call_timeout_ms: 8_000,
   google_call_retries: 1,
   manage_token_ttl_hours_after_slot: 48,
+  meeting_url: 'https://zoom.us/j/4284801619',
 }

--- a/src/lib/booking/google-calendar.ts
+++ b/src/lib/booking/google-calendar.ts
@@ -4,8 +4,8 @@
  * Uses fetch() for all calls (Workers-compatible). Handles event CRUD,
  * free/busy queries, and access token refresh.
  *
- * Events include Google Meet conferencing via `conferenceData` and
- * store the assessment_id in `extendedProperties.private`.
+ * Video call URLs are configured separately (see BOOKING_CONFIG.meeting_url).
+ * Events store the assessment_id in `extendedProperties.private`.
  */
 
 import { BOOKING_CONFIG } from './config.js'
@@ -29,7 +29,6 @@ export interface CalendarEventInput {
 export interface CalendarEvent {
   id: string
   htmlLink: string
-  hangoutLink?: string
   summary: string
   start: { dateTime: string; timeZone: string }
   end: { dateTime: string; timeZone: string }
@@ -84,12 +83,6 @@ function buildEventBody(event: CalendarEventInput): Record<string, unknown> {
     description: event.description,
     start: event.start,
     end: event.end,
-    conferenceData: {
-      createRequest: {
-        requestId: crypto.randomUUID(),
-        conferenceSolutionKey: { type: 'hangoutsMeet' },
-      },
-    },
   }
 
   if (event.attendees?.length) {
@@ -110,14 +103,14 @@ function buildEventBody(event: CalendarEventInput): Record<string, unknown> {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a Google Calendar event with Google Meet conferencing.
+ * Create a Google Calendar event.
  */
 export async function createCalendarEvent(
   accessToken: string,
   calendarId: string,
   event: CalendarEventInput
 ): Promise<CalendarEvent> {
-  const url = `${BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?conferenceDataVersion=1&sendUpdates=all`
+  const url = `${BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?sendUpdates=all`
   const body = buildEventBody(event)
 
   const response = await googleFetch(url, accessToken, {
@@ -142,7 +135,7 @@ export async function updateCalendarEvent(
   eventId: string,
   event: Partial<CalendarEventInput>
 ): Promise<CalendarEvent> {
-  const url = `${BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}?conferenceDataVersion=1&sendUpdates=all`
+  const url = `${BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}?sendUpdates=all`
 
   const body: Record<string, unknown> = {}
   if (event.summary) body.summary = event.summary

--- a/src/lib/booking/ics.ts
+++ b/src/lib/booking/ics.ts
@@ -40,7 +40,7 @@ export interface BuildIcsInput {
   title: string
   /** Plain text description. URLs allowed; HTML is not. */
   description: string
-  /** Optional location string (Google Meet URL works fine here). */
+  /** Optional location string (video call URL). */
   location?: string
   organizerName: string
   organizerEmail: string

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -300,7 +300,7 @@ export interface BookingConfirmationEmailInput {
   businessName: string
   /** Localized slot label, e.g., "Tuesday, April 14 at 9:00 AM (Phoenix)". */
   slotLabel: string
-  /** Google Meet URL or null if Meet creation failed. */
+  /** Video call URL (e.g. Zoom personal meeting link). */
   meetUrl: string | null
   manageUrl: string
   meetingLabel: string
@@ -341,7 +341,7 @@ export function bookingConfirmationEmailHtml(input: BookingConfirmationEmailInpu
               <p style="font-size:13px;color:#1e40af;margin:0 0 8px;font-weight:600;">Join the call</p>
               <a href="${escapeBookingHtml(input.meetUrl)}" style="font-size:14px;color:#1e40af;word-break:break-all;">${escapeBookingHtml(input.meetUrl)}</a>
             </div>`
-          : `<p style="font-size:13px;color:#64748b;margin:0 0 24px;">We'll send the video call link shortly.</p>`
+          : ''
       }
 
       <p style="font-size:14px;color:#334155;margin:0 0 8px;">

--- a/src/pages/admin/assessments/[id].astro
+++ b/src/pages/admin/assessments/[id].astro
@@ -252,7 +252,7 @@ function contextTypeBadge(type: string): string {
                     rel="noopener noreferrer"
                     class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 transition-colors"
                   >
-                    Join Google Meet
+                    Join Video Call
                   </a>
                 </div>
               )}

--- a/src/pages/admin/settings/google-connect.astro
+++ b/src/pages/admin/settings/google-connect.astro
@@ -171,7 +171,7 @@ const errorMessages: Record<string, string> = {
               </div>
               <p class="text-sm text-slate-600 mb-6">
                 Connect your Google Calendar to automatically create events when assessments are
-                booked, include Google Meet links, and check availability in real time.
+                booked and check availability in real time.
               </p>
               <a
                 href="/api/auth/google/connect"

--- a/src/pages/api/booking/manage/[token]/reschedule.ts
+++ b/src/pages/api/booking/manage/[token]/reschedule.ts
@@ -133,7 +133,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
         await updateScheduleGoogleSync(env.DB, schedule.id, {
           googleEventId: updatedEvent.id,
           googleEventLink: updatedEvent.htmlLink ?? null,
-          googleMeetUrl: updatedEvent.hangoutLink ?? null,
+          googleMeetUrl: BOOKING_CONFIG.meeting_url,
         })
       } catch (err) {
         console.error('[api/booking/manage/reschedule] Google Calendar update failed:', err)

--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -247,6 +247,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
   try {
     const slotLabel = formatSlotLabelLong(slotStartUtc, BOOKING_CONFIG.consultant.timezone)
 
+    const meetUrl = BOOKING_CONFIG.meeting_url
     const eventResult = await createGoogleCalendarEvent(accessToken, calendarId, {
       summary: `Assessment: ${businessName} (${name})`,
       description: buildEventDescription(name, email, businessName, intakeLines),
@@ -258,13 +259,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     googleEventId = eventResult.eventId
     googleEventLink = eventResult.htmlLink
-    googleMeetUrl = eventResult.meetUrl
+    googleMeetUrl = meetUrl
 
     // Update schedule with Google sync data
     await updateScheduleGoogleSync(env.DB, scheduleId, {
       googleEventId: eventResult.eventId,
       googleEventLink: eventResult.htmlLink,
-      googleMeetUrl: eventResult.meetUrl,
+      googleMeetUrl: meetUrl,
     })
   } catch (err) {
     // Google sync failed — compensating rollback
@@ -403,7 +404,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 interface CreateEventResult {
   eventId: string
   htmlLink: string | null
-  meetUrl: string | null
 }
 
 async function createGoogleCalendarEvent(
@@ -423,7 +423,7 @@ async function createGoogleCalendarEvent(
 
   try {
     const response = await fetch(
-      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?conferenceDataVersion=1&sendUpdates=all`,
+      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?sendUpdates=all`,
       {
         method: 'POST',
         headers: {
@@ -436,12 +436,6 @@ async function createGoogleCalendarEvent(
           start: { dateTime: params.startUtc, timeZone: 'UTC' },
           end: { dateTime: params.endUtc, timeZone: 'UTC' },
           attendees: [{ email: params.guestEmail }],
-          conferenceData: {
-            createRequest: {
-              requestId: params.assessmentId,
-              conferenceSolutionKey: { type: 'hangoutsMeet' },
-            },
-          },
           extendedProperties: {
             private: {
               assessmentId: params.assessmentId,
@@ -467,23 +461,11 @@ async function createGoogleCalendarEvent(
     const data = (await response.json()) as {
       id: string
       htmlLink?: string
-      hangoutLink?: string
-      conferenceData?: {
-        entryPoints?: Array<{ entryPointType: string; uri: string }>
-      }
-    }
-
-    // Extract Meet URL from conferenceData or hangoutLink
-    let meetUrl: string | null = data.hangoutLink ?? null
-    if (!meetUrl && data.conferenceData?.entryPoints) {
-      const videoEntry = data.conferenceData.entryPoints.find((ep) => ep.entryPointType === 'video')
-      if (videoEntry) meetUrl = videoEntry.uri
     }
 
     return {
       eventId: data.id,
       htmlLink: data.htmlLink ?? null,
-      meetUrl,
     }
   } finally {
     clearTimeout(timeout)

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -361,7 +361,7 @@ const turnstileSiteKey = Astro.locals.runtime?.env?.PUBLIC_TURNSTILE_SITE_KEY ??
                   rel="noopener"
                   class="text-sm font-medium text-primary hover:text-primary-hover"
                 >
-                  Join Google Meet
+                  Join Video Call
                 </a>
               </div>
               <div id="conf-manage-row" class="hidden flex items-start gap-3">

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,6 +25,7 @@ pages_build_output_dir = "dist"
 APP_BASE_URL = "https://smd.services"
 PORTAL_BASE_URL = "https://portal.smd.services"
 PUBLIC_TURNSTILE_SITE_KEY = ""
+MEETING_URL = "https://zoom.us/j/4284801619"
 
 # ---------- D1 (structured data) ----------
 [[d1_databases]]


### PR DESCRIPTION
## Summary

- Replaces Google Meet auto-generation with a static Zoom personal meeting link (`https://zoom.us/j/4284801619`)
- Removes `conferenceData` and `conferenceDataVersion=1` from all Google Calendar API calls (create + update)
- Uses `BOOKING_CONFIG.meeting_url` as the single source of truth for the video call URL across reserve, reschedule, ICS generation, and email templates
- Updates all user-facing labels from "Join Google Meet" to "Join Video Call"

Closes #304

**Note:** The `google_meet_url` database column is unchanged — it now stores the Zoom URL. No migration needed. The Zoom meeting ID is also set as `MEETING_URL` in `wrangler.toml` for env-level visibility.

## Test plan

- [ ] Verify `npm run verify` passes (typecheck, lint, format, build, tests)
- [ ] Book a test assessment and confirm the Google Calendar event is created without `conferenceData`
- [ ] Confirm confirmation email contains the Zoom link, not "We'll send the video call link shortly"
- [ ] Confirm reschedule flow writes the Zoom URL to `google_meet_url` column
- [ ] Verify admin assessment detail page shows "Join Video Call" with correct Zoom link
- [ ] Verify `/book` confirmation panel shows "Join Video Call" with correct Zoom link
- [ ] Verify `/book/manage/[token]` shows the Zoom URL under "Video call"

🤖 Generated with [Claude Code](https://claude.com/claude-code)