### PR TITLE
fix(new-business): dedup signals on source_ref instead of broken slug

### DIFF
--- a/workers/new-business/src/index.ts
+++ b/workers/new-business/src/index.ts
@@ -14,7 +14,6 @@
 import { ORG_ID } from '../../../src/lib/constants.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
-import { computeSlug } from '../../../src/lib/entities/slug.js'
 import { fetchAllPermits } from './soda.js'
 import { qualifyNewBusiness } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -44,12 +43,13 @@ async function run(env: Env): Promise<RunSummary> {
 
   for (const permit of permits) {
     try {
-      const slug = computeSlug(permit.business_name, permit.address)
-      const existing = await env.DB.prepare('SELECT 1 FROM entities WHERE org_id = ? AND slug = ?')
-        .bind(ORG_ID, slug)
+      const alreadyProcessed = await env.DB.prepare(
+        `SELECT 1 FROM context WHERE org_id = ? AND source = 'new_business' AND source_ref = ?`
+      )
+        .bind(ORG_ID, permit.permit_number)
         .first()
 
-      if (existing) continue
+      if (alreadyProcessed) continue
 
       summary.newPermits++
 
@@ -104,6 +104,7 @@ async function run(env: Env): Promise<RunSummary> {
         type: 'signal',
         content,
         source: 'new_business',
+        source_ref: permit.permit_number,
         metadata,
       })
 


### PR DESCRIPTION
## Summary

- The new-business worker used slug-based dedup against the `entities` table, but Claude normalizes business names during qualification. The slug computed from raw SODA permit data never matched the slug from Claude's normalized name, so every permit was treated as new on every cron run — creating duplicate signals.
- Switched to `source_ref`-based dedup against the `context` table using `permit_number`, matching the pattern already established in job-monitor (#312) and review-mining (#314).
- The dedup check now runs before the `qualifyNewBusiness` Claude call, saving unnecessary API costs on already-processed permits.

Closes #315

## Changes

1. Removed `computeSlug` import (no longer needed)
2. Replaced slug-based entity dedup with `source_ref`-based context dedup
3. Added `source_ref: permit.permit_number` to the `appendContext` call

## Test plan

- [x] `npm run verify` passes (typecheck, lint, format, build, 1014 tests)
- [ ] Verify on next cron run that previously-processed permits are correctly skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)