### PR TITLE
chore(process): labels, CODEOWNERS, branch-protection setup doc (#377)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS — routing-only
+# Per #377: client-facing rendering paths route to Captain for content
+# review. This is documentation of intent. Actual enforcement lives in:
+#   .github/workflows/scope-deferred-todo.yml
+#   .github/workflows/unmet-ac-on-close.yml
+
+src/pages/portal/**         @smdurgan-llc
+src/lib/portal/**           @smdurgan-llc
+src/components/portal/**    @smdurgan-llc

--- a/docs/process/branch-protection-setup.md
+++ b/docs/process/branch-protection-setup.md
@@ -1,0 +1,28 @@
+# Branch Protection Setup
+
+Required status checks to enforce on `main`. Repo-admin access required.
+
+**Settings URL:** https://github.com/venturecrane/ss-console/settings/branches
+
+## Steps
+
+1. Go to the URL above.
+2. Under "Branch protection rules", click **Add rule** (or edit the existing `main` rule if one exists).
+3. Set **Branch name pattern** to `main`.
+4. Check **Require status checks to pass before merging**.
+5. Check **Require branches to be up to date before merging**.
+6. In the search box, find and check the following status checks:
+
+   | Check name                             | Workflow                  |
+   | -------------------------------------- | ------------------------- |
+   | `Block undeferred TODO(#NNN) patterns` | `scope-deferred-todo.yml` |
+   | `Typecheck, Lint, Format, Test`        | CI workflow               |
+   | `npm audit (high+)`                    | audit workflow            |
+
+7. Click **Save changes**.
+
+## Note on check visibility
+
+A status check only appears in the dropdown after the workflow has run at least once on a PR targeting `main`. The `Block undeferred TODO(#NNN) patterns` check became available after PR #379 merged — it should appear in the search now.
+
+If `Typecheck, Lint, Format, Test` or `npm audit (high+)` are already required, no action needed for those rows.


### PR DESCRIPTION
## Summary

Adds three GitHub labels required by the process enforcement workflows, a CODEOWNERS routing entry for portal paths, and a branch-protection setup guide for Captain. These are the remaining mechanical follow-ons after PR #379 merged Moves 1–3.

## Linked issue

Refs #377

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Move 1 — workflow blocking new TODO(#NNN) patterns without scope-deferred label | met | Merged in #379 |
| Move 2 — workflow reopening issues closed with unchecked ACs (override via force-close label) | met | Merged in #379 |
| Move 3 — .github/PULL_REQUEST_TEMPLATE.md enumerating per-AC satisfaction | met | Merged in #379 |
| CODEOWNERS entry for src/pages/portal/** (routing aid; not the enforcement) | met | .github/CODEOWNERS |
| GitHub labels scope-deferred, force-close, closed-with-unmet-ac created | met | gh label create (executed via CLI, no file change needed) |

The remaining ACs (audit report, guardrail rule, schema, empty-state pattern, retroactive sweep) are in-progress on other tracks — not deferred from this PR.

## Deferred ACs (required if `scope-deferred` label is set)

N/A — no ACs deferred in this PR.

## Test plan

- [x] `npm run verify` passes (37 test files, 1079 tests)
- [x] Labels verified via `gh api repos/venturecrane/ss-console/labels` — correct colors and descriptions
- [x] CODEOWNERS paths confirmed against actual src/ directory (src/emails/** omitted — directory does not exist)
- [x] Branch-protection doc includes direct settings URL and click-by-click steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)