### PR TITLE
fix(portal): replace client_id with entity_id in portal pages

### DIFF
--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { getPortalClient } from '../../../lib/portal/session'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listMilestones } from '../../../lib/db/milestones'
 import type { Milestone } from '../../../lib/db/milestones'
@@ -10,30 +11,22 @@ import type { Milestone } from '../../../lib/db/milestones'
  * Shows the client's active engagement with milestone progress,
  * scope summary, and timeline. Protected by auth middleware (role=client).
  *
- * Looks up the user's client_id via the users table to scope data.
+ * Resolves entity via getPortalClient() using users.entity_id.
  */
 
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
-// Look up client_id from the users table
-interface UserRow {
-  id: string
-  client_id: string | null
-}
-
-const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
-  .bind(session.userId)
-  .first<UserRow>()
-
-const clientId = user?.client_id
+// Resolve client entity from session
+const portalData = await getPortalClient(env.DB, session.userId)
+const entityId = portalData?.client.id ?? null
 
 let engagement = null
 let milestones: Milestone[] = []
 
-if (clientId) {
+if (entityId) {
   // Get active engagement (not completed or cancelled)
-  const engagements = await listEngagements(env.DB, session.orgId, clientId)
+  const engagements = await listEngagements(env.DB, session.orgId, entityId)
   engagement = engagements.find((e) => e.status !== 'completed' && e.status !== 'cancelled') ?? null
 
   if (engagement) {

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -47,7 +47,7 @@ interface MilestoneRow {
 }
 
 const activeEngagement = await env.DB.prepare(
-  `SELECT id, status, scope_summary, start_date, estimated_end FROM engagements WHERE client_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net') ORDER BY created_at DESC LIMIT 1`
+  `SELECT id, status, scope_summary, start_date, estimated_end FROM engagements WHERE entity_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net') ORDER BY created_at DESC LIMIT 1`
 )
   .bind(client.id)
   .first<EngagementRow>()

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { getPortalClient } from '../../../lib/portal/session'
 import { listInvoicesForEntity, INVOICE_STATUSES } from '../../../lib/db/invoices'
 import type { Invoice } from '../../../lib/db/invoices'
 
@@ -9,28 +10,20 @@ import type { Invoice } from '../../../lib/db/invoices'
  * Shows the client's invoices with status, amount, and payment links.
  * Protected by auth middleware (role=client).
  *
- * Looks up the user's client_id via the users table to scope data.
+ * Resolves entity via getPortalClient() using users.entity_id.
  */
 
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
-// Look up client_id from the users table
-interface UserRow {
-  id: string
-  client_id: string | null
-}
-
-const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
-  .bind(session.userId)
-  .first<UserRow>()
-
-const clientId = user?.client_id
+// Resolve client entity from session
+const portalData = await getPortalClient(env.DB, session.userId)
+const entityId = portalData?.client.id ?? null
 
 let invoices: Awaited<ReturnType<typeof listInvoicesForEntity>> = []
 
-if (clientId) {
-  invoices = await listInvoicesForEntity(env.DB, clientId)
+if (entityId) {
+  invoices = await listInvoicesForEntity(env.DB, entityId)
 }
 
 // Status badge colors for portal-visible statuses

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -444,9 +444,9 @@ describe('invoices: portal view', () => {
     expect(source()).toContain('listInvoicesForEntity')
   })
 
-  it('looks up client_id from user session', () => {
+  it('resolves entity via getPortalClient', () => {
     const code = source()
-    expect(code).toContain('client_id')
+    expect(code).toContain('getPortalClient')
     expect(code).toContain('session.userId')
   })
 

--- a/tests/portal-docs.test.ts
+++ b/tests/portal-docs.test.ts
@@ -17,10 +17,9 @@ describe('portal: engagement progress page', () => {
     expect(source()).toContain('listMilestones')
   })
 
-  it('looks up client_id from users table', () => {
+  it('resolves entity via getPortalClient', () => {
     const code = source()
-    expect(code).toContain('client_id')
-    expect(code).toContain('users')
+    expect(code).toContain('getPortalClient')
     expect(code).toContain('session.userId')
   })
 


### PR DESCRIPTION
## Summary

- Portal pages still referenced the dropped `client_id` column (removed in migration 0010/0018), causing 500 errors on portal load
- `portal/index.astro`: fixed `engagements WHERE client_id` → `entity_id`
- `portal/engagement/index.astro` and `portal/invoices/index.astro`: replaced manual `users.client_id` lookup with `getPortalClient()` (consistent with dashboard)

## Test plan

- [x] `npm run verify` passes (1017 tests)
- [ ] Load portal.smd.services after deploy — dashboard, engagement, and invoices pages all render

🤖 Generated with [Claude Code](https://claude.com/claude-code)