### PR TITLE
feat(portal): provision client users on SOW signing

### DIFF
--- a/migrations/0018_users_add_entity_id.sql
+++ b/migrations/0018_users_add_entity_id.sql
@@ -1,0 +1,55 @@
+-- Add entity_id to users and expand outbox_jobs type constraint.
+--
+-- Migration 0010 dropped client_id from contacts, assessments, quotes,
+-- engagements, and invoices but skipped the users table. This migration
+-- completes that work: drops the legacy client_id column and adds
+-- entity_id, which the portal session resolver (getPortalClient) expects.
+--
+-- Also expands the outbox_jobs type CHECK to allow 'send_portal_invitation',
+-- used to send a welcome email when a client portal user is provisioned
+-- during SOW signing.
+
+-- ---------------------------------------------------------------
+-- 1. users: drop legacy client_id, add entity_id
+-- ---------------------------------------------------------------
+DROP INDEX IF EXISTS idx_users_client_id;
+ALTER TABLE users DROP COLUMN client_id;
+
+ALTER TABLE users ADD COLUMN entity_id TEXT;
+CREATE INDEX idx_users_entity ON users(org_id, entity_id);
+
+-- ---------------------------------------------------------------
+-- 2. outbox_jobs: expand type CHECK constraint
+--
+-- SQLite cannot ALTER CHECK constraints. Rebuild the table with the
+-- updated constraint. Only 2 rows at time of writing.
+-- ---------------------------------------------------------------
+CREATE TABLE outbox_jobs_new (
+  id                  TEXT PRIMARY KEY,
+  org_id              TEXT NOT NULL REFERENCES organizations(id),
+  signature_request_id TEXT NOT NULL REFERENCES signature_requests(id),
+  type                TEXT NOT NULL CHECK (type IN (
+                        'send_sow_signed_email', 'send_deposit_invoice',
+                        'send_portal_invitation'
+                      )),
+  status              TEXT NOT NULL CHECK (status IN (
+                        'pending', 'processing', 'completed', 'failed'
+                      )),
+  dedupe_key          TEXT NOT NULL,
+  payload_json        TEXT NOT NULL,
+  attempt_count       INTEGER NOT NULL DEFAULT 0,
+  available_at        TEXT NOT NULL,
+  last_error          TEXT,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO outbox_jobs_new SELECT * FROM outbox_jobs;
+DROP TABLE outbox_jobs;
+ALTER TABLE outbox_jobs_new RENAME TO outbox_jobs;
+
+CREATE UNIQUE INDEX idx_outbox_jobs_dedupe
+  ON outbox_jobs(dedupe_key);
+
+CREATE INDEX idx_outbox_jobs_request_status
+  ON outbox_jobs(signature_request_id, status, available_at);

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -279,6 +279,59 @@ export function portalInvitationEmailHtml(clientName: string, magicLinkUrl: stri
 }
 
 // ===========================================================================
+// Portal welcome email (SOW signed — user provisioned)
+// ===========================================================================
+
+/**
+ * Welcome email sent when a client's portal user is provisioned after SOW signing.
+ *
+ * Unlike portalInvitationEmailHtml (which embeds a 15-minute magic link),
+ * this links to the portal login page with the client's email pre-filled.
+ * The client clicks "Send sign-in link" to get a fresh token on demand.
+ * No expiry concern — the email stays valid indefinitely.
+ */
+export function portalWelcomeEmailHtml(clientName: string, loginUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;text-align:center;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Hi${clientName ? ` ${clientName}` : ''},
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 8px;">
+        Your client portal is ready. This is where you'll find your project details, milestones, invoices, and everything related to our work together.
+      </p>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Click below to sign in. We'll send a secure link to your email.
+      </p>
+
+      <a href="${loginUrl}"
+         style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                font-size:14px;font-weight:600;text-decoration:none;
+                padding:12px 32px;border-radius:6px;">
+        Sign In to Your Portal
+      </a>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        You can access your portal anytime at portal.smd.services
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+// ===========================================================================
 // Booking emails (Calendly replacement — added with migration 0011)
 // ===========================================================================
 

--- a/src/lib/sow/service.ts
+++ b/src/lib/sow/service.ts
@@ -37,6 +37,7 @@ import { createSignatureRequest as createSignWellRequest, getSignedPdf } from '.
 import { getSowSigningFields } from '../signwell/field-config'
 import type { SignWellCreateDocumentRequest, SignWellWebhookPayload } from '../signwell/types'
 import { sendEmail } from '../email/resend'
+import { portalWelcomeEmailHtml } from '../email/templates'
 import { createStripeInvoice, sendStripeInvoice } from '../stripe/client'
 
 export interface SOWState {
@@ -298,9 +299,10 @@ export async function finalizeCompletedSOWSignature(args: {
   apiKey: string
   resendApiKey: string | undefined
   stripeApiKey: string | undefined
+  appBaseUrl: string | undefined
   payload: SignWellWebhookPayload
 }): Promise<Response> {
-  const { db, storage, apiKey, resendApiKey, stripeApiKey, payload } = args
+  const { db, storage, apiKey, resendApiKey, stripeApiKey, appBaseUrl, payload } = args
   const providerRequestId = payload.data.object.id
   const request = await getSignatureRequestByProviderRequestId(db, 'signwell', providerRequestId)
 
@@ -309,7 +311,7 @@ export async function finalizeCompletedSOWSignature(args: {
   }
 
   if (request.status === 'completed') {
-    await processOutboxJobsForSignatureRequest(db, request, resendApiKey, stripeApiKey)
+    await processOutboxJobsForSignatureRequest(db, request, resendApiKey, stripeApiKey, appBaseUrl)
     return okResponse()
   }
 
@@ -345,7 +347,13 @@ export async function finalizeCompletedSOWSignature(args: {
         providerRequestId
       )
       if (latestRequest?.status === 'completed') {
-        await processOutboxJobsForSignatureRequest(db, latestRequest, resendApiKey, stripeApiKey)
+        await processOutboxJobsForSignatureRequest(
+          db,
+          latestRequest,
+          resendApiKey,
+          stripeApiKey,
+          appBaseUrl
+        )
       }
       return okResponse()
     }
@@ -385,6 +393,16 @@ export async function finalizeCompletedSOWSignature(args: {
     engagement_id: engagementId,
     signature_request_id: request.id,
   })
+
+  // Parse signer identity for portal user provisioning
+  const signerSnapshot = JSON.parse(request.signer_snapshot_json) as {
+    contactId: string
+    name: string
+    email: string
+    title: string | null
+  }
+  const clientUserId = crypto.randomUUID()
+  const normalizedSignerEmail = signerSnapshot.email.toLowerCase().trim()
 
   const milestoneStmts = lineItems.map((item, i) =>
     db
@@ -512,6 +530,44 @@ export async function finalizeCompletedSOWSignature(args: {
           now,
           now
         ),
+      // Provision portal client user (idempotent — UPSERT backfills entity_id if NULL)
+      db
+        .prepare(
+          `INSERT INTO users (id, org_id, email, name, role, entity_id, created_at)
+           VALUES (?, ?, ?, ?, 'client', ?, ?)
+           ON CONFLICT(org_id, email) DO UPDATE SET
+             entity_id = COALESCE(users.entity_id, excluded.entity_id)`
+        )
+        .bind(
+          clientUserId,
+          request.org_id,
+          normalizedSignerEmail,
+          signerSnapshot.name,
+          quote.entity_id,
+          now
+        ),
+      // Queue portal welcome email
+      db
+        .prepare(
+          `INSERT INTO outbox_jobs (
+            id, org_id, signature_request_id, type, status, dedupe_key, payload_json, available_at, created_at, updated_at
+          ) VALUES (?, ?, ?, 'send_portal_invitation', 'pending', ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          crypto.randomUUID(),
+          request.org_id,
+          request.id,
+          `portal-invitation:${request.id}`,
+          JSON.stringify({
+            signature_request_id: request.id,
+            entity_id: quote.entity_id,
+            user_email: normalizedSignerEmail,
+            user_name: signerSnapshot.name,
+          }),
+          now,
+          now,
+          now
+        ),
     ])
   } catch (err) {
     console.error('[sow/finalize] Finalization batch failed:', err)
@@ -527,7 +583,13 @@ export async function finalizeCompletedSOWSignature(args: {
     providerRequestId
   )
   if (completedRequest) {
-    await processOutboxJobsForSignatureRequest(db, completedRequest, resendApiKey, stripeApiKey)
+    await processOutboxJobsForSignatureRequest(
+      db,
+      completedRequest,
+      resendApiKey,
+      stripeApiKey,
+      appBaseUrl
+    )
   }
   return okResponse()
 }
@@ -536,7 +598,8 @@ async function processOutboxJobsForSignatureRequest(
   db: D1Database,
   request: SignatureRequest,
   resendApiKey: string | undefined,
-  stripeApiKey: string | undefined
+  stripeApiKey: string | undefined,
+  appBaseUrl: string | undefined
 ): Promise<void> {
   const jobs = await listOutboxJobsForSignatureRequest(db, request.org_id, request.id)
   for (const job of jobs) {
@@ -556,6 +619,8 @@ async function processOutboxJobsForSignatureRequest(
         await handleSignedEmailJob(db, request.org_id, resendApiKey, job)
       } else if (job.type === 'send_deposit_invoice') {
         await handleDepositInvoiceJob(db, request.org_id, stripeApiKey, job)
+      } else if (job.type === 'send_portal_invitation') {
+        await handlePortalInvitationJob(db, request.org_id, resendApiKey, appBaseUrl, job)
       }
 
       await db
@@ -612,6 +677,37 @@ async function handleSignedEmailJob(
     to: contact.email,
     subject: 'SOW Signed - Next Steps',
     html: signatureConfirmationEmailHtml(entity?.name ?? 'there'),
+  })
+}
+
+async function handlePortalInvitationJob(
+  _db: D1Database,
+  _orgId: string,
+  resendApiKey: string | undefined,
+  appBaseUrl: string | undefined,
+  job: OutboxJob
+): Promise<void> {
+  const payload = JSON.parse(job.payload_json) as {
+    user_email: string
+    user_name: string
+  }
+
+  if (!resendApiKey) {
+    console.log('[sow/outbox] Portal invitation skipped (no RESEND_API_KEY)')
+    return
+  }
+
+  // Build portal login URL with email pre-filled.
+  // Uses PORTAL_BASE_URL convention: portal.<domain> or falls back to appBaseUrl + /auth/portal-login
+  const portalLoginUrl = appBaseUrl
+    ? `${appBaseUrl.replace('://', '://portal.')}`
+    : 'https://portal.smd.services'
+  const loginUrlWithEmail = `${portalLoginUrl}?email=${encodeURIComponent(payload.user_email)}`
+
+  await sendEmail(resendApiKey, {
+    to: payload.user_email,
+    subject: 'Your SMD Services portal is ready',
+    html: portalWelcomeEmailHtml(payload.user_name, loginUrlWithEmail),
   })
 }
 

--- a/src/lib/sow/store.ts
+++ b/src/lib/sow/store.ts
@@ -112,7 +112,10 @@ export interface CreateSignatureRequestData {
   failure_reason?: string | null
 }
 
-export type OutboxJobType = 'send_sow_signed_email' | 'send_deposit_invoice'
+export type OutboxJobType =
+  | 'send_sow_signed_email'
+  | 'send_deposit_invoice'
+  | 'send_portal_invitation'
 export type OutboxJobStatus = 'pending' | 'processing' | 'completed' | 'failed'
 
 export interface OutboxJob {

--- a/src/lib/webhooks/signwell-handler.test.ts
+++ b/src/lib/webhooks/signwell-handler.test.ts
@@ -251,6 +251,7 @@ describe('handleDocumentCompleted — milestone creation', () => {
       'fake-api-key',
       undefined,
       undefined,
+      'https://test.smd.services',
       makePayload()
     )
 
@@ -273,7 +274,15 @@ describe('handleDocumentCompleted — milestone creation', () => {
 
   it('sets payment_trigger = true only on the last milestone', async () => {
     const r2 = createFakeR2()
-    await handleDocumentCompleted(db, r2, 'fake-api-key', undefined, undefined, makePayload())
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
 
     const milestones = await db
       .prepare('SELECT * FROM milestones ORDER BY sort_order ASC')
@@ -290,7 +299,15 @@ describe('handleDocumentCompleted — milestone creation', () => {
 
   it('preserves sort_order matching line item index', async () => {
     const r2 = createFakeR2()
-    await handleDocumentCompleted(db, r2, 'fake-api-key', undefined, undefined, makePayload())
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
 
     const milestones = await db
       .prepare('SELECT sort_order, name FROM milestones ORDER BY sort_order ASC')
@@ -302,7 +319,15 @@ describe('handleDocumentCompleted — milestone creation', () => {
 
   it('writes a stage_change context entry', async () => {
     const r2 = createFakeR2()
-    await handleDocumentCompleted(db, r2, 'fake-api-key', undefined, undefined, makePayload())
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
 
     const contextEntries = await db
       .prepare("SELECT * FROM context WHERE entity_id = ? AND type = 'stage_change'")
@@ -324,7 +349,15 @@ describe('handleDocumentCompleted — milestone creation', () => {
 
   it('links milestones to the created engagement', async () => {
     const r2 = createFakeR2()
-    await handleDocumentCompleted(db, r2, 'fake-api-key', undefined, undefined, makePayload())
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
 
     const engagement = await db
       .prepare('SELECT id FROM engagements WHERE quote_id = ?')
@@ -352,6 +385,7 @@ describe('handleDocumentCompleted — milestone creation', () => {
       'fake-api-key',
       undefined,
       undefined,
+      'https://test.smd.services',
       payload
     )
     expect(res1.status).toBe(200)
@@ -362,6 +396,7 @@ describe('handleDocumentCompleted — milestone creation', () => {
       'fake-api-key',
       undefined,
       undefined,
+      'https://test.smd.services',
       payload
     )
     expect(res2.status).toBe(200)
@@ -377,7 +412,15 @@ describe('handleDocumentCompleted — milestone creation', () => {
 
   it('creates all records atomically in a single batch', async () => {
     const r2 = createFakeR2()
-    await handleDocumentCompleted(db, r2, 'fake-api-key', undefined, undefined, makePayload())
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
 
     const quote = await db
       .prepare('SELECT status FROM quotes WHERE id = ?')
@@ -405,5 +448,86 @@ describe('handleDocumentCompleted — milestone creation', () => {
 
     const context = await db.prepare("SELECT * FROM context WHERE type = 'stage_change'").all()
     expect(context.results).toHaveLength(1)
+  })
+
+  it('provisions a client portal user from the signer snapshot', async () => {
+    const r2 = createFakeR2()
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
+
+    const user = await db
+      .prepare("SELECT * FROM users WHERE role = 'client'")
+      .first<Record<string, unknown>>()
+
+    expect(user).not.toBeNull()
+    expect(user!.email).toBe('owner@test.com')
+    expect(user!.name).toBe('Test Owner')
+    expect(user!.role).toBe('client')
+    expect(user!.entity_id).toBe(ENTITY_ID)
+    expect(user!.org_id).toBe(ORG_ID)
+  })
+
+  it('creates a portal invitation outbox job', async () => {
+    const r2 = createFakeR2()
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      makePayload()
+    )
+
+    const job = await db
+      .prepare("SELECT * FROM outbox_jobs WHERE type = 'send_portal_invitation'")
+      .first<Record<string, unknown>>()
+
+    expect(job).not.toBeNull()
+    expect(job!.dedupe_key).toBe(`portal-invitation:${SIGNATURE_REQUEST_ID}`)
+
+    const payload = JSON.parse(job!.payload_json as string)
+    expect(payload.user_email).toBe('owner@test.com')
+    expect(payload.user_name).toBe('Test Owner')
+    expect(payload.entity_id).toBe(ENTITY_ID)
+  })
+
+  it('handles idempotent user provisioning on webhook replay', async () => {
+    const r2 = createFakeR2()
+    const payload = makePayload()
+
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      payload
+    )
+    await handleDocumentCompleted(
+      db,
+      r2,
+      'fake-api-key',
+      undefined,
+      undefined,
+      'https://test.smd.services',
+      payload
+    )
+
+    const users = await db
+      .prepare("SELECT * FROM users WHERE role = 'client'")
+      .all<Record<string, unknown>>()
+
+    expect(users.results).toHaveLength(1)
+    expect(users.results[0].email).toBe('owner@test.com')
+    expect(users.results[0].entity_id).toBe(ENTITY_ID)
   })
 })

--- a/src/lib/webhooks/signwell-handler.ts
+++ b/src/lib/webhooks/signwell-handler.ts
@@ -18,6 +18,7 @@ export async function handleDocumentCompleted(
   apiKey: string,
   resendApiKey: string | undefined,
   stripeApiKey: string | undefined,
+  appBaseUrl: string | undefined,
   payload: SignWellWebhookPayload
 ): Promise<Response> {
   return finalizeCompletedSOWSignature({
@@ -26,6 +27,7 @@ export async function handleDocumentCompleted(
     apiKey,
     resendApiKey,
     stripeApiKey,
+    appBaseUrl,
     payload,
   })
 }

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -10,7 +10,7 @@ interface UserRow {
   email: string
   name: string
   role: string
-  client_id: string | null
+  entity_id: string | null
 }
 
 /**

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -10,7 +10,7 @@ interface UserRow {
   email: string
   name: string
   role: string
-  client_id: string | null
+  entity_id: string | null
 }
 
 /**

--- a/src/pages/api/webhooks/signwell.ts
+++ b/src/pages/api/webhooks/signwell.ts
@@ -100,6 +100,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       apiKey,
       env.RESEND_API_KEY,
       env.STRIPE_API_KEY,
+      env.APP_BASE_URL,
       payload
     )
   }

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -12,6 +12,7 @@ import '../../styles/global.css'
 
 const status = Astro.url.searchParams.get('status')
 const error = Astro.url.searchParams.get('error')
+const prefillEmail = Astro.url.searchParams.get('email') ?? ''
 
 const statusMessages: Record<string, { text: string; type: 'success' | 'error' }> = {
   sent: { text: 'Check your email — we just sent you a sign-in link.', type: 'success' },
@@ -77,6 +78,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
               type="email"
               required
               autocomplete="email"
+              value={prefillEmail}
               class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -38,7 +38,7 @@ interface UserRow {
   email: string
   name: string
   role: string
-  client_id: string | null
+  entity_id: string | null
 }
 
 const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ? AND role = 'client'`)


### PR DESCRIPTION
## Summary

- Adds client user provisioning to the SOW signing atomic batch — when a SOW is signed, the signer is automatically created as a portal user (idempotent UPSERT)
- Sends a portal welcome email via new outbox job type, linking to the login page (not a time-bombed magic link)
- Adds `entity_id` column to `users` table and drops legacy `client_id` (completing migration 0010's work)
- Supports `?email=` pre-fill on portal login page for smoother onboarding

Fixes the root cause of portal login silently failing for sprint walkthrough entity Precision Plumbing AZ (#341 step 9).

## Test plan

- [x] `npm run verify` passes (typecheck, lint, format, build, 1017 tests)
- [x] New tests: user provisioned from signer snapshot, outbox job created, idempotent on webhook replay
- [ ] After merge + deploy: apply migration 0018, backfill Precision Plumbing user via wrangler, verify portal login at portal.smd.services

🤖 Generated with [Claude Code](https://claude.com/claude-code)