### PR TITLE
feat(brand): centralize BRAND_NAME + remove consultant/receipt fallbacks + rewrite support-window phrase (#377)

### DIFF
--- a/src/components/portal/ConsultantBlock.astro
+++ b/src/components/portal/ConsultantBlock.astro
@@ -18,7 +18,7 @@
 interface Props {
   name: string
   photoUrl: string | null
-  role: string
+  role: string | null
   nextTouchpointAt?: string | null
   nextTouchpointLabel?: string | null
   phone?: string | null
@@ -101,9 +101,11 @@ const touchpointText = formatTouchpoint()
       <p class="text-base font-semibold text-[color:var(--color-text-primary)]">
         {name}
       </p>
-      <p class="text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
-        {role}
-      </p>
+      {
+        role && (
+          <p class="text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">{role}</p>
+        )
+      }
       {
         touchpointText && (
           <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">

--- a/src/lib/config/brand.ts
+++ b/src/lib/config/brand.ts
@@ -1,0 +1,5 @@
+/**
+ * Client-facing brand name. Single source of truth so future renames are
+ * one-line changes. Per #377 audit.
+ */
+export const BRAND_NAME = 'SMD Services' as const

--- a/src/lib/email/booking-emails.ts
+++ b/src/lib/email/booking-emails.ts
@@ -7,6 +7,7 @@
  * try/catch and log failures without blocking the booking flow.
  */
 
+import { BRAND_NAME } from '../config/brand'
 import { sendEmail } from './resend'
 import type { SendResult, EmailAttachment } from './resend'
 import {
@@ -46,7 +47,7 @@ export async function sendBookingConfirmation(
 
   return sendEmail(apiKey, {
     to: input.guestEmail,
-    subject: `Confirmed: ${input.meetingLabel} with SMD Services`,
+    subject: `Confirmed: ${input.meetingLabel} with ${BRAND_NAME}`,
     html,
     ...(attachments.length > 0 ? { attachments } : {}),
   })
@@ -74,7 +75,7 @@ export async function sendBookingReschedule(
 
   return sendEmail(apiKey, {
     to: input.guestEmail,
-    subject: `Rescheduled: ${input.meetingLabel} with SMD Services`,
+    subject: `Rescheduled: ${input.meetingLabel} with ${BRAND_NAME}`,
     html,
     ...(attachments.length > 0 ? { attachments } : {}),
   })
@@ -102,7 +103,7 @@ export async function sendBookingCancellation(
 
   return sendEmail(apiKey, {
     to: input.guestEmail,
-    subject: 'Cancelled: Assessment call with SMD Services',
+    subject: `Cancelled: Assessment call with ${BRAND_NAME}`,
     html,
     ...(attachments.length > 0 ? { attachments } : {}),
   })

--- a/src/lib/email/follow-up-templates.ts
+++ b/src/lib/email/follow-up-templates.ts
@@ -5,6 +5,7 @@
  * Templates produce self-contained HTML emails with inline styles.
  * No external CSS or image dependencies.
  */
+import { BRAND_NAME } from '../config/brand'
 
 export interface FollowUpEmailData {
   clientName: string
@@ -27,12 +28,12 @@ function emailWrapper(body: string): string {
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 24px;text-align:center;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 24px;text-align:center;">${BRAND_NAME}</h1>
 ${body}
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -189,7 +190,7 @@ export function referralAskEmail(data: FollowUpEmailData): FollowUpEmail {
         Just reply to this email with their name and we'll take it from there.
       </p>
       <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
-        Thank you for choosing SMD Services.
+        Thank you for choosing ${BRAND_NAME}.
       </p>`
 
   return {
@@ -210,7 +211,8 @@ export function safetyNetCheckinEmail(data: FollowUpEmailData): FollowUpEmail {
         We wanted to check in and see how things are going at ${data.businessName} since we wrapped up. Has the team settled into the new workflows?
       </p>
       <p style="font-size:15px;color:#334155;margin:0 0 24px;">
-        If anything needs adjusting or questions have come up, we're still here — that's what the support window is for. Reply to this email or reach out anytime.
+        If anything needs adjusting or questions have come up, we're still here.
+        Reply to this email or reach out anytime.
       </p>
       <div style="text-align:center;">
         <a href="${data.portalUrl}"
@@ -251,7 +253,7 @@ export function feedback30DayEmail(data: FollowUpEmailData): FollowUpEmail {
         Just reply to this email — a few sentences is all we need. Your feedback helps us get better, and we genuinely appreciate it.
       </p>
       <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;text-align:center;">
-        Thank you for working with SMD Services.
+        Thank you for working with ${BRAND_NAME}.
       </p>`
 
   return {

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -4,11 +4,13 @@
  * Sends emails via the Resend API (https://resend.com/docs/api-reference).
  * In dev/test environments (no RESEND_API_KEY), logs emails to console instead.
  *
- * Sender: SMD Services <team@smd.services>
+ * Sender name is sourced from BRAND_NAME (../config/brand.ts).
  */
 
+import { BRAND_NAME } from '../config/brand'
+
 const RESEND_API_URL = 'https://api.resend.com/emails'
-const SENDER = 'SMD Services <team@smd.services>'
+const SENDER = `${BRAND_NAME} <team@smd.services>`
 
 export interface EmailAttachment {
   filename: string

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -4,6 +4,7 @@
  * All templates produce self-contained HTML emails with inline styles.
  * No external CSS or image dependencies.
  */
+import { BRAND_NAME } from '../config/brand'
 
 /**
  * Build the magic link URL for token verification.
@@ -24,7 +25,7 @@ export function magicLinkEmailHtml(clientName: string, magicLinkUrl: string): st
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
@@ -50,7 +51,7 @@ export function magicLinkEmailHtml(clientName: string, magicLinkUrl: string): st
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -69,14 +70,14 @@ export function quoteSentEmailHtml(clientName: string, portalUrl: string): strin
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
         Hi${clientName ? ` ${clientName}` : ''},
       </p>
       <p style="font-size:15px;color:#334155;margin:0 0 24px;">
-        Your proposal from SMD Services is ready for review. Sign in to your portal to view the details.
+        Your proposal from ${BRAND_NAME} is ready for review. Sign in to your portal to view the details.
       </p>
 
       <a href="${portalUrl}"
@@ -92,7 +93,7 @@ export function quoteSentEmailHtml(clientName: string, portalUrl: string): strin
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -118,14 +119,14 @@ export function invoiceSentEmailHtml(
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
         Hi${clientName ? ` ${clientName}` : ''},
       </p>
       <p style="font-size:15px;color:#334155;margin:0 0 24px;">
-        Your invoice from SMD Services for ${amount} is ready. Sign in to your portal to view the details and make a payment.
+        Your invoice from ${BRAND_NAME} for ${amount} is ready. Sign in to your portal to view the details and make a payment.
       </p>
 
       <a href="${portalUrl}"
@@ -141,7 +142,7 @@ export function invoiceSentEmailHtml(
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -159,7 +160,7 @@ export function paymentConfirmationEmailHtml(clientName: string, amount: string)
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
@@ -178,7 +179,7 @@ export function paymentConfirmationEmailHtml(clientName: string, amount: string)
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -203,7 +204,7 @@ export function scorecardReportEmailHtml(
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Operations Health Scorecard</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
@@ -229,7 +230,7 @@ export function scorecardReportEmailHtml(
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -244,7 +245,7 @@ export function portalInvitationEmailHtml(clientName: string, magicLinkUrl: stri
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
@@ -270,7 +271,7 @@ export function portalInvitationEmailHtml(clientName: string, magicLinkUrl: stri
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -297,7 +298,7 @@ export function portalWelcomeEmailHtml(clientName: string, loginUrl: string): st
 <body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
   <div style="max-width:480px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;text-align:center;">
-      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">SMD Services</h1>
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">${BRAND_NAME}</h1>
       <p style="font-size:14px;color:#64748b;margin:0 0 24px;">Client Portal</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 8px;">
@@ -323,7 +324,7 @@ export function portalWelcomeEmailHtml(clientName: string, loginUrl: string): st
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -376,7 +377,7 @@ export function bookingConfirmationEmailHtml(input: BookingConfirmationEmailInpu
   <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;">
       <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">You're booked.</h1>
-      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">SMD Services &middot; ${meetingLabel}</p>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">${BRAND_NAME} &middot; ${meetingLabel}</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">Hi ${guestName},</p>
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">
@@ -406,12 +407,12 @@ export function bookingConfirmationEmailHtml(input: BookingConfirmationEmailInpu
 
       <p style="font-size:13px;color:#64748b;margin:0;">
         Looking forward to talking,<br>
-        Scott Durgan &middot; SMD Services
+        ${BRAND_NAME}
       </p>
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -476,7 +477,7 @@ export function bookingRescheduledEmailHtml(input: BookingRescheduledEmailInput)
   <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;">
       <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">Your call has been rescheduled.</h1>
-      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">SMD Services &middot; ${meetingLabel}</p>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">${BRAND_NAME} &middot; ${meetingLabel}</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">Hi ${guestName},</p>
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">
@@ -508,7 +509,7 @@ export function bookingRescheduledEmailHtml(input: BookingRescheduledEmailInput)
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>
@@ -539,7 +540,7 @@ export function bookingCancelledEmailHtml(input: BookingCancelledEmailInput): st
   <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
     <div style="padding:32px 24px;">
       <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">Your call has been cancelled.</h1>
-      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">SMD Services</p>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">${BRAND_NAME}</p>
 
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">Hi ${guestName},</p>
       <p style="font-size:15px;color:#334155;margin:0 0 16px;">
@@ -552,12 +553,12 @@ export function bookingCancelledEmailHtml(input: BookingCancelledEmailInput): st
       </p>
 
       <p style="font-size:13px;color:#64748b;margin:0;">
-        — Scott Durgan &middot; SMD Services
+        — ${BRAND_NAME}
       </p>
     </div>
     <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
       <p style="font-size:11px;color:#94a3b8;margin:0;">
-        &copy; ${new Date().getFullYear()} SMD Services &middot; Phoenix, AZ
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
       </p>
     </div>
   </div>

--- a/src/lib/pdf/sow-template.tsx
+++ b/src/lib/pdf/sow-template.tsx
@@ -15,6 +15,7 @@
 
 import React from 'react'
 import { Document, Page, View, Text } from '@formepdf/react'
+import { BRAND_NAME } from '../config/brand'
 import { SIGNING_PAGE } from './signing-layout'
 
 // ---------------------------------------------------------------------------
@@ -161,7 +162,7 @@ export function SOWTemplate(props: SOWTemplateProps) {
                 color: colors.primary,
               }}
             >
-              SMD Services
+              {BRAND_NAME}
             </Text>
             <Text
               style={{
@@ -432,7 +433,7 @@ export function SOWTemplate(props: SOWTemplateProps) {
         >
           <View style={{ height: 1, backgroundColor: colors.border, marginBottom: 8 }} />
           <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-            <Text style={finePrintStyle}>SMD Services | smd.services</Text>
+            <Text style={finePrintStyle}>{BRAND_NAME} | smd.services</Text>
             <Text style={finePrintStyle}>{doc.sowNumber} | Page 1 of 3</Text>
           </View>
         </View>
@@ -549,7 +550,7 @@ export function SOWTemplate(props: SOWTemplateProps) {
         >
           <View style={{ height: 1, backgroundColor: colors.border, marginBottom: 8 }} />
           <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-            <Text style={finePrintStyle}>SMD Services | smd.services</Text>
+            <Text style={finePrintStyle}>{BRAND_NAME} | smd.services</Text>
             <Text style={finePrintStyle}>{doc.sowNumber} | Page 2 of 3</Text>
           </View>
         </View>
@@ -576,7 +577,7 @@ export function SOWTemplate(props: SOWTemplateProps) {
         <Text style={sectionHeadingStyle}>AGREEMENT</Text>
         <Text style={{ ...bodyTextStyle, marginBottom: 16 }}>
           By signing below, the client agrees to the scope, timeline, pricing, and terms described
-          in this document. SMD Services agrees by presenting this Statement of Work for signature.
+          in this document. {BRAND_NAME} agrees by presenting this Statement of Work for signature.
         </Text>
         <View style={{ width: SIGNING_PAGE.columnWidth }}>
           <Text
@@ -631,7 +632,7 @@ export function SOWTemplate(props: SOWTemplateProps) {
               lineHeight: 1.4,
             }}
           >
-            SMD Services assents to this agreement by presenting this Statement of Work for
+            {BRAND_NAME} assents to this agreement by presenting this Statement of Work for
             signature.
           </Text>
         </View>
@@ -647,7 +648,7 @@ export function SOWTemplate(props: SOWTemplateProps) {
         >
           <View style={{ height: 1, backgroundColor: colors.border, marginBottom: 8 }} />
           <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-            <Text style={finePrintStyle}>SMD Services | smd.services</Text>
+            <Text style={finePrintStyle}>{BRAND_NAME} | smd.services</Text>
             <Text style={finePrintStyle}>{doc.sowNumber} | Page 3 of 3</Text>
           </View>
         </View>

--- a/src/lib/portal/states.ts
+++ b/src/lib/portal/states.ts
@@ -67,17 +67,18 @@ function readStateParam(params: SearchParamSource | null | undefined): string | 
  *   4. `default` — render the pay CTA
  *
  * The `firstName` arg is the consultant first name used in the next-step
- * copy ("Text {FirstName} for a refreshed link").
+ * copy ("Text {FirstName} for a refreshed link"). When null, the "text
+ * consultant" escalation collapses to a generic message.
  */
 export function resolveInvoiceState(
   invoice: InvoiceLike,
   params: SearchParamSource | null,
-  firstName: string
+  firstName: string | null
 ): InvoiceSurface {
   if (invoice.paid_at) {
     return {
       state: 'paid',
-      next: `Receipt attached. Head back to the engagement dashboard.`,
+      next: `Head back to the engagement dashboard.`,
     }
   }
 
@@ -86,7 +87,9 @@ export function resolveInvoiceState(
   if (hint === 'declined') {
     return {
       state: 'declined',
-      next: `Your card was declined. Try again, or text ${firstName} if this keeps happening.`,
+      next: firstName
+        ? `Your card was declined. Try again, or text ${firstName} if this keeps happening.`
+        : `Your card was declined. Try again.`,
     }
   }
 
@@ -100,7 +103,9 @@ export function resolveInvoiceState(
   if (hint === 'expired') {
     return {
       state: 'expired',
-      next: `This payment link has expired. Text ${firstName} for a refreshed link.`,
+      next: firstName
+        ? `This payment link has expired. Text ${firstName} for a refreshed link.`
+        : `This payment link has expired.`,
     }
   }
 
@@ -129,7 +134,7 @@ export function resolveInvoiceState(
 export function resolveProposalState(
   quote: QuoteLike,
   params: SearchParamSource | null,
-  firstName: string,
+  firstName: string | null,
   nextStepText: string | null = null
 ): ProposalSurface {
   const status = (quote.status ?? '').toLowerCase()
@@ -142,7 +147,9 @@ export function resolveProposalState(
   if (status === 'declined') {
     return {
       state: 'declined',
-      next: `Text ${firstName} if you'd like to talk through a revision.`,
+      next: firstName
+        ? `Text ${firstName} if you'd like to talk through a revision.`
+        : `Reach out if you'd like to talk through a revision.`,
     }
   }
 
@@ -160,7 +167,9 @@ export function resolveProposalState(
   if (serverExpired) {
     return {
       state: 'expired',
-      next: `This proposal has expired. Text ${firstName} to pick it back up.`,
+      next: firstName
+        ? `This proposal has expired. Text ${firstName} to pick it back up.`
+        : `This proposal has expired.`,
     }
   }
 
@@ -168,7 +177,9 @@ export function resolveProposalState(
   if (hint === 'expired') {
     return {
       state: 'expired',
-      next: `This proposal has expired. Text ${firstName} to pick it back up.`,
+      next: firstName
+        ? `This proposal has expired. Text ${firstName} to pick it back up.`
+        : `This proposal has expired.`,
     }
   }
 

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { BRAND_NAME } from '../../../lib/config/brand'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listDocuments } from '../../../lib/storage/r2'
 import { getPortalClient } from '../../../lib/portal/session'
@@ -89,7 +90,7 @@ function formatDate(iso: string): string {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>Documents — SMD Services</title>
+    <title>Documents — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <header class="bg-white border-b border-slate-200">
@@ -98,7 +99,7 @@ function formatDate(iso: string): string {
           <a
             href="/portal"
             class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
+            >{BRAND_NAME}</a
           >
           <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
         </div>

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { BRAND_NAME } from '../../../lib/config/brand'
 import { CLIENT_STATUS_LABELS, CLIENT_STATUS_COLORS } from '../../../lib/portal/constants'
 import { getPortalClient } from '../../../lib/portal/session'
 import { listEngagements } from '../../../lib/db/engagements'
@@ -64,7 +65,7 @@ function formatDate(iso: string | null): string {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>Engagement Progress — SMD Services</title>
+    <title>Engagement Progress — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <header class="bg-white border-b border-slate-200">
@@ -73,7 +74,7 @@ function formatDate(iso: string | null): string {
           <a
             href="/portal"
             class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
+            >{BRAND_NAME}</a
           >
           <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
         </div>

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../styles/global.css'
+import { BRAND_NAME } from '../../lib/config/brand'
 import { getPortalClient } from '../../lib/portal/session'
 import PortalHeader from '../../components/portal/PortalHeader.astro'
 import ConsultantBlock from '../../components/portal/ConsultantBlock.astro'
@@ -192,7 +193,7 @@ for (const inv of invoices) {
     timeline.push({
       ts: inv.paid_at,
       date: shortDate(inv.paid_at),
-      body: 'Invoice paid. Receipt attached.',
+      body: 'Invoice paid.',
       artifactLabel: `Invoice #${inv.id.slice(0, 6)}`,
       artifactHref: `/portal/invoices/${inv.id}`,
       artifactIcon: 'receipt_long',
@@ -225,17 +226,21 @@ const timelineEntries = timeline.slice(0, 5)
 // Derived display values
 // ---------------------------------------------------------------------------
 
-const consultant = {
-  name: activeEngagement?.consultant_name ?? 'Scott Durgan',
-  photoUrl: activeEngagement?.consultant_photo_url ?? null,
-  role: activeEngagement?.consultant_role ?? 'Your consultant',
-  phone: activeEngagement?.consultant_phone ?? null,
-  nextTouchpointAt: activeEngagement?.next_touchpoint_at ?? null,
-  nextTouchpointLabel: activeEngagement?.next_touchpoint_label ?? null,
-}
+const consultant = activeEngagement?.consultant_name
+  ? {
+      name: activeEngagement.consultant_name,
+      photoUrl: activeEngagement.consultant_photo_url ?? null,
+      role: activeEngagement.consultant_role ?? null,
+      phone: activeEngagement.consultant_phone ?? null,
+      nextTouchpointAt: activeEngagement.next_touchpoint_at ?? null,
+      nextTouchpointLabel: activeEngagement.next_touchpoint_label ?? null,
+    }
+  : null
 
-const consultantFirst = (consultant.name || '').trim().split(/\s+/)[0] || 'us'
-const smsHref = consultant.phone ? `sms:${consultant.phone.replace(/[^+\d]/g, '')}` : null
+const consultantFirst = consultant
+  ? consultant.name.trim().split(/\s+/)[0] || consultant.name
+  : null
+const smsHref = consultant?.phone ? `sms:${consultant.phone.replace(/[^+\d]/g, '')}` : null
 
 const invoiceAmountCents = pendingInvoice ? Math.round(pendingInvoice.amount * 100) : null
 const invoiceDueText = pendingInvoice?.due_date ? `Due ${shortDate(pendingInvoice.due_date)}` : null
@@ -249,6 +254,7 @@ const invoiceCaption = pendingInvoice
   : null
 
 const touchpointText: string | null = (() => {
+  if (!consultant) return null
   if (consultant.nextTouchpointLabel) return consultant.nextTouchpointLabel
   if (!consultant.nextTouchpointAt) return null
   const d = new Date(consultant.nextTouchpointAt)
@@ -265,9 +271,11 @@ const touchpointText: string | null = (() => {
 const contextHeadline = activeEngagement
   ? 'Your engagement is in flight.'
   : 'Welcome to your portal.'
-const contextSubtext = touchpointText
-  ? `Next check-in ${touchpointText} with ${consultantFirst}.`
-  : `${consultantFirst} will reach out to schedule your next check-in.`
+const contextSubtext = consultantFirst
+  ? touchpointText
+    ? `Next check-in ${touchpointText} with ${consultantFirst}.`
+    : `${consultantFirst} will reach out to schedule your next check-in.`
+  : null
 ---
 
 <!doctype html>
@@ -287,14 +295,14 @@ const contextSubtext = touchpointText
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Portal — SMD Services</title>
+    <title>Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
     <PortalHeader
       clientName={client.name}
       showSms={Boolean(smsHref)}
       smsHref={smsHref ?? undefined}
-      smsLabel={`Text ${consultantFirst}`}
+      smsLabel={consultantFirst ? `Text ${consultantFirst}` : undefined}
     >
       <form method="POST" action="/api/auth/logout">
         <button
@@ -325,8 +333,9 @@ const contextSubtext = touchpointText
                     Something went wrong loading your portal.
                   </h1>
                   <p class="mt-2 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
-                    Give it a moment and try again. If it keeps happening, {consultantFirst} can
-                    help.
+                    {consultantFirst
+                      ? `Give it a moment and try again. If it keeps happening, ${consultantFirst} can help.`
+                      : 'Give it a moment and try again.'}
                   </p>
                   <div class="mt-5 flex flex-wrap gap-3">
                     <a
@@ -339,14 +348,16 @@ const contextSubtext = touchpointText
                 </div>
               </div>
             </section>
-            <ConsultantBlock
-              name={consultant.name}
-              photoUrl={consultant.photoUrl}
-              role={consultant.role}
-              nextTouchpointAt={consultant.nextTouchpointAt}
-              nextTouchpointLabel={consultant.nextTouchpointLabel}
-              phone={consultant.phone}
-            />
+            {consultant && (
+              <ConsultantBlock
+                name={consultant.name}
+                photoUrl={consultant.photoUrl}
+                role={consultant.role}
+                nextTouchpointAt={consultant.nextTouchpointAt}
+                nextTouchpointLabel={consultant.nextTouchpointLabel}
+                phone={consultant.phone}
+              />
+            )}
           </div>
         ) : null
       }
@@ -381,9 +392,11 @@ const contextSubtext = touchpointText
                 <p class="mt-5 font-['Plus_Jakarta_Sans'] font-extrabold text-[28px] leading-[34px] tracking-[-0.02em] text-[color:var(--color-text-primary)]">
                   {touchpointText}
                 </p>
-                <p class="mt-2 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-muted)]">
-                  with {consultantFirst}
-                </p>
+                {consultantFirst && (
+                  <p class="mt-2 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-muted)]">
+                    with {consultantFirst}
+                  </p>
+                )}
               </section>
             ) : (
               <section
@@ -396,21 +409,27 @@ const contextSubtext = touchpointText
                 <p class="mt-5 text-base leading-6 text-[color:var(--color-text-secondary)]">
                   Nothing needs your attention right now.
                 </p>
-                <p class="mt-2 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
-                  {consultantFirst} will reach out to schedule the next touchpoint.
-                </p>
+                {consultantFirst && (
+                  <p class="mt-2 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
+                    {consultantFirst} will reach out to schedule the next touchpoint.
+                  </p>
+                )}
               </section>
             )
           }
 
-          <ConsultantBlock
-            name={consultant.name}
-            photoUrl={consultant.photoUrl}
-            role={consultant.role}
-            nextTouchpointAt={consultant.nextTouchpointAt}
-            nextTouchpointLabel={consultant.nextTouchpointLabel}
-            phone={consultant.phone}
-          />
+          {
+            consultant && (
+              <ConsultantBlock
+                name={consultant.name}
+                photoUrl={consultant.photoUrl}
+                role={consultant.role}
+                nextTouchpointAt={consultant.nextTouchpointAt}
+                nextTouchpointLabel={consultant.nextTouchpointLabel}
+                phone={consultant.phone}
+              />
+            )
+          }
         </aside>
 
         <!-- Main column: eyebrow + context (desktop), recent activity. -->
@@ -428,9 +447,13 @@ const contextSubtext = touchpointText
             >
               {contextHeadline}
             </h1>
-            <p class="mt-3 text-base leading-6 text-[color:var(--color-text-secondary)]">
-              {contextSubtext}
-            </p>
+            {
+              contextSubtext && (
+                <p class="mt-3 text-base leading-6 text-[color:var(--color-text-secondary)]">
+                  {contextSubtext}
+                </p>
+              )
+            }
           </div>
 
           <div

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import {
   getInvoiceForEntity,
@@ -94,8 +95,10 @@ const displayLineItems: InvoiceLineItem[] =
       ]
 
 // Consultant first name is needed early so we can thread it into the state
-// resolver's next-step copy.
-const consultantFirstEarly = (engagement?.consultant_name ?? 'Scott Durgan').trim().split(/\s+/)[0]
+// resolver's next-step copy. Null when the engagement has no consultant.
+const consultantFirstEarly = engagement?.consultant_name
+  ? engagement.consultant_name.trim().split(/\s+/)[0] || engagement.consultant_name
+  : null
 
 // Resolve the surface state once, up front. Everything below branches on it.
 const surface = resolveInvoiceState(invoice, Astro.url.searchParams, consultantFirstEarly)
@@ -182,9 +185,11 @@ const depositNote =
       })} already received.`
     : null
 
-// Consultant block props (ConsultantBlock never renders initials)
-const consultantName = engagement?.consultant_name ?? 'Scott Durgan'
-const consultantRole = engagement?.consultant_role ?? 'Consultant, SMD Services'
+// Consultant block props. When the engagement has no consultant_name, the
+// block is hidden entirely (empty-state pattern) rather than rendering a
+// hardcoded fallback identity.
+const consultantName = engagement?.consultant_name ?? null
+const consultantRole = engagement?.consultant_role ?? null
 const consultantPhotoUrl = engagement?.consultant_photo_url ?? null
 const consultantPhone = engagement?.consultant_phone ?? null
 const nextTouchpointAt = engagement?.next_touchpoint_at ?? null
@@ -192,7 +197,7 @@ const nextTouchpointLabel = engagement?.next_touchpoint_label ?? null
 
 // PortalHeader SMS link (mobile thumb-zone affordance)
 const smsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g, '')}` : null
-const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
+const smsFirstName = consultantName ? consultantName.trim().split(/\s+/)[0] || consultantName : null
 ---
 
 <!doctype html>
@@ -210,14 +215,14 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Invoice — SMD Services</title>
+    <title>Invoice — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
     <PortalHeader
       clientName={client.name}
-      showSms={!!smsHref && !isPaid}
+      showSms={!!smsHref && !isPaid && !!smsFirstName}
       smsHref={smsHref ?? undefined}
-      smsLabel={smsHref ? `Text ${smsFirstName}` : undefined}
+      smsLabel={smsHref && smsFirstName ? `Text ${smsFirstName}` : undefined}
     >
       <form method="POST" action="/api/auth/logout">
         <button
@@ -262,7 +267,7 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
             {
               isPaid && paidShortDate && (
                 <p class="mt-3 text-[13px] leading-[18px] font-medium text-[color:var(--color-complete)]">
-                  Paid {paidShortDate}. Receipt attached.
+                  Paid {paidShortDate}.
                 </p>
               )
             }
@@ -406,16 +411,20 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
           </div>
 
           <!-- Mobile-only consultant block (desktop renders it in the rail) -->
-          <div class="md:hidden">
-            <ConsultantBlock
-              name={consultantName}
-              photoUrl={consultantPhotoUrl}
-              role={consultantRole}
-              nextTouchpointAt={nextTouchpointAt}
-              nextTouchpointLabel={nextTouchpointLabel}
-              phone={consultantPhone}
-            />
-          </div>
+          {
+            consultantName && (
+              <div class="md:hidden">
+                <ConsultantBlock
+                  name={consultantName}
+                  photoUrl={consultantPhotoUrl}
+                  role={consultantRole}
+                  nextTouchpointAt={nextTouchpointAt}
+                  nextTouchpointLabel={nextTouchpointLabel}
+                  phone={consultantPhone}
+                />
+              </div>
+            )
+          }
 
           <!-- Mobile-only back link -->
           <a
@@ -443,7 +452,7 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
                 </div>
                 {paidShortDate && (
                   <p class="mt-6 text-[13px] text-[color:var(--color-text-muted)]">
-                    Paid {paidShortDate}. Receipt attached.
+                    Paid {paidShortDate}.
                   </p>
                 )}
               </div>
@@ -502,14 +511,18 @@ const smsFirstName = consultantName.trim().split(/\s+/)[0] || consultantName
             )
           }
 
-          <ConsultantBlock
-            name={consultantName}
-            photoUrl={consultantPhotoUrl}
-            role={consultantRole}
-            nextTouchpointAt={nextTouchpointAt}
-            nextTouchpointLabel={nextTouchpointLabel}
-            phone={consultantPhone}
-          />
+          {
+            consultantName && (
+              <ConsultantBlock
+                name={consultantName}
+                photoUrl={consultantPhotoUrl}
+                role={consultantRole}
+                nextTouchpointAt={nextTouchpointAt}
+                nextTouchpointLabel={nextTouchpointLabel}
+                phone={consultantPhone}
+              />
+            )
+          }
 
           <a
             href="/portal"

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { listInvoicesForEntity, INVOICE_STATUSES } from '../../../lib/db/invoices'
 import type { Invoice } from '../../../lib/db/invoices'
@@ -67,7 +68,7 @@ function formatDate(iso: string | null): string {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>Invoices — SMD Services</title>
+    <title>Invoices — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <header class="bg-white border-b border-slate-200">
@@ -76,7 +77,7 @@ function formatDate(iso: string | null): string {
           <a
             href="/portal"
             class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >SMD Services</a
+            >{BRAND_NAME}</a
           >
           <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
         </div>

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -3,6 +3,7 @@ import '../../../styles/global.css'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import MoneyDisplay from '../../../components/portal/MoneyDisplay.astro'
 import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
+import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { getQuoteForEntity, parseSchedule, parseDeliverables } from '../../../lib/db/quotes'
 import type { LineItem, ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
@@ -97,8 +98,9 @@ const engagementSubtitle =
     ? `A focused scope across ${deliverables.length} work areas tailored to your operation.`
     : 'A focused scope of work tailored to your operation.'
 
-const consultantName = 'Scott Durgan'
-const consultantFirst = consultantName.split(/\s+/)[0]
+// Attribution comes from the engagement row (below). Quotes that aren't
+// yet attached to an engagement render a blank attribution block per #377
+// — no hardcoded fallback identity.
 
 // Pull engagement for consultant metadata + scope_summary so the signed-state
 // "what happens next" copy is concrete. The engagement row joins by quote_id
@@ -125,6 +127,9 @@ const engagement = await env.DB.prepare(
 )
   .bind(quote.id)
   .first<EngagementLookupRow>()
+
+const consultantName = engagement?.consultant_name ?? null
+const consultantFirst = consultantName ? consultantName.split(/\s+/)[0] || consultantName : null
 
 // Superseded: a newer quote on the same engagement / parent chain. We look
 // up a child quote whose parent_quote_id points at this one OR (fallback) a
@@ -184,14 +189,14 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Proposal — Portal — SMD Services</title>
+    <title>Proposal — Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
     <PortalHeader
       clientName={client.name}
-      showSms={!!headerSmsHref && !isSigned}
+      showSms={!!headerSmsHref && !isSigned && !!consultantFirst}
       smsHref={headerSmsHref ?? undefined}
-      smsLabel={headerSmsHref ? `Text ${consultantFirst}` : undefined}
+      smsLabel={headerSmsHref && consultantFirst ? `Text ${consultantFirst}` : undefined}
     >
       <span class="text-sm text-[color:var(--color-text-secondary)] hidden sm:inline"
         >{session.email}</span
@@ -421,20 +426,26 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
           }
 
           <!-- Consultant block (mobile — above footer; desktop hides here, shown in rail) -->
-          <div class="lg:hidden pt-2">
-            <div class="h-px bg-[color:var(--color-border)] mb-8"></div>
-            <ConsultantBlock
-              name={engagement?.consultant_name ?? consultantName}
-              photoUrl={engagement?.consultant_photo_url ?? null}
-              role={engagement?.consultant_role ?? 'Your consultant'}
-              nextTouchpointAt={engagement?.next_touchpoint_at ?? null}
-              nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
-              phone={engagement?.consultant_phone ?? null}
-            />
-            <p class="mt-4 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
-              Text {consultantFirst} with questions.
-            </p>
-          </div>
+          {
+            consultantName && (
+              <div class="lg:hidden pt-2">
+                <div class="h-px bg-[color:var(--color-border)] mb-8" />
+                <ConsultantBlock
+                  name={consultantName}
+                  photoUrl={engagement?.consultant_photo_url ?? null}
+                  role={engagement?.consultant_role ?? null}
+                  nextTouchpointAt={engagement?.next_touchpoint_at ?? null}
+                  nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
+                  phone={engagement?.consultant_phone ?? null}
+                />
+                {consultantFirst && (
+                  <p class="mt-4 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
+                    Text {consultantFirst} with questions.
+                  </p>
+                )}
+              </div>
+            )
+          }
 
           <!-- Back link -->
           <div class="pt-4">
@@ -549,17 +560,25 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
             </div>
 
             <!-- Consultant card -->
-            <ConsultantBlock
-              name={engagement?.consultant_name ?? consultantName}
-              photoUrl={engagement?.consultant_photo_url ?? null}
-              role={engagement?.consultant_role ?? 'Your consultant'}
-              nextTouchpointAt={engagement?.next_touchpoint_at ?? null}
-              nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
-              phone={engagement?.consultant_phone ?? null}
-            />
-            <p class="text-[13px] leading-[18px] text-[color:var(--color-text-muted)] px-1">
-              Text {consultantFirst} with questions.
-            </p>
+            {
+              consultantName && (
+                <>
+                  <ConsultantBlock
+                    name={consultantName}
+                    photoUrl={engagement?.consultant_photo_url ?? null}
+                    role={engagement?.consultant_role ?? null}
+                    nextTouchpointAt={engagement?.next_touchpoint_at ?? null}
+                    nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
+                    phone={engagement?.consultant_phone ?? null}
+                  />
+                  {consultantFirst && (
+                    <p class="text-[13px] leading-[18px] text-[color:var(--color-text-muted)] px-1">
+                      Text {consultantFirst} with questions.
+                    </p>
+                  )}
+                </>
+              )
+            }
           </div>
         </aside>
       </div>

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../../../styles/global.css'
+import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { listQuotesForEntity } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
@@ -56,14 +57,14 @@ const statusLabelMap: Record<string, string> = {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
-    <title>Proposals — Portal — SMD Services</title>
+    <title>Proposals — Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <header class="bg-white border-b border-slate-200">
       <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
         <div class="flex items-center gap-3">
           <a href="/portal" class="text-lg font-bold text-slate-900 hover:text-slate-700"
-            >SMD Services</a
+            >{BRAND_NAME}</a
           >
           <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
         </div>

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -570,7 +570,7 @@ describe('invoices: email templates', () => {
   })
 
   it('invoiceSentEmailHtml mentions invoice is ready', () => {
-    expect(source()).toContain('invoice from SMD Services')
+    expect(source()).toContain('invoice from ${BRAND_NAME}')
   })
 
   it('exports paymentConfirmationEmailHtml function', () => {

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -101,7 +101,7 @@ describe('magic-link: email module', () => {
 
   it('magic link email template is branded', () => {
     const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
-    expect(source).toContain('SMD Services')
+    expect(source).toContain('BRAND_NAME')
     expect(source).toContain('Client Portal')
   })
 
@@ -260,9 +260,9 @@ describe('magic-link: portal page', () => {
     expect(source).toContain('noindex')
   })
 
-  it('portal page is branded with SMD Services Portal', () => {
+  it('portal page is branded via BRAND_NAME', () => {
     const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
-    expect(source).toContain('SMD Services')
+    expect(source).toContain('BRAND_NAME')
     expect(source).toContain('Portal')
   })
 })

--- a/tests/portal-states.test.ts
+++ b/tests/portal-states.test.ts
@@ -48,6 +48,29 @@ describe('resolveInvoiceState', () => {
     expect(surface.state).toBe('default')
   })
 
+  it('omits the text-first-name CTA when firstName is null', () => {
+    const declined = resolveInvoiceState(
+      { paid_at: null },
+      new URLSearchParams('?state=declined'),
+      null
+    )
+    expect(declined.state).toBe('declined')
+    expect(declined.next.toLowerCase()).not.toContain('text ')
+
+    const expired = resolveInvoiceState(
+      { paid_at: null },
+      new URLSearchParams('?state=expired'),
+      null
+    )
+    expect(expired.state).toBe('expired')
+    expect(expired.next.toLowerCase()).not.toContain('text ')
+  })
+
+  it('paid next-step never claims a receipt is attached', () => {
+    const surface = resolveInvoiceState({ paid_at: '2026-04-10T00:00:00Z' }, null, 'Scott')
+    expect(surface.next.toLowerCase()).not.toContain('receipt attached')
+  })
+
   it('never surfaces raw provider text — copy is portal voice', () => {
     const surface = resolveInvoiceState(
       { paid_at: null },
@@ -126,6 +149,25 @@ describe('resolveProposalState', () => {
       'Scott'
     )
     expect(surface.state).toBe('default')
+  })
+
+  it('drops the text-first-name CTA when firstName is null', () => {
+    const declined = resolveProposalState(
+      { status: 'declined', accepted_at: null, expires_at: null },
+      null,
+      null
+    )
+    expect(declined.state).toBe('declined')
+    expect(declined.next.toLowerCase()).not.toContain('text ')
+
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    const expired = resolveProposalState(
+      { status: 'sent', accepted_at: null, expires_at: past },
+      null,
+      null
+    )
+    expect(expired.state).toBe('expired')
+    expect(expired.next.toLowerCase()).not.toContain('text ')
   })
 })
 

--- a/tests/quotes.test.ts
+++ b/tests/quotes.test.ts
@@ -251,7 +251,7 @@ describe('quotes: email template', () => {
 
   it('quote sent email includes proposal language', () => {
     const code = source()
-    expect(code).toContain('Your proposal from SMD Services is ready for review')
+    expect(code).toContain('Your proposal from ${BRAND_NAME} is ready for review')
   })
 
   it('quote sent email includes portal link', () => {

--- a/tests/sow-template.test.ts
+++ b/tests/sow-template.test.ts
@@ -264,7 +264,7 @@ describe('sow-template: signature block', () => {
 
   it('includes agreement text', () => {
     expect(source()).toContain('By signing below, the client agrees')
-    expect(source()).toContain('SMD Services agrees by presenting this Statement of Work')
+    expect(source()).toContain('{BRAND_NAME} agrees by presenting this Statement of Work')
   })
 })
 


### PR DESCRIPTION
## Summary

Four Pattern A remediations from the #377 audit (per #385 Part 2). One PR, mechanical + small follow-on to make the empty-state pattern reachable from every client-facing surface. Follow-on to hotfix #378.

Refs #377 #385

## Linked issue

Refs #377
Refs #385

## Acceptance criteria status

| AC (from #377 / #385 Part 2) | Status | Evidence |
| --- | --- | --- |
| Brand 'SMD Services' centralized behind a single constant (#385 Part 2.1) | met | `src/lib/config/brand.ts` exports `BRAND_NAME`; imported in 10 files; ~27 literal replacements across `src/lib/email/*`, `src/lib/pdf/sow-template.tsx`, and 6 portal pages |
| 'Scott Durgan' hardcoded fallbacks removed from all four client-facing surfaces (#385 Part 2.2) | met | `src/pages/portal/quotes/[id].astro:100-104,131-132`; `src/pages/portal/invoices/[id].astro:188-196`; `src/pages/portal/index.astro:229-238`; `src/lib/email/templates.ts:408-410,553-555` — all now render empty-state (portal: gated on `consultant_name`; email: sign from brand) |
| 'Consultant, SMD Services' role fallback removed | met | `src/pages/portal/invoices/[id].astro:189`; `ConsultantBlock.astro` accepts `role: string \| null` and skips the role line when null |
| 'Receipt attached' removed from all 3 portal surfaces (#385 Part 2.3) | met | `src/pages/portal/index.astro:196` (timeline body now `'Invoice paid.'`); `src/pages/portal/invoices/[id].astro:267,448` (paid caption now `'Paid {date}.'`); `src/lib/portal/states.ts:80` (paid next-step now `'Head back to the engagement dashboard.'`) |
| 'support window' phrase rewritten (#385 Part 2.5) | met | `src/lib/email/follow-up-templates.ts:213-215` — rewritten to decisions-doc text: `"we're still here. Reply to this email or reach out anytime."` |
| Tests do not rely on removed fallbacks | met | Updated `tests/magic-link.test.ts`, `tests/quotes.test.ts`, `tests/invoices.test.ts`, `tests/sow-template.test.ts` to assert on `BRAND_NAME` interpolation rather than the old literal. Added two null-firstName tests to `tests/portal-states.test.ts`. |

Note: the audit flagged 18 Captain-decision occurrences of `'SMD Services'`; I also swapped literals that were not on that list but live in the same files (page titles, copyright lines, SOW PDF footers) so the constant is the single source of truth. No out-of-scope Pattern B work touched.

### Deferred

Admin engagements editor (`src/pages/admin/engagements/[id].astro`) does not currently expose a `consultant_name` field. Making `consultant_name` NOT NULL at the DB layer is out of scope for this PR — the removal of the render-time fallback is already Pattern A prevention. When the admin UI for engagement-contact roles lands (#69), that work can also add required-at-author-time enforcement.

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, build, 1133/1135 tests; 2 skipped are pre-existing SOW render tests)
- [x] Portal states tests now cover the null-firstName path for both invoice and proposal resolvers
- [x] Email template tests updated to check `BRAND_NAME` interpolation
- [ ] Manual: open a portal invoice / proposal / home surface on an engagement with `consultant_name = NULL` and verify the consultant block is hidden (not rendered with a fallback identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)