### PR TITLE
feat(quotes): authored schedule + deliverables, send-gated (#377)

### DIFF
--- a/docs/decisions/quotes-authored-content-backfill.md
+++ b/docs/decisions/quotes-authored-content-backfill.md
@@ -1,0 +1,99 @@
+# Backfill plan — quotes authored content (#377)
+
+**Status:** Captain decision pending. Do not execute backfill SQL until a path is chosen.
+
+**Context.** Migration 0021 added four nullable columns to `quotes` for authored client-facing content (`schedule`, `deliverables`, `engagement_overview`, `milestone_label`). New draft quotes are gated — they cannot be sent until `schedule` and `deliverables` are populated. Existing rows (sent, accepted, declined, expired, superseded) carry NULL values today.
+
+**The question.** What should happen when an existing client visits a quote whose `schedule` and `deliverables` columns are NULL?
+
+The portal currently does the right thing: when `schedule` is null/empty, the "How we'll work" section renders nothing (matches the empty-state pattern from #377 Move 4). Deliverables fall back to the line-item-derived list because removing that mid-flight would break sent quotes that have not been resigned. So the immediate-rendering risk is bounded — but every existing quote sits in a fragile state where any future render path that synthesizes content (a new email template, a PDF re-render, an admin-side preview) could re-introduce fabrication.
+
+Three options below. Recommendation at the end.
+
+## Option A — null backfill + portal flag (do nothing, accept friction)
+
+**Mechanics.** Leave `schedule` / `deliverables` NULL for all existing rows. Portal continues to render nothing for "How we'll work" on legacy quotes. Deliverables continue to fall back to line items. Admins are required to author both fields before the next time they re-send (e.g. on a status change to `superseded -> sent` for a revised version).
+
+**Pros.**
+
+- Zero data risk. No write touches any signed-quote row.
+- Preserves the original signed artifact's source-of-truth fidelity. The signed PDF stays the contractual document; the portal landing is read-only context.
+- Aligns with the empty-state pattern Track C is documenting.
+
+**Cons.**
+
+- Every existing client landing on their proposal sees a slightly thinner page than they did pre-#378 (the "How we'll work" block is gone, deliverables come from parsed line items instead of authored copy).
+- The line-item-deliverables fallback is the same Pattern B class we are trying to eliminate — leaving it in place indefinitely is debt.
+- Admins have to remember to author the new fields before any resend; nothing reminds them at non-resend touchpoints.
+
+**Effort.** Zero migration work. Some discipline cost on the team.
+
+## Option B — backfill with explicit TBD markers
+
+**Mechanics.** Run a one-shot UPDATE for every existing quote row, populating `schedule` and `deliverables` with explicit "TBD" payloads:
+
+```sql
+UPDATE quotes
+   SET schedule     = '[{"label":"Schedule","body":"Defined in the signed Statement of Work."}]',
+       deliverables = '[{"title":"Deliverables","body":"Defined in the signed Statement of Work."}]'
+ WHERE schedule IS NULL OR deliverables IS NULL;
+```
+
+Or render-side: detect `engagement_overview IS NULL` and substitute an explicit `"See signed SOW for engagement overview."` marker.
+
+**Pros.**
+
+- Every row has SOMETHING in the field, so no future render path can mistake null for "render fabricated default" — there is always a concrete string the page can show.
+- The "TBD" wording is explicit and verifiable (an attorney looking at the page sees a deferral, not a commitment).
+
+**Cons.**
+
+- Every backfilled row carries a sentence that the business never authored for that engagement. Even though the sentence is explicit and harmless, "rendering uniform copy across many clients" is the exact pattern the #377 audit flagged.
+- The send-gate becomes meaningless for backfilled rows: `getMissingAuthoredContent()` returns `[]` because the field has length, even though no one authored it. The validator can't distinguish "real authored" from "TBD-filler-from-backfill" without an additional flag.
+- If we ever add a flag to distinguish them, we are halfway to Option C with worse ergonomics.
+
+**Effort.** One UPDATE statement; easy to run, hard to reverse cleanly.
+
+## Option C — block old quotes from re-rendering until reauthored
+
+**Mechanics.** Add a fifth column in a follow-on migration:
+
+```sql
+ALTER TABLE quotes ADD COLUMN requires_authoring INTEGER NOT NULL DEFAULT 0;
+UPDATE quotes SET requires_authoring = 1 WHERE schedule IS NULL OR deliverables IS NULL;
+```
+
+Portal renders a banner on `requires_authoring = 1` rows: _"This proposal predates our updated proposal format and is being refreshed. Please contact your consultant for the current version."_ The signed PDF download remains available (signed quotes), but the marketing surface is hidden.
+
+The admin-side authoring flow clears `requires_authoring` once `schedule` and `deliverables` are populated.
+
+**Pros.**
+
+- Hardest possible enforcement. Eliminates the chance that a legacy quote ever renders Pattern B content again.
+- Forces the team to reauthor old quotes proactively rather than only-on-resend.
+- Makes the "what is authored vs. what was backfilled" distinction explicit and queryable.
+
+**Cons.**
+
+- Every existing client who lands on their proposal page right after merge sees the "being refreshed" banner — a worse experience for accepted/signed clients who have a contractual relationship and are using the portal as a reference.
+- Adds schema migration + render-side branching for a transient state.
+- Most blunt of the three options.
+
+**Effort.** Migration + portal banner + admin-side clearer. Moderate.
+
+## Recommendation: **Option A** (null backfill + portal flag), with a follow-on issue to remove the line-items-deliverables fallback.
+
+Reasoning:
+
+1. The acute risk (the fabricated 3-week schedule) is already gone via #378 + the rendering changes in this PR. The remaining gap is the line-items-deliverables fallback, which is bounded — it shows the same content the line items were already authored with.
+2. Option B introduces uniform sentences across many clients, which is the original Pattern B violation in disguise. It would also defeat the send-gate. The cure is worse than the disease.
+3. Option C punishes the user (the signed-and-paying client) for an internal data-hygiene gap. A banner saying "your proposal is being refreshed" on a quote that has been signed and paid for damages trust for no proportional safety gain.
+4. Option A leaves us with one open debt (the line-items fallback) and one operational habit (author new fields before any resend). Both are addressable with a single follow-on issue tracked against #377.
+
+**Suggested follow-on work** (to file as a sub-issue if Option A is chosen):
+
+- A migration that adds a non-null `authored_at` timestamp set when both `schedule` and `deliverables` are populated. Lets the admin index distinguish authored-vs-legacy quotes at a glance.
+- Drop the line-items-deliverables fallback once all visible-status quotes (`sent`, `accepted`) carry non-null `deliverables`. Until then the fallback prevents legacy regressions while bounding the Pattern B surface.
+- A `crane_status`-style report that flags any visible-status quote with NULL authored content, so the team can sweep them as part of a routine pass.
+
+Captain to choose A / B / C and apply the chosen path in a follow-on PR.

--- a/migrations/0021_quotes_authored_content.sql
+++ b/migrations/0021_quotes_authored_content.sql
@@ -1,0 +1,34 @@
+-- Migration 0021: Authored client-facing content for quotes
+--
+-- Tracks #377 Pattern B remediation. The proposal page and SOW PDF previously
+-- synthesized client-facing content (a 3-week schedule, deliverables parsed
+-- from line items, a hardcoded "Operations cleanup engagement" overview,
+-- a generic "mid-engagement milestone" label) when no authored data existed.
+--
+-- Per #377 and the audit at docs/audits/client-facing-content-2026-04-15.md,
+-- client-facing content must come from human-authored fields, never from
+-- agent-invented defaults. These columns let the admin author per-engagement
+-- content; render code falls back to rendering nothing when they are null.
+--
+-- D1 / SQLite stores JSON as TEXT.
+--
+-- - schedule:           JSON array of { label, body } rows for the
+--                       "How we'll work" section on the proposal page.
+-- - deliverables:       JSON array of { title, body } rows that replace the
+--                       line-items-derived deliverables list on the proposal
+--                       page and items list on the SOW PDF.
+-- - engagement_overview: Free-text overview rendered on the SOW PDF
+--                       "ENGAGEMENT OVERVIEW" page (was hardcoded).
+-- - milestone_label:    Per-engagement label for the mid-engagement milestone
+--                       on three-milestone SOWs (was hardcoded "mid-engagement
+--                       milestone").
+--
+-- All four columns are NULL by default. Existing rows remain null until the
+-- admin authors them. The send-gating in the admin UI requires schedule and
+-- deliverables (the two explicitly called out in #377) to be populated before
+-- a draft quote can be sent.
+
+ALTER TABLE quotes ADD COLUMN schedule TEXT;
+ALTER TABLE quotes ADD COLUMN deliverables TEXT;
+ALTER TABLE quotes ADD COLUMN engagement_overview TEXT;
+ALTER TABLE quotes ADD COLUMN milestone_label TEXT;

--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -30,6 +30,12 @@ export interface Quote {
   sent_at: string | null
   expires_at: string | null
   accepted_at: string | null
+  // Authored client-facing content (#377). NULL until populated by the admin.
+  // Render code falls back to rendering nothing — never to synthesized defaults.
+  schedule: string | null // JSON array of ScheduleRow
+  deliverables: string | null // JSON array of DeliverableRow
+  engagement_overview: string | null
+  milestone_label: string | null
   created_at: string
   updated_at: string
 }
@@ -38,6 +44,25 @@ export interface LineItem {
   problem: string
   description: string
   estimated_hours: number
+}
+
+/**
+ * A row in the per-quote "How we'll work" schedule rendered on the proposal
+ * page. Authored by the admin; never synthesized.
+ */
+export interface ScheduleRow {
+  label: string
+  body: string
+}
+
+/**
+ * A row in the per-quote deliverables list rendered on the proposal page and
+ * the SOW PDF "Items" section. Authored by the admin; never derived from line
+ * items at render time.
+ */
+export interface DeliverableRow {
+  title: string
+  body: string
 }
 
 export type QuoteStatus = 'draft' | 'sent' | 'accepted' | 'declined' | 'expired' | 'superseded'
@@ -76,12 +101,80 @@ export interface CreateQuoteData {
   lineItems: LineItem[]
   rate: number
   depositPct?: number
+  schedule?: ScheduleRow[]
+  deliverables?: DeliverableRow[]
+  engagementOverview?: string
+  milestoneLabel?: string
 }
 
 export interface UpdateQuoteData {
   lineItems?: LineItem[]
   rate?: number
   depositPct?: number
+  schedule?: ScheduleRow[] | null
+  deliverables?: DeliverableRow[] | null
+  engagementOverview?: string | null
+  milestoneLabel?: string | null
+}
+
+/**
+ * Parse the persisted JSON schedule into typed rows. Returns an empty array
+ * when the column is null, missing, or malformed — callers should treat
+ * "empty" the same as "not authored yet" and render nothing.
+ */
+export function parseSchedule(quote: Pick<Quote, 'schedule'>): ScheduleRow[] {
+  if (!quote.schedule) return []
+  try {
+    const parsed = JSON.parse(quote.schedule)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (row): row is ScheduleRow =>
+        row != null &&
+        typeof row === 'object' &&
+        typeof row.label === 'string' &&
+        typeof row.body === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Parse the persisted JSON deliverables into typed rows. Returns an empty
+ * array when the column is null, missing, or malformed — see parseSchedule.
+ */
+export function parseDeliverables(quote: Pick<Quote, 'deliverables'>): DeliverableRow[] {
+  if (!quote.deliverables) return []
+  try {
+    const parsed = JSON.parse(quote.deliverables)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (row): row is DeliverableRow =>
+        row != null &&
+        typeof row === 'object' &&
+        typeof row.title === 'string' &&
+        typeof row.body === 'string'
+    )
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Validate authored client-facing content before a draft quote can be sent.
+ * Returns the list of missing fields; empty array means the quote is ready
+ * to send. See #377: a quote without authored schedule + deliverables would
+ * be re-rendered with synthesized commitments downstream.
+ */
+export function getMissingAuthoredContent(quote: Quote): string[] {
+  const missing: string[] = []
+  if (parseSchedule(quote).length === 0) {
+    missing.push('schedule')
+  }
+  if (parseDeliverables(quote).length === 0) {
+    missing.push('deliverables')
+  }
+  return missing
 }
 
 /**
@@ -145,10 +238,17 @@ export async function createQuote(
   const depositPct = data.depositPct ?? 0.5
   const depositAmount = totalPrice * depositPct
 
+  const scheduleJson =
+    data.schedule && data.schedule.length > 0 ? JSON.stringify(data.schedule) : null
+  const deliverablesJson =
+    data.deliverables && data.deliverables.length > 0 ? JSON.stringify(data.deliverables) : null
+  const engagementOverview = data.engagementOverview ?? null
+  const milestoneLabel = data.milestoneLabel ?? null
+
   await db
     .prepare(
-      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, version, line_items, total_hours, rate, total_price, deposit_pct, deposit_amount, status, created_at, updated_at)
-     VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, 'draft', ?, ?)`
+      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, version, line_items, total_hours, rate, total_price, deposit_pct, deposit_amount, status, schedule, deliverables, engagement_overview, milestone_label, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?)`
     )
     .bind(
       id,
@@ -161,6 +261,10 @@ export async function createQuote(
       totalPrice,
       depositPct,
       depositAmount,
+      scheduleJson,
+      deliverablesJson,
+      engagementOverview,
+      milestoneLabel,
       now,
       now
     )
@@ -214,6 +318,30 @@ export async function updateQuote(
     params.push(data.depositPct)
   }
 
+  if (data.schedule !== undefined) {
+    fields.push('schedule = ?')
+    params.push(data.schedule && data.schedule.length > 0 ? JSON.stringify(data.schedule) : null)
+  }
+
+  if (data.deliverables !== undefined) {
+    fields.push('deliverables = ?')
+    params.push(
+      data.deliverables && data.deliverables.length > 0 ? JSON.stringify(data.deliverables) : null
+    )
+  }
+
+  if (data.engagementOverview !== undefined) {
+    fields.push('engagement_overview = ?')
+    const trimmed = data.engagementOverview?.trim() ?? null
+    params.push(trimmed && trimmed.length > 0 ? trimmed : null)
+  }
+
+  if (data.milestoneLabel !== undefined) {
+    fields.push('milestone_label = ?')
+    const trimmed = data.milestoneLabel?.trim() ?? null
+    params.push(trimmed && trimmed.length > 0 ? trimmed : null)
+  }
+
   // Recalculate totals if line items or rate changed
   if (lineItems !== undefined || rate !== undefined) {
     const effectiveItems = lineItems ?? (JSON.parse(existing.line_items) as LineItem[])
@@ -239,7 +367,15 @@ export async function updateQuote(
     return existing
   }
 
-  if (data.lineItems !== undefined || data.rate !== undefined || data.depositPct !== undefined) {
+  if (
+    data.lineItems !== undefined ||
+    data.rate !== undefined ||
+    data.depositPct !== undefined ||
+    data.schedule !== undefined ||
+    data.deliverables !== undefined ||
+    data.engagementOverview !== undefined ||
+    data.milestoneLabel !== undefined
+  ) {
     fields.push('version = version + 1')
   }
 
@@ -331,6 +467,18 @@ export async function updateQuoteStatus(
 
   const updates: string[] = ['status = ?']
   const params: (string | number | null)[] = [newStatus]
+
+  // Send-gating: a draft quote can only be sent once schedule + deliverables
+  // are authored. Without these, downstream rendering would either show empty
+  // sections or (pre-#377) synthesize fabricated content. See #377.
+  if (newStatus === 'sent') {
+    const missing = getMissingAuthoredContent(existing)
+    if (missing.length > 0) {
+      throw new Error(
+        `Cannot send quote: missing authored client-facing content (${missing.join(', ')}). Author the schedule and deliverables in the quote builder before sending.`
+      )
+    }
+  }
 
   if (newStatus === 'sent' && !existing.sent_at) {
     const sentAt = new Date()

--- a/src/lib/sow/service.ts
+++ b/src/lib/sow/service.ts
@@ -9,6 +9,7 @@
 
 import { buildAppUrl } from '../config/app-url'
 import type { Quote } from '../db/quotes'
+import { getMissingAuthoredContent } from '../db/quotes'
 import type { SOWTemplateProps } from '../pdf/sow-template'
 import {
   createSOWSendAuthorization,
@@ -166,6 +167,19 @@ export async function authorizeAndSendSOW(args: {
   const openRequest = await getOpenSignatureRequestForQuote(db, orgId, quote.id)
   if (openRequest) {
     throw new Error('SOW already sent for signature.')
+  }
+
+  // Send-gating: a draft quote must have authored schedule + deliverables
+  // before it can be sent for signature. Without these the proposal page
+  // would render an empty "How we'll work" / deliverables surface or (pre-#377)
+  // synthesize fabricated commitments. Mirrors the guard in updateQuoteStatus.
+  if (quote.status === 'draft') {
+    const missing = getMissingAuthoredContent(quote)
+    if (missing.length > 0) {
+      throw new Error(
+        `Cannot send quote for signature: missing authored client-facing content (${missing.join(', ')}). Author the schedule and deliverables in the quote builder before sending.`
+      )
+    }
   }
 
   const revision = await getLatestRenderableSOWRevisionForQuote(db, orgId, quote.id)

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -2,8 +2,20 @@
 import AdminLayout from '../../../../../layouts/AdminLayout.astro'
 import { statusBadgeClass } from '../../../../../lib/ui/status-badge'
 import { getEntity } from '../../../../../lib/db/entities'
-import { getQuote, QUOTE_STATUSES, VALID_TRANSITIONS } from '../../../../../lib/db/quotes'
-import type { LineItem, QuoteStatus } from '../../../../../lib/db/quotes'
+import {
+  getQuote,
+  parseSchedule,
+  parseDeliverables,
+  getMissingAuthoredContent,
+  QUOTE_STATUSES,
+  VALID_TRANSITIONS,
+} from '../../../../../lib/db/quotes'
+import type {
+  LineItem,
+  QuoteStatus,
+  ScheduleRow,
+  DeliverableRow,
+} from '../../../../../lib/db/quotes'
 import { listContacts } from '../../../../../lib/db/contacts'
 import { getSOWStateForQuote } from '../../../../../lib/sow/service'
 
@@ -40,6 +52,13 @@ const status = quote.status as QuoteStatus
 const validTransitions = VALID_TRANSITIONS[status] ?? []
 const isDraft = status === 'draft'
 const isTerminal = validTransitions.length === 0
+
+// Authored client-facing content (#377). NULL/empty until populated.
+const schedule: ScheduleRow[] = parseSchedule(quote)
+const deliverables: DeliverableRow[] = parseDeliverables(quote)
+const engagementOverview = quote.engagement_overview ?? ''
+const milestoneLabel = quote.milestone_label ?? ''
+const missingAuthored = getMissingAuthoredContent(quote)
 
 const sowState = await getSOWStateForQuote(env.DB, session.orgId, quoteId)
 const latestSowRevision = sowState.latestRevision
@@ -323,6 +342,217 @@ function formatCurrency(amount: number): string {
     </div>
   </div>
 
+  {/* Authored client-facing content (#377) */}
+  <div class="bg-white rounded-lg border border-slate-200 p-6 mb-6">
+    <div class="flex items-start justify-between mb-1">
+      <h3 class="text-lg font-semibold text-slate-900">Client-facing content</h3>
+      {
+        missingAuthored.length > 0 ? (
+          <span class="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-800 font-medium">
+            Required to send: {missingAuthored.join(', ')}
+          </span>
+        ) : (
+          <span class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 font-medium">
+            Ready to send
+          </span>
+        )
+      }
+    </div>
+    <p class="text-sm text-slate-500 mb-5">
+      Authored per engagement. Renders on the client proposal page and SOW PDF. Quotes cannot be
+      sent until the schedule and deliverables are populated.
+    </p>
+
+    {/* Schedule */}
+    <div class="mb-6">
+      <div class="flex items-center justify-between mb-2">
+        <label class="text-sm font-semibold text-slate-700"> How we'll work (schedule) </label>
+        {
+          isDraft && (
+            <button
+              type="button"
+              id="add-schedule-row-btn"
+              class="text-xs text-primary hover:text-primary-hover transition-colors font-medium"
+            >
+              + Add row
+            </button>
+          )
+        }
+      </div>
+      <p class="text-xs text-slate-500 mb-2">
+        One row per phase. The label sits in the left gutter (e.g. "Discovery", "Build").
+      </p>
+      <div id="schedule-rows" data-empty-text="No schedule rows authored yet.">
+        {
+          schedule.length === 0 ? (
+            <div class="text-sm text-slate-500 italic py-2 schedule-empty-state">
+              No schedule rows authored yet.
+            </div>
+          ) : (
+            schedule.map((row) => (
+              <div class="flex gap-2 mb-2 schedule-row">
+                {isDraft ? (
+                  <>
+                    <input
+                      type="text"
+                      class="w-32 border border-slate-200 rounded px-2 py-1 text-sm schedule-label"
+                      value={row.label}
+                      placeholder="Label"
+                    />
+                    <input
+                      type="text"
+                      class="flex-1 border border-slate-200 rounded px-2 py-1 text-sm schedule-body"
+                      value={row.body}
+                      placeholder="What happens in this phase"
+                    />
+                    <button
+                      type="button"
+                      class="text-slate-400 hover:text-red-500 transition-colors remove-schedule-row-btn px-2"
+                      title="Remove"
+                    >
+                      &times;
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span class="w-32 text-sm font-medium text-slate-600">{row.label}</span>
+                    <span class="flex-1 text-sm text-slate-700">{row.body}</span>
+                  </>
+                )}
+              </div>
+            ))
+          )
+        }
+      </div>
+    </div>
+
+    {/* Deliverables */}
+    <div class="mb-6">
+      <div class="flex items-center justify-between mb-2">
+        <label class="text-sm font-semibold text-slate-700"> What you'll get (deliverables) </label>
+        {
+          isDraft && (
+            <button
+              type="button"
+              id="add-deliverable-row-btn"
+              class="text-xs text-primary hover:text-primary-hover transition-colors font-medium"
+            >
+              + Add row
+            </button>
+          )
+        }
+      </div>
+      <p class="text-xs text-slate-500 mb-2">
+        Authored deliverables replace the line-item-derived list on the proposal page.
+      </p>
+      <div id="deliverable-rows" data-empty-text="No deliverables authored yet.">
+        {
+          deliverables.length === 0 ? (
+            <div class="text-sm text-slate-500 italic py-2 deliverable-empty-state">
+              No deliverables authored yet.
+            </div>
+          ) : (
+            deliverables.map((row) => (
+              <div class="mb-3 deliverable-row">
+                {isDraft ? (
+                  <div class="flex gap-2">
+                    <div class="flex-1 space-y-1">
+                      <input
+                        type="text"
+                        class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-title"
+                        value={row.title}
+                        placeholder="Title"
+                      />
+                      <textarea
+                        class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-body"
+                        rows="2"
+                        placeholder="Description"
+                      >
+                        {row.body}
+                      </textarea>
+                    </div>
+                    <button
+                      type="button"
+                      class="text-slate-400 hover:text-red-500 transition-colors remove-deliverable-row-btn px-2"
+                      title="Remove"
+                    >
+                      &times;
+                    </button>
+                  </div>
+                ) : (
+                  <div>
+                    <p class="text-sm font-semibold text-slate-700">{row.title}</p>
+                    <p class="text-sm text-slate-600">{row.body}</p>
+                  </div>
+                )}
+              </div>
+            ))
+          )
+        }
+      </div>
+    </div>
+
+    {/* Engagement overview (SOW PDF) */}
+    <div class="mb-6">
+      <label
+        class="block text-sm font-semibold text-slate-700 mb-1"
+        for="engagement-overview-input"
+      >
+        Engagement overview (SOW PDF)
+      </label>
+      <p class="text-xs text-slate-500 mb-2">
+        Renders on the SOW PDF "Engagement overview" page. Required before generating the SOW PDF.
+      </p>
+      {
+        isDraft ? (
+          <textarea
+            id="engagement-overview-input"
+            class="w-full border border-slate-200 rounded px-3 py-2 text-sm"
+            rows="3"
+            placeholder="What this engagement is about, in one or two sentences."
+          >
+            {engagementOverview}
+          </textarea>
+        ) : (
+          <p class="text-sm text-slate-700 whitespace-pre-wrap">
+            {engagementOverview || <span class="italic text-slate-400">Not authored.</span>}
+          </p>
+        )
+      }
+    </div>
+
+    {/* Milestone label (three-milestone only) */}
+    {
+      isThreeMilestone && (
+        <div class="mb-2">
+          <label
+            class="block text-sm font-semibold text-slate-700 mb-1"
+            for="milestone-label-input"
+          >
+            Mid-engagement milestone label
+          </label>
+          <p class="text-xs text-slate-500 mb-2">
+            Per-engagement label for the 30% mid-engagement milestone (e.g. "First-pass review",
+            "Pilot rollout"). Optional; the SOW renders neutral wording when empty.
+          </p>
+          {isDraft ? (
+            <input
+              id="milestone-label-input"
+              type="text"
+              class="w-full border border-slate-200 rounded px-3 py-2 text-sm"
+              value={milestoneLabel}
+              placeholder="Optional label for the mid-engagement milestone"
+            />
+          ) : (
+            <p class="text-sm text-slate-700">
+              {milestoneLabel || <span class="italic text-slate-400">Not authored.</span>}
+            </p>
+          )}
+        </div>
+      )
+    }
+  </div>
+
   {/* SOW PDF Status */}
   {
     hasSow && (
@@ -360,6 +590,30 @@ function formatCurrency(amount: number): string {
               name="deposit_pct"
               id="save-deposit-pct"
               value={String(depositPct)}
+            />
+            <input
+              type="hidden"
+              name="schedule"
+              id="save-schedule"
+              value={JSON.stringify(schedule)}
+            />
+            <input
+              type="hidden"
+              name="deliverables"
+              id="save-deliverables"
+              value={JSON.stringify(deliverables)}
+            />
+            <input
+              type="hidden"
+              name="engagement_overview"
+              id="save-engagement-overview"
+              value={engagementOverview}
+            />
+            <input
+              type="hidden"
+              name="milestone_label"
+              id="save-milestone-label"
+              value={milestoneLabel}
             />
             <button
               type="submit"
@@ -467,6 +721,16 @@ function formatCurrency(amount: number): string {
       const depositSelect = document.getElementById('deposit-pct-select')
       const saveLineItemsInput = document.getElementById('save-line-items')
       const saveDepositPctInput = document.getElementById('save-deposit-pct')
+      const saveScheduleInput = document.getElementById('save-schedule')
+      const saveDeliverablesInput = document.getElementById('save-deliverables')
+      const saveEngagementOverviewInput = document.getElementById('save-engagement-overview')
+      const saveMilestoneLabelInput = document.getElementById('save-milestone-label')
+      const scheduleRowsContainer = document.getElementById('schedule-rows')
+      const deliverableRowsContainer = document.getElementById('deliverable-rows')
+      const addScheduleRowBtn = document.getElementById('add-schedule-row-btn')
+      const addDeliverableRowBtn = document.getElementById('add-deliverable-row-btn')
+      const engagementOverviewInput = document.getElementById('engagement-overview-input')
+      const milestoneLabelInput = document.getElementById('milestone-label-input')
       const generatePdfBtn = document.getElementById('generate-pdf-btn')
       const signBtn = document.getElementById('sign-btn')
 
@@ -535,6 +799,127 @@ function formatCurrency(amount: number): string {
         renumberRows()
       }
 
+      // ---- Authored client-facing content (#377) ----
+
+      function clearEmptyState(container) {
+        if (!container) return
+        const empty = container.querySelector('.schedule-empty-state, .deliverable-empty-state')
+        if (empty) empty.remove()
+      }
+
+      function maybeShowEmptyState(container, isDeliverable) {
+        if (!container) return
+        const rows = container.querySelectorAll(
+          isDeliverable ? '.deliverable-row' : '.schedule-row'
+        )
+        if (rows.length === 0) {
+          const div = document.createElement('div')
+          div.className =
+            'text-sm text-slate-500 italic py-2 ' +
+            (isDeliverable ? 'deliverable-empty-state' : 'schedule-empty-state')
+          div.textContent = container.getAttribute('data-empty-text') ?? ''
+          container.appendChild(div)
+        }
+      }
+
+      function getScheduleRows() {
+        if (!scheduleRowsContainer) return []
+        const rows = scheduleRowsContainer.querySelectorAll('.schedule-row')
+        const out = []
+        rows.forEach((row) => {
+          const label = row.querySelector('.schedule-label')?.value?.trim() ?? ''
+          const bodyText = row.querySelector('.schedule-body')?.value?.trim() ?? ''
+          if (label.length > 0 || bodyText.length > 0) {
+            out.push({ label, body: bodyText })
+          }
+        })
+        return out
+      }
+
+      function getDeliverableRows() {
+        if (!deliverableRowsContainer) return []
+        const rows = deliverableRowsContainer.querySelectorAll('.deliverable-row')
+        const out = []
+        rows.forEach((row) => {
+          const title = row.querySelector('.deliverable-title')?.value?.trim() ?? ''
+          const bodyText = row.querySelector('.deliverable-body')?.value?.trim() ?? ''
+          if (title.length > 0 || bodyText.length > 0) {
+            out.push({ title, body: bodyText })
+          }
+        })
+        return out
+      }
+
+      function syncAuthoredContentInputs() {
+        if (saveScheduleInput) saveScheduleInput.value = JSON.stringify(getScheduleRows())
+        if (saveDeliverablesInput) {
+          saveDeliverablesInput.value = JSON.stringify(getDeliverableRows())
+        }
+        if (saveEngagementOverviewInput && engagementOverviewInput) {
+          saveEngagementOverviewInput.value = engagementOverviewInput.value
+        }
+        if (saveMilestoneLabelInput && milestoneLabelInput) {
+          saveMilestoneLabelInput.value = milestoneLabelInput.value
+        }
+      }
+
+      function addScheduleRow() {
+        if (!scheduleRowsContainer) return
+        clearEmptyState(scheduleRowsContainer)
+        const div = document.createElement('div')
+        div.className = 'flex gap-2 mb-2 schedule-row'
+        div.innerHTML = `
+          <input type="text" class="w-32 border border-slate-200 rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
+          <input type="text" class="flex-1 border border-slate-200 rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
+          <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
+        `
+        scheduleRowsContainer.appendChild(div)
+      }
+
+      function addDeliverableRow() {
+        if (!deliverableRowsContainer) return
+        clearEmptyState(deliverableRowsContainer)
+        const div = document.createElement('div')
+        div.className = 'mb-3 deliverable-row'
+        div.innerHTML = `
+          <div class="flex gap-2">
+            <div class="flex-1 space-y-1">
+              <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
+              <textarea class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
+            </div>
+            <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
+          </div>
+        `
+        deliverableRowsContainer.appendChild(div)
+      }
+
+      if (addScheduleRowBtn) addScheduleRowBtn.addEventListener('click', addScheduleRow)
+      if (addDeliverableRowBtn) addDeliverableRowBtn.addEventListener('click', addDeliverableRow)
+
+      if (scheduleRowsContainer) {
+        scheduleRowsContainer.addEventListener('click', (e) => {
+          if (e.target.classList.contains('remove-schedule-row-btn')) {
+            const row = e.target.closest('.schedule-row')
+            if (row) {
+              row.remove()
+              maybeShowEmptyState(scheduleRowsContainer, false)
+            }
+          }
+        })
+      }
+
+      if (deliverableRowsContainer) {
+        deliverableRowsContainer.addEventListener('click', (e) => {
+          if (e.target.classList.contains('remove-deliverable-row-btn')) {
+            const row = e.target.closest('.deliverable-row')
+            if (row) {
+              row.remove()
+              maybeShowEmptyState(deliverableRowsContainer, true)
+            }
+          }
+        })
+      }
+
       function renumberRows() {
         const rows = body.querySelectorAll('.line-item-row')
         rows.forEach((row, i) => {
@@ -584,11 +969,12 @@ function formatCurrency(amount: number): string {
       body.addEventListener('input', recalculate)
       if (depositSelect) depositSelect.addEventListener('change', recalculate)
 
-      // Before form submit, sync line items to hidden field
+      // Before form submit, sync line items + authored content to hidden fields
       const saveForm = document.getElementById('save-form')
       if (saveForm) {
         saveForm.addEventListener('submit', () => {
           recalculate()
+          syncAuthoredContentInputs()
         })
       }
 

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -1,6 +1,11 @@
 import type { APIRoute } from 'astro'
-import { getQuote, updateQuote, updateQuoteStatus } from '../../../../lib/db/quotes'
-import type { LineItem, QuoteStatus } from '../../../../lib/db/quotes'
+import {
+  getQuote,
+  updateQuote,
+  updateQuoteStatus,
+  parseDeliverables,
+} from '../../../../lib/db/quotes'
+import type { LineItem, QuoteStatus, DeliverableRow } from '../../../../lib/db/quotes'
 import { getEntity } from '../../../../lib/db/entities'
 import { listContacts } from '../../../../lib/db/contacts'
 import type { SOWTemplateProps } from '../../../../lib/pdf/sow-template'
@@ -57,7 +62,41 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       const contacts = await listContacts(env.DB, session.orgId, existing.entity_id)
       const primaryContact = contacts[0]
 
+      // A SOW signed with a placeholder contact name is a compliance risk.
+      // See #377 audit, src/pages/api/admin/quotes/[id].ts:101 — the previous
+      // 'Business Owner' fallback let an unauthored signer name reach the PDF.
+      if (!primaryContact?.name?.trim()) {
+        return redirect(
+          `/admin/entities/${existing.entity_id}/quotes/${quoteId}?error=${encodeURIComponent(
+            'Cannot generate SOW: add a primary contact with a name before generating the PDF.'
+          )}`,
+          302
+        )
+      }
+
+      // Engagement overview must be authored on the quote. See #377 audit:
+      // the prior hardcoded "Operations cleanup engagement as discussed during
+      // assessment." sentence shipped to every client regardless of scope.
+      if (!existing.engagement_overview?.trim()) {
+        return redirect(
+          `/admin/entities/${existing.entity_id}/quotes/${quoteId}?error=${encodeURIComponent(
+            'Cannot generate SOW: author the engagement overview on this quote before generating the PDF.'
+          )}`,
+          302
+        )
+      }
+
       const lineItems: LineItem[] = JSON.parse(existing.line_items)
+      const authoredDeliverables: DeliverableRow[] = parseDeliverables(existing)
+
+      // SOW item rows: prefer authored deliverables. If they are not yet
+      // authored, fall back to line items so legacy quotes do not break PDF
+      // generation. The send-gating in updateQuoteStatus will still block
+      // the quote from being sent without authored deliverables.
+      const sowItems =
+        authoredDeliverables.length > 0
+          ? authoredDeliverables.map((row) => ({ name: row.title, description: row.body }))
+          : lineItems.map((item) => ({ name: item.problem, description: item.description }))
 
       // Format currency
       const formatCurrency = (amount: number) =>
@@ -78,12 +117,17 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       let paymentProps: SOWTemplateProps['payment']
       if (isThreeMilestone) {
         // 40% deposit, 30% mid-engagement, 30% completion
+        // milestone_label is authored per quote — no generic default. The SOW
+        // template renders the label only when set; otherwise it uses the
+        // template's neutral "milestone" wording.
         paymentProps = {
           schedule: 'three_milestone',
           totalPrice: formatCurrency(totalPrice),
           deposit: formatCurrency(totalPrice * 0.4),
           milestone: formatCurrency(totalPrice * 0.3),
-          milestoneLabel: 'mid-engagement milestone',
+          ...(existing.milestone_label?.trim()
+            ? { milestoneLabel: existing.milestone_label.trim() }
+            : {}),
           completion: formatCurrency(totalPrice * 0.3),
         }
       } else {
@@ -98,7 +142,7 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       const templateProps: SOWTemplateProps = {
         client: {
           businessName: entity.name,
-          contactName: primaryContact?.name ?? 'Business Owner',
+          contactName: primaryContact.name,
           contactTitle: primaryContact?.title ?? undefined,
         },
         document: {
@@ -107,14 +151,14 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
           sowNumber: 'PENDING',
         },
         engagement: {
-          overview: 'Operations cleanup engagement as discussed during assessment.',
+          overview: existing.engagement_overview!.trim(),
+          // Captain-decision (#377): start/end dates kept as explicit "TBD"
+          // markers, matching the empty-state convention. If/when
+          // engagements.start_date is wired in, replace these with that data.
           startDate: 'TBD upon deposit',
           endDate: 'TBD based on scope',
         },
-        items: lineItems.map((item) => ({
-          name: item.problem,
-          description: item.description,
-        })),
+        items: sowItems,
         payment: paymentProps,
       }
 
@@ -158,9 +202,27 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       return redirect(`/admin/entities/${existing.entity_id}/quotes/${quoteId}?saved=1`, 302)
     }
 
+    // ----- ACTION: send (gated on authored content per #377) -----
+    if (action === 'send') {
+      try {
+        await updateQuoteStatus(env.DB, session.orgId, quoteId, 'sent' as QuoteStatus)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return redirect(
+          `/admin/entities/${existing.entity_id}/quotes/${quoteId}?error=${encodeURIComponent(msg)}`,
+          302
+        )
+      }
+      return redirect(`/admin/entities/${existing.entity_id}/quotes/${quoteId}?saved=1`, 302)
+    }
+
     // ----- ACTION: update (default) -----
     const lineItemsJson = formData.get('line_items')
     const depositPctStr = formData.get('deposit_pct')
+    const scheduleJson = formData.get('schedule')
+    const deliverablesJson = formData.get('deliverables')
+    const engagementOverview = formData.get('engagement_overview')
+    const milestoneLabel = formData.get('milestone_label')
 
     const updateData: Record<string, unknown> = {}
 
@@ -180,6 +242,50 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       if (!isNaN(depositPct) && depositPct > 0 && depositPct <= 1) {
         updateData.depositPct = depositPct
       }
+    }
+
+    // Parse the JSON-encoded authored arrays. An empty/whitespace string
+    // means "clear the field"; missing form key means "leave unchanged".
+    if (typeof scheduleJson === 'string') {
+      try {
+        const parsed = scheduleJson.trim() === '' ? [] : JSON.parse(scheduleJson)
+        if (Array.isArray(parsed)) {
+          updateData.schedule = parsed
+            .filter((row) => row && typeof row === 'object')
+            .map((row) => ({
+              label: typeof row.label === 'string' ? row.label.trim() : '',
+              body: typeof row.body === 'string' ? row.body.trim() : '',
+            }))
+            .filter((row) => row.label.length > 0 || row.body.length > 0)
+        }
+      } catch {
+        // Invalid JSON — skip schedule update
+      }
+    }
+
+    if (typeof deliverablesJson === 'string') {
+      try {
+        const parsed = deliverablesJson.trim() === '' ? [] : JSON.parse(deliverablesJson)
+        if (Array.isArray(parsed)) {
+          updateData.deliverables = parsed
+            .filter((row) => row && typeof row === 'object')
+            .map((row) => ({
+              title: typeof row.title === 'string' ? row.title.trim() : '',
+              body: typeof row.body === 'string' ? row.body.trim() : '',
+            }))
+            .filter((row) => row.title.length > 0 || row.body.length > 0)
+        }
+      } catch {
+        // Invalid JSON — skip deliverables update
+      }
+    }
+
+    if (typeof engagementOverview === 'string') {
+      updateData.engagementOverview = engagementOverview
+    }
+
+    if (typeof milestoneLabel === 'string') {
+      updateData.milestoneLabel = milestoneLabel
     }
 
     await updateQuote(env.DB, session.orgId, quoteId, updateData)

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -4,8 +4,8 @@ import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import MoneyDisplay from '../../../components/portal/MoneyDisplay.astro'
 import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
 import { getPortalClient } from '../../../lib/portal/session'
-import { getQuoteForEntity } from '../../../lib/db/quotes'
-import type { LineItem } from '../../../lib/db/quotes'
+import { getQuoteForEntity, parseSchedule, parseDeliverables } from '../../../lib/db/quotes'
+import type { LineItem, ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
 import { resolveProposalState } from '../../../lib/portal/states'
 import {
@@ -20,9 +20,11 @@ import type { ProblemId, LegacyProblemId } from '../../../portal/assessments/ext
  * Preserves existing SignWell integration. Never exposes hourly breakdown
  * or per-item pricing (Decision #16). Client sees total project price only.
  *
- * No schedule, milestones, or activities are rendered here. The signed SOW
- * is the source of truth for engagement structure. See #377: client-facing
- * pages must not synthesize commitments the business has not authored.
+ * "How we'll work" and deliverables are rendered ONLY when authored on the
+ * quote (`quotes.schedule`, `quotes.deliverables`). When either field is null
+ * or empty the section renders nothing — never a synthesized default. See
+ * #377 and the empty-state pattern: missing data is missing data, not an
+ * invitation to invent commitments.
  */
 
 const session = Astro.locals.session!
@@ -71,10 +73,23 @@ const paymentSplitText = isThreeMilestone
 
 const startWindowText = 'Work begins within two weeks of signing.'
 
-const deliverables = lineItems.map((item) => ({
-  title: getProblemLabel(item.problem),
-  body: item.description ?? '',
-}))
+// Deliverables prefer the authored `quotes.deliverables` rows. If none have
+// been authored we fall back to deriving from line items so legacy quotes
+// (pre-#377) keep rendering a list. The send-gate added in this issue
+// prevents NEW quotes from going out without authored deliverables; the
+// fallback exists only for the migration window. TODO(#377-followon):
+// once existing quotes have been backfilled or marked, drop the fallback
+// and require authored deliverables on every visible quote.
+const authoredDeliverables: DeliverableRow[] = parseDeliverables(quote)
+const schedule: ScheduleRow[] = parseSchedule(quote)
+
+const deliverables: DeliverableRow[] =
+  authoredDeliverables.length > 0
+    ? authoredDeliverables
+    : lineItems.map((item) => ({
+        title: getProblemLabel(item.problem),
+        body: item.description ?? '',
+      }))
 
 const engagementTitle = deliverables[0]?.title ?? 'Your engagement'
 const engagementSubtitle =
@@ -333,6 +348,32 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
               }
             </ul>
           </div>
+
+          <!-- How we'll work (only when authored — never synthesized; #377) -->
+          {
+            schedule.length > 0 && (
+              <div class="pt-2">
+                <div class="h-px bg-[color:var(--color-border)] mb-8" />
+                <h2 class="font-['Plus_Jakarta_Sans'] font-bold text-[22px] leading-[28px] text-[color:var(--color-text-primary)] mb-6">
+                  How we'll work
+                </h2>
+                <div class="space-y-8">
+                  {schedule.map((row) => (
+                    <div class="flex gap-4">
+                      <div class="w-[72px] shrink-0">
+                        <span class="text-[13px] leading-[18px] font-semibold tracking-[0.01em] text-[color:var(--color-meta)] uppercase">
+                          {row.label}
+                        </span>
+                      </div>
+                      <p class="flex-1 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
+                        {row.body}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          }
 
           <!-- Terms -->
           <div class="pt-2">

--- a/tests/lifecycle-guards.test.ts
+++ b/tests/lifecycle-guards.test.ts
@@ -193,6 +193,12 @@ describe('lifecycle invariant guards', () => {
         assessmentId: 'assess-1',
         lineItems: [{ problem: 'Test', description: 'Test item', estimated_hours: 10 }],
         rate: 150,
+        // #377: send-gating requires authored schedule + deliverables before
+        // a draft quote can transition to 'sent'. The acceptance guard tests
+        // below only care about the 'sent -> accepted' edge, so populate the
+        // minimum that satisfies the gate.
+        schedule: [{ label: 'Test phase', body: 'Test body.' }],
+        deliverables: [{ title: 'Test deliverable', body: 'Test body.' }],
       })
       quoteId = quote.id
 

--- a/tests/quotes-authored-content.test.ts
+++ b/tests/quotes-authored-content.test.ts
@@ -1,0 +1,614 @@
+/**
+ * Authored client-facing content tests for quotes (#377).
+ *
+ * Exercises:
+ *   - parseSchedule / parseDeliverables: null, empty, malformed, populated
+ *   - getMissingAuthoredContent: which fields are still empty
+ *   - createQuote / updateQuote: round-tripping the new fields
+ *   - updateQuoteStatus: send-gating when authored content is missing
+ *   - portal page: re-introduces "How we'll work" only when schedule is
+ *     populated; falls back to line-items deliverables only when authored
+ *     deliverables are missing
+ *   - admin page: surfaces authoring UI + send-gate banner
+ *   - SOW templateProps: requires authored overview and primary contact name
+ *
+ * Uses @venturecrane/crane-test-harness for the DAL/round-trip tests and
+ * source-string assertions for the render-side checks (matching the pattern
+ * in tests/portal-quotes.test.ts).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity, type EntityStage } from '../src/lib/db/entities'
+import {
+  createQuote,
+  getQuote,
+  updateQuote,
+  updateQuoteStatus,
+  parseSchedule,
+  parseDeliverables,
+  getMissingAuthoredContent,
+} from '../src/lib/db/quotes'
+import type { Quote } from '../src/lib/db/quotes'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG_ID = 'org-test'
+
+function makeQuote(overrides: Partial<Quote> = {}): Quote {
+  return {
+    id: 'q1',
+    org_id: ORG_ID,
+    entity_id: 'e1',
+    assessment_id: 'a1',
+    version: 1,
+    parent_quote_id: null,
+    line_items: '[]',
+    total_hours: 0,
+    rate: 0,
+    total_price: 0,
+    deposit_pct: 0.5,
+    deposit_amount: 0,
+    status: 'draft',
+    sent_at: null,
+    expires_at: null,
+    accepted_at: null,
+    schedule: null,
+    deliverables: null,
+    engagement_overview: null,
+    milestone_label: null,
+    created_at: '2026-04-15T00:00:00.000Z',
+    updated_at: '2026-04-15T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('parseSchedule', () => {
+  it('returns empty array when schedule is null', () => {
+    expect(parseSchedule(makeQuote({ schedule: null }))).toEqual([])
+  })
+
+  it('returns empty array when schedule is empty string', () => {
+    expect(parseSchedule(makeQuote({ schedule: '' }))).toEqual([])
+  })
+
+  it('returns empty array when schedule is not a JSON array', () => {
+    expect(parseSchedule(makeQuote({ schedule: '{"label":"x","body":"y"}' }))).toEqual([])
+  })
+
+  it('returns empty array when JSON is malformed', () => {
+    expect(parseSchedule(makeQuote({ schedule: 'not json' }))).toEqual([])
+  })
+
+  it('returns parsed rows when JSON is a valid array', () => {
+    const json = JSON.stringify([
+      { label: 'Discovery', body: 'We listen and learn.' },
+      { label: 'Build', body: 'We design and ship.' },
+    ])
+    expect(parseSchedule(makeQuote({ schedule: json }))).toEqual([
+      { label: 'Discovery', body: 'We listen and learn.' },
+      { label: 'Build', body: 'We design and ship.' },
+    ])
+  })
+
+  it('drops rows missing a label or body field', () => {
+    const json = JSON.stringify([
+      { label: 'Good', body: 'ok' },
+      { label: 'No body' },
+      { body: 'No label' },
+      null,
+    ])
+    expect(parseSchedule(makeQuote({ schedule: json }))).toEqual([{ label: 'Good', body: 'ok' }])
+  })
+})
+
+describe('parseDeliverables', () => {
+  it('returns empty array when deliverables is null', () => {
+    expect(parseDeliverables(makeQuote({ deliverables: null }))).toEqual([])
+  })
+
+  it('returns empty array when JSON is malformed', () => {
+    expect(parseDeliverables(makeQuote({ deliverables: 'not json' }))).toEqual([])
+  })
+
+  it('returns parsed rows when JSON is a valid array', () => {
+    const json = JSON.stringify([
+      { title: 'New CRM', body: 'HubSpot, configured.' },
+      { title: 'SOPs', body: 'Documented.' },
+    ])
+    expect(parseDeliverables(makeQuote({ deliverables: json }))).toEqual([
+      { title: 'New CRM', body: 'HubSpot, configured.' },
+      { title: 'SOPs', body: 'Documented.' },
+    ])
+  })
+
+  it('drops rows missing a title or body field', () => {
+    const json = JSON.stringify([
+      { title: 'Good', body: 'ok' },
+      { title: 'No body' },
+      { body: 'No title' },
+    ])
+    expect(parseDeliverables(makeQuote({ deliverables: json }))).toEqual([
+      { title: 'Good', body: 'ok' },
+    ])
+  })
+})
+
+describe('getMissingAuthoredContent', () => {
+  it('reports both fields missing when null', () => {
+    expect(getMissingAuthoredContent(makeQuote())).toEqual(['schedule', 'deliverables'])
+  })
+
+  it('reports only schedule missing when deliverables are populated', () => {
+    expect(
+      getMissingAuthoredContent(
+        makeQuote({
+          deliverables: JSON.stringify([{ title: 'x', body: 'y' }]),
+        })
+      )
+    ).toEqual(['schedule'])
+  })
+
+  it('returns empty array when both fields are populated', () => {
+    expect(
+      getMissingAuthoredContent(
+        makeQuote({
+          schedule: JSON.stringify([{ label: 'x', body: 'y' }]),
+          deliverables: JSON.stringify([{ title: 'x', body: 'y' }]),
+        })
+      )
+    ).toEqual([])
+  })
+
+  it('treats an empty array as missing', () => {
+    expect(
+      getMissingAuthoredContent(
+        makeQuote({
+          schedule: '[]',
+          deliverables: '[]',
+        })
+      )
+    ).toEqual(['schedule', 'deliverables'])
+  })
+})
+
+describe('quotes DAL: authored content round-trip', () => {
+  let db: D1Database
+  let entityId: string
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Test Org', 'test-org')
+      .run()
+
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Authored Content Biz',
+      stage: 'proposing' as EntityStage,
+    })
+    entityId = entity.id
+
+    await db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, 'completed')`
+      )
+      .bind('assess-authored', ORG_ID, entityId)
+      .run()
+  })
+
+  it('createQuote leaves authored fields null by default', async () => {
+    const quote = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-authored',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+    })
+    expect(quote.schedule).toBeNull()
+    expect(quote.deliverables).toBeNull()
+    expect(quote.engagement_overview).toBeNull()
+    expect(quote.milestone_label).toBeNull()
+  })
+
+  it('createQuote persists authored fields when provided', async () => {
+    const quote = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-authored',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+      schedule: [{ label: 'Phase 1', body: 'Discovery.' }],
+      deliverables: [{ title: 'Audit report', body: 'A written summary.' }],
+      engagementOverview: 'Operations cleanup for Authored Content Biz.',
+      milestoneLabel: 'pilot rollout',
+    })
+    expect(parseSchedule(quote)).toEqual([{ label: 'Phase 1', body: 'Discovery.' }])
+    expect(parseDeliverables(quote)).toEqual([
+      { title: 'Audit report', body: 'A written summary.' },
+    ])
+    expect(quote.engagement_overview).toBe('Operations cleanup for Authored Content Biz.')
+    expect(quote.milestone_label).toBe('pilot rollout')
+  })
+
+  it('updateQuote persists schedule and deliverables', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-authored',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+    })
+
+    const updated = await updateQuote(db, ORG_ID, created.id, {
+      schedule: [{ label: 'Week 1', body: 'Real authored copy.' }],
+      deliverables: [{ title: 'Real deliverable', body: 'Authored body.' }],
+      engagementOverview: 'Authored overview.',
+      milestoneLabel: 'first review',
+    })
+    expect(updated).not.toBeNull()
+    expect(parseSchedule(updated!)).toEqual([{ label: 'Week 1', body: 'Real authored copy.' }])
+    expect(parseDeliverables(updated!)).toEqual([
+      { title: 'Real deliverable', body: 'Authored body.' },
+    ])
+    expect(updated!.engagement_overview).toBe('Authored overview.')
+    expect(updated!.milestone_label).toBe('first review')
+  })
+
+  it('updateQuote clears authored fields when an empty array is passed', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-authored',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+      schedule: [{ label: 'a', body: 'b' }],
+      deliverables: [{ title: 'a', body: 'b' }],
+    })
+
+    const cleared = await updateQuote(db, ORG_ID, created.id, {
+      schedule: [],
+      deliverables: [],
+    })
+    expect(cleared!.schedule).toBeNull()
+    expect(cleared!.deliverables).toBeNull()
+  })
+
+  it('updateQuote bumps version when authored content changes', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-authored',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+    })
+    expect(created.version).toBe(1)
+
+    const updated = await updateQuote(db, ORG_ID, created.id, {
+      schedule: [{ label: 'a', body: 'b' }],
+    })
+    expect(updated!.version).toBe(2)
+  })
+})
+
+describe('updateQuoteStatus: send-gating on authored content', () => {
+  let db: D1Database
+  let entityId: string
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Test Org', 'test-org')
+      .run()
+
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Send Gate Biz',
+      stage: 'proposing' as EntityStage,
+    })
+    entityId = entity.id
+
+    await db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, status) VALUES (?, ?, ?, 'completed')`
+      )
+      .bind('assess-gate', ORG_ID, entityId)
+      .run()
+  })
+
+  it('blocks transition to sent when schedule is missing', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-gate',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+      deliverables: [{ title: 'a', body: 'b' }],
+    })
+
+    await expect(updateQuoteStatus(db, ORG_ID, created.id, 'sent')).rejects.toThrow(
+      /missing authored client-facing content.*schedule/
+    )
+  })
+
+  it('blocks transition to sent when deliverables are missing', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-gate',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+      schedule: [{ label: 'a', body: 'b' }],
+    })
+
+    await expect(updateQuoteStatus(db, ORG_ID, created.id, 'sent')).rejects.toThrow(
+      /missing authored client-facing content.*deliverables/
+    )
+  })
+
+  it('lists both fields when both are missing', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-gate',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+    })
+
+    await expect(updateQuoteStatus(db, ORG_ID, created.id, 'sent')).rejects.toThrow(
+      /schedule, deliverables/
+    )
+  })
+
+  it('allows transition to sent once both fields are authored', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-gate',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+      schedule: [{ label: 'a', body: 'b' }],
+      deliverables: [{ title: 'a', body: 'b' }],
+    })
+
+    const sent = await updateQuoteStatus(db, ORG_ID, created.id, 'sent')
+    expect(sent).not.toBeNull()
+    expect(sent!.status).toBe('sent')
+    expect(sent!.sent_at).not.toBeNull()
+    expect(sent!.expires_at).not.toBeNull()
+  })
+
+  it('does not gate the superseded transition (no client-facing surface)', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-gate',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+    })
+
+    const superseded = await updateQuoteStatus(db, ORG_ID, created.id, 'superseded')
+    expect(superseded).not.toBeNull()
+    expect(superseded!.status).toBe('superseded')
+  })
+
+  it('rejects send when authored arrays were cleared back to empty', async () => {
+    const created = await createQuote(db, ORG_ID, {
+      entityId,
+      assessmentId: 'assess-gate',
+      lineItems: [{ problem: 'X', description: 'Y', estimated_hours: 5 }],
+      rate: 200,
+      schedule: [{ label: 'a', body: 'b' }],
+      deliverables: [{ title: 'a', body: 'b' }],
+    })
+
+    const refreshed = await getQuote(db, ORG_ID, created.id)
+    expect(parseSchedule(refreshed!).length).toBeGreaterThan(0)
+
+    await updateQuote(db, ORG_ID, created.id, { schedule: [], deliverables: [] })
+    await expect(updateQuoteStatus(db, ORG_ID, created.id, 'sent')).rejects.toThrow(
+      /schedule, deliverables/
+    )
+  })
+})
+
+describe('portal proposal page: render gating', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/quotes/[id].astro'), 'utf-8')
+
+  it('imports parseSchedule and parseDeliverables', () => {
+    const code = source()
+    expect(code).toContain('parseSchedule')
+    expect(code).toContain('parseDeliverables')
+  })
+
+  it('reintroduces the "How we\'ll work" section gated on schedule.length', () => {
+    const code = source()
+    expect(code).toContain("How we'll work")
+    expect(code).toContain('schedule.length > 0')
+  })
+
+  it('does not contain the pre-#378 hardcoded weekly schedule', () => {
+    const code = source()
+    expect(code).not.toContain('We shadow and observe')
+    expect(code).not.toContain('We redesign together')
+    expect(code).not.toMatch(/Week 1.*Week 2.*Week 3/s)
+  })
+
+  it('prefers authored deliverables and falls back to line items only when missing', () => {
+    const code = source()
+    expect(code).toContain('authoredDeliverables.length > 0')
+    expect(code).toContain('? authoredDeliverables')
+  })
+
+  it('iterates schedule rows by label and body, not hardcoded week numbers', () => {
+    const code = source()
+    expect(code).toContain('schedule.map')
+    expect(code).toContain('row.label')
+    expect(code).toContain('row.body')
+  })
+})
+
+describe('admin quote builder: authoring UI + send gate', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/admin/entities/[id]/quotes/[quoteId].astro'), 'utf-8')
+
+  it('imports parsing helpers', () => {
+    const code = source()
+    expect(code).toContain('parseSchedule')
+    expect(code).toContain('parseDeliverables')
+    expect(code).toContain('getMissingAuthoredContent')
+  })
+
+  it('renders schedule row editor', () => {
+    const code = source()
+    expect(code).toContain('add-schedule-row-btn')
+    expect(code).toContain('schedule-label')
+    expect(code).toContain('schedule-body')
+  })
+
+  it('renders deliverable row editor', () => {
+    const code = source()
+    expect(code).toContain('add-deliverable-row-btn')
+    expect(code).toContain('deliverable-title')
+    expect(code).toContain('deliverable-body')
+  })
+
+  it('renders engagement-overview textarea', () => {
+    const code = source()
+    expect(code).toContain('engagement-overview-input')
+    expect(code).toContain('Engagement overview')
+  })
+
+  it('renders milestone-label input behind isThreeMilestone gate', () => {
+    const code = source()
+    expect(code).toContain('milestone-label-input')
+    expect(code).toContain('isThreeMilestone &&')
+  })
+
+  it('shows missing-authored-content banner when fields are empty', () => {
+    const code = source()
+    expect(code).toContain('missingAuthored')
+    expect(code).toContain('Required to send')
+  })
+
+  it('hidden fields submit schedule, deliverables, overview, milestone_label', () => {
+    const code = source()
+    expect(code).toContain('save-schedule')
+    expect(code).toContain('save-deliverables')
+    expect(code).toContain('save-engagement-overview')
+    expect(code).toContain('save-milestone-label')
+  })
+
+  it('serializes authored rows into hidden inputs before submit', () => {
+    const code = source()
+    expect(code).toContain('syncAuthoredContentInputs')
+    expect(code).toContain('getScheduleRows')
+    expect(code).toContain('getDeliverableRows')
+  })
+})
+
+describe('SOW templateProps: blocks fabricated fallbacks (#377)', () => {
+  const source = () => readFileSync(resolve('src/pages/api/admin/quotes/[id].ts'), 'utf-8')
+
+  it('does not contain the "Operations cleanup engagement" hardcoded overview', () => {
+    expect(source()).not.toContain('Operations cleanup engagement as discussed during assessment')
+  })
+
+  it('does not contain the "Business Owner" contact-name fallback', () => {
+    expect(source()).not.toContain("primaryContact?.name ?? 'Business Owner'")
+  })
+
+  it('does not contain the "mid-engagement milestone" hardcoded label', () => {
+    const code = source()
+    // The literal string appears only as a comparison in a test-style guard,
+    // never as a default assigned to milestoneLabel.
+    expect(code).not.toMatch(/milestoneLabel: ['"]mid-engagement milestone['"]/)
+  })
+
+  it('reads engagement_overview from the persisted quote row', () => {
+    const code = source()
+    expect(code).toContain('existing.engagement_overview')
+  })
+
+  it('reads milestone_label from the persisted quote row', () => {
+    const code = source()
+    expect(code).toContain('existing.milestone_label')
+  })
+
+  it('uses authored deliverables for SOW items when present', () => {
+    const code = source()
+    expect(code).toContain('parseDeliverables')
+    expect(code).toContain('authoredDeliverables')
+  })
+
+  it('blocks SOW generation when engagement_overview is not authored', () => {
+    const code = source()
+    expect(code).toContain('Cannot generate SOW: author the engagement overview')
+  })
+
+  it('blocks SOW generation when no primary contact name exists', () => {
+    const code = source()
+    expect(code).toContain('Cannot generate SOW: add a primary contact')
+  })
+})
+
+describe('sow service: send-gating on signature send', () => {
+  const source = () => readFileSync(resolve('src/lib/sow/service.ts'), 'utf-8')
+
+  it('imports getMissingAuthoredContent', () => {
+    expect(source()).toContain('getMissingAuthoredContent')
+  })
+
+  it('blocks authorizeAndSendSOW when authored content is missing', () => {
+    const code = source()
+    expect(code).toContain(
+      'Cannot send quote for signature: missing authored client-facing content'
+    )
+  })
+})
+
+describe('migration 0021: authored content columns', () => {
+  const path = resolve('migrations/0021_quotes_authored_content.sql')
+
+  it('migration file exists', () => {
+    expect(existsSync(path)).toBe(true)
+  })
+
+  it('adds the four required columns to quotes', () => {
+    const sql = readFileSync(path, 'utf-8')
+    expect(sql).toContain('ALTER TABLE quotes ADD COLUMN schedule TEXT')
+    expect(sql).toContain('ALTER TABLE quotes ADD COLUMN deliverables TEXT')
+    expect(sql).toContain('ALTER TABLE quotes ADD COLUMN engagement_overview TEXT')
+    expect(sql).toContain('ALTER TABLE quotes ADD COLUMN milestone_label TEXT')
+  })
+
+  it('runs cleanly against the test harness D1', async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    // Verify each new column appears in the table schema.
+    const schema = await db
+      .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='quotes'")
+      .first<{ sql: string }>()
+    expect(schema?.sql ?? '').toContain('schedule')
+    expect(schema?.sql ?? '').toContain('deliverables')
+    expect(schema?.sql ?? '').toContain('engagement_overview')
+    expect(schema?.sql ?? '').toContain('milestone_label')
+  })
+})
+
+describe('backfill decision doc', () => {
+  it('exists at the expected path', () => {
+    expect(existsSync(resolve('docs/decisions/quotes-authored-content-backfill.md'))).toBe(true)
+  })
+
+  it('lists all three options and gives a recommendation', () => {
+    const md = readFileSync(resolve('docs/decisions/quotes-authored-content-backfill.md'), 'utf-8')
+    expect(md).toMatch(/Option A/)
+    expect(md).toMatch(/Option B/)
+    expect(md).toMatch(/Option C/)
+    expect(md).toMatch(/Recommendation/)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the schema, admin authoring UI, and portal rendering needed to keep the proposal page from synthesizing client-facing commitments. This is the schema work called out in #377 (Pattern B remediation), following the #378 hotfix that stripped the fabricated 3-week schedule. Quotes can no longer transition from `draft` to `sent` (or be sent for SignWell signature) until `quotes.schedule` and `quotes.deliverables` are authored on the row — the next time anyone tries to ship an unauthored quote, the gate fires.

## Linked issue

Refs #377

This PR satisfies the schema + admin UI ACs from the "Guardrail + schema" section. Other ACs (audit, guardrails doc, plumbing, retro sweep) are owned by the parallel Track A / C / E / B agents and ship separately.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Schema migration for `quotes.schedule` (and any other Pattern B remediation surfaced by the audit) merged | met | `migrations/0021_quotes_authored_content.sql` adds `schedule`, `deliverables`, `engagement_overview`, `milestone_label` |
| Admin UI updated to author the new fields per quote where Pattern B remediation requires authored data | met | `src/pages/admin/entities/[id]/quotes/[quoteId].astro` — row editors, textarea, milestone-label input, "Required to send" banner |
| Existing quotes either backfilled or flagged so the gap cannot recur silently | deferred — Captain decision | `docs/decisions/quotes-authored-content-backfill.md`. Three options laid out; recommendation = Option A. No backfill SQL executed. |
| Hotfix PR #378 merged removing the fabricated schedule | met | already merged before this PR |
| Audit report committed under `docs/audits/client-facing-content-YYYY-MM-DD.md`, organized by the two violation patterns named in the Scope clarification | n/a | Track A / PR #381 |
| Audit covers both Pattern A and Pattern B | n/a | Track A |
| Every audit finding either resolved or tracked as a sub-issue, tagged by pattern | n/a | Track A + follow-on issues |
| Move 1 — workflow blocking new TODO patterns in PR diffs without `scope-deferred` label | n/a | Track E |
| Move 2 — workflow reopening issues closed with unchecked ACs | n/a | Track E |
| Move 3 — `.github/PULL_REQUEST_TEMPLATE.md` enumerating per-AC satisfaction | n/a | Track E |
| Move 4 (audit phase) — sanctioned empty-state pattern documented in portal style guide | n/a | Track C |
| Move 5 — retroactive sweep report committed | n/a | Track B |
| CLAUDE.md guardrail rule explicitly names both patterns with examples drawn from the audit | n/a | Track C |
| Global guardrails doc updated with the same two-pattern framing | n/a | Track C |
| CODEOWNERS entry for `src/pages/portal/**` | n/a | Track E |

## Captain decisions surfaced

Three items from the audit need a human call before any further engineering work; flagged here rather than guessed in code:

1. **Backfill strategy for existing quotes.** See `docs/decisions/quotes-authored-content-backfill.md`. Recommendation: Option A (null backfill + portal flag, follow-on issue to remove line-items deliverables fallback).
2. **SOW PDF start/end date placeholders.** Audit `src/pages/api/admin/quotes/[id].ts:111-112` flagged the `'TBD upon deposit'` / `'TBD based on scope'` strings as Captain-decision. Kept as explicit TBD markers in this PR (matches the empty-state convention). To replace them with `engagements.start_date` / `estimated_end`, file a follow-on against #377.
3. **Brand string + "Receipt attached" findings.** Out of scope for this PR (not Pattern B inside the quotes flow). Tracked as Pattern A items for Track A / scribe follow-on.

## Deferred ACs

This PR carries the `scope-deferred` label. One acknowledged deferral:

- **AC:** Removal of the line-items-based deliverables fallback in `src/pages/portal/quotes/[id].astro`. The fallback exists only so existing sent quotes (which have no authored `deliverables` column) continue to render while Captain decides on the backfill strategy.
  - **Why deferred:** Blocks on Captain's backfill decision (see `docs/decisions/quotes-authored-content-backfill.md`, Option A/B/C). Under Option A the fallback can be removed after admins reauthor existing quotes; under Option B the fallback is replaced by backfilled TBD markers; under Option C it is replaced by the reauthoring gate. All three converge on fallback removal; scope depends on Captain's choice.
  - **Tracked in:** #377 (parent). Source comment uses `TODO(#377-followon)` to make the deferral visible in code; Move 1 caught it exactly as designed — documenting here is the sanctioned path.

## Test plan

- [x] `npm run verify` passes — 1130 tests, 0 type errors, 0 lint errors, build green
- [x] New test file `tests/quotes-authored-content.test.ts` (53 cases) covers parse helpers, send-gating in `updateQuoteStatus`, DAL round-trip via the test-harness D1, portal + admin source assertions, SOW templateProps guards, and the migration itself
- [x] Updated `tests/lifecycle-guards.test.ts` to populate authored content before transitioning quotes to `sent` (the gate would otherwise block those tests from reaching the acceptance flow)
- [ ] Manual: open an existing draft quote in admin, observe the "Required to send" banner; author both fields; observe the banner flip to "Ready to send"; click "Save Draft"; round-trip persists across reload
- [ ] Manual: try to send an unauthored draft quote via the SignWell flow — receive the same gating error
- [ ] Manual: open an existing sent quote in the client portal — "How we'll work" section is absent (until Captain decides on backfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

