### PR TITLE
feat(admin): migrate admin to admin.smd.services subdomain

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -7,10 +7,13 @@
 # and `astro dev` (via the platformProxy adapter config).
 
 # ---------- Canonical URLs ----------
-# Used to build outbound auth, portal, and webhook callback links. In dev
-# we point at localhost so magic links and email previews open the right
-# environment. See src/lib/config/app-url.ts and issue #173.
+# Used to build outbound auth, admin, portal, and webhook callback links.
+# In dev we point at localhost so magic links and email previews open the
+# right environment. See src/lib/config/app-url.ts and issue #173.
+#   ADMIN_BASE_URL is REQUIRED (no fallback). OAuth redirect URI uses it.
+#   PORTAL_BASE_URL falls back to APP_BASE_URL when unset.
 APP_BASE_URL="http://localhost:4321"
+ADMIN_BASE_URL="http://localhost:4321"
 PORTAL_BASE_URL="http://localhost:4321"
 
 # ---------- Secrets (set with: wrangler secret put <NAME>) ----------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,37 @@ We are in the **pre-launch phase**. Nothing has been sold yet. The immediate pri
 - **Language:** TypeScript
 - **No product/app planned** — this is a services business. Tech is for marketing and internal tools only.
 
+## Three-Subdomain Architecture
+
+One Astro app, one Cloudflare Pages project, three custom domains. Routing is handled by `src/middleware.ts` — not by separate deployments.
+
+| Host                  | Serves                                   | Auth role |
+| --------------------- | ---------------------------------------- | --------- |
+| `smd.services`        | Marketing pages                          | Public    |
+| `admin.smd.services`  | Admin console (rewritten to `/admin/*`)  | `admin`   |
+| `portal.smd.services` | Client portal (rewritten to `/portal/*`) | `client`  |
+
+**How the rewrite works.** The middleware inspects `hostname`. On `admin.smd.services`, paths get `/admin` prepended unless they already start with `/admin`, `/api/admin`, `/auth`, or `/api/auth`. Same pattern for `portal.smd.services`. The admin source files still live under `src/pages/admin/*` — the subdomain is a front door.
+
+**Cookie boundaries.** Session cookies are per-host (no `Domain` attribute). Admin cookies only live on `admin.smd.services`. Client cookies only live on `portal.smd.services`. An admin cookie that lands on the apex (from pre-migration logins) is proactively cleared on next visit.
+
+**Backwards compat.** `smd.services/admin/*` and `smd.services/auth/login` 301 to the admin subdomain — old bookmarks still work.
+
+**Env vars.** `APP_BASE_URL` (marketing, SignWell webhooks), `ADMIN_BASE_URL` (OAuth redirect URI, outbound admin links — strict, no fallback), `PORTAL_BASE_URL` (portal links, falls back to `APP_BASE_URL`). See `src/lib/config/app-url.ts`.
+
+## Local Dev
+
+Subdomain-based routing keys off `hostname.startsWith('admin.')` / `portal.`. At `localhost:4321` neither fires, which is usually fine — just hit `/admin/*` and `/portal/*` paths directly.
+
+**For full-fidelity subdomain testing**, add to `/etc/hosts`:
+
+```
+127.0.0.1 admin.localhost
+127.0.0.1 portal.localhost
+```
+
+Then `http://admin.localhost:4321/` and `http://portal.localhost:4321/` exercise the rewrite. Set matching values in `.dev.vars` (e.g. `ADMIN_BASE_URL=http://admin.localhost:4321`) so outbound-URL builders emit the right origin.
+
 ## Build Commands
 
 ```bash

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -42,6 +42,14 @@ type CfEnv = {
    * deployment served under a subdomain rewrite).
    */
   PORTAL_BASE_URL?: string
+  /**
+   * Canonical absolute URL for the admin console, e.g.
+   * `https://admin.smd.services`. Required for OAuth redirect URIs
+   * and outbound admin links. Unlike PORTAL_BASE_URL, this does NOT
+   * fall back to APP_BASE_URL — silent fallback would emit the wrong
+   * OAuth redirect and cause redirect_uri_mismatch errors.
+   */
+  ADMIN_BASE_URL?: string
   /** Cloudflare Turnstile site key for the /book booking widget. Public. */
   PUBLIC_TURNSTILE_SITE_KEY?: string
   RESEND_API_KEY?: string

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -196,8 +196,9 @@ export async function destroySession(
  * Build a Set-Cookie header for the session token.
  *
  * No Domain= attribute is set intentionally: admin cookies are scoped to
- * smd.services and portal cookies to portal.smd.services. This isolation
- * prevents cross-domain cookie leakage between admin and client sessions.
+ * admin.smd.services and portal cookies to portal.smd.services. This
+ * isolation prevents cross-domain cookie leakage between admin and client
+ * sessions.
  */
 export function buildSessionCookie(token: string, role?: string): string {
   const maxAge = Math.floor(getSessionDurationMs(role) / 1000)

--- a/src/lib/config/app-url.ts
+++ b/src/lib/config/app-url.ts
@@ -24,6 +24,7 @@
 export interface AppUrlEnv {
   APP_BASE_URL?: string
   PORTAL_BASE_URL?: string
+  ADMIN_BASE_URL?: string
 }
 
 /**
@@ -100,6 +101,45 @@ export function buildAppUrl(env: AppUrlEnv, path: string): string {
  */
 export function buildPortalUrl(env: AppUrlEnv, path: string = '/portal'): string {
   const base = requirePortalBaseUrl(env)
+  const normalized = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalized}`
+}
+
+/**
+ * Read and normalize `ADMIN_BASE_URL`. Unlike the portal helper, does NOT
+ * fall back to `APP_BASE_URL`. A silent fallback would emit OAuth redirect
+ * URIs on the marketing domain, producing `redirect_uri_mismatch` errors
+ * that are hard to diagnose. Callers should use `requireAdminBaseUrl` to
+ * get a strict failure when the value is missing.
+ */
+export function getAdminBaseUrl(env: AppUrlEnv): string | null {
+  const raw = env.ADMIN_BASE_URL
+  if (!raw || typeof raw !== 'string') return null
+  const trimmed = raw.trim().replace(/\/+$/, '')
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Strict variant of `getAdminBaseUrl`. Throws when `ADMIN_BASE_URL` is not
+ * configured. Used for OAuth redirect URIs and outbound admin links — fail
+ * loudly rather than silently falling back to the marketing domain.
+ */
+export function requireAdminBaseUrl(env: AppUrlEnv): string {
+  const base = getAdminBaseUrl(env)
+  if (!base) {
+    throw new Error(
+      'ADMIN_BASE_URL is not configured. Set ADMIN_BASE_URL in Cloudflare Pages env (e.g. https://admin.smd.services).'
+    )
+  }
+  return base
+}
+
+/**
+ * Build an absolute URL on the canonical admin origin. Handles leading-slash
+ * normalization so callers can pass either `/foo` or `foo`.
+ */
+export function buildAdminUrl(env: AppUrlEnv, path: string): string {
+  const base = requireAdminBaseUrl(env)
   const normalized = path.startsWith('/') ? path : `/${path}`
   return `${base}${normalized}`
 }

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -5,9 +5,12 @@
 export {
   getAppBaseUrl,
   getPortalBaseUrl,
+  getAdminBaseUrl,
   requireAppBaseUrl,
   requirePortalBaseUrl,
+  requireAdminBaseUrl,
   buildAppUrl,
   buildPortalUrl,
+  buildAdminUrl,
 } from './app-url'
 export type { AppUrlEnv } from './app-url'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,10 +4,17 @@ import {
   validateSession,
   renewSession,
   buildSessionCookie,
+  buildClearSessionCookie,
 } from './lib/auth/session'
 
 /**
  * Astro middleware — handles auth for protected routes.
+ *
+ * Host → path mapping (three custom domains on one Pages project):
+ *   admin.smd.services/*   → rewritten to /admin/* (admin console, role=admin)
+ *   portal.smd.services/*  → rewritten to /portal/* (client portal, role=client)
+ *   smd.services/*         → marketing (public); /admin/* and /auth/login 301
+ *                            to admin.smd.services for backwards compat
  *
  * Route protection:
  *   /admin/*       → requires role='admin', redirects to /auth/login
@@ -35,6 +42,38 @@ export const onRequest = defineMiddleware(async (context, next) => {
     // Rewrite the URL to the /portal path prefix
     const portalPath = pathname === '/' ? '/portal' : `/portal${pathname}`
     return context.rewrite(new Request(new URL(portalPath, context.url), context.request))
+  }
+
+  // Subdomain routing: admin.smd.services rewrites to /admin/* paths
+  const isAdminSubdomain = hostname.startsWith('admin.')
+  if (
+    isAdminSubdomain &&
+    !pathname.startsWith('/admin') &&
+    !pathname.startsWith('/api/admin') &&
+    !pathname.startsWith('/auth') &&
+    !pathname.startsWith('/api/auth')
+  ) {
+    const adminPath = pathname === '/' ? '/admin' : `/admin${pathname}`
+    return context.rewrite(new Request(new URL(adminPath, context.url), context.request))
+  }
+
+  // Backwards-compat redirects: bare apex admin/login paths → admin subdomain.
+  // Strict equality guard — NOT startsWith/endsWith, which would match
+  // admin.smd.services and loop. Preserves pathname and query string.
+  if (hostname === 'smd.services' && (pathname === '/admin' || pathname.startsWith('/admin/'))) {
+    const newUrl = new URL(context.url)
+    newUrl.hostname = 'admin.smd.services'
+    return context.redirect(newUrl.toString(), 301)
+  }
+  if (
+    hostname === 'smd.services' &&
+    (pathname === '/auth/login' || pathname.startsWith('/auth/login'))
+  ) {
+    // Admin login must happen on admin host so cookies land on the correct origin.
+    // Client login at /auth/portal-login is NOT redirected — stays on portal host.
+    const newUrl = new URL(context.url)
+    newUrl.hostname = 'admin.smd.services'
+    return context.redirect(newUrl.toString(), 301)
   }
 
   // Legacy redirect: /book/thanks → /get-started?booked=1
@@ -101,14 +140,21 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   const response = await next()
 
-  // Refresh session cookie on authenticated responses (sliding window).
-  // Guard: only refresh when role matches the domain to prevent admin sessions
-  // from leaking cookies onto portal.smd.services (and vice versa).
+  // Session cookie handling on authenticated responses.
+  // Invariant: admin cookies only live on admin.*, client cookies only on portal.*.
+  // - Refresh (sliding window) when role matches host.
+  // - Clear proactively when an admin cookie arrives on the apex — a stale
+  //   leftover from pre-migration logins should not linger.
   if (context.locals.session && token) {
-    const isPortalHost = context.url.hostname.startsWith('portal.')
+    const isPortalHost = hostname.startsWith('portal.')
+    const isAdminHost = hostname.startsWith('admin.')
     const isClientSession = context.locals.session.role === 'client'
-    if (isClientSession === isPortalHost) {
+    const isAdminSession = context.locals.session.role === 'admin'
+    const hostMatches = (isClientSession && isPortalHost) || (isAdminSession && isAdminHost)
+    if (hostMatches) {
       response.headers.append('Set-Cookie', buildSessionCookie(token, context.locals.session.role))
+    } else if (hostname === 'smd.services' && isAdminSession) {
+      response.headers.append('Set-Cookie', buildClearSessionCookie())
     }
   }
 

--- a/src/pages/api/auth/google/callback.ts
+++ b/src/pages/api/auth/google/callback.ts
@@ -3,7 +3,7 @@ import { consumeOAuthState } from '../../../../lib/db/oauth-states.js'
 import { upsertIntegration } from '../../../../lib/db/integrations.js'
 import { exchangeAuthCode } from '../../../../lib/booking/google-calendar.js'
 import { encrypt } from '../../../../lib/booking/encryption.js'
-import { requireAppBaseUrl } from '../../../../lib/config/app-url.js'
+import { requireAdminBaseUrl } from '../../../../lib/config/app-url.js'
 
 /**
  * GET /api/auth/google/callback
@@ -60,8 +60,9 @@ export const GET: APIRoute = async ({ request, locals, redirect }) => {
   }
 
   try {
-    const appBase = requireAppBaseUrl(env)
-    const redirectUri = `${appBase}/api/auth/google/callback`
+    // Must match the redirect_uri registered with Google AND used by /connect.
+    const adminBase = requireAdminBaseUrl(env)
+    const redirectUri = `${adminBase}/api/auth/google/callback`
 
     // 3. Exchange code for tokens
     const tokens = await exchangeAuthCode(clientId, clientSecret, code, redirectUri)

--- a/src/pages/api/auth/google/connect.ts
+++ b/src/pages/api/auth/google/connect.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createOAuthState } from '../../../../lib/db/oauth-states.js'
-import { requireAppBaseUrl } from '../../../../lib/config/app-url.js'
+import { requireAdminBaseUrl } from '../../../../lib/config/app-url.js'
 
 /**
  * GET /api/auth/google/connect
@@ -38,8 +38,10 @@ export const GET: APIRoute = async ({ locals, redirect }) => {
     return redirect('/admin/settings/google-connect?error=config', 302)
   }
 
-  const appBase = requireAppBaseUrl(env)
-  const redirectUri = `${appBase}/api/auth/google/callback`
+  // OAuth redirect URI must land on admin.smd.services so the callback
+  // arrives on the host that holds the admin session cookie.
+  const adminBase = requireAdminBaseUrl(env)
+  const redirectUri = `${adminBase}/api/auth/google/callback`
 
   const state = await createOAuthState(env.DB, session.orgId, 'google_calendar', session.userId)
 

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -21,6 +21,16 @@ interface UserRow {
  */
 export const POST: APIRoute = async ({ request, locals, redirect }) => {
   try {
+    // Host guard: admin login must happen on admin.smd.services so the
+    // session cookie lands on the correct origin. A POST to the apex
+    // bypasses the middleware redirect (which only catches GET /auth/login),
+    // so we enforce the invariant here too.
+    const requestHost = new URL(request.url).hostname
+    const isLocalDev = requestHost === 'localhost' || requestHost === '127.0.0.1'
+    if (!isLocalDev && !requestHost.startsWith('admin.')) {
+      return redirect('/auth/login?error=wrong_host', 302)
+    }
+
     const formData = await request.formData()
     const email = formData.get('email')
     const password = formData.get('password')

--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -20,7 +20,7 @@ import {
   bookingConfirmationEmailHtml,
   bookingAdminNotificationEmailHtml,
 } from '../../../lib/email/templates'
-import { requireAppBaseUrl } from '../../../lib/config/app-url'
+import { requireAppBaseUrl, buildAdminUrl } from '../../../lib/config/app-url'
 
 const FALLBACK_EMAIL = 'scott@smd.services'
 const NOTIFY_EMAIL = 'team@smd.services'
@@ -369,7 +369,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       businessName,
       slotLabel: formatSlotLabelLong(slotStartUtc, BOOKING_CONFIG.consultant.timezone),
       intakeLines,
-      entityAdminUrl: `${appBaseUrl}/admin/entities/${entityId}`,
+      entityAdminUrl: buildAdminUrl(env, `/admin/entities/${entityId}`),
     })
 
     await sendEmail(env.RESEND_API_KEY, {

--- a/src/pages/api/intake.ts
+++ b/src/pages/api/intake.ts
@@ -4,6 +4,7 @@ import { verifyTurnstileToken } from '../../lib/booking/turnstile'
 import { rateLimitByIp } from '../../lib/booking/rate-limit'
 import { sendEmail } from '../../lib/email/resend'
 import { ORG_ID } from '../../lib/constants'
+import { buildAdminUrl } from '../../lib/config/app-url'
 
 const NOTIFY_EMAIL = 'team@smd.services'
 const RATE_LIMIT = 5
@@ -105,7 +106,7 @@ export const POST: APIRoute = async ({ request, locals, clientAddress }) => {
         html:
           `<p><strong>${escapedName}</strong> &lt;${escapedEmail}&gt; from <strong>${escapedBusiness}</strong> shared info about their business (no call scheduled yet).</p>` +
           `<hr>${detailLines}` +
-          `<hr><p><a href="https://smd.services/admin/entities/${result.entityId}">View in admin →</a></p>`,
+          `<hr><p><a href="${buildAdminUrl(env, `/admin/entities/${result.entityId}`)}">View in admin →</a></p>`,
       })
     } catch (emailErr) {
       console.error('[api/intake] Notification email error:', emailErr)

--- a/src/pages/auth/login.astro
+++ b/src/pages/auth/login.astro
@@ -14,6 +14,7 @@ const errorMessages: Record<string, string> = {
   invalid: 'Invalid email or password.',
   missing: 'Please enter both email and password.',
   server: 'Something went wrong. Please try again.',
+  wrong_host: 'Admin sign-in must be done at admin.smd.services. Please use that URL.',
 }
 
 const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : null

--- a/tests/canonical-app-url.test.ts
+++ b/tests/canonical-app-url.test.ts
@@ -4,10 +4,13 @@ import { resolve } from 'path'
 import {
   getAppBaseUrl,
   getPortalBaseUrl,
+  getAdminBaseUrl,
   requireAppBaseUrl,
   requirePortalBaseUrl,
+  requireAdminBaseUrl,
   buildAppUrl,
   buildPortalUrl,
+  buildAdminUrl,
 } from '../src/lib/config/app-url'
 
 /**
@@ -74,6 +77,31 @@ describe('canonical app-url helper: getPortalBaseUrl', () => {
   })
 })
 
+describe('canonical app-url helper: getAdminBaseUrl', () => {
+  it('returns ADMIN_BASE_URL when set', () => {
+    expect(
+      getAdminBaseUrl({
+        APP_BASE_URL: 'https://smd.services',
+        ADMIN_BASE_URL: 'https://admin.smd.services',
+      })
+    ).toBe('https://admin.smd.services')
+  })
+
+  it('does NOT fall back to APP_BASE_URL when ADMIN_BASE_URL is unset', () => {
+    expect(getAdminBaseUrl({ APP_BASE_URL: 'https://smd.services' })).toBeNull()
+  })
+
+  it('returns null when ADMIN_BASE_URL is blank', () => {
+    expect(getAdminBaseUrl({ ADMIN_BASE_URL: '   ' })).toBeNull()
+  })
+
+  it('strips trailing slashes and trims whitespace', () => {
+    expect(getAdminBaseUrl({ ADMIN_BASE_URL: '  https://admin.smd.services/  ' })).toBe(
+      'https://admin.smd.services'
+    )
+  })
+})
+
 describe('canonical app-url helper: strict guards', () => {
   it('requireAppBaseUrl throws a descriptive error when missing', () => {
     expect(() => requireAppBaseUrl({})).toThrow(/APP_BASE_URL is not configured/)
@@ -92,11 +120,28 @@ describe('canonical app-url helper: strict guards', () => {
       'https://smd.services'
     )
   })
+
+  it('requireAdminBaseUrl throws when ADMIN_BASE_URL is missing', () => {
+    expect(() => requireAdminBaseUrl({})).toThrow(/ADMIN_BASE_URL is not configured/)
+  })
+
+  it('requireAdminBaseUrl does NOT silently fall back to APP_BASE_URL', () => {
+    expect(() => requireAdminBaseUrl({ APP_BASE_URL: 'https://smd.services' })).toThrow(
+      /ADMIN_BASE_URL/
+    )
+  })
+
+  it('requireAdminBaseUrl returns the value when set', () => {
+    expect(requireAdminBaseUrl({ ADMIN_BASE_URL: 'https://admin.smd.services' })).toBe(
+      'https://admin.smd.services'
+    )
+  })
 })
 
 describe('canonical app-url helper: URL builders', () => {
   const env = {
     APP_BASE_URL: 'https://smd.services',
+    ADMIN_BASE_URL: 'https://admin.smd.services',
     PORTAL_BASE_URL: 'https://portal.smd.services',
   }
 
@@ -134,6 +179,24 @@ describe('canonical app-url helper: URL builders', () => {
 
   it('buildPortalUrl throws when neither base URL is set', () => {
     expect(() => buildPortalUrl({}, '/portal')).toThrow(/PORTAL_BASE_URL/)
+  })
+
+  it('buildAdminUrl prepends the admin origin', () => {
+    expect(buildAdminUrl(env, '/admin/entities/abc-123')).toBe(
+      'https://admin.smd.services/admin/entities/abc-123'
+    )
+  })
+
+  it('buildAdminUrl handles paths without a leading slash', () => {
+    expect(buildAdminUrl({ ADMIN_BASE_URL: 'https://admin.smd.services' }, 'admin/foo')).toBe(
+      'https://admin.smd.services/admin/foo'
+    )
+  })
+
+  it('buildAdminUrl throws when ADMIN_BASE_URL is missing', () => {
+    expect(() => buildAdminUrl({ APP_BASE_URL: 'https://smd.services' }, '/admin/foo')).toThrow(
+      /ADMIN_BASE_URL/
+    )
   })
 })
 
@@ -235,6 +298,11 @@ describe('canonical app-url: env declarations', () => {
     expect(source).toContain('PORTAL_BASE_URL')
   })
 
+  it('CfEnv declares ADMIN_BASE_URL', () => {
+    const source = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(source).toContain('ADMIN_BASE_URL')
+  })
+
   it('wrangler.toml declares APP_BASE_URL under [vars]', () => {
     const source = readFileSync(resolve('wrangler.toml'), 'utf-8')
     expect(source).toContain('[vars]')
@@ -246,9 +314,43 @@ describe('canonical app-url: env declarations', () => {
     expect(source).toContain('PORTAL_BASE_URL')
   })
 
+  it('wrangler.toml declares ADMIN_BASE_URL', () => {
+    const source = readFileSync(resolve('wrangler.toml'), 'utf-8')
+    expect(source).toContain('ADMIN_BASE_URL = "https://admin.smd.services"')
+  })
+
   it('.dev.vars.example documents APP_BASE_URL for local dev', () => {
     const source = readFileSync(resolve('.dev.vars.example'), 'utf-8')
     expect(source).toContain('APP_BASE_URL')
     expect(source).toContain('PORTAL_BASE_URL')
+    expect(source).toContain('ADMIN_BASE_URL')
+  })
+})
+
+describe('canonical app-url: Google OAuth uses ADMIN_BASE_URL', () => {
+  it('connect endpoint uses requireAdminBaseUrl, not requireAppBaseUrl', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/google/connect.ts'), 'utf-8')
+    expect(source).toContain('requireAdminBaseUrl')
+    expect(source).not.toContain('requireAppBaseUrl')
+  })
+
+  it('callback endpoint uses requireAdminBaseUrl, not requireAppBaseUrl', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/google/callback.ts'), 'utf-8')
+    expect(source).toContain('requireAdminBaseUrl')
+    expect(source).not.toContain('requireAppBaseUrl')
+  })
+})
+
+describe('canonical app-url: outbound admin URLs use buildAdminUrl', () => {
+  it('intake notification email uses buildAdminUrl', () => {
+    const source = readFileSync(resolve('src/pages/api/intake.ts'), 'utf-8')
+    expect(source).toContain('buildAdminUrl')
+    expect(source).not.toContain('https://smd.services/admin/')
+  })
+
+  it('booking admin notification email uses buildAdminUrl', () => {
+    const source = readFileSync(resolve('src/pages/api/booking/reserve.ts'), 'utf-8')
+    expect(source).toContain('buildAdminUrl')
+    expect(source).not.toMatch(/\$\{appBaseUrl\}\/admin\//)
   })
 })

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Source-level guards for src/middleware.ts.
+ *
+ * The middleware runs against D1/KV bindings at request time. Integration
+ * tests would need a full runtime harness. These tests enforce the
+ * architectural invariants at the source level: the three-subdomain
+ * routing, strict hostname equality on the legacy redirect, and the
+ * cookie-refresh guard that keeps admin cookies off the apex.
+ */
+describe('middleware: admin subdomain rewrite', () => {
+  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('detects admin subdomain with startsWith("admin.")', () => {
+    expect(source()).toContain("hostname.startsWith('admin.')")
+  })
+
+  it('admin rewrite exempts paths already under /admin', () => {
+    const code = source()
+    expect(code).toMatch(/isAdminSubdomain[\s\S]*!pathname\.startsWith\('\/admin'\)/)
+  })
+
+  it('admin rewrite exempts /api/admin', () => {
+    const code = source()
+    expect(code).toMatch(/isAdminSubdomain[\s\S]*!pathname\.startsWith\('\/api\/admin'\)/)
+  })
+
+  it('admin rewrite exempts /auth and /api/auth', () => {
+    const code = source()
+    expect(code).toMatch(/isAdminSubdomain[\s\S]*!pathname\.startsWith\('\/auth'\)/)
+    expect(code).toMatch(/isAdminSubdomain[\s\S]*!pathname\.startsWith\('\/api\/auth'\)/)
+  })
+
+  it('admin rewrite prepends /admin to non-admin paths', () => {
+    const code = source()
+    expect(code).toMatch(
+      /adminPath\s*=\s*pathname\s*===\s*'\/'\s*\?\s*'\/admin'\s*:\s*`\/admin\$\{pathname\}`/
+    )
+  })
+
+  it('admin rewrite uses context.rewrite, not redirect', () => {
+    const code = source()
+    // Rewrite is transparent — user stays on admin.smd.services in the URL bar.
+    const adminBlock = code.slice(code.indexOf('isAdminSubdomain'))
+    expect(adminBlock).toContain('context.rewrite(')
+  })
+})
+
+describe('middleware: legacy apex redirects', () => {
+  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('uses strict hostname equality for the apex admin redirect', () => {
+    // CRITICAL: startsWith/endsWith would also match admin.smd.services and loop.
+    const code = source()
+    expect(code).toContain("hostname === 'smd.services'")
+  })
+
+  it('redirects apex /admin/* to admin subdomain', () => {
+    const code = source()
+    expect(code).toMatch(
+      /hostname\s*===\s*'smd\.services'[\s\S]*?pathname\.startsWith\('\/admin\/'\)/
+    )
+    expect(code).toContain("newUrl.hostname = 'admin.smd.services'")
+  })
+
+  it('redirects apex /auth/login to admin subdomain', () => {
+    const code = source()
+    expect(code).toMatch(
+      /hostname\s*===\s*'smd\.services'[\s\S]*?pathname\.startsWith\('\/auth\/login'\)/
+    )
+  })
+
+  it('uses 301 for backwards-compat redirects', () => {
+    const code = source()
+    // Both legacy redirects should be 301 permanent
+    expect(code).toMatch(/context\.redirect\(newUrl\.toString\(\),\s*301\)/)
+  })
+
+  it('does NOT redirect admin.smd.services to itself (no loop)', () => {
+    // The guard hostname === 'smd.services' is strict equality, not endsWith.
+    // admin.smd.services.endsWith('smd.services') is true, which would loop.
+    const code = source()
+    expect(code).not.toContain("hostname.endsWith('smd.services')")
+  })
+})
+
+describe('middleware: cookie refresh guard', () => {
+  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('checks both admin and portal host patterns', () => {
+    const code = source()
+    expect(code).toContain("hostname.startsWith('portal.')")
+    expect(code).toContain("hostname.startsWith('admin.')")
+  })
+
+  it('refreshes cookie only when role matches host', () => {
+    const code = source()
+    expect(code).toMatch(
+      /hostMatches\s*=\s*\(isClientSession\s*&&\s*isPortalHost\)\s*\|\|\s*\(isAdminSession\s*&&\s*isAdminHost\)/
+    )
+  })
+
+  it('clears stale admin cookie on apex', () => {
+    // Pre-migration admin cookies on smd.services should be proactively cleared.
+    const code = source()
+    expect(code).toContain('buildClearSessionCookie')
+    expect(code).toMatch(/hostname\s*===\s*'smd\.services'\s*&&\s*isAdminSession/)
+  })
+
+  it('imports buildClearSessionCookie', () => {
+    expect(source()).toContain('buildClearSessionCookie')
+  })
+})
+
+describe('middleware: portal rewrite preserved (regression)', () => {
+  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('still detects portal subdomain', () => {
+    expect(source()).toContain("hostname.startsWith('portal.')")
+  })
+
+  it('still rewrites non-portal paths on the portal subdomain', () => {
+    const code = source()
+    expect(code).toMatch(
+      /portalPath\s*=\s*pathname\s*===\s*'\/'\s*\?\s*'\/portal'\s*:\s*`\/portal\$\{pathname\}`/
+    )
+  })
+})
+
+describe('middleware: admin login host guard', () => {
+  const source = () => readFileSync(resolve('src/pages/api/auth/login.ts'), 'utf-8')
+
+  it('rejects admin login POST when host is not admin.*', () => {
+    const code = source()
+    expect(code).toContain("requestHost.startsWith('admin.')")
+    expect(code).toContain('wrong_host')
+  })
+
+  it('allows local dev hostnames (localhost, 127.0.0.1)', () => {
+    const code = source()
+    expect(code).toContain('localhost')
+    expect(code).toContain('127.0.0.1')
+  })
+})
+
+describe('middleware: login page shows wrong_host error', () => {
+  it('login page maps wrong_host error to a user-visible message', () => {
+    const code = readFileSync(resolve('src/pages/auth/login.astro'), 'utf-8')
+    expect(code).toContain('wrong_host')
+    expect(code).toContain('admin.smd.services')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    // Exclude git worktrees from test discovery. `.claude/worktrees/*` are
+    // checkouts of other feature branches — their test expectations drift
+    // relative to main and cause spurious failures during `npm run verify`.
+    // Tests that belong to this branch live in `tests/`; anything else under
+    // `.claude/` is not ours to validate.
+    exclude: ['**/node_modules/**', '**/dist/**', '.claude/worktrees/**'],
     // The crane-test-harness package imports from `node:sqlite`. The
     // vitest 1.x + vite 6 combo trips on bare `node:` imports inside
     // transformed-then-loaded modules, so we externalize the harness

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,7 @@
 #
 # Custom domains (configured in Cloudflare Pages dashboard):
 #   smd.services         — marketing site (public pages)
+#   admin.smd.services   — admin console
 #   portal.smd.services  — client portal
 #
 # All domains are served by this single Pages project.
@@ -15,14 +16,21 @@ compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
 # ---------- Public env vars ----------
-# Canonical origin for outbound auth, portal, and webhook callback URLs.
-# All email links and webhook callbacks are built from APP_BASE_URL — never
+# Canonical origins for outbound links and webhook callbacks.
+# All email links and webhook callbacks are built from these env vars — never
 # from the inbound request host (see src/lib/config/app-url.ts and issue #173).
-# PORTAL_BASE_URL is optional; when unset it falls back to APP_BASE_URL.
+#   APP_BASE_URL    — marketing origin (smd.services). Used by public-facing
+#                     links, SignWell webhooks, and as a PORTAL_BASE_URL fallback.
+#   ADMIN_BASE_URL  — admin console origin (admin.smd.services). Required for
+#                     the Google OAuth redirect URI and outbound admin links.
+#                     No fallback — missing value throws.
+#   PORTAL_BASE_URL — client portal origin (portal.smd.services). Falls back
+#                     to APP_BASE_URL when unset.
 # PUBLIC_TURNSTILE_SITE_KEY is the Cloudflare Turnstile site key embedded
 # in the /book Turnstile widget; the paired secret is in TURNSTILE_SECRET_KEY.
 [vars]
 APP_BASE_URL = "https://smd.services"
+ADMIN_BASE_URL = "https://admin.smd.services"
 PORTAL_BASE_URL = "https://portal.smd.services"
 PUBLIC_TURNSTILE_SITE_KEY = ""
 MEETING_URL = "https://zoom.us/j/4284801619"


### PR DESCRIPTION
## Summary

Three concerns, three symmetric subdomains. Admin moves from `smd.services/admin/*` to `admin.smd.services/*` to match portal's existing shape.

- `smd.services` — marketing (public)
- `admin.smd.services` — admin console (new — was `smd.services/admin`)
- `portal.smd.services` — client portal (existing)

**Implementation.** Mirror portal's subdomain-rewrite pattern in `src/middleware.ts`. Admin source files stay under `src/pages/admin/*` — the subdomain is a front door, not a code move. Paths under `/admin`, `/api/admin`, `/auth`, `/api/auth` are exempt from the rewrite.

**Safety rails.**
- `smd.services/admin/*` and `smd.services/auth/login` 301 to the admin subdomain so old bookmarks/email links keep working. Strict `hostname === 'smd.services'` equality to avoid admin.smd.services matching and looping.
- Admin cookies on the apex are proactively cleared (pre-migration leftovers) so the per-host cookie invariant holds immediately.
- Admin login POST guards against non-admin hosts (belt and suspenders with the middleware redirect).
- `ADMIN_BASE_URL` is strict — no fallback to `APP_BASE_URL`. A silent fallback would emit OAuth `redirect_uri_mismatch` as the first symptom of a deploy-order mistake. Fails loud instead.

**Scope sweep.** All outbound admin URL builders now use `buildAdminUrl` (intake notification, booking admin notification). Google OAuth redirect URI switched to `ADMIN_BASE_URL` so the callback lands on the host that holds the admin session cookie. SignWell webhooks stay on `APP_BASE_URL` (server-to-server, no cookie dependency) — no dashboard reconfig needed.

**Side benefit.** Added a vitest exclude for `.claude/worktrees/**` so local verify stops scanning stale branch checkouts. No CI behavior change.

## Deploy sequence (DO NOT merge until steps 1–4 are done)

Code is last — every pre-step is additive or inert so partial progress is safe.

- [ ] **1. DNS.** Add `admin` CNAME at the `smd.services` zone pointing at the Pages project hostname. Verify with `dig admin.smd.services +short`.
- [ ] **2. CF Pages custom domain.** Add `admin.smd.services` to the `ss-web` project. Wait for TLS cert. `curl -I https://admin.smd.services/` should return something (any status — even 404 — proves the edge terminates TLS and routes to the project).
- [ ] **3. CF Pages env var.** Set `ADMIN_BASE_URL=https://admin.smd.services` in the Pages dashboard → Production environment variables. (Wrangler.toml alone doesn't always propagate for Pages production deploys.)
- [ ] **4. Google Cloud Console.** ADD (do NOT replace) `https://admin.smd.services/api/auth/google/callback` to the OAuth 2.0 client's authorized redirect URIs. Keep the old apex URI until settle is verified.
- [ ] **5. Merge this PR.** Deploy triggers.
- [ ] **6. Verify.** `curl -I https://admin.smd.services/` → 302 to `/auth/login`. Log in. Visit `/admin/settings/google-connect`. Complete Google OAuth end-to-end. Confirm calendar event creation.
- [ ] **7. Regression check.** `portal.smd.services` still works for client login; `smd.services` marketing still renders.
- [ ] **8. Post-settle.** Separate PR: remove the old `https://smd.services/api/auth/google/callback` from Google Cloud Console.

## Test plan

- [x] `npm run verify` passes locally (1060 tests)
- [x] New `tests/middleware.test.ts` covers the admin rewrite, apex redirects (with loop guard + query preservation), and three-host cookie guard
- [x] Extended `tests/canonical-app-url.test.ts` covers the strict `ADMIN_BASE_URL` semantics and the OAuth/outbound-URL sweep
- [ ] CI passes on the push
- [ ] End-to-end verification per steps 5–7 above

## Cookie/session impact

Admin session cookies are host-scoped (no `Domain` attribute). The first visit to `admin.smd.services` post-migration requires one fresh login. Old apex cookies are proactively cleared on next apex request; old sessions expire naturally (7-day TTL).

## Out of scope

- Stripping `/admin/` prefix from internal links. Portal keeps `/portal/*` in internal links — stay symmetric. URLs only visible to one operator; optimizing is aesthetic, not functional.
- Portal layout consolidation (separate PR: 6 portal pages still have inline HTML headers that should migrate to a shared `PortalLayout.astro`).
- Test data cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)