### PR TITLE
fix(booking): remove fixed height on slot grid to prevent nested scroll

### DIFF
--- a/src/components/booking/SlotPicker.astro
+++ b/src/components/booking/SlotPicker.astro
@@ -106,7 +106,7 @@
       <!-- Right: Time slots for selected date -->
       <div class="sm:w-1/2">
         <p id="sp-date-label" class="mb-3 text-sm font-semibold text-slate-900"></p>
-        <div id="sp-slots" class="grid grid-cols-2 gap-2 max-h-72 overflow-y-auto pr-1"></div>
+        <div id="sp-slots" class="grid grid-cols-2 gap-2"></div>
         <p id="sp-no-slots-day" class="hidden py-8 text-center text-sm text-slate-500">
           No available times on this date.
         </p>


### PR DESCRIPTION
## Summary
- The slot column was capped at `max-h-72 overflow-y-auto`, which clipped rows past ~5 slots and forced a nested scroll inside the booking card.
- On mobile, the calendar stacks above the slots, so users had to scroll the page *and then* scroll inside an inner container to reach later times — unprofessional UX.
- Removed the height cap and scroll affordance from `#sp-slots`. The grid now expands to fit all available slots; the page scrolls naturally.

## Test plan
- [x] `npm run verify` passes
- [ ] Visit `/book` on mobile — all slots for a day visible with a single page scroll, no inner scroll container
- [ ] Visit `/book` on desktop — card grows taller on days with many slots; calendar column remains fixed height

🤖 Generated with [Claude Code](https://claude.com/claude-code)