### PR TITLE
docs(process): no-fabrication guardrail + empty-state pattern (#377)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,27 @@ This creates a session, loads documentation, and establishes handoff context.
 - **Scope discipline.** Discover additional work mid-task — finish current scope, file a new issue.
 - **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min — stop and escalate.
 
+### No fabricated client-facing content
+
+Any information displayed to a client (timelines, schedules, deliverables, pricing, deposit terms, guarantees, consultant names, dates, scope language, post-signing promises, first-person sentences about future business behavior) MUST come from data authored for that specific engagement. That means database columns populated by a human-reviewed admin flow, CMS content, or source files explicitly reviewed by Captain.
+
+**Two violation patterns are prohibited:**
+
+- **Pattern A (committed template sentences that imply uncontracted commitments).** Hardcoded sentences in source, even ones that interpolate authored values, that promise specific business behavior the engagement has not contracted. Real examples from the 2026-04-15 audit:
+  - `'We'll reach out to schedule kickoff.'` (`src/lib/portal/states.ts:138`)
+  - `'Work begins within two weeks of signing.'` (`src/pages/portal/quotes/[id].astro:72`)
+  - `'Replies within 1 business day.'` (`src/components/portal/ConsultantBlock.astro:136`)
+  - `'A 2-week stabilization period follows the final handoff.'` (`src/lib/pdf/sow-template.tsx:529`)
+
+- **Pattern B (runtime fabrication from non-authoritative fields).** Values rendered from sources never authored as client-facing content: placeholder defaults, parsed or derived text, brief-borrowed copy. Real examples from the audit:
+  - The 3-week schedule constant (`'We shadow and observe.'` / `'We redesign together.'` / `'Training and handoff.'`) at `src/pages/portal/quotes/[id].astro:79-83`, stripped by hotfix #378
+  - `overview: 'Operations cleanup engagement as discussed during assessment.'` injected into every SOW PDF at `src/pages/api/admin/quotes/[id].ts:110`
+  - `contactName: primaryContact?.name ?? 'Business Owner'` at `src/pages/api/admin/quotes/[id].ts:101` (a SOW signed as "Business Owner" is a compliance risk)
+
+**If authored data is missing:** render nothing or an explicit "TBD in SOW" marker. See `docs/style/empty-state-pattern.md`. Never invent plausible content.
+
+**Enforcement.** Violations are P0. Merge gate is `.github/workflows/scope-deferred-todo.yml` (blocks TODO-deferred ACs without the `scope-deferred` label). Issue-close gate is `.github/workflows/unmet-ac-on-close.yml` (reopens issues closed with unchecked ACs).
+
 ## Tone & Positioning Standard
 
 **These rules apply to ALL external-facing content: website copy, outreach, proposals, collateral, and any client-facing language. They also apply to internal content that may inform external copy (e.g., one-liners, scripts).**

--- a/docs/style/empty-state-pattern.md
+++ b/docs/style/empty-state-pattern.md
@@ -1,0 +1,163 @@
+# Empty-state pattern for client-facing surfaces
+
+When authored data for a section is missing, render NOTHING or an explicit
+"TBD in SOW" marker. Never synthesize content, never borrow brief copy, never
+fall back to "sensible defaults". This is the only sanctioned alternative to
+having authored data.
+
+This document exists because the proposal page incident (#377, hotfix #378)
+showed that agents (and reviewers) will accept fabricated content over a
+visually empty section. Until the empty-state pattern is the path of least
+resistance, the no-fabrication rule in the project [CLAUDE.md](../../CLAUDE.md)
+will keep getting routed around. The two work as a pair: the rule prohibits
+invention, this doc shows what to do instead.
+
+## When to render nothing
+
+Render nothing when the section's absence is not meaningful to the client and
+they will not miss it. The surface still reads as complete because the section
+was conditional on data the client never expected.
+
+Use this pattern when:
+
+- The section is one of several that a complete record will populate, and the
+  client has no per-engagement reason to expect any specific one (for example,
+  the timeline section on a portal home dashboard for an engagement that
+  hasn't started yet).
+- The section is purely additive (a "next check-in" callout, a consultant
+  contact block, a deliverables list on a draft proposal) and the surface
+  above and below it stands on its own.
+- The section was not promised in any prior client communication. If the
+  proposal email said "you'll see your kickoff date in the portal," do not
+  silently omit the kickoff date. Use the explicit marker pattern instead.
+
+## When to render "TBD in SOW"
+
+Render an explicit "TBD in SOW" marker (or the surface-appropriate equivalent)
+when the section's absence would confuse the client and they need a signal
+that the gap is intentional. The marker tells the client "this is coming and
+will be set in the signed SOW," which is true and bounded.
+
+Use this pattern when:
+
+- The section is a labeled field the client expects to see populated (project
+  start date, end date, milestone names). Rendering an empty cell next to a
+  populated one looks like a bug.
+- The section is something the engagement contracted but has not yet
+  finalized. The marker is a placeholder for authored content that will land,
+  not a stand-in for content that may never exist.
+- A signed legal document (SOW PDF) needs the field present for layout and
+  audit reasons even if its value is not yet known. The existing
+  `'TBD upon deposit'` and `'TBD based on scope'` markers at
+  `src/pages/api/admin/quotes/[id].ts:111-112` are the precedent.
+
+The marker text should be short, capitalized as a label, and never sound like
+filler. `'TBD in SOW'` is the standard. `'TBD'` alone is acceptable inline
+(see `src/pages/portal/engagement/index.astro:48`). Do not write
+`'Coming soon'`, `'To be determined later'`, or any phrasing that implies
+business behavior the engagement has not contracted.
+
+## Implementation
+
+The portal is Astro with React islands. Both render the same way for this
+pattern.
+
+**Render-nothing pattern.** Gate the entire section on the authored field, not
+on a fallback:
+
+```astro
+{
+  engagement?.next_step_text && (
+    <p class="text-sm text-slate-600">Here's what happens next: {engagement.next_step_text}</p>
+  )
+}
+```
+
+Not this:
+
+```astro
+<p class="text-sm text-slate-600">
+  Here's what happens next: {engagement?.next_step_text ?? "We'll reach out to schedule kickoff."}
+</p>
+```
+
+The fallback string is a Pattern A violation. Even when the surrounding
+sentence interpolates an authored value, the literal wrapper is a commitment
+the engagement may not have contracted.
+
+**TBD-marker pattern.** Render the label with the marker as the value:
+
+```astro
+<dl>
+  <dt>Estimated Completion</dt>
+  <dd>{engagement.estimated_end ? formatDate(engagement.estimated_end) : 'TBD in SOW'}</dd>
+</dl>
+```
+
+The `formatDate` helper at `src/pages/portal/engagement/index.astro:48`
+already implements this for date fields. Reuse it. For non-date fields, use
+the same conditional shape, never a string literal as the fallback.
+
+**Server-truth gating.** When the section's presence depends on a database
+state (a `superseding` row exists, the quote is `accepted_at`-set, the
+invoice is `paid_at`-set), gate on that row, not on a derived placeholder.
+This is what `src/pages/portal/quotes/[id].astro:252-255` already does
+correctly with `'A revised version is available.'` (the sentence renders only
+when a superseding row exists).
+
+**Component prop default note.** If a presentational component (for example
+`ConsultantBlock`) takes optional props, the component's job is to omit the
+sub-section when the prop is absent. The host page should pass through the
+authored value or `null`, not a default string. Pattern A violations have
+been entering the codebase via component-level defaults that look harmless
+in isolation.
+
+## Anti-patterns (from audit)
+
+These are real instances from the 2026-04-15 audit
+(`docs/audits/client-facing-content-2026-04-15.md`). Each shows the violation
+and the empty-state pattern that should have been used.
+
+**1. Fallback consultant identity at `src/pages/portal/quotes/[id].astro:85`.**
+
+```ts
+const consultantName = 'Scott Durgan'
+```
+
+This renders to every client whose engagement does not have
+`engagements.consultant_name` populated. The SMD Services voice standard
+(CLAUDE.md §6) is "we" / "our team," and a single hardcoded name runs
+counter to that. Correct pattern: gate the consultant block on
+`engagement?.consultant_name`. If absent, render nothing in that surface.
+
+**2. Process-commitment fallback at `src/lib/portal/states.ts:138`.**
+
+```ts
+nextStepText ?? "We'll reach out to schedule kickoff."
+```
+
+Every client whose engagement does not have an authored next-step sentence
+sees the same kickoff promise. Correct pattern: drop the fallback, return
+`null`, and let the host page conditionally render the "what happens next"
+sentence.
+
+**3. SOW PDF overview at `src/pages/api/admin/quotes/[id].ts:110`.**
+
+```ts
+overview: 'Operations cleanup engagement as discussed during assessment.'
+```
+
+This sentence becomes the Page 1 "ENGAGEMENT OVERVIEW" body on every signed
+SOW regardless of what was actually scoped. Correct pattern: require an
+authored `quotes.engagement_overview` before SOW generation. If absent,
+block generation rather than ship a SOW with a fabricated overview.
+
+**4. SOW signature contact fallback at `src/pages/api/admin/quotes/[id].ts:101`.**
+
+```ts
+contactName: primaryContact?.name ?? 'Business Owner'
+```
+
+A SOW signed as "Business Owner" is a compliance risk. Correct pattern:
+block SOW generation if no primary contact name is on file. There is no
+acceptable empty-state for a signature line on a legal document.


### PR DESCRIPTION
## Summary

Adds the durable guardrail rule for #377 (Track C / scribe). Two committed files plus one proposed update to the global guardrails doc that needs Captain to apply via the crane upload script.

## Linked issue

Refs #377

This PR satisfies three of #377's "Guardrail + schema" acceptance criteria. Engineering tracks (D) and triage (B) ship separately.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| CLAUDE.md guardrail rule explicitly names **both patterns** with examples drawn from the audit | met | `CLAUDE.md` (new "No fabricated client-facing content" section under Enterprise Rules) with 4 verbatim Pattern A examples and 3 verbatim Pattern B examples, each with file:line citations from `docs/audits/client-facing-content-2026-04-15.md` |
| Global guardrails doc updated with the same two-pattern framing | proposed (Captain action required) | Draft at `/tmp/guardrails-proposed.md` on scribe's machine; full diff intent below. The crane MCP exposes `crane_doc` (read-only); upload requires `./scripts/upload-doc-to-context-worker.sh` which does not live in this repo. |
| Move 4 (audit phase) — sanctioned empty-state pattern documented in portal style guide | met | `docs/style/empty-state-pattern.md` (new file) |
| Audit report committed under `docs/audits/client-facing-content-YYYY-MM-DD.md` | already-met | Track A / PR #381 |
| Move 1 — workflow blocking new TODO(#NNN) without scope-deferred label | already-met | `.github/workflows/scope-deferred-todo.yml` (Track E) |
| Move 2 — workflow reopening issues closed with unchecked ACs | already-met | `.github/workflows/unmet-ac-on-close.yml` (Track E) |
| Move 3 — PR template enumerating per-AC satisfaction | already-met | `.github/PULL_REQUEST_TEMPLATE.md` (Track E) |
| CODEOWNERS entry for `src/pages/portal/**` | already-met | Track E |
| Move 5 — retroactive sweep report | already-met | Track B |
| Hotfix PR #378 merged removing the fabricated schedule | already-met | #378 |
| Schema migration / admin UI / backfill | n/a (this PR) | Track D |

## Deferred ACs

None. The global guardrails update is "proposed not deferred" — the work is done, it just needs Captain to apply via the upload script.

## Proposed global guardrails update (Captain action)

The current doc (`crane_doc('global', 'guardrails.md')`, v22) has three Protected Action categories: Feature Deprecation, Schema Changes, Auth Flow Changes. The proposed update adds a fourth: **Fabricated Client-Facing Content**, with the same two-pattern framing as the project CLAUDE.md rule.

Specific changes in the draft (`/tmp/guardrails-proposed.md` on scribe's machine; reproduced below for review):

1. Lead "Rule:" line gains: `Never ship fabricated client-facing content.`
2. SOD summary block gains a new bullet covering both patterns + the "render nothing or TBD" remediation.
3. New "Fabricated Client-Facing Content" subsection under Protected Actions, with Pattern A and Pattern B definitions and verbatim examples ("We'll reach out to schedule kickoff.", "A 2-week stabilization period follows the final handoff.", "Replies within 1 business day.", the 3-week schedule constant, "Operations cleanup engagement as discussed during assessment.", "Business Owner" fallback).
4. Two new heuristics under Concrete Heuristics (fallback strings, parsing line items into deliverables).
5. Standing rule: client-facing strings that aren't unambiguous interpolations of authored fields are protected actions.
6. Escalation Format gains the new category.

The full proposed text is available on scribe's machine. Captain can either pull it from `/tmp/guardrails-proposed.md` or request scribe re-paste it into a follow-up comment. After review, apply via `./scripts/upload-doc-to-context-worker.sh docs/instructions/guardrails.md` from the context-worker repo where the global doc lives.

## Test plan

- [x] `npm run verify` passes (tested locally, exit 0; 1077 tests pass, 0 errors, 0 warnings, 19 hints)
- [x] Prettier reformatted `docs/style/empty-state-pattern.md` cleanly (re-formatted with `npx prettier --write`)
- [x] CLAUDE.md guardrail rule references concrete file paths that exist (`docs/style/empty-state-pattern.md`, `.github/workflows/scope-deferred-todo.yml`, `.github/workflows/unmet-ac-on-close.yml`)
- [x] All Pattern A and Pattern B examples in the rule are verbatim from the audit report with valid file:line citations
- [x] Empty-state pattern doc grounded in real codebase patterns (references `formatDate` helper at `src/pages/portal/engagement/index.astro:48`, `'TBD upon deposit'` precedent at `src/pages/api/admin/quotes/[id].ts:111-112`, server-truth gating at `src/pages/portal/quotes/[id].astro:252-255`)
- [x] No em-dashes, no parallel three-part structures, no AI-polished phrasing in the new copy (per `feedback_no_ai_copy.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)