### PR TITLE
chore(process): §3 SOW carve-out + guardrails upload script + .mcp.json gitignore (#377)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ dist/
 # OS
 .DS_Store
 
+# User-local MCP config
+.mcp.json
+
 # Testing
 coverage/
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "crane": {
-      "command": "crane-mcp",
-      "args": [],
-      "env": {}
-    }
-  }
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Timeframes are scoped per engagement, just like pricing. Do not publish specific
 - **Do:** "We start with a conversation," "Hands-on training with your team"
 - **Don't:** "1-hour call," "10-day sprint," "60-minute training," "2-week support window"
 
+**Applies to marketing content only.** This rule does not apply to signed contractual documents (SOW PDFs, invoices, countersigned agreements). A signed SOW is a contract where specific timeframes are the product of the conversation, not marketing copy. Timeframes in signed documents stay as authored.
+
 ### 4. No published dollar amounts
 
 No dollar amounts appear on the website or in marketing materials. The client sees a project price in their proposal — never on a public page.
@@ -241,6 +243,8 @@ One Astro app, one Cloudflare Pages project, three custom domains. Routing is ha
 **Env vars.** `APP_BASE_URL` (marketing, SignWell webhooks), `ADMIN_BASE_URL` (OAuth redirect URI, outbound admin links — strict, no fallback), `PORTAL_BASE_URL` (portal links, falls back to `APP_BASE_URL`). See `src/lib/config/app-url.ts`.
 
 ## Local Dev
+
+`.mcp.json` is user-local config (gitignored). Create it in the repo root with at minimum the `crane` MCP entry. It is not checked in.
 
 Subdomain-based routing keys off `hostname.startsWith('admin.')` / `portal.`. At `localhost:4321` neither fires, which is usually fine — just hit `/admin/*` and `/portal/*` paths directly.
 

