### PR TITLE
fix(engagement): load Tailwind CSS via Astro import

### DIFF
--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -1,4 +1,5 @@
 ---
+import '../../../styles/global.css'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEngagement, VALID_TRANSITIONS } from '../../../lib/db/engagements'
 import type { EngagementStatus } from '../../../lib/db/engagements'
@@ -110,7 +111,6 @@ function fileSize(bytes: number): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Engagement - {entity?.name ?? 'Unknown'} | Admin</title>
-    <link rel="stylesheet" href="/global.css" />
   </head>
   <body class="bg-slate-50 text-slate-900">
     <header class="bg-white border-b border-slate-200 px-6 py-3 flex items-center gap-4">


### PR DESCRIPTION
## Summary
- Engagement detail page was completely unstyled — no CSS loading at all
- Root cause: used `<link rel="stylesheet" href="/global.css" />` (static file that doesn't exist in Astro build) instead of the module import pattern all other admin pages use
- Fix: replace with `import '../../../styles/global.css'` in the frontmatter

## Test plan
- [ ] Visit `/admin/engagements/{id}` — page should render with full Tailwind styling
- [ ] Compare with entity detail page styling — should match admin layout pattern

Found during E2E lifecycle walkthrough (#341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)