### PR TITLE
feat(portal): redesign home dashboard (#361)

### DIFF
--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -1,25 +1,24 @@
 ---
 import '../../styles/global.css'
 import { getPortalClient } from '../../lib/portal/session'
-import { CLIENT_STATUS_LABELS, CLIENT_STATUS_COLORS } from '../../lib/portal/constants'
-import { listQuotesForEntity } from '../../lib/db/quotes'
-import type { Quote } from '../../lib/db/quotes'
+import PortalHeader from '../../components/portal/PortalHeader.astro'
+import ConsultantBlock from '../../components/portal/ConsultantBlock.astro'
+import TimelineEntry from '../../components/portal/TimelineEntry.astro'
+import ActionCard from '../../components/portal/ActionCard.astro'
 
 /**
- * Client portal dashboard — protected by auth middleware (role=client).
+ * Client portal home — C-hybrid: action-centric above the fold with an inline
+ * timeline below. See .stitch/portal-ux-brief.md and .stitch/designs/portal-v1.
  *
- * Shows:
- * - Welcome message with client business name
- * - Active engagement status (if any)
- * - Pending quotes requiring action
- * - Recent activity feed
- * - Quick links to sections
+ * - Mobile: invoice ActionCard (or next-touchpoint dominant block) pins above
+ *   the fold, consultant block below, recent activity timeline after a divider.
+ * - Desktop (>=md): two-column split — main column holds eyebrow + client
+ *   context + timeline; sticky right rail holds ActionCard + ConsultantBlock.
  */
 
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
-// Resolve client from session
 const portalData = await getPortalClient(env.DB, session.userId)
 if (!portalData) {
   return Astro.redirect('/auth/portal-login?error=no_account')
@@ -27,79 +26,233 @@ if (!portalData) {
 
 const { client } = portalData
 
-// Load quotes for this client
-const quotes = await listQuotesForEntity(env.DB, client.id)
-const pendingQuotes = quotes.filter((q: Quote) => q.status === 'sent')
-
-// Load active engagement (if any)
 interface EngagementRow {
   id: string
   status: string
   scope_summary: string | null
   start_date: string | null
   estimated_end: string | null
+  consultant_name: string | null
+  consultant_photo_url: string | null
+  consultant_role: string | null
+  consultant_phone: string | null
+  next_touchpoint_at: string | null
+  next_touchpoint_label: string | null
+}
+
+const activeEngagement = await env.DB.prepare(
+  `SELECT id, status, scope_summary, start_date, estimated_end,
+          consultant_name, consultant_photo_url, consultant_role, consultant_phone,
+          next_touchpoint_at, next_touchpoint_label
+     FROM engagements
+    WHERE entity_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net')
+    ORDER BY created_at DESC
+    LIMIT 1`
+)
+  .bind(client.id)
+  .first<EngagementRow>()
+
+interface InvoiceRow {
+  id: string
+  amount: number
+  status: string
+  due_date: string | null
+  sent_at: string | null
+  paid_at: string | null
+}
+
+interface QuoteRow {
+  id: string
+  status: string
+  sent_at: string | null
+  accepted_at: string | null
 }
 
 interface MilestoneRow {
   id: string
   name: string
-  status: string
-  sort_order: number
+  completed_at: string | null
 }
 
-const activeEngagement = await env.DB.prepare(
-  `SELECT id, status, scope_summary, start_date, estimated_end FROM engagements WHERE entity_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net') ORDER BY created_at DESC LIMIT 1`
+let pendingInvoice: InvoiceRow | null = null
+let invoices: InvoiceRow[] = []
+let quotes: QuoteRow[] = []
+let completedMilestones: MilestoneRow[] = []
+
+if (activeEngagement) {
+  const invoiceResult = await env.DB.prepare(
+    `SELECT id, amount, status, due_date, sent_at, paid_at
+       FROM invoices
+      WHERE engagement_id = ? AND status != 'void'
+      ORDER BY created_at DESC`
+  )
+    .bind(activeEngagement.id)
+    .all<InvoiceRow>()
+  invoices = invoiceResult.results ?? []
+
+  // Next pending invoice: earliest-due among sent/overdue (null due_date last).
+  const pending = invoices.filter((i) => i.status === 'sent' || i.status === 'overdue')
+  pending.sort((a, b) => {
+    if (a.due_date && b.due_date) return a.due_date < b.due_date ? -1 : 1
+    if (a.due_date) return -1
+    if (b.due_date) return 1
+    return 0
+  })
+  pendingInvoice = pending[0] ?? null
+
+  const milestoneResult = await env.DB.prepare(
+    `SELECT id, name, completed_at
+       FROM milestones
+      WHERE engagement_id = ? AND status = 'completed' AND completed_at IS NOT NULL
+      ORDER BY completed_at DESC
+      LIMIT 5`
+  )
+    .bind(activeEngagement.id)
+    .all<MilestoneRow>()
+  completedMilestones = milestoneResult.results ?? []
+}
+
+const quoteResult = await env.DB.prepare(
+  `SELECT id, status, sent_at, accepted_at
+     FROM quotes
+    WHERE entity_id = ?
+    ORDER BY updated_at DESC
+    LIMIT 5`
 )
   .bind(client.id)
-  .first<EngagementRow>()
+  .all<QuoteRow>()
+quotes = quoteResult.results ?? []
 
-// Load milestones for active engagement
-let currentMilestone: MilestoneRow | null = null
-if (activeEngagement) {
-  currentMilestone =
-    (await env.DB.prepare(
-      `SELECT id, name, status, sort_order FROM milestones WHERE engagement_id = ? AND status IN ('pending', 'in_progress') ORDER BY sort_order ASC LIMIT 1`
-    )
-      .bind(activeEngagement.id)
-      .first<MilestoneRow>()) ?? null
-}
+// ---------------------------------------------------------------------------
+// Timeline — most recent first, up to 5 entries. Past-tense, concrete events.
+// ---------------------------------------------------------------------------
 
-// Build recent activity
-interface ActivityItem {
-  description: string
+interface TimelineItem {
+  ts: string
   date: string
-  type: 'quote' | 'engagement'
-  href?: string
+  body: string
+  artifactLabel?: string
+  artifactHref?: string
+  artifactIcon?: string
 }
 
-const recentActivity: ActivityItem[] = []
-for (const q of quotes.slice(0, 5)) {
-  if (q.sent_at) {
-    recentActivity.push({
-      description: 'Proposal sent',
-      date: q.sent_at,
-      type: 'quote',
-      href: `/portal/quotes/${q.id}`,
-    })
-  }
-  if (q.accepted_at) {
-    recentActivity.push({
-      description: 'Proposal signed',
-      date: q.accepted_at,
-      type: 'quote',
-      href: `/portal/quotes/${q.id}`,
-    })
-  }
-}
-recentActivity.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-
-// Helpers
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString('en-US', {
+const shortDate = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const now = new Date()
+  const sameYear = d.getFullYear() === now.getFullYear()
+  return d.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
-    year: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
   })
+}
+
+const timeline: TimelineItem[] = []
+
+for (const q of quotes) {
+  if (q.accepted_at) {
+    timeline.push({
+      ts: q.accepted_at,
+      date: shortDate(q.accepted_at),
+      body: 'Proposal signed. Deposit due.',
+      artifactLabel: 'Proposal',
+      artifactHref: `/portal/quotes/${q.id}`,
+      artifactIcon: 'description',
+    })
+  } else if (q.sent_at && q.status === 'sent') {
+    timeline.push({
+      ts: q.sent_at,
+      date: shortDate(q.sent_at),
+      body: 'Proposal sent for review.',
+      artifactLabel: 'Proposal',
+      artifactHref: `/portal/quotes/${q.id}`,
+      artifactIcon: 'description',
+    })
+  }
+}
+
+for (const inv of invoices) {
+  if (inv.paid_at) {
+    timeline.push({
+      ts: inv.paid_at,
+      date: shortDate(inv.paid_at),
+      body: 'Invoice paid. Receipt attached.',
+      artifactLabel: `Invoice #${inv.id.slice(0, 6)}`,
+      artifactHref: `/portal/invoices/${inv.id}`,
+      artifactIcon: 'receipt_long',
+    })
+  } else if (inv.sent_at) {
+    timeline.push({
+      ts: inv.sent_at,
+      date: shortDate(inv.sent_at),
+      body: 'Invoice sent.',
+      artifactLabel: `Invoice #${inv.id.slice(0, 6)}`,
+      artifactHref: `/portal/invoices/${inv.id}`,
+      artifactIcon: 'receipt_long',
+    })
+  }
+}
+
+for (const m of completedMilestones) {
+  if (!m.completed_at) continue
+  timeline.push({
+    ts: m.completed_at,
+    date: shortDate(m.completed_at),
+    body: m.name,
+  })
+}
+
+timeline.sort((a, b) => (a.ts < b.ts ? 1 : -1))
+const timelineEntries = timeline.slice(0, 5)
+
+// ---------------------------------------------------------------------------
+// Derived display values
+// ---------------------------------------------------------------------------
+
+const consultant = {
+  name: activeEngagement?.consultant_name ?? 'Scott Durgan',
+  photoUrl: activeEngagement?.consultant_photo_url ?? null,
+  role: activeEngagement?.consultant_role ?? 'Your consultant',
+  phone: activeEngagement?.consultant_phone ?? null,
+  nextTouchpointAt: activeEngagement?.next_touchpoint_at ?? null,
+  nextTouchpointLabel: activeEngagement?.next_touchpoint_label ?? null,
+}
+
+const consultantFirst = (consultant.name || '').trim().split(/\s+/)[0] || 'us'
+const smsHref = consultant.phone ? `sms:${consultant.phone.replace(/[^+\d]/g, '')}` : null
+
+const invoiceAmountCents = pendingInvoice ? Math.round(pendingInvoice.amount * 100) : null
+const invoiceDueText = pendingInvoice?.due_date ? `Due ${shortDate(pendingInvoice.due_date)}` : null
+const invoicePillLabel = pendingInvoice
+  ? pendingInvoice.status === 'overdue'
+    ? 'Invoice overdue'
+    : 'Invoice due'
+  : null
+const invoiceCaption = pendingInvoice
+  ? `Invoice #${pendingInvoice.id.slice(0, 6)}${invoiceDueText ? ` • ${invoiceDueText}` : ''}`
+  : null
+
+const touchpointText: string | null = (() => {
+  if (consultant.nextTouchpointLabel) return consultant.nextTouchpointLabel
+  if (!consultant.nextTouchpointAt) return null
+  const d = new Date(consultant.nextTouchpointAt)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+})()
+
+const contextHeadline = activeEngagement
+  ? 'Your engagement is in flight.'
+  : 'Welcome to your portal.'
+const contextSubtext = touchpointText
+  ? `Next check-in ${touchpointText} with ${consultantFirst}.`
+  : `${consultantFirst} will reach out to schedule your next check-in.`
 ---
 
 <!doctype html>
@@ -109,263 +262,134 @@ const formatDate = (d: string) =>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>Portal — SMD Services</title>
   </head>
-  <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <h1 class="text-lg font-bold text-slate-900">SMD Services</h1>
-          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600 hidden sm:inline">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <PortalHeader
+      clientName={client.name}
+      showSms={Boolean(smsHref)}
+      smsHref={smsHref ?? undefined}
+      smsLabel={`Text ${consultantFirst}`}
+    />
 
-    <main class="max-w-5xl mx-auto px-4 py-6 sm:py-8">
-      <!-- Welcome -->
-      <h2 class="text-xl sm:text-2xl font-bold text-slate-900 mb-1">
-        Welcome, {client.name}
-      </h2>
-      <p class="text-sm text-slate-500 mb-6">
-        {
-          activeEngagement
-            ? `Your engagement is ${(CLIENT_STATUS_LABELS[activeEngagement.status] ?? activeEngagement.status).toLowerCase()}`
-            : pendingQuotes.length > 0
-              ? 'You have a proposal ready for review'
-              : 'Your client portal for SMD Services'
-        }
-      </p>
-
-      <!-- Pending Quotes Alert -->
-      {
-        pendingQuotes.length > 0 && (
-          <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <div class="flex flex-col sm:flex-row sm:items-center gap-3">
-              <div class="flex-1">
-                <p class="text-sm font-medium text-blue-900">
-                  {pendingQuotes.length === 1
-                    ? 'You have a proposal ready for review'
-                    : `You have ${pendingQuotes.length} proposals ready for review`}
-                </p>
-                <p class="text-xs text-blue-700 mt-0.5">Review the scope and sign to get started</p>
-              </div>
-              <a
-                href="/portal/quotes"
-                class="inline-flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors min-h-[44px]"
-              >
-                Review Proposals
-              </a>
-            </div>
-          </div>
-        )
-      }
-
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <!-- Main Column -->
-        <div class="lg:col-span-2 space-y-6">
-          <!-- Active Engagement -->
+    <main class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      <!-- Desktop: two-column grid. Mobile: single column, action-first. -->
+      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_340px] md:gap-12 md:items-start">
+        <!-- On mobile, dominant action (right-rail content) renders FIRST.
+             On desktop it moves to the right column via md:order-2. -->
+        <aside class="md:order-2 md:sticky md:top-10 space-y-6">
           {
-            activeEngagement && (
-              <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
-                <div class="flex items-center gap-3 mb-4">
-                  <h3 class="text-base font-semibold text-slate-900">Current Engagement</h3>
-                  <span
-                    class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${CLIENT_STATUS_COLORS[activeEngagement.status] ?? 'bg-slate-100 text-slate-600'}`}
-                  >
-                    {CLIENT_STATUS_LABELS[activeEngagement.status] ?? activeEngagement.status}
-                  </span>
-                </div>
-                {activeEngagement.scope_summary && (
-                  <p class="text-sm text-slate-600 mb-3">{activeEngagement.scope_summary}</p>
-                )}
-                {currentMilestone && (
-                  <div class="p-3 bg-slate-50 rounded-lg">
-                    <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">
-                      Current Milestone
-                    </p>
-                    <p class="text-sm font-medium text-slate-900">{currentMilestone.name}</p>
-                  </div>
-                )}
-                {activeEngagement.estimated_end && (
-                  <p class="text-xs text-slate-400 mt-3">
-                    Estimated completion: {formatDate(activeEngagement.estimated_end)}
-                  </p>
-                )}
-              </div>
+            pendingInvoice && invoicePillLabel ? (
+              <ActionCard
+                pillLabel={invoicePillLabel}
+                amountCents={invoiceAmountCents ?? 0}
+                amountLabel={invoiceCaption}
+                ctaLabel="Pay invoice"
+                ctaHref={`/portal/invoices/${pendingInvoice.id}`}
+                ctaSubtext="Secure payment via Stripe."
+              />
+            ) : touchpointText ? (
+              <section
+                class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-6 sm:p-8"
+                aria-label="Next check-in"
+              >
+                <span class="inline-flex items-center rounded-full bg-[color:var(--color-primary)]/10 px-3 py-1 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-primary)]">
+                  Next check-in
+                </span>
+                <p class="mt-5 font-['Plus_Jakarta_Sans'] font-extrabold text-[28px] leading-[34px] tracking-[-0.02em] text-[color:var(--color-text-primary)]">
+                  {touchpointText}
+                </p>
+                <p class="mt-2 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-muted)]">
+                  with {consultantFirst}
+                </p>
+              </section>
+            ) : (
+              <section
+                class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-6 sm:p-8"
+                aria-label="Engagement status"
+              >
+                <span class="inline-flex items-center rounded-full bg-[color:var(--color-primary)]/10 px-3 py-1 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-primary)]">
+                  In flight
+                </span>
+                <p class="mt-5 text-base leading-6 text-[color:var(--color-text-secondary)]">
+                  Nothing needs your attention right now.
+                </p>
+                <p class="mt-2 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
+                  {consultantFirst} will reach out to schedule the next touchpoint.
+                </p>
+              </section>
             )
           }
 
-          <!-- Recent Activity -->
-          <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
-            <h3 class="text-base font-semibold text-slate-900 mb-4">Recent Activity</h3>
+          <ConsultantBlock
+            name={consultant.name}
+            photoUrl={consultant.photoUrl}
+            role={consultant.role}
+            nextTouchpointAt={consultant.nextTouchpointAt}
+            nextTouchpointLabel={consultant.nextTouchpointLabel}
+            phone={consultant.phone}
+          />
+        </aside>
+
+        <!-- Main column: eyebrow + context (desktop), recent activity. -->
+        <section class="md:order-1 mt-8 md:mt-0">
+          <!-- Desktop eyebrow + headline. Hidden on mobile so the action
+               dominates above the fold. -->
+          <div class="hidden md:block mb-10">
+            <p
+              class="text-[12px] font-bold tracking-[0.1em] uppercase text-[color:var(--color-meta)]"
+            >
+              Client Portal
+            </p>
+            <h1
+              class="mt-3 font-['Plus_Jakarta_Sans'] font-extrabold text-[32px] leading-[36px] tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+            >
+              {contextHeadline}
+            </h1>
+            <p class="mt-3 text-base leading-6 text-[color:var(--color-text-secondary)]">
+              {contextSubtext}
+            </p>
+          </div>
+
+          <div
+            class="mt-8 md:mt-0 pt-8 md:pt-0 border-t md:border-t-0 border-[color:var(--color-border)]"
+          >
+            <h2
+              class="font-['Plus_Jakarta_Sans'] font-bold text-[18px] leading-[24px] text-[color:var(--color-text-primary)]"
+            >
+              Recent activity
+            </h2>
             {
-              recentActivity.length > 0 ? (
-                <ul class="space-y-3">
-                  {recentActivity.slice(0, 5).map((activity) => (
-                    <li>
-                      {activity.href ? (
-                        <a
-                          href={activity.href}
-                          class="flex items-start gap-3 p-1.5 -m-1.5 rounded-lg hover:bg-slate-50 transition-colors"
-                        >
-                          <div
-                            class={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${activity.type === 'quote' ? 'bg-blue-400' : 'bg-green-400'}`}
-                          />
-                          <div>
-                            <p class="text-sm text-slate-700">{activity.description}</p>
-                            <p class="text-xs text-slate-400">{formatDate(activity.date)}</p>
-                          </div>
-                        </a>
-                      ) : (
-                        <div class="flex items-start gap-3">
-                          <div
-                            class={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${activity.type === 'quote' ? 'bg-blue-400' : 'bg-green-400'}`}
-                          />
-                          <div>
-                            <p class="text-sm text-slate-700">{activity.description}</p>
-                            <p class="text-xs text-slate-400">{formatDate(activity.date)}</p>
-                          </div>
-                        </div>
-                      )}
-                    </li>
+              timelineEntries.length > 0 ? (
+                <div class="mt-6 flex flex-col gap-6">
+                  {timelineEntries.map((entry) => (
+                    <TimelineEntry
+                      date={entry.date}
+                      body={entry.body}
+                      artifactLabel={entry.artifactLabel}
+                      artifactHref={entry.artifactHref}
+                      artifactIcon={entry.artifactIcon}
+                    />
                   ))}
-                </ul>
+                </div>
               ) : (
-                <p class="text-sm text-slate-500">No recent activity to show.</p>
+                <p class="mt-6 text-sm leading-[20px] text-[color:var(--color-text-secondary)]">
+                  Nothing here yet. First entry lands after your next touchpoint.
+                </p>
               )
             }
           </div>
-        </div>
-
-        <!-- Sidebar -->
-        <div class="space-y-6">
-          <!-- Quick Links -->
-          <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
-            <h3 class="text-base font-semibold text-slate-900 mb-4">Quick Links</h3>
-            <nav class="space-y-2">
-              <a
-                href="/portal/quotes"
-                class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors min-h-[44px]"
-              >
-                <svg
-                  class="w-5 h-5 text-slate-400 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                  ></path>
-                </svg>
-                <div>
-                  <p class="text-sm font-medium text-slate-900">Proposals</p>
-                  <p class="text-xs text-slate-500">View and sign proposals</p>
-                </div>
-                {
-                  pendingQuotes.length > 0 && (
-                    <span class="ml-auto bg-blue-100 text-blue-800 text-xs font-medium px-2 py-0.5 rounded-full">
-                      {pendingQuotes.length}
-                    </span>
-                  )
-                }
-              </a>
-            </nav>
-          </div>
-
-          <!-- Quotes Summary -->
-          {
-            quotes.length > 0 && (
-              <div class="bg-white rounded-lg border border-slate-200 p-5 sm:p-6">
-                <h3 class="text-base font-semibold text-slate-900 mb-3">Proposal Summary</h3>
-                <div class="space-y-2 text-sm">
-                  {pendingQuotes.length > 0 && (
-                    <div class="flex justify-between">
-                      <span class="text-slate-500">Pending review</span>
-                      <span class="font-medium text-blue-600">{pendingQuotes.length}</span>
-                    </div>
-                  )}
-                  {quotes.filter((q: Quote) => q.status === 'accepted').length > 0 && (
-                    <div class="flex justify-between">
-                      <span class="text-slate-500">Accepted</span>
-                      <span class="font-medium text-green-600">
-                        {quotes.filter((q: Quote) => q.status === 'accepted').length}
-                      </span>
-                    </div>
-                  )}
-                </div>
-                <a
-                  href="/portal/quotes"
-                  class="block mt-3 pt-3 border-t border-slate-100 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
-                >
-                  View all proposals
-                </a>
-              </div>
-            )
-          }
-        </div>
-      </div>
-
-      <!-- Quick Actions -->
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
-        <a
-          href="/portal/engagement"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <h3
-            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-          >
-            Engagement Progress
-          </h3>
-          <p class="text-sm text-slate-500 mt-1">
-            View your engagement milestones, timeline, and current status.
-          </p>
-        </a>
-
-        <a
-          href="/portal/documents"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <h3
-            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-          >
-            Documents
-          </h3>
-          <p class="text-sm text-slate-500 mt-1">
-            Access your statement of work, deliverables, and other engagement documents.
-          </p>
-        </a>
-
-        <a
-          href="/portal/invoices"
-          class="bg-white rounded-lg border border-slate-200 p-6 hover:border-slate-300 transition-colors group"
-        >
-          <h3
-            class="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors"
-          >
-            Invoices
-          </h3>
-          <p class="text-sm text-slate-500 mt-1">
-            View invoices and make payments for your engagement.
-          </p>
-        </a>
+        </section>
       </div>
     </main>
   </body>

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -280,7 +280,18 @@ const contextSubtext = touchpointText
       showSms={Boolean(smsHref)}
       smsHref={smsHref ?? undefined}
       smsLabel={`Text ${consultantFirst}`}
-    />
+    >
+      <form method="POST" action="/api/auth/logout">
+        <button
+          type="submit"
+          aria-label="Sign out"
+          title="Sign out"
+          class="inline-flex items-center justify-center w-9 h-9 rounded-full text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-primary)]/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 transition-colors"
+        >
+          <span class="material-symbols-outlined text-[20px]">logout</span>
+        </button>
+      </form>
+    </PortalHeader>
 
     <main class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
       <!-- Desktop: two-column grid. Mobile: single column, action-first. -->

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -608,10 +608,19 @@ describe('invoices: env.d.ts bindings', () => {
 describe('invoices: portal dashboard integration', () => {
   const source = () => readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
 
-  it('portal dashboard has Invoices quick link', () => {
+  it('surfaces the pending invoice as the dominant action', () => {
     const code = source()
-    expect(code).toContain('/portal/invoices')
-    expect(code).toContain('Invoices')
+    // C-hybrid replaces the Invoices quick link with an ActionCard that deep-links
+    // to the specific invoice. Keep users one tap away from payment.
+    expect(code).toContain('pendingInvoice')
+    expect(code).toContain('/portal/invoices/')
+    expect(code).toContain('Pay invoice')
+  })
+
+  it('links paid and sent invoices from the activity timeline', () => {
+    const code = source()
+    expect(code).toContain('/portal/invoices/')
+    expect(code).toMatch(/Invoice #/)
   })
 })
 

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -73,37 +73,42 @@ describe('portal quotes: dashboard', () => {
     expect(source()).toContain('client.name')
   })
 
-  it('shows pending quotes section', () => {
+  it('surfaces proposal activity in the timeline', () => {
     const code = source()
-    expect(code).toContain('pendingQuotes')
-    expect(code).toContain('proposal')
+    // C-hybrid timeline merges quote, invoice, and milestone events.
+    expect(code).toContain('quotes')
+    expect(code).toMatch(/proposal/i)
   })
 
-  it('loads quotes via listQuotesForEntity', () => {
-    expect(source()).toContain('listQuotesForEntity')
+  it('loads quotes scoped to the signed-in entity', () => {
+    const code = source()
+    // New design inlines the query (needs richer columns than listQuotesForEntity exposes).
+    expect(code).toContain('FROM quotes')
+    expect(code).toContain('entity_id = ?')
   })
 
   it('resolves client via getPortalClient', () => {
     expect(source()).toContain('getPortalClient')
   })
 
-  it('shows active engagement status', () => {
+  it('shows active engagement context', () => {
     const code = source()
     expect(code).toContain('activeEngagement')
-    expect(code).toContain('Current Engagement')
+    // Guide voice: "Your engagement is in flight." replaces "Current Engagement".
+    expect(code).toMatch(/engagement is in flight/i)
   })
 
-  it('shows current milestone', () => {
-    expect(source()).toContain('currentMilestone')
+  it('surfaces completed milestones in the timeline', () => {
+    expect(source()).toContain('completedMilestones')
   })
 
   it('shows recent activity feed', () => {
-    expect(source()).toContain('recentActivity')
-    expect(source()).toContain('Recent Activity')
+    expect(source()).toContain('timeline')
+    expect(source()).toContain('Recent activity')
   })
 
-  it('has quick links to quotes section', () => {
-    expect(source()).toContain('/portal/quotes')
+  it('links proposal timeline entries to the quotes surface', () => {
+    expect(source()).toContain('/portal/quotes/')
   })
 
   it('has mobile viewport meta tag', () => {


### PR DESCRIPTION
Closes #361.

## Summary
- Rewrites `src/pages/portal/index.astro` to the action-centric C-hybrid layout from `.stitch/portal-ux-brief.md`.
- Mobile: dominant action (invoice `ActionCard` or next-touchpoint block) pins above the fold, `ConsultantBlock` below, timeline after a divider.
- Desktop: two-column grid — eyebrow + context + timeline on the left, sticky `ActionCard` + `ConsultantBlock` on the right (targets 1280px).
- No-pending-invoice state promotes next touchpoint to the dominant element; falls through to a neutral "in flight" panel if neither is known.
- Recent activity merges quote events, invoice events, and completed milestones; most-recent-first, up to 5 entries. Past-tense copy, inline `ArtifactChip` on entries referencing files.

## What was removed
- "Welcome, {name}" greeting
- Quick Links sidebar card
- Proposals / Documents / Invoices 3-up tile grid
- Quick Actions grid
- Inline "Current Engagement" status card (collapsed into timeline + context line)
- "Sign out" form in header (out of scope; follow-up for account-menu work)

## Voice and tokens
- Brief hex tokens used via `src/styles/global.css` custom properties; Stitch HTML's `#00288e` / `#173bab` hallucinations ignored.
- No em dashes in user-facing copy. No "Welcome back" greetings. Guide persona.
- Composes only shared components from `src/components/portal/*`; zero inline re-implementation.

## Verification
- `npm run typecheck` — 0 errors, 0 warnings in this change.
- `npm run lint` — 0 errors (existing warnings in unrelated files only).
- `npm run build` — clean.

## Acceptance
- [x] Pay-invoice button sits in the right-thumb zone above the fold on 390×844 (invoice `ActionCard` is the first stacked block on mobile).
- [x] Desktop two-column split with sticky right rail (`md:order-2 md:sticky md:top-10`).
- [x] No nav tabs, footer chrome, testimonials, or "Welcome back" greeting.
- [x] No-pending-action state renders next-touchpoint as the dominant element.
- [x] Imports only from `src/components/portal/*`.
- [x] typecheck / lint / build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)