### PR TITLE
fix: leave invoice at draft when Stripe send fails

### DIFF
--- a/src/pages/api/admin/invoices/[id].ts
+++ b/src/pages/api/admin/invoices/[id].ts
@@ -110,14 +110,10 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
         await updateInvoiceStatus(env.DB, session.orgId, invoiceId, 'sent' as InvoiceStatus)
       } catch (err) {
         console.error('[api/admin/invoices/[id]] Stripe send error:', err)
-        // Still transition to sent locally even if Stripe fails
-        // Admin can see the invoice needs attention (no stripe link)
-        try {
-          await updateInvoiceStatus(env.DB, session.orgId, invoiceId, 'sent' as InvoiceStatus)
-        } catch (statusErr) {
-          console.error('[api/admin/invoices/[id]] Status update also failed:', statusErr)
-          return redirect(`${target}?error=server`, 302)
-        }
+        // Leave at draft so admin can retry — advancing to sent with no
+        // stripe_invoice_id creates an unrecoverable state.
+        const message = err instanceof Error ? err.message : 'Stripe error'
+        return redirect(`${target}?error=${encodeURIComponent(message)}`, 302)
       }
 
       // Best-effort: send notification email to client


### PR DESCRIPTION
## Summary
- Invoice send endpoint was catching Stripe errors and still transitioning invoice to `sent` with no `stripe_invoice_id`
- This created an unrecoverable state: invoice stuck at `sent`, admin can't retry (draft gate blocks it)
- Now returns error redirect and leaves invoice at draft so admin can diagnose and retry

Found during E2E lifecycle walkthrough (#341).

## Test plan
- [x] `npm run verify` passes (1014 tests, 0 errors)
- [ ] Retry deposit invoice send after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)