### PR TITLE
fix(portal): audit and fix client portal UX issues

### DIFF
--- a/src/lib/portal/constants.ts
+++ b/src/lib/portal/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared constants for the client portal.
+ *
+ * Single source of truth for client-facing engagement status labels and colors.
+ * Used by both the portal dashboard and the engagement progress page.
+ */
+
+/** Client-friendly engagement status labels. */
+export const CLIENT_STATUS_LABELS: Record<string, string> = {
+  scheduled: 'Starting Soon',
+  active: 'Underway',
+  handoff: 'Wrapping Up',
+  safety_net: 'Support',
+  completed: 'Complete',
+  cancelled: 'Cancelled',
+}
+
+/** Tailwind classes for engagement status badges. */
+export const CLIENT_STATUS_COLORS: Record<string, string> = {
+  scheduled: 'bg-slate-100 text-slate-600',
+  active: 'bg-blue-100 text-blue-800',
+  handoff: 'bg-amber-100 text-amber-800',
+  safety_net: 'bg-green-100 text-green-800',
+  completed: 'bg-emerald-100 text-emerald-700',
+  cancelled: 'bg-slate-100 text-slate-500',
+}

--- a/src/pages/api/portal/documents/[...key].ts
+++ b/src/pages/api/portal/documents/[...key].ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { streamDocument } from '../../../../lib/storage/r2'
 import { listEngagements } from '../../../../lib/db/engagements'
+import { getPortalClient } from '../../../../lib/portal/session'
 
 /**
  * GET /api/portal/documents/:key
@@ -10,6 +11,7 @@ import { listEngagements } from '../../../../lib/db/engagements'
  *
  * Security:
  * - Requires valid client session (middleware ensures role=client)
+ * - Resolves entity via getPortalClient() (users.entity_id)
  * - Verifies the R2 key belongs to this client's org/engagement
  * - Prevents path traversal by checking key prefix
  *
@@ -17,11 +19,6 @@ import { listEngagements } from '../../../../lib/db/engagements'
  * - PDFs: inline (view in browser)
  * - Everything else: attachment (download)
  */
