### PR TITLE
refactor(admin): consolidate navigation into shared AdminLayout

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,0 +1,115 @@
+---
+import '../styles/global.css'
+
+interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface Props {
+  title: string
+  breadcrumbs?: BreadcrumbItem[]
+  maxWidth?: 'max-w-5xl' | 'max-w-6xl'
+}
+
+const { title, breadcrumbs = [], maxWidth = 'max-w-5xl' } = Astro.props
+const session = Astro.locals.session!
+const pathname = Astro.url.pathname
+
+const navItems = [
+  { label: 'Dashboard', href: '/admin', match: (p: string) => p === '/admin' || p === '/admin/' },
+  {
+    label: 'Entities',
+    href: '/admin/entities',
+    match: (p: string) => p.startsWith('/admin/entities'),
+  },
+  {
+    label: 'Follow-ups',
+    href: '/admin/follow-ups',
+    match: (p: string) => p.startsWith('/admin/follow-ups'),
+  },
+  {
+    label: 'Analytics',
+    href: '/admin/analytics',
+    match: (p: string) => p.startsWith('/admin/analytics'),
+  },
+]
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>{title}</title>
+  </head>
+  <body class="min-h-screen bg-slate-50 text-slate-900">
+    <header class="bg-white border-b border-slate-200">
+      <div class={`${maxWidth} mx-auto px-4 py-3 flex items-center justify-between`}>
+        <div class="flex items-center gap-3">
+          <a
+            href="/admin"
+            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            >SMD Services</a
+          >
+          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+        </div>
+        <div class="flex items-center gap-4">
+          {
+            navItems.map((item) => (
+              <a
+                href={item.href}
+                class:list={[
+                  'text-sm transition-colors',
+                  item.match(pathname)
+                    ? 'text-primary font-medium'
+                    : 'text-slate-600 hover:text-slate-900',
+                ]}
+              >
+                {item.label}
+              </a>
+            ))
+          }
+          <span class="text-sm text-slate-400">|</span>
+          <span class="text-sm text-slate-600">{session.email}</span>
+          <form method="POST" action="/api/auth/logout">
+            <button
+              type="submit"
+              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </header>
+
+    <main class={`${maxWidth} mx-auto px-4 py-8`}>
+      {
+        breadcrumbs.length > 0 && (
+          <nav class="text-sm text-slate-500 mb-4">
+            {breadcrumbs.map((crumb, i) => (
+              <>
+                {i > 0 && <span class="mx-1">/</span>}
+                {crumb.href ? (
+                  <a href={crumb.href} class="hover:text-primary transition-colors">
+                    {crumb.label}
+                  </a>
+                ) : (
+                  <span class="text-slate-900">{crumb.label}</span>
+                )}
+              </>
+            ))}
+          </nav>
+        )
+      }
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import {
   getPipelineConversion,
   getQuoteAccuracy,
@@ -98,342 +98,294 @@ function complianceBarWidth(pct: number): string {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Analytics — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+<AdminLayout
+  title="Analytics — SMD Services"
+  breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Analytics' }]}
+>
+  <h2 class="text-xl font-semibold text-slate-900 mb-6">Analytics</h2>
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Analytics</span>
-      </nav>
-
-      <h2 class="text-xl font-semibold text-slate-900 mb-6">Analytics</h2>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* ── Pipeline Funnel ──────────────────────────────── */}
-        <div class="bg-white rounded-lg border border-slate-200 p-6">
-          <h3 class="text-base font-semibold text-slate-900 mb-4">Pipeline Funnel</h3>
-          {
-            totalClients === 0 ? (
-              <p class="text-sm text-slate-500">No clients yet.</p>
-            ) : (
-              <div class="space-y-3">
-                {pipelineStages.map((stage) => (
-                  <div class="flex items-center gap-3">
-                    <span class="text-sm text-slate-600 w-24 shrink-0">{stage.label}</span>
-                    <div class="flex-1 bg-slate-100 rounded-full h-6 overflow-hidden">
-                      <div
-                        class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
-                        style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
-                      >
-                        {pipeline[stage.key] > 0 && (
-                          <span class="text-xs font-medium text-white">
-                            {pipeline[stage.key].toLocaleString()}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    {pipeline[stage.key] === 0 && (
-                      <span class="text-xs text-slate-400 w-6 text-right">0</span>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    {/* ── Pipeline Funnel ──────────────────────────────── */}
+    <div class="bg-white rounded-lg border border-slate-200 p-6">
+      <h3 class="text-base font-semibold text-slate-900 mb-4">Pipeline Funnel</h3>
+      {
+        totalClients === 0 ? (
+          <p class="text-sm text-slate-500">No clients yet.</p>
+        ) : (
+          <div class="space-y-3">
+            {pipelineStages.map((stage) => (
+              <div class="flex items-center gap-3">
+                <span class="text-sm text-slate-600 w-24 shrink-0">{stage.label}</span>
+                <div class="flex-1 bg-slate-100 rounded-full h-6 overflow-hidden">
+                  <div
+                    class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
+                    style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
+                  >
+                    {pipeline[stage.key] > 0 && (
+                      <span class="text-xs font-medium text-white">
+                        {pipeline[stage.key].toLocaleString()}
+                      </span>
                     )}
                   </div>
-                ))}
-                <p class="text-xs text-slate-400 mt-2 pt-2 border-t border-slate-100">
-                  Total clients: {totalClients.toLocaleString()}
-                </p>
-              </div>
-            )
-          }
-        </div>
-
-        {/* ── Engagement Health ────────────────────────────── */}
-        <div class="bg-white rounded-lg border border-slate-200 p-6">
-          <h3 class="text-base font-semibold text-slate-900 mb-4">Engagement Health</h3>
-          {
-            health.total_engagements === 0 ? (
-              <p class="text-sm text-slate-500">No completed engagements yet.</p>
-            ) : (
-              <div class="space-y-4">
-                <div class="grid grid-cols-2 gap-4">
-                  <div>
-                    <p class="text-2xl font-bold text-slate-900">
-                      {health.avg_days_to_completion.toLocaleString()}
-                    </p>
-                    <p class="text-xs text-slate-500">Avg days to completion</p>
-                  </div>
-                  <div>
-                    <p class="text-2xl font-bold text-slate-900">
-                      {health.total_engagements.toLocaleString()}
-                    </p>
-                    <p class="text-xs text-slate-500">Completed engagements</p>
-                  </div>
-                  <div>
-                    <p class="text-2xl font-bold text-slate-900">
-                      {health.avg_parking_lot_items.toLocaleString()}
-                    </p>
-                    <p class="text-xs text-slate-500">Avg parking lot items</p>
-                  </div>
-                  <div>
-                    <p class="text-2xl font-bold text-slate-900">{health.on_time_pct}%</p>
-                    <p class="text-xs text-slate-500">On-time completion</p>
-                  </div>
                 </div>
-                <div>
-                  <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
-                    <span>On-time rate</span>
-                    <span>{health.on_time_pct}%</span>
-                  </div>
-                  <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
-                    <div
-                      class="h-full rounded-full bg-emerald-500"
-                      style={`width: ${complianceBarWidth(health.on_time_pct)}`}
-                    />
-                  </div>
-                </div>
-              </div>
-            )
-          }
-        </div>
-
-        {/* ── Revenue Summary ─────────────────────────────── */}
-        <div class="bg-white rounded-lg border border-slate-200 p-6">
-          <h3 class="text-base font-semibold text-slate-900 mb-4">Revenue Summary</h3>
-          {
-            revenue.total_revenue === 0 ? (
-              <p class="text-sm text-slate-500">No invoices yet.</p>
-            ) : (
-              <div class="space-y-4">
-                <div class="grid grid-cols-3 gap-4">
-                  <div>
-                    <p class="text-lg font-bold text-slate-900">
-                      {formatCurrency(revenue.total_invoiced)}
-                    </p>
-                    <p class="text-xs text-slate-500">Total invoiced</p>
-                  </div>
-                  <div>
-                    <p class="text-lg font-bold text-green-700">
-                      {formatCurrency(revenue.total_paid)}
-                    </p>
-                    <p class="text-xs text-slate-500">Total paid</p>
-                  </div>
-                  <div>
-                    <p class="text-lg font-bold text-amber-700">{formatCurrency(outstanding)}</p>
-                    <p class="text-xs text-slate-500">Outstanding</p>
-                  </div>
-                </div>
-
-                {revenue.by_month.length > 0 && (
-                  <div>
-                    <h4 class="text-sm font-medium text-slate-700 mb-2">Monthly Revenue</h4>
-                    <div class="space-y-2">
-                      {revenue.by_month.map((m) => (
-                        <div class="flex items-center gap-3">
-                          <span class="text-xs text-slate-600 w-20 shrink-0">
-                            {formatMonthLabel(m.month)}
-                          </span>
-                          <div class="flex-1 bg-slate-100 rounded-full h-5 overflow-hidden">
-                            <div
-                              class="h-full rounded-full bg-green-500 flex items-center justify-end pr-2"
-                              style={`width: ${revenueBarWidth(m.amount)}`}
-                            >
-                              {m.amount > 0 && (
-                                <span class="text-xs font-medium text-white">
-                                  {formatCurrency(m.amount)}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {revenue.by_vertical.length > 0 && (
-                  <div>
-                    <h4 class="text-sm font-medium text-slate-700 mb-2">Revenue by Vertical</h4>
-                    <div class="space-y-1">
-                      {revenue.by_vertical.map((v) => (
-                        <div class="flex items-center justify-between text-sm">
-                          <span class="text-slate-600">{getVerticalLabel(v.vertical)}</span>
-                          <span class="font-medium text-slate-900">{formatCurrency(v.amount)}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+                {pipeline[stage.key] === 0 && (
+                  <span class="text-xs text-slate-400 w-6 text-right">0</span>
                 )}
               </div>
-            )
-          }
-        </div>
+            ))}
+            <p class="text-xs text-slate-400 mt-2 pt-2 border-t border-slate-100">
+              Total clients: {totalClients.toLocaleString()}
+            </p>
+          </div>
+        )
+      }
+    </div>
 
-        {/* ── Follow-up Compliance ────────────────────────── */}
-        <div class="bg-white rounded-lg border border-slate-200 p-6">
-          <h3 class="text-base font-semibold text-slate-900 mb-4">Follow-up Compliance</h3>
-          {
-            compliance.total === 0 ? (
-              <p class="text-sm text-slate-500">No follow-ups yet.</p>
-            ) : (
-              <div class="space-y-4">
-                <div class="text-center">
-                  <p class="text-4xl font-bold text-slate-900">{compliance.compliance_pct}%</p>
-                  <p class="text-sm text-slate-500">Compliance rate</p>
-                </div>
-                <div class="grid grid-cols-3 gap-4 text-center">
-                  <div>
-                    <p class="text-lg font-bold text-green-700">
-                      {compliance.completed_on_time.toLocaleString()}
-                    </p>
-                    <p class="text-xs text-slate-500">On time</p>
-                  </div>
-                  <div>
-                    <p class="text-lg font-bold text-amber-700">
-                      {compliance.completed_late.toLocaleString()}
-                    </p>
-                    <p class="text-xs text-slate-500">Late</p>
-                  </div>
-                  <div>
-                    <p class="text-lg font-bold text-red-700">
-                      {compliance.missed.toLocaleString()}
-                    </p>
-                    <p class="text-xs text-slate-500">Missed</p>
-                  </div>
-                </div>
-                <div>
-                  <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
-                    <span>Compliance</span>
-                    <span>{compliance.compliance_pct}%</span>
-                  </div>
-                  <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
-                    <div
-                      class="h-full rounded-full bg-green-500"
-                      style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
-                    />
-                  </div>
-                </div>
-                <p class="text-xs text-slate-400 pt-2 border-t border-slate-100">
-                  Total follow-ups: {compliance.total.toLocaleString()}
+    {/* ── Engagement Health ────────────────────────────── */}
+    <div class="bg-white rounded-lg border border-slate-200 p-6">
+      <h3 class="text-base font-semibold text-slate-900 mb-4">Engagement Health</h3>
+      {
+        health.total_engagements === 0 ? (
+          <p class="text-sm text-slate-500">No completed engagements yet.</p>
+        ) : (
+          <div class="space-y-4">
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <p class="text-2xl font-bold text-slate-900">
+                  {health.avg_days_to_completion.toLocaleString()}
                 </p>
+                <p class="text-xs text-slate-500">Avg days to completion</p>
               </div>
-            )
-          }
-        </div>
+              <div>
+                <p class="text-2xl font-bold text-slate-900">
+                  {health.total_engagements.toLocaleString()}
+                </p>
+                <p class="text-xs text-slate-500">Completed engagements</p>
+              </div>
+              <div>
+                <p class="text-2xl font-bold text-slate-900">
+                  {health.avg_parking_lot_items.toLocaleString()}
+                </p>
+                <p class="text-xs text-slate-500">Avg parking lot items</p>
+              </div>
+              <div>
+                <p class="text-2xl font-bold text-slate-900">{health.on_time_pct}%</p>
+                <p class="text-xs text-slate-500">On-time completion</p>
+              </div>
+            </div>
+            <div>
+              <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+                <span>On-time rate</span>
+                <span>{health.on_time_pct}%</span>
+              </div>
+              <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
+                <div
+                  class="h-full rounded-full bg-emerald-500"
+                  style={`width: ${complianceBarWidth(health.on_time_pct)}`}
+                />
+              </div>
+            </div>
+          </div>
+        )
+      }
+    </div>
 
-        {/* ── Quote Accuracy ──────────────────────────────── */}
-        <div class="bg-white rounded-lg border border-slate-200 p-6 md:col-span-2">
-          <h3 class="text-base font-semibold text-slate-900 mb-4">Quote Accuracy</h3>
-          {
-            quoteAccuracy.length === 0 ? (
-              <p class="text-sm text-slate-500">No completed engagements yet.</p>
-            ) : (
-              <div class="overflow-x-auto">
-                <table class="w-full text-sm">
-                  <thead>
-                    <tr class="text-left text-xs text-slate-500 border-b border-slate-200">
-                      <th class="pb-2 font-medium">Client</th>
-                      <th class="pb-2 font-medium text-right">Estimated</th>
-                      <th class="pb-2 font-medium text-right">Actual</th>
-                      <th class="pb-2 font-medium text-right">Variance</th>
-                      <th class="pb-2 font-medium text-right">Accuracy</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-slate-100">
-                    {quoteAccuracy.map((row) => {
-                      const variance = row.actual_hours - row.estimated_hours
-                      const varianceStr =
-                        variance > 0
-                          ? `+${variance.toLocaleString()}h`
-                          : `${variance.toLocaleString()}h`
-                      return (
-                        <tr>
-                          <td class="py-2 text-slate-900">{row.client_name}</td>
-                          <td class="py-2 text-right text-slate-600">
-                            {row.estimated_hours.toLocaleString()}h
-                          </td>
-                          <td class="py-2 text-right text-slate-600">
-                            {row.actual_hours.toLocaleString()}h
-                          </td>
-                          <td class="py-2 text-right text-slate-600">{varianceStr}</td>
-                          <td class="py-2 text-right">
-                            <span
-                              class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(row.accuracy_pct)}`}
-                            >
-                              {row.accuracy_pct}%
+    {/* ── Revenue Summary ─────────────────────────────── */}
+    <div class="bg-white rounded-lg border border-slate-200 p-6">
+      <h3 class="text-base font-semibold text-slate-900 mb-4">Revenue Summary</h3>
+      {
+        revenue.total_revenue === 0 ? (
+          <p class="text-sm text-slate-500">No invoices yet.</p>
+        ) : (
+          <div class="space-y-4">
+            <div class="grid grid-cols-3 gap-4">
+              <div>
+                <p class="text-lg font-bold text-slate-900">
+                  {formatCurrency(revenue.total_invoiced)}
+                </p>
+                <p class="text-xs text-slate-500">Total invoiced</p>
+              </div>
+              <div>
+                <p class="text-lg font-bold text-green-700">{formatCurrency(revenue.total_paid)}</p>
+                <p class="text-xs text-slate-500">Total paid</p>
+              </div>
+              <div>
+                <p class="text-lg font-bold text-amber-700">{formatCurrency(outstanding)}</p>
+                <p class="text-xs text-slate-500">Outstanding</p>
+              </div>
+            </div>
+
+            {revenue.by_month.length > 0 && (
+              <div>
+                <h4 class="text-sm font-medium text-slate-700 mb-2">Monthly Revenue</h4>
+                <div class="space-y-2">
+                  {revenue.by_month.map((m) => (
+                    <div class="flex items-center gap-3">
+                      <span class="text-xs text-slate-600 w-20 shrink-0">
+                        {formatMonthLabel(m.month)}
+                      </span>
+                      <div class="flex-1 bg-slate-100 rounded-full h-5 overflow-hidden">
+                        <div
+                          class="h-full rounded-full bg-green-500 flex items-center justify-end pr-2"
+                          style={`width: ${revenueBarWidth(m.amount)}`}
+                        >
+                          {m.amount > 0 && (
+                            <span class="text-xs font-medium text-white">
+                              {formatCurrency(m.amount)}
                             </span>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                  <tfoot>
-                    <tr class="border-t border-slate-200 font-medium">
-                      <td class="py-2 text-slate-900">Average</td>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {revenue.by_vertical.length > 0 && (
+              <div>
+                <h4 class="text-sm font-medium text-slate-700 mb-2">Revenue by Vertical</h4>
+                <div class="space-y-1">
+                  {revenue.by_vertical.map((v) => (
+                    <div class="flex items-center justify-between text-sm">
+                      <span class="text-slate-600">{getVerticalLabel(v.vertical)}</span>
+                      <span class="font-medium text-slate-900">{formatCurrency(v.amount)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      }
+    </div>
+
+    {/* ── Follow-up Compliance ────────────────────────── */}
+    <div class="bg-white rounded-lg border border-slate-200 p-6">
+      <h3 class="text-base font-semibold text-slate-900 mb-4">Follow-up Compliance</h3>
+      {
+        compliance.total === 0 ? (
+          <p class="text-sm text-slate-500">No follow-ups yet.</p>
+        ) : (
+          <div class="space-y-4">
+            <div class="text-center">
+              <p class="text-4xl font-bold text-slate-900">{compliance.compliance_pct}%</p>
+              <p class="text-sm text-slate-500">Compliance rate</p>
+            </div>
+            <div class="grid grid-cols-3 gap-4 text-center">
+              <div>
+                <p class="text-lg font-bold text-green-700">
+                  {compliance.completed_on_time.toLocaleString()}
+                </p>
+                <p class="text-xs text-slate-500">On time</p>
+              </div>
+              <div>
+                <p class="text-lg font-bold text-amber-700">
+                  {compliance.completed_late.toLocaleString()}
+                </p>
+                <p class="text-xs text-slate-500">Late</p>
+              </div>
+              <div>
+                <p class="text-lg font-bold text-red-700">{compliance.missed.toLocaleString()}</p>
+                <p class="text-xs text-slate-500">Missed</p>
+              </div>
+            </div>
+            <div>
+              <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+                <span>Compliance</span>
+                <span>{compliance.compliance_pct}%</span>
+              </div>
+              <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
+                <div
+                  class="h-full rounded-full bg-green-500"
+                  style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
+                />
+              </div>
+            </div>
+            <p class="text-xs text-slate-400 pt-2 border-t border-slate-100">
+              Total follow-ups: {compliance.total.toLocaleString()}
+            </p>
+          </div>
+        )
+      }
+    </div>
+
+    {/* ── Quote Accuracy ──────────────────────────────── */}
+    <div class="bg-white rounded-lg border border-slate-200 p-6 md:col-span-2">
+      <h3 class="text-base font-semibold text-slate-900 mb-4">Quote Accuracy</h3>
+      {
+        quoteAccuracy.length === 0 ? (
+          <p class="text-sm text-slate-500">No completed engagements yet.</p>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-xs text-slate-500 border-b border-slate-200">
+                  <th class="pb-2 font-medium">Client</th>
+                  <th class="pb-2 font-medium text-right">Estimated</th>
+                  <th class="pb-2 font-medium text-right">Actual</th>
+                  <th class="pb-2 font-medium text-right">Variance</th>
+                  <th class="pb-2 font-medium text-right">Accuracy</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100">
+                {quoteAccuracy.map((row) => {
+                  const variance = row.actual_hours - row.estimated_hours
+                  const varianceStr =
+                    variance > 0
+                      ? `+${variance.toLocaleString()}h`
+                      : `${variance.toLocaleString()}h`
+                  return (
+                    <tr>
+                      <td class="py-2 text-slate-900">{row.client_name}</td>
                       <td class="py-2 text-right text-slate-600">
-                        {Math.round(
-                          quoteAccuracy.reduce((s, r) => s + r.estimated_hours, 0) /
-                            quoteAccuracy.length
-                        ).toLocaleString()}
-                        h
+                        {row.estimated_hours.toLocaleString()}h
                       </td>
                       <td class="py-2 text-right text-slate-600">
-                        {Math.round(
-                          quoteAccuracy.reduce((s, r) => s + r.actual_hours, 0) /
-                            quoteAccuracy.length
-                        ).toLocaleString()}
-                        h
+                        {row.actual_hours.toLocaleString()}h
                       </td>
-                      <td class="py-2" />
+                      <td class="py-2 text-right text-slate-600">{varianceStr}</td>
                       <td class="py-2 text-right">
                         <span
-                          class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(avgAccuracy)}`}
+                          class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(row.accuracy_pct)}`}
                         >
-                          {avgAccuracy}%
+                          {row.accuracy_pct}%
                         </span>
                       </td>
                     </tr>
-                  </tfoot>
-                </table>
-              </div>
-            )
-          }
-        </div>
-      </div>
-    </main>
-  </body>
-</html>
+                  )
+                })}
+              </tbody>
+              <tfoot>
+                <tr class="border-t border-slate-200 font-medium">
+                  <td class="py-2 text-slate-900">Average</td>
+                  <td class="py-2 text-right text-slate-600">
+                    {Math.round(
+                      quoteAccuracy.reduce((s, r) => s + r.estimated_hours, 0) /
+                        quoteAccuracy.length
+                    ).toLocaleString()}
+                    h
+                  </td>
+                  <td class="py-2 text-right text-slate-600">
+                    {Math.round(
+                      quoteAccuracy.reduce((s, r) => s + r.actual_hours, 0) / quoteAccuracy.length
+                    ).toLocaleString()}
+                    h
+                  </td>
+                  <td class="py-2" />
+                  <td class="py-2 text-right">
+                    <span
+                      class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(avgAccuracy)}`}
+                    >
+                      {avgAccuracy}%
+                    </span>
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )
+      }
+    </div>
+  </div>
+</AdminLayout>

--- a/src/pages/admin/assessments/[id].astro
+++ b/src/pages/admin/assessments/[id].astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getAssessment } from '../../../lib/db/assessments'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
@@ -119,431 +119,368 @@ function contextTypeBadge(type: string): string {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Assessment: {entity.name} — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
+<AdminLayout
+  title={`Assessment: ${entity?.name ?? 'Entity'} — SMD Services`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: entity?.name ?? 'Entity', href: `/admin/entities/${entity?.id}` },
+    { label: 'Assessment' },
+  ]}
+>
+  {
+    error && (
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+        {decodeURIComponent(error)}
       </div>
-    </header>
+    )
+  }
+  {
+    saved && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Changes saved.
+      </div>
+    )
+  }
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
-        <span class="mx-1">/</span>
-        <a href={`/admin/entities/${entity.id}`} class="hover:text-primary transition-colors"
-          >{entity.name}</a
-        >
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Assessment</span>
-      </nav>
-
-      {
-        error && (
-          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
-            {decodeURIComponent(error)}
-          </div>
-        )
-      }
-      {
-        saved && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Changes saved.
-          </div>
-        )
-      }
-
-      {/* Entity + Assessment Info */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-        <div class="flex items-start justify-between gap-4 mb-4">
-          <div>
-            <div class="flex items-center gap-3 mb-2">
-              <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
-              <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
-                {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
-              </span>
-              {
-                entity.tier && (
-                  <span class={`text-xs px-2 py-0.5 rounded ${tierBadgeClass(entity.tier)}`}>
-                    {entity.tier}
-                  </span>
-                )
-              }
-            </div>
-
-            <div class="flex items-center gap-4 text-sm text-slate-500 flex-wrap">
-              {
-                entity.pain_score != null && (
-                  <span>
-                    Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
-                  </span>
-                )
-              }
-              {
-                entity.vertical && (
-                  <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>
-                )
-              }
-              {entity.area && <span>{entity.area}</span>}
-            </div>
-          </div>
-          <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(assessment.status)}`}>
-            {assessment.status}
+  {/* Entity + Assessment Info */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <div class="flex items-start justify-between gap-4 mb-4">
+      <div>
+        <div class="flex items-center gap-3 mb-2">
+          <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+          <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
+            {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
           </span>
-        </div>
-
-        {/* Schedule details */}
-        {
-          schedule && (
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-              <div>
-                <span class="text-slate-500">Scheduled:</span>
-                <span class="ml-1 text-slate-900 font-medium">
-                  {formatDateTime(schedule.slot_start_utc)}
-                </span>
-                <span class="text-slate-400 ml-1">({schedule.timezone})</span>
-              </div>
-              <div>
-                <span class="text-slate-500">Contact:</span>
-                <span class="ml-1 text-slate-900">{schedule.guest_name}</span>
-                <a
-                  href={`mailto:${schedule.guest_email}`}
-                  class="ml-1 text-blue-600 hover:underline"
-                >
-                  {schedule.guest_email}
-                </a>
-              </div>
-              {schedule.google_meet_url && (
-                <div>
-                  <a
-                    href={schedule.google_meet_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 transition-colors"
-                  >
-                    Join Video Call
-                  </a>
-                </div>
-              )}
-              {schedule.google_event_link && (
-                <div>
-                  <a
-                    href={schedule.google_event_link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline"
-                  >
-                    View Calendar Event
-                  </a>
-                </div>
-              )}
-            </div>
-          )
-        }
-        {
-          !schedule && assessment.scheduled_at && (
-            <div class="text-sm text-slate-500">
-              Scheduled: {formatDateTime(assessment.scheduled_at)}
-            </div>
-          )
-        }
-      </div>
-
-      {/* Live Notes */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-        <div class="flex items-center justify-between mb-3">
-          <h3 class="text-base font-semibold text-slate-900">Live Notes</h3>
-          <span id="save-status" class="text-xs text-slate-400">Saved</span>
-        </div>
-        <textarea
-          id="live-notes"
-          rows="10"
-          class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
-          placeholder="Take notes during the call...">{liveNotesValue}</textarea
-        >
-      </div>
-
-      {/* Complete Assessment Form (collapsible) */}
-      <div class="bg-white rounded-lg border border-slate-200 mb-6">
-        <button
-          type="button"
-          id="toggle-complete"
-          class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-slate-50 transition-colors"
-        >
-          <h3 class="text-base font-semibold text-slate-900">Complete Assessment</h3>
-          <svg
-            id="toggle-icon"
-            class="w-5 h-5 text-slate-400 transition-transform"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"
-            ></path>
-          </svg>
-        </button>
-
-        <div id="complete-form" class="hidden px-6 pb-6 border-t border-slate-100">
-          <form
-            method="POST"
-            action={`/api/admin/assessments/${assessmentId}/complete`}
-            enctype="multipart/form-data"
-            class="space-y-6 pt-4"
-          >
-            {/* Problems identified */}
-            <div>
-              <label class="block text-sm font-medium text-slate-700 mb-2"
-                >Problems Identified</label
-              >
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
-                <label class="flex items-center gap-2 text-sm text-slate-700">
-                  <input type="checkbox" name="process_design" class="rounded border-slate-300" />
-                  Process design
-                </label>
-                <label class="flex items-center gap-2 text-sm text-slate-700">
-                  <input type="checkbox" name="tool_systems" class="rounded border-slate-300" />
-                  Tools & systems
-                </label>
-                <label class="flex items-center gap-2 text-sm text-slate-700">
-                  <input type="checkbox" name="data_visibility" class="rounded border-slate-300" />
-                  Data & visibility
-                </label>
-                <label class="flex items-center gap-2 text-sm text-slate-700">
-                  <input
-                    type="checkbox"
-                    name="customer_pipeline"
-                    class="rounded border-slate-300"
-                  />
-                  Customer pipeline
-                </label>
-                <label class="flex items-center gap-2 text-sm text-slate-700">
-                  <input type="checkbox" name="team_operations" class="rounded border-slate-300" />
-                  Team operations
-                </label>
-              </div>
-              <div class="mt-2">
-                <input
-                  type="text"
-                  name="other_problem"
-                  placeholder="Other (describe)"
-                  class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                />
-              </div>
-            </div>
-
-            {/* Disqualifiers */}
-            <div class="border border-slate-200 rounded-lg p-4">
-              <label class="flex items-center gap-2 text-sm text-slate-700 mb-2">
-                <input
-                  type="checkbox"
-                  name="disqualified"
-                  id="disqualified-check"
-                  class="rounded border-slate-300"
-                />
-                <span class="font-medium">Disqualified</span>
-              </label>
-              <input
-                type="text"
-                name="disqualify_reason"
-                id="disqualify-reason"
-                placeholder="Reason for disqualification"
-                class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:opacity-50 disabled:bg-slate-50"
-                disabled
-              />
-            </div>
-
-            {/* Duration */}
-            <div>
-              <label for="duration_minutes" class="block text-sm font-medium text-slate-700 mb-1"
-                >Duration (minutes)</label
-              >
-              <input
-                type="number"
-                name="duration_minutes"
-                id="duration_minutes"
-                min="1"
-                max="300"
-                placeholder="30"
-                class="w-32 text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-              />
-            </div>
-
-            {/* Notes */}
-            <div>
-              <label for="complete-notes" class="block text-sm font-medium text-slate-700 mb-1"
-                >Notes</label
-              >
-              <textarea
-                name="notes"
-                id="complete-notes"
-                rows="4"
-                class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                placeholder="Assessment notes..."></textarea>
-            </div>
-
-            {/* Transcript upload */}
-            <div>
-              <label for="transcript" class="block text-sm font-medium text-slate-700 mb-1"
-                >Transcript (optional)</label
-              >
-              <input
-                type="file"
-                name="transcript"
-                id="transcript"
-                accept=".txt,.md,.pdf,.doc,.docx"
-                class="text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200"
-              />
-            </div>
-
-            {/* Submit */}
-            <div class="flex items-center gap-3 pt-2">
-              <button
-                type="submit"
-                class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-lg hover:bg-green-700 transition-colors font-medium"
-              >
-                Complete & Draft Proposal
-              </button>
-              <span class="text-xs text-slate-400"
-                >Creates a draft quote and transitions to proposing stage</span
-              >
-            </div>
-          </form>
-        </div>
-      </div>
-
-      {/* Entity Context Timeline */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6">
-        <h3 class="text-base font-semibold text-slate-900 mb-4">
-          Entity Context Timeline
-          <span class="text-sm font-normal text-slate-400 ml-1"
-            >({contextEntries.length} entries)</span
-          >
-        </h3>
-
-        {
-          timelineEntries.length === 0 && (
-            <p class="text-sm text-slate-400">No context entries yet.</p>
-          )
-        }
-
-        <div class="space-y-3">
           {
-            timelineEntries.map((entry) => (
-              <div class="border border-slate-100 rounded-lg p-3">
-                <div class="flex items-center gap-2 mb-1">
-                  <span class={`text-xs px-1.5 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
-                    {entry.type.replace(/_/g, ' ')}
-                  </span>
-                  <span class="text-xs text-slate-400">{entry.source}</span>
-                  <span class="text-xs text-slate-300 ml-auto">{formatDate(entry.created_at)}</span>
-                </div>
-                <div class="text-sm text-slate-700 whitespace-pre-wrap break-words">
-                  {entry.content.length > 500 ? entry.content.slice(0, 500) + '...' : entry.content}
-                </div>
-              </div>
-            ))
+            entity.tier && (
+              <span class={`text-xs px-2 py-0.5 rounded ${tierBadgeClass(entity.tier)}`}>
+                {entity.tier}
+              </span>
+            )
           }
         </div>
-      </div>
-    </main>
 
-    <script define:vars={{ assessmentId }}>
-      // Live notes auto-save
-      const textarea = document.getElementById('live-notes')
-      const saveStatus = document.getElementById('save-status')
-      let saveTimer = null
-      let lastSaved = textarea?.value ?? ''
-
-      async function saveLiveNotes() {
-        const value = textarea?.value ?? ''
-        if (value === lastSaved) return
-
-        saveStatus.textContent = 'Saving...'
-        try {
-          const res = await fetch(`/api/admin/assessments/${assessmentId}/live-notes`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ live_notes: value }),
-          })
-          if (res.ok) {
-            lastSaved = value
-            saveStatus.textContent = 'Saved'
-          } else {
-            saveStatus.textContent = 'Save failed'
+        <div class="flex items-center gap-4 text-sm text-slate-500 flex-wrap">
+          {
+            entity.pain_score != null && (
+              <span>
+                Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
+              </span>
+            )
           }
-        } catch {
+          {entity.vertical && <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>}
+          {entity.area && <span>{entity.area}</span>}
+        </div>
+      </div>
+      <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(assessment.status)}`}>
+        {assessment.status}
+      </span>
+    </div>
+
+    {/* Schedule details */}
+    {
+      schedule && (
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div>
+            <span class="text-slate-500">Scheduled:</span>
+            <span class="ml-1 text-slate-900 font-medium">
+              {formatDateTime(schedule.slot_start_utc)}
+            </span>
+            <span class="text-slate-400 ml-1">({schedule.timezone})</span>
+          </div>
+          <div>
+            <span class="text-slate-500">Contact:</span>
+            <span class="ml-1 text-slate-900">{schedule.guest_name}</span>
+            <a href={`mailto:${schedule.guest_email}`} class="ml-1 text-blue-600 hover:underline">
+              {schedule.guest_email}
+            </a>
+          </div>
+          {schedule.google_meet_url && (
+            <div>
+              <a
+                href={schedule.google_meet_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 transition-colors"
+              >
+                Join Video Call
+              </a>
+            </div>
+          )}
+          {schedule.google_event_link && (
+            <div>
+              <a
+                href={schedule.google_event_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-blue-600 hover:underline"
+              >
+                View Calendar Event
+              </a>
+            </div>
+          )}
+        </div>
+      )
+    }
+    {
+      !schedule && assessment.scheduled_at && (
+        <div class="text-sm text-slate-500">
+          Scheduled: {formatDateTime(assessment.scheduled_at)}
+        </div>
+      )
+    }
+  </div>
+
+  {/* Live Notes */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="text-base font-semibold text-slate-900">Live Notes</h3>
+      <span id="save-status" class="text-xs text-slate-400">Saved</span>
+    </div>
+    <textarea
+      id="live-notes"
+      rows="10"
+      class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
+      placeholder="Take notes during the call...">{liveNotesValue}</textarea
+    >
+  </div>
+
+  {/* Complete Assessment Form (collapsible) */}
+  <div class="bg-white rounded-lg border border-slate-200 mb-6">
+    <button
+      type="button"
+      id="toggle-complete"
+      class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-slate-50 transition-colors"
+    >
+      <h3 class="text-base font-semibold text-slate-900">Complete Assessment</h3>
+      <svg
+        id="toggle-icon"
+        class="w-5 h-5 text-slate-400 transition-transform"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"
+        ></path>
+      </svg>
+    </button>
+
+    <div id="complete-form" class="hidden px-6 pb-6 border-t border-slate-100">
+      <form
+        method="POST"
+        action={`/api/admin/assessments/${assessmentId}/complete`}
+        enctype="multipart/form-data"
+        class="space-y-6 pt-4"
+      >
+        {/* Problems identified */}
+        <div>
+          <label class="block text-sm font-medium text-slate-700 mb-2">Problems Identified</label>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="process_design" class="rounded border-slate-300" />
+              Process design
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="tool_systems" class="rounded border-slate-300" />
+              Tools & systems
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="data_visibility" class="rounded border-slate-300" />
+              Data & visibility
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="customer_pipeline" class="rounded border-slate-300" />
+              Customer pipeline
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" name="team_operations" class="rounded border-slate-300" />
+              Team operations
+            </label>
+          </div>
+          <div class="mt-2">
+            <input
+              type="text"
+              name="other_problem"
+              placeholder="Other (describe)"
+              class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+        </div>
+
+        {/* Disqualifiers */}
+        <div class="border border-slate-200 rounded-lg p-4">
+          <label class="flex items-center gap-2 text-sm text-slate-700 mb-2">
+            <input
+              type="checkbox"
+              name="disqualified"
+              id="disqualified-check"
+              class="rounded border-slate-300"
+            />
+            <span class="font-medium">Disqualified</span>
+          </label>
+          <input
+            type="text"
+            name="disqualify_reason"
+            id="disqualify-reason"
+            placeholder="Reason for disqualification"
+            class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:opacity-50 disabled:bg-slate-50"
+            disabled
+          />
+        </div>
+
+        {/* Duration */}
+        <div>
+          <label for="duration_minutes" class="block text-sm font-medium text-slate-700 mb-1"
+            >Duration (minutes)</label
+          >
+          <input
+            type="number"
+            name="duration_minutes"
+            id="duration_minutes"
+            min="1"
+            max="300"
+            placeholder="30"
+            class="w-32 text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          />
+        </div>
+
+        {/* Notes */}
+        <div>
+          <label for="complete-notes" class="block text-sm font-medium text-slate-700 mb-1"
+            >Notes</label
+          >
+          <textarea
+            name="notes"
+            id="complete-notes"
+            rows="4"
+            class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            placeholder="Assessment notes..."></textarea>
+        </div>
+
+        {/* Transcript upload */}
+        <div>
+          <label for="transcript" class="block text-sm font-medium text-slate-700 mb-1"
+            >Transcript (optional)</label
+          >
+          <input
+            type="file"
+            name="transcript"
+            id="transcript"
+            accept=".txt,.md,.pdf,.doc,.docx"
+            class="text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200"
+          />
+        </div>
+
+        {/* Submit */}
+        <div class="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-lg hover:bg-green-700 transition-colors font-medium"
+          >
+            Complete & Draft Proposal
+          </button>
+          <span class="text-xs text-slate-400"
+            >Creates a draft quote and transitions to proposing stage</span
+          >
+        </div>
+      </form>
+    </div>
+  </div>
+
+  {/* Entity Context Timeline */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6">
+    <h3 class="text-base font-semibold text-slate-900 mb-4">
+      Entity Context Timeline
+      <span class="text-sm font-normal text-slate-400 ml-1">({contextEntries.length} entries)</span>
+    </h3>
+
+    {timelineEntries.length === 0 && <p class="text-sm text-slate-400">No context entries yet.</p>}
+
+    <div class="space-y-3">
+      {
+        timelineEntries.map((entry) => (
+          <div class="border border-slate-100 rounded-lg p-3">
+            <div class="flex items-center gap-2 mb-1">
+              <span class={`text-xs px-1.5 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
+                {entry.type.replace(/_/g, ' ')}
+              </span>
+              <span class="text-xs text-slate-400">{entry.source}</span>
+              <span class="text-xs text-slate-300 ml-auto">{formatDate(entry.created_at)}</span>
+            </div>
+            <div class="text-sm text-slate-700 whitespace-pre-wrap break-words">
+              {entry.content.length > 500 ? entry.content.slice(0, 500) + '...' : entry.content}
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+  <script define:vars={{ assessmentId }}>
+    // Live notes auto-save
+    const textarea = document.getElementById('live-notes')
+    const saveStatus = document.getElementById('save-status')
+    let saveTimer = null
+    let lastSaved = textarea?.value ?? ''
+
+    async function saveLiveNotes() {
+      const value = textarea?.value ?? ''
+      if (value === lastSaved) return
+
+      saveStatus.textContent = 'Saving...'
+      try {
+        const res = await fetch(`/api/admin/assessments/${assessmentId}/live-notes`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ live_notes: value }),
+        })
+        if (res.ok) {
+          lastSaved = value
+          saveStatus.textContent = 'Saved'
+        } else {
           saveStatus.textContent = 'Save failed'
         }
+      } catch {
+        saveStatus.textContent = 'Save failed'
       }
+    }
 
-      textarea?.addEventListener('input', () => {
-        saveStatus.textContent = 'Unsaved changes'
-        clearTimeout(saveTimer)
-        saveTimer = setTimeout(saveLiveNotes, 10000) // 10 second auto-save
-      })
+    textarea?.addEventListener('input', () => {
+      saveStatus.textContent = 'Unsaved changes'
+      clearTimeout(saveTimer)
+      saveTimer = setTimeout(saveLiveNotes, 10000) // 10 second auto-save
+    })
 
-      // Save on blur (tab away)
-      textarea?.addEventListener('blur', () => {
-        clearTimeout(saveTimer)
-        saveLiveNotes()
-      })
+    // Save on blur (tab away)
+    textarea?.addEventListener('blur', () => {
+      clearTimeout(saveTimer)
+      saveLiveNotes()
+    })
 
-      // Toggle complete form
-      const toggleBtn = document.getElementById('toggle-complete')
-      const completeForm = document.getElementById('complete-form')
-      const toggleIcon = document.getElementById('toggle-icon')
+    // Toggle complete form
+    const toggleBtn = document.getElementById('toggle-complete')
+    const completeForm = document.getElementById('complete-form')
+    const toggleIcon = document.getElementById('toggle-icon')
 
-      toggleBtn?.addEventListener('click', () => {
-        completeForm?.classList.toggle('hidden')
-        toggleIcon?.classList.toggle('rotate-180')
-      })
+    toggleBtn?.addEventListener('click', () => {
+      completeForm?.classList.toggle('hidden')
+      toggleIcon?.classList.toggle('rotate-180')
+    })
 
-      // Disqualifier checkbox controls reason input
-      const dqCheck = document.getElementById('disqualified-check')
-      const dqReason = document.getElementById('disqualify-reason')
+    // Disqualifier checkbox controls reason input
+    const dqCheck = document.getElementById('disqualified-check')
+    const dqReason = document.getElementById('disqualify-reason')
 
-      dqCheck?.addEventListener('change', () => {
-        dqReason.disabled = !dqCheck.checked
-        if (!dqCheck.checked) dqReason.value = ''
-      })
+    dqCheck?.addEventListener('change', () => {
+      dqReason.disabled = !dqCheck.checked
+      if (!dqCheck.checked) dqReason.value = ''
+    })
 
-      // Pre-fill completion notes from live notes
-      const completeNotes = document.getElementById('complete-notes')
-      toggleBtn?.addEventListener('click', () => {
-        if (completeNotes && !completeNotes.value && textarea?.value) {
-          completeNotes.value = textarea.value
-        }
-      })
-    </script>
-  </body>
-</html>
+    // Pre-fill completion notes from live notes
+    const completeNotes = document.getElementById('complete-notes')
+    toggleBtn?.addEventListener('click', () => {
+      if (completeNotes && !completeNotes.value && textarea?.value) {
+        completeNotes.value = textarea.value
+      }
+    })
+  </script>
+</AdminLayout>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEngagement, VALID_TRANSITIONS } from '../../../lib/db/engagements'
 import type { EngagementStatus } from '../../../lib/db/engagements'
@@ -106,601 +106,571 @@ function fileSize(bytes: number): string {
 }
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Engagement - {entity?.name ?? 'Unknown'} | Admin</title>
-  </head>
-  <body class="bg-slate-50 text-slate-900">
-    <header class="bg-white border-b border-slate-200 px-6 py-3 flex items-center gap-4">
-      <a href="/admin" class="text-sm text-slate-500 hover:text-slate-700">Admin</a>
-      <span class="text-slate-300">/</span>
-      {
-        entity && (
-          <>
-            <a
-              href={`/admin/entities/${entity.id}`}
-              class="text-sm text-slate-500 hover:text-slate-700"
-            >
-              {entity.name}
-            </a>
-            <span class="text-slate-300">/</span>
-          </>
-        )
-      }
-      <span class="text-sm font-medium text-slate-900">Engagement</span>
-    </header>
-
-    <main class="max-w-5xl mx-auto px-6 py-8 space-y-6">
-      {
-        saved && (
-          <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
-            Changes saved.
-          </div>
-        )
-      }
-      {
-        milestoneAdded && (
-          <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
-            Milestone added.
-          </div>
-        )
-      }
-      {
-        milestoneDeleted && (
-          <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
-            Milestone deleted.
-          </div>
-        )
-      }
-      {
-        error && (
-          <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-2 rounded text-sm">
-            {error === 'invalid_status'
-              ? 'Invalid status transition.'
-              : error === 'invalid_transition'
-                ? 'Invalid transition.'
-                : error === 'not_found'
-                  ? 'Resource not found.'
-                  : 'An error occurred.'}
-          </div>
-        )
-      }
-
-      <!-- Header -->
-      <div class="bg-white rounded-lg border border-slate-200 p-6">
-        <div class="flex items-start justify-between">
-          <div>
-            <div class="flex items-center gap-3 mb-2">
-              <h1 class="text-2xl font-semibold text-slate-900">
-                {entity?.name ?? 'Unknown Entity'}
-              </h1>
-              <span
-                class={`text-xs px-2.5 py-1 rounded font-medium ${statusBadgeClass(engagement.status)}`}
-              >
-                {engagement.status}
-              </span>
-            </div>
-            <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-500">
-              <span>Start: {formatDate(engagement.start_date)}</span>
-              <span>Est. End: {formatDate(engagement.estimated_end)}</span>
-              {
-                engagement.handoff_date && (
-                  <span>Handoff: {formatDate(engagement.handoff_date)}</span>
-                )
-              }
-              {engagement.actual_end && <span>Completed: {formatDate(engagement.actual_end)}</span>}
-            </div>
-          </div>
-          {
-            nextStatuses.length > 0 && (
-              <div class="flex gap-2">
-                {nextStatuses.map((ns) => (
-                  <form method="POST" action={`/api/admin/engagements/${engagementId}`}>
-                    <input type="hidden" name="action" value="transition_status" />
-                    <input type="hidden" name="new_status" value={ns} />
-                    <button
-                      type="submit"
-                      class={`text-xs px-3 py-1.5 rounded font-medium border transition-colors ${
-                        ns === 'cancelled'
-                          ? 'border-red-300 text-red-700 hover:bg-red-50'
-                          : 'border-slate-300 text-slate-700 hover:bg-slate-50'
-                      }`}
-                    >
-                      {ns === 'active'
-                        ? 'Start'
-                        : ns === 'handoff'
-                          ? 'Mark Handoff'
-                          : ns === 'safety_net'
-                            ? 'Start Safety Net'
-                            : ns === 'completed'
-                              ? 'Mark Complete'
-                              : ns === 'cancelled'
-                                ? 'Cancel'
-                                : ns}
-                    </button>
-                  </form>
-                ))}
-              </div>
-            )
-          }
+<AdminLayout
+  title={`Engagement - ${entity?.name ?? 'Unknown'} | Admin`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    ...(entity ? [{ label: entity.name, href: `/admin/entities/${entity.id}` }] : []),
+    { label: 'Engagement' },
+  ]}
+>
+  <div class="space-y-6">
+    {
+      saved && (
+        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
+          Changes saved.
         </div>
+      )
+    }
+    {
+      milestoneAdded && (
+        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
+          Milestone added.
+        </div>
+      )
+    }
+    {
+      milestoneDeleted && (
+        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
+          Milestone deleted.
+        </div>
+      )
+    }
+    {
+      error && (
+        <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-2 rounded text-sm">
+          {error === 'invalid_status'
+            ? 'Invalid status transition.'
+            : error === 'invalid_transition'
+              ? 'Invalid transition.'
+              : error === 'not_found'
+                ? 'Resource not found.'
+                : 'An error occurred.'}
+        </div>
+      )
+    }
 
-        {/* Quote summary */}
+    <!-- Header -->
+    <div class="bg-white rounded-lg border border-slate-200 p-6">
+      <div class="flex items-start justify-between">
+        <div>
+          <div class="flex items-center gap-3 mb-2">
+            <h1 class="text-2xl font-semibold text-slate-900">
+              {entity?.name ?? 'Unknown Entity'}
+            </h1>
+            <span
+              class={`text-xs px-2.5 py-1 rounded font-medium ${statusBadgeClass(engagement.status)}`}
+            >
+              {engagement.status}
+            </span>
+          </div>
+          <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-500">
+            <span>Start: {formatDate(engagement.start_date)}</span>
+            <span>Est. End: {formatDate(engagement.estimated_end)}</span>
+            {engagement.handoff_date && <span>Handoff: {formatDate(engagement.handoff_date)}</span>}
+            {engagement.actual_end && <span>Completed: {formatDate(engagement.actual_end)}</span>}
+          </div>
+        </div>
         {
-          quote && (
-            <div class="mt-4 pt-4 border-t border-slate-100">
-              <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm">
-                <span class="text-slate-500">
-                  Quote:{' '}
-                  <span class="font-medium text-slate-700">
-                    ${quote.total_price.toLocaleString()}
-                  </span>
-                </span>
-                <span class="text-slate-500">
-                  Hours: <span class="font-medium text-slate-700">{quote.total_hours}h est</span>
-                  {engagement.actual_hours > 0 && (
-                    <span class="ml-1">/ {engagement.actual_hours}h actual</span>
-                  )}
-                </span>
-                {quote.deposit_pct != null && (
-                  <span class="text-slate-500">
-                    Deposit:{' '}
-                    <span class="font-medium text-slate-700">
-                      {(quote.deposit_pct * 100).toFixed(0)}%
-                    </span>
-                  </span>
-                )}
-              </div>
-              {depositInvoice && (
-                <div class="mt-2 text-sm">
-                  <span class="text-slate-500">Deposit Invoice:</span>{' '}
-                  <span
-                    class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(depositInvoice.status)}`}
+          nextStatuses.length > 0 && (
+            <div class="flex gap-2">
+              {nextStatuses.map((ns) => (
+                <form method="POST" action={`/api/admin/engagements/${engagementId}`}>
+                  <input type="hidden" name="action" value="transition_status" />
+                  <input type="hidden" name="new_status" value={ns} />
+                  <button
+                    type="submit"
+                    class={`text-xs px-3 py-1.5 rounded font-medium border transition-colors ${
+                      ns === 'cancelled'
+                        ? 'border-red-300 text-red-700 hover:bg-red-50'
+                        : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                    }`}
                   >
-                    {depositInvoice.status}
-                  </span>
-                  <span class="ml-2 text-slate-500">${depositInvoice.amount.toLocaleString()}</span>
-                </div>
-              )}
-            </div>
-          )
-        }
-
-        {
-          engagement.scope_summary && (
-            <div class="mt-4 pt-4 border-t border-slate-100">
-              <p class="text-sm text-slate-600 whitespace-pre-wrap">{engagement.scope_summary}</p>
+                    {ns === 'active'
+                      ? 'Start'
+                      : ns === 'handoff'
+                        ? 'Mark Handoff'
+                        : ns === 'safety_net'
+                          ? 'Start Safety Net'
+                          : ns === 'completed'
+                            ? 'Mark Complete'
+                            : ns === 'cancelled'
+                              ? 'Cancel'
+                              : ns}
+                  </button>
+                </form>
+              ))}
             </div>
           )
         }
       </div>
 
-      <!-- Edit Details -->
-      <details class="bg-white rounded-lg border border-slate-200">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
-          Edit Details
-        </summary>
-        <div class="px-6 pb-6">
-          <form method="POST" action={`/api/admin/engagements/${engagementId}`} class="space-y-4">
+      {/* Quote summary */}
+      {
+        quote && (
+          <div class="mt-4 pt-4 border-t border-slate-100">
+            <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+              <span class="text-slate-500">
+                Quote:{' '}
+                <span class="font-medium text-slate-700">
+                  ${quote.total_price.toLocaleString()}
+                </span>
+              </span>
+              <span class="text-slate-500">
+                Hours: <span class="font-medium text-slate-700">{quote.total_hours}h est</span>
+                {engagement.actual_hours > 0 && (
+                  <span class="ml-1">/ {engagement.actual_hours}h actual</span>
+                )}
+              </span>
+              {quote.deposit_pct != null && (
+                <span class="text-slate-500">
+                  Deposit:{' '}
+                  <span class="font-medium text-slate-700">
+                    {(quote.deposit_pct * 100).toFixed(0)}%
+                  </span>
+                </span>
+              )}
+            </div>
+            {depositInvoice && (
+              <div class="mt-2 text-sm">
+                <span class="text-slate-500">Deposit Invoice:</span>{' '}
+                <span
+                  class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(depositInvoice.status)}`}
+                >
+                  {depositInvoice.status}
+                </span>
+                <span class="ml-2 text-slate-500">${depositInvoice.amount.toLocaleString()}</span>
+              </div>
+            )}
+          </div>
+        )
+      }
+
+      {
+        engagement.scope_summary && (
+          <div class="mt-4 pt-4 border-t border-slate-100">
+            <p class="text-sm text-slate-600 whitespace-pre-wrap">{engagement.scope_summary}</p>
+          </div>
+        )
+      }
+    </div>
+
+    <!-- Edit Details -->
+    <details class="bg-white rounded-lg border border-slate-200">
+      <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900"> Edit Details </summary>
+      <div class="px-6 pb-6">
+        <form method="POST" action={`/api/admin/engagements/${engagementId}`} class="space-y-4">
+          <div>
+            <label for="scope_summary" class="block text-sm font-medium text-slate-700 mb-1">
+              Scope Summary
+            </label>
+            <textarea
+              id="scope_summary"
+              name="scope_summary"
+              rows="3"
+              class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+              >{engagement.scope_summary ?? ''}</textarea
+            >
+          </div>
+          <div class="grid grid-cols-2 gap-4">
             <div>
-              <label for="scope_summary" class="block text-sm font-medium text-slate-700 mb-1">
-                Scope Summary
+              <label for="start_date" class="block text-sm font-medium text-slate-700 mb-1">
+                Start Date
               </label>
-              <textarea
-                id="scope_summary"
-                name="scope_summary"
-                rows="3"
+              <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value={engagement.start_date?.split('T')[0] ?? ''}
                 class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
-                >{engagement.scope_summary ?? ''}</textarea
-              >
+              />
             </div>
-            <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="estimated_end" class="block text-sm font-medium text-slate-700 mb-1">
+                Estimated End
+              </label>
+              <input
+                type="date"
+                id="estimated_end"
+                name="estimated_end"
+                value={engagement.estimated_end?.split('T')[0] ?? ''}
+                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label for="estimated_hours" class="block text-sm font-medium text-slate-700 mb-1">
+                Estimated Hours
+              </label>
+              <input
+                type="number"
+                id="estimated_hours"
+                name="estimated_hours"
+                step="0.5"
+                value={engagement.estimated_hours ?? ''}
+                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label for="actual_hours" class="block text-sm font-medium text-slate-700 mb-1">
+                Actual Hours
+              </label>
+              <input
+                type="number"
+                id="actual_hours"
+                name="actual_hours"
+                step="0.5"
+                value={engagement.actual_hours ?? ''}
+                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+          <div class="flex justify-end">
+            <button
+              type="submit"
+              class="bg-slate-900 text-white text-sm px-4 py-2 rounded hover:bg-slate-800 transition-colors"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </details>
+
+    <!-- Milestones -->
+    <div class="bg-white rounded-lg border border-slate-200">
+      <div class="px-6 py-4 border-b border-slate-100">
+        <h2 class="font-medium text-slate-900">Milestones</h2>
+      </div>
+      <div class="divide-y divide-slate-100">
+        {
+          milestones.length === 0 && (
+            <div class="px-6 py-8 text-center text-sm text-slate-400">No milestones yet.</div>
+          )
+        }
+        {
+          milestones.map((ms) => {
+            const msStatus = ms.status as MilestoneStatus
+            const msNext = MS_TRANSITIONS[msStatus] ?? []
+            return (
+              <div class="px-6 py-4 flex items-center justify-between gap-4">
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2">
+                    <span class={`text-xs px-2 py-0.5 rounded ${msBadgeClass(ms.status)}`}>
+                      {ms.status}
+                    </span>
+                    <span class="text-sm font-medium text-slate-900 truncate">{ms.name}</span>
+                    {ms.payment_trigger ? (
+                      <span class="text-xs px-1.5 py-0.5 rounded bg-amber-100 text-amber-700">
+                        $
+                      </span>
+                    ) : null}
+                  </div>
+                  {ms.description && (
+                    <p class="text-xs text-slate-500 mt-1 truncate">{ms.description}</p>
+                  )}
+                  {ms.due_date && (
+                    <span class="text-xs text-slate-400 mt-1 block">
+                      Due: {formatDate(ms.due_date)}
+                    </span>
+                  )}
+                </div>
+                <div class="flex items-center gap-2 flex-shrink-0">
+                  {/* Payment trigger toggle */}
+                  <form method="POST" action={`/api/admin/engagements/${engagementId}/milestones`}>
+                    <input type="hidden" name="action" value="toggle_payment_trigger" />
+                    <input type="hidden" name="milestone_id" value={ms.id} />
+                    <button
+                      type="submit"
+                      title={
+                        ms.payment_trigger ? 'Remove payment trigger' : 'Set as payment trigger'
+                      }
+                      class={`text-xs px-2 py-1 rounded border transition-colors ${
+                        ms.payment_trigger
+                          ? 'border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100'
+                          : 'border-slate-200 text-slate-400 hover:text-slate-600 hover:border-slate-300'
+                      }`}
+                    >
+                      $
+                    </button>
+                  </form>
+                  {/* Status transitions */}
+                  {msNext.map((ns) => (
+                    <form
+                      method="POST"
+                      action={`/api/admin/engagements/${engagementId}/milestones`}
+                    >
+                      <input type="hidden" name="action" value="transition_status" />
+                      <input type="hidden" name="milestone_id" value={ms.id} />
+                      <input type="hidden" name="new_status" value={ns} />
+                      <button
+                        type="submit"
+                        class={`text-xs px-2.5 py-1 rounded border transition-colors ${
+                          ns === 'completed'
+                            ? 'border-green-300 text-green-700 hover:bg-green-50'
+                            : ns === 'in_progress'
+                              ? 'border-blue-300 text-blue-700 hover:bg-blue-50'
+                              : 'border-slate-300 text-slate-600 hover:bg-slate-50'
+                        }`}
+                      >
+                        {ns === 'in_progress'
+                          ? 'Start'
+                          : ns === 'completed'
+                            ? 'Complete'
+                            : ns === 'skipped'
+                              ? 'Skip'
+                              : ns}
+                      </button>
+                    </form>
+                  ))}
+                  {/* Delete */}
+                  {msStatus === 'pending' && (
+                    <form
+                      method="POST"
+                      action={`/api/admin/engagements/${engagementId}/milestones`}
+                    >
+                      <input type="hidden" name="_method" value="DELETE" />
+                      <input type="hidden" name="milestone_id" value={ms.id} />
+                      <button
+                        type="submit"
+                        class="text-xs px-2 py-1 rounded border border-red-200 text-red-500 hover:bg-red-50 transition-colors"
+                        onclick="return confirm('Delete this milestone?')"
+                      >
+                        Del
+                      </button>
+                    </form>
+                  )}
+                </div>
+              </div>
+            )
+          })
+        }
+      </div>
+
+      {/* Add milestone form */}
+      <details class="border-t border-slate-100">
+        <summary class="px-6 py-3 cursor-pointer text-sm text-slate-500 hover:text-slate-700">
+          + Add Milestone
+        </summary>
+        <div class="px-6 pb-4">
+          <form
+            method="POST"
+            action={`/api/admin/engagements/${engagementId}/milestones`}
+            class="space-y-3"
+          >
+            <div class="grid grid-cols-2 gap-3">
               <div>
-                <label for="start_date" class="block text-sm font-medium text-slate-700 mb-1">
-                  Start Date
+                <label for="ms_name" class="block text-xs font-medium text-slate-600 mb-1">
+                  Name *
+                </label>
+                <input
+                  type="text"
+                  id="ms_name"
+                  name="name"
+                  required
+                  class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
+                />
+              </div>
+              <div>
+                <label for="ms_due" class="block text-xs font-medium text-slate-600 mb-1">
+                  Due Date
                 </label>
                 <input
                   type="date"
-                  id="start_date"
-                  name="start_date"
-                  value={engagement.start_date?.split('T')[0] ?? ''}
-                  class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
-                />
-              </div>
-              <div>
-                <label for="estimated_end" class="block text-sm font-medium text-slate-700 mb-1">
-                  Estimated End
-                </label>
-                <input
-                  type="date"
-                  id="estimated_end"
-                  name="estimated_end"
-                  value={engagement.estimated_end?.split('T')[0] ?? ''}
-                  class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                  id="ms_due"
+                  name="due_date"
+                  class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
                 />
               </div>
             </div>
-            <div class="grid grid-cols-2 gap-4">
-              <div>
-                <label for="estimated_hours" class="block text-sm font-medium text-slate-700 mb-1">
-                  Estimated Hours
-                </label>
-                <input
-                  type="number"
-                  id="estimated_hours"
-                  name="estimated_hours"
-                  step="0.5"
-                  value={engagement.estimated_hours ?? ''}
-                  class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
-                />
-              </div>
-              <div>
-                <label for="actual_hours" class="block text-sm font-medium text-slate-700 mb-1">
-                  Actual Hours
-                </label>
-                <input
-                  type="number"
-                  id="actual_hours"
-                  name="actual_hours"
-                  step="0.5"
-                  value={engagement.actual_hours ?? ''}
-                  class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
-                />
-              </div>
+            <div>
+              <label for="ms_desc" class="block text-xs font-medium text-slate-600 mb-1">
+                Description
+              </label>
+              <input
+                type="text"
+                id="ms_desc"
+                name="description"
+                class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
+              />
             </div>
-            <div class="flex justify-end">
+            <div class="flex items-center gap-4">
+              <label class="flex items-center gap-2 text-sm text-slate-600">
+                <input type="checkbox" name="payment_trigger" value="1" />
+                Payment trigger
+              </label>
+              <input type="hidden" name="sort_order" value={String(milestones.length)} />
               <button
                 type="submit"
-                class="bg-slate-900 text-white text-sm px-4 py-2 rounded hover:bg-slate-800 transition-colors"
+                class="ml-auto bg-slate-900 text-white text-xs px-3 py-1.5 rounded hover:bg-slate-800 transition-colors"
               >
-                Save Changes
+                Add Milestone
               </button>
             </div>
           </form>
         </div>
       </details>
+    </div>
 
-      <!-- Milestones -->
-      <div class="bg-white rounded-lg border border-slate-200">
-        <div class="px-6 py-4 border-b border-slate-100">
-          <h2 class="font-medium text-slate-900">Milestones</h2>
-        </div>
-        <div class="divide-y divide-slate-100">
-          {
-            milestones.length === 0 && (
-              <div class="px-6 py-8 text-center text-sm text-slate-400">No milestones yet.</div>
-            )
-          }
-          {
-            milestones.map((ms) => {
-              const msStatus = ms.status as MilestoneStatus
-              const msNext = MS_TRANSITIONS[msStatus] ?? []
-              return (
-                <div class="px-6 py-4 flex items-center justify-between gap-4">
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2">
-                      <span class={`text-xs px-2 py-0.5 rounded ${msBadgeClass(ms.status)}`}>
-                        {ms.status}
-                      </span>
-                      <span class="text-sm font-medium text-slate-900 truncate">{ms.name}</span>
-                      {ms.payment_trigger ? (
-                        <span class="text-xs px-1.5 py-0.5 rounded bg-amber-100 text-amber-700">
-                          $
-                        </span>
-                      ) : null}
-                    </div>
-                    {ms.description && (
-                      <p class="text-xs text-slate-500 mt-1 truncate">{ms.description}</p>
-                    )}
-                    {ms.due_date && (
-                      <span class="text-xs text-slate-400 mt-1 block">
-                        Due: {formatDate(ms.due_date)}
-                      </span>
-                    )}
-                  </div>
-                  <div class="flex items-center gap-2 flex-shrink-0">
-                    {/* Payment trigger toggle */}
-                    <form
-                      method="POST"
-                      action={`/api/admin/engagements/${engagementId}/milestones`}
+    <!-- Deliverables -->
+    <div class="bg-white rounded-lg border border-slate-200">
+      <div class="px-6 py-4 border-b border-slate-100">
+        <h2 class="font-medium text-slate-900">Deliverables</h2>
+      </div>
+      <div class="px-6 py-4">
+        {
+          documents.length === 0 && (
+            <p class="text-sm text-slate-400 mb-4">No files uploaded yet.</p>
+          )
+        }
+        {
+          documents.length > 0 && (
+            <ul class="space-y-2 mb-4">
+              {documents.map((doc) => {
+                const name = doc.key.split('/').pop() ?? doc.key
+                return (
+                  <li class="flex items-center justify-between text-sm">
+                    <a
+                      href={`/api/admin/engagements/${engagementId}/deliverables/${name}`}
+                      class="text-blue-600 hover:underline truncate"
                     >
-                      <input type="hidden" name="action" value="toggle_payment_trigger" />
-                      <input type="hidden" name="milestone_id" value={ms.id} />
-                      <button
-                        type="submit"
-                        title={
-                          ms.payment_trigger ? 'Remove payment trigger' : 'Set as payment trigger'
-                        }
-                        class={`text-xs px-2 py-1 rounded border transition-colors ${
-                          ms.payment_trigger
-                            ? 'border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100'
-                            : 'border-slate-200 text-slate-400 hover:text-slate-600 hover:border-slate-300'
-                        }`}
-                      >
-                        $
-                      </button>
-                    </form>
-                    {/* Status transitions */}
-                    {msNext.map((ns) => (
-                      <form
-                        method="POST"
-                        action={`/api/admin/engagements/${engagementId}/milestones`}
-                      >
-                        <input type="hidden" name="action" value="transition_status" />
-                        <input type="hidden" name="milestone_id" value={ms.id} />
-                        <input type="hidden" name="new_status" value={ns} />
-                        <button
-                          type="submit"
-                          class={`text-xs px-2.5 py-1 rounded border transition-colors ${
-                            ns === 'completed'
-                              ? 'border-green-300 text-green-700 hover:bg-green-50'
-                              : ns === 'in_progress'
-                                ? 'border-blue-300 text-blue-700 hover:bg-blue-50'
-                                : 'border-slate-300 text-slate-600 hover:bg-slate-50'
-                          }`}
-                        >
-                          {ns === 'in_progress'
-                            ? 'Start'
-                            : ns === 'completed'
-                              ? 'Complete'
-                              : ns === 'skipped'
-                                ? 'Skip'
-                                : ns}
-                        </button>
-                      </form>
-                    ))}
-                    {/* Delete */}
-                    {msStatus === 'pending' && (
-                      <form
-                        method="POST"
-                        action={`/api/admin/engagements/${engagementId}/milestones`}
-                      >
-                        <input type="hidden" name="_method" value="DELETE" />
-                        <input type="hidden" name="milestone_id" value={ms.id} />
-                        <button
-                          type="submit"
-                          class="text-xs px-2 py-1 rounded border border-red-200 text-red-500 hover:bg-red-50 transition-colors"
-                          onclick="return confirm('Delete this milestone?')"
-                        >
-                          Del
-                        </button>
-                      </form>
-                    )}
-                  </div>
-                </div>
-              )
-            })
-          }
-        </div>
-
-        {/* Add milestone form */}
-        <details class="border-t border-slate-100">
-          <summary class="px-6 py-3 cursor-pointer text-sm text-slate-500 hover:text-slate-700">
-            + Add Milestone
-          </summary>
-          <div class="px-6 pb-4">
-            <form
-              method="POST"
-              action={`/api/admin/engagements/${engagementId}/milestones`}
-              class="space-y-3"
-            >
-              <div class="grid grid-cols-2 gap-3">
-                <div>
-                  <label for="ms_name" class="block text-xs font-medium text-slate-600 mb-1">
-                    Name *
-                  </label>
-                  <input
-                    type="text"
-                    id="ms_name"
-                    name="name"
-                    required
-                    class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
-                  />
-                </div>
-                <div>
-                  <label for="ms_due" class="block text-xs font-medium text-slate-600 mb-1">
-                    Due Date
-                  </label>
-                  <input
-                    type="date"
-                    id="ms_due"
-                    name="due_date"
-                    class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
-                  />
-                </div>
-              </div>
-              <div>
-                <label for="ms_desc" class="block text-xs font-medium text-slate-600 mb-1">
-                  Description
-                </label>
-                <input
-                  type="text"
-                  id="ms_desc"
-                  name="description"
-                  class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
-                />
-              </div>
-              <div class="flex items-center gap-4">
-                <label class="flex items-center gap-2 text-sm text-slate-600">
-                  <input type="checkbox" name="payment_trigger" value="1" />
-                  Payment trigger
-                </label>
-                <input type="hidden" name="sort_order" value={String(milestones.length)} />
-                <button
-                  type="submit"
-                  class="ml-auto bg-slate-900 text-white text-xs px-3 py-1.5 rounded hover:bg-slate-800 transition-colors"
-                >
-                  Add Milestone
-                </button>
-              </div>
-            </form>
-          </div>
-        </details>
-      </div>
-
-      <!-- Deliverables -->
-      <div class="bg-white rounded-lg border border-slate-200">
-        <div class="px-6 py-4 border-b border-slate-100">
-          <h2 class="font-medium text-slate-900">Deliverables</h2>
-        </div>
-        <div class="px-6 py-4">
-          {
-            documents.length === 0 && (
-              <p class="text-sm text-slate-400 mb-4">No files uploaded yet.</p>
-            )
-          }
-          {
-            documents.length > 0 && (
-              <ul class="space-y-2 mb-4">
-                {documents.map((doc) => {
-                  const name = doc.key.split('/').pop() ?? doc.key
-                  return (
-                    <li class="flex items-center justify-between text-sm">
-                      <a
-                        href={`/api/admin/engagements/${engagementId}/deliverables/${name}`}
-                        class="text-blue-600 hover:underline truncate"
-                      >
-                        {name}
-                      </a>
-                      <span class="text-xs text-slate-400 flex-shrink-0 ml-4">
-                        {fileSize(doc.size)} &middot; {formatDate(doc.uploaded.toISOString())}
-                      </span>
-                    </li>
-                  )
-                })}
-              </ul>
-            )
-          }
-          <div
-            id="upload-area"
-            class="border-2 border-dashed border-slate-200 rounded-lg p-6 text-center"
-          >
-            <p class="text-sm text-slate-500 mb-2">Drag files here or click to upload</p>
-            <input type="file" id="file-input" class="hidden" multiple />
-            <button
-              type="button"
-              id="upload-btn"
-              class="text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-600 hover:bg-slate-50 transition-colors"
-            >
-              Choose Files
-            </button>
-            <div id="upload-status" class="text-xs text-slate-400 mt-2 hidden"></div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Invoices -->
-      {
-        invoices.length > 0 && (
-          <div class="bg-white rounded-lg border border-slate-200">
-            <div class="px-6 py-4 border-b border-slate-100">
-              <h2 class="font-medium text-slate-900">Invoices</h2>
-            </div>
-            <div class="divide-y divide-slate-100">
-              {invoices.map((inv) => (
-                <div class="px-6 py-3 flex items-center justify-between text-sm">
-                  <div class="flex items-center gap-3">
-                    <span class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(inv.status)}`}>
-                      {inv.status}
+                      {name}
+                    </a>
+                    <span class="text-xs text-slate-400 flex-shrink-0 ml-4">
+                      {fileSize(doc.size)} &middot; {formatDate(doc.uploaded.toISOString())}
                     </span>
-                    <span class="text-slate-700 capitalize">{inv.type}</span>
-                  </div>
-                  <div class="flex items-center gap-4 text-slate-500">
-                    <span class="font-medium text-slate-700">${inv.amount.toLocaleString()}</span>
-                    {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
-                    {inv.paid_at && <span>Paid: {formatDate(inv.paid_at)}</span>}
-                  </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )
+        }
+        <div
+          id="upload-area"
+          class="border-2 border-dashed border-slate-200 rounded-lg p-6 text-center"
+        >
+          <p class="text-sm text-slate-500 mb-2">Drag files here or click to upload</p>
+          <input type="file" id="file-input" class="hidden" multiple />
+          <button
+            type="button"
+            id="upload-btn"
+            class="text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-600 hover:bg-slate-50 transition-colors"
+          >
+            Choose Files
+          </button>
+          <div id="upload-status" class="text-xs text-slate-400 mt-2 hidden"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Invoices -->
+    {
+      invoices.length > 0 && (
+        <div class="bg-white rounded-lg border border-slate-200">
+          <div class="px-6 py-4 border-b border-slate-100">
+            <h2 class="font-medium text-slate-900">Invoices</h2>
+          </div>
+          <div class="divide-y divide-slate-100">
+            {invoices.map((inv) => (
+              <div class="px-6 py-3 flex items-center justify-between text-sm">
+                <div class="flex items-center gap-3">
+                  <span class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(inv.status)}`}>
+                    {inv.status}
+                  </span>
+                  <span class="text-slate-700 capitalize">{inv.type}</span>
                 </div>
-              ))}
-            </div>
+                <div class="flex items-center gap-4 text-slate-500">
+                  <span class="font-medium text-slate-700">${inv.amount.toLocaleString()}</span>
+                  {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
+                  {inv.paid_at && <span>Paid: {formatDate(inv.paid_at)}</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+    }
+
+    <!-- Context Timeline -->
+    <div class="bg-white rounded-lg border border-slate-200">
+      <div class="px-6 py-4 border-b border-slate-100">
+        <h2 class="font-medium text-slate-900">Timeline</h2>
+      </div>
+      {
+        contextEntries.length === 0 && (
+          <div class="px-6 py-8 text-center text-sm text-slate-400">
+            No context entries for this engagement.
           </div>
         )
       }
-
-      <!-- Context Timeline -->
-      <div class="bg-white rounded-lg border border-slate-200">
-        <div class="px-6 py-4 border-b border-slate-100">
-          <h2 class="font-medium text-slate-900">Timeline</h2>
-        </div>
-        {
-          contextEntries.length === 0 && (
-            <div class="px-6 py-8 text-center text-sm text-slate-400">
-              No context entries for this engagement.
-            </div>
-          )
-        }
-        {
-          contextEntries.length > 0 && (
-            <div class="divide-y divide-slate-100">
-              {contextEntries.map((entry) => (
-                <div class="px-6 py-3">
-                  <div class="flex items-center gap-2 mb-1">
-                    <span
-                      class={`text-xs px-2 py-0.5 rounded ${contextTypeBadgeClass(entry.type)}`}
-                    >
-                      {entry.type.replace(/_/g, ' ')}
-                    </span>
-                    <span class="text-xs text-slate-400">{formatDate(entry.created_at)}</span>
-                    <span class="text-xs text-slate-400">via {entry.source}</span>
-                  </div>
-                  <p class="text-sm text-slate-700 whitespace-pre-wrap">{entry.content}</p>
+      {
+        contextEntries.length > 0 && (
+          <div class="divide-y divide-slate-100">
+            {contextEntries.map((entry) => (
+              <div class="px-6 py-3">
+                <div class="flex items-center gap-2 mb-1">
+                  <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadgeClass(entry.type)}`}>
+                    {entry.type.replace(/_/g, ' ')}
+                  </span>
+                  <span class="text-xs text-slate-400">{formatDate(entry.created_at)}</span>
+                  <span class="text-xs text-slate-400">via {entry.source}</span>
                 </div>
-              ))}
-            </div>
-          )
-        }
-      </div>
-    </main>
-
-    <script define:vars={{ engagementId }}>
-      const fileInput = document.getElementById('file-input')
-      const uploadBtn = document.getElementById('upload-btn')
-      const uploadArea = document.getElementById('upload-area')
-      const uploadStatus = document.getElementById('upload-status')
-
-      uploadBtn.addEventListener('click', () => fileInput.click())
-      fileInput.addEventListener('change', () => uploadFiles(fileInput.files))
-
-      uploadArea.addEventListener('dragover', (e) => {
-        e.preventDefault()
-        uploadArea.classList.add('border-blue-400', 'bg-blue-50')
-      })
-      uploadArea.addEventListener('dragleave', () => {
-        uploadArea.classList.remove('border-blue-400', 'bg-blue-50')
-      })
-      uploadArea.addEventListener('drop', (e) => {
-        e.preventDefault()
-        uploadArea.classList.remove('border-blue-400', 'bg-blue-50')
-        uploadFiles(e.dataTransfer.files)
-      })
-
-      async function uploadFiles(files) {
-        if (!files || files.length === 0) return
-        uploadStatus.classList.remove('hidden')
-
-        for (const file of files) {
-          uploadStatus.textContent = `Uploading ${file.name}...`
-          const form = new FormData()
-          form.append('file', file)
-          try {
-            const res = await fetch(`/api/admin/engagements/${engagementId}/deliverables`, {
-              method: 'POST',
-              body: form,
-            })
-            if (!res.ok) {
-              const data = await res.json().catch(() => ({}))
-              uploadStatus.textContent = `Failed: ${data.error || res.statusText}`
-            } else {
-              uploadStatus.textContent = `Uploaded ${file.name}`
-            }
-          } catch (err) {
-            uploadStatus.textContent = `Error: ${err.message}`
-          }
-        }
-        setTimeout(() => location.reload(), 800)
+                <p class="text-sm text-slate-700 whitespace-pre-wrap">{entry.content}</p>
+              </div>
+            ))}
+          </div>
+        )
       }
-    </script>
-  </body>
-</html>
+    </div>
+  </div>
+
+  <script define:vars={{ engagementId }}>
+    const fileInput = document.getElementById('file-input')
+    const uploadBtn = document.getElementById('upload-btn')
+    const uploadArea = document.getElementById('upload-area')
+    const uploadStatus = document.getElementById('upload-status')
+
+    uploadBtn.addEventListener('click', () => fileInput.click())
+    fileInput.addEventListener('change', () => uploadFiles(fileInput.files))
+
+    uploadArea.addEventListener('dragover', (e) => {
+      e.preventDefault()
+      uploadArea.classList.add('border-blue-400', 'bg-blue-50')
+    })
+    uploadArea.addEventListener('dragleave', () => {
+      uploadArea.classList.remove('border-blue-400', 'bg-blue-50')
+    })
+    uploadArea.addEventListener('drop', (e) => {
+      e.preventDefault()
+      uploadArea.classList.remove('border-blue-400', 'bg-blue-50')
+      uploadFiles(e.dataTransfer.files)
+    })
+
+    async function uploadFiles(files) {
+      if (!files || files.length === 0) return
+      uploadStatus.classList.remove('hidden')
+
+      for (const file of files) {
+        uploadStatus.textContent = `Uploading ${file.name}...`
+        const form = new FormData()
+        form.append('file', file)
+        try {
+          const res = await fetch(`/api/admin/engagements/${engagementId}/deliverables`, {
+            method: 'POST',
+            body: form,
+          })
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}))
+            uploadStatus.textContent = `Failed: ${data.error || res.statusText}`
+          } else {
+            uploadStatus.textContent = `Uploaded ${file.name}`
+          }
+        } catch (err) {
+          uploadStatus.textContent = `Error: ${err.message}`
+        }
+      }
+      setTimeout(() => location.reload(), 800)
+    }
+  </script>
+</AdminLayout>

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { EntityStage } from '../../../lib/db/entities'
@@ -278,587 +278,534 @@ function confidenceColor(confidence: string): string {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>{entity.name} — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
+<AdminLayout
+  title={`${entity.name} — SMD Services`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Entities', href: `/admin/entities?stage=${entity.stage}` },
+    { label: entity.name },
+  ]}
+>
+  {
+    promoted && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Entity promoted to prospect.
       </div>
-    </header>
-
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
-        <span class="mx-1">/</span>
-        <a
-          href={`/admin/entities?stage=${entity.stage}`}
-          class="hover:text-primary transition-colors">Entities</a
-        >
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">{entity.name}</span>
-      </nav>
-
-      {
-        promoted && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Entity promoted to prospect.
-          </div>
-        )
-      }
-      {
-        noteAdded && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Note added.
-          </div>
-        )
-      }
-      {
-        stageUpdated && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Stage updated.
-          </div>
-        )
-      }
-      {
-        dossierGenerated && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Intelligence dossier generated. See enrichment entries in the timeline below.
-          </div>
-        )
-      }
-      {
-        error && (
-          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
-            {decodeURIComponent(error)}
-          </div>
-        )
-      }
-
-      {/* Entity Summary */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-        <div class="flex items-start justify-between gap-4">
-          <div>
-            <div class="flex items-center gap-3 mb-2">
-              <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
-              <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
-                {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
-              </span>
-              {
-                entity.tier && (
-                  <span
-                    class={`text-xs px-2 py-0.5 rounded ${
-                      entity.tier === 'hot'
-                        ? 'bg-red-100 text-red-700'
-                        : entity.tier === 'warm'
-                          ? 'bg-amber-100 text-amber-700'
-                          : entity.tier === 'cool'
-                            ? 'bg-blue-100 text-blue-700'
-                            : 'bg-slate-100 text-slate-500'
-                    }`}
-                  >
-                    {entity.tier}
-                  </span>
-                )
-              }
-            </div>
-
-            <div class="flex items-center gap-4 text-sm text-slate-500 mb-2 flex-wrap">
-              {
-                entity.pain_score && (
-                  <span>
-                    Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
-                  </span>
-                )
-              }
-              {
-                entity.vertical && (
-                  <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>
-                )
-              }
-              {entity.area && <span>{entity.area}</span>}
-              {entity.employee_count && <span>~{entity.employee_count} employees</span>}
-            </div>
-
-            <div class="flex items-center gap-3 text-xs text-slate-400">
-              {
-                entity.source_pipeline && (
-                  <span>Source: {entity.source_pipeline.replace(/_/g, ' ')}</span>
-                )
-              }
-              <span>Created {formatDate(entity.created_at)}</span>
-              {entity.phone && <span>{entity.phone}</span>}
-              {
-                entity.website && (
-                  <a
-                    href={
-                      entity.website.startsWith('http')
-                        ? entity.website
-                        : `https://${entity.website}`
-                    }
-                    target="_blank"
-                    class="text-blue-500 hover:underline"
-                  >
-                    {entity.website}
-                  </a>
-                )
-              }
-            </div>
-
-            {
-              entity.next_action && (
-                <div class="mt-3 bg-amber-50 border border-amber-200 px-3 py-2 rounded text-sm">
-                  <span class="font-medium text-amber-800">Next:</span>
-                  <span class="text-amber-700">
-                    {entity.next_action}
-                    {entity.next_action_at && ` — ${formatDate(entity.next_action_at)}`}
-                  </span>
-                </div>
-              )
-            }
-          </div>
-
-          {/* Stage transition buttons */}
-          <div class="flex items-center gap-2 shrink-0">
-            {
-              TRANSITIONS[entity.stage]?.map((t) => (
-                <form method="POST" action={t.action ?? `/api/admin/entities/${entity.id}/stage`}>
-                  <input type="hidden" name="stage" value={t.stage} />
-                  <input type="hidden" name="reason" value={`${t.label} by admin.`} />
-                  <button
-                    type="submit"
-                    class={`text-xs px-3 py-1.5 rounded-md transition-colors ${t.style}`}
-                  >
-                    {t.label}
-                  </button>
-                </form>
-              ))
-            }
-            {
-              showDossierButton && (
-                <form
-                  method="POST"
-                  action={`/api/admin/entities/${entity.id}/dossier`}
-                  id="dossier-form"
-                >
-                  <button
-                    type="submit"
-                    id="dossier-btn"
-                    class="text-xs px-3 py-1.5 rounded-md transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    Generate Dossier
-                  </button>
-                </form>
-              )
-            }
-          </div>
-        </div>
+    )
+  }
+  {
+    noteAdded && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Note added.
       </div>
-
-      {/* Add Note */}
-      <div class="bg-white rounded-lg border border-slate-200 p-4 mb-6">
-        <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-3">
-          <input type="hidden" name="type" value="note" />
-          <textarea
-            name="content"
-            placeholder="Add a note..."
-            rows="2"
-            class="flex-1 text-sm border border-slate-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-          ></textarea>
-          <button
-            type="submit"
-            class="self-end text-sm bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors"
-          >
-            Add Note
-          </button>
-        </form>
+    )
+  }
+  {
+    stageUpdated && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Stage updated.
       </div>
+    )
+  }
+  {
+    dossierGenerated && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Intelligence dossier generated. See enrichment entries in the timeline below.
+      </div>
+    )
+  }
+  {
+    error && (
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+        {decodeURIComponent(error)}
+      </div>
+    )
+  }
 
-      {/* Dossier Summary */}
-      {
-        hasDossier && (
-          <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-            <h3 class="text-base font-semibold text-slate-900 mb-4">Dossier Summary</h3>
-
-            {/* Zone 1: Quick Stats */}
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
-              {reviewMeta?.unified_rating != null && (
-                <div class="bg-slate-50 rounded-lg p-3">
-                  <div class="text-2xl font-bold text-slate-900">
-                    {reviewMeta.unified_rating.toFixed(1)}
-                    <span class="text-sm font-normal text-slate-400"> / 5</span>
-                  </div>
-                  <div class="text-xs text-slate-500">
-                    {reviewMeta.total_reviews_across_platforms ?? 0} reviews
-                  </div>
-                </div>
-              )}
-              {reviewMeta?.sentiment_trend &&
-                reviewMeta.sentiment_trend !== 'insufficient_data' && (
-                  <div class="bg-slate-50 rounded-lg p-3">
-                    <div
-                      class={`text-sm font-semibold px-2 py-0.5 rounded inline-block ${sentimentColor(reviewMeta.sentiment_trend)}`}
-                    >
-                      {reviewMeta.sentiment_trend}
-                    </div>
-                    <div class="text-xs text-slate-500 mt-1">Sentiment trend</div>
-                  </div>
-                )}
-              {websiteMeta?.digital_maturity?.score != null && (
-                <div class="bg-slate-50 rounded-lg p-3">
-                  <div class="text-2xl font-bold text-slate-900">
-                    {websiteMeta.digital_maturity.score}
-                    <span class="text-sm font-normal text-slate-400"> / 10</span>
-                  </div>
-                  <div class="text-xs text-slate-500">Digital maturity</div>
-                </div>
-              )}
-              {competitorMeta?.entity_rank_by_rating != null &&
-                competitorMeta?.total_competitors != null && (
-                  <div class="bg-slate-50 rounded-lg p-3">
-                    <div class="text-2xl font-bold text-slate-900">
-                      #{competitorMeta.entity_rank_by_rating}
-                      <span class="text-sm font-normal text-slate-400">
-                        {' '}
-                        of {competitorMeta.total_competitors}
-                      </span>
-                    </div>
-                    <div class="text-xs text-slate-500">Local ranking</div>
-                  </div>
-                )}
-            </div>
-
-            {/* Zone 2: Identified Problems */}
-            {reviewMeta?.operational_problems && reviewMeta.operational_problems.length > 0 && (
-              <div class="mb-5">
-                <div class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">
-                  Identified Problems
-                </div>
-                <div class="flex flex-wrap gap-2">
-                  {reviewMeta.operational_problems.map((p) => (
-                    <span
-                      class={`text-xs px-2.5 py-1 rounded-full font-medium ${confidenceColor(p.confidence)}`}
-                      title={p.evidence}
-                    >
-                      {p.problem.replace(/_/g, ' ')}
-                      <span class="opacity-60 ml-1">({p.confidence})</span>
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Zone 3: Intelligence Brief */}
-            <div class="border-t border-slate-100 pt-4 mb-4">
-              <details>
-                <summary class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-3 cursor-pointer">
-                  Intelligence Brief
-                </summary>
-                <div
-                  class="max-h-[50vh] overflow-y-auto"
-                  set:html={renderSimpleMarkdown(dossierBrief!.content)}
-                />
-              </details>
-            </div>
-
-            {/* Zone 4: Outreach Draft */}
-            {outreachEntry && (
-              <div class="border-t border-slate-100 pt-4">
-                <div class="flex items-center justify-between mb-2">
-                  <div class="text-xs font-medium text-slate-500 uppercase tracking-wide">
-                    Outreach Draft
-                    {!outreachFromDossier && (
-                      <span class="normal-case font-normal text-slate-400 ml-2">
-                        Pre-dossier draft
-                      </span>
-                    )}
-                  </div>
-                  <button
-                    id="copy-outreach-btn"
-                    class="text-xs px-2 py-1 rounded bg-slate-100 text-slate-600 hover:bg-slate-200 transition-colors"
-                  >
-                    Copy
-                  </button>
-                </div>
-                <pre
-                  id="outreach-content"
-                  class="text-sm text-slate-700 whitespace-pre-wrap bg-slate-50 rounded-lg p-4 border border-slate-100"
-                >
-                  {outreachEntry.content}
-                </pre>
-              </div>
-            )}
-          </div>
-        )
-      }
-
-      {/* Context Timeline */}
-      <div class="mb-6">
-        <div class="flex items-center justify-between mb-3">
-          <h3 class="text-base font-semibold text-slate-900">
-            Context Timeline
-            <span class="text-sm font-normal text-slate-400">({contextEntries.length})</span>
-          </h3>
-        </div>
-
-        {/* Type filter pills */}
-        <div class="flex gap-1 mb-4 flex-wrap">
-          <a
-            href={`/admin/entities/${entity.id}`}
-            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'}`}
-          >
-            All ({contextEntries.length})
-          </a>
+  {/* Entity Summary */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <div class="flex items-center gap-3 mb-2">
+          <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+          <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
+            {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
+          </span>
           {
-            Object.entries(typeCounts).map(([type, count]) => (
-              <a
-                href={`/admin/entities/${entity.id}?type=${type}`}
-                class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-slate-900 text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
+            entity.tier && (
+              <span
+                class={`text-xs px-2 py-0.5 rounded ${
+                  entity.tier === 'hot'
+                    ? 'bg-red-100 text-red-700'
+                    : entity.tier === 'warm'
+                      ? 'bg-amber-100 text-amber-700'
+                      : entity.tier === 'cool'
+                        ? 'bg-blue-100 text-blue-700'
+                        : 'bg-slate-100 text-slate-500'
+                }`}
               >
-                {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
-              </a>
-            ))
+                {entity.tier}
+              </span>
+            )
           }
         </div>
 
-        {/* Timeline entries */}
+        <div class="flex items-center gap-4 text-sm text-slate-500 mb-2 flex-wrap">
+          {
+            entity.pain_score && (
+              <span>
+                Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
+              </span>
+            )
+          }
+          {entity.vertical && <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>}
+          {entity.area && <span>{entity.area}</span>}
+          {entity.employee_count && <span>~{entity.employee_count} employees</span>}
+        </div>
+
+        <div class="flex items-center gap-3 text-xs text-slate-400">
+          {
+            entity.source_pipeline && (
+              <span>Source: {entity.source_pipeline.replace(/_/g, ' ')}</span>
+            )
+          }
+          <span>Created {formatDate(entity.created_at)}</span>
+          {entity.phone && <span>{entity.phone}</span>}
+          {
+            entity.website && (
+              <a
+                href={
+                  entity.website.startsWith('http') ? entity.website : `https://${entity.website}`
+                }
+                target="_blank"
+                class="text-blue-500 hover:underline"
+              >
+                {entity.website}
+              </a>
+            )
+          }
+        </div>
+
         {
-          filteredEntries.length === 0 ? (
-            <div class="bg-white rounded-lg border border-slate-200 p-4">
-              <p class="text-slate-500 text-sm">No context entries yet.</p>
-            </div>
-          ) : (
-            <div class="space-y-3">
-              {filteredEntries.map((entry: ContextEntry) => {
-                const meta = parseMetadata(entry.metadata)
-                const problems = meta?.top_problems as string[] | undefined
-                return (
-                  <div class="bg-white rounded-lg border border-slate-200 px-4 py-3">
-                    <div class="flex items-center gap-2 mb-1.5">
-                      <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
-                        {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
-                      </span>
-                      <span class="text-xs text-slate-400">{entry.source}</span>
-                      <span class="text-xs text-slate-400">{formatDateTime(entry.created_at)}</span>
-                      {entry.type === 'signal' && meta?.pain_score && (
-                        <span class="text-xs font-semibold text-red-600">
-                          Pain: {String(meta.pain_score)}/10
-                        </span>
-                      )}
-                    </div>
-
-                    {problems && problems.length > 0 && (
-                      <div class="flex gap-1 mb-1.5">
-                        {problems.map((p: string) => (
-                          <span class="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded">
-                            {p.replace(/_/g, ' ')}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-
-                    <details class="group">
-                      <summary class="text-sm text-slate-700 cursor-pointer line-clamp-3 group-open:line-clamp-none whitespace-pre-wrap">
-                        {entry.content}
-                      </summary>
-                    </details>
-                  </div>
-                )
-              })}
+          entity.next_action && (
+            <div class="mt-3 bg-amber-50 border border-amber-200 px-3 py-2 rounded text-sm">
+              <span class="font-medium text-amber-800">Next:</span>
+              <span class="text-amber-700">
+                {entity.next_action}
+                {entity.next_action_at && ` — ${formatDate(entity.next_action_at)}`}
+              </span>
             </div>
           )
         }
       </div>
 
-      {/* Related Data Panels */}
-      {
-        contacts.length > 0 && (
-          <details class="bg-white rounded-lg border border-slate-200 mb-4" open>
-            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
-              Contacts ({contacts.length})
+      {/* Stage transition buttons */}
+      <div class="flex items-center gap-2 shrink-0">
+        {
+          TRANSITIONS[entity.stage]?.map((t) => (
+            <form method="POST" action={t.action ?? `/api/admin/entities/${entity.id}/stage`}>
+              <input type="hidden" name="stage" value={t.stage} />
+              <input type="hidden" name="reason" value={`${t.label} by admin.`} />
+              <button
+                type="submit"
+                class={`text-xs px-3 py-1.5 rounded-md transition-colors ${t.style}`}
+              >
+                {t.label}
+              </button>
+            </form>
+          ))
+        }
+        {
+          showDossierButton && (
+            <form
+              method="POST"
+              action={`/api/admin/entities/${entity.id}/dossier`}
+              id="dossier-form"
+            >
+              <button
+                type="submit"
+                id="dossier-btn"
+                class="text-xs px-3 py-1.5 rounded-md transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Generate Dossier
+              </button>
+            </form>
+          )
+        }
+      </div>
+    </div>
+  </div>
+
+  {/* Add Note */}
+  <div class="bg-white rounded-lg border border-slate-200 p-4 mb-6">
+    <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-3">
+      <input type="hidden" name="type" value="note" />
+      <textarea
+        name="content"
+        placeholder="Add a note..."
+        rows="2"
+        class="flex-1 text-sm border border-slate-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+      ></textarea>
+      <button
+        type="submit"
+        class="self-end text-sm bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors"
+      >
+        Add Note
+      </button>
+    </form>
+  </div>
+
+  {/* Dossier Summary */}
+  {
+    hasDossier && (
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <h3 class="text-base font-semibold text-slate-900 mb-4">Dossier Summary</h3>
+
+        {/* Zone 1: Quick Stats */}
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-5">
+          {reviewMeta?.unified_rating != null && (
+            <div class="bg-slate-50 rounded-lg p-3">
+              <div class="text-2xl font-bold text-slate-900">
+                {reviewMeta.unified_rating.toFixed(1)}
+                <span class="text-sm font-normal text-slate-400"> / 5</span>
+              </div>
+              <div class="text-xs text-slate-500">
+                {reviewMeta.total_reviews_across_platforms ?? 0} reviews
+              </div>
+            </div>
+          )}
+          {reviewMeta?.sentiment_trend && reviewMeta.sentiment_trend !== 'insufficient_data' && (
+            <div class="bg-slate-50 rounded-lg p-3">
+              <div
+                class={`text-sm font-semibold px-2 py-0.5 rounded inline-block ${sentimentColor(reviewMeta.sentiment_trend)}`}
+              >
+                {reviewMeta.sentiment_trend}
+              </div>
+              <div class="text-xs text-slate-500 mt-1">Sentiment trend</div>
+            </div>
+          )}
+          {websiteMeta?.digital_maturity?.score != null && (
+            <div class="bg-slate-50 rounded-lg p-3">
+              <div class="text-2xl font-bold text-slate-900">
+                {websiteMeta.digital_maturity.score}
+                <span class="text-sm font-normal text-slate-400"> / 10</span>
+              </div>
+              <div class="text-xs text-slate-500">Digital maturity</div>
+            </div>
+          )}
+          {competitorMeta?.entity_rank_by_rating != null &&
+            competitorMeta?.total_competitors != null && (
+              <div class="bg-slate-50 rounded-lg p-3">
+                <div class="text-2xl font-bold text-slate-900">
+                  #{competitorMeta.entity_rank_by_rating}
+                  <span class="text-sm font-normal text-slate-400">
+                    {' '}
+                    of {competitorMeta.total_competitors}
+                  </span>
+                </div>
+                <div class="text-xs text-slate-500">Local ranking</div>
+              </div>
+            )}
+        </div>
+
+        {/* Zone 2: Identified Problems */}
+        {reviewMeta?.operational_problems && reviewMeta.operational_problems.length > 0 && (
+          <div class="mb-5">
+            <div class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">
+              Identified Problems
+            </div>
+            <div class="flex flex-wrap gap-2">
+              {reviewMeta.operational_problems.map((p) => (
+                <span
+                  class={`text-xs px-2.5 py-1 rounded-full font-medium ${confidenceColor(p.confidence)}`}
+                  title={p.evidence}
+                >
+                  {p.problem.replace(/_/g, ' ')}
+                  <span class="opacity-60 ml-1">({p.confidence})</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Zone 3: Intelligence Brief */}
+        <div class="border-t border-slate-100 pt-4 mb-4">
+          <details>
+            <summary class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-3 cursor-pointer">
+              Intelligence Brief
             </summary>
-            <div class="px-6 pb-4 divide-y divide-slate-100">
-              {contacts.map((c) => (
-                <div class="py-2 flex items-center justify-between">
-                  <div>
-                    <span class="text-sm font-medium text-slate-900">{c.name}</span>
-                    {c.role && (
-                      <span class="text-xs bg-slate-100 text-slate-500 px-1.5 py-0.5 rounded ml-2">
-                        {c.role}
+            <div
+              class="max-h-[50vh] overflow-y-auto"
+              set:html={renderSimpleMarkdown(dossierBrief!.content)}
+            />
+          </details>
+        </div>
+
+        {/* Zone 4: Outreach Draft */}
+        {outreachEntry && (
+          <div class="border-t border-slate-100 pt-4">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-xs font-medium text-slate-500 uppercase tracking-wide">
+                Outreach Draft
+                {!outreachFromDossier && (
+                  <span class="normal-case font-normal text-slate-400 ml-2">Pre-dossier draft</span>
+                )}
+              </div>
+              <button
+                id="copy-outreach-btn"
+                class="text-xs px-2 py-1 rounded bg-slate-100 text-slate-600 hover:bg-slate-200 transition-colors"
+              >
+                Copy
+              </button>
+            </div>
+            <pre
+              id="outreach-content"
+              class="text-sm text-slate-700 whitespace-pre-wrap bg-slate-50 rounded-lg p-4 border border-slate-100"
+            >
+              {outreachEntry.content}
+            </pre>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  {/* Context Timeline */}
+  <div class="mb-6">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="text-base font-semibold text-slate-900">
+        Context Timeline
+        <span class="text-sm font-normal text-slate-400">({contextEntries.length})</span>
+      </h3>
+    </div>
+
+    {/* Type filter pills */}
+    <div class="flex gap-1 mb-4 flex-wrap">
+      <a
+        href={`/admin/entities/${entity.id}`}
+        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'}`}
+      >
+        All ({contextEntries.length})
+      </a>
+      {
+        Object.entries(typeCounts).map(([type, count]) => (
+          <a
+            href={`/admin/entities/${entity.id}?type=${type}`}
+            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-slate-900 text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
+          >
+            {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
+          </a>
+        ))
+      }
+    </div>
+
+    {/* Timeline entries */}
+    {
+      filteredEntries.length === 0 ? (
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <p class="text-slate-500 text-sm">No context entries yet.</p>
+        </div>
+      ) : (
+        <div class="space-y-3">
+          {filteredEntries.map((entry: ContextEntry) => {
+            const meta = parseMetadata(entry.metadata)
+            const problems = meta?.top_problems as string[] | undefined
+            return (
+              <div class="bg-white rounded-lg border border-slate-200 px-4 py-3">
+                <div class="flex items-center gap-2 mb-1.5">
+                  <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
+                    {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
+                  </span>
+                  <span class="text-xs text-slate-400">{entry.source}</span>
+                  <span class="text-xs text-slate-400">{formatDateTime(entry.created_at)}</span>
+                  {entry.type === 'signal' && meta?.pain_score && (
+                    <span class="text-xs font-semibold text-red-600">
+                      Pain: {String(meta.pain_score)}/10
+                    </span>
+                  )}
+                </div>
+
+                {problems && problems.length > 0 && (
+                  <div class="flex gap-1 mb-1.5">
+                    {problems.map((p: string) => (
+                      <span class="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded">
+                        {p.replace(/_/g, ' ')}
                       </span>
-                    )}
+                    ))}
                   </div>
-                  <div class="text-xs text-slate-400 flex gap-3">
-                    {c.email && <span>{c.email}</span>}
-                    {c.phone && <span>{c.phone}</span>}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </details>
-        )
-      }
+                )}
 
-      {
-        assessments.length > 0 && (
-          <details class="bg-white rounded-lg border border-slate-200 mb-4">
-            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
-              Assessments ({assessments.length})
-            </summary>
-            <div class="px-6 pb-4 divide-y divide-slate-100">
-              {assessments.map((a) => (
-                <div class="py-2 flex items-center gap-2">
-                  <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(a.status)}`}>
-                    {a.status}
+                <details class="group">
+                  <summary class="text-sm text-slate-700 cursor-pointer line-clamp-3 group-open:line-clamp-none whitespace-pre-wrap">
+                    {entry.content}
+                  </summary>
+                </details>
+              </div>
+            )
+          })}
+        </div>
+      )
+    }
+  </div>
+
+  {/* Related Data Panels */}
+  {
+    contacts.length > 0 && (
+      <details class="bg-white rounded-lg border border-slate-200 mb-4" open>
+        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+          Contacts ({contacts.length})
+        </summary>
+        <div class="px-6 pb-4 divide-y divide-slate-100">
+          {contacts.map((c) => (
+            <div class="py-2 flex items-center justify-between">
+              <div>
+                <span class="text-sm font-medium text-slate-900">{c.name}</span>
+                {c.role && (
+                  <span class="text-xs bg-slate-100 text-slate-500 px-1.5 py-0.5 rounded ml-2">
+                    {c.role}
                   </span>
-                  {a.scheduled_at && (
-                    <span class="text-sm text-slate-700">{formatDate(a.scheduled_at)}</span>
-                  )}
-                  {a.duration_minutes && (
-                    <span class="text-xs text-slate-400">{a.duration_minutes} min</span>
-                  )}
-                </div>
-              ))}
+                )}
+              </div>
+              <div class="text-xs text-slate-400 flex gap-3">
+                {c.email && <span>{c.email}</span>}
+                {c.phone && <span>{c.phone}</span>}
+              </div>
             </div>
-          </details>
-        )
-      }
+          ))}
+        </div>
+      </details>
+    )
+  }
 
-      {
-        engagements.length > 0 && (
-          <details class="bg-white rounded-lg border border-slate-200 mb-4">
-            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
-              Engagements ({engagements.length})
-            </summary>
-            <div class="px-6 pb-4 divide-y divide-slate-100">
-              {engagements.map((e) => (
-                <a
-                  href={`/admin/engagements/${e.id}`}
-                  class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
-                >
-                  <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(e.status)}`}>
-                    {e.status}
-                  </span>
-                  {e.start_date && (
-                    <span class="text-sm text-slate-700">{formatDate(e.start_date)}</span>
-                  )}
-                  {e.estimated_hours && (
-                    <span class="text-xs text-slate-400">
-                      {e.actual_hours}/{e.estimated_hours} hrs
-                    </span>
-                  )}
-                </a>
-              ))}
+  {
+    assessments.length > 0 && (
+      <details class="bg-white rounded-lg border border-slate-200 mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+          Assessments ({assessments.length})
+        </summary>
+        <div class="px-6 pb-4 divide-y divide-slate-100">
+          {assessments.map((a) => (
+            <div class="py-2 flex items-center gap-2">
+              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(a.status)}`}>
+                {a.status}
+              </span>
+              {a.scheduled_at && (
+                <span class="text-sm text-slate-700">{formatDate(a.scheduled_at)}</span>
+              )}
+              {a.duration_minutes && (
+                <span class="text-xs text-slate-400">{a.duration_minutes} min</span>
+              )}
             </div>
-          </details>
-        )
-      }
+          ))}
+        </div>
+      </details>
+    )
+  }
 
-      {
-        quotes.length > 0 && (
-          <details class="bg-white rounded-lg border border-slate-200 mb-4">
-            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
-              Quotes ({quotes.length})
-            </summary>
-            <div class="px-6 pb-4 divide-y divide-slate-100">
-              {quotes.map((q) => (
-                <a
-                  href={`/admin/entities/${entity.id}/quotes/${q.id}`}
-                  class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
-                >
-                  <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(q.status)}`}>
-                    {q.status}
-                  </span>
-                  <span class="text-sm font-medium text-slate-700">
-                    ${q.total_price.toLocaleString()}
-                  </span>
-                  <span class="text-xs text-slate-400">{q.total_hours} hrs</span>
-                  <span class="text-xs text-slate-400">v{q.version}</span>
-                </a>
-              ))}
+  {
+    engagements.length > 0 && (
+      <details class="bg-white rounded-lg border border-slate-200 mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+          Engagements ({engagements.length})
+        </summary>
+        <div class="px-6 pb-4 divide-y divide-slate-100">
+          {engagements.map((e) => (
+            <a
+              href={`/admin/engagements/${e.id}`}
+              class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
+            >
+              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(e.status)}`}>
+                {e.status}
+              </span>
+              {e.start_date && (
+                <span class="text-sm text-slate-700">{formatDate(e.start_date)}</span>
+              )}
+              {e.estimated_hours && (
+                <span class="text-xs text-slate-400">
+                  {e.actual_hours}/{e.estimated_hours} hrs
+                </span>
+              )}
+            </a>
+          ))}
+        </div>
+      </details>
+    )
+  }
+
+  {
+    quotes.length > 0 && (
+      <details class="bg-white rounded-lg border border-slate-200 mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+          Quotes ({quotes.length})
+        </summary>
+        <div class="px-6 pb-4 divide-y divide-slate-100">
+          {quotes.map((q) => (
+            <a
+              href={`/admin/entities/${entity.id}/quotes/${q.id}`}
+              class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
+            >
+              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(q.status)}`}>
+                {q.status}
+              </span>
+              <span class="text-sm font-medium text-slate-700">
+                ${q.total_price.toLocaleString()}
+              </span>
+              <span class="text-xs text-slate-400">{q.total_hours} hrs</span>
+              <span class="text-xs text-slate-400">v{q.version}</span>
+            </a>
+          ))}
+        </div>
+      </details>
+    )
+  }
+
+  {
+    invoices.length > 0 && (
+      <details class="bg-white rounded-lg border border-slate-200 mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+          Invoices ({invoices.length})
+        </summary>
+        <div class="px-6 pb-4 divide-y divide-slate-100">
+          {invoices.map((inv) => (
+            <div class="py-2 flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(inv.status)}`}>
+                  {inv.status}
+                </span>
+                <span class="text-sm font-medium text-slate-700">
+                  ${inv.amount.toLocaleString()}
+                </span>
+                <span class="text-xs text-slate-400">{inv.type}</span>
+                {inv.due_date && (
+                  <span class="text-xs text-slate-400">Due {formatDate(inv.due_date)}</span>
+                )}
+              </div>
             </div>
-          </details>
-        )
-      }
+          ))}
+        </div>
+      </details>
+    )
+  }
+  <script>
+    const form = document.getElementById('dossier-form')
+    const btn = document.getElementById('dossier-btn') as HTMLButtonElement | null
+    if (form && btn) {
+      form.addEventListener('submit', () => {
+        btn.disabled = true
+        btn.textContent = 'Generating...'
+      })
+    }
 
-      {
-        invoices.length > 0 && (
-          <details class="bg-white rounded-lg border border-slate-200 mb-4">
-            <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
-              Invoices ({invoices.length})
-            </summary>
-            <div class="px-6 pb-4 divide-y divide-slate-100">
-              {invoices.map((inv) => (
-                <div class="py-2 flex items-center justify-between">
-                  <div class="flex items-center gap-2">
-                    <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(inv.status)}`}>
-                      {inv.status}
-                    </span>
-                    <span class="text-sm font-medium text-slate-700">
-                      ${inv.amount.toLocaleString()}
-                    </span>
-                    <span class="text-xs text-slate-400">{inv.type}</span>
-                    {inv.due_date && (
-                      <span class="text-xs text-slate-400">Due {formatDate(inv.due_date)}</span>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </details>
-        )
-      }
-    </main>
-    <script>
-      const form = document.getElementById('dossier-form')
-      const btn = document.getElementById('dossier-btn') as HTMLButtonElement | null
-      if (form && btn) {
-        form.addEventListener('submit', () => {
-          btn.disabled = true
-          btn.textContent = 'Generating...'
-        })
-      }
-
-      const copyBtn = document.getElementById('copy-outreach-btn')
-      const outreachEl = document.getElementById('outreach-content')
-      if (copyBtn && outreachEl) {
-        copyBtn.addEventListener('click', async () => {
-          await navigator.clipboard.writeText(outreachEl.textContent ?? '')
-          copyBtn.textContent = 'Copied!'
-          setTimeout(() => {
-            copyBtn.textContent = 'Copy'
-          }, 2000)
-        })
-      }
-    </script>
-  </body>
-</html>
+    const copyBtn = document.getElementById('copy-outreach-btn')
+    const outreachEl = document.getElementById('outreach-content')
+    if (copyBtn && outreachEl) {
+      copyBtn.addEventListener('click', async () => {
+        await navigator.clipboard.writeText(outreachEl.textContent ?? '')
+        copyBtn.textContent = 'Copied!'
+        setTimeout(() => {
+          copyBtn.textContent = 'Copy'
+        }, 2000)
+      })
+    }
+  </script>
+</AdminLayout>

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -1,5 +1,5 @@
 ---
-import '../../../../../styles/global.css'
+import AdminLayout from '../../../../../layouts/AdminLayout.astro'
 import { statusBadgeClass } from '../../../../../lib/ui/status-badge'
 import { getEntity } from '../../../../../lib/db/entities'
 import { getQuote, QUOTE_STATUSES, VALID_TRANSITIONS } from '../../../../../lib/db/quotes'
@@ -75,529 +75,481 @@ function formatCurrency(amount: number): string {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Quote — {entity.name} — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
+<AdminLayout
+  title={`Quote — ${entity.name} — SMD Services`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Entities', href: `/admin/entities?stage=${entity.stage}` },
+    { label: entity.name, href: `/admin/entities/${entityId}` },
+    { label: 'Quote' },
+  ]}
+>
+  {
+    saved && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Quote saved.
       </div>
-    </header>
+    )
+  }
+  {
+    error && (
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+        {error === 'invalid_transition'
+          ? 'Invalid status transition.'
+          : error === 'no_sow'
+            ? 'Generate a SOW PDF first.'
+            : error === 'already_sent'
+              ? 'SOW already sent for signature.'
+              : error === 'no_contact_email'
+                ? 'No contact email found. Add a contact with email first.'
+                : error === 'client_not_found'
+                  ? 'Client not found.'
+                  : decodeURIComponent(error)}
+      </div>
+    )
+  }
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
-        <span class="mx-1">/</span>
-        <a
-          href={`/admin/entities?stage=${entity.stage}`}
-          class="hover:text-primary transition-colors">Entities</a
-        >
-        <span class="mx-1">/</span>
-        <a href={`/admin/entities/${entityId}`} class="hover:text-primary transition-colors"
-          >{entity.name}</a
-        >
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Quote</span>
-      </nav>
+  {/* Stale PDF warning (OQ-006) */}
+  {
+    isSowStale && (
+      <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-lg mb-4">
+        The quote has been modified since the last SOW PDF was generated. Re-generate the PDF before
+        sending.
+      </div>
+    )
+  }
 
-      {
-        saved && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Quote saved.
-          </div>
-        )
-      }
-      {
-        error && (
-          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
-            {error === 'invalid_transition'
-              ? 'Invalid status transition.'
-              : error === 'no_sow'
-                ? 'Generate a SOW PDF first.'
-                : error === 'already_sent'
-                  ? 'SOW already sent for signature.'
-                  : error === 'no_contact_email'
-                    ? 'No contact email found. Add a contact with email first.'
-                    : error === 'client_not_found'
-                      ? 'Client not found.'
-                      : decodeURIComponent(error)}
-          </div>
-        )
-      }
-
-      {/* Stale PDF warning (OQ-006) */}
-      {
-        isSowStale && (
-          <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-lg mb-4">
-            The quote has been modified since the last SOW PDF was generated. Re-generate the PDF
-            before sending.
-          </div>
-        )
-      }
-
-      {/* Header */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-        <div class="flex items-start justify-between gap-4">
-          <div>
-            <div class="flex items-center gap-3 mb-2">
-              <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
-              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(status)}`}>
-                {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
+  {/* Header */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <div class="flex items-center gap-3 mb-2">
+          <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+          <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(status)}`}>
+            {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
+          </span>
+        </div>
+        <div class="flex items-center gap-4 text-sm text-slate-500">
+          <span>Created {formatDate(quote.created_at)}</span>
+          {
+            expiresAt && (
+              <span class={isExpired ? 'text-red-600 font-medium' : ''}>
+                {isExpired ? 'Expired' : 'Expires'} {formatDate(quote.expires_at!)}
               </span>
-            </div>
-            <div class="flex items-center gap-4 text-sm text-slate-500">
-              <span>Created {formatDate(quote.created_at)}</span>
-              {
-                expiresAt && (
-                  <span class={isExpired ? 'text-red-600 font-medium' : ''}>
-                    {isExpired ? 'Expired' : 'Expires'} {formatDate(quote.expires_at!)}
-                  </span>
-                )
-              }
-              <span>Rate: {formatCurrency(quote.rate)}/hr</span>
-              <span>v{quote.version}</span>
-            </div>
-          </div>
+            )
+          }
+          <span>Rate: {formatCurrency(quote.rate)}/hr</span>
+          <span>v{quote.version}</span>
         </div>
       </div>
+    </div>
+  </div>
 
-      {/* Line Item Editor */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-lg font-semibold text-slate-900">Line Items</h3>
-          <div id="line-item-warning" class="hidden text-sm text-amber-600 font-medium">
-            Consider keeping scope focused — 3+ line items may indicate too broad an engagement
-            (OQ-005)
-          </div>
-        </div>
+  {/* Line Item Editor */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-lg font-semibold text-slate-900">Line Items</h3>
+      <div id="line-item-warning" class="hidden text-sm text-amber-600 font-medium">
+        Consider keeping scope focused — 3+ line items may indicate too broad an engagement (OQ-005)
+      </div>
+    </div>
 
-        <div id="line-items-container">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-slate-200">
-                <th class="text-left py-2 px-2 text-slate-500 font-medium w-8">#</th>
-                <th class="text-left py-2 px-2 text-slate-500 font-medium w-48">Problem</th>
-                <th class="text-left py-2 px-2 text-slate-500 font-medium">Description</th>
-                <th class="text-right py-2 px-2 text-slate-500 font-medium w-24">Est. Hours</th>
-                {isDraft && <th class="py-2 px-2 w-10" />}
+    <div id="line-items-container">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-slate-200">
+            <th class="text-left py-2 px-2 text-slate-500 font-medium w-8">#</th>
+            <th class="text-left py-2 px-2 text-slate-500 font-medium w-48">Problem</th>
+            <th class="text-left py-2 px-2 text-slate-500 font-medium">Description</th>
+            <th class="text-right py-2 px-2 text-slate-500 font-medium w-24">Est. Hours</th>
+            {isDraft && <th class="py-2 px-2 w-10" />}
+          </tr>
+        </thead>
+        <tbody id="line-items-body">
+          {
+            lineItems.map((item, index) => (
+              <tr class="border-b border-slate-100 line-item-row" data-index={index}>
+                <td class="py-2 px-2 text-slate-400 row-number">{index + 1}</td>
+                <td class="py-2 px-2">
+                  {isDraft ? (
+                    <input
+                      type="text"
+                      class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem"
+                      value={item.problem}
+                      placeholder="e.g., Scheduling chaos"
+                    />
+                  ) : (
+                    <span class="text-slate-700">{item.problem}</span>
+                  )}
+                </td>
+                <td class="py-2 px-2">
+                  {isDraft ? (
+                    <input
+                      type="text"
+                      class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-description"
+                      value={item.description}
+                      placeholder="What we'll deliver"
+                    />
+                  ) : (
+                    <span class="text-slate-700">{item.description}</span>
+                  )}
+                </td>
+                <td class="py-2 px-2 text-right">
+                  {isDraft ? (
+                    <input
+                      type="number"
+                      class="w-20 border border-slate-200 rounded px-2 py-1 text-sm text-right item-hours"
+                      value={item.estimated_hours}
+                      min="0.5"
+                      step="0.5"
+                    />
+                  ) : (
+                    <span class="text-slate-700">{item.estimated_hours}</span>
+                  )}
+                </td>
+                {isDraft && (
+                  <td class="py-2 px-2 text-center">
+                    <button
+                      type="button"
+                      class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn"
+                      title="Remove"
+                    >
+                      &times;
+                    </button>
+                  </td>
+                )}
               </tr>
-            </thead>
-            <tbody id="line-items-body">
-              {
-                lineItems.map((item, index) => (
-                  <tr class="border-b border-slate-100 line-item-row" data-index={index}>
-                    <td class="py-2 px-2 text-slate-400 row-number">{index + 1}</td>
-                    <td class="py-2 px-2">
-                      {isDraft ? (
-                        <input
-                          type="text"
-                          class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem"
-                          value={item.problem}
-                          placeholder="e.g., Scheduling chaos"
-                        />
-                      ) : (
-                        <span class="text-slate-700">{item.problem}</span>
-                      )}
-                    </td>
-                    <td class="py-2 px-2">
-                      {isDraft ? (
-                        <input
-                          type="text"
-                          class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-description"
-                          value={item.description}
-                          placeholder="What we'll deliver"
-                        />
-                      ) : (
-                        <span class="text-slate-700">{item.description}</span>
-                      )}
-                    </td>
-                    <td class="py-2 px-2 text-right">
-                      {isDraft ? (
-                        <input
-                          type="number"
-                          class="w-20 border border-slate-200 rounded px-2 py-1 text-sm text-right item-hours"
-                          value={item.estimated_hours}
-                          min="0.5"
-                          step="0.5"
-                        />
-                      ) : (
-                        <span class="text-slate-700">{item.estimated_hours}</span>
-                      )}
-                    </td>
-                    {isDraft && (
-                      <td class="py-2 px-2 text-center">
-                        <button
-                          type="button"
-                          class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn"
-                          title="Remove"
-                        >
-                          &times;
-                        </button>
-                      </td>
-                    )}
-                  </tr>
-                ))
-              }
-            </tbody>
-          </table>
-
-          {
-            isDraft && (
-              <button
-                type="button"
-                id="add-line-item-btn"
-                class="mt-3 text-sm text-primary hover:text-primary-hover transition-colors font-medium"
-              >
-                + Add line item
-              </button>
-            )
+            ))
           }
-        </div>
+        </tbody>
+      </table>
 
-        {/* Totals */}
-        <div class="mt-4 pt-4 border-t border-slate-200 flex justify-end">
-          <div class="text-right space-y-1">
-            <div class="text-sm text-slate-500">
-              Total hours: <span id="total-hours" class="font-medium text-slate-900"
-                >{quote.total_hours}</span
-              >
-            </div>
-            <div class="text-lg font-semibold text-slate-900">
-              Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Payment Structure */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-        <h3 class="text-lg font-semibold text-slate-900 mb-4">Payment Structure</h3>
-
-        <div class="space-y-3">
-          <div class="flex items-center gap-4">
-            <label class="text-sm text-slate-600 w-36">Deposit percentage:</label>
-            {
-              isDraft ? (
-                <select
-                  id="deposit-pct-select"
-                  class="border border-slate-200 rounded px-2 py-1 text-sm"
-                >
-                  <option value="0.5" selected={depositPct === 0.5}>
-                    50%
-                  </option>
-                  <option value="0.4" selected={depositPct === 0.4}>
-                    40%
-                  </option>
-                </select>
-              ) : (
-                <span class="text-sm text-slate-900">{Math.round(depositPct * 100)}%</span>
-              )
-            }
-          </div>
-
-          {
-            isThreeMilestone && (
-              <div class="text-sm text-amber-600 bg-amber-50 border border-amber-200 px-3 py-2 rounded">
-                40+ hour engagement — 3-milestone payment applies (40% deposit, 30% mid-engagement,
-                30% completion)
-              </div>
-            )
-          }
-
-          <div class="text-sm text-slate-600 space-y-1">
-            <div class="flex justify-between max-w-xs">
-              <span>Deposit:</span>
-              <span id="deposit-amount" class="font-medium text-slate-900">
-                {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
-              </span>
-            </div>
-            {
-              isThreeMilestone ? (
-                <>
-                  <div class="flex justify-between max-w-xs">
-                    <span>Mid-engagement milestone:</span>
-                    <span class="font-medium text-slate-900">
-                      {formatCurrency(quote.total_price * 0.3)}
-                    </span>
-                  </div>
-                  <div class="flex justify-between max-w-xs">
-                    <span>Completion:</span>
-                    <span class="font-medium text-slate-900">
-                      {formatCurrency(quote.total_price * 0.3)}
-                    </span>
-                  </div>
-                </>
-              ) : (
-                <div class="flex justify-between max-w-xs">
-                  <span>Completion:</span>
-                  <span id="completion-amount" class="font-medium text-slate-900">
-                    {formatCurrency(quote.total_price * (1 - depositPct))}
-                  </span>
-                </div>
-              )
-            }
-          </div>
-        </div>
-      </div>
-
-      {/* SOW PDF Status */}
       {
-        hasSow && (
-          <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
-            <h3 class="text-lg font-semibold text-slate-900 mb-2">SOW PDF</h3>
-            <div class="text-sm text-slate-600 space-y-1">
-              <div>
-                Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
-              </div>
-              {activeSignatureRequest?.provider_request_id && (
-                <div class="text-green-700">Sent for signature via SignWell</div>
-              )}
-            </div>
-          </div>
+        isDraft && (
+          <button
+            type="button"
+            id="add-line-item-btn"
+            class="mt-3 text-sm text-primary hover:text-primary-hover transition-colors font-medium"
+          >
+            + Add line item
+          </button>
         )
       }
+    </div>
 
-      {/* Actions */}
-      <div class="bg-white rounded-lg border border-slate-200 p-6">
-        <h3 class="text-lg font-semibold text-slate-900 mb-4">Actions</h3>
-        <div class="flex flex-wrap gap-3">
-          {/* Save Draft */}
-          {
-            isDraft && (
-              <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="save-form">
-                <input type="hidden" name="action" value="update" />
-                <input
-                  type="hidden"
-                  name="line_items"
-                  id="save-line-items"
-                  value={JSON.stringify(lineItems)}
-                />
-                <input
-                  type="hidden"
-                  name="deposit_pct"
-                  id="save-deposit-pct"
-                  value={String(depositPct)}
-                />
-                <button
-                  type="submit"
-                  class="px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors text-sm font-medium"
-                >
-                  Save Draft
-                </button>
-              </form>
-            )
-          }
-
-          {/* Generate SOW PDF */}
-          {
-            isDraft && (
-              <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="generate-pdf-form">
-                <input type="hidden" name="action" value="generate-pdf" />
-                <button
-                  type="submit"
-                  class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors text-sm font-medium"
-                  id="generate-pdf-btn"
-                >
-                  {hasSow ? 'Re-generate SOW PDF' : 'Generate SOW PDF'}
-                </button>
-              </form>
-            )
-          }
-
-          {/* Send via SignWell */}
-          {
-            (isDraft || status === 'sent') && hasSow && !activeSignatureRequest && (
-              <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
-                <select
-                  name="signer_contact_id"
-                  class="px-3 py-2 border border-slate-300 rounded text-sm bg-white"
-                  required
-                >
-                  {contacts
-                    .filter((contact) => contact.email)
-                    .map((contact) => (
-                      <option value={contact.id}>
-                        {contact.name} {contact.email ? `(${contact.email})` : ''}
-                      </option>
-                    ))}
-                </select>
-                <button
-                  type="submit"
-                  class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors text-sm font-medium"
-                  id="sign-btn"
-                >
-                  Send via SignWell
-                </button>
-              </form>
-            )
-          }
-          {/* Decline */}
-          {
-            validTransitions.includes('declined') && (
-              <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
-                <input type="hidden" name="action" value="decline" />
-                <button
-                  type="submit"
-                  class="px-4 py-2 bg-slate-100 text-slate-600 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
-                >
-                  Decline
-                </button>
-              </form>
-            )
-          }
-
-          {/* Mark Expired */}
-          {
-            validTransitions.includes('expired') && (
-              <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
-                <input type="hidden" name="action" value="expire" />
-                <button
-                  type="submit"
-                  class="px-4 py-2 bg-slate-100 text-slate-500 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
-                >
-                  Mark Expired
-                </button>
-              </form>
-            )
-          }
+    {/* Totals */}
+    <div class="mt-4 pt-4 border-t border-slate-200 flex justify-end">
+      <div class="text-right space-y-1">
+        <div class="text-sm text-slate-500">
+          Total hours: <span id="total-hours" class="font-medium text-slate-900"
+            >{quote.total_hours}</span
+          >
         </div>
+        <div class="text-lg font-semibold text-slate-900">
+          Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
+        </div>
+      </div>
+    </div>
+  </div>
 
+  {/* Payment Structure */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <h3 class="text-lg font-semibold text-slate-900 mb-4">Payment Structure</h3>
+
+    <div class="space-y-3">
+      <div class="flex items-center gap-4">
+        <label class="text-sm text-slate-600 w-36">Deposit percentage:</label>
         {
-          isTerminal && (
-            <p class="mt-3 text-sm text-slate-500">
-              This quote is in a terminal state ({status}) and cannot be modified.
-            </p>
+          isDraft ? (
+            <select
+              id="deposit-pct-select"
+              class="border border-slate-200 rounded px-2 py-1 text-sm"
+            >
+              <option value="0.5" selected={depositPct === 0.5}>
+                50%
+              </option>
+              <option value="0.4" selected={depositPct === 0.4}>
+                40%
+              </option>
+            </select>
+          ) : (
+            <span class="text-sm text-slate-900">{Math.round(depositPct * 100)}%</span>
           )
         }
       </div>
-    </main>
 
-    <script define:vars={{ lineItems, isDraft, rate: quote.rate }}>
-      if (!isDraft) {
-        // Read-only mode — no interactive behavior needed
-      } else {
-        const body = document.getElementById('line-items-body')
-        const addBtn = document.getElementById('add-line-item-btn')
-        const warning = document.getElementById('line-item-warning')
-        const totalHoursEl = document.getElementById('total-hours')
-        const totalPriceEl = document.getElementById('total-price')
-        const depositAmountEl = document.getElementById('deposit-amount')
-        const completionAmountEl = document.getElementById('completion-amount')
-        const depositSelect = document.getElementById('deposit-pct-select')
-        const saveLineItemsInput = document.getElementById('save-line-items')
-        const saveDepositPctInput = document.getElementById('save-deposit-pct')
-        const generatePdfBtn = document.getElementById('generate-pdf-btn')
-        const signBtn = document.getElementById('sign-btn')
+      {
+        isThreeMilestone && (
+          <div class="text-sm text-amber-600 bg-amber-50 border border-amber-200 px-3 py-2 rounded">
+            40+ hour engagement — 3-milestone payment applies (40% deposit, 30% mid-engagement, 30%
+            completion)
+          </div>
+        )
+      }
 
-        function getLineItems() {
-          const rows = body.querySelectorAll('.line-item-row')
-          const items = []
-          rows.forEach((row) => {
-            const problem = row.querySelector('.item-problem')?.value ?? ''
-            const description = row.querySelector('.item-description')?.value ?? ''
-            const hours = parseFloat(row.querySelector('.item-hours')?.value ?? '0')
-            if (problem.trim() || description.trim()) {
-              items.push({
-                problem: problem.trim(),
-                description: description.trim(),
-                estimated_hours: isNaN(hours) ? 0 : hours,
-              })
-            }
-          })
-          return items
+      <div class="text-sm text-slate-600 space-y-1">
+        <div class="flex justify-between max-w-xs">
+          <span>Deposit:</span>
+          <span id="deposit-amount" class="font-medium text-slate-900">
+            {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
+          </span>
+        </div>
+        {
+          isThreeMilestone ? (
+            <>
+              <div class="flex justify-between max-w-xs">
+                <span>Mid-engagement milestone:</span>
+                <span class="font-medium text-slate-900">
+                  {formatCurrency(quote.total_price * 0.3)}
+                </span>
+              </div>
+              <div class="flex justify-between max-w-xs">
+                <span>Completion:</span>
+                <span class="font-medium text-slate-900">
+                  {formatCurrency(quote.total_price * 0.3)}
+                </span>
+              </div>
+            </>
+          ) : (
+            <div class="flex justify-between max-w-xs">
+              <span>Completion:</span>
+              <span id="completion-amount" class="font-medium text-slate-900">
+                {formatCurrency(quote.total_price * (1 - depositPct))}
+              </span>
+            </div>
+          )
+        }
+      </div>
+    </div>
+  </div>
+
+  {/* SOW PDF Status */}
+  {
+    hasSow && (
+      <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+        <h3 class="text-lg font-semibold text-slate-900 mb-2">SOW PDF</h3>
+        <div class="text-sm text-slate-600 space-y-1">
+          <div>
+            Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
+          </div>
+          {activeSignatureRequest?.provider_request_id && (
+            <div class="text-green-700">Sent for signature via SignWell</div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  {/* Actions */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6">
+    <h3 class="text-lg font-semibold text-slate-900 mb-4">Actions</h3>
+    <div class="flex flex-wrap gap-3">
+      {/* Save Draft */}
+      {
+        isDraft && (
+          <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="save-form">
+            <input type="hidden" name="action" value="update" />
+            <input
+              type="hidden"
+              name="line_items"
+              id="save-line-items"
+              value={JSON.stringify(lineItems)}
+            />
+            <input
+              type="hidden"
+              name="deposit_pct"
+              id="save-deposit-pct"
+              value={String(depositPct)}
+            />
+            <button
+              type="submit"
+              class="px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors text-sm font-medium"
+            >
+              Save Draft
+            </button>
+          </form>
+        )
+      }
+
+      {/* Generate SOW PDF */}
+      {
+        isDraft && (
+          <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="generate-pdf-form">
+            <input type="hidden" name="action" value="generate-pdf" />
+            <button
+              type="submit"
+              class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors text-sm font-medium"
+              id="generate-pdf-btn"
+            >
+              {hasSow ? 'Re-generate SOW PDF' : 'Generate SOW PDF'}
+            </button>
+          </form>
+        )
+      }
+
+      {/* Send via SignWell */}
+      {
+        (isDraft || status === 'sent') && hasSow && !activeSignatureRequest && (
+          <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
+            <select
+              name="signer_contact_id"
+              class="px-3 py-2 border border-slate-300 rounded text-sm bg-white"
+              required
+            >
+              {contacts
+                .filter((contact) => contact.email)
+                .map((contact) => (
+                  <option value={contact.id}>
+                    {contact.name} {contact.email ? `(${contact.email})` : ''}
+                  </option>
+                ))}
+            </select>
+            <button
+              type="submit"
+              class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors text-sm font-medium"
+              id="sign-btn"
+            >
+              Send via SignWell
+            </button>
+          </form>
+        )
+      }
+      {/* Decline */}
+      {
+        validTransitions.includes('declined') && (
+          <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+            <input type="hidden" name="action" value="decline" />
+            <button
+              type="submit"
+              class="px-4 py-2 bg-slate-100 text-slate-600 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
+            >
+              Decline
+            </button>
+          </form>
+        )
+      }
+
+      {/* Mark Expired */}
+      {
+        validTransitions.includes('expired') && (
+          <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+            <input type="hidden" name="action" value="expire" />
+            <button
+              type="submit"
+              class="px-4 py-2 bg-slate-100 text-slate-500 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
+            >
+              Mark Expired
+            </button>
+          </form>
+        )
+      }
+    </div>
+
+    {
+      isTerminal && (
+        <p class="mt-3 text-sm text-slate-500">
+          This quote is in a terminal state ({status}) and cannot be modified.
+        </p>
+      )
+    }
+  </div>
+  <script define:vars={{ lineItems, isDraft, rate: quote.rate }}>
+    if (!isDraft) {
+      // Read-only mode — no interactive behavior needed
+    } else {
+      const body = document.getElementById('line-items-body')
+      const addBtn = document.getElementById('add-line-item-btn')
+      const warning = document.getElementById('line-item-warning')
+      const totalHoursEl = document.getElementById('total-hours')
+      const totalPriceEl = document.getElementById('total-price')
+      const depositAmountEl = document.getElementById('deposit-amount')
+      const completionAmountEl = document.getElementById('completion-amount')
+      const depositSelect = document.getElementById('deposit-pct-select')
+      const saveLineItemsInput = document.getElementById('save-line-items')
+      const saveDepositPctInput = document.getElementById('save-deposit-pct')
+      const generatePdfBtn = document.getElementById('generate-pdf-btn')
+      const signBtn = document.getElementById('sign-btn')
+
+      function getLineItems() {
+        const rows = body.querySelectorAll('.line-item-row')
+        const items = []
+        rows.forEach((row) => {
+          const problem = row.querySelector('.item-problem')?.value ?? ''
+          const description = row.querySelector('.item-description')?.value ?? ''
+          const hours = parseFloat(row.querySelector('.item-hours')?.value ?? '0')
+          if (problem.trim() || description.trim()) {
+            items.push({
+              problem: problem.trim(),
+              description: description.trim(),
+              estimated_hours: isNaN(hours) ? 0 : hours,
+            })
+          }
+        })
+        return items
+      }
+
+      function recalculate() {
+        const items = getLineItems()
+        const totalHours = items.reduce((sum, item) => sum + item.estimated_hours, 0)
+        const totalPrice = totalHours * rate
+        const depositPct = parseFloat(depositSelect?.value ?? '0.5')
+
+        if (totalHoursEl) totalHoursEl.textContent = String(totalHours)
+        if (totalPriceEl) {
+          totalPriceEl.textContent =
+            '$' +
+            totalPrice.toLocaleString('en-US', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            })
         }
 
-        function recalculate() {
-          const items = getLineItems()
-          const totalHours = items.reduce((sum, item) => sum + item.estimated_hours, 0)
-          const totalPrice = totalHours * rate
-          const depositPct = parseFloat(depositSelect?.value ?? '0.5')
-
-          if (totalHoursEl) totalHoursEl.textContent = String(totalHours)
-          if (totalPriceEl) {
-            totalPriceEl.textContent =
-              '$' +
-              totalPrice.toLocaleString('en-US', {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0,
-              })
-          }
-
-          const depositAmount = totalPrice * depositPct
-          const completionAmount = totalPrice * (1 - depositPct)
-          if (depositAmountEl) {
-            depositAmountEl.textContent =
-              '$' +
-              depositAmount.toLocaleString('en-US', {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0,
-              })
-          }
-          if (completionAmountEl) {
-            completionAmountEl.textContent =
-              '$' +
-              completionAmount.toLocaleString('en-US', {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0,
-              })
-          }
-
-          // OQ-005: soft warning at 3+ line items
-          if (warning) {
-            warning.classList.toggle('hidden', items.length < 3)
-          }
-
-          // Update hidden form fields
-          if (saveLineItemsInput) saveLineItemsInput.value = JSON.stringify(items)
-          if (saveDepositPctInput) saveDepositPctInput.value = String(depositPct)
-
-          renumberRows()
+        const depositAmount = totalPrice * depositPct
+        const completionAmount = totalPrice * (1 - depositPct)
+        if (depositAmountEl) {
+          depositAmountEl.textContent =
+            '$' +
+            depositAmount.toLocaleString('en-US', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            })
+        }
+        if (completionAmountEl) {
+          completionAmountEl.textContent =
+            '$' +
+            completionAmount.toLocaleString('en-US', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            })
         }
 
-        function renumberRows() {
-          const rows = body.querySelectorAll('.line-item-row')
-          rows.forEach((row, i) => {
-            const num = row.querySelector('.row-number')
-            if (num) num.textContent = String(i + 1)
-            row.setAttribute('data-index', String(i))
-          })
+        // OQ-005: soft warning at 3+ line items
+        if (warning) {
+          warning.classList.toggle('hidden', items.length < 3)
         }
 
-        function addRow() {
-          const index = body.querySelectorAll('.line-item-row').length
-          const tr = document.createElement('tr')
-          tr.className = 'border-b border-slate-100 line-item-row'
-          tr.setAttribute('data-index', String(index))
-          tr.innerHTML = `
+        // Update hidden form fields
+        if (saveLineItemsInput) saveLineItemsInput.value = JSON.stringify(items)
+        if (saveDepositPctInput) saveDepositPctInput.value = String(depositPct)
+
+        renumberRows()
+      }
+
+      function renumberRows() {
+        const rows = body.querySelectorAll('.line-item-row')
+        rows.forEach((row, i) => {
+          const num = row.querySelector('.row-number')
+          if (num) num.textContent = String(i + 1)
+          row.setAttribute('data-index', String(i))
+        })
+      }
+
+      function addRow() {
+        const index = body.querySelectorAll('.line-item-row').length
+        const tr = document.createElement('tr')
+        tr.className = 'border-b border-slate-100 line-item-row'
+        tr.setAttribute('data-index', String(index))
+        tr.innerHTML = `
             <td class="py-2 px-2 text-slate-400 row-number">${index + 1}</td>
             <td class="py-2 px-2">
               <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
@@ -612,56 +564,55 @@ function formatCurrency(amount: number): string {
               <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
             </td>
           `
-          body.appendChild(tr)
-          recalculate()
-        }
-
-        if (addBtn) addBtn.addEventListener('click', addRow)
-
-        // Event delegation for remove buttons and input changes
-        body.addEventListener('click', (e) => {
-          if (e.target.classList.contains('remove-item-btn')) {
-            const row = e.target.closest('.line-item-row')
-            if (row && body.querySelectorAll('.line-item-row').length > 1) {
-              row.remove()
-              recalculate()
-            }
-          }
-        })
-
-        body.addEventListener('input', recalculate)
-        if (depositSelect) depositSelect.addEventListener('change', recalculate)
-
-        // Before form submit, sync line items to hidden field
-        const saveForm = document.getElementById('save-form')
-        if (saveForm) {
-          saveForm.addEventListener('submit', () => {
-            recalculate()
-          })
-        }
-
-        // Disable buttons on submit to prevent double-clicks
-        const generatePdfForm = document.getElementById('generate-pdf-form')
-        if (generatePdfForm && generatePdfBtn) {
-          generatePdfForm.addEventListener('submit', () => {
-            generatePdfBtn.disabled = true
-            generatePdfBtn.textContent = 'Generating...'
-          })
-        }
-
-        const signForm = document.getElementById('sign-form')
-        if (signForm && signBtn) {
-          signForm.addEventListener('submit', () => {
-            signBtn.disabled = true
-            signBtn.textContent = 'Sending...'
-          })
-        }
-
-        // Initial state check for OQ-005
-        if (warning && lineItems.length >= 3) {
-          warning.classList.remove('hidden')
-        }
+        body.appendChild(tr)
+        recalculate()
       }
-    </script>
-  </body>
-</html>
+
+      if (addBtn) addBtn.addEventListener('click', addRow)
+
+      // Event delegation for remove buttons and input changes
+      body.addEventListener('click', (e) => {
+        if (e.target.classList.contains('remove-item-btn')) {
+          const row = e.target.closest('.line-item-row')
+          if (row && body.querySelectorAll('.line-item-row').length > 1) {
+            row.remove()
+            recalculate()
+          }
+        }
+      })
+
+      body.addEventListener('input', recalculate)
+      if (depositSelect) depositSelect.addEventListener('change', recalculate)
+
+      // Before form submit, sync line items to hidden field
+      const saveForm = document.getElementById('save-form')
+      if (saveForm) {
+        saveForm.addEventListener('submit', () => {
+          recalculate()
+        })
+      }
+
+      // Disable buttons on submit to prevent double-clicks
+      const generatePdfForm = document.getElementById('generate-pdf-form')
+      if (generatePdfForm && generatePdfBtn) {
+        generatePdfForm.addEventListener('submit', () => {
+          generatePdfBtn.disabled = true
+          generatePdfBtn.textContent = 'Generating...'
+        })
+      }
+
+      const signForm = document.getElementById('sign-form')
+      if (signForm && signBtn) {
+        signForm.addEventListener('submit', () => {
+          signBtn.disabled = true
+          signBtn.textContent = 'Sending...'
+        })
+      }
+
+      // Initial state check for OQ-005
+      if (warning && lineItems.length >= 3) {
+        warning.classList.remove('hidden')
+      }
+    }
+  </script>
+</AdminLayout>

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { listEntities, countEntitiesByStage, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { Entity, EntityStage } from '../../../lib/db/entities'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
@@ -111,213 +111,166 @@ function formatDate(iso: string): string {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Entities — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
+<AdminLayout
+  title="Entities — SMD Services"
+  breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Entities' }]}
+>
+  {
+    promoted && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Entity promoted to prospect.
       </div>
-    </header>
-
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Entities</span>
-      </nav>
-
-      {
-        promoted && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Entity promoted to prospect.
-          </div>
-        )
-      }
-      {
-        dismissed && (
-          <div class="bg-slate-50 border border-slate-200 text-slate-600 text-sm px-4 py-3 rounded-lg mb-4">
-            Entity dismissed.
-          </div>
-        )
-      }
-      {
-        error && (
-          <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
-            {error}
-          </div>
-        )
-      }
-
-      <div class="flex items-center justify-between mb-6">
-        <h2 class="text-xl font-semibold text-slate-900">Entities</h2>
-        <form method="GET" class="flex items-center gap-2">
-          <input type="hidden" name="stage" value={filterStage} />
-          <select
-            name="pipeline"
-            class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
-            onchange="this.form.submit()"
-          >
-            <option value="">All pipelines</option>
-            {
-              LEAD_PIPELINES.map((p) => (
-                <option value={p.value} selected={filterPipeline === p.value}>
-                  {p.label}
-                </option>
-              ))
-            }
-          </select>
-        </form>
+    )
+  }
+  {
+    dismissed && (
+      <div class="bg-slate-50 border border-slate-200 text-slate-600 text-sm px-4 py-3 rounded-lg mb-4">
+        Entity dismissed.
       </div>
+    )
+  }
+  {
+    error && (
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+        {error}
+      </div>
+    )
+  }
 
-      {/* Stage tabs */}
-      <div class="flex gap-1 mb-6 border-b border-slate-200 overflow-x-auto">
+  <div class="flex items-center justify-between mb-6">
+    <h2 class="text-xl font-semibold text-slate-900">Entities</h2>
+    <form method="GET" class="flex items-center gap-2">
+      <input type="hidden" name="stage" value={filterStage} />
+      <select
+        name="pipeline"
+        class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+        onchange="this.form.submit()"
+      >
+        <option value="">All pipelines</option>
         {
-          ENTITY_STAGES.map((s) => (
-            <a
-              href={`/admin/entities?stage=${s.value}${filterPipeline ? `&pipeline=${filterPipeline}` : ''}`}
-              class={`px-3 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
-                filterStage === s.value
-                  ? stageBadgeClass(s.value) + ' border-current'
-                  : 'border-transparent text-slate-500 hover:text-slate-700'
-              }`}
-            >
-              {s.label}
-              {s.value === 'signal' && signalCount > 0 && (
-                <span class="ml-1 text-xs bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded-full">
-                  {signalCount}
-                </span>
-              )}
-            </a>
+          LEAD_PIPELINES.map((p) => (
+            <option value={p.value} selected={filterPipeline === p.value}>
+              {p.label}
+            </option>
           ))
         }
+      </select>
+    </form>
+  </div>
+
+  {/* Stage tabs */}
+  <div class="flex gap-1 mb-6 border-b border-slate-200 overflow-x-auto">
+    {
+      ENTITY_STAGES.map((s) => (
+        <a
+          href={`/admin/entities?stage=${s.value}${filterPipeline ? `&pipeline=${filterPipeline}` : ''}`}
+          class={`px-3 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+            filterStage === s.value
+              ? stageBadgeClass(s.value) + ' border-current'
+              : 'border-transparent text-slate-500 hover:text-slate-700'
+          }`}
+        >
+          {s.label}
+          {s.value === 'signal' && signalCount > 0 && (
+            <span class="ml-1 text-xs bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded-full">
+              {signalCount}
+            </span>
+          )}
+        </a>
+      ))
+    }
+  </div>
+
+  {/* Entity list */}
+  {
+    entities.length === 0 ? (
+      <div class="bg-white rounded-lg border border-slate-200 p-6">
+        <p class="text-slate-500 text-sm">
+          No entities at the <strong>{filterStage}</strong> stage.
+        </p>
       </div>
+    ) : (
+      <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+        {entities.map((e: Entity) => (
+          <div class="px-6 py-4">
+            <div class="flex items-start justify-between gap-4">
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 mb-1 flex-wrap">
+                  <a
+                    href={`/admin/entities/${e.id}`}
+                    class="text-sm font-medium text-slate-900 hover:text-primary transition-colors"
+                  >
+                    {e.name}
+                  </a>
+                  {e.source_pipeline && (
+                    <span
+                      class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
+                    >
+                      {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
+                    </span>
+                  )}
+                  {e.pain_score && (
+                    <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
+                      Pain: {e.pain_score}/10
+                    </span>
+                  )}
+                  {e.tier && (
+                    <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
+                      {e.tier}
+                    </span>
+                  )}
+                </div>
 
-      {/* Entity list */}
-      {
-        entities.length === 0 ? (
-          <div class="bg-white rounded-lg border border-slate-200 p-6">
-            <p class="text-slate-500 text-sm">
-              No entities at the <strong>{filterStage}</strong> stage.
-            </p>
-          </div>
-        ) : (
-          <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
-            {entities.map((e: Entity) => (
-              <div class="px-6 py-4">
-                <div class="flex items-start justify-between gap-4">
-                  <div class="min-w-0 flex-1">
-                    <div class="flex items-center gap-2 mb-1 flex-wrap">
-                      <a
-                        href={`/admin/entities/${e.id}`}
-                        class="text-sm font-medium text-slate-900 hover:text-primary transition-colors"
-                      >
-                        {e.name}
-                      </a>
-                      {e.source_pipeline && (
-                        <span
-                          class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
-                        >
-                          {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
-                        </span>
-                      )}
-                      {e.pain_score && (
-                        <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
-                          Pain: {e.pain_score}/10
-                        </span>
-                      )}
-                      {e.tier && (
-                        <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
-                          {e.tier}
-                        </span>
-                      )}
-                    </div>
+                {e.summary && <p class="text-xs text-slate-600 mb-1 line-clamp-2">{e.summary}</p>}
 
-                    {e.summary && (
-                      <p class="text-xs text-slate-600 mb-1 line-clamp-2">{e.summary}</p>
-                    )}
+                {e.next_action && (
+                  <p class="text-xs text-amber-600 mb-1">
+                    <span class="font-medium">Next:</span> {e.next_action}
+                    {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
+                  </p>
+                )}
 
-                    {e.next_action && (
-                      <p class="text-xs text-amber-600 mb-1">
-                        <span class="font-medium">Next:</span> {e.next_action}
-                        {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
-                      </p>
-                    )}
-
-                    <div class="flex items-center gap-3 text-xs text-slate-400 mt-1">
-                      <span>{formatDate(e.created_at)}</span>
-                      {e.area && <span>{e.area}</span>}
-                      {e.vertical && (
-                        <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>
-                      )}
-                      {e.employee_count && <span>~{e.employee_count} employees</span>}
-                    </div>
-                  </div>
-
-                  <div class="flex items-center gap-2 shrink-0">
-                    {e.stage === 'signal' ? (
-                      <>
-                        <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
-                          <button
-                            type="submit"
-                            class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
-                          >
-                            Promote
-                          </button>
-                        </form>
-                        <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
-                          <button
-                            type="submit"
-                            class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
-                          >
-                            Dismiss
-                          </button>
-                        </form>
-                      </>
-                    ) : (
-                      <a
-                        href={`/admin/entities/${e.id}`}
-                        class="text-xs bg-slate-50 text-slate-700 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
-                      >
-                        View
-                      </a>
-                    )}
-                  </div>
+                <div class="flex items-center gap-3 text-xs text-slate-400 mt-1">
+                  <span>{formatDate(e.created_at)}</span>
+                  {e.area && <span>{e.area}</span>}
+                  {e.vertical && <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>}
+                  {e.employee_count && <span>~{e.employee_count} employees</span>}
                 </div>
               </div>
-            ))}
+
+              <div class="flex items-center gap-2 shrink-0">
+                {e.stage === 'signal' ? (
+                  <>
+                    <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
+                      <button
+                        type="submit"
+                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                      >
+                        Promote
+                      </button>
+                    </form>
+                    <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
+                      <button
+                        type="submit"
+                        class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                      >
+                        Dismiss
+                      </button>
+                    </form>
+                  </>
+                ) : (
+                  <a
+                    href={`/admin/entities/${e.id}`}
+                    class="text-xs bg-slate-50 text-slate-700 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                  >
+                    View
+                  </a>
+                )}
+              </div>
+            </div>
           </div>
-        )
-      }
-    </main>
-  </body>
-</html>
+        ))}
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { listFollowUps, FOLLOW_UP_TYPES } from '../../../lib/db/follow-ups'
 import type { FollowUp, FollowUpType } from '../../../lib/db/follow-ups'
 
@@ -88,203 +88,160 @@ function daysLabel(iso: string): string {
 const success = Astro.url.searchParams.get('saved')
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Follow-ups — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
+<AdminLayout
+  title="Follow-ups — SMD Services"
+  breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Follow-ups' }]}
+>
+  {
+    success && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+        Follow-up updated successfully.
       </div>
-    </header>
+    )
+  }
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/admin" class="hover:text-primary transition-colors">Dashboard</a>
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Follow-ups</span>
-      </nav>
+  <div class="flex items-center justify-between mb-6">
+    <h2 class="text-xl font-semibold text-slate-900">Follow-ups</h2>
 
-      {
-        success && (
-          <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
-            Follow-up updated successfully.
+    {/* Type filter */}
+    <form method="GET" class="flex items-center gap-2">
+      <input type="hidden" name="tab" value={activeTab} />
+      <select
+        name="type"
+        class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+        onchange="this.form.submit()"
+      >
+        <option value="">All types</option>
+        {
+          FOLLOW_UP_TYPES.map((t) => (
+            <option value={t.value} selected={filterType === t.value}>
+              {t.label}
+            </option>
+          ))
+        }
+      </select>
+    </form>
+  </div>
+
+  {/* Tabs */}
+  <div class="flex gap-1 mb-6 border-b border-slate-200">
+    <a
+      href={`/admin/follow-ups?tab=upcoming${filterType ? `&type=${filterType}` : ''}`}
+      class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        activeTab === 'upcoming'
+          ? 'border-primary text-primary'
+          : 'border-transparent text-slate-500 hover:text-slate-700'
+      }`}
+    >
+      Upcoming ({upcoming.length})
+    </a>
+    <a
+      href={`/admin/follow-ups?tab=overdue${filterType ? `&type=${filterType}` : ''}`}
+      class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        activeTab === 'overdue'
+          ? 'border-red-500 text-red-600'
+          : 'border-transparent text-slate-500 hover:text-slate-700'
+      }`}
+    >
+      Overdue ({overdue.length})
+    </a>
+    <a
+      href={`/admin/follow-ups?tab=completed${filterType ? `&type=${filterType}` : ''}`}
+      class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        activeTab === 'completed'
+          ? 'border-green-500 text-green-600'
+          : 'border-transparent text-slate-500 hover:text-slate-700'
+      }`}
+    >
+      Completed ({completed.length})
+    </a>
+  </div>
+
+  {/* Follow-up list */}
+  {
+    (() => {
+      const items =
+        activeTab === 'overdue' ? overdue : activeTab === 'completed' ? completed : upcoming
+      if (items.length === 0) {
+        return (
+          <div class="bg-white rounded-lg border border-slate-200 p-6">
+            <p class="text-slate-500 text-sm">
+              {activeTab === 'upcoming' && 'No upcoming follow-ups.'}
+              {activeTab === 'overdue' && 'No overdue follow-ups.'}
+              {activeTab === 'completed' && 'No completed follow-ups.'}
+            </p>
           </div>
         )
       }
-
-      <div class="flex items-center justify-between mb-6">
-        <h2 class="text-xl font-semibold text-slate-900">Follow-ups</h2>
-
-        {/* Type filter */}
-        <form method="GET" class="flex items-center gap-2">
-          <input type="hidden" name="tab" value={activeTab} />
-          <select
-            name="type"
-            class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
-            onchange="this.form.submit()"
-          >
-            <option value="">All types</option>
-            {
-              FOLLOW_UP_TYPES.map((t) => (
-                <option value={t.value} selected={filterType === t.value}>
-                  {t.label}
-                </option>
-              ))
-            }
-          </select>
-        </form>
-      </div>
-
-      {/* Tabs */}
-      <div class="flex gap-1 mb-6 border-b border-slate-200">
-        <a
-          href={`/admin/follow-ups?tab=upcoming${filterType ? `&type=${filterType}` : ''}`}
-          class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'upcoming'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-slate-500 hover:text-slate-700'
-          }`}
-        >
-          Upcoming ({upcoming.length})
-        </a>
-        <a
-          href={`/admin/follow-ups?tab=overdue${filterType ? `&type=${filterType}` : ''}`}
-          class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'overdue'
-              ? 'border-red-500 text-red-600'
-              : 'border-transparent text-slate-500 hover:text-slate-700'
-          }`}
-        >
-          Overdue ({overdue.length})
-        </a>
-        <a
-          href={`/admin/follow-ups?tab=completed${filterType ? `&type=${filterType}` : ''}`}
-          class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'completed'
-              ? 'border-green-500 text-green-600'
-              : 'border-transparent text-slate-500 hover:text-slate-700'
-          }`}
-        >
-          Completed ({completed.length})
-        </a>
-      </div>
-
-      {/* Follow-up list */}
-      {
-        (() => {
-          const items =
-            activeTab === 'overdue' ? overdue : activeTab === 'completed' ? completed : upcoming
-          if (items.length === 0) {
-            return (
-              <div class="bg-white rounded-lg border border-slate-200 p-6">
-                <p class="text-slate-500 text-sm">
-                  {activeTab === 'upcoming' && 'No upcoming follow-ups.'}
-                  {activeTab === 'overdue' && 'No overdue follow-ups.'}
-                  {activeTab === 'completed' && 'No completed follow-ups.'}
-                </p>
-              </div>
-            )
-          }
-          return (
-            <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
-              {items.map((f: FollowUp) => (
-                <div class="px-6 py-4">
-                  <div class="flex items-start justify-between gap-4">
-                    <div class="min-w-0 flex-1">
-                      <div class="flex items-center gap-2 mb-1">
-                        <span
-                          class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-slate-900' : 'italic text-slate-400'}`}
-                        >
-                          {f.entity_id ? (clientMap[f.entity_id] ?? 'Missing entity') : 'Unlinked'}
-                        </span>
-                        <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">
-                          {getTypeLabel(f.type)}
-                        </span>
-                      </div>
-                      <div class="flex items-center gap-3 text-xs text-slate-400">
-                        <span>{formatDate(f.scheduled_for)}</span>
-                        {f.status === 'scheduled' && (
-                          <span
-                            class={
-                              daysUntil(f.scheduled_for) < 0
-                                ? 'text-red-500 font-medium'
-                                : 'text-slate-500'
-                            }
-                          >
-                            {daysLabel(f.scheduled_for)}
-                          </span>
-                        )}
-                        {f.completed_at && <span>Completed: {formatDate(f.completed_at)}</span>}
-                      </div>
-                    </div>
-
+      return (
+        <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+          {items.map((f: FollowUp) => (
+            <div class="px-6 py-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2 mb-1">
+                    <span
+                      class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-slate-900' : 'italic text-slate-400'}`}
+                    >
+                      {f.entity_id ? (clientMap[f.entity_id] ?? 'Missing entity') : 'Unlinked'}
+                    </span>
+                    <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">
+                      {getTypeLabel(f.type)}
+                    </span>
+                  </div>
+                  <div class="flex items-center gap-3 text-xs text-slate-400">
+                    <span>{formatDate(f.scheduled_for)}</span>
                     {f.status === 'scheduled' && (
-                      <div class="flex items-center gap-2 shrink-0">
-                        <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
-                          <input type="hidden" name="action" value="send_email" />
-                          <button
-                            type="submit"
-                            class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
-                          >
-                            Send Email
-                          </button>
-                        </form>
-                        <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
-                          <input type="hidden" name="action" value="complete" />
-                          <button
-                            type="submit"
-                            class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-md hover:bg-green-100 transition-colors"
-                          >
-                            Mark Complete
-                          </button>
-                        </form>
-                        <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
-                          <input type="hidden" name="action" value="skip" />
-                          <button
-                            type="submit"
-                            class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
-                          >
-                            Skip
-                          </button>
-                        </form>
-                      </div>
+                      <span
+                        class={
+                          daysUntil(f.scheduled_for) < 0
+                            ? 'text-red-500 font-medium'
+                            : 'text-slate-500'
+                        }
+                      >
+                        {daysLabel(f.scheduled_for)}
+                      </span>
                     )}
+                    {f.completed_at && <span>Completed: {formatDate(f.completed_at)}</span>}
                   </div>
                 </div>
-              ))}
+
+                {f.status === 'scheduled' && (
+                  <div class="flex items-center gap-2 shrink-0">
+                    <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
+                      <input type="hidden" name="action" value="send_email" />
+                      <button
+                        type="submit"
+                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                      >
+                        Send Email
+                      </button>
+                    </form>
+                    <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
+                      <input type="hidden" name="action" value="complete" />
+                      <button
+                        type="submit"
+                        class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-md hover:bg-green-100 transition-colors"
+                      >
+                        Mark Complete
+                      </button>
+                    </form>
+                    <form method="POST" action={`/api/admin/follow-ups/${f.id}`}>
+                      <input type="hidden" name="action" value="skip" />
+                      <button
+                        type="submit"
+                        class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                      >
+                        Skip
+                      </button>
+                    </form>
+                  </div>
+                )}
+              </div>
             </div>
-          )
-        })()
-      }
-    </main>
-  </body>
-</html>
+          ))}
+        </div>
+      )
+    })()
+  }
+</AdminLayout>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,5 +1,5 @@
 ---
-import '../../styles/global.css'
+import AdminLayout from '../../layouts/AdminLayout.astro'
 import { listFollowUps } from '../../lib/db/follow-ups'
 import {
   getPipelineConversion,
@@ -141,381 +141,337 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 })
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Dashboard — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <h1 class="text-lg font-bold text-slate-900">SMD Services</h1>
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <a href="/admin/entities" class="text-sm text-slate-600 hover:text-slate-900">Entities</a>
-          <a href="/admin/follow-ups" class="text-sm text-slate-600 hover:text-slate-900"
-            >Follow-ups</a
+<AdminLayout title="Dashboard — SMD Services" maxWidth="max-w-6xl">
+  <div class="space-y-6">
+    <!-- Card 1: Today's Work -->
+    <section class="bg-white rounded-lg border border-slate-200 p-6">
+      <h2 class="text-base font-semibold text-slate-900 mb-4">Today's Work</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <a
+          href="/admin/entities?stage=signal"
+          class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors"
+        >
+          <div
+            class:list={[
+              'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+              signalCount > 0 ? 'bg-amber-100 text-amber-700' : 'bg-slate-100 text-slate-400',
+            ]}
           >
-          <a href="/admin/analytics" class="text-sm text-slate-600 hover:text-slate-900"
-            >Analytics</a
-          >
-          <span class="text-sm text-slate-400">|</span>
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+            {signalCount}
+          </div>
+          <div>
+            <div class="text-sm font-medium text-slate-900">Signals to triage</div>
+            <div class="text-xs text-slate-500">Promote or dismiss</div>
+          </div>
+        </a>
 
-    <main class="max-w-6xl mx-auto px-4 py-8 space-y-6">
-      <!-- Card 1: Today's Work -->
-      <section class="bg-white rounded-lg border border-slate-200 p-6">
-        <h2 class="text-base font-semibold text-slate-900 mb-4">Today's Work</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <a
-            href="/admin/entities?stage=signal"
-            class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors"
+        <div class="flex items-center gap-3 p-3 rounded-lg">
+          <div
+            class:list={[
+              'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+              todayAssessments.length > 0
+                ? 'bg-indigo-100 text-indigo-700'
+                : 'bg-slate-100 text-slate-400',
+            ]}
           >
-            <div
-              class:list={[
-                'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
-                signalCount > 0 ? 'bg-amber-100 text-amber-700' : 'bg-slate-100 text-slate-400',
-              ]}
-            >
-              {signalCount}
-            </div>
-            <div>
-              <div class="text-sm font-medium text-slate-900">Signals to triage</div>
-              <div class="text-xs text-slate-500">Promote or dismiss</div>
-            </div>
-          </a>
-
-          <div class="flex items-center gap-3 p-3 rounded-lg">
-            <div
-              class:list={[
-                'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+            {todayAssessments.length}
+          </div>
+          <div>
+            <div class="text-sm font-medium text-slate-900">Assessments today</div>
+            <div class="text-xs text-slate-500">
+              {
                 todayAssessments.length > 0
-                  ? 'bg-indigo-100 text-indigo-700'
-                  : 'bg-slate-100 text-slate-400',
-              ]}
-            >
-              {todayAssessments.length}
-            </div>
-            <div>
-              <div class="text-sm font-medium text-slate-900">Assessments today</div>
-              <div class="text-xs text-slate-500">
-                {
-                  todayAssessments.length > 0
-                    ? todayAssessments
-                        .map((a) => {
-                          const time = a.scheduled_at
-                            ? new Date(a.scheduled_at).toLocaleTimeString('en-US', {
-                                hour: 'numeric',
-                                minute: '2-digit',
-                              })
-                            : ''
-                          return time
-                        })
-                        .join(', ')
-                    : 'None scheduled'
-                }
-              </div>
+                  ? todayAssessments
+                      .map((a) => {
+                        const time = a.scheduled_at
+                          ? new Date(a.scheduled_at).toLocaleTimeString('en-US', {
+                              hour: 'numeric',
+                              minute: '2-digit',
+                            })
+                          : ''
+                        return time
+                      })
+                      .join(', ')
+                  : 'None scheduled'
+              }
             </div>
           </div>
+        </div>
 
-          <a
-            href="/admin/follow-ups?filter=overdue"
-            class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors"
+        <a
+          href="/admin/follow-ups?filter=overdue"
+          class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors"
+        >
+          <div
+            class:list={[
+              'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+              overdueCount > 0 ? 'bg-red-100 text-red-700' : 'bg-slate-100 text-slate-400',
+            ]}
           >
-            <div
+            {overdueCount}
+          </div>
+          <div>
+            <div class="text-sm font-medium text-slate-900">Overdue follow-ups</div>
+            <div class="text-xs text-slate-500">
+              {overdueCount > 0 ? 'Needs attention' : 'All clear'}
+            </div>
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <!-- Card 2: Pipeline State -->
+    <section class="bg-white rounded-lg border border-slate-200 p-6">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-base font-semibold text-slate-900">Pipeline</h2>
+        <a href="/admin/entities" class="text-xs text-slate-500 hover:text-slate-700"
+          >{totalPipeline} total</a
+        >
+      </div>
+
+      <!-- Funnel bar -->
+      {
+        totalPipeline > 0 && (
+          <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-slate-100">
+            {pipelineStages.map((s) =>
+              s.count > 0 ? (
+                <div
+                  class:list={[
+                    s.color === 'amber' && 'bg-amber-400',
+                    s.color === 'blue' && 'bg-blue-400',
+                    s.color === 'indigo' && 'bg-indigo-400',
+                    s.color === 'purple' && 'bg-purple-400',
+                    s.color === 'green' && 'bg-green-400',
+                    s.color === 'teal' && 'bg-teal-400',
+                  ]}
+                  style={`width: ${(s.count / totalPipeline) * 100}%`}
+                  title={`${s.label}: ${s.count}`}
+                />
+              ) : null
+            )}
+          </div>
+        )
+      }
+
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
+        {
+          pipelineStages.map((s) => (
+            <a
+              href={`/admin/entities?stage=${s.stage}`}
+              class="text-center p-2 rounded-lg hover:bg-slate-50 transition-colors"
+            >
+              <div
+                class:list={[
+                  'text-2xl font-bold',
+                  s.count > 0 ? 'text-slate-900' : 'text-slate-300',
+                ]}
+              >
+                {s.count}
+              </div>
+              <div class="text-xs text-slate-500">{s.label}</div>
+            </a>
+          ))
+        }
+      </div>
+
+      {
+        pipeline.lost > 0 && (
+          <div class="mt-3 pt-3 border-t border-slate-100 text-center">
+            <a
+              href="/admin/entities?stage=lost"
+              class="text-xs text-slate-400 hover:text-slate-600"
+            >
+              {pipeline.lost} lost
+            </a>
+          </div>
+        )
+      }
+    </section>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <!-- Card 3: Revenue -->
+      <section class="bg-white rounded-lg border border-slate-200 p-6">
+        <h2 class="text-base font-semibold text-slate-900 mb-4">Revenue</h2>
+        <div class="space-y-3">
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">Invoiced</span>
+            <span class="text-lg font-semibold text-slate-900">
+              ${revenue.total_invoiced.toLocaleString('en-US', { minimumFractionDigits: 0 })}
+            </span>
+          </div>
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">Paid</span>
+            <span class="text-lg font-semibold text-green-600">
+              ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
+            </span>
+          </div>
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">Outstanding</span>
+            <span
               class:list={[
-                'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
-                overdueCount > 0 ? 'bg-red-100 text-red-700' : 'bg-slate-100 text-slate-400',
+                'text-lg font-semibold',
+                outstandingTotal > 0 ? 'text-amber-600' : 'text-slate-400',
               ]}
             >
-              {overdueCount}
+              ${outstandingTotal.toLocaleString('en-US', { minimumFractionDigits: 0 })}
+            </span>
+          </div>
+
+          <div class="pt-3 border-t border-slate-100">
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Active engagements</span>
+              <span class="text-sm font-medium text-slate-900">{activeEngagements.length}</span>
             </div>
-            <div>
-              <div class="text-sm font-medium text-slate-900">Overdue follow-ups</div>
-              <div class="text-xs text-slate-500">
-                {overdueCount > 0 ? 'Needs attention' : 'All clear'}
-              </div>
-            </div>
-          </a>
+            {
+              health.avg_days_to_completion > 0 && (
+                <div class="flex justify-between items-baseline mt-1">
+                  <span class="text-sm text-slate-500">Avg completion</span>
+                  <span class="text-sm font-medium text-slate-900">
+                    {health.avg_days_to_completion} days
+                  </span>
+                </div>
+              )
+            }
+          </div>
         </div>
       </section>
 
-      <!-- Card 2: Pipeline State -->
+      <!-- Card 4: Follow-up Health -->
       <section class="bg-white rounded-lg border border-slate-200 p-6">
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-base font-semibold text-slate-900">Pipeline</h2>
-          <a href="/admin/entities" class="text-xs text-slate-500 hover:text-slate-700"
-            >{totalPipeline} total</a
+          <h2 class="text-base font-semibold text-slate-900">Follow-up Health</h2>
+          <a href="/admin/follow-ups" class="text-xs text-slate-500 hover:text-slate-700"
+            >View all</a
           >
         </div>
+        <div class="space-y-3">
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">On-time rate</span>
+            <span
+              class:list={[
+                'text-lg font-semibold',
+                compliance.compliance_pct >= 80
+                  ? 'text-green-600'
+                  : compliance.compliance_pct >= 50
+                    ? 'text-amber-600'
+                    : 'text-red-600',
+              ]}
+            >
+              {compliance.compliance_pct}%
+            </span>
+          </div>
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">Sent on time</span>
+            <span class="text-sm font-medium text-slate-900">{compliance.completed_on_time}</span>
+          </div>
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">Sent late</span>
+            <span
+              class:list={[
+                'text-sm font-medium',
+                compliance.completed_late > 0 ? 'text-amber-600' : 'text-slate-900',
+              ]}
+            >
+              {compliance.completed_late}
+            </span>
+          </div>
+          <div class="flex justify-between items-baseline">
+            <span class="text-sm text-slate-500">Missed</span>
+            <span
+              class:list={[
+                'text-sm font-medium',
+                compliance.missed > 0 ? 'text-red-600' : 'text-slate-900',
+              ]}
+            >
+              {compliance.missed}
+            </span>
+          </div>
 
-        <!-- Funnel bar -->
+          <div class="pt-3 border-t border-slate-100">
+            <div class="flex justify-between items-baseline">
+              <span class="text-sm text-slate-500">Upcoming</span>
+              <span class="text-sm font-medium text-slate-900"
+                >{upcomingFollowUps.length} scheduled</span
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Card 5: Automations -->
+    <section class="bg-white rounded-lg border border-slate-200 p-6">
+      <h2 class="text-base font-semibold text-slate-900 mb-4">Automations</h2>
+      <div class="divide-y divide-slate-100">
+        <!-- Google Calendar -->
+        <div class="flex items-center justify-between py-2">
+          <div class="flex items-center gap-2">
+            <div
+              class:list={[
+                'w-2 h-2 rounded-full',
+                calStatus === 'active'
+                  ? 'bg-green-500'
+                  : calStatus === 'error' || calStatus === 'revoked'
+                    ? 'bg-red-500'
+                    : 'bg-slate-300',
+              ]}
+            >
+            </div>
+            <span class="text-sm text-slate-600">Google Calendar</span>
+          </div>
+          <span
+            class:list={[
+              'text-xs',
+              calStatus === 'error' || calStatus === 'revoked' ? 'text-red-600' : 'text-slate-400',
+            ]}
+          >
+            {
+              calStatus === 'active'
+                ? calEmail
+                : calStatus === 'error'
+                  ? (calError?.slice(0, 40) ?? 'Error')
+                  : calStatus === 'revoked'
+                    ? 'Reconnect required'
+                    : 'Not connected'
+            }
+          </span>
+        </div>
+
+        {/* Booking sync warnings */}
         {
-          totalPipeline > 0 && (
-            <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-slate-100">
-              {pipelineStages.map((s) =>
-                s.count > 0 ? (
-                  <div
-                    class:list={[
-                      s.color === 'amber' && 'bg-amber-400',
-                      s.color === 'blue' && 'bg-blue-400',
-                      s.color === 'indigo' && 'bg-indigo-400',
-                      s.color === 'purple' && 'bg-purple-400',
-                      s.color === 'green' && 'bg-green-400',
-                      s.color === 'teal' && 'bg-teal-400',
-                    ]}
-                    style={`width: ${(s.count / totalPipeline) * 100}%`}
-                    title={`${s.label}: ${s.count}`}
-                  />
-                ) : null
+          (syncErrors > 0 || syncStuck > 0) && (
+            <div class="py-2 pl-4">
+              {syncErrors > 0 && (
+                <p class="text-xs text-red-600">
+                  {syncErrors} booking{syncErrors === 1 ? '' : 's'} failed to sync
+                </p>
+              )}
+              {syncStuck > 0 && (
+                <p class="text-xs text-amber-600">
+                  {syncStuck} booking{syncStuck === 1 ? '' : 's'} stuck pending
+                </p>
               )}
             </div>
           )
         }
 
-        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
-          {
-            pipelineStages.map((s) => (
-              <a
-                href={`/admin/entities?stage=${s.stage}`}
-                class="text-center p-2 rounded-lg hover:bg-slate-50 transition-colors"
-              >
-                <div
-                  class:list={[
-                    'text-2xl font-bold',
-                    s.count > 0 ? 'text-slate-900' : 'text-slate-300',
-                  ]}
-                >
-                  {s.count}
-                </div>
-                <div class="text-xs text-slate-500">{s.label}</div>
-              </a>
-            ))
-          }
-        </div>
-
+        <!-- Lead Pipelines -->
         {
-          pipeline.lost > 0 && (
-            <div class="mt-3 pt-3 border-t border-slate-100 text-center">
-              <a
-                href="/admin/entities?stage=lost"
-                class="text-xs text-slate-400 hover:text-slate-600"
-              >
-                {pipeline.lost} lost
-              </a>
-            </div>
+          pipelineRows.length > 0 ? (
+            pipelineRows.map((p) => (
+              <div class="flex items-center justify-between py-2">
+                <div class="flex items-center gap-2">
+                  <div class:list={['w-2 h-2 rounded-full', p.color]} />
+                  <span class="text-sm text-slate-600">{p.label}</span>
+                </div>
+                <span class="text-xs text-slate-400">{p.ago}</span>
+              </div>
+            ))
+          ) : (
+            <div class="py-2 text-xs text-slate-400">No pipeline data yet</div>
           )
         }
-      </section>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <!-- Card 3: Revenue -->
-        <section class="bg-white rounded-lg border border-slate-200 p-6">
-          <h2 class="text-base font-semibold text-slate-900 mb-4">Revenue</h2>
-          <div class="space-y-3">
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Invoiced</span>
-              <span class="text-lg font-semibold text-slate-900">
-                ${revenue.total_invoiced.toLocaleString('en-US', { minimumFractionDigits: 0 })}
-              </span>
-            </div>
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Paid</span>
-              <span class="text-lg font-semibold text-green-600">
-                ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
-              </span>
-            </div>
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Outstanding</span>
-              <span
-                class:list={[
-                  'text-lg font-semibold',
-                  outstandingTotal > 0 ? 'text-amber-600' : 'text-slate-400',
-                ]}
-              >
-                ${outstandingTotal.toLocaleString('en-US', { minimumFractionDigits: 0 })}
-              </span>
-            </div>
-
-            <div class="pt-3 border-t border-slate-100">
-              <div class="flex justify-between items-baseline">
-                <span class="text-sm text-slate-500">Active engagements</span>
-                <span class="text-sm font-medium text-slate-900">{activeEngagements.length}</span>
-              </div>
-              {
-                health.avg_days_to_completion > 0 && (
-                  <div class="flex justify-between items-baseline mt-1">
-                    <span class="text-sm text-slate-500">Avg completion</span>
-                    <span class="text-sm font-medium text-slate-900">
-                      {health.avg_days_to_completion} days
-                    </span>
-                  </div>
-                )
-              }
-            </div>
-          </div>
-        </section>
-
-        <!-- Card 4: Follow-up Health -->
-        <section class="bg-white rounded-lg border border-slate-200 p-6">
-          <div class="flex items-center justify-between mb-4">
-            <h2 class="text-base font-semibold text-slate-900">Follow-up Health</h2>
-            <a href="/admin/follow-ups" class="text-xs text-slate-500 hover:text-slate-700"
-              >View all</a
-            >
-          </div>
-          <div class="space-y-3">
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">On-time rate</span>
-              <span
-                class:list={[
-                  'text-lg font-semibold',
-                  compliance.compliance_pct >= 80
-                    ? 'text-green-600'
-                    : compliance.compliance_pct >= 50
-                      ? 'text-amber-600'
-                      : 'text-red-600',
-                ]}
-              >
-                {compliance.compliance_pct}%
-              </span>
-            </div>
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Sent on time</span>
-              <span class="text-sm font-medium text-slate-900">{compliance.completed_on_time}</span>
-            </div>
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Sent late</span>
-              <span
-                class:list={[
-                  'text-sm font-medium',
-                  compliance.completed_late > 0 ? 'text-amber-600' : 'text-slate-900',
-                ]}
-              >
-                {compliance.completed_late}
-              </span>
-            </div>
-            <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Missed</span>
-              <span
-                class:list={[
-                  'text-sm font-medium',
-                  compliance.missed > 0 ? 'text-red-600' : 'text-slate-900',
-                ]}
-              >
-                {compliance.missed}
-              </span>
-            </div>
-
-            <div class="pt-3 border-t border-slate-100">
-              <div class="flex justify-between items-baseline">
-                <span class="text-sm text-slate-500">Upcoming</span>
-                <span class="text-sm font-medium text-slate-900"
-                  >{upcomingFollowUps.length} scheduled</span
-                >
-              </div>
-            </div>
-          </div>
-        </section>
       </div>
-
-      <!-- Card 5: Automations -->
-      <section class="bg-white rounded-lg border border-slate-200 p-6">
-        <h2 class="text-base font-semibold text-slate-900 mb-4">Automations</h2>
-        <div class="divide-y divide-slate-100">
-          <!-- Google Calendar -->
-          <div class="flex items-center justify-between py-2">
-            <div class="flex items-center gap-2">
-              <div
-                class:list={[
-                  'w-2 h-2 rounded-full',
-                  calStatus === 'active'
-                    ? 'bg-green-500'
-                    : calStatus === 'error' || calStatus === 'revoked'
-                      ? 'bg-red-500'
-                      : 'bg-slate-300',
-                ]}
-              >
-              </div>
-              <span class="text-sm text-slate-600">Google Calendar</span>
-            </div>
-            <span
-              class:list={[
-                'text-xs',
-                calStatus === 'error' || calStatus === 'revoked'
-                  ? 'text-red-600'
-                  : 'text-slate-400',
-              ]}
-            >
-              {
-                calStatus === 'active'
-                  ? calEmail
-                  : calStatus === 'error'
-                    ? (calError?.slice(0, 40) ?? 'Error')
-                    : calStatus === 'revoked'
-                      ? 'Reconnect required'
-                      : 'Not connected'
-              }
-            </span>
-          </div>
-
-          {/* Booking sync warnings */}
-          {
-            (syncErrors > 0 || syncStuck > 0) && (
-              <div class="py-2 pl-4">
-                {syncErrors > 0 && (
-                  <p class="text-xs text-red-600">
-                    {syncErrors} booking{syncErrors === 1 ? '' : 's'} failed to sync
-                  </p>
-                )}
-                {syncStuck > 0 && (
-                  <p class="text-xs text-amber-600">
-                    {syncStuck} booking{syncStuck === 1 ? '' : 's'} stuck pending
-                  </p>
-                )}
-              </div>
-            )
-          }
-
-          <!-- Lead Pipelines -->
-          {
-            pipelineRows.length > 0 ? (
-              pipelineRows.map((p) => (
-                <div class="flex items-center justify-between py-2">
-                  <div class="flex items-center gap-2">
-                    <div class:list={['w-2 h-2 rounded-full', p.color]} />
-                    <span class="text-sm text-slate-600">{p.label}</span>
-                  </div>
-                  <span class="text-xs text-slate-400">{p.ago}</span>
-                </div>
-              ))
-            ) : (
-              <div class="py-2 text-xs text-slate-400">No pipeline data yet</div>
-            )
-          }
-        </div>
-      </section>
-    </main>
-  </body>
-</html>
+    </section>
+  </div>
+</AdminLayout>

--- a/src/pages/admin/settings/google-connect.astro
+++ b/src/pages/admin/settings/google-connect.astro
@@ -1,5 +1,5 @@
 ---
-import '../../../styles/global.css'
+import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { getIntegration, deleteIntegration } from '../../../lib/db/integrations'
 
 /**
@@ -44,145 +44,105 @@ const errorMessages: Record<string, string> = {
 }
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <title>Google Calendar — Settings — SMD Services</title>
-  </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
-          >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Settings</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
+<AdminLayout
+  title="Google Calendar — Settings — SMD Services"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Settings' },
+    { label: 'Google Calendar' },
+  ]}
+>
+  <h2 class="text-xl font-semibold text-slate-900 mb-6">Google Calendar Integration</h2>
+
+  {
+    successParam === 'connected' && (
+      <div class="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg">
+        <p class="text-sm text-green-800">Google Calendar connected successfully.</p>
+      </div>
+    )
+  }
+
+  {
+    successParam === 'disconnected' && (
+      <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <p class="text-sm text-blue-800">Google Calendar disconnected.</p>
+      </div>
+    )
+  }
+
+  {
+    errorParam && (
+      <div class="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+        <p class="text-sm text-red-800">
+          {errorMessages[errorParam] ?? `Something went wrong (${errorParam}). Please try again.`}
+        </p>
+      </div>
+    )
+  }
+
+  <div class="bg-white rounded-lg border border-slate-200 p-6">
+    {
+      isConnected ? (
+        <div>
+          <div class="flex items-center gap-3 mb-4">
+            <div class="w-3 h-3 rounded-full bg-green-500" />
+            <span class="text-sm font-medium text-slate-900">Connected</span>
+          </div>
+          <dl class="grid grid-cols-1 gap-3 text-sm mb-6">
+            <div>
+              <dt class="text-slate-500">Account</dt>
+              <dd class="text-slate-900 font-medium">{integration.account_email}</dd>
+            </div>
+            <div>
+              <dt class="text-slate-500">Calendar</dt>
+              <dd class="text-slate-900">{integration.calendar_id}</dd>
+            </div>
+            <div>
+              <dt class="text-slate-500">Status</dt>
+              <dd class="text-slate-900">{integration.status}</dd>
+            </div>
+            <div>
+              <dt class="text-slate-500">Connected</dt>
+              <dd class="text-slate-900">
+                {new Date(integration.created_at).toLocaleDateString()}
+              </dd>
+            </div>
+            {integration.last_error && (
+              <div>
+                <dt class="text-slate-500">Last error</dt>
+                <dd class="text-red-600">{integration.last_error}</dd>
+              </div>
+            )}
+          </dl>
+          <form method="POST">
+            <input type="hidden" name="action" value="disconnect" />
             <button
               type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+              class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100 transition-colors"
+              onclick="return confirm('Disconnect Google Calendar? Existing booked events will not be affected.')"
             >
-              Sign out
+              Disconnect
             </button>
           </form>
         </div>
-      </div>
-    </header>
-
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <div class="mb-6">
-        <a href="/admin" class="text-sm text-slate-500 hover:text-slate-700 transition-colors">
-          &larr; Back to Dashboard
-        </a>
-      </div>
-
-      <h2 class="text-xl font-semibold text-slate-900 mb-6">Google Calendar Integration</h2>
-
-      {
-        successParam === 'connected' && (
-          <div class="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg">
-            <p class="text-sm text-green-800">Google Calendar connected successfully.</p>
+      ) : (
+        <div>
+          <div class="flex items-center gap-3 mb-4">
+            <div class="w-3 h-3 rounded-full bg-slate-300" />
+            <span class="text-sm font-medium text-slate-900">Not connected</span>
           </div>
-        )
-      }
-
-      {
-        successParam === 'disconnected' && (
-          <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <p class="text-sm text-blue-800">Google Calendar disconnected.</p>
-          </div>
-        )
-      }
-
-      {
-        errorParam && (
-          <div class="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
-            <p class="text-sm text-red-800">
-              {errorMessages[errorParam] ??
-                `Something went wrong (${errorParam}). Please try again.`}
-            </p>
-          </div>
-        )
-      }
-
-      <div class="bg-white rounded-lg border border-slate-200 p-6">
-        {
-          isConnected ? (
-            <div>
-              <div class="flex items-center gap-3 mb-4">
-                <div class="w-3 h-3 rounded-full bg-green-500" />
-                <span class="text-sm font-medium text-slate-900">Connected</span>
-              </div>
-              <dl class="grid grid-cols-1 gap-3 text-sm mb-6">
-                <div>
-                  <dt class="text-slate-500">Account</dt>
-                  <dd class="text-slate-900 font-medium">{integration.account_email}</dd>
-                </div>
-                <div>
-                  <dt class="text-slate-500">Calendar</dt>
-                  <dd class="text-slate-900">{integration.calendar_id}</dd>
-                </div>
-                <div>
-                  <dt class="text-slate-500">Status</dt>
-                  <dd class="text-slate-900">{integration.status}</dd>
-                </div>
-                <div>
-                  <dt class="text-slate-500">Connected</dt>
-                  <dd class="text-slate-900">
-                    {new Date(integration.created_at).toLocaleDateString()}
-                  </dd>
-                </div>
-                {integration.last_error && (
-                  <div>
-                    <dt class="text-slate-500">Last error</dt>
-                    <dd class="text-red-600">{integration.last_error}</dd>
-                  </div>
-                )}
-              </dl>
-              <form method="POST">
-                <input type="hidden" name="action" value="disconnect" />
-                <button
-                  type="submit"
-                  class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100 transition-colors"
-                  onclick="return confirm('Disconnect Google Calendar? Existing booked events will not be affected.')"
-                >
-                  Disconnect
-                </button>
-              </form>
-            </div>
-          ) : (
-            <div>
-              <div class="flex items-center gap-3 mb-4">
-                <div class="w-3 h-3 rounded-full bg-slate-300" />
-                <span class="text-sm font-medium text-slate-900">Not connected</span>
-              </div>
-              <p class="text-sm text-slate-600 mb-6">
-                Connect your Google Calendar to automatically create events when assessments are
-                booked and check availability in real time.
-              </p>
-              <a
-                href="/api/auth/google/connect"
-                class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
-              >
-                Connect Google Calendar
-              </a>
-            </div>
-          )
-        }
-      </div>
-    </main>
-  </body>
-</html>
+          <p class="text-sm text-slate-600 mb-6">
+            Connect your Google Calendar to automatically create events when assessments are booked
+            and check availability in real time.
+          </p>
+          <a
+            href="/api/auth/google/connect"
+            class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+          >
+            Connect Google Calendar
+          </a>
+        </div>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -253,7 +253,8 @@ describe('analytics: dashboard page', () => {
   })
 
   it('is not indexed by search engines', () => {
-    expect(source()).toContain('noindex')
+    const layout = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
+    expect(layout).toContain('noindex')
   })
 
   it('uses responsive grid layout', () => {
@@ -287,10 +288,10 @@ describe('analytics: admin dashboard integration', () => {
     expect(source()).toContain('getPipelineConversion')
   })
 
-  it('admin dashboard shows Analytics card', () => {
-    const code = source()
-    expect(code).toContain('Analytics')
-    expect(code).toContain('/admin/analytics')
+  it('admin layout shows Analytics nav link', () => {
+    const layout = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
+    expect(layout).toContain('Analytics')
+    expect(layout).toContain('/admin/analytics')
   })
 
   it('admin dashboard shows pipeline total metric', () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -164,13 +164,13 @@ describe('auth: admin dashboard', () => {
     expect(source).toContain('Astro.locals.session')
   })
 
-  it('admin page includes logout form', () => {
-    const source = readFileSync(resolve('src/pages/admin/index.astro'), 'utf-8')
+  it('admin layout includes logout form', () => {
+    const source = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
     expect(source).toContain('/api/auth/logout')
   })
 
-  it('admin page is not indexed by search engines', () => {
-    const source = readFileSync(resolve('src/pages/admin/index.astro'), 'utf-8')
+  it('admin layout is not indexed by search engines', () => {
+    const source = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
     expect(source).toContain('noindex')
   })
 })

--- a/tests/follow-ups.test.ts
+++ b/tests/follow-ups.test.ts
@@ -300,7 +300,8 @@ describe('follow-ups: dashboard page', () => {
   })
 
   it('is not indexed by search engines', () => {
-    expect(source()).toContain('noindex')
+    const layout = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
+    expect(layout).toContain('noindex')
   })
 })
 
@@ -369,10 +370,10 @@ describe('follow-ups: admin dashboard integration', () => {
     expect(source()).toContain('listFollowUps')
   })
 
-  it('admin dashboard shows follow-ups card', () => {
-    const code = source()
-    expect(code).toContain('Follow-ups')
-    expect(code).toContain('/admin/follow-ups')
+  it('admin layout shows follow-ups nav link', () => {
+    const layout = readFileSync(resolve('src/layouts/AdminLayout.astro'), 'utf-8')
+    expect(layout).toContain('Follow-ups')
+    expect(layout).toContain('/admin/follow-ups')
   })
 
   it('admin dashboard shows upcoming and overdue follow-ups', () => {


### PR DESCRIPTION
## Summary
- Creates `AdminLayout.astro` — shared layout for all admin pages with consistent header (branding, Admin badge, nav links, email, sign out), configurable breadcrumbs, and CSS import
- Migrates all 9 admin pages from inline `<html>` wrappers to the shared layout, removing ~300 lines of duplicated boilerplate
- Fixes engagement detail page which had **no header, no nav links, no email, no sign out** — just a bare breadcrumb

## What changed
- **New:** `src/layouts/AdminLayout.astro` — nav links (Dashboard, Entities, Follow-ups, Analytics) with active state highlighting, breadcrumb support, consistent max-width
- **Modified:** All 9 admin pages — removed inline HTML/header/breadcrumb, wrapped in `<AdminLayout>`
- **Tests:** Updated 6 tests that checked for content that moved from page files to the layout

## Test plan
- [ ] `npm run verify` passes (1017 tests, 0 errors)
- [ ] Visit every admin page — consistent header with nav links on all
- [ ] Engagement detail page now has full header (was missing entirely)
- [ ] Breadcrumbs render correctly at each depth level
- [ ] Active nav highlighting works (Entities page highlights "Entities", etc.)
- [ ] Sign out works from every page
- [ ] Inline `<script>` blocks still function on engagement, assessment, and quote pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)