### PR TITLE
fix(stripe): use amount without quantity for invoice items

### DIFF
--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -141,10 +141,9 @@ export async function createStripeInvoice(
     const itemBody = new URLSearchParams()
     itemBody.append('customer', customerId)
     itemBody.append('invoice', invoice.id)
-    itemBody.append('unit_amount', String(Math.round(item.amount / item.quantity)))
+    itemBody.append('amount', String(item.amount))
     itemBody.append('currency', item.currency)
     itemBody.append('description', item.description)
-    itemBody.append('quantity', String(item.quantity))
 
     const itemRes = await fetch(`${STRIPE_API_BASE}/invoiceitems`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Corrects Stripe invoice item parameter: just `amount` (total cents), no `quantity`
- Previous fix (#347) changed `amount`+`quantity` to `unit_amount`+`quantity`, but `unit_amount` is invalid for `/v1/invoiceitems` ("Did you mean unit_amount_decimal?")
- The correct Stripe API pattern: `amount` alone represents total cents, no quantity needed

Found during E2E lifecycle walkthrough (#341).

## Test plan
- [x] `npm run verify` passes (1014 tests, 0 errors)
- [ ] Retry deposit invoice send — should succeed with correct params

🤖 Generated with [Claude Code](https://claude.com/claude-code)