-
-interface UserRow {
-  id: string
-  client_id: string | null
-}
 
 const CONTENT_TYPES: Record<string, string> = {
   '.pdf': 'application/pdf',
@@ -60,12 +57,9 @@ export const GET: APIRoute = async ({ locals, params }) => {
 
   const env = locals.runtime.env
 
-  // Look up client_id from users table
-  const user = await env.DB.prepare('SELECT id, client_id FROM users WHERE id = ?')
-    .bind(session.userId)
-    .first<UserRow>()
-
-  if (!user?.client_id) {
+  // Resolve client entity from session
+  const portalData = await getPortalClient(env.DB, session.userId)
+  if (!portalData) {
     return new Response(JSON.stringify({ error: 'Forbidden' }), {
       status: 403,
       headers: { 'Content-Type': 'application/json' },
@@ -89,7 +83,7 @@ export const GET: APIRoute = async ({ locals, params }) => {
   }
 
   // Verify the key belongs to this client's engagement
-  const engagements = await listEngagements(env.DB, session.orgId, user.client_id)
+  const engagements = await listEngagements(env.DB, session.orgId, portalData.client.id)
   const engagementIds = engagements.map((e) => e.id)
   const quoteIds = engagements.map((e) => e.quote_id)
 

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { CLIENT_STATUS_LABELS, CLIENT_STATUS_COLORS } from '../../../lib/portal/constants'
 import { getPortalClient } from '../../../lib/portal/session'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listMilestones } from '../../../lib/db/milestones'
@@ -40,15 +41,6 @@ const statusIcon: Record<string, { color: string; icon: string; label: string }>
   in_progress: { color: 'text-blue-600 bg-blue-50', icon: '&#8635;', label: 'In Progress' },
   completed: { color: 'text-green-600 bg-green-50', icon: '&#10003;', label: 'Completed' },
   skipped: { color: 'text-slate-400 bg-slate-50', icon: '&#8212;', label: 'Skipped' },
-}
-
-const engagementStatusLabel: Record<string, string> = {
-  scheduled: 'Scheduled',
-  active: 'Active',
-  handoff: 'Handoff',
-  safety_net: 'Support Window',
-  completed: 'Completed',
-  cancelled: 'Cancelled',
 }
 
 function formatDate(iso: string | null): string {
@@ -121,8 +113,10 @@ function formatDate(iso: string | null): string {
             <div class="bg-white rounded-lg border border-slate-200 p-6">
               <div class="flex items-center justify-between mb-4">
                 <h3 class="text-base font-semibold text-slate-900">Overview</h3>
-                <span class="text-sm font-medium text-blue-700 bg-blue-50 px-3 py-1 rounded-full">
-                  {engagementStatusLabel[engagement.status] ?? engagement.status}
+                <span
+                  class={`text-sm font-medium px-3 py-1 rounded-full ${CLIENT_STATUS_COLORS[engagement.status] ?? 'bg-slate-100 text-slate-600'}`}
+                >
+                  {CLIENT_STATUS_LABELS[engagement.status] ?? engagement.status}
                 </span>
               </div>
 
@@ -142,7 +136,7 @@ function formatDate(iso: string | null): string {
                 <div>
                   <span class="text-slate-500">Current Phase</span>
                   <p class="font-medium text-slate-900">
-                    {engagementStatusLabel[engagement.status] ?? engagement.status}
+                    {CLIENT_STATUS_LABELS[engagement.status] ?? engagement.status}
                   </p>
                 </div>
               </div>

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -1,6 +1,7 @@
 ---
 import '../../styles/global.css'
 import { getPortalClient } from '../../lib/portal/session'
+import { CLIENT_STATUS_LABELS, CLIENT_STATUS_COLORS } from '../../lib/portal/constants'
 import { listQuotesForEntity } from '../../lib/db/quotes'
 import type { Quote } from '../../lib/db/quotes'
 
@@ -68,6 +69,7 @@ interface ActivityItem {
   description: string
   date: string
   type: 'quote' | 'engagement'
+  href?: string
 }
 
 const recentActivity: ActivityItem[] = []
@@ -77,6 +79,7 @@ for (const q of quotes.slice(0, 5)) {
       description: 'Proposal sent',
       date: q.sent_at,
       type: 'quote',
+      href: `/portal/quotes/${q.id}`,
     })
   }
   if (q.accepted_at) {
@@ -84,6 +87,7 @@ for (const q of quotes.slice(0, 5)) {
       description: 'Proposal signed',
       date: q.accepted_at,
       type: 'quote',
+      href: `/portal/quotes/${q.id}`,
     })
   }
 }
@@ -96,20 +100,6 @@ const formatDate = (d: string) =>
     day: 'numeric',
     year: 'numeric',
   })
-
-const engagementStatusLabels: Record<string, string> = {
-  scheduled: 'Scheduled',
-  active: 'In Progress',
-  handoff: 'Handoff',
-  safety_net: 'Support',
-}
-
-const engagementStatusColors: Record<string, string> = {
-  scheduled: 'bg-slate-100 text-slate-600',
-  active: 'bg-blue-100 text-blue-800',
-  handoff: 'bg-amber-100 text-amber-800',
-  safety_net: 'bg-green-100 text-green-800',
-}
 ---
 
 <!doctype html>
@@ -151,7 +141,15 @@ const engagementStatusColors: Record<string, string> = {
       <h2 class="text-xl sm:text-2xl font-bold text-slate-900 mb-1">
         Welcome, {client.name}
       </h2>
-      <p class="text-sm text-slate-500 mb-6">Your client portal for SMD Services</p>
+      <p class="text-sm text-slate-500 mb-6">
+        {
+          activeEngagement
+            ? `Your engagement is ${(CLIENT_STATUS_LABELS[activeEngagement.status] ?? activeEngagement.status).toLowerCase()}`
+            : pendingQuotes.length > 0
+              ? 'You have a proposal ready for review'
+              : 'Your client portal for SMD Services'
+        }
+      </p>
 
       <!-- Pending Quotes Alert -->
       {
@@ -187,9 +185,9 @@ const engagementStatusColors: Record<string, string> = {
                 <div class="flex items-center gap-3 mb-4">
                   <h3 class="text-base font-semibold text-slate-900">Current Engagement</h3>
                   <span
-                    class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${engagementStatusColors[activeEngagement.status] ?? 'bg-slate-100 text-slate-600'}`}
+                    class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${CLIENT_STATUS_COLORS[activeEngagement.status] ?? 'bg-slate-100 text-slate-600'}`}
                   >
-                    {engagementStatusLabels[activeEngagement.status] ?? activeEngagement.status}
+                    {CLIENT_STATUS_LABELS[activeEngagement.status] ?? activeEngagement.status}
                   </span>
                 </div>
                 {activeEngagement.scope_summary && (
@@ -219,14 +217,31 @@ const engagementStatusColors: Record<string, string> = {
               recentActivity.length > 0 ? (
                 <ul class="space-y-3">
                   {recentActivity.slice(0, 5).map((activity) => (
-                    <li class="flex items-start gap-3">
-                      <div
-                        class={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${activity.type === 'quote' ? 'bg-blue-400' : 'bg-green-400'}`}
-                      />
-                      <div>
-                        <p class="text-sm text-slate-700">{activity.description}</p>
-                        <p class="text-xs text-slate-400">{formatDate(activity.date)}</p>
-                      </div>
+                    <li>
+                      {activity.href ? (
+                        <a
+                          href={activity.href}
+                          class="flex items-start gap-3 p-1.5 -m-1.5 rounded-lg hover:bg-slate-50 transition-colors"
+                        >
+                          <div
+                            class={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${activity.type === 'quote' ? 'bg-blue-400' : 'bg-green-400'}`}
+                          />
+                          <div>
+                            <p class="text-sm text-slate-700">{activity.description}</p>
+                            <p class="text-xs text-slate-400">{formatDate(activity.date)}</p>
+                          </div>
+                        </a>
+                      ) : (
+                        <div class="flex items-start gap-3">
+                          <div
+                            class={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${activity.type === 'quote' ? 'bg-blue-400' : 'bg-green-400'}`}
+                          />
+                          <div>
+                            <p class="text-sm text-slate-700">{activity.description}</p>
+                            <p class="text-xs text-slate-400">{formatDate(activity.date)}</p>
+                          </div>
+                        </div>
+                      )}
                     </li>
                   ))}
                 </ul>
@@ -296,55 +311,61 @@ const engagementStatusColors: Record<string, string> = {
                     </div>
                   )}
                 </div>
+                <a
+                  href="/portal/quotes"
+                  class="block mt-3 pt-3 border-t border-slate-100 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+                >
+                  View all proposals
+                </a>
               </div>
             )
           }
         </div>
+      </div>
 
-        <!-- Engagement & Documents Quick Links -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
-          <a
-            href="/portal/engagement"
-            class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+      <!-- Quick Actions -->
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
+        <a
+          href="/portal/engagement"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <h3
+            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
           >
-            <h3
-              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-            >
-              Engagement Progress
-            </h3>
-            <p class="text-sm text-slate-500 mt-1">
-              View your engagement milestones, timeline, and current status.
-            </p>
-          </a>
+            Engagement Progress
+          </h3>
+          <p class="text-sm text-slate-500 mt-1">
+            View your engagement milestones, timeline, and current status.
+          </p>
+        </a>
 
-          <a
-            href="/portal/documents"
-            class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        <a
+          href="/portal/documents"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <h3
+            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
           >
-            <h3
-              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-            >
-              Documents
-            </h3>
-            <p class="text-sm text-slate-500 mt-1">
-              Access your statement of work, deliverables, and other engagement documents.
-            </p>
-          </a>
+            Documents
+          </h3>
+          <p class="text-sm text-slate-500 mt-1">
+            Access your statement of work, deliverables, and other engagement documents.
+          </p>
+        </a>
 
-          <a
-            href="/portal/invoices"
-            class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        <a
+          href="/portal/invoices"
+          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
+        >
+          <h3
+            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
           >
-            <h3
-              class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-            >
-              Invoices
-            </h3>
-            <p class="text-sm text-slate-500 mt-1">
-              View invoices and make payments for your engagement.
-            </p>
-          </a>
-        </div>
+            Invoices
+          </h3>
+          <p class="text-sm text-slate-500 mt-1">
+            View invoices and make payments for your engagement.
+          </p>
+        </a>
       </div>
     </main>
   </body>


### PR DESCRIPTION
## Summary
- Fix document download API returning 403 — was querying dropped `client_id` column, now uses `getPortalClient()` with `entity_id`
- Fix dashboard layout — action cards (Engagement Progress, Documents, Invoices) were trapped inside a 3-column grid as a single-column child; moved outside the grid with proper `sm:grid-cols-3`
- Replace internal status jargon with client-friendly labels ("Underway" not "Active"/"In Progress") via shared `CLIENT_STATUS_LABELS` constant used by both dashboard and engagement page
- Add drill-through links: Proposal Summary card links to `/portal/quotes`, Recent Activity items link to individual proposals
- Contextual welcome copy based on engagement state

## Test plan
- [ ] `npm run verify` passes
- [ ] Visit `/portal` — 3 action cards render at full width in a row
- [ ] Navigate to `/portal/documents` — document list renders, "View" link streams PDF (not 403)
- [ ] Click Proposal Summary → navigates to `/portal/quotes`
- [ ] Click Recent Activity item → navigates to individual proposal
- [ ] Engagement status badges show "Underway" (not "In Progress" or "Active")
- [ ] Sign out button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)