### PR TITLE
fix(admin): shared status badge + cancelled assessment handling

### DIFF
--- a/src/lib/ui/status-badge.ts
+++ b/src/lib/ui/status-badge.ts
@@ -1,0 +1,26 @@
+/**
+ * Returns Tailwind badge classes for a given status string.
+ * Canonical source of truth for all status badge colors across admin UI.
+ */
+export function statusBadgeClass(status: string): string {
+  const map: Record<string, string> = {
+    scheduled: 'bg-blue-100 text-blue-700',
+    active: 'bg-green-100 text-green-700',
+    completed: 'bg-emerald-100 text-emerald-700',
+    handoff: 'bg-teal-100 text-teal-700',
+    safety_net: 'bg-amber-100 text-amber-700',
+    cancelled: 'bg-slate-100 text-slate-500',
+    disqualified: 'bg-red-100 text-red-600',
+    converted: 'bg-green-100 text-green-700',
+    draft: 'bg-slate-100 text-slate-600',
+    sent: 'bg-blue-100 text-blue-700',
+    accepted: 'bg-green-100 text-green-700',
+    declined: 'bg-red-100 text-red-700',
+    expired: 'bg-slate-100 text-slate-500',
+    paid: 'bg-green-100 text-green-700',
+    overdue: 'bg-red-100 text-red-700',
+    void: 'bg-slate-100 text-slate-400',
+    superseded: 'bg-slate-100 text-slate-400',
+  }
+  return map[status] ?? 'bg-slate-100 text-slate-600'
+}

--- a/src/pages/admin/assessments/[id].astro
+++ b/src/pages/admin/assessments/[id].astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getAssessment } from '../../../lib/db/assessments'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
 import { listContext } from '../../../lib/db/context'
@@ -216,9 +217,7 @@ function contextTypeBadge(type: string): string {
               {entity.area && <span>{entity.area}</span>}
             </div>
           </div>
-          <span
-            class={`text-xs px-2 py-0.5 rounded ${assessment.status === 'scheduled' ? 'bg-blue-100 text-blue-700' : assessment.status === 'completed' ? 'bg-green-100 text-green-700' : 'bg-slate-100 text-slate-500'}`}
-          >
+          <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(assessment.status)}`}>
             {assessment.status}
           </span>
         </div>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -1,4 +1,5 @@
 ---
+import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEngagement, VALID_TRANSITIONS } from '../../../lib/db/engagements'
 import type { EngagementStatus } from '../../../lib/db/engagements'
 import { getEntity } from '../../../lib/db/entities'
@@ -48,25 +49,6 @@ function formatDate(d: string | null): string {
     day: 'numeric',
     year: 'numeric',
   })
-}
-
-function statusBadgeClass(s: string): string {
-  switch (s) {
-    case 'scheduled':
-      return 'bg-blue-100 text-blue-700'
-    case 'active':
-      return 'bg-green-100 text-green-700'
-    case 'handoff':
-      return 'bg-yellow-100 text-yellow-700'
-    case 'safety_net':
-      return 'bg-orange-100 text-orange-700'
-    case 'completed':
-      return 'bg-slate-100 text-slate-600'
-    case 'cancelled':
-      return 'bg-red-100 text-red-600'
-    default:
-      return 'bg-slate-100 text-slate-600'
-  }
 }
 
 function msBadgeClass(s: string): string {

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { EntityStage } from '../../../lib/db/entities'
 import { listContext, CONTEXT_TYPES } from '../../../lib/db/context'
@@ -179,28 +180,6 @@ function formatDateTime(iso: string): string {
     hour: 'numeric',
     minute: '2-digit',
   })
-}
-
-function statusBadgeClass(status: string): string {
-  const map: Record<string, string> = {
-    scheduled: 'bg-blue-100 text-blue-700',
-    active: 'bg-green-100 text-green-700',
-    completed: 'bg-emerald-100 text-emerald-700',
-    handoff: 'bg-teal-100 text-teal-700',
-    safety_net: 'bg-amber-100 text-amber-700',
-    cancelled: 'bg-slate-100 text-slate-500',
-    draft: 'bg-slate-100 text-slate-600',
-    sent: 'bg-blue-100 text-blue-700',
-    accepted: 'bg-green-100 text-green-700',
-    declined: 'bg-red-100 text-red-700',
-    expired: 'bg-slate-100 text-slate-500',
-    paid: 'bg-green-100 text-green-700',
-    overdue: 'bg-red-100 text-red-700',
-    void: 'bg-slate-100 text-slate-400',
-    disqualified: 'bg-red-100 text-red-600',
-    converted: 'bg-green-100 text-green-700',
-  }
-  return map[status] ?? 'bg-slate-100 text-slate-600'
 }
 
 function parseMetadata(json: string | null): Record<string, unknown> | null {

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -1,5 +1,6 @@
 ---
 import '../../../../../styles/global.css'
+import { statusBadgeClass } from '../../../../../lib/ui/status-badge'
 import { getEntity } from '../../../../../lib/db/entities'
 import { getQuote, QUOTE_STATUSES, VALID_TRANSITIONS } from '../../../../../lib/db/quotes'
 import type { LineItem, QuoteStatus } from '../../../../../lib/db/quotes'
@@ -60,18 +61,6 @@ const depositPct = quote.deposit_pct
 // URL params
 const saved = Astro.url.searchParams.get('saved')
 const error = Astro.url.searchParams.get('error')
-
-function statusBadgeClass(s: string): string {
-  const map: Record<string, string> = {
-    draft: 'bg-slate-100 text-slate-600',
-    sent: 'bg-blue-100 text-blue-700',
-    accepted: 'bg-green-100 text-green-700',
-    declined: 'bg-red-100 text-red-700',
-    expired: 'bg-slate-100 text-slate-500',
-    superseded: 'bg-slate-100 text-slate-400',
-  }
-  return map[s] ?? 'bg-slate-100 text-slate-600'
-}
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', {


### PR DESCRIPTION
## Summary
- Extracts a shared `statusBadgeClass()` helper in `src/lib/ui/status-badge.ts` as the canonical source of truth for all status badge colors across admin UI
- Replaces 4 local copies/inline ternaries across assessments, entities, engagements, and quotes detail pages with the shared import
- Fixes the cancelled assessment badge that was previously falling through to the generic fallback instead of getting its own color

**Note:** Engagement page status badge colors change intentionally (e.g., `handoff` moves from yellow to teal, `safety_net` from orange to amber, `completed` from slate to emerald) for cross-page consistency.

## Test plan
- [ ] Verify assessment detail page shows correct badge colors for all 5 statuses (scheduled, completed, cancelled, disqualified, converted)
- [ ] Verify entity detail page badges still render correctly for assessments, engagements, quotes, and invoices
- [ ] Verify engagement detail page badges render correctly
- [ ] Verify quote detail page badges render correctly
- [ ] `npm run verify` passes (typecheck, format, lint, build, tests)

Closes #227

Generated with [Claude Code](https://claude.ai/code)