### PR TITLE
feat(portal): SMS wiring and error states (#364, #365)

### DIFF
--- a/src/components/portal/ConsultantBlock.astro
+++ b/src/components/portal/ConsultantBlock.astro
@@ -6,8 +6,13 @@
  * Photo fallback is a neutral SVG portrait silhouette. NEVER initials — brief
  * §Anti-patterns and §Photo placeholder rule.
  *
- * SMS link uses the sms: URI scheme for mobile deep linking. When phone is
- * missing we fall back to a plain mailto/noop so layout remains intact.
+ * Contact affordance:
+ * - Mobile UAs render `sms:` deep link as the primary action (tap-to-text)
+ *   per brief §Mobile thumb zone.
+ * - Desktop UAs render an inline `tel:` number for click-to-call via
+ *   FaceTime / soft phones.
+ * - When phone is null but email is set: render a `mailto:` fallback instead.
+ * - When both are null: hide the contact block entirely.
  */
 
 interface Props {
@@ -17,12 +22,29 @@ interface Props {
   nextTouchpointAt?: string | null
   nextTouchpointLabel?: string | null
   phone?: string | null
+  email?: string | null
 }
 
-const { name, photoUrl, role, nextTouchpointAt, nextTouchpointLabel, phone } = Astro.props
+const { name, photoUrl, role, nextTouchpointAt, nextTouchpointLabel, phone, email } = Astro.props
 
 const firstName = (name ?? '').trim().split(/\s+/)[0] || name
-const smsHref = phone ? `sms:${phone.replace(/[^+\d]/g, '')}` : null
+
+const phoneDigits = phone ? phone.replace(/[^+\d]/g, '') : null
+const smsHref = phoneDigits ? `sms:${phoneDigits}` : null
+const telHref = phoneDigits ? `tel:${phoneDigits}` : null
+
+// Display a human-formatted phone for the desktop inline affordance. Falls
+// back to the digit string when the format isn't recognized.
+function formatUsPhone(digits: string): string {
+  const m = digits.match(/^\+?1?(\d{3})(\d{3})(\d{4})$/)
+  if (!m) return digits
+  return `(${m[1]}) ${m[2]}-${m[3]}`
+}
+const phoneDisplay = phoneDigits ? formatUsPhone(phoneDigits) : null
+
+// Mailto fallback used only when phone is absent. Email is never shown as an
+// inline button when phone is present — SMS is the primary affordance.
+const mailtoHref = !phoneDigits && email ? `mailto:${email}` : null
 
 function formatTouchpoint(): string | null {
   if (nextTouchpointLabel) return nextTouchpointLabel
@@ -92,14 +114,39 @@ const touchpointText = formatTouchpoint()
     </div>
   </div>
   {
-    smsHref && (
+    smsHref && telHref && (
       <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
+        {/* Mobile: SMS deep link. Hidden on desktop (sm+). */}
         <a
           href={smsHref}
-          class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+          class="consultant-sms-mobile inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
         >
           <span class="material-symbols-outlined text-[18px]">sms</span>
           Text {firstName}
+        </a>
+        {/* Desktop: inline phone number with click-to-call. */}
+        <a
+          href={telHref}
+          class="consultant-tel-desktop hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+        >
+          <span class="material-symbols-outlined text-[18px]">call</span>
+          {phoneDisplay}
+        </a>
+        <p class="mt-1 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
+          Replies within 1 business day.
+        </p>
+      </div>
+    )
+  }
+  {
+    !smsHref && mailtoHref && (
+      <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
+        <a
+          href={mailtoHref}
+          class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+        >
+          <span class="material-symbols-outlined text-[18px]">mail</span>
+          Email {firstName}
         </a>
         <p class="mt-1 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
           Replies within 1 business day.

--- a/src/lib/portal/states.ts
+++ b/src/lib/portal/states.ts
@@ -1,0 +1,216 @@
+/**
+ * Portal surface state resolver.
+ *
+ * Translates persisted record state + URL query params into a single surface
+ * state plus a concrete next-step text. Each portal deep link surface
+ * (invoice, proposal) narrows to one of these states before rendering.
+ *
+ * The resolver is pure and synchronous — it does not read the database.
+ * Callers pass in the already-loaded record plus Astro.url.searchParams.
+ *
+ * Provider error messages (Stripe, SignWell) must NOT be surfaced raw. The
+ * query param is a trusted hint from our own API surface; the copy that
+ * renders is always written in portal voice.
+ */
+
+export type InvoiceSurfaceState = 'default' | 'paid' | 'declined' | 'card_expired' | 'expired'
+
+export type ProposalSurfaceState = 'default' | 'signed' | 'declined' | 'expired' | 'superseded'
+
+export interface InvoiceSurface {
+  state: InvoiceSurfaceState
+  next: string
+}
+
+export interface ProposalSurface {
+  state: ProposalSurfaceState
+  next: string
+}
+
+/**
+ * Minimal invoice shape the resolver needs. Callers may pass the full Invoice
+ * row; extra fields are ignored.
+ */
+interface InvoiceLike {
+  paid_at: string | null
+  due_date?: string | null
+  status?: string | null
+}
+
+/**
+ * Minimal quote shape the resolver needs.
+ */
+interface QuoteLike {
+  status: string
+  accepted_at: string | null
+  expires_at: string | null
+}
+
+type SearchParamSource = URLSearchParams | { get(name: string): string | null }
+
+function readStateParam(params: SearchParamSource | null | undefined): string | null {
+  if (!params) return null
+  const raw = params.get('state')
+  if (!raw) return null
+  return raw.trim().toLowerCase()
+}
+
+/**
+ * Resolve the surface state for an invoice deep link.
+ *
+ * Priority order:
+ *   1. `invoice.paid_at` → `paid` (server truth always wins)
+ *   2. `?state=` hint (declined, card_expired, expired) after a Stripe
+ *      redirect — we translate to portal voice, never surface raw provider
+ *      messages
+ *   3. Server-side expiration (future enhancement)
+ *   4. `default` — render the pay CTA
+ *
+ * The `firstName` arg is the consultant first name used in the next-step
+ * copy ("Text {FirstName} for a refreshed link").
+ */
+export function resolveInvoiceState(
+  invoice: InvoiceLike,
+  params: SearchParamSource | null,
+  firstName: string
+): InvoiceSurface {
+  if (invoice.paid_at) {
+    return {
+      state: 'paid',
+      next: `Receipt attached. Head back to the engagement dashboard.`,
+    }
+  }
+
+  const hint = readStateParam(params)
+
+  if (hint === 'declined') {
+    return {
+      state: 'declined',
+      next: `Your card was declined. Try again, or text ${firstName} if this keeps happening.`,
+    }
+  }
+
+  if (hint === 'card_expired') {
+    return {
+      state: 'card_expired',
+      next: `The card on file has expired. Update your payment method to continue.`,
+    }
+  }
+
+  if (hint === 'expired') {
+    return {
+      state: 'expired',
+      next: `This payment link has expired. Text ${firstName} for a refreshed link.`,
+    }
+  }
+
+  return {
+    state: 'default',
+    next: 'Secure payment via Stripe.',
+  }
+}
+
+/**
+ * Resolve the surface state for a proposal deep link.
+ *
+ * Priority:
+ *   1. `status === 'accepted'` → `signed` (server truth)
+ *   2. `status === 'declined'` → `declined`
+ *   3. `status === 'superseded'` → `superseded` (caller supplies the newer
+ *      quote ID via a separate lookup)
+ *   4. `status === 'expired'` OR server-side `expires_at < now` → `expired`
+ *   5. `?state=` hint for signal propagation
+ *   6. `default` — render the sign surface
+ *
+ * nextStepText is the engagement-specific "what happens next" copy, pulled
+ * from engagement.scope_summary / next_touchpoint_label by the caller. When
+ * missing we fall back to a generic kickoff sentence.
+ */
+export function resolveProposalState(
+  quote: QuoteLike,
+  params: SearchParamSource | null,
+  firstName: string,
+  nextStepText: string | null = null
+): ProposalSurface {
+  const status = (quote.status ?? '').toLowerCase()
+
+  if (status === 'accepted' || quote.accepted_at) {
+    const next = nextStepText?.trim() || `We'll reach out to schedule kickoff.`
+    return { state: 'signed', next }
+  }
+
+  if (status === 'declined') {
+    return {
+      state: 'declined',
+      next: `Text ${firstName} if you'd like to talk through a revision.`,
+    }
+  }
+
+  if (status === 'superseded') {
+    return {
+      state: 'superseded',
+      next: `A revised version of this proposal is available.`,
+    }
+  }
+
+  const serverExpired =
+    status === 'expired' ||
+    (!!quote.expires_at && new Date(quote.expires_at).getTime() < Date.now())
+
+  if (serverExpired) {
+    return {
+      state: 'expired',
+      next: `This proposal has expired. Text ${firstName} to pick it back up.`,
+    }
+  }
+
+  const hint = readStateParam(params)
+  if (hint === 'expired') {
+    return {
+      state: 'expired',
+      next: `This proposal has expired. Text ${firstName} to pick it back up.`,
+    }
+  }
+
+  return {
+    state: 'default',
+    next: `Review and sign when you're ready.`,
+  }
+}
+
+/**
+ * Mobile vs desktop contact-link resolver.
+ *
+ * Mobile UAs use `sms:` for direct SMS compose. Desktop UAs use `tel:` so
+ * click-to-call via FaceTime / dialers works and users don't hit a dead
+ * `sms:` link. When `phone` is null we return null and the caller should
+ * hide the contact affordance (or render a mailto fallback if configured).
+ *
+ * The UA regex is the standard Cloudflare / Astro SSR guidance — imperfect
+ * but acceptable for a hint. Clients can always tap the inline phone number.
+ */
+const MOBILE_UA_RE = /iPhone|iPad|Android|Mobile/i
+
+export interface ContactLink {
+  smsHref: string | null
+  telHref: string | null
+  isMobile: boolean
+}
+
+export function resolveContactLink(
+  phone: string | null | undefined,
+  userAgent: string | null | undefined
+): ContactLink {
+  if (!phone) {
+    return { smsHref: null, telHref: null, isMobile: false }
+  }
+
+  const digits = phone.replace(/[^+\d]/g, '')
+  const isMobile = !!userAgent && MOBILE_UA_RE.test(userAgent)
+
+  return {
+    smsHref: `sms:${digits}`,
+    telHref: `tel:${digits}`,
+    isMobile,
+  }
+}

--- a/src/pages/dev/portal-states.astro
+++ b/src/pages/dev/portal-states.astro
@@ -1,0 +1,128 @@
+---
+import '../../styles/global.css'
+
+/**
+ * Dev-only harness for QA'ing all portal error/edge states in one place.
+ *
+ * Each surface lists every `?state=` query param the resolver recognizes.
+ * Production 404s this page so it never ships to clients.
+ *
+ * The three route params below are placeholders — replace `:id` with a real
+ * invoice / quote ID from the running D1 when testing locally.
+ */
+
+if (import.meta.env.PROD) {
+  return new Response('Not found', { status: 404 })
+}
+
+const invoiceStates = [
+  { label: 'Default (pay)', query: '' },
+  { label: 'Payment declined', query: '?state=declined' },
+  { label: 'Card expired', query: '?state=card_expired' },
+  { label: 'Link expired', query: '?state=expired' },
+  { label: 'Already paid (server state — seed invoice.paid_at)', query: '' },
+]
+
+const proposalStates = [
+  { label: 'Default (ready to sign)', query: '' },
+  { label: 'Signed (server state — seed quote.accepted_at)', query: '' },
+  { label: 'Declined (server state — set status=declined)', query: '' },
+  { label: 'Expired (hint)', query: '?state=expired' },
+  { label: 'Expired (server state — expires_at in past)', query: '' },
+  { label: 'Superseded (server state — set status=superseded)', query: '' },
+]
+
+const dashboardStates = [
+  { label: 'Default', path: '/portal' },
+  { label: 'Data fetch error', path: '/portal?state=error' },
+]
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Portal states — dev</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <main class="max-w-3xl mx-auto px-4 sm:px-6 py-10 space-y-10">
+      <header>
+        <p class="text-[12px] font-bold tracking-[0.1em] uppercase text-[color:var(--color-meta)]">
+          Dev harness
+        </p>
+        <h1
+          class="mt-3 font-['Plus_Jakarta_Sans'] font-extrabold text-[32px] leading-[36px] tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        >
+          Portal error and edge states
+        </h1>
+        <p class="mt-3 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
+          Replace <code>:id</code> with a real invoice or quote ID from your local D1.
+        </p>
+      </header>
+
+      <section>
+        <h2
+          class="font-['Plus_Jakarta_Sans'] font-bold text-[20px] leading-[26px] text-[color:var(--color-text-primary)] mb-4"
+        >
+          Dashboard
+        </h2>
+        <ul class="space-y-2">
+          {
+            dashboardStates.map((s) => (
+              <li>
+                <a
+                  href={s.path}
+                  class="text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)] text-sm"
+                >
+                  {s.label} — <code>{s.path}</code>
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+
+      <section>
+        <h2
+          class="font-['Plus_Jakarta_Sans'] font-bold text-[20px] leading-[26px] text-[color:var(--color-text-primary)] mb-4"
+        >
+          Invoice
+        </h2>
+        <ul class="space-y-2">
+          {
+            invoiceStates.map((s) => (
+              <li class="text-sm text-[color:var(--color-text-secondary)]">
+                <span class="font-semibold text-[color:var(--color-text-primary)]">{s.label}</span>
+                {s.query && <code class="ml-2">/portal/invoices/:id{s.query}</code>}
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+
+      <section>
+        <h2
+          class="font-['Plus_Jakarta_Sans'] font-bold text-[20px] leading-[26px] text-[color:var(--color-text-primary)] mb-4"
+        >
+          Proposal
+        </h2>
+        <ul class="space-y-2">
+          {
+            proposalStates.map((s) => (
+              <li class="text-sm text-[color:var(--color-text-secondary)]">
+                <span class="font-semibold text-[color:var(--color-text-primary)]">{s.label}</span>
+                {s.query && <code class="ml-2">/portal/quotes/:id{s.query}</code>}
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -40,18 +40,6 @@ interface EngagementRow {
   next_touchpoint_label: string | null
 }
 
-const activeEngagement = await env.DB.prepare(
-  `SELECT id, status, scope_summary, start_date, estimated_end,
-          consultant_name, consultant_photo_url, consultant_role, consultant_phone,
-          next_touchpoint_at, next_touchpoint_label
-     FROM engagements
-    WHERE entity_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net')
-    ORDER BY created_at DESC
-    LIMIT 1`
-)
-  .bind(client.id)
-  .first<EngagementRow>()
-
 interface InvoiceRow {
   id: string
   amount: number
@@ -74,54 +62,81 @@ interface MilestoneRow {
   completed_at: string | null
 }
 
+let activeEngagement: EngagementRow | null = null
 let pendingInvoice: InvoiceRow | null = null
 let invoices: InvoiceRow[] = []
 let quotes: QuoteRow[] = []
 let completedMilestones: MilestoneRow[] = []
+// When a DB read fails we render a single error state rather than a partial
+// dashboard. ConsultantBlock still renders so the client has a concrete
+// next step (text Scott).
+let dashboardError = false
 
-if (activeEngagement) {
-  const invoiceResult = await env.DB.prepare(
-    `SELECT id, amount, status, due_date, sent_at, paid_at
-       FROM invoices
-      WHERE engagement_id = ? AND status != 'void'
-      ORDER BY created_at DESC`
+try {
+  activeEngagement = await env.DB.prepare(
+    `SELECT id, status, scope_summary, start_date, estimated_end,
+            consultant_name, consultant_photo_url, consultant_role, consultant_phone,
+            next_touchpoint_at, next_touchpoint_label
+       FROM engagements
+      WHERE entity_id = ? AND status IN ('scheduled', 'active', 'handoff', 'safety_net')
+      ORDER BY created_at DESC
+      LIMIT 1`
   )
-    .bind(activeEngagement.id)
-    .all<InvoiceRow>()
-  invoices = invoiceResult.results ?? []
+    .bind(client.id)
+    .first<EngagementRow>()
 
-  // Next pending invoice: earliest-due among sent/overdue (null due_date last).
-  const pending = invoices.filter((i) => i.status === 'sent' || i.status === 'overdue')
-  pending.sort((a, b) => {
-    if (a.due_date && b.due_date) return a.due_date < b.due_date ? -1 : 1
-    if (a.due_date) return -1
-    if (b.due_date) return 1
-    return 0
-  })
-  pendingInvoice = pending[0] ?? null
+  if (activeEngagement) {
+    const invoiceResult = await env.DB.prepare(
+      `SELECT id, amount, status, due_date, sent_at, paid_at
+         FROM invoices
+        WHERE engagement_id = ? AND status != 'void'
+        ORDER BY created_at DESC`
+    )
+      .bind(activeEngagement.id)
+      .all<InvoiceRow>()
+    invoices = invoiceResult.results ?? []
 
-  const milestoneResult = await env.DB.prepare(
-    `SELECT id, name, completed_at
-       FROM milestones
-      WHERE engagement_id = ? AND status = 'completed' AND completed_at IS NOT NULL
-      ORDER BY completed_at DESC
+    // Next pending invoice: earliest-due among sent/overdue (null due_date last).
+    const pending = invoices.filter((i) => i.status === 'sent' || i.status === 'overdue')
+    pending.sort((a, b) => {
+      if (a.due_date && b.due_date) return a.due_date < b.due_date ? -1 : 1
+      if (a.due_date) return -1
+      if (b.due_date) return 1
+      return 0
+    })
+    pendingInvoice = pending[0] ?? null
+
+    const milestoneResult = await env.DB.prepare(
+      `SELECT id, name, completed_at
+         FROM milestones
+        WHERE engagement_id = ? AND status = 'completed' AND completed_at IS NOT NULL
+        ORDER BY completed_at DESC
+        LIMIT 5`
+    )
+      .bind(activeEngagement.id)
+      .all<MilestoneRow>()
+    completedMilestones = milestoneResult.results ?? []
+  }
+
+  const quoteResult = await env.DB.prepare(
+    `SELECT id, status, sent_at, accepted_at
+       FROM quotes
+      WHERE entity_id = ?
+      ORDER BY updated_at DESC
       LIMIT 5`
   )
-    .bind(activeEngagement.id)
-    .all<MilestoneRow>()
-  completedMilestones = milestoneResult.results ?? []
+    .bind(client.id)
+    .all<QuoteRow>()
+  quotes = quoteResult.results ?? []
+} catch (err) {
+  console.error('portal/index: data fetch failure', err)
+  dashboardError = true
 }
 
-const quoteResult = await env.DB.prepare(
-  `SELECT id, status, sent_at, accepted_at
-     FROM quotes
-    WHERE entity_id = ?
-    ORDER BY updated_at DESC
-    LIMIT 5`
-)
-  .bind(client.id)
-  .all<QuoteRow>()
-quotes = quoteResult.results ?? []
+// Surface dev-only query override so the error state is reachable in QA.
+if (!dashboardError && Astro.url.searchParams.get('state') === 'error') {
+  dashboardError = true
+}
 
 // ---------------------------------------------------------------------------
 // Timeline — most recent first, up to 5 entries. Past-tense, concrete events.
@@ -294,8 +309,54 @@ const contextSubtext = touchpointText
     </PortalHeader>
 
     <main class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+      {
+        dashboardError ? (
+          <div class="flex flex-col gap-6">
+            <section
+              class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-attention)]/30 p-6 sm:p-8"
+              aria-live="polite"
+            >
+              <div class="flex items-start gap-3">
+                <span class="material-symbols-outlined text-[24px] text-[color:var(--color-attention)] mt-0.5">
+                  error
+                </span>
+                <div class="min-w-0">
+                  <h1 class="font-['Plus_Jakarta_Sans'] font-bold text-[22px] leading-[28px] text-[color:var(--color-text-primary)]">
+                    Something went wrong loading your portal.
+                  </h1>
+                  <p class="mt-2 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
+                    Give it a moment and try again. If it keeps happening, {consultantFirst} can
+                    help.
+                  </p>
+                  <div class="mt-5 flex flex-wrap gap-3">
+                    <a
+                      href="/portal"
+                      class="inline-flex items-center justify-center min-h-[44px] px-5 py-2.5 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                    >
+                      Retry
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <ConsultantBlock
+              name={consultant.name}
+              photoUrl={consultant.photoUrl}
+              role={consultant.role}
+              nextTouchpointAt={consultant.nextTouchpointAt}
+              nextTouchpointLabel={consultant.nextTouchpointLabel}
+              phone={consultant.phone}
+            />
+          </div>
+        ) : null
+      }
       <!-- Desktop: two-column grid. Mobile: single column, action-first. -->
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_340px] md:gap-12 md:items-start">
+      <div
+        class:list={[
+          'grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_340px] md:gap-12 md:items-start',
+          dashboardError ? 'hidden' : '',
+        ]}
+      >
         <!-- On mobile, dominant action (right-rail content) renders FIRST.
              On desktop it moves to the right column via md:order-2. -->
         <aside class="md:order-2 md:sticky md:top-10 space-y-6">

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -10,6 +10,7 @@ import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import MoneyDisplay from '../../../components/portal/MoneyDisplay.astro'
 import ActionCard from '../../../components/portal/ActionCard.astro'
 import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
+import { resolveInvoiceState } from '../../../lib/portal/states'
 
 /**
  * Invoice landing — deep-link surface per .stitch/portal-ux-brief.md.
@@ -92,9 +93,20 @@ const displayLineItems: InvoiceLineItem[] =
         },
       ]
 
+// Consultant first name is needed early so we can thread it into the state
+// resolver's next-step copy.
+const consultantFirstEarly = (engagement?.consultant_name ?? 'Scott Durgan').trim().split(/\s+/)[0]
+
+// Resolve the surface state once, up front. Everything below branches on it.
+const surface = resolveInvoiceState(invoice, Astro.url.searchParams, consultantFirstEarly)
+const isPaid = surface.state === 'paid'
+const isDeclined = surface.state === 'declined'
+const isCardExpired = surface.state === 'card_expired'
+const isLinkExpired = surface.state === 'expired'
+const isErrorState = isDeclined || isCardExpired || isLinkExpired
+
 // CTA: prefer Stripe hosted URL when present and usable, otherwise a server
 // endpoint placeholder. The server endpoint is out of scope for this PR.
-const isPaid = !!invoice.paid_at
 const stripeUrl =
   invoice.stripe_hosted_url && invoice.stripe_hosted_url !== '#dev-mode'
     ? invoice.stripe_hosted_url
@@ -264,13 +276,43 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
               {isPaid ? 'Paid in full' : 'Remaining balance'}
             </p>
             {
-              !isPaid && (
+              isErrorState && (
+                <div
+                  class="mt-6 rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-4"
+                  role="status"
+                >
+                  <div class="flex items-start gap-3">
+                    <span class="material-symbols-outlined text-[20px] text-[color:var(--color-attention)] mt-0.5">
+                      error
+                    </span>
+                    <div class="min-w-0">
+                      <p class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                        {isDeclined
+                          ? 'Payment declined'
+                          : isCardExpired
+                            ? 'Card expired'
+                            : 'Link expired'}
+                      </p>
+                      <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
+                        {surface.next}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )
+            }
+            {
+              !isPaid && !isLinkExpired && (
                 <>
                   <a
                     href={payHref}
                     class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
                   >
-                    Pay invoice
+                    {isDeclined
+                      ? 'Try again'
+                      : isCardExpired
+                        ? 'Update payment method'
+                        : 'Pay invoice'}
                     <span class="material-symbols-outlined text-[20px]">arrow_forward</span>
                   </a>
                   <div class="mt-3 flex items-center gap-2 text-[13px] text-[color:var(--color-text-muted)]">
@@ -405,15 +447,58 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
                   </p>
                 )}
               </div>
+            ) : isLinkExpired ? (
+              <div class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-6 sm:p-8">
+                <span class="inline-flex items-center rounded-full bg-[color:var(--color-attention)]/10 px-3 py-1 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-attention)]">
+                  Link expired
+                </span>
+                <div class="mt-5">
+                  <MoneyDisplay amountCents={amountCents} size="display" />
+                  <p class="mt-2 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-muted)]">
+                    Remaining balance
+                  </p>
+                </div>
+                <p class="mt-6 text-sm text-[color:var(--color-text-secondary)]">{surface.next}</p>
+              </div>
             ) : (
-              <ActionCard
-                pillLabel={pillLabel}
-                amountCents={amountCents}
-                amountLabel="Remaining balance"
-                ctaLabel="Pay invoice"
-                ctaHref={payHref}
-                ctaSubtext="Secure payment via Stripe."
-              />
+              <>
+                {isErrorState && (
+                  <div
+                    class="rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-4"
+                    role="status"
+                  >
+                    <div class="flex items-start gap-3">
+                      <span class="material-symbols-outlined text-[20px] text-[color:var(--color-attention)] mt-0.5">
+                        error
+                      </span>
+                      <div class="min-w-0">
+                        <p class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                          {isDeclined ? 'Payment declined' : 'Card expired'}
+                        </p>
+                        <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
+                          {surface.next}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+                <ActionCard
+                  pillLabel={
+                    isDeclined ? 'Try again' : isCardExpired ? 'Update payment method' : pillLabel
+                  }
+                  amountCents={amountCents}
+                  amountLabel="Remaining balance"
+                  ctaLabel={
+                    isDeclined
+                      ? 'Try again'
+                      : isCardExpired
+                        ? 'Update payment method'
+                        : 'Pay invoice'
+                  }
+                  ctaHref={payHref}
+                  ctaSubtext="Secure payment via Stripe."
+                />
+              </>
             )
           }
 

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -7,6 +7,7 @@ import { getPortalClient } from '../../../lib/portal/session'
 import { getQuoteForEntity } from '../../../lib/db/quotes'
 import type { LineItem } from '../../../lib/db/quotes'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
+import { resolveProposalState } from '../../../lib/portal/states'
 import {
   PROBLEM_LABELS,
   LEGACY_PROBLEM_LABELS,
@@ -87,16 +88,76 @@ const engagementSubtitle =
     ? `A focused scope across ${deliverables.length} work areas tailored to your operation.`
     : 'A focused scope of work tailored to your operation.'
 
-const isSigned = quote.status === 'accepted'
-const isSent = quote.status === 'sent'
-const isDeclined = quote.status === 'declined'
-const isExpired = quote.status === 'expired'
+const consultantName = 'Scott Durgan'
+const consultantFirst = consultantName.split(/\s+/)[0]
+
+// Pull engagement for consultant metadata + scope_summary so the signed-state
+// "what happens next" copy is concrete. The engagement row joins by quote_id
+// when one exists. A draft or just-signed quote may not yet have one, in
+// which case we render the generic kickoff fallback.
+interface EngagementLookupRow {
+  id: string
+  scope_summary: string | null
+  consultant_name: string | null
+  consultant_photo_url: string | null
+  consultant_role: string | null
+  consultant_phone: string | null
+  next_touchpoint_at: string | null
+  next_touchpoint_label: string | null
+}
+
+const engagement = await env.DB.prepare(
+  `SELECT id, scope_summary, consultant_name, consultant_photo_url, consultant_role,
+          consultant_phone, next_touchpoint_at, next_touchpoint_label
+     FROM engagements
+    WHERE quote_id = ?
+    ORDER BY created_at DESC
+    LIMIT 1`
+)
+  .bind(quote.id)
+  .first<EngagementLookupRow>()
+
+// Superseded: a newer quote on the same engagement / parent chain. We look
+// up a child quote whose parent_quote_id points at this one OR (fallback) a
+// sibling version for the same assessment.
+interface SupersedingRow {
+  id: string
+}
+const superseding = await env.DB.prepare(
+  `SELECT id FROM quotes
+    WHERE (parent_quote_id = ? OR (assessment_id = ? AND version > ? AND status IN ('sent', 'accepted')))
+      AND entity_id = ?
+    ORDER BY version DESC
+    LIMIT 1`
+)
+  .bind(quote.id, quote.assessment_id, quote.version, client.id)
+  .first<SupersedingRow>()
+
+// Build the concrete "what happens next" string for signed quotes. If the
+// engagement has a next_touchpoint_label we lean on that; otherwise the
+// scope_summary seeds a short sentence. If neither is set the resolver's
+// generic kickoff fallback kicks in.
+const nextStepText: string | null = engagement?.next_touchpoint_label
+  ? `We'll ${engagement.next_touchpoint_label.toLowerCase()}.`
+  : engagement?.scope_summary
+    ? `Kickoff next: ${engagement.scope_summary}.`
+    : null
+
+const surface = resolveProposalState(quote, Astro.url.searchParams, consultantFirst, nextStepText)
+
+const isSigned = surface.state === 'signed'
+const isDeclined = surface.state === 'declined'
+const isExpired = surface.state === 'expired'
+const isSuperseded = surface.state === 'superseded'
+const isSent = quote.status === 'sent' && surface.state === 'default'
 const hasSow = !!downloadableRevision
 const hasActiveSignature = isSent && !!activeSignatureRequest
 const pdfHref = hasSow ? `/api/portal/quotes/${quote.id}/sow` : null
 
-const consultantName = 'Scott Durgan'
-const consultantFirst = consultantName.split(/\s+/)[0]
+const supersedingQuoteId = isSuperseded ? (superseding?.id ?? null) : null
+
+const consultantPhone = engagement?.consultant_phone ?? null
+const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g, '')}` : null
 ---
 
 <!doctype html>
@@ -117,7 +178,12 @@ const consultantFirst = consultantName.split(/\s+/)[0]
     <title>Proposal — Portal — SMD Services</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
-    <PortalHeader clientName={client.name}>
+    <PortalHeader
+      clientName={client.name}
+      showSms={!!headerSmsHref && !isSigned}
+      smsHref={headerSmsHref ?? undefined}
+      smsLabel={headerSmsHref ? `Text ${consultantFirst}` : undefined}
+    >
       <span class="text-sm text-[color:var(--color-text-secondary)] hidden sm:inline"
         >{session.email}</span
       >
@@ -182,18 +248,35 @@ const consultantFirst = consultantName.split(/\s+/)[0]
                         Signed{quote.accepted_at ? ` ${formatDate(quote.accepted_at)}` : ''}.
                       </p>
                       <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
-                        Here's what happens next: we'll reach out to schedule kickoff.
+                        Here's what happens next: {surface.next}
                       </p>
                     </div>
                   </div>
+                ) : isSuperseded ? (
+                  <div class="mt-6 rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-4">
+                    <p class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                      A revised version is available.
+                    </p>
+                    <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
+                      This proposal has been replaced by a newer version.
+                    </p>
+                    {supersedingQuoteId && (
+                      <a
+                        href={`/portal/quotes/${supersedingQuoteId}`}
+                        class="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                      >
+                        Go to the latest proposal
+                        <span class="material-symbols-outlined text-[16px]">arrow_forward</span>
+                      </a>
+                    )}
+                  </div>
                 ) : isDeclined ? (
                   <p class="mt-6 text-sm text-[color:var(--color-text-secondary)]">
-                    This proposal was declined. Text {consultantFirst} if you'd like to talk through
-                    a revision.
+                    This proposal was declined. {surface.next}
                   </p>
                 ) : isExpired ? (
                   <p class="mt-6 text-sm text-[color:var(--color-text-secondary)]">
-                    This proposal has expired. Text {consultantFirst} to pick it back up.
+                    {surface.next}
                   </p>
                 ) : hasActiveSignature ? (
                   <a
@@ -332,10 +415,12 @@ const consultantFirst = consultantName.split(/\s+/)[0]
           <div class="lg:hidden pt-2">
             <div class="h-px bg-[color:var(--color-border)] mb-8"></div>
             <ConsultantBlock
-              name={consultantName}
-              photoUrl={null}
-              role="Your consultant"
-              phone={null}
+              name={engagement?.consultant_name ?? consultantName}
+              photoUrl={engagement?.consultant_photo_url ?? null}
+              role={engagement?.consultant_role ?? 'Your consultant'}
+              nextTouchpointAt={engagement?.next_touchpoint_at ?? null}
+              nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
+              phone={engagement?.consultant_phone ?? null}
             />
             <p class="mt-4 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
               Text {consultantFirst} with questions.
@@ -366,13 +451,15 @@ const consultantFirst = consultantName.split(/\s+/)[0]
                 {
                   isSigned
                     ? 'Signed'
-                    : isDeclined
-                      ? 'Declined'
-                      : isExpired
-                        ? 'Expired'
-                        : hasActiveSignature
-                          ? 'Ready to sign'
-                          : 'Being prepared'
+                    : isSuperseded
+                      ? 'Superseded'
+                      : isDeclined
+                        ? 'Declined'
+                        : isExpired
+                          ? 'Expired'
+                          : hasActiveSignature
+                            ? 'Ready to sign'
+                            : 'Being prepared'
                 }
               </span>
               <div class="mt-5">
@@ -401,14 +488,29 @@ const consultantFirst = consultantName.split(/\s+/)[0]
                           Signed{quote.accepted_at ? ` ${formatDate(quote.accepted_at)}` : ''}.
                         </p>
                         <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
-                          We'll reach out to schedule kickoff.
+                          {surface.next}
                         </p>
                       </div>
                     </div>
                   </div>
+                ) : isSuperseded ? (
+                  <div class="mt-6 rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-4">
+                    <p class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                      A revised version is available.
+                    </p>
+                    {supersedingQuoteId && (
+                      <a
+                        href={`/portal/quotes/${supersedingQuoteId}`}
+                        class="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                      >
+                        Go to the latest proposal
+                        <span class="material-symbols-outlined text-[16px]">arrow_forward</span>
+                      </a>
+                    )}
+                  </div>
                 ) : isDeclined || isExpired ? (
                   <p class="mt-6 text-sm text-[color:var(--color-text-secondary)]">
-                    Text {consultantFirst} to talk through next steps.
+                    {surface.next}
                   </p>
                 ) : hasActiveSignature ? (
                   <a
@@ -439,10 +541,12 @@ const consultantFirst = consultantName.split(/\s+/)[0]
 
             <!-- Consultant card -->
             <ConsultantBlock
-              name={consultantName}
-              photoUrl={null}
-              role="Your consultant"
-              phone={null}
+              name={engagement?.consultant_name ?? consultantName}
+              photoUrl={engagement?.consultant_photo_url ?? null}
+              role={engagement?.consultant_role ?? 'Your consultant'}
+              nextTouchpointAt={engagement?.next_touchpoint_at ?? null}
+              nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
+              phone={engagement?.consultant_phone ?? null}
             />
             <p class="text-[13px] leading-[18px] text-[color:var(--color-text-muted)] px-1">
               Text {consultantFirst} with questions.

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -288,13 +288,13 @@ describe('portal quotes: quote detail page', () => {
   it('shows accepted confirmation state', () => {
     const code = source()
     expect(code).toContain('Signed')
-    expect(code).toContain("quote.status === 'accepted'")
+    expect(code).toContain('isSigned')
   })
 
   it('shows declined and expired states', () => {
     const code = source()
-    expect(code).toContain("quote.status === 'declined'")
-    expect(code).toContain("quote.status === 'expired'")
+    expect(code).toContain('isDeclined')
+    expect(code).toContain('isExpired')
   })
 
   it('has mobile viewport meta tag', () => {

--- a/tests/portal-states.test.ts
+++ b/tests/portal-states.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveInvoiceState,
+  resolveProposalState,
+  resolveContactLink,
+} from '../src/lib/portal/states'
+
+describe('resolveInvoiceState', () => {
+  it('returns paid when invoice.paid_at is set, regardless of query hint', () => {
+    const params = new URLSearchParams('?state=declined')
+    const surface = resolveInvoiceState({ paid_at: '2026-04-10T00:00:00Z' }, params, 'Scott')
+    expect(surface.state).toBe('paid')
+  })
+
+  it('returns declined with Scott-named next step on ?state=declined', () => {
+    const surface = resolveInvoiceState(
+      { paid_at: null },
+      new URLSearchParams('?state=declined'),
+      'Scott'
+    )
+    expect(surface.state).toBe('declined')
+    expect(surface.next.toLowerCase()).toContain('scott')
+    expect(surface.next.toLowerCase()).toContain('try again')
+  })
+
+  it('returns card_expired on ?state=card_expired', () => {
+    const surface = resolveInvoiceState(
+      { paid_at: null },
+      new URLSearchParams('?state=card_expired'),
+      'Scott'
+    )
+    expect(surface.state).toBe('card_expired')
+    expect(surface.next.toLowerCase()).toContain('expired')
+  })
+
+  it('returns expired on ?state=expired with a refreshed-link call to action', () => {
+    const surface = resolveInvoiceState(
+      { paid_at: null },
+      new URLSearchParams('?state=expired'),
+      'Scott'
+    )
+    expect(surface.state).toBe('expired')
+    expect(surface.next.toLowerCase()).toContain('refreshed link')
+  })
+
+  it('returns default when no state hint and not paid', () => {
+    const surface = resolveInvoiceState({ paid_at: null }, null, 'Scott')
+    expect(surface.state).toBe('default')
+  })
+
+  it('never surfaces raw provider text — copy is portal voice', () => {
+    const surface = resolveInvoiceState(
+      { paid_at: null },
+      new URLSearchParams('?state=declined'),
+      'Scott'
+    )
+    expect(surface.next.toLowerCase()).not.toContain('stripe')
+    expect(surface.next.toLowerCase()).not.toContain('error code')
+  })
+})
+
+describe('resolveProposalState', () => {
+  it('returns signed when status=accepted', () => {
+    const surface = resolveProposalState(
+      { status: 'accepted', accepted_at: '2026-04-10T00:00:00Z', expires_at: null },
+      null,
+      'Scott'
+    )
+    expect(surface.state).toBe('signed')
+  })
+
+  it('uses engagement-specific nextStepText for signed copy when provided', () => {
+    const surface = resolveProposalState(
+      { status: 'accepted', accepted_at: '2026-04-10T00:00:00Z', expires_at: null },
+      null,
+      'Scott',
+      'Kickoff next: Migrate the intake workflow.'
+    )
+    expect(surface.next).toBe('Kickoff next: Migrate the intake workflow.')
+  })
+
+  it('falls back to generic kickoff when nextStepText is missing', () => {
+    const surface = resolveProposalState(
+      { status: 'accepted', accepted_at: '2026-04-10T00:00:00Z', expires_at: null },
+      null,
+      'Scott'
+    )
+    expect(surface.next.toLowerCase()).toContain('kickoff')
+  })
+
+  it('returns declined with revision call-out', () => {
+    const surface = resolveProposalState(
+      { status: 'declined', accepted_at: null, expires_at: null },
+      null,
+      'Scott'
+    )
+    expect(surface.state).toBe('declined')
+    expect(surface.next.toLowerCase()).toContain('revision')
+  })
+
+  it('returns superseded when status=superseded', () => {
+    const surface = resolveProposalState(
+      { status: 'superseded', accepted_at: null, expires_at: null },
+      null,
+      'Scott'
+    )
+    expect(surface.state).toBe('superseded')
+    expect(surface.next.toLowerCase()).toContain('revised version')
+  })
+
+  it('returns expired when server-side expires_at is past', () => {
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    const surface = resolveProposalState(
+      { status: 'sent', accepted_at: null, expires_at: past },
+      null,
+      'Scott'
+    )
+    expect(surface.state).toBe('expired')
+  })
+
+  it('returns default for an active sent quote', () => {
+    const future = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString()
+    const surface = resolveProposalState(
+      { status: 'sent', accepted_at: null, expires_at: future },
+      null,
+      'Scott'
+    )
+    expect(surface.state).toBe('default')
+  })
+})
+
+describe('resolveContactLink', () => {
+  it('returns both sms and tel hrefs when phone is present', () => {
+    const link = resolveContactLink('+1 (480) 555-0100', 'iPhone')
+    expect(link.smsHref).toBe('sms:+14805550100')
+    expect(link.telHref).toBe('tel:+14805550100')
+    expect(link.isMobile).toBe(true)
+  })
+
+  it('detects desktop UA as non-mobile', () => {
+    const link = resolveContactLink(
+      '+14805550100',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit'
+    )
+    expect(link.isMobile).toBe(false)
+  })
+
+  it('returns all nulls when phone is absent', () => {
+    const link = resolveContactLink(null, 'iPhone')
+    expect(link.smsHref).toBeNull()
+    expect(link.telHref).toBeNull()
+  })
+
+  it('strips non-digit characters except leading plus', () => {
+    const link = resolveContactLink('(480) 555-0100 x123', null)
+    expect(link.smsHref).toBe('sms:4805550100123')
+  })
+})


### PR DESCRIPTION
Closes #364 and #365.

Layers tap-to-SMS on `ConsultantBlock` and comprehensive error/edge states across all portal surfaces. Every error state includes `ConsultantBlock` with a concrete next step — no generic 500s, no raw provider copy.

## Summary

- **SMS wiring** (`#364`): `sms:` on mobile, `tel:` on desktop, `mailto:` fallback. "Replies within 1 business day" sets the operational commitment.
- **Shared state resolver** at `src/lib/portal/states.ts`: pure functions for invoice, proposal, and contact-link surfaces. Portal-voice copy translates provider errors into something a client can act on.
- **Invoice states** (`#365`): `?state=declined` → Try again. `?state=card_expired` → Update payment method. `?state=expired` → Text Scott for refreshed link. Server-side `paid_at` always wins over query hints.
- **Proposal states**: signed pulls next step from `engagement.next_touchpoint_label` or `scope_summary` (falls back to generic kickoff). Superseded links to the newer version. Expired honored from server `expires_at` and query hint.
- **Dashboard**: all D1 reads wrapped in `try/catch`; failure renders a single error card with `ConsultantBlock` + retry link. `?state=error` dev override for QA.
- **Dev harness** at `/dev/portal-states` (404s in production) enumerates every state with its query param for manual review.

## Test plan

- [x] `npm test` — 1041 passing, 2 skipped
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — success
- [x] `npm run format:check` — clean
- [ ] Manual: pull `?state=declined` / `?state=card_expired` / `?state=expired` on a real invoice URL; verify CTA labels, banner colors, and ConsultantBlock surfaces
- [ ] Manual: open a superseded quote; verify link to newer version renders
- [ ] Manual: tap the "Text Scott" CTA on iOS and Android; verify `sms:` handoff; check `tel:` on desktop
- [ ] Manual: visit `/dev/portal-states` locally; verify it 404s in production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)