--- a/docs/process/global-guardrails-upload.md
+++ b/docs/process/global-guardrails-upload.md
@@ -1,0 +1,27 @@
+# Global Guardrails Upload
+
+Upload the global guardrails doc to the crane context worker.
+
+## When to run
+
+After editing the guardrails source to add new protected action categories, heuristics, or SOD summary lines.
+
+## Invocation
+
+```bash
+CRANE_ADMIN_KEY=<key> ./scripts/upload-doc-to-context-worker.sh /path/to/guardrails.md global
+```
+
+The script uses `basename` of the path as the doc name, so the file must be named `guardrails.md`.
+
+Get `CRANE_ADMIN_KEY` from Infisical: `infisical secrets get CRANE_ADMIN_KEY --env=dev --plain`.
+
+## Verify
+
+Confirm the upload via crane MCP: `crane_doc('global', 'guardrails.md')` and check the version number incremented.
+
+## Notes
+
+- Script is at `scripts/upload-doc-to-context-worker.sh` (copied from sc-console, #377).
+- The context worker endpoint is `https://crane-context.automation-ab6.workers.dev/admin/docs`.
+- If the admin key rejects, confirm the correct key with Captain. The key in Infisical `ss` dev env may not match the key registered in the worker.

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# Upload Documentation to Context Worker
+#
+# Uploads a markdown file to Context Worker with appropriate scope.
+# Used by GitHub Actions for automatic sync and manual uploads.
+#
+# Usage:
+#   ./scripts/upload-doc-to-context-worker.sh <doc-path> [scope]
+#
+# Arguments:
+#   doc-path: Path to markdown file (e.g., docs/process/cc-cli-starting-prompts.md)
+#   scope:    (Optional) Override scope. If not provided, auto-determined from doc name.
+#
+# Environment Variables (Required):
+#   CRANE_ADMIN_KEY: Admin key for Context Worker authentication
+#   GITHUB_REPOSITORY: (Optional) Used to determine venture for venture-specific docs
+#
+# Examples:
+#   # Upload global doc (auto-detected from whitelist)
+#   ./scripts/upload-doc-to-context-worker.sh docs/process/cc-cli-starting-prompts.md
+#
+#   # Upload venture-specific doc (scope from repo)
+#   GITHUB_REPOSITORY="venturecrane/crane-console" \
+#     ./scripts/upload-doc-to-context-worker.sh docs/process/PROJECT_INSTRUCTIONS.md
+#
+#   # Force specific scope
+#   ./scripts/upload-doc-to-context-worker.sh docs/process/custom-doc.md global
+#
+
+set -e  # Exit on error
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+API_BASE="https://crane-context.automation-ab6.workers.dev"
+
+# Global docs whitelist (docs that apply to all ventures)
+GLOBAL_DOCS=(
+  "cc-cli-starting-prompts.md"
+  "team-workflow.md"
+  "slash-commands-guide.md"
+  "parallel-dev-track-runbook.md"
+  "eod-sod-process.md"
+  "dev-directive-pr-workflow.md"
+  "agent-persona-briefs.md"
+)
+
+# Validate arguments
+if [ -z "$1" ]; then
+  echo -e "${RED}Error: Doc path required${NC}"
+  echo "Usage: $0 <doc-path> [scope]"
+  exit 1
+fi
+
+DOC_PATH="$1"
+OVERRIDE_SCOPE="$2"
+
+# Check file exists
+if [ ! -f "$DOC_PATH" ]; then
+  echo -e "${RED}Error: File not found: $DOC_PATH${NC}"
+  exit 1
+fi
+
+# Check admin key
+if [ -z "$CRANE_ADMIN_KEY" ]; then
+  echo -e "${RED}Error: CRANE_ADMIN_KEY environment variable not set${NC}"
+  exit 1
+fi
+
+# Extract doc name from path
+DOC_NAME=$(basename "$DOC_PATH")
+
+# Determine scope
+if [ -n "$OVERRIDE_SCOPE" ]; then
+  # Scope explicitly provided
+  SCOPE="$OVERRIDE_SCOPE"
+  echo -e "${BLUE}Scope: $SCOPE (explicit)${NC}"
+else
+  # Auto-determine scope
+  IS_GLOBAL=false
+  for global_doc in "${GLOBAL_DOCS[@]}"; do
+    if [ "$DOC_NAME" = "$global_doc" ]; then
+      IS_GLOBAL=true
+      break
+    fi
+  done
+
+  if [ "$IS_GLOBAL" = true ]; then
+    SCOPE="global"
+    echo -e "${BLUE}Scope: global (whitelisted doc)${NC}"
+  else
+    # Venture-specific: determine from repo
+    if [ -n "$GITHUB_REPOSITORY" ]; then
+      case "$GITHUB_REPOSITORY" in
+        *venturecrane/crane-console*)
+          SCOPE="vc"
+          ;;
+        *siliconcrane/sc-console*)
+          SCOPE="sc"
+          ;;
+        *durganfieldguide/dfg-console*)
+          SCOPE="dfg"
+          ;;
+        *)
+          echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
+          echo "Supported repos: venturecrane/crane-console, siliconcrane/sc-console, durganfieldguide/dfg-console"
+          exit 1
+          ;;
+      esac
+      echo -e "${BLUE}Scope: $SCOPE (from repository: $GITHUB_REPOSITORY)${NC}"
+    else
+      echo -e "${RED}Error: Cannot determine scope${NC}"
+      echo "Doc '$DOC_NAME' is not in global whitelist and GITHUB_REPOSITORY not set."
+      echo ""
+      echo "Options:"
+      echo "  1. Add doc to GLOBAL_DOCS whitelist in this script"
+      echo "  2. Set GITHUB_REPOSITORY environment variable"
+      echo "  3. Provide scope as second argument: $0 $DOC_PATH <scope>"
+      exit 1
+    fi
+  fi
+fi
+
+# Read doc content
+DOC_CONTENT=$(cat "$DOC_PATH")
+
+# Extract title from first # heading
+TITLE=$(echo "$DOC_CONTENT" | grep -m 1 "^# " | sed 's/^# //' || echo "$DOC_NAME")
+
+# Create JSON payload (properly escape content)
+PAYLOAD=$(jq -n \
+  --arg scope "$SCOPE" \
+  --arg doc_name "$DOC_NAME" \
+  --arg content "$DOC_CONTENT" \
+  --arg title "$TITLE" \
+  --arg source_repo "${GITHUB_REPOSITORY:-manual}" \
+  --arg source_path "$DOC_PATH" \
+  --arg uploaded_by "${GITHUB_ACTOR:-script}" \
+  '{
+    scope: $scope,
+    doc_name: $doc_name,
+    content: $content,
+    title: $title,
+    source_repo: $source_repo,
+    source_path: $source_path,
+    uploaded_by: $uploaded_by
+  }')
+
+# Upload to Context Worker
+echo -e "${YELLOW}Uploading: $DOC_PATH → $SCOPE/$DOC_NAME${NC}"
+
+RESPONSE=$(curl -s -X POST \
+  "$API_BASE/admin/docs" \
+  -H "X-Admin-Key: $CRANE_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+
+# Check success
+SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+if [ "$SUCCESS" = "true" ]; then
+  VERSION=$(echo "$RESPONSE" | jq -r '.version')
+  CREATED=$(echo "$RESPONSE" | jq -r '.created')
+  CONTENT_HASH=$(echo "$RESPONSE" | jq -r '.content_hash')
+  SIZE=$(echo "$RESPONSE" | jq -r '.content_size_bytes')
+
+  if [ "$CREATED" = "true" ]; then
+    echo -e "${GREEN}✓ Created: $SCOPE/$DOC_NAME (v$VERSION, ${SIZE} bytes)${NC}"
+  else
+    PREV_VERSION=$(echo "$RESPONSE" | jq -r '.previous_version')
+    echo -e "${GREEN}✓ Updated: $SCOPE/$DOC_NAME (v$PREV_VERSION → v$VERSION, ${SIZE} bytes)${NC}"
+  fi
+
+  echo -e "${BLUE}Content hash: $CONTENT_HASH${NC}"
+else
+  ERROR=$(echo "$RESPONSE" | jq -r '.error // "Unknown error"')
+  echo -e "${RED}✗ Upload failed: $ERROR${NC}"
+  echo "$RESPONSE" | jq '.'
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a §3 carve-out to CLAUDE.md clarifying that the no-fixed-timeframes rule applies to marketing content only — not to signed contractual documents like SOW PDFs. Removes `.mcp.json` from git tracking (it is user-local config) and adds the `upload-doc-to-context-worker.sh` script from sc-console for future guardrails uploads.

## Linked issue

Refs #377
Refs #385

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| CLAUDE.md §3 carve-out for signed contractual documents | met | `CLAUDE.md` lines 92-94 |
| `upload-doc-to-context-worker.sh` copied to `scripts/` | met | `scripts/upload-doc-to-context-worker.sh` |
| `docs/process/global-guardrails-upload.md` created | met | `docs/process/global-guardrails-upload.md` |
| `.mcp.json` added to `.gitignore` and removed from tracking | met | `.gitignore`, `git rm --cached .mcp.json` |
| Local Dev note in CLAUDE.md about `.mcp.json` | met | `CLAUDE.md` line 247 |
| guardrails.md uploaded to context worker | deferred | See below |

## Deferred ACs (required if `scope-deferred` label is set)

- **AC:** Upload guardrails.md to crane context worker
  - **Why deferred:** `CRANE_ADMIN_KEY` in Infisical ss/dev env returns "Unauthorized - Invalid admin key" from `https://crane-context.automation-ab6.workers.dev/admin/docs`. Script and process doc are in this PR. Captain needs to run: `CRANE_ADMIN_KEY=<valid-key> ./scripts/upload-doc-to-context-worker.sh /tmp/guardrails-proposed.md global` (file is at `/tmp/guardrails-proposed.md` on the session host).
  - **Tracked in:** #377 (manual step noted)

## Test plan

- [ ] `npm run verify` — typecheck errors are pre-existing in `portal/index.astro` (consultant null safety from triage-executor's in-progress branch work); docs/config-only changes do not introduce new failures
- [x] §3 carve-out added to CLAUDE.md without disturbing existing bullets
- [x] `.mcp.json` removed from git index, confirmed gitignored
- [x] `scripts/upload-doc-to-context-worker.sh` is executable (chmod +x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)