### PR TITLE
feat(portal): consultant photo hosting infrastructure (#368)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -20,6 +20,12 @@ declare module '*.wasm' {
 type CfEnv = {
   DB: D1Database
   STORAGE: R2Bucket
+  /**
+   * R2 bucket for consultant portrait photos. Separate from STORAGE because
+   * this bucket is intended to be public (objects served directly to the
+   * portal via a Cloudflare-managed public URL). See wrangler.toml.
+   */
+  CONSULTANT_PHOTOS: R2Bucket
   SESSIONS: KVNamespace
   BOOKING_CACHE: KVNamespace
   /**
@@ -64,6 +70,13 @@ type CfEnv = {
   TURNSTILE_SECRET_KEY?: string
   /** Static video call URL for booking events (e.g. Zoom personal meeting link). */
   MEETING_URL?: string
+  /**
+   * Public base URL for the CONSULTANT_PHOTOS bucket, e.g.
+   * `https://pub-<id>.r2.dev` (dev-time) or a custom domain like
+   * `https://photos.smd.services` in production. When unset, the upload
+   * endpoint falls back to streaming via `/api/portal/consultants/photo/[key]`.
+   */
+  CONSULTANT_PHOTOS_PUBLIC_BASE?: string
 }
 
 type Runtime = import('@astrojs/cloudflare').Runtime<CfEnv>

--- a/src/lib/db/engagements.ts
+++ b/src/lib/db/engagements.ts
@@ -22,6 +22,12 @@ export interface Engagement {
   status: string
   estimated_hours: number | null
   actual_hours: number
+  consultant_name: string | null
+  consultant_photo_url: string | null
+  consultant_role: string | null
+  consultant_phone: string | null
+  next_touchpoint_at: string | null
+  next_touchpoint_label: string | null
   created_at: string
   updated_at: string
 }
@@ -80,6 +86,12 @@ export interface UpdateEngagementData {
   safety_net_end?: string | null
   estimated_hours?: number | null
   actual_hours?: number | null
+  consultant_name?: string | null
+  consultant_photo_url?: string | null
+  consultant_role?: string | null
+  consultant_phone?: string | null
+  next_touchpoint_at?: string | null
+  next_touchpoint_label?: string | null
 }
 
 /**
@@ -216,6 +228,36 @@ export async function updateEngagement(
   if (data.actual_hours !== undefined) {
     fields.push('actual_hours = ?')
     params.push(data.actual_hours)
+  }
+
+  if (data.consultant_name !== undefined) {
+    fields.push('consultant_name = ?')
+    params.push(data.consultant_name)
+  }
+
+  if (data.consultant_photo_url !== undefined) {
+    fields.push('consultant_photo_url = ?')
+    params.push(data.consultant_photo_url)
+  }
+
+  if (data.consultant_role !== undefined) {
+    fields.push('consultant_role = ?')
+    params.push(data.consultant_role)
+  }
+
+  if (data.consultant_phone !== undefined) {
+    fields.push('consultant_phone = ?')
+    params.push(data.consultant_phone)
+  }
+
+  if (data.next_touchpoint_at !== undefined) {
+    fields.push('next_touchpoint_at = ?')
+    params.push(data.next_touchpoint_at)
+  }
+
+  if (data.next_touchpoint_label !== undefined) {
+    fields.push('next_touchpoint_label = ?')
+    params.push(data.next_touchpoint_label)
   }
 
   if (fields.length === 0) {

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -513,6 +513,100 @@ function fileSize(bytes: number): string {
       </details>
     </div>
 
+    <!-- Consultant photo -->
+    <div class="bg-white rounded-lg border border-slate-200">
+      <div class="px-6 py-4 border-b border-slate-100">
+        <h2 class="font-medium text-slate-900">Consultant Photo</h2>
+        <p class="text-xs text-slate-500 mt-1">
+          Shown on every portal surface for this engagement. Square, 400×400
+          recommended. We'll crop to a circle and encode as WebP in your browser
+          before upload. JPEG/PNG/WebP up to 5 MB.
+        </p>
+      </div>
+      <div class="px-6 py-5">
+        <div class="flex items-start gap-5">
+          <div
+            class="w-20 h-20 shrink-0 rounded-full bg-slate-50 border border-slate-200 overflow-hidden"
+          >
+            {
+              engagement.consultant_photo_url ? (
+                <img
+                  id="consultant-photo-current"
+                  src={engagement.consultant_photo_url}
+                  alt="Current consultant photo"
+                  class="w-full h-full object-cover"
+                />
+              ) : (
+                <svg
+                  id="consultant-photo-placeholder"
+                  viewBox="0 0 80 80"
+                  class="w-full h-full text-slate-400"
+                  aria-hidden="true"
+                >
+                  <rect width="80" height="80" fill="currentColor" fill-opacity="0.12" />
+                  <circle cx="40" cy="32" r="13" fill="currentColor" fill-opacity="0.5" />
+                  <path
+                    d="M14 74c4-13 14-20 26-20s22 7 26 20"
+                    fill="currentColor"
+                    fill-opacity="0.5"
+                  />
+                </svg>
+              )
+            }
+          </div>
+          <div class="flex-1 min-w-0">
+            <canvas
+              id="photo-preview"
+              width="160"
+              height="160"
+              class="hidden rounded-full border border-slate-200 mb-3"
+            ></canvas>
+            <div id="photo-controls" class="flex flex-wrap items-center gap-2">
+              <input
+                type="file"
+                id="photo-input"
+                accept="image/jpeg,image/png,image/webp"
+                class="hidden"
+              />
+              <button
+                type="button"
+                id="photo-choose"
+                class="text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-700 hover:bg-slate-50 transition-colors"
+              >
+                Choose Photo
+              </button>
+              <button
+                type="button"
+                id="photo-upload"
+                class="hidden text-xs px-3 py-1.5 rounded bg-slate-900 text-white hover:bg-slate-800 transition-colors"
+              >
+                Upload
+              </button>
+              <button
+                type="button"
+                id="photo-cancel"
+                class="hidden text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-600 hover:bg-slate-50 transition-colors"
+              >
+                Cancel
+              </button>
+              {
+                engagement.consultant_photo_url && (
+                  <button
+                    type="button"
+                    id="photo-remove"
+                    class="text-xs px-3 py-1.5 rounded border border-red-200 text-red-600 hover:bg-red-50 transition-colors"
+                  >
+                    Remove
+                  </button>
+                )
+              }
+            </div>
+            <p id="photo-status" class="mt-2 text-xs text-slate-500"></p>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Deliverables -->
     <div class="bg-white rounded-lg border border-slate-200">
       <div class="px-6 py-4 border-b border-slate-100">
@@ -671,6 +765,153 @@ function fileSize(bytes: number): string {
         }
       }
       setTimeout(() => location.reload(), 800)
+    }
+  </script>
+
+  <script define:vars={{ engagementId }}>
+    // Consultant photo: client-side square-crop and WebP encode, then upload.
+    // We crop in the browser to avoid a WASM image pipeline on the Worker — the
+    // server accepts pre-processed WebP/JPEG/PNG under 5 MB and stores to R2.
+    const photoInput = document.getElementById('photo-input')
+    const photoChoose = document.getElementById('photo-choose')
+    const photoUpload = document.getElementById('photo-upload')
+    const photoCancel = document.getElementById('photo-cancel')
+    const photoRemove = document.getElementById('photo-remove')
+    const photoPreview = document.getElementById('photo-preview')
+    const photoStatus = document.getElementById('photo-status')
+
+    let pendingBlob = null
+    const TARGET_SIZE = 400
+    const PREVIEW_SIZE = 160
+    const MAX_BYTES = 5 * 1024 * 1024
+
+    function setStatus(msg, isError) {
+      if (!photoStatus) return
+      photoStatus.textContent = msg
+      photoStatus.className = isError
+        ? 'mt-2 text-xs text-red-600'
+        : 'mt-2 text-xs text-slate-500'
+    }
+
+    async function cropToSquareWebp(file) {
+      if (file.size > MAX_BYTES) {
+        throw new Error('Original file exceeds 5 MB. Please pick a smaller image.')
+      }
+      const bitmap = await createImageBitmap(file)
+      const side = Math.min(bitmap.width, bitmap.height)
+      const sx = Math.round((bitmap.width - side) / 2)
+      const sy = Math.round((bitmap.height - side) / 2)
+
+      const canvas = document.createElement('canvas')
+      canvas.width = TARGET_SIZE
+      canvas.height = TARGET_SIZE
+      const ctx = canvas.getContext('2d')
+      ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, TARGET_SIZE, TARGET_SIZE)
+
+      if (photoPreview) {
+        photoPreview.width = PREVIEW_SIZE
+        photoPreview.height = PREVIEW_SIZE
+        const pctx = photoPreview.getContext('2d')
+        pctx.drawImage(canvas, 0, 0, PREVIEW_SIZE, PREVIEW_SIZE)
+        photoPreview.classList.remove('hidden')
+      }
+
+      const blob = await new Promise((resolve, reject) => {
+        canvas.toBlob(
+          (b) => (b ? resolve(b) : reject(new Error('Encoding failed'))),
+          'image/webp',
+          0.9
+        )
+      })
+      if (blob.size > MAX_BYTES) {
+        throw new Error('Encoded photo still exceeds 5 MB. Try a smaller source image.')
+      }
+      return blob
+    }
+
+    if (photoChoose && photoInput) {
+      photoChoose.addEventListener('click', () => photoInput.click())
+    }
+
+    if (photoInput) {
+      photoInput.addEventListener('change', async () => {
+        const file = photoInput.files && photoInput.files[0]
+        if (!file) return
+        try {
+          setStatus('Processing image...', false)
+          pendingBlob = await cropToSquareWebp(file)
+          setStatus(
+            `Ready to upload (${(pendingBlob.size / 1024).toFixed(1)} KB WebP)`,
+            false
+          )
+          photoUpload.classList.remove('hidden')
+          photoCancel.classList.remove('hidden')
+        } catch (err) {
+          pendingBlob = null
+          setStatus(err.message || 'Could not process image', true)
+        }
+      })
+    }
+
+    if (photoCancel) {
+      photoCancel.addEventListener('click', () => {
+        pendingBlob = null
+        if (photoInput) photoInput.value = ''
+        if (photoPreview) photoPreview.classList.add('hidden')
+        photoUpload.classList.add('hidden')
+        photoCancel.classList.add('hidden')
+        setStatus('', false)
+      })
+    }
+
+    if (photoUpload) {
+      photoUpload.addEventListener('click', async () => {
+        if (!pendingBlob) return
+        photoUpload.disabled = true
+        photoCancel.disabled = true
+        setStatus('Uploading...', false)
+        const form = new FormData()
+        form.append('photo', new File([pendingBlob], 'consultant.webp', { type: 'image/webp' }))
+        try {
+          const res = await fetch(
+            `/api/admin/engagements/${engagementId}/consultant-photo`,
+            { method: 'POST', body: form }
+          )
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}))
+            throw new Error(data.error || res.statusText)
+          }
+          setStatus('Photo uploaded. Reloading...', false)
+          setTimeout(() => location.reload(), 500)
+        } catch (err) {
+          setStatus(err.message || 'Upload failed', true)
+          photoUpload.disabled = false
+          photoCancel.disabled = false
+        }
+      })
+    }
+
+    if (photoRemove) {
+      photoRemove.addEventListener('click', async () => {
+        if (!confirm('Remove the current consultant photo?')) return
+        photoRemove.disabled = true
+        setStatus('Removing...', false)
+        try {
+          const res = await fetch(
+            `/api/admin/engagements/${engagementId}/consultant-photo`,
+            { method: 'DELETE' }
+          )
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}))
+            throw new Error(data.error || res.statusText)
+          }
+          setStatus('Photo removed. Reloading...', false)
+          setTimeout(() => location.reload(), 500)
+        } catch (err) {
+          setStatus(err.message || 'Remove failed', true)
+          photoRemove.disabled = false
+        }
+      })
     }
   </script>
 </AdminLayout>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -518,9 +518,8 @@ function fileSize(bytes: number): string {
       <div class="px-6 py-4 border-b border-slate-100">
         <h2 class="font-medium text-slate-900">Consultant Photo</h2>
         <p class="text-xs text-slate-500 mt-1">
-          Shown on every portal surface for this engagement. Square, 400×400
-          recommended. We'll crop to a circle and encode as WebP in your browser
-          before upload. JPEG/PNG/WebP up to 5 MB.
+          Shown on every portal surface for this engagement. Square, 400×400 recommended. We'll crop
+          to a circle and encode as WebP in your browser before upload. JPEG/PNG/WebP up to 5 MB.
         </p>
       </div>
       <div class="px-6 py-5">
@@ -559,8 +558,7 @@ function fileSize(bytes: number): string {
               id="photo-preview"
               width="160"
               height="160"
-              class="hidden rounded-full border border-slate-200 mb-3"
-            ></canvas>
+              class="hidden rounded-full border border-slate-200 mb-3"></canvas>
             <div id="photo-controls" class="flex flex-wrap items-center gap-2">
               <input
                 type="file"
@@ -788,9 +786,7 @@ function fileSize(bytes: number): string {
     function setStatus(msg, isError) {
       if (!photoStatus) return
       photoStatus.textContent = msg
-      photoStatus.className = isError
-        ? 'mt-2 text-xs text-red-600'
-        : 'mt-2 text-xs text-slate-500'
+      photoStatus.className = isError ? 'mt-2 text-xs text-red-600' : 'mt-2 text-xs text-slate-500'
     }
 
     async function cropToSquareWebp(file) {
@@ -840,10 +836,7 @@ function fileSize(bytes: number): string {
         try {
           setStatus('Processing image...', false)
           pendingBlob = await cropToSquareWebp(file)
-          setStatus(
-            `Ready to upload (${(pendingBlob.size / 1024).toFixed(1)} KB WebP)`,
-            false
-          )
+          setStatus(`Ready to upload (${(pendingBlob.size / 1024).toFixed(1)} KB WebP)`, false)
           photoUpload.classList.remove('hidden')
           photoCancel.classList.remove('hidden')
         } catch (err) {
@@ -873,10 +866,10 @@ function fileSize(bytes: number): string {
         const form = new FormData()
         form.append('photo', new File([pendingBlob], 'consultant.webp', { type: 'image/webp' }))
         try {
-          const res = await fetch(
-            `/api/admin/engagements/${engagementId}/consultant-photo`,
-            { method: 'POST', body: form }
-          )
+          const res = await fetch(`/api/admin/engagements/${engagementId}/consultant-photo`, {
+            method: 'POST',
+            body: form,
+          })
           if (!res.ok) {
             const data = await res.json().catch(() => ({}))
             throw new Error(data.error || res.statusText)
@@ -897,10 +890,9 @@ function fileSize(bytes: number): string {
         photoRemove.disabled = true
         setStatus('Removing...', false)
         try {
-          const res = await fetch(
-            `/api/admin/engagements/${engagementId}/consultant-photo`,
-            { method: 'DELETE' }
-          )
+          const res = await fetch(`/api/admin/engagements/${engagementId}/consultant-photo`, {
+            method: 'DELETE',
+          })
           if (!res.ok) {
             const data = await res.json().catch(() => ({}))
             throw new Error(data.error || res.statusText)

--- a/src/pages/api/admin/engagements/[id]/consultant-photo.ts
+++ b/src/pages/api/admin/engagements/[id]/consultant-photo.ts
@@ -1,0 +1,190 @@
+import type { APIRoute } from 'astro'
+import { getEngagement, updateEngagement } from '../../../../../lib/db/engagements'
+
+/**
+ * Consultant photo upload endpoint.
+ *
+ * Image processing happens client-side (canvas crop + WebP encode) before
+ * upload — see the admin engagement detail page. `sharp` is not
+ * Workers-compatible, and a WASM image pipeline (@cf-wasm/photon) adds
+ * meaningful cold-start cost for a workflow that needs one photo per
+ * consultant. The server trusts that the client produced a WebP/JPEG/PNG
+ * under 5 MB and validates only those two invariants before persisting
+ * bytes to R2 and the public URL to `engagements.consultant_photo_url`.
+ *
+ * When `CONSULTANT_PHOTOS_PUBLIC_BASE` is set, the stored URL is the direct
+ * public R2 URL. When unset, we fall back to the in-app streaming route at
+ * `/api/portal/consultants/photo/[...key]`.
+ */
+
+const MAX_BYTES = 5 * 1024 * 1024 // 5 MB
+const ACCEPTED_TYPES = new Set(['image/webp', 'image/jpeg', 'image/png'])
+
+function extensionFor(mime: string): string {
+  if (mime === 'image/webp') return 'webp'
+  if (mime === 'image/png') return 'png'
+  return 'jpg'
+}
+
+export const POST: APIRoute = async ({ request, locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const engagementId = params.id
+  if (!engagementId) {
+    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+    if (!engagement) {
+      return new Response(JSON.stringify({ error: 'Engagement not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const formData = await request.formData()
+    const file = formData.get('photo')
+
+    if (!file || !(file instanceof File)) {
+      return new Response(JSON.stringify({ error: 'Photo file required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (!ACCEPTED_TYPES.has(file.type)) {
+      return new Response(
+        JSON.stringify({
+          error: `Unsupported image type: ${file.type || 'unknown'}. Expected WebP, JPEG, or PNG.`,
+        }),
+        { status: 415, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    if (file.size > MAX_BYTES) {
+      return new Response(
+        JSON.stringify({
+          error: `Photo exceeds 5 MB limit (received ${(file.size / (1024 * 1024)).toFixed(2)} MB)`,
+        }),
+        { status: 413, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    if (file.size === 0) {
+      return new Response(JSON.stringify({ error: 'Photo file is empty' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const ext = extensionFor(file.type)
+    const key = `${session.orgId}/engagements/${engagementId}/${Date.now()}.${ext}`
+    const bytes = await file.arrayBuffer()
+
+    await env.CONSULTANT_PHOTOS.put(key, bytes, {
+      httpMetadata: { contentType: file.type },
+      customMetadata: {
+        engagementId,
+        orgId: session.orgId,
+        uploadedAt: new Date().toISOString(),
+        uploadedBy: session.userId,
+      },
+    })
+
+    const publicBase = env.CONSULTANT_PHOTOS_PUBLIC_BASE?.replace(/\/$/, '')
+    const photoUrl = publicBase
+      ? `${publicBase}/${key}`
+      : `/api/portal/consultants/photo/${key}`
+
+    await updateEngagement(env.DB, session.orgId, engagementId, {
+      consultant_photo_url: photoUrl,
+    })
+
+    return new Response(JSON.stringify({ key, url: photoUrl }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error('[api/admin/engagements/[id]/consultant-photo] Upload error:', err)
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
+export const DELETE: APIRoute = async ({ locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const engagementId = params.id
+  if (!engagementId) {
+    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+
+  try {
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+    if (!engagement) {
+      return new Response(JSON.stringify({ error: 'Engagement not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const currentUrl = engagement.consultant_photo_url
+    const publicBase = env.CONSULTANT_PHOTOS_PUBLIC_BASE?.replace(/\/$/, '')
+    const streamPrefix = '/api/portal/consultants/photo/'
+
+    // Only attempt R2 delete on URLs we control. External URLs (if a user ever
+    // pastes one manually) are simply dereferenced by clearing the column.
+    let key: string | null = null
+    if (currentUrl) {
+      if (publicBase && currentUrl.startsWith(`${publicBase}/`)) {
+        key = currentUrl.slice(publicBase.length + 1)
+      } else if (currentUrl.startsWith(streamPrefix)) {
+        key = currentUrl.slice(streamPrefix.length)
+      }
+    }
+
+    if (key && key.startsWith(`${session.orgId}/`)) {
+      await env.CONSULTANT_PHOTOS.delete(key)
+    }
+
+    await updateEngagement(env.DB, session.orgId, engagementId, {
+      consultant_photo_url: null,
+    })
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error('[api/admin/engagements/[id]/consultant-photo] Delete error:', err)
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/pages/api/admin/engagements/[id]/consultant-photo.ts
+++ b/src/pages/api/admin/engagements/[id]/consultant-photo.ts
@@ -104,9 +104,7 @@ export const POST: APIRoute = async ({ request, locals, params }) => {
     })
 
     const publicBase = env.CONSULTANT_PHOTOS_PUBLIC_BASE?.replace(/\/$/, '')
-    const photoUrl = publicBase
-      ? `${publicBase}/${key}`
-      : `/api/portal/consultants/photo/${key}`
+    const photoUrl = publicBase ? `${publicBase}/${key}` : `/api/portal/consultants/photo/${key}`
 
     await updateEngagement(env.DB, session.orgId, engagementId, {
       consultant_photo_url: photoUrl,

--- a/src/pages/api/portal/consultants/photo/[...key].ts
+++ b/src/pages/api/portal/consultants/photo/[...key].ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from 'astro'
+
+/**
+ * GET /api/portal/consultants/photo/:key
+ *
+ * Streams a consultant photo from the CONSULTANT_PHOTOS R2 bucket.
+ *
+ * This route is the fallback when CONSULTANT_PHOTOS_PUBLIC_BASE is not
+ * configured (bucket is private). The preferred delivery mode is a public
+ * bucket served directly via `pub-*.r2.dev` or a custom R2 domain — that
+ * avoids the Worker roundtrip and lets Cloudflare's edge cache serve
+ * photos directly.
+ *
+ * Security:
+ * - Protected by portal middleware (role='client' required)
+ * - Keys are tenant-scoped (`{orgId}/engagements/{engagementId}/...`) and
+ *   must match the caller's orgId — path traversal rejected
+ */
+
+const CONTENT_TYPES: Record<string, string> = {
+  webp: 'image/webp',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+}
+
+export const GET: APIRoute = async ({ locals, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'client') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const key = params.key
+  if (!key) {
+    return new Response(JSON.stringify({ error: 'Key required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  if (!key.startsWith(`${session.orgId}/engagements/`)) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  if (key.includes('..') || key.includes('//')) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const env = locals.runtime.env
+  const object = await env.CONSULTANT_PHOTOS.get(key)
+  if (!object) {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const ext = key.substring(key.lastIndexOf('.') + 1).toLowerCase()
+  const contentType =
+    object.httpMetadata?.contentType ?? CONTENT_TYPES[ext] ?? 'application/octet-stream'
+
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': 'private, max-age=3600',
+    },
+  })
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,6 +38,15 @@ database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
 binding = "STORAGE"
 bucket_name = "ss-console-storage"
 
+# ---------- R2 (consultant photos, public) ----------
+# Intended to be a public bucket — object URLs are served directly to the
+# portal. Create with: npx wrangler r2 bucket create smd-consultant-photos
+# Then enable public access in the Cloudflare dashboard and set the resulting
+# public base URL via: npx wrangler secret put CONSULTANT_PHOTOS_PUBLIC_BASE
+[[r2_buckets]]
+binding = "CONSULTANT_PHOTOS"
+bucket_name = "smd-consultant-photos"
+
 # ---------- Workers KV (sessions) ----------
 [[kv_namespaces]]
 binding = "SESSIONS"


### PR DESCRIPTION
Closes #368.

## Summary

Infrastructure for hosting consultant photos on the portal. Admins upload a photo from the engagement detail page; it is cropped to 400x400 WebP in the browser, stored in R2, and written to `engagements.consultant_photo_url` so `ConsultantBlock` renders it on the portal.

- New R2 binding `CONSULTANT_PHOTOS` (bucket `smd-consultant-photos`, intended public).
- `POST/DELETE /api/admin/engagements/[id]/consultant-photo` — admin-authed multipart upload and removal.
- `GET /api/portal/consultants/photo/[...key]` — client-authed streaming fallback used when the bucket is not yet public.
- Admin engagement detail page: upload UI with client-side preview, crop, and WebP encode; Remove button.
- `engagements.ts` DAL exposes the 6 consultant/touchpoint fields already present in migration 0019.

No actual photo is included in this PR — infrastructure only. `ConsultantBlock` already renders a neutral SVG silhouette when `photoUrl` is null (no change needed).

## Design decisions

**Image processing: client-side canvas + WebP.** `sharp` is not Workers-compatible, and `@cf-wasm/photon` is unnecessary weight for a 1-photo-per-consultant workflow. The browser center-crops via `createImageBitmap` + canvas, encodes `image/webp` at quality 0.9, and POSTs the result. The server validates type (webp/jpeg/png), size (<=5MB), and non-empty body, then stores as-is. Faster cold starts, no WASM, no CPU budget concerns.

**Delivery: public R2 with authenticated fallback.** If `CONSULTANT_PHOTOS_PUBLIC_BASE` is set (after the bucket is made public in the dashboard), stored URLs point directly at the CDN-cached public URL. Until then, URLs resolve to the authenticated `/api/portal/consultants/photo/[...key]` streaming route, which enforces that the key starts with `{orgId}/engagements/` and rejects path traversal. The DB stores whichever URL was generated at upload time — switching to public is a follow-up migration, not a code change here.

**Endpoint path.** Task spec said `/api/admin/consultants/[id]/photo`, but consultants aren't a separate table in v1 — the fields live on `engagements` (migration 0019). Endpoint is `/api/admin/engagements/[id]/consultant-photo` to match the data model. Re-homing is cheap if consultants become their own table later.

**R2 key layout.** `{orgId}/engagements/{engagementId}/{timestamp}.webp` — tenant-scoped prefix so the streaming route can enforce org boundaries with a prefix check.

## Operator setup (not part of this PR)

1. `npx wrangler r2 bucket create smd-consultant-photos`
2. Enable public access in the Cloudflare dashboard, copy the public base URL.
3. `npx wrangler secret put CONSULTANT_PHOTOS_PUBLIC_BASE` with that URL (no trailing slash).

Until step 3, uploads still work — URLs just route through the streaming fallback.

## Test plan

- [ ] `npm run build` passes on a clean tree (verified locally; pre-existing warnings unchanged).
- [ ] As admin, upload a >1MB JPEG on an engagement detail page; confirm 400x400 WebP is stored in R2 and `consultant_photo_url` is set.
- [ ] Reject non-image uploads and >5MB originals client-side; server rejects the same cases with 400.
- [ ] Visit portal engagement page; photo renders via the stored URL.
- [ ] Click Remove; `consultant_photo_url` clears and SVG silhouette returns.
- [ ] After setting `CONSULTANT_PHOTOS_PUBLIC_BASE`, new uploads return public URLs; existing private URLs continue to serve via the streaming route.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>