### PR TITLE
fix(portal): strip fabricated schedule from proposal page (#377)

### DIFF
--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -20,9 +20,9 @@ import type { ProblemId, LegacyProblemId } from '../../../portal/assessments/ext
  * Preserves existing SignWell integration. Never exposes hourly breakdown
  * or per-item pricing (Decision #16). Client sees total project price only.
  *
- * TODO(#363): source deliverables and week-by-week schedule from quote
- * columns once fields land on the quotes table. For now we fall back to
- * parsed line items and a sensible 3-week default schedule.
+ * No schedule, milestones, or activities are rendered here. The signed SOW
+ * is the source of truth for engagement structure. See #377: client-facing
+ * pages must not synthesize commitments the business has not authored.
  */
 
 const session = Astro.locals.session!
@@ -75,12 +75,6 @@ const deliverables = lineItems.map((item) => ({
   title: getProblemLabel(item.problem),
   body: item.description ?? '',
 }))
-
-const schedule = [
-  { label: 'Week 1', body: 'We shadow and observe.' },
-  { label: 'Week 2', body: 'We redesign together. You approve every change.' },
-  { label: 'Week 3', body: 'Training and handoff.' },
-]
 
 const engagementTitle = deliverables[0]?.title ?? 'Your engagement'
 const engagementSubtitle =
@@ -338,32 +332,6 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
                 ))
               }
             </ul>
-          </div>
-
-          <!-- How we'll work -->
-          <div class="pt-2">
-            <div class="h-px bg-[color:var(--color-border)] mb-8"></div>
-            <h2
-              class="font-['Plus_Jakarta_Sans'] font-bold text-[22px] leading-[28px] text-[color:var(--color-text-primary)] mb-6"
-            >
-              How we'll work
-            </h2>
-            <div class="space-y-8">
-              {
-                schedule.map((row) => (
-                  <div class="flex gap-4">
-                    <div class="w-[72px] shrink-0">
-                      <span class="text-[13px] leading-[18px] font-semibold tracking-[0.01em] text-[color:var(--color-meta)] uppercase">
-                        {row.label}
-                      </span>
-                    </div>
-                    <p class="flex-1 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
-                      {row.body}
-                    </p>
-                  </div>
-                ))
-              }
-            </div>
           </div>
 
           <!-- Terms -->


### PR DESCRIPTION
## Summary

P0 hotfix for #377. The portal proposal page (`src/pages/portal/quotes/[id].astro`) hardcoded a 3-week schedule ("Week 1: We shadow and observe", etc.) rendered to every client viewing a proposal, regardless of actual scope. Introduced as a placeholder default in PR #370 and shipped despite the in-file TODO acknowledging the gap.

This is a misrepresentation of the business's commitments and a compliance/legal risk.

## Changes

- Removed the `schedule` constant (lines 79–83 pre-fix)
- Removed the entire "How we'll work" section from the rendered page
- Updated the file-level comment to document the rule: client-facing pages must not synthesize commitments the business has not authored. Signed SOW remains the source of truth for engagement structure.

Per #377 hotfix scope: render nothing in the schedule's place. Do not replace with another invented default.

## Out of scope (tracked in #377)

- Full client-facing-content audit across `src/pages/portal/**`
- Schema work for `quotes.schedule` and `quotes.deliverables`
- Admin authoring UI for per-quote schedule + deliverables
- CLAUDE.md guardrail: "no fabricated client-facing content"
- PR-process change: Captain content review on `client-facing` PRs

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds
- [x] `npm run test` — 1077 passed, 2 skipped
- [ ] Manual: render a sent-state quote in portal and confirm the "How we'll work" block is gone and no layout regression remains
- [ ] Manual: render a signed-state quote and confirm the SignWell flow / consultant block / terms still render correctly

## Strings the client will see (per #377 process change)

Every visible string on this page after the change comes from authored data:

| String | Source |
|---|---|
| `engagementTitle` / `engagementSubtitle` | Derived from `lineItems` (authored in admin quote builder) |
| Total / `paymentSplitText` | `quote.total_price`, `quote.deposit_pct`, `quote.total_hours` |
| `startWindowText` "Work begins within two weeks of signing." | **Hardcoded.** Flagged in #377 for audit-phase resolution |
| Deliverables list | `lineItems[].description` (authored). Flagged in #377 for audit-phase resolution |
| Consultant block | `engagements.consultant_*` columns (authored) |
| State copy (signed/declined/expired/superseded) | `resolveProposalState` |

`startWindowText` and the deliverables list are explicitly called out in #377 as audit-phase items, not hotfix-phase. Captain to confirm whether to expand the hotfix scope to cover them now.

Closes nothing; #377 stays open for follow-on audit + schema + guardrail work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)