### PR TITLE
fix(stripe): use unit_amount instead of amount for invoice items

### DIFF
--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -141,7 +141,7 @@ export async function createStripeInvoice(
     const itemBody = new URLSearchParams()
     itemBody.append('customer', customerId)
     itemBody.append('invoice', invoice.id)
-    itemBody.append('amount', String(item.amount))
+    itemBody.append('unit_amount', String(Math.round(item.amount / item.quantity)))
     itemBody.append('currency', item.currency)
     itemBody.append('description', item.description)
     itemBody.append('quantity', String(item.quantity))


### PR DESCRIPTION
## Summary
- Stripe API rejects invoice items with both `amount` and `quantity` parameters
- Changed to `unit_amount` (amount/quantity) + `quantity` which is the correct pattern
- This caused the deposit invoice to fail silently after SOW signing — the atomic batch committed but the best-effort Stripe call returned 400

Found during E2E lifecycle walkthrough (#341).

## Test plan
- [x] `npm run verify` passes (1014 tests, 0 errors)
- [ ] Retry deposit invoice send after deploy to verify Stripe accepts the fixed params

🤖 Generated with [Claude Code](https://claude.com/claude-code)