### PR TITLE
fix(portal): persist session across refresh and extend client duration

### DIFF
--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -14,7 +14,19 @@
  */
 
 export const SESSION_COOKIE_NAME = 'session_token'
-export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+export const ADMIN_SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+export const CLIENT_SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+/** @deprecated Use getSessionDurationMs(role) instead. Kept for backward compat. */
+export const SESSION_DURATION_MS = ADMIN_SESSION_DURATION_MS
+
+/**
+ * Return session duration based on role.
+ * Clients get 30 days (infrequent portal visitors), admins get 7 days.
+ */
+export function getSessionDurationMs(role?: string): number {
+  return role === 'client' ? CLIENT_SESSION_DURATION_MS : ADMIN_SESSION_DURATION_MS
+}
 
 export interface SessionData {
   userId: string
@@ -46,7 +58,8 @@ export async function createSession(
 ): Promise<string> {
   const token = crypto.randomUUID()
   const sessionId = crypto.randomUUID()
-  const expiresAt = new Date(Date.now() + SESSION_DURATION_MS).toISOString()
+  const durationMs = getSessionDurationMs(user.role)
+  const expiresAt = new Date(Date.now() + durationMs).toISOString()
 
   // Write to D1 (source of truth)
   await db
@@ -66,7 +79,7 @@ export async function createSession(
     expiresAt,
   }
 
-  const kvTtlSeconds = Math.floor(SESSION_DURATION_MS / 1000)
+  const kvTtlSeconds = Math.floor(durationMs / 1000)
   await kv.put(`session:${token}`, JSON.stringify(sessionData), {
     expirationTtl: kvTtlSeconds,
   })
@@ -141,7 +154,10 @@ export async function renewSession(
   token: string,
   currentData: SessionData
 ): Promise<void> {
-  const newExpiresAt = new Date(Date.now() + SESSION_DURATION_MS).toISOString()
+  // Role comes from KV-cached session data and may be stale if changed
+  // mid-session by an admin. Self-heals on next KV expiry + D1 fallback.
+  const durationMs = getSessionDurationMs(currentData.role)
+  const newExpiresAt = new Date(Date.now() + durationMs).toISOString()
 
   // Update D1
   await db
@@ -155,7 +171,7 @@ export async function renewSession(
     expiresAt: newExpiresAt,
   }
 
-  const kvTtlSeconds = Math.floor(SESSION_DURATION_MS / 1000)
+  const kvTtlSeconds = Math.floor(durationMs / 1000)
   await kv.put(`session:${token}`, JSON.stringify(updatedData), {
     expirationTtl: kvTtlSeconds,
   })
@@ -178,9 +194,13 @@ export async function destroySession(
 
 /**
  * Build a Set-Cookie header for the session token.
+ *
+ * No Domain= attribute is set intentionally: admin cookies are scoped to
+ * smd.services and portal cookies to portal.smd.services. This isolation
+ * prevents cross-domain cookie leakage between admin and client sessions.
  */
-export function buildSessionCookie(token: string): string {
-  const maxAge = Math.floor(SESSION_DURATION_MS / 1000)
+export function buildSessionCookie(token: string, role?: string): string {
+  const maxAge = Math.floor(getSessionDurationMs(role) / 1000)
   return `${SESSION_COOKIE_NAME}=${token}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAge}`
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,10 @@
 import { defineMiddleware } from 'astro:middleware'
-import { parseSessionToken, validateSession, renewSession } from './lib/auth/session'
+import {
+  parseSessionToken,
+  validateSession,
+  renewSession,
+  buildSessionCookie,
+} from './lib/auth/session'
 
 /**
  * Astro middleware — handles auth for protected routes.
@@ -64,38 +69,48 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
   }
 
-  // Unprotected routes: session is attached if valid, but not required
-  if (!isProtectedRoute) {
-    return next()
-  }
-
   // Protected routes: enforce session + role
-  if (!context.locals.session) {
-    if (isAdminApiRoute || isPortalApiRoute) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' },
-      })
+  if (isProtectedRoute) {
+    if (!context.locals.session) {
+      if (isAdminApiRoute || isPortalApiRoute) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (isPortalRoute) {
+        return context.redirect('/auth/portal-login')
+      }
+      return context.redirect('/auth/login')
     }
-    if (isPortalRoute) {
-      return context.redirect('/auth/portal-login')
+
+    const requiredRole = isAdminRoute || isAdminApiRoute ? 'admin' : 'client'
+    if (context.locals.session.role !== requiredRole) {
+      if (isAdminApiRoute || isPortalApiRoute) {
+        return new Response(JSON.stringify({ error: 'Forbidden' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (isPortalRoute) {
+        return context.redirect('/auth/portal-login')
+      }
+      return context.redirect('/auth/login')
     }
-    return context.redirect('/auth/login')
   }
 
-  const requiredRole = isAdminRoute || isAdminApiRoute ? 'admin' : 'client'
-  if (context.locals.session.role !== requiredRole) {
-    if (isAdminApiRoute || isPortalApiRoute) {
-      return new Response(JSON.stringify({ error: 'Forbidden' }), {
-        status: 403,
-        headers: { 'Content-Type': 'application/json' },
-      })
+  const response = await next()
+
+  // Refresh session cookie on authenticated responses (sliding window).
+  // Guard: only refresh when role matches the domain to prevent admin sessions
+  // from leaking cookies onto portal.smd.services (and vice versa).
+  if (context.locals.session && token) {
+    const isPortalHost = context.url.hostname.startsWith('portal.')
+    const isClientSession = context.locals.session.role === 'client'
+    if (isClientSession === isPortalHost) {
+      response.headers.append('Set-Cookie', buildSessionCookie(token, context.locals.session.role))
     }
-    if (isPortalRoute) {
-      return context.redirect('/auth/portal-login')
-    }
-    return context.redirect('/auth/login')
   }
 
-  return next()
+  return response
 })

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createMagicLink } from '../../../lib/auth/magic-link'
-import { requireAppBaseUrl } from '../../../lib/config/app-url'
+import { requirePortalBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, portalInvitationEmailHtml } from '../../../lib/email/templates'
 
@@ -97,9 +97,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
     // Create magic link
     const token = await createMagicLink(env.DB, targetEmail)
 
-    // Build verification URL from the canonical APP_BASE_URL.
+    // Build verification URL from the canonical PORTAL_BASE_URL.
     // Never derive from request host — see issue #173.
-    const baseUrl = requireAppBaseUrl(env)
+    const baseUrl = requirePortalBaseUrl(env)
     const magicLinkUrl = buildMagicLinkUrl(baseUrl, token)
 
     // Send invitation email

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -60,7 +60,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     })
 
     // Redirect to admin with session cookie
-    const cookie = buildSessionCookie(token)
+    const cookie = buildSessionCookie(token, user.role)
     return new Response(null, {
       status: 302,
       headers: {

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createMagicLink } from '../../../lib/auth/magic-link'
-import { requireAppBaseUrl } from '../../../lib/config/app-url'
+import { requirePortalBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, magicLinkEmailHtml } from '../../../lib/email/templates'
 
@@ -51,9 +51,9 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     // Create magic link token
     const token = await createMagicLink(env.DB, normalizedEmail)
 
-    // Build the verification URL from the canonical APP_BASE_URL.
+    // Build the verification URL from the canonical PORTAL_BASE_URL.
     // Never derive from request host — see issue #173.
-    const baseUrl = requireAppBaseUrl(env)
+    const baseUrl = requirePortalBaseUrl(env)
     const magicLinkUrl = buildMagicLinkUrl(baseUrl, token)
 
     // Send the email

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -2,6 +2,7 @@
 import '../../styles/global.css'
 import { verifyMagicLink } from '../../lib/auth/magic-link'
 import { createSession, buildSessionCookie } from '../../lib/auth/session'
+import { getPortalBaseUrl } from '../../lib/config/app-url'
 
 /**
  * Magic link verification page — GET /auth/verify?token=...
@@ -63,11 +64,14 @@ const sessionToken = await createSession(env.DB, env.SESSIONS, {
 })
 
 // Redirect to portal with session cookie
+const portalBaseUrl = getPortalBaseUrl(env)
+const redirectTo = portalBaseUrl ? `${portalBaseUrl}/` : '/portal'
+
 return new Response(null, {
   status: 302,
   headers: {
-    Location: '/portal',
-    'Set-Cookie': buildSessionCookie(sessionToken),
+    Location: redirectTo,
+    'Set-Cookie': buildSessionCookie(sessionToken, user.role),
   },
 })
 ---

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -66,6 +66,36 @@ describe('auth: session module', () => {
     // D1 fallback
     expect(source).toContain('SELECT * FROM sessions WHERE token')
   })
+
+  it('client session duration is 30 days', () => {
+    const source = readFileSync(resolve('src/lib/auth/session.ts'), 'utf-8')
+    expect(source).toContain('30 * 24 * 60 * 60 * 1000')
+  })
+
+  it('exports getSessionDurationMs helper', () => {
+    const source = readFileSync(resolve('src/lib/auth/session.ts'), 'utf-8')
+    expect(source).toContain('export function getSessionDurationMs')
+  })
+})
+
+describe('auth: buildSessionCookie behavior', () => {
+  it('sets 30-day Max-Age for client role', async () => {
+    const { buildSessionCookie } = await import('../src/lib/auth/session')
+    const cookie = buildSessionCookie('test-token', 'client')
+    expect(cookie).toContain('Max-Age=2592000')
+  })
+
+  it('sets 7-day Max-Age for admin role', async () => {
+    const { buildSessionCookie } = await import('../src/lib/auth/session')
+    const cookie = buildSessionCookie('test-token', 'admin')
+    expect(cookie).toContain('Max-Age=604800')
+  })
+
+  it('defaults to admin duration when role omitted', async () => {
+    const { buildSessionCookie } = await import('../src/lib/auth/session')
+    const cookie = buildSessionCookie('test-token')
+    expect(cookie).toContain('Max-Age=604800')
+  })
 })
 
 describe('auth: middleware', () => {
@@ -92,6 +122,11 @@ describe('auth: middleware', () => {
   it('renews session on each authenticated request', () => {
     const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
     expect(source).toContain('renewSession')
+  })
+
+  it('refreshes session cookie on authenticated response', () => {
+    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+    expect(source).toContain('buildSessionCookie')
   })
 })
 

--- a/tests/canonical-app-url.test.ts
+++ b/tests/canonical-app-url.test.ts
@@ -140,10 +140,10 @@ describe('canonical app-url helper: URL builders', () => {
 describe('canonical app-url: magic-link endpoint uses canonical helper', () => {
   const path = resolve('src/pages/api/auth/magic-link.ts')
 
-  it('imports requireAppBaseUrl from the config helper', () => {
+  it('imports requirePortalBaseUrl from the config helper', () => {
     const source = readFileSync(path, 'utf-8')
     expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
-    expect(source).toContain('requireAppBaseUrl')
+    expect(source).toContain('requirePortalBaseUrl')
   })
 
   it('does not derive base URL from request host/protocol', () => {
@@ -162,10 +162,10 @@ describe('canonical app-url: magic-link endpoint uses canonical helper', () => {
 describe('canonical app-url: resend-invitation endpoint uses canonical helper', () => {
   const path = resolve('src/pages/api/admin/resend-invitation.ts')
 
-  it('imports requireAppBaseUrl from the config helper', () => {
+  it('imports requirePortalBaseUrl from the config helper', () => {
     const source = readFileSync(path, 'utf-8')
     expect(source).toMatch(/from ['"][^'"]*lib\/config\/app-url['"]/)
-    expect(source).toContain('requireAppBaseUrl')
+    expect(source).toContain('requirePortalBaseUrl')
   })
 
   it('does not derive base URL from request host/protocol', () => {

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -185,9 +185,9 @@ describe('magic-link: verify page', () => {
     expect(source).toContain('buildSessionCookie')
   })
 
-  it('redirects to /portal on success', () => {
+  it('redirects to portal base URL on success', () => {
     const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain("'/portal'")
+    expect(source).toContain('getPortalBaseUrl')
   })
 
   it('redirects to portal-login on invalid token', () => {


### PR DESCRIPTION
## Summary
- Switch magic link URLs to use `PORTAL_BASE_URL` so cookies land on `portal.smd.services` instead of `smd.services`
- Add role-based session duration (30 days for clients, 7 days for admins) with sliding window cookie refresh in middleware
- Guard cookie refresh against cross-domain leakage (admin sessions don't leak onto portal subdomain)

## Test plan
- [ ] `npm run verify` passes
- [ ] Deploy → go to `portal.smd.services` → enter email → get link → click → portal loads
- [ ] Refresh page → stays logged in
- [ ] Close browser, reopen → navigate to `portal.smd.services` → stays logged in
- [ ] Check devtools: cookie on `portal.smd.services`, Max-Age ~2592000 (30 days)
- [ ] Check Network tab: exactly one `Set-Cookie` header per response

🤖 Generated with [Claude Code](https://claude.com/claude-code)