### PR TITLE
feat(nav-spec): NAVIGATION.md v1 + retrofit shipped chrome to spec

### DIFF
--- a/.claude/commands/nav-spec.md
+++ b/.claude/commands/nav-spec.md
@@ -1,0 +1,48 @@
+---
+name: nav-spec
+description: Author or revise `.stitch/NAVIGATION.md` — the navigation specification that eliminates chrome drift across Stitch-generated screens and live code.
+---
+
+# /nav-spec - Navigation Specification
+
+Invokes the `nav-spec` skill (`~/.agents/skills/nav-spec/`). Produces or revises `.stitch/NAVIGATION.md`.
+
+## Usage
+
+```
+/nav-spec                        # Author (first time) or check status (if spec exists)
+/nav-spec --revise [flags]       # Update existing spec
+/nav-spec --audit                # Run drift audit only, no authoring
+/nav-spec --phase-0              # Re-run Phase 0 injection compliance test
+/nav-spec --classify-help        # Show classification decision rubric
+```
+
+### Revise flags
+
+```
+--add-surface-class <class>      # Add a new auth-model surface class
+--add-archetype <archetype>      # Add a new screen archetype
+--align-to-code <path>           # Align spec to shipped code at path (resolves code-spec mismatch)
+```
+
+## Behavior
+
+1. Resolves this venture's Stitch project ID via `crane_ventures` (fails fast if `stitchProjectId` is null).
+2. Routes to the appropriate workflow based on presence of `.stitch/NAVIGATION.md` and supplied flags:
+   - Absent + no flags → `workflows/author.md`
+   - Present + `--revise` → `workflows/revise.md`
+   - Present + no flags → status summary + suggest next action
+   - `--audit` → `workflows/audit.md`
+   - `--phase-0` → `workflows/phase-0-compliance-test.md`
+3. Produces artifacts:
+   - `.stitch/NAVIGATION.md` (primary output)
+   - `.stitch/drift-audit-<YYYY-MM-DD>.md` (audit runs)
+   - Phase 0 compliance report copied to the skill's `examples/` folder for reuse
+
+## After first run
+
+On first successful author, the command produces a **separate PR** with edits to `stitch-design` and `stitch-ux-brief` that consume the new spec via graceful-degradation guards. This PR lands after the NAVIGATION.md itself — never bundled.
+
+## Execution
+
+Run the `nav-spec` skill. Start with its `SKILL.md` for phase orientation. The skill's fail-fast preconditions cover project-ID resolution, DESIGN.md check, and NAVIGATION.md presence.

--- a/.stitch/NAVIGATION.md
+++ b/.stitch/NAVIGATION.md
@@ -1,0 +1,783 @@
+---
+spec-version: 1
+design-md-sha: absent
+stitch-project-id: '17873719980790683333'
+phase-0-compliance:
+  categorical: '93%'
+  strict: '87%'
+  date: '2026-04-15'
+enforcement: 'injection-first + required validator (nav-spec/validate.py)'
+approval-state: 'approved (retrofit landed in PR feat/nav-spec-v1)'
+---
+
+# SMD Services — Navigation Specification
+
+Single source of truth for navigation chrome across `smd.services`, `admin.smd.services`, and `portal.smd.services`. Every Stitch-generated screen and every new shipped component must conform. Deviations require a spec-version bump, not a one-off exception.
+
+Companion skill: `~/.agents/skills/nav-spec/`. Spec is consumed by `stitch-design` (via NAV CONTRACT injection) and `stitch-ux-brief` (Phase 7 concept template, Phase 11 strip directive). Post-generation enforcement via `nav-spec/validate.py`.
+
+**v1 status:** spec is authored; approval is held on the refactor checklist in Section 11. Validator is in injection-first + belt-and-suspenders mode per Phase 0 compliance evidence (see `nav-spec/examples/phase-0-compliance-report.md`).
+
+---
+
+## 1. Information architecture
+
+### Sitemap (by subdomain)
+
+**`smd.services`** (marketing and auth entry — served from apex)
+
+- `/` — marketing home (public, dashboard archetype)
+- `/contact` — contact form (public, form)
+- `/book` — booking flow (public, form)
+- `/book/manage/` — query-param redirect handler; renders an inline "invalid link" fallback when no token (public, error)
+- `/book/manage/[token]` — **token-auth**, manage existing booking (token-auth, detail)
+- `/get-started` — onboarding CTA page (public, dashboard)
+- `/scorecard` — self-serve assessment (public, wizard)
+- `/contact` — contact form (public, form)
+- `/404` — shared not-found page (renders in all subdomain contexts; see "Cross-subdomain 404" in Section 7)
+- `/auth/login` — admin OAuth entry (**auth-gate**, form)
+- `/auth/portal-login` — client magic-link request (**auth-gate**, form)
+- `/auth/verify` — magic-link verification (**auth-gate**, transient)
+
+**`admin.smd.services`**
+
+- `/admin` — dashboard (session-auth-admin, dashboard)
+- `/admin/entities` — client list (session-auth-admin, list)
+- `/admin/entities/[id]` — client detail (session-auth-admin, detail)
+- `/admin/entities/[id]/quotes/[quoteId]` — quote detail, nested (session-auth-admin, detail)
+- `/admin/engagements/[id]` — engagement detail (session-auth-admin, detail) — no `/admin/engagements` list; parent is the client detail
+- `/admin/assessments/[id]` — assessment detail (session-auth-admin, detail) — no list; parent is the client detail
+- `/admin/follow-ups` — follow-ups list (session-auth-admin, list)
+- `/admin/analytics` — analytics dashboard (session-auth-admin, dashboard)
+- `/admin/settings/google-connect` — integration settings (session-auth-admin, form)
+
+**`portal.smd.services`**
+
+- `/portal` — dashboard (session-auth-client, dashboard)
+- `/portal/invoices` — list (session-auth-client, list)
+- `/portal/invoices/[id]` — detail (session-auth-client, detail)
+- `/portal/quotes` — list (session-auth-client, list)
+- `/portal/quotes/[id]` — detail (session-auth-client, detail)
+- `/portal/documents` — index (session-auth-client, list)
+- `/portal/engagement` — current engagement summary (session-auth-client, detail)
+
+**Dev-only (exempt from spec enforcement)**
+
+- `/dev/portal-components`, `/dev/portal-states` — internal component preview harnesses, noindex, not Stitch generation targets
+
+### Auth boundary table
+
+| Surface class         | Auth model                                                   | Base URL                                                                        | Session cookie                                        | Redirect on logout                                |
+| --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `public`              | None                                                         | `smd.services/*` (default marketing)                                            | None                                                  | n/a                                               |
+| `auth-gate`           | Anonymous; surface exists to produce or consume a credential | `smd.services/auth/*`                                                           | None pre-submit; session set on post-success redirect | n/a — surface IS the redirect target after logout |
+| `token-auth`          | Signed URL token in path segment                             | `/book/manage/[token]` (and any future `/proposal/[token]`, `/invoice/[token]`) | None                                                  | n/a — link expiry replaces logout                 |
+| `session-auth-client` | Client cookie session (portal user)                          | `portal.smd.services/*`                                                         | `__Host-portal_session`                               | `smd.services/auth/portal-login`                  |
+| `session-auth-admin`  | Admin cookie session (operator)                              | `admin.smd.services/*`                                                          | `__Host-admin_session`                                | `smd.services/auth/login`                         |
+
+### Deep-link inventory
+
+Every URL reachable from outside the app (email, SMS, saved bookmark):
+
+- `/` and public marketing — organic traffic
+- `/book/manage/[token]` — emailed after booking confirmation (signed token, session-less)
+- `/portal` and `/portal/*` — arrived via `/auth/portal-login` after a magic-link email
+- `/admin` — arrived via `/auth/login` (Google OAuth)
+
+Portal detail pages (`/portal/invoices/[id]`, `/portal/quotes/[id]`) always require session auth in the current architecture. If token-auth landings for these ship later, they must route through a distinct URL (e.g., `portal.smd.services/proposal/[token]`) and render `token-auth` chrome per Appendix B — **not** portal chrome. See "Surface-class selection when subdomain is ambiguous" in Section 2.
+
+---
+
+## 2. Surface-class taxonomy
+
+Classes are modeled by **auth model**, not subdomain. Subdomain is a secondary attribute; two surface classes can coexist on one subdomain (e.g., `portal.smd.services` can host `session-auth-client` dashboards and `token-auth` proposal landings under distinct URL paths).
+
+| Class                 | One-line definition                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `public`              | No authentication. Addressed to a stranger or first-time visitor. Marketing, contact, scorecard.      |
+| `auth-gate`           | Anonymous; surface exists solely to produce or consume an auth credential. Minimal chrome. `noindex`. |
+| `token-auth`          | Signed URL token grants access without an account. User arrived via an emailed link; token expires.   |
+| `session-auth-client` | Authenticated client with a portal cookie session. Low-privilege; views their own records.            |
+| `session-auth-admin`  | Authenticated operator with an admin cookie session. High-privilege; views all records.               |
+
+### Surface-class selection when subdomain is ambiguous
+
+If the same subdomain hosts multiple surface classes (e.g., a future `portal.smd.services/proposal/[token]`), disambiguation:
+
+1. **Presence of a valid session cookie** is the primary signal. If present → session-auth-client (or admin on admin subdomain). If absent but a URL token is valid → token-auth.
+2. **Token-auth on an authenticated subdomain must render distinct chrome** so an authenticated user who refreshes the tab can tell the session expired. Use a visible "Viewing via secure link" badge in the header band plus the Appendix B token-auth chrome (not Appendix C portal chrome).
+3. **Middleware enforcement:** `src/middleware.ts` must carve out token-auth paths before session-auth checks; otherwise the middleware redirects token-auth users to login.
+
+---
+
+## 3. Screen archetype taxonomy
+
+10 archetypes. 9 interactive + 1 transient. See `~/.agents/skills/nav-spec/references/archetype-catalog.md` for full per-archetype contracts.
+
+| Archetype   | Allowed surface classes            | Back                                   | Breadcrumbs                  |
+| ----------- | ---------------------------------- | -------------------------------------- | ---------------------------- |
+| `dashboard` | session-auth-\*, public (landing)  | no                                     | no                           |
+| `list`      | session-auth-\*                    | yes → parent                           | session-auth-admin: 2 levels |
+| `detail`    | all five                           | yes → parent                           | session-auth-admin: 3 levels |
+| `form`      | session-auth-\*, public, auth-gate | cancel+save OR submit-only (auth-gate) | no                           |
+| `wizard`    | session-auth-\*, public            | prev/next                              | no                           |
+| `empty`     | session-auth-\*, token-auth        | inherit                                | inherit                      |
+| `error`     | all five                           | no                                     | no                           |
+| `modal`     | session-auth-\*, token-auth        | close                                  | no                           |
+| `drawer`    | session-auth-\*, token-auth        | close                                  | no                           |
+| `transient` | auth-gate                          | n/a                                    | n/a                          |
+
+`transient` is new: a server-side processing surface with no user-facing chrome (renders only a fallback if the redirect fails). Used by `/auth/verify`.
+
+---
+
+## 4. Chrome component contracts (defaults)
+
+Chrome pieces default to shapes in `~/.agents/skills/nav-spec/references/chrome-component-contracts.md`. Surface-class appendices override.
+
+### Default header band
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between px-4 md:px-6">
+    <!-- left: per surface class -->
+    <!-- right: per surface class -->
+  </div>
+</header>
+```
+
+**Height class placement:** `h-14 md:h-16` MUST be on the `<header>` element, not on an inner wrapper. The validator checks the `<header>`'s class list only. Inner-div `py-*` produces a different computed height and fails validation.
+
+**Width wrapper:** `max-w-5xl mx-auto` lives on the inner `<div>`, inside `<header>`. The outer `<header>` is full-bleed so the bottom border spans the viewport.
+
+### Token acceptance forms
+
+The spec uses literal hex (`#e2e8f0`) in examples. The validator and the Stitch injection accept these equivalent forms for every token:
+
+| Token        | Literal hex | CSS variable                  | Tailwind named color |
+| ------------ | ----------- | ----------------------------- | -------------------- |
+| Border       | `#e2e8f0`   | `var(--color-border)`         | `slate-200`          |
+| Text default | `#475569`   | `var(--color-text-secondary)` | `slate-600`          |
+| Text bold    | `#0f172a`   | `var(--color-text-primary)`   | `slate-900`          |
+| Primary      | `#1e40af`   | `var(--color-primary)`        | `blue-800`           |
+| Focus ring   | `#3b82f6`   | `var(--color-action)`         | `blue-500`           |
+
+Astro components should prefer the CSS-var form. Stitch generations emit literal hex. Validator accepts any.
+
+### Default back affordance (detail archetypes)
+
+```html
+<a href="<canonical-parent-url>" aria-label="<parent-label>" class="inline-flex items-center gap-1 w-11 h-11 text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded-lg">
+  <span class="material-symbols-outlined">chevron_left</span>
+  <span class="text-[13px] font-medium"><parent-label></span>
+</a>
+```
+
+Positioned inside `<main>`, above content, never inside `<header>`.
+
+### Breadcrumbs
+
+Admin only, depth ≥ 2.
+
+### Skip-to-main link (all surfaces, no exceptions)
+
+```html
+<a
+  href="#main"
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] bg-white px-4 py-2 rounded-lg border border-[#e2e8f0] text-[#1e40af] font-medium"
+>
+  Skip to main content
+</a>
+```
+
+First element in `<body>`, before `<header>`. `<main id="main">` is the target.
+
+---
+
+## 5. Mobile ↔ desktop transforms
+
+**Single breakpoint for chrome:** `md:` (768px). Content layouts may use `sm:` / `lg:` / `xl:`; **chrome never does, with one named exception (right-rail sticky).**
+
+### Transforms per chrome piece
+
+| Chrome                                 | Mobile (<768)                                                         | Desktop (≥768)                                |
+| -------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------- |
+| Header height                          | `h-14` (56px) on `<header>`                                           | `md:h-16` (64px) on `<header>`                |
+| Header padding x                       | `px-4` on inner div                                                   | `md:px-6` on inner div                        |
+| Header max-width                       | full bleed (no wrapper constraint below md)                           | `md:max-w-5xl md:mx-auto` on inner div        |
+| Back affordance                        | in-flow, left of content, inside `<main>`                             | same                                          |
+| Admin nav tabs (Appendix D)            | `hidden`, collapsed into user menu                                    | `md:flex`, inline                             |
+| Admin user menu trigger (Appendix D)   | icon button, right of header                                          | `md:hidden` (email + Sign out visible inline) |
+| ActionCard (portal detail, Appendix C) | **above** `<main>` content                                            | inside right rail                             |
+| Right rail (portal detail, dashboard)  | stacks below (collapsed)                                              | `md:` (see below)                             |
+| Breadcrumbs                            | segment truncation at 24ch                                            | full labels                                   |
+| Safe-area bottom                       | `pb-[max(1rem,env(safe-area-inset-bottom))]` on `<main>` or container | n/a                                           |
+
+### Right-rail stickiness (named exception)
+
+The right rail is the **only** chrome piece that may use `lg:` classes. Live shipped portal code uses `md:` for the rail, and the spec ratifies this after reviewing the evidence:
+
+- Permitted class pattern on `<aside>` elements inside `<main>`: `md:w-[340px] md:sticky md:top-20 md:self-start`
+- Forbidden on all other chrome elements: `sm:`, `lg:`, `xl:` classes anywhere in `<header>`, `<footer>`, nav elements, or back affordances.
+
+Rail top offset is `md:top-20` (80px), which clears the 64px sticky header + 16px buffer. If header height changes, rail offset must update in lockstep.
+
+---
+
+## 6. State conventions
+
+Pulled from `src/styles/global.css`. Hex values authoritative.
+
+| State                        | Hex                         | CSS var                  | Tailwind name (equivalent) |
+| ---------------------------- | --------------------------- | ------------------------ | -------------------------- |
+| Primary / active link        | `#1e40af`                   | `--color-primary`        | `blue-800`                 |
+| Primary hover                | `#1e3a8a`                   | `--color-primary-hover`  | `blue-900`                 |
+| Default text                 | `#475569`                   | `--color-text-secondary` | `slate-600`                |
+| Bold text / hover on default | `#0f172a`                   | `--color-text-primary`   | `slate-900`                |
+| Disabled text                | `#94a3b8`                   | `--color-text-muted`     | `slate-400`                |
+| Border                       | `#e2e8f0`                   | `--color-border`         | `slate-200`                |
+| Focus ring                   | `#3b82f6` @ 2px, 2px offset | `--color-action`         | `blue-500`                 |
+| Error                        | `#ef4444`                   | `--color-error`          | `red-500`                  |
+| Success / paid               | `#10b981`                   | `--color-complete`       | `emerald-500`              |
+| Attention                    | `#f59e0b`                   | `--color-attention`      | `amber-500`                |
+| Meta (timeline dates)        | `#6366f1`                   | `--color-meta`           | `indigo-500`               |
+
+### Touch-state parity (critical for mobile)
+
+Every `hover:` utility on an interactive element MUST be paired with a matching `focus-visible:` utility (keyboard users) AND an `active:` utility (pressed state on touch). Without `active:`, touch devices exhibit "stuck hover" — a tapped element stays in hover state until another element is tapped.
+
+**Canonical interactive-element class pattern:**
+
+```
+text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2
+```
+
+Apply this pattern to every chrome link, button, and CTA.
+
+### Tap target enforcement
+
+Tap target minimum: 44×44px. Every interactive chrome element declares an explicit `min-h-11 min-w-11` (or `w-11 h-11` for icon-only, or `min-h-11` + negative horizontal margins when the ink is text). This is load-bearing; do not omit.
+
+### aria-current
+
+Active nav item carries `aria-current="page"` and the active hex. The validator checks for this on any rendered nav.
+
+---
+
+## 7. Transition contracts
+
+### Back-target resolution
+
+All back buttons and cancel buttons resolve to a **hardcoded canonical URL string**. Never `#`, `javascript:`, or `history.back()`. Token-auth leaves (which have no parent) have **no back button** at all.
+
+### Canonical parents (authoritative; every shipped dynamic route enumerated)
+
+| From                                    | Back target            | Label                                              |
+| --------------------------------------- | ---------------------- | -------------------------------------------------- |
+| `/portal/invoices/[id]`                 | `/portal/invoices`     | "All invoices"                                     |
+| `/portal/quotes/[id]`                   | `/portal/quotes`       | "All quotes"                                       |
+| `/portal/engagement`                    | `/portal`              | "Home"                                             |
+| `/portal/documents/[id]` (future)       | `/portal/documents`    | "All documents"                                    |
+| `/admin/entities/[id]`                  | `/admin/entities`      | "All clients"                                      |
+| `/admin/entities/[id]/quotes/[quoteId]` | `/admin/entities/[id]` | "<Client name>"                                    |
+| `/admin/engagements/[id]`               | `/admin/entities/[id]` | "<Client name>" (engagement is scoped to a client) |
+| `/admin/assessments/[id]`               | `/admin/entities/[id]` | "<Client name>" (same pattern)                     |
+| `/admin/settings/google-connect`        | `/admin`               | "Dashboard"                                        |
+| `/admin/follow-ups`                     | `/admin`               | "Dashboard"                                        |
+| `/admin/analytics`                      | `/admin`               | "Dashboard"                                        |
+| `/contact` submit/cancel                | `/`                    | "Home"                                             |
+| `/book` cancel                          | `/`                    | "Home"                                             |
+| `/get-started`                          | `/`                    | "Home"                                             |
+| `/scorecard`                            | `/`                    | "Home"                                             |
+
+No fallback row. Every new dynamic route must add a row during spec revision.
+
+### Modal / drawer close
+
+Esc closes. Click-outside (scrim) closes. X button closes. Focus returns to the triggering element.
+
+### Cross-auth-boundary transitions (full enumeration)
+
+| From                | To                            | Mechanism                                                                 | Clears cookie?                 |
+| ------------------- | ----------------------------- | ------------------------------------------------------------------------- | ------------------------------ |
+| public              | auth-gate (`/auth/*`)         | `<a href="smd.services/auth/...">` (same origin)                          | no                             |
+| auth-gate           | session-auth-client           | 302 to `portal.smd.services/portal` + Set-Cookie                          | sets `__Host-portal_session`   |
+| auth-gate           | session-auth-admin            | 302 to `admin.smd.services/admin` + Set-Cookie                            | sets `__Host-admin_session`    |
+| session-auth-client | auth-gate (logout)            | form POST to `/api/auth/logout` → 302 to `smd.services/auth/portal-login` | clears `__Host-portal_session` |
+| session-auth-admin  | auth-gate (logout)            | form POST to `/api/auth/logout` → 302 to `smd.services/auth/login`        | clears `__Host-admin_session`  |
+| session-auth-\*     | public (marketing link click) | `<a>` with target subdomain origin                                        | no                             |
+| session-auth-admin  | session-auth-client           | not supported; operator must log out and re-login                         | n/a                            |
+| token-auth          | anywhere (via link click)     | `<a>` with explicit origin; token does not follow                         | n/a                            |
+
+All cross-subdomain transitions are **full page loads**; no client-side routing across origins.
+
+### Post-login redirects (also table rows above)
+
+- Client magic-link verify success → 302 `portal.smd.services/portal`
+- Admin OAuth success → 302 `admin.smd.services/admin`
+- Any auth-gate failure → 302 back to same auth-gate page with `?error=<code>`
+
+### Cross-subdomain 404
+
+`src/pages/404.astro` is a shared not-found page that renders in all three subdomain contexts. Current implementation has no layout, so it ships chrome-less — which is actually acceptable per the spec's `error` archetype rules (minimal header, back-to-safety link). Target link resolves by subdomain:
+
+- On `smd.services` → `/`
+- On `portal.smd.services` → `/portal`
+- On `admin.smd.services` → `/admin`
+
+Middleware detects host and sets `Astro.locals.homeUrl`; 404 page reads it for the back-to-safety link.
+
+---
+
+## 8. Anti-patterns (forbidden by default)
+
+See `~/.agents/skills/nav-spec/references/anti-patterns.md` for rationale.
+
+| Anti-pattern                                       | Forbidden by default on                            | Exceptions                            |
+| -------------------------------------------------- | -------------------------------------------------- | ------------------------------------- |
+| Global nav tabs in header                          | public, session-auth-client, token-auth, auth-gate | Admin (see Appendix D.2)              |
+| Sidebar / hamburger / drawer as primary nav        | all                                                | none                                  |
+| Bottom-tab nav on mobile                           | all                                                | none                                  |
+| Sticky-bottom action bar on viewport               | all                                                | See escape hatches below              |
+| Footer                                             | auth-gate, session-auth-\*, token-auth             | Public (Appendix A)                   |
+| Marketing CTAs on auth surface                     | session-auth-\*, token-auth, auth-gate             | none                                  |
+| Testimonials / pull quotes                         | all                                                | Public marketing (explicit in prompt) |
+| Hero imagery on auth surface                       | session-auth-\*, token-auth, auth-gate             | Public marketing (explicit)           |
+| Real-face photo placeholders                       | all                                                | none; see consultant-block rule below |
+| Breadcrumbs on non-admin                           | public, auth-gate, session-auth-client, token-auth | Admin only                            |
+| `<nav aria-label="Breadcrumb">` around single link | all                                                | none                                  |
+| `fixed top-0` on header                            | all                                                | none; always `sticky top-0`           |
+| `backdrop-blur-*` / translucent header bg          | session-auth-\*, token-auth, auth-gate             | Public hero bands (explicit)          |
+| Icon before client name in header                  | session-auth-\*, token-auth                        | none                                  |
+| Back `href="#"` / `javascript:` / `history.back()` | all                                                | none                                  |
+
+### Sticky-bottom escape hatches (for long forms on mobile)
+
+Sticky-bottom action bars that stick to the viewport (`fixed bottom-0`, `sticky bottom-0` with a `fixed` ancestor) are **forbidden**. For long forms or wizards where the primary CTA would fall below the fold on 390×844:
+
+1. **Primary CTA at the natural end of `<main>`** (inside document flow). Preferred.
+2. **Wizard split** — break the form into steps so each step's CTA fits above the fold. Required for forms ≥ 6 fields on mobile.
+3. **Duplicate CTA at top and bottom of `<main>`** (both in document flow). Acceptable for public-facing forms (contact, book) where the form length is outside the designer's control.
+4. **`sticky bottom-0` scoped to a scrollable container inside `<main>`** — permitted only inside `modal` and `drawer` archetypes. Not a header-level escape.
+
+### Consultant block photo placeholder
+
+Defers to `.stitch/portal-ux-brief.md § Photo placeholder rule`. Current rule: **neutral SVG silhouette**, never initials, never real photos. The spec in Section 4 and `chrome-component-contracts.md` is superseded by the portal-ux-brief on this specific element.
+
+---
+
+## 9. Accessibility floor
+
+- **Landmarks on every page:** `<header role="banner">`, `<main role="main" id="main">`, `<footer role="contentinfo">` (public only).
+- **Skip-to-main link** first in `<body>` (no exceptions; see Section 4).
+- **Keyboard order matches visual order.** No positive `tabindex` values.
+- **Focus rings** on keyboard focus only (`focus-visible:`); no always-on rings.
+- **aria-label** on every icon-only button, link, or control.
+- **`aria-current="page"`** on the active nav item if any nav is rendered.
+- **Tap target** ≥ 44×44px on touch surfaces. Enforce via `min-h-11` or `w-11 h-11`.
+- **Touch-state parity** (Section 6) — `hover:` paired with `focus-visible:` and `active:`.
+- **Safe-area insets (mobile):** pages whose last interactive element is near the bottom apply `pb-[max(1rem,env(safe-area-inset-bottom))]` to `<main>` or the page container. Public footers apply the inset inside `<footer>`.
+- **Contrast:** body text `#475569` on `#ffffff` = 8.6:1, bold `#0f172a` = 19.0:1 (WCAG 2.2 AAA).
+- **No autoplay media, no carousels on auth surfaces.**
+
+---
+
+## 10. Content rules
+
+- **Nav labels**: sentence case ("Text Scott", "All invoices"). Not Title Case. Not ALL CAPS.
+- **Mobile breadcrumb truncation**: each segment caps at 24ch via `truncate max-w-[24ch]`. Full label on desktop.
+- **Icon + label pairing**: icon-only buttons must have `aria-label`; icon + visible-text buttons must not duplicate the label as `aria-label` (redundant to screen readers).
+- **Status pills**: sentence case ("Paid", "Due Friday"). Colors via state-token table. Never three attention colors in one view (use exactly one attention color per surface).
+- **Date format in chrome**: "Apr 18" (short) in back labels / breadcrumbs; never "04/18" or ISO format.
+- **Contact channel labels**: "Email Scott", "Text Scott", "Call Scott" (sentence case, action verb + name).
+
+---
+
+## 11. Refactor checklist (prerequisites for v1 approval)
+
+Per user decision, v1 of this spec is held until the following retrofits land. All are spec-conformance refactors against shipped code; none change user-visible behavior materially.
+
+### Blocking (v1 held until complete)
+
+| #   | File / Scope                                                                 | Change                                                                                                                        | Est. LOC          |
+| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| 1   | New `src/components/SkipToMain.astro`                                        | Create reusable component per Section 4 contract                                                                              | 10                |
+| 2   | Every layout + every page outside a layout                                   | Insert `<SkipToMain />` as first child of `<body>`                                                                            | ~15 insertions    |
+| 3   | Every `<main>` element                                                       | Add `id="main"`                                                                                                               | ~15               |
+| 4   | `src/components/Nav.astro`                                                   | Move `h-16` from inner div to `<header>`; add mobile `h-14`                                                                   | 3                 |
+| 5   | `src/components/portal/PortalHeader.astro`                                   | Replace `py-4` with `h-14 md:h-16` on `<header>`; add `sticky top-0 z-50`                                                     | 3                 |
+| 6   | `src/layouts/AdminLayout.astro`                                              | Replace `py-3` with `h-14 md:h-16` on `<header>`; add `sticky top-0 z-50`; add mobile user-menu transform per D.1-mobile      | ~40               |
+| 7   | `src/pages/portal/invoices/[id].astro`, `src/pages/portal/quotes/[id].astro` | Add back affordance inside `<main>` per canonical-parents table                                                               | ~6 per file = 12  |
+| 8   | `src/layouts/AdminLayout.astro`                                              | Breadcrumb separator: replace text `/` with `<span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>` | 3                 |
+| 9   | `~/.agents/skills/nav-spec/validate.py`                                      | Guard R6b with `surface != "session-auth-admin"`; expand token regex to accept CSS-var, slate-N, and literal hex forms        | 10                |
+| 10  | Portal + Token-auth headers                                                  | Implement three-icon contact control (email/SMS/phone) per Appendix B/C                                                       | ~15 per component |
+
+**Total estimated scope:** ~120 LOC across ~10 files.
+
+### Non-blocking (v2 follow-ups, tracked separately)
+
+- Right-rail offset update when admin + portal headers become sticky — may require QA visual check of `md:top-20` being correct across all detail pages
+- `<aside>` semantic audit for right-rail elements (ensure `<aside>` not `<div>`)
+- `.stitch/designs/portal-v1/` artifact regeneration under the new spec (optional; existing artifacts are historical)
+- `/privacy` and `/terms` marketing pages — currently linked from Appendix A footer but not shipped; either create minimal pages or remove links from footer
+
+Once all 10 blocking items are merged, bump front matter to `spec-version: 1` (remove `-pending` suffix) and mark approval state as `approved`.
+
+---
+
+# Appendix A — `public` (marketing)
+
+Base URL: `smd.services`. Visitor is a stranger or first-time prospect; goal is clear communication of offering.
+
+## A.1 Chrome allowed
+
+### Header
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between px-4 md:px-6">
+    <a
+      href="/"
+      class="text-lg font-bold tracking-tight text-[#0f172a] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded"
+      >SMD Services</a
+    >
+    <div class="flex items-center gap-5">
+      <a
+        href="/contact"
+        class="text-sm font-medium text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 min-h-11 px-2 -mx-2 inline-flex items-center rounded"
+        >Contact</a
+      >
+      <a
+        href="/book"
+        class="inline-flex items-center bg-[#1e40af] hover:bg-[#1e3a8a] active:bg-[#1e3a8a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 px-5 py-2 rounded font-medium text-white min-h-11"
+        >Book a Call</a
+      >
+    </div>
+  </div>
+</header>
+```
+
+**Delta vs default header:** logo wordmark (only surface class where a logo appears) + one text link + one CTA button.
+
+### Footer (public only)
+
+```html
+<footer role="contentinfo" class="bg-white border-t border-[#e2e8f0] mt-16">
+  <div
+    class="max-w-5xl mx-auto px-4 md:px-6 py-8 pb-[max(2rem,env(safe-area-inset-bottom))] flex flex-col md:flex-row justify-between gap-4 text-[13px] text-[#475569]"
+  >
+    <span>© 2026 SMDurgan LLC. All rights reserved.</span>
+    <nav aria-label="Legal" class="flex gap-4">
+      <a
+        href="/contact"
+        class="hover:text-[#0f172a] active:text-[#0f172a] min-h-11 inline-flex items-center"
+        >Contact</a
+      >
+    </nav>
+  </div>
+</footer>
+```
+
+**`/privacy` and `/terms` are not shipped as of v1.** Footer omits them until pages exist. Re-add when ready (tracked in non-blocking follow-ups).
+
+### Hero imagery
+
+Allowed on `/`, `/get-started`, `/scorecard` — must be explicitly specified in the page prompt. Stock headshots forbidden (validator R9).
+
+## A.2 Chrome forbidden on public
+
+Universal anti-patterns from Section 8, plus:
+
+- Sidebar / hamburger / drawer as primary nav
+- Bottom-tab nav
+- Sticky-bottom action bar (the header CTA is sufficient for marketing)
+- Testimonials on non-`/` pages
+- `backdrop-blur-*` / translucent header bg (marketing can use solid hero bands; header is always solid white)
+
+## A.3 Archetype-specific notes
+
+- `dashboard` = the marketing home `/`. The public landing.
+- `form` = `/contact`, `/book`. Cancel returns to `/`.
+- `wizard` = `/scorecard`, `/get-started`. Multi-step with progress indicator in header band.
+- `error` = `/404` (on `smd.services` context). Back-to-safety returns to `/`.
+
+---
+
+# Appendix B — `token-auth`
+
+Base URL examples: `smd.services/book/manage/[token]`. Future: `portal.smd.services/proposal/[token]`, `portal.smd.services/invoice/[token]`. No account; token encodes identity.
+
+## B.1 Chrome allowed
+
+### Header (three-icon contact control, per user rule: "clients know what they want")
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between gap-4 px-4 md:px-6">
+    <p class="text-[13px] leading-[18px] font-medium text-[#475569] truncate"><recipient name or "Your booking"></p>
+    <div class="flex items-center gap-1">
+      <a href="mailto:<email>" aria-label="Email Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+      </a>
+      <a href="sms:<phone>" aria-label="Text Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">sms</span>
+      </a>
+      <a href="tel:<phone>" aria-label="Call Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">call</span>
+      </a>
+    </div>
+  </div>
+</header>
+```
+
+**Delta vs default:** no logo; recipient name left; **three contact channels on the right** (email / SMS / phone), each 44×44, each with `aria-label`. Client picks the channel that works for them; every channel works on every device. `<mailto:>`, `<sms:>`, and `<tel:>` handle fallbacks automatically per OS/browser.
+
+### Back affordance
+
+**Absent.** Token-auth pages are leaf surfaces; user arrived from a link.
+
+## B.2 Chrome forbidden on token-auth
+
+Universal anti-patterns from Section 8. Additionally:
+
+- Links to authenticated surfaces (`/portal`, `/admin`) — user has no session
+- "Sign up" / "Create account" CTAs — not the job of token-auth
+
+## B.3 Archetype-specific notes
+
+- `detail` — primary; managing a booking, viewing a proposal/invoice
+- `form` — reschedule via token; submit-only (no cancel affordance — user closes tab)
+- `empty`, `error` — the three-icon contact control is the only recovery path
+
+---
+
+# Appendix C — `session-auth-client` (portal)
+
+Base URL: `portal.smd.services`. Authenticated client viewing their own records. The working surface this spec's rigor was tuned against.
+
+## C.1 Chrome allowed
+
+### Header (three-icon contact control)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between gap-4 px-4 md:px-6">
+    <p class="text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[#475569] truncate"><client name></p>
+    <div class="flex items-center gap-1">
+      <a href="mailto:<email>" aria-label="Email Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+      </a>
+      <a href="sms:<phone>" aria-label="Text Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">sms</span>
+      </a>
+      <a href="tel:<phone>" aria-label="Call Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">call</span>
+      </a>
+      <slot /> <!-- host page may pass Sign out form -->
+    </div>
+  </div>
+</header>
+```
+
+Shipped component: `src/components/portal/PortalHeader.astro`. Refactor item #5 in Section 11 aligns shipped component to this contract.
+
+### Back affordance (detail archetypes)
+
+Default contract from Section 4. Positioned inside `<main>` above content.
+
+### Right rail (detail + dashboard, `md:` and up)
+
+```html
+<aside class="w-full md:w-[340px] md:sticky md:top-20 md:self-start space-y-6">
+  <!-- ActionCard, ConsultantBlock, related links -->
+</aside>
+```
+
+Width 340px ratifies live shipped portal code. `md:top-20` (80px) clears the 64px sticky header + 16px buffer.
+
+### Mobile stack order (detail archetype)
+
+On mobile (<`md:`), the ActionCard moves **above** `<main>` content — the primary CTA must be above the fold. Order: `<header>` → `<main>` → back button → **ActionCard** → main content body → ConsultantBlock → related links.
+
+On desktop (`md:` and up), ActionCard lives in the right rail.
+
+### ConsultantBlock
+
+Shipped component: `src/components/portal/ConsultantBlock.astro`. Photo placeholder treatment is the **SVG silhouette** defined in `.stitch/portal-ux-brief.md § Photo placeholder rule`. The nav-spec defers to the UX brief on this element specifically (do not substitute initials).
+
+## C.2 Chrome forbidden on session-auth-client
+
+Universal anti-patterns. Especially:
+
+- **Breadcrumbs** — never; portal is shallow (≤2 levels)
+- **Global nav tabs** — portal is narrow; no tab bar
+- **Sticky-bottom action bar** — primary action is in ActionCard above the fold
+- **Logo in header** — client name identifies context
+
+## C.3 Archetype-specific notes
+
+- `dashboard` = `/portal`. No back. Two-column on `md:`. ActionCard above timeline on mobile.
+- `list` = `/portal/invoices`, `/portal/quotes`, `/portal/documents`. Back → `/portal`. Filter bar below header.
+- `detail` = `/portal/*/[id]`. Back → canonical parent. ActionCard above main on mobile, in right rail on `md:`.
+- `form` — rare on portal; none currently live. Cancel → origin.
+- `empty` — inside list views; no CTA (user doesn't create these records).
+- `error` — three-icon contact control is the recovery.
+
+---
+
+# Appendix D — `session-auth-admin`
+
+Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA than portal; nav tabs allowed as a ratified exception.
+
+## D.1 Chrome allowed
+
+### Desktop header (`md:` and up)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16 hidden md:block">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between px-4 md:px-6">
+    <div class="flex items-center gap-3">
+      <a href="/admin" class="text-lg font-bold text-[#0f172a] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded">SMD Services</a>
+      <span class="text-xs bg-[#f1f5f9] text-[#475569] px-2 py-0.5 rounded">Admin</span>
+    </div>
+    <div class="flex items-center gap-4">
+      <!-- nav tabs per D.2, rendered hidden md:flex -->
+      <span class="text-sm text-[#94a3b8]" aria-hidden="true">|</span>
+      <span class="text-sm text-[#475569]"><operator email></span>
+      <form method="POST" action="/api/auth/logout">
+        <button type="submit" class="text-sm text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 min-h-11 px-2 -mx-2 rounded">Sign out</button>
+      </form>
+    </div>
+  </div>
+</header>
+```
+
+### Mobile header (<`md:`)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:hidden">
+  <div class="h-full flex items-center justify-between px-4">
+    <div class="flex items-center gap-3">
+      <a href="/admin" class="text-lg font-bold text-[#0f172a] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded">SMD Services</a>
+      <span class="text-xs bg-[#f1f5f9] text-[#475569] px-2 py-0.5 rounded">Admin</span>
+    </div>
+    <details class="relative">
+      <summary aria-label="Open menu" class="list-none w-11 h-11 flex items-center justify-center rounded-lg hover:bg-[#f1f5f9] active:bg-[#f1f5f9] focus-visible:ring-2 focus-visible:ring-[#3b82f6] cursor-pointer">
+        <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+      </summary>
+      <div class="absolute right-0 top-12 w-64 bg-white border border-[#e2e8f0] rounded-lg shadow-lg p-2 z-50">
+        <nav aria-label="Primary" class="flex flex-col">
+          <a href="/admin" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Dashboard</a>
+          <a href="/admin/entities" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Entities</a>
+          <a href="/admin/follow-ups" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Follow-ups</a>
+          <a href="/admin/analytics" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Analytics</a>
+        </nav>
+        <hr class="my-2 border-[#e2e8f0]">
+        <p class="px-3 py-1.5 text-xs text-[#475569]"><operator email></p>
+        <form method="POST" action="/api/auth/logout">
+          <button type="submit" class="w-full text-left px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Sign out</button>
+        </form>
+      </div>
+    </details>
+  </div>
+</header>
+```
+
+Below `md:`, tabs + email + Sign out collapse into a `<details>` menu triggered by an icon button. This is a **ratified menu-trigger pattern** (not a general hamburger) — it exists specifically to collapse the admin-only tab bar below `md:`. The pattern is scoped to admin; no other surface class gets a menu trigger.
+
+### D.2 Admin nav tabs (ratified exception)
+
+```html
+<nav aria-label="Primary" class="hidden md:flex items-center gap-4">
+  <a href="/admin" aria-current={active ? "page" : undefined}
+     class={`text-sm transition-colors min-h-11 inline-flex items-center px-2 -mx-2 rounded focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 ${active ? "text-[#1e40af] font-medium" : "text-[#475569] hover:text-[#0f172a] active:text-[#0f172a]"}`}>
+    Dashboard
+  </a>
+  <!-- Entities, Follow-ups, Analytics — same pattern -->
+</nav>
+```
+
+Rationale for exception: admin has 4 top-level sections with distinct IA (Entities, Follow-ups, Analytics, plus Dashboard). Tab bar is clearest IA for a single-operator surface. Cap at 5 tabs; if a 6th appears, revisit via `/nav-spec --revise`.
+
+### D.3 Breadcrumbs
+
+Admin is the only surface class rendering breadcrumbs. Live `AdminLayout.astro` ships an optional breadcrumb prop; keep it. Format per `chrome-component-contracts.md` (use `<chevron_right aria-hidden="true">`, not `/` text).
+
+Depth caps:
+
+- `list`: 2 levels
+- `detail`: 3 levels
+
+### D.4 Back vs breadcrumbs
+
+If the page has breadcrumbs, it does **not** also have a back button. If no breadcrumbs (e.g., admin dashboard), no back either — the nav tabs/menu is the navigation.
+
+## D.5 Chrome forbidden on session-auth-admin
+
+Universal anti-patterns, **except** nav tabs (D.2 exception) and the mobile `<details>` menu (D.1 exception). Additionally:
+
+- Sidebar (permanent) — no
+- Right rail — no (data-dense; 3-column is cramped)
+- Footer — no (authenticated)
+- Marketing CTAs, testimonials, hero imagery — obviously forbidden
+
+## D.6 Archetype-specific notes
+
+- `dashboard` = `/admin`. Grid of metric cards.
+- `list` = `/admin/entities`, `/admin/follow-ups`. Filter bar. 2-level breadcrumbs acceptable.
+- `detail` = `/admin/*/[id]`. 3-level breadcrumbs. No back button (breadcrumbs carry the affordance).
+- `form` = `/admin/settings/*`, `/admin/*/[id]/edit`. Cancel + Save. 2-level breadcrumbs.
+
+---
+
+# Appendix E — `auth-gate`
+
+Base URLs: `smd.services/auth/login`, `/auth/verify`, `/auth/portal-login`. Anonymous surface; exists to produce or consume an auth credential. All pages in this class carry `<meta name="robots" content="noindex, nofollow">`.
+
+## E.1 Chrome allowed
+
+### Header (wordmark only)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-sm md:max-w-md mx-auto h-full flex items-center justify-center px-4">
+    <span class="text-lg font-bold tracking-tight text-[#0f172a]">SMD Services</span>
+  </div>
+</header>
+```
+
+**Delta vs default:** wordmark centered (not linked — no destination is safe from an auth-gate); no Contact, no Book a Call, no nav, no contact icons. Narrower max-width to focus the form.
+
+### No footer, no back affordance
+
+Auth-gate has no parent destination and no legal chrome. Post-success redirects happen server-side (Section 7's cross-auth-boundary table).
+
+## E.2 Chrome forbidden
+
+Universal anti-patterns. Additionally:
+
+- Contact link / Book a Call CTA — wrong audience; users are trying to sign in
+- Footer with legal links — if legal is required by an OAuth consent screen, it's rendered by the OAuth provider, not by this surface
+- Links to authenticated surfaces — session doesn't exist yet
+- Links to marketing pages — distracting mid-auth
+
+## E.3 Archetype-specific notes
+
+- `form` — `/auth/login` (admin OAuth), `/auth/portal-login` (client magic-link). Submit-only (no cancel). Errors render inline via `?error=` query param.
+- `transient` — `/auth/verify`. Server-side processing + redirect. Renders a fallback error only if the redirect fails. No header required (server sends a bare HTML document with a `<noscript>` fallback link).
+
+## E.4 Post-auth transitions
+
+Enumerated in Section 7 cross-auth-boundary table. Summary:
+
+- Admin OAuth success → 302 `admin.smd.services/admin`
+- Client magic-link verify success → 302 `portal.smd.services/portal`
+- Any failure → 302 back to same auth-gate with `?error=<code>`
+
+---
+
+## Revision history
+
+| spec-version | Date       | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Approver |
+| ------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 1            | 2026-04-15 | Initial spec authored via `/nav-spec`. Grounded in Phase 0 compliance run (categorical 93%, strict 87%) and drift audit of shipped code. Approves: admin nav tabs as documented exception (D.2), admin mobile `<details>` menu (D.1-mobile), ratified live portal right-rail `md:` + 340px + `md:top-20`, SVG silhouette for ConsultantBlock (defers to portal-ux-brief), three-icon contact control in portal and token-auth headers (per user: "clients know what they want"). Introduces `auth-gate` surface class (Appendix E) for `/auth/*` pages and `transient` archetype for `/auth/verify`. All 10 Section 11 retrofit items shipped in PR feat/nav-spec-v1; verify pipeline green (1077 tests pass). | Captain  |

--- a/.stitch/designs/v1-verification/RUN-LOG.md
+++ b/.stitch/designs/v1-verification/RUN-LOG.md
@@ -1,0 +1,82 @@
+# NAVIGATION.md v1-pending — verification run log
+
+Date: 2026-04-15
+Spec version checked: 1-pending
+Skill: `~/.agents/skills/nav-spec/` v1
+Stitch project: 17873719980790683333
+
+## Phase 7 — integration check (self-consistency)
+
+Regenerate `portal-v1/home-mobile` with the full updated NAV CONTRACT injection (session-auth-client / dashboard / mobile). Validate against spec.
+
+**Result:** 1 violation — R1 (fixed vs sticky). All categorical rules honored; three-icon contact control, skip-to-main link, SVG silhouette (no real face), no nav tabs, no bottom chrome, no footer, no marketing. Validator false-positive bugs discovered (R3 limited to before-client-name; R15 attribute order) — both fixed in validate.py. Re-validation: 1 remaining violation, which is a real Stitch blindspot.
+
+**Artifact:** `phase7-portal-home-mobile.html`
+
+## Phase 8 — adversarial verification (unseen combos)
+
+Three prompts on {surface × archetype × viewport} combinations the spec author did NOT tune against:
+
+### Portal settings form (session-auth-client, form, mobile)
+
+**Result:** 1 violation — R1 (fixed vs sticky). Correctly produced:
+
+- No back button (form uses cancel+save) ✓
+- Three-icon contact control ✓
+- Skip-to-main with matching `id="main"` ✓
+- No footer on auth surface ✓
+- No breadcrumbs ✓
+
+**Artifact:** `phase8-portal-settings-form-mobile.html`
+
+### Admin audit log detail (session-auth-admin, detail, desktop)
+
+**Result:** 1 violation — R9 (real-face photo; Stitch used stock image for operator avatar). Correctly produced:
+
+- **`sticky top-0 z-50`** (admin header sticky — no R1 this time!) ✓
+- **`<nav class="hidden md:flex">`** nav tabs pattern exactly matching Appendix D.2 ✓
+- Four tabs (Dashboard, Entities active, Follow-ups, Analytics) with active state ✓
+- Skip-to-main → matching `id="main-content"` on `<main>` ✓
+- No sidebar, no footer ✓
+- R6b admin-exception guard worked — no false positive on 4 nav tabs ✓
+
+**Artifact:** `phase8-admin-audit-log-detail-desktop.html`
+
+### Marketing blog post (public, detail, desktop)
+
+**Result:** 1 violation — R9 (real-face photos; Stitch used stock images for author avatar + related-article previews). Correctly produced:
+
+- Sticky header with logo + Contact link + Book a Call CTA — exact Appendix A.1 match ✓
+- Skip-to-main → matching `id="main"` ✓
+- **`<footer>` present** — public surface allowed by rule correctly ✓
+- No breadcrumbs (blog is flat) ✓
+- No sidebar, no bottom-tab ✓
+
+**Artifact:** `phase8-marketing-blog-post-desktop.html`
+
+## Drift-prevention assessment
+
+| Metric                                                    | Result                                                                       |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Structural violations from taxonomy gaps                  | **0 across 3 adversarial runs**                                              |
+| Semantic violations (non-blindspot)                       | 0                                                                            |
+| Known blindspots caught by validator                      | R1 (1×), R9 (2×) — all correctly flagged                                     |
+| Cross-surface-class behavior                              | All three surface-class appendices (A/C/D) produced distinct, correct chrome |
+| `md:-only` chrome rule + right-rail `lg:` exception       | Respected across admin and portal generations                                |
+| Three-icon contact control (new pattern introduced in v1) | Implemented correctly across 2 runs                                          |
+
+**Conclusion:** the spec's taxonomy and injection mechanism handle unseen {surface × archetype × viewport} combinations without structural drift. The adversarial verification passes the plan's gate ("chrome matches spec's prediction for each combo").
+
+## Outstanding v1-approval prerequisites
+
+Per NAVIGATION.md §11, v1 approval is held on the retrofit PR. Verification passed; spec is correct. Retrofit remains: ~120 LOC across ~10 files (skip-to-main component + landmarks + height-class placement + three-icon contact in PortalHeader + admin sticky + admin mobile `<details>` menu + portal detail back affordances + breadcrumb separator swap).
+
+Once retrofit merges and `spec-version` front matter flips from `1-pending` → `1`, this verification run becomes the baseline for comparison on any future spec revision.
+
+## Artifacts in this folder
+
+- `phase7-portal-home-mobile.html` — integration-check regeneration
+- `phase8-portal-settings-form-mobile.html` — adversarial: new archetype on known surface
+- `phase8-admin-audit-log-detail-desktop.html` — adversarial: new surface class (admin)
+- `phase8-marketing-blog-post-desktop.html` — adversarial: new surface class (public)
+- `RUN-LOG.md` — this file

--- a/.stitch/designs/v1-verification/phase7-portal-home-mobile.html
+++ b/.stitch/designs/v1-verification/phase7-portal-home-mobile.html
@@ -1,0 +1,292 @@
+<!doctype html>
+
+<html class="light" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Delgado Plumbing - Dashboard</title>
+    <!-- Fonts: Plus Jakarta Sans for authority, Inter for functional text -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&amp;family=Inter:wght@400;500;600&amp;display=swap"
+      rel="stylesheet"
+    />
+    <!-- Material Symbols Outlined -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              secondary: '#515f74',
+              'on-secondary-container': '#57657a',
+              background: '#faf8ff',
+              'inverse-on-surface': '#eef0ff',
+              outline: '#757684',
+              'error-container': '#ffdad6',
+              'on-background': '#131b2e',
+              'secondary-fixed-dim': '#b9c7df',
+              'on-surface': '#131b2e',
+              'surface-container-highest': '#dae2fd',
+              'secondary-fixed': '#d5e3fc',
+              'on-surface-variant': '#444653',
+              'primary-container': '#1e40af',
+              'on-primary': '#ffffff',
+              'primary-fixed-dim': '#b8c4ff',
+              'surface-variant': '#dae2fd',
+              'tertiary-fixed-dim': '#adc6ff',
+              'tertiary-container': '#00489e',
+              'surface-tint': '#3755c3',
+              error: '#ba1a1a',
+              tertiary: '#003272',
+              surface: '#faf8ff',
+              'on-secondary': '#ffffff',
+              'surface-container-high': '#e2e7ff',
+              'surface-container-lowest': '#ffffff',
+              'surface-container': '#eaedff',
+              'surface-bright': '#faf8ff',
+              primary: '#00288e',
+              'primary-fixed': '#dde1ff',
+              'tertiary-fixed': '#d8e2ff',
+              'secondary-container': '#d5e3fc',
+              'surface-container-low': '#f2f3ff',
+              'on-secondary-fixed': '#0d1c2e',
+              'inverse-surface': '#283044',
+              'on-tertiary-container': '#9cbbff',
+              'on-error': '#ffffff',
+              'on-primary-fixed': '#001453',
+              'on-primary-container': '#a8b8ff',
+              'on-tertiary-fixed-variant': '#004395',
+              'outline-variant': '#c4c5d5',
+              'inverse-primary': '#b8c4ff',
+              'on-secondary-fixed-variant': '#3a485b',
+              'on-tertiary-fixed': '#001a42',
+              'surface-dim': '#d2d9f4',
+              'on-primary-fixed-variant': '#173bab',
+              'on-error-container': '#93000a',
+              'on-tertiary': '#ffffff',
+            },
+            borderRadius: {
+              DEFAULT: '0.25rem',
+              lg: '0.5rem',
+              xl: '0.75rem',
+              full: '9999px',
+            },
+            fontFamily: {
+              headline: ['Plus Jakarta Sans'],
+              body: ['Inter'],
+              label: ['Inter'],
+            },
+          },
+        },
+      }
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+      }
+      .tap-target-44 {
+        min-width: 44px;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      body {
+        font-family: 'Inter', sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+      h1,
+      h2,
+      h3,
+      .display-lg {
+        font-family: 'Plus Jakarta Sans', sans-serif;
+      }
+    </style>
+    <style>
+      body {
+        min-height: max(884px, 100dvh);
+      }
+    </style>
+  </head>
+  <body class="bg-surface text-on-surface min-h-screen">
+    <!-- Skip Link -->
+    <a
+      class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-primary focus:text-white focus:px-4 focus:py-2 focus:rounded-full"
+      href="#main-content"
+      >Skip to main content</a
+    >
+    <!-- TopAppBar -->
+    <header
+      class="fixed top-0 left-0 w-full z-50 flex justify-between items-center px-4 h-14 bg-white border-b border-[#e2e8f0]"
+    >
+      <div class="plus-jakarta-sans text-[13px] font-medium tracking-tight text-slate-600">
+        Delgado Plumbing
+      </div>
+      <nav class="flex items-center -mr-2">
+        <button
+          aria-label="Email"
+          class="tap-target-44 text-slate-600 hover:bg-slate-100 transition-colors"
+        >
+          <span aria-hidden="true" class="material-symbols-outlined">mail</span>
+        </button>
+        <button
+          aria-label="SMS"
+          class="tap-target-44 text-slate-600 hover:bg-slate-100 transition-colors"
+        >
+          <span aria-hidden="true" class="material-symbols-outlined">chat_bubble</span>
+        </button>
+        <button
+          aria-label="Call"
+          class="tap-target-44 text-slate-600 hover:bg-slate-100 transition-colors"
+        >
+          <span aria-hidden="true" class="material-symbols-outlined">phone</span>
+        </button>
+      </nav>
+    </header>
+    <main class="pt-20 pb-12 px-6 max-w-[390px] mx-auto overflow-x-hidden" id="main-content">
+      <!-- Action Card: The "Blackout" Task Layer -->
+      <section class="mb-10">
+        <div
+          class="bg-inverse-surface text-on-primary p-8 rounded-xl shadow-lg relative overflow-hidden"
+          style="background: linear-gradient(135deg, #283044 0%, #131b2e 100%)"
+        >
+          <!-- Eyebrow -->
+          <p
+            class="text-[13px] font-medium text-on-primary-container tracking-tight mb-2 opacity-90"
+          >
+            Invoice due Friday
+          </p>
+          <!-- Amount -->
+          <div class="text-[44px] font-extrabold leading-none tracking-tighter mb-4">$4,250</div>
+          <!-- Metadata -->
+          <p class="text-[13px] font-normal text-on-primary-container opacity-70 mb-8">
+            Invoice #1023 • Due Apr 18
+          </p>
+          <!-- Button -->
+          <button
+            class="w-full bg-primary-container hover:bg-blue-700 text-white font-semibold py-4 px-6 rounded-full transition-all active:scale-[0.98] flex items-center justify-center gap-2 mb-4"
+          >
+            Pay invoice
+          </button>
+          <!-- Subtext -->
+          <div
+            class="flex items-center justify-center gap-1.5 text-[11px] font-medium opacity-60 uppercase tracking-widest"
+          >
+            <span class="material-symbols-outlined text-[14px]">lock</span>
+            Secured by Stripe
+          </div>
+        </div>
+      </section>
+      <!-- Consultant Block -->
+      <section class="mb-12">
+        <div class="flex items-center gap-4 bg-surface-container-low p-4 rounded-xl">
+          <!-- Silhouette Placeholder -->
+          <div
+            class="w-14 h-14 rounded-full bg-surface-container-high flex items-center justify-center text-primary-fixed-dim"
+          >
+            <svg
+              class="opacity-80"
+              fill="none"
+              height="40"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              viewbox="0 0 24 24"
+              width="40"
+            >
+              <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path>
+              <circle cx="12" cy="7" r="4"></circle>
+            </svg>
+          </div>
+          <div>
+            <h3 class="text-[16px] font-bold text-on-surface leading-tight">Scott Durgan</h3>
+            <p class="text-[14px] text-on-surface-variant font-normal">Primary Consultant</p>
+            <p class="text-[12px] text-outline mt-1 font-medium italic">
+              Replies within 1 business day
+            </p>
+          </div>
+        </div>
+      </section>
+      <!-- Activity Timeline -->
+      <section>
+        <h2 class="text-[18px] font-bold text-[#0F172A] tracking-tight mb-8">Recent activity</h2>
+        <div class="space-y-8 relative">
+          <!-- Timeline Items (No lines as per Ledger rule) -->
+          <div class="flex items-baseline gap-6">
+            <div
+              class="w-14 shrink-0 text-[13px] font-medium text-outline uppercase tracking-wider"
+            >
+              Apr 18
+            </div>
+            <div
+              class="text-[14px] text-on-surface-variant font-normal border-l-2 border-primary-fixed pl-6 py-1"
+            >
+              Invoice sent
+            </div>
+          </div>
+          <div class="flex items-baseline gap-6">
+            <div
+              class="w-14 shrink-0 text-[13px] font-medium text-outline uppercase tracking-wider"
+            >
+              Apr 16
+            </div>
+            <div
+              class="text-[14px] text-on-surface-variant font-normal border-l-2 border-primary-fixed pl-6 py-1"
+            >
+              Assessment call completed
+            </div>
+          </div>
+          <div class="flex items-baseline gap-6">
+            <div
+              class="w-14 shrink-0 text-[13px] font-medium text-outline uppercase tracking-wider"
+            >
+              Apr 09
+            </div>
+            <div
+              class="text-[14px] text-on-surface-variant font-normal border-l-2 border-primary-fixed pl-6 py-1"
+            >
+              Two issues identified with dispatcher
+            </div>
+          </div>
+          <div class="flex items-baseline gap-6">
+            <div
+              class="w-14 shrink-0 text-[13px] font-medium text-outline uppercase tracking-wider"
+            >
+              Apr 02
+            </div>
+            <div
+              class="text-[14px] text-on-surface-variant font-normal border-l-2 border-primary-fixed pl-6 py-1"
+            >
+              <p>Proposal signed</p>
+              <p class="text-primary font-medium mt-0.5">Deposit received</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <!-- Functional Space (No Footer per instructions) -->
+      <div class="h-12"></div>
+    </main>
+    <!-- Aesthetic Decorative Texture (Subtle) -->
+    <div
+      aria-hidden="true"
+      class="fixed inset-0 pointer-events-none opacity-[0.02] z-[-1]"
+      style="
+        background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuCUO1mZjm79hZdmLEq4G670VDq3JqN_HU_gpaoGW8MGIK6qEdfsbcKBESMnLaAyluflVY101DjYwO60KQWwRQMlBcGDpwuMEtQ5gq9uPE6Q8c1SXZAS80wego5EPMfN_Av7tFuUpgRvHtAiCAMxTxbDblom6DZwtSeuvKeCYkZ5opt1dWfD3_VEmghKm4aNDTBVyEZnqsjt4ziATq-3uBrueBidOHDKPs5lDCNZQqx2jOoC6swVFoAO9-KA9rEAKp3B6zg-qcE2iGfW');
+      "
+    ></div>
+  </body>
+</html>

--- a/.stitch/designs/v1-verification/phase8-admin-audit-log-detail-desktop.html
+++ b/.stitch/designs/v1-verification/phase8-admin-audit-log-detail-desktop.html
@@ -1,0 +1,342 @@
+<!doctype html>
+
+<html class="light" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Audit Event #4721 | SMD Services Admin</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              'outline-variant': '#87b5f0',
+              'on-secondary-fixed': '#3f3f43',
+              'secondary-fixed-dim': '#d6d3d8',
+              'surface-tint': '#3755c3',
+              'on-tertiary-fixed': '#433b55',
+              'on-primary-fixed-variant': '#3352c0',
+              'surface-variant': '#d3e4ff',
+              'error-dim': '#4f0116',
+              'on-tertiary': '#fdf7ff',
+              'on-error': '#fff7f7',
+              'surface-container': '#e6eeff',
+              'secondary-dim': '#535356',
+              'on-primary': '#f8f7ff',
+              'primary-container': '#dde1ff',
+              'on-surface-variant': '#306197',
+              secondary: '#5f5e62',
+              'primary-fixed': '#dde1ff',
+              surface: '#f8f9ff',
+              'surface-bright': '#f8f9ff',
+              outline: '#4f7db5',
+              'on-surface': '#00345e',
+              'on-secondary-fixed-variant': '#5c5b5f',
+              'on-error-container': '#782232',
+              'primary-fixed-dim': '#cad2ff',
+              'surface-container-highest': '#d3e4ff',
+              'secondary-container': '#e4e1e6',
+              tertiary: '#635b77',
+              'inverse-on-surface': '#8f9eb4',
+              'surface-container-high': '#dce9ff',
+              'on-tertiary-container': '#564d69',
+              'on-primary-container': '#2747b6',
+              'inverse-surface': '#010f20',
+              'secondary-fixed': '#e4e1e6',
+              'surface-dim': '#c4dcff',
+              'tertiary-fixed-dim': '#dbcff0',
+              'tertiary-dim': '#574f6a',
+              'on-primary-fixed': '#0732a3',
+              'tertiary-container': '#e9ddff',
+              'error-container': '#ff8b9a',
+              error: '#9e3f4e',
+              background: '#f8f9ff',
+              'on-background': '#00345e',
+              'primary-dim': '#2848b7',
+              'on-tertiary-fixed-variant': '#605773',
+              'on-secondary-container': '#525155',
+              primary: '#3755c3',
+              'tertiary-fixed': '#e9ddff',
+              'on-secondary': '#fbf8fc',
+              'surface-container-lowest': '#ffffff',
+              'inverse-primary': '#6d89fa',
+              'surface-container-low': '#eff4ff',
+            },
+            borderRadius: {
+              DEFAULT: '0.125rem',
+              lg: '0.5rem',
+              xl: '0.5rem',
+              full: '9999px',
+            },
+            fontFamily: {
+              headline: ['Inter', 'sans-serif'],
+              body: ['Inter', 'sans-serif'],
+              label: ['Inter', 'sans-serif'],
+              mono: ['JetBrains Mono', 'monospace'],
+            },
+          },
+        },
+      }
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+        vertical-align: middle;
+        font-size: 1.25rem;
+      }
+      body {
+        font-family: 'Inter', sans-serif;
+      }
+      .code-block {
+        font-family: 'JetBrains Mono', monospace;
+      }
+      .no-scrollbar::-webkit-scrollbar {
+        display: none;
+      }
+    </style>
+  </head>
+  <body
+    class="bg-surface text-on-surface min-h-screen selection:bg-primary-container selection:text-on-primary-container"
+  >
+    <a
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-white focus:rounded-lg"
+      href="#main-content"
+    >
+      Skip to main content
+    </a>
+    <!-- TopNavBar (Shared Component) -->
+    <header
+      class="sticky top-0 z-50 flex items-center justify-between px-6 w-full h-16 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800"
+    >
+      <div class="flex items-center gap-8">
+        <div class="flex items-center gap-3">
+          <span class="text-xl font-bold text-slate-900 dark:text-slate-50 tracking-tight"
+            >SMD Services</span
+          >
+          <span
+            class="bg-surface-container-high text-on-surface-variant text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-widest border border-outline-variant/20"
+            >Admin</span
+          >
+        </div>
+        <nav class="hidden md:flex items-center gap-6 h-16">
+          <a
+            class="text-slate-600 dark:text-slate-400 font-medium hover:text-blue-600 dark:hover:text-blue-300 transition-colors duration-200 h-full flex items-center"
+            href="#"
+            >Dashboard</a
+          >
+          <a
+            class="text-blue-700 dark:text-blue-400 border-b-2 border-blue-700 dark:border-blue-400 pb-0.5 font-semibold h-full flex items-center"
+            href="#"
+            >Entities</a
+          >
+          <a
+            class="text-slate-600 dark:text-slate-400 font-medium hover:text-blue-600 dark:hover:text-blue-300 transition-colors duration-200 h-full flex items-center"
+            href="#"
+            >Follow-ups</a
+          >
+          <a
+            class="text-slate-600 dark:text-slate-400 font-medium hover:text-blue-600 dark:hover:text-blue-300 transition-colors duration-200 h-full flex items-center"
+            href="#"
+            >Analytics</a
+          >
+        </nav>
+      </div>
+      <div class="flex items-center gap-4">
+        <span class="text-sm text-on-surface-variant font-medium">operator@smd-services.com</span>
+        <button
+          class="text-sm font-semibold text-primary hover:text-primary-dim transition-all active:scale-95"
+        >
+          Sign out
+        </button>
+      </div>
+    </header>
+    <main class="max-w-[1280px] mx-auto px-8 py-8" id="main-content">
+      <!-- Breadcrumbs -->
+      <nav aria-label="Breadcrumb" class="mb-6">
+        <ol class="flex items-center gap-2 text-sm text-on-surface-variant font-medium">
+          <li><a class="hover:text-primary transition-colors" href="#">Entities</a></li>
+          <li aria-hidden="true" class="flex items-center gap-2">
+            <span class="material-symbols-outlined text-[16px] text-outline">chevron_right</span>
+            <a class="hover:text-primary transition-colors" href="#">Delgado Plumbing</a>
+          </li>
+          <li aria-current="page" class="flex items-center gap-2 text-on-surface font-semibold">
+            <span class="material-symbols-outlined text-[16px] text-outline">chevron_right</span>
+            Audit log
+          </li>
+        </ol>
+      </nav>
+      <!-- Page Header -->
+      <div class="mb-10">
+        <h1 class="text-3xl font-bold tracking-tight text-[#0F172A] mb-2">Audit event #4721</h1>
+        <p class="text-on-surface-variant max-w-2xl">
+          Detailed breakdown of the system execution event including origin actor, subject entity,
+          and raw JSON data payload.
+        </p>
+      </div>
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+        <!-- Left Column: Primary Data -->
+        <div class="lg:col-span-8 space-y-8">
+          <!-- METADATA CARD -->
+          <section
+            class="bg-surface-container-lowest border border-[#E2E8F0] rounded-lg overflow-hidden"
+          >
+            <div class="bg-surface-container-high px-6 py-3 border-b border-[#E2E8F0]/40">
+              <h2 class="text-xs font-bold uppercase tracking-wider text-on-surface-variant">
+                Event Specifications
+              </h2>
+            </div>
+            <div class="grid grid-cols-2 gap-px bg-[#E2E8F0]/40">
+              <div class="bg-white p-6">
+                <label
+                  class="block text-[11px] font-bold text-on-surface-variant uppercase tracking-widest mb-1"
+                  >Event Type</label
+                >
+                <span class="text-lg font-semibold text-on-surface">Invoice generated</span>
+              </div>
+              <div class="bg-white p-6">
+                <label
+                  class="block text-[11px] font-bold text-on-surface-variant uppercase tracking-widest mb-1"
+                  >Timestamp</label
+                >
+                <span class="text-lg font-semibold text-on-surface">Apr 14, 2026, 3:42 PM MST</span>
+              </div>
+              <div class="bg-white p-6">
+                <label
+                  class="block text-[11px] font-bold text-on-surface-variant uppercase tracking-widest mb-1"
+                  >Actor</label
+                >
+                <div class="flex items-center gap-2">
+                  <div class="w-2 h-2 rounded-full bg-primary"></div>
+                  <span class="text-lg font-semibold text-on-surface">Scott Durgan</span>
+                </div>
+              </div>
+              <div class="bg-white p-6">
+                <label
+                  class="block text-[11px] font-bold text-on-surface-variant uppercase tracking-widest mb-1"
+                  >Subject</label
+                >
+                <span class="text-lg font-semibold text-on-surface">Delgado Plumbing</span>
+              </div>
+            </div>
+          </section>
+          <!-- PAYLOAD CARD -->
+          <section class="bg-[#F8FAFC] border border-[#E2E8F0] rounded-lg overflow-hidden">
+            <div
+              class="flex items-center justify-between px-6 py-4 border-b border-[#E2E8F0]/40 bg-white"
+            >
+              <h2 class="text-sm font-bold text-on-surface">Event payload</h2>
+              <button
+                class="text-xs font-semibold text-primary hover:bg-primary-container px-3 py-1 rounded transition-colors"
+              >
+                Copy JSON
+              </button>
+            </div>
+            <div class="p-6 overflow-x-auto">
+              <pre class="code-block text-sm text-slate-700 leading-relaxed"><code>{
+  <span class="text-blue-700">"invoice_id"</span>: <span class="text-emerald-700">"INV-2026-089"</span>,
+  <span class="text-blue-700">"amount"</span>: <span class="text-amber-700">4250</span>,
+  <span class="text-blue-700">"currency"</span>: <span class="text-emerald-700">"USD"</span>,
+  <span class="text-blue-700">"status"</span>: <span class="text-emerald-700">"generated"</span>,
+  <span class="text-blue-700">"previous_status"</span>: <span class="text-emerald-700">"draft"</span>
+}</code></pre>
+            </div>
+          </section>
+        </div>
+        <!-- Right Column: Sidebar -->
+        <aside class="lg:col-span-4 space-y-8">
+          <!-- RELATED EVENTS -->
+          <section class="bg-surface-container-low rounded-lg p-6">
+            <div class="flex items-center gap-2 mb-6">
+              <span class="material-symbols-outlined text-primary">history</span>
+              <h2 class="font-bold text-on-surface">Related Events</h2>
+            </div>
+            <div class="space-y-4">
+              <div
+                class="group bg-surface-container-lowest p-4 rounded-lg border border-transparent hover:border-outline-variant/40 transition-all"
+              >
+                <div class="flex justify-between items-start mb-1">
+                  <span class="text-[11px] font-mono text-on-surface-variant"
+                    >2026-04-14 15:40:12</span
+                  >
+                  <a class="text-xs font-bold text-[#1E40AF] hover:underline" href="#"
+                    >View detail</a
+                  >
+                </div>
+                <p class="text-sm font-semibold text-on-surface">Draft finalized</p>
+              </div>
+              <div
+                class="group bg-surface-container-lowest p-4 rounded-lg border border-transparent hover:border-outline-variant/40 transition-all"
+              >
+                <div class="flex justify-between items-start mb-1">
+                  <span class="text-[11px] font-mono text-on-surface-variant"
+                    >2026-04-14 15:35:00</span
+                  >
+                  <a class="text-xs font-bold text-[#1E40AF] hover:underline" href="#"
+                    >View detail</a
+                  >
+                </div>
+                <p class="text-sm font-semibold text-on-surface">Invoice initial creation</p>
+              </div>
+              <div
+                class="group bg-surface-container-lowest p-4 rounded-lg border border-transparent hover:border-outline-variant/40 transition-all"
+              >
+                <div class="flex justify-between items-start mb-1">
+                  <span class="text-[11px] font-mono text-on-surface-variant"
+                    >2026-04-14 14:12:44</span
+                  >
+                  <a class="text-xs font-bold text-[#1E40AF] hover:underline" href="#"
+                    >View detail</a
+                  >
+                </div>
+                <p class="text-sm font-semibold text-on-surface">New billable item added</p>
+              </div>
+            </div>
+            <button
+              class="w-full mt-6 py-2 px-4 bg-white border border-outline-variant/20 text-on-surface-variant text-xs font-bold rounded hover:bg-white/50 transition-colors uppercase tracking-widest"
+            >
+              Show all history
+            </button>
+          </section>
+          <!-- Context Card -->
+          <div class="relative h-48 rounded-lg overflow-hidden group">
+            <img
+              alt=""
+              class="absolute inset-0 w-full h-full object-cover grayscale brightness-50 group-hover:scale-105 transition-transform duration-700"
+              data-alt="Modern high-tech server room background with blue ambient lighting and blurred network rack infrastructure representing digital data security"
+              src="https://lh3.googleusercontent.com/aida-public/AB6AXuDvUENLPqgiqEE4mSDHQ-4Fihk0DxnM5hTNgygmKKlwzYne-X6sLzCoYGtIIeHOaU0QTuF7pcNO2s_IuRggAnb8wNVKIEpzNPOjZXCfsMZkZyvPKfd2ai5BliYAF45t6WdgIImTkhX3vuWHOrOHP9TubT6VZazCtx3afz-gDoSuNdC_YN2AlbCb6SpCkblx9mUk85Hti2YSoOZJo-NiTFefrVJKyMgGu8jDFWTchrDqoiSw07zqeb0LIpHN-uEx63kQa35NPtzJRAqk"
+            />
+            <div
+              class="absolute inset-0 bg-gradient-to-t from-inverse-surface to-transparent p-6 flex flex-col justify-end"
+            >
+              <span
+                class="text-[10px] font-bold text-primary-container uppercase tracking-widest mb-1"
+                >Security Status</span
+              >
+              <p class="text-white text-sm font-medium leading-snug">
+                This event was verified via SHA-256 integrity check upon persistence.
+              </p>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/.stitch/designs/v1-verification/phase8-marketing-blog-post-desktop.html
+++ b/.stitch/designs/v1-verification/phase8-marketing-blog-post-desktop.html
@@ -1,0 +1,330 @@
+<!doctype html>
+
+<html class="light" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Why we walk alongside owners instead of auditing them | SMD Services</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Plus+Jakarta+Sans:wght@700;800&amp;family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              'primary-fixed-dim': '#b8c4ff',
+              'on-tertiary-container': '#b3b5ff',
+              'on-secondary-fixed-variant': '#3a485b',
+              'on-secondary-fixed': '#0d1c2e',
+              background: '#faf8ff',
+              'tertiary-fixed-dim': '#c0c1ff',
+              'surface-container': '#eaedff',
+              'inverse-on-surface': '#eef0ff',
+              'secondary-fixed-dim': '#b9c7df',
+              'on-background': '#131b2e',
+              'surface-container-highest': '#dae2fd',
+              'inverse-surface': '#283044',
+              'primary-container': '#1e40af',
+              'on-tertiary-fixed': '#07006c',
+              'on-secondary': '#ffffff',
+              'surface-container-lowest': '#ffffff',
+              'inverse-primary': '#b8c4ff',
+              secondary: '#515f74',
+              'on-error': '#ffffff',
+              'on-surface-variant': '#444653',
+              'surface-tint': '#3755c3',
+              'surface-variant': '#dae2fd',
+              'tertiary-fixed': '#e1e0ff',
+              'on-primary': '#ffffff',
+              outline: '#757684',
+              'on-error-container': '#93000a',
+              tertiary: '#170cae',
+              primary: '#00288e',
+              'on-surface': '#131b2e',
+              'tertiary-container': '#3433c3',
+              'on-secondary-container': '#57657a',
+              'on-tertiary-fixed-variant': '#2f2ebe',
+              surface: '#faf8ff',
+              'surface-dim': '#d2d9f4',
+              'surface-container-low': '#f2f3ff',
+              'error-container': '#ffdad6',
+              'surface-bright': '#faf8ff',
+              'primary-fixed': '#dde1ff',
+              'surface-container-high': '#e2e7ff',
+              'on-tertiary': '#ffffff',
+              'outline-variant': '#c4c5d5',
+              'secondary-container': '#d5e3fc',
+              'on-primary-fixed': '#001453',
+              'secondary-fixed': '#d5e3fc',
+              'on-primary-container': '#a8b8ff',
+              error: '#ba1a1a',
+              'on-primary-fixed-variant': '#173bab',
+            },
+            borderRadius: {
+              DEFAULT: '0.25rem',
+              lg: '0.5rem',
+              xl: '0.75rem',
+              full: '9999px',
+            },
+            fontFamily: {
+              headline: ['Plus Jakarta Sans'],
+              body: ['Inter'],
+              label: ['Inter'],
+            },
+          },
+        },
+      }
+    </script>
+    <style>
+      .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+        display: inline-block;
+        vertical-align: middle;
+        line-height: 1;
+      }
+      body {
+        font-family: 'Inter', sans-serif;
+      }
+      h1,
+      h2,
+      h3,
+      .headline {
+        font-family: 'Plus Jakarta Sans', sans-serif;
+      }
+      .back-to-blog:hover svg {
+        transform: translateX(-4px);
+      }
+    </style>
+  </head>
+  <body class="bg-surface-container-lowest text-on-surface antialiased">
+    <a
+      class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:bg-primary focus:text-on-primary focus:px-6 focus:py-3 focus:rounded-lg focus:shadow-xl"
+      href="#main"
+      >Skip to main content</a
+    >
+    <!-- TopNavBar -->
+    <header
+      class="bg-white dark:bg-slate-900 h-16 sticky top-0 z-50 w-full border-b border-slate-200 dark:border-slate-800 shadow-sm dark:shadow-none"
+    >
+      <nav
+        aria-label="Global Navigation"
+        class="flex items-center justify-between max-w-5xl mx-auto px-6 w-full h-full"
+      >
+        <a class="text-xl font-bold tracking-tight text-slate-900 dark:text-white" href="/"
+          >SMD Services</a
+        >
+        <div class="flex items-center gap-8">
+          <ul class="hidden md:flex items-center gap-6">
+            <li>
+              <a
+                class="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors duration-200 font-medium"
+                href="/contact"
+                >Contact</a
+              >
+            </li>
+          </ul>
+          <a
+            class="bg-primary hover:bg-primary-container text-on-primary px-5 py-2.5 rounded-lg font-semibold transition-all active:scale-95 active:opacity-90"
+            href="/book"
+          >
+            Book a Call
+          </a>
+        </div>
+      </nav>
+    </header>
+    <main class="max-w-3xl mx-auto px-6 py-12 lg:py-24" id="main">
+      <!-- Back Link -->
+      <a
+        class="back-to-blog flex items-center gap-2 text-on-surface-variant hover:text-on-surface transition-all mb-12 group focus:outline-none focus:ring-2 focus:ring-primary focus:rounded px-1"
+        href="/blog"
+      >
+        <span class="material-symbols-outlined transition-transform">arrow_back</span>
+        <span class="font-medium text-sm tracking-wide">All posts</span>
+      </a>
+      <!-- Article Header -->
+      <header class="mb-12">
+        <span class="text-[#6366f1] font-bold text-xs uppercase tracking-widest mb-4 block"
+          >Methodology</span
+        >
+        <h1
+          class="text-4xl lg:text-5xl font-extrabold leading-tight text-on-surface tracking-tight mb-8"
+        >
+          Why we walk alongside owners instead of auditing them
+        </h1>
+        <div class="flex items-center gap-4 py-6 border-y border-outline-variant/10">
+          <div
+            class="w-12 h-12 rounded-full bg-secondary-container flex items-center justify-center overflow-hidden"
+          >
+            <svg
+              fill="none"
+              height="48"
+              viewbox="0 0 48 48"
+              width="48"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle cx="24" cy="24" fill="#d5e3fc" r="24"></circle>
+              <circle cx="24" cy="18" fill="#515f74" r="8"></circle>
+              <path
+                d="M8 40C8 31.1634 15.1634 24 24 24V24C32.8366 24 40 31.1634 40 40V48H8V40Z"
+                fill="#515f74"
+              ></path>
+            </svg>
+          </div>
+          <div class="flex flex-col">
+            <span class="font-semibold text-on-surface">Scott Durgan</span>
+            <div class="flex items-center gap-2 text-[#6366f1] text-sm">
+              <span>Apr 10, 2026</span>
+              <span class="opacity-30">•</span>
+              <span>5 min read</span>
+            </div>
+          </div>
+        </div>
+      </header>
+      <!-- Article Body -->
+      <article class="font-body text-[17px] leading-[28px] text-on-surface-variant space-y-8">
+        <p>
+          In the modern consulting landscape, the traditional audit has become a performance of
+          distance. A consultant arrives, observes from a safe perimeter, compiles a spreadsheet of
+          failures, and departs, leaving behind a thick document that often sits unopened on a hard
+          drive. At SMD Services, we realized early on that this "observer effect" rarely yields
+          sustainable change.
+        </p>
+        <h2 class="text-2xl font-bold text-on-surface pt-4">Beyond the Spreadsheet</h2>
+        <p>
+          An audit is a snapshot of what is wrong; a walk-along is a deep dive into
+          <em>why</em> things are the way they are. When we join owners on the floor or in the
+          strategy room, we aren't looking for compliance checkboxes. We are looking for the
+          friction points that prevent great people from doing their best work.
+        </p>
+        <blockquote
+          class="py-6 my-4 border-l-4 border-primary-container pl-6 bg-surface-container-low rounded-r-xl"
+        >
+          <p class="italic text-primary font-medium text-xl leading-relaxed">
+            "True consulting isn't just about pointing out the leaks; it's about holding the wrench
+            together until the flow is steady."
+          </p>
+        </blockquote>
+        <p>
+          This collaborative approach breaks down the natural defensiveness that arises during
+          formal inspections. When the consultant is viewed as a peer rather than a judge, the flow
+          of information becomes transparent. We discover the "workarounds" that employees have
+          created to bypass broken systems—insights that never surface in a formal interview or a
+          sanitized audit report.
+        </p>
+        <h2 class="text-2xl font-bold text-on-surface pt-4">The Implementation Gap</h2>
+        <p>
+          The greatest tragedy in business optimization is the implementation gap: the space between
+          a good idea and its daily execution. By walking alongside owners, we bridge this gap in
+          real-time. We don't just recommend a new workflow; we test it together on Tuesday
+          afternoon. If it fails, we pivot immediately. If it works, it's already part of the
+          culture before we leave.
+        </p>
+        <p>
+          Our authority isn't derived from a title or a proprietary software suite. It is built
+          through the shared experience of solving complex problems in the trenches. We believe that
+          the only way to truly understand a business is to feel the weight of its daily operations
+          alongside those who carry it every day.
+        </p>
+      </article>
+      <!-- Related Articles Section -->
+      <section class="mt-24 pt-12 border-t border-outline-variant/10">
+        <h3 class="text-lg font-bold text-on-surface mb-8 tracking-tight">Related insights</h3>
+        <div class="grid md:grid-cols-2 gap-12">
+          <!-- Related 1 -->
+          <article class="group">
+            <div
+              class="aspect-video w-full mb-6 overflow-hidden rounded-lg bg-surface-container-high"
+            >
+              <img
+                class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                data-alt="professional minimalist office space with large windows and clean lines reflecting a sense of order and clarity"
+                src="https://lh3.googleusercontent.com/aida-public/AB6AXuDClN8q-Llm-6l5Owy9ArNTlTPBwANNk_0Rlwm-V6GEGBZxX5qcHn-fmfrwzxu04buXzwglvapoq7TFYQK_mkjfAb9PqDNKcHYHWWa9I_Fx1VtManx2miw6jMvTGatMNtZX8yQJxHv_XNh9v7qfBerJRjdG8s-ga292DJK320mzKXrrvJisOdiA0k0L4ohuMlg-IMjcWh8FS_l9wuO7RyGC64A0yEP1iAbKd-WC0QzrBdrlceyQS7RqUbtaXlSW3DOJkF4VF3rlQ5mp"
+              />
+            </div>
+            <span class="text-[#6366f1] text-xs font-bold uppercase tracking-widest block mb-3"
+              >Strategy</span
+            >
+            <h4
+              class="text-xl font-bold text-on-surface mb-3 group-hover:text-primary transition-colors"
+            >
+              The friction tax: Hidden costs of operational clutter
+            </h4>
+            <p class="text-on-surface-variant text-sm mb-4 line-clamp-2">
+              How minor inefficiencies compound over time to create a significant drag on your
+              bottom line performance.
+            </p>
+            <a
+              class="inline-flex items-center gap-1 text-primary font-semibold text-sm hover:underline underline-offset-4"
+              href="/blog/friction-tax"
+            >
+              Read more <span class="material-symbols-outlined text-sm">arrow_forward</span>
+            </a>
+          </article>
+          <!-- Related 2 -->
+          <article class="group">
+            <div
+              class="aspect-video w-full mb-6 overflow-hidden rounded-lg bg-surface-container-high"
+            >
+              <img
+                class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                data-alt="close up of architectural blueprints and a professional fountain pen on a desk under soft warm morning light"
+                src="https://lh3.googleusercontent.com/aida-public/AB6AXuDQmF9Q2FoNgBpMoP2AFvBBy0gj93BPN6MvEt-kDy2c506d7QRwRv-YaV4KnLzIO4ifgzdeM806rW8SqA5iiOciRx11M4OLWaLljkK20BazkOty7YqOMDd98BHeYK9kckdBEDWoGa7zP-GPy66RNK1yrJOkdsrrE3xtxzAcW2GANlJY7MXaehDP4-R1QI1w5tGBxof-7-09jmMxbFkuwQQY7KR6DRrRDswtP5UIOVUL4RS0kXGzIQ5DCxshSY-ANQ76xekF1A7L3ThU"
+              />
+            </div>
+            <span class="text-[#6366f1] text-xs font-bold uppercase tracking-widest block mb-3"
+              >Culture</span
+            >
+            <h4
+              class="text-xl font-bold text-on-surface mb-3 group-hover:text-primary transition-colors"
+            >
+              Developing institutional memory in small teams
+            </h4>
+            <p class="text-on-surface-variant text-sm mb-4 line-clamp-2">
+              Ensuring that critical knowledge doesn't walk out the door when your key employees do.
+            </p>
+            <a
+              class="inline-flex items-center gap-1 text-primary font-semibold text-sm hover:underline underline-offset-4"
+              href="/blog/institutional-memory"
+            >
+              Read more <span class="material-symbols-outlined text-sm">arrow_forward</span>
+            </a>
+          </article>
+        </div>
+      </section>
+    </main>
+    <!-- Footer -->
+    <footer
+      class="w-full py-12 mt-12 bg-white dark:bg-slate-900 border-t border-slate-100 dark:border-slate-800"
+    >
+      <div
+        class="max-w-5xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-6"
+      >
+        <p class="text-sm font-body text-slate-500">© 2026 SMD Services</p>
+        <div class="flex items-center gap-8">
+          <a
+            class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            href="/contact"
+            >Contact</a
+          >
+          <a
+            class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            href="/privacy"
+            >Privacy Policy</a
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/.stitch/designs/v1-verification/phase8-portal-settings-form-mobile.html
+++ b/.stitch/designs/v1-verification/phase8-portal-settings-form-mobile.html
@@ -1,0 +1,306 @@
+<!doctype html>
+
+<html class="light" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=390, height=844, initial-scale=1.0" name="viewport" />
+    <title>The Precision Portal - Settings</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+      rel="stylesheet"
+    />
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              'surface-variant': '#dae2fd',
+              'on-secondary-container': '#57657a',
+              'on-surface': '#131b2e',
+              'on-secondary-fixed-variant': '#3a485b',
+              'surface-dim': '#d2d9f4',
+              'secondary-fixed-dim': '#b9c7df',
+              'on-background': '#131b2e',
+              'tertiary-fixed': '#ffdbce',
+              background: '#faf8ff',
+              secondary: '#515f74',
+              'surface-container': '#eaedff',
+              'on-secondary-fixed': '#0d1c2e',
+              'on-error': '#ffffff',
+              'surface-container-low': '#f2f3ff',
+              surface: '#faf8ff',
+              'on-tertiary-fixed': '#380d00',
+              error: '#ba1a1a',
+              tertiary: '#611e00',
+              'on-error-container': '#93000a',
+              'on-secondary': '#ffffff',
+              'inverse-surface': '#283044',
+              'surface-tint': '#3755c3',
+              'primary-container': '#1e40af',
+              'surface-container-high': '#e2e7ff',
+              'on-tertiary': '#ffffff',
+              outline: '#757684',
+              'error-container': '#ffdad6',
+              'inverse-on-surface': '#eef0ff',
+              'on-primary-fixed': '#001453',
+              'secondary-container': '#d5e3fc',
+              'on-primary': '#ffffff',
+              'primary-fixed-dim': '#b8c4ff',
+              'outline-variant': '#c4c5d5',
+              'inverse-primary': '#b8c4ff',
+              'surface-container-lowest': '#ffffff',
+              'on-primary-container': '#a8b8ff',
+              'surface-container-highest': '#dae2fd',
+              'on-surface-variant': '#444653',
+              'primary-fixed': '#dde1ff',
+              'on-primary-fixed-variant': '#173bab',
+              'on-tertiary-fixed-variant': '#802a00',
+              primary: '#00288e',
+              'surface-bright': '#faf8ff',
+              'tertiary-container': '#872d00',
+              'tertiary-fixed-dim': '#ffb59a',
+              'on-tertiary-container': '#ffa583',
+              'secondary-fixed': '#d5e3fc',
+            },
+            borderRadius: {
+              DEFAULT: '0.25rem',
+              lg: '0.5rem',
+              xl: '0.75rem',
+              full: '9999px',
+            },
+            fontFamily: {
+              headline: ['Inter', 'sans-serif'],
+              body: ['Inter', 'sans-serif'],
+              label: ['Inter', 'sans-serif'],
+            },
+          },
+        },
+      }
+    </script>
+    <style>
+      body {
+        font-family: 'Inter', sans-serif;
+        background-color: #faf8ff;
+      }
+      .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+      }
+      input:focus,
+      button:focus {
+        outline: 2px solid #3b82f6;
+        outline-offset: 2px;
+      }
+      /* Custom Toggle Switch */
+      .toggle-checkbox:checked {
+        right: 0;
+        background-color: #1e40af;
+      }
+      .toggle-checkbox:checked + .toggle-label {
+        background-color: #1e40af;
+      }
+    </style>
+    <style>
+      body {
+        min-height: max(884px, 100dvh);
+      }
+    </style>
+  </head>
+  <body class="text-on-background antialiased">
+    <a
+      class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:bg-white focus:p-4 focus:text-primary focus:font-bold"
+      href="#main"
+      >Skip to main content</a
+    >
+    <header
+      class="fixed top-0 w-full z-50 h-14 bg-white border-b border-[#e2e8f0] flex items-center justify-between px-4"
+    >
+      <span class="text-[13px] font-medium text-[#475569]">Mike Delgado</span>
+      <div class="flex items-center space-x-1">
+        <a
+          aria-label="Email Scott"
+          class="w-[44px] h-[44px] flex items-center justify-center text-slate-500 hover:text-primary transition-colors"
+          href="mailto:scott@example.com"
+        >
+          <span class="material-symbols-outlined">mail</span>
+        </a>
+        <a
+          aria-label="Text Scott"
+          class="w-[44px] h-[44px] flex items-center justify-center text-slate-500 hover:text-primary transition-colors"
+          href="sms:+1234567890"
+        >
+          <span class="material-symbols-outlined">chat_bubble</span>
+        </a>
+        <a
+          aria-label="Call Scott"
+          class="w-[44px] h-[44px] flex items-center justify-center text-slate-500 hover:text-primary transition-colors"
+          href="tel:+1234567890"
+        >
+          <span class="material-symbols-outlined">call</span>
+        </a>
+      </div>
+    </header>
+    <main class="pt-20 pb-24 px-6 max-w-[390px] mx-auto" id="main" role="main">
+      <h1 class="text-2xl font-bold text-[#0F172A] mb-8 tracking-tight">Portal Settings</h1>
+      <form class="space-y-10">
+        <!-- Profile Section -->
+        <section class="space-y-6">
+          <div class="flex items-center space-x-3 mb-2">
+            <div
+              class="w-10 h-10 rounded-full bg-surface-container flex items-center justify-center text-primary"
+            >
+              <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1"
+                >person</span
+              >
+            </div>
+            <h2 class="text-lg font-semibold text-[#0F172A]">Profile</h2>
+          </div>
+          <div class="space-y-5">
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-semibold text-on-surface-variant" for="name">Name</label>
+              <input
+                class="h-[48px] px-4 rounded-lg bg-surface-container-lowest border-0 ring-1 ring-outline-variant/20 focus:ring-2 focus:ring-primary text-on-surface"
+                id="name"
+                name="name"
+                type="text"
+                value="Mike Delgado"
+              />
+            </div>
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-semibold text-on-surface-variant" for="company"
+                >Company</label
+              >
+              <input
+                class="h-[48px] px-4 rounded-lg bg-surface-container-lowest border-0 ring-1 ring-outline-variant/20 focus:ring-2 focus:ring-primary text-on-surface"
+                id="company"
+                name="company"
+                type="text"
+                value="Delgado Plumbing"
+              />
+            </div>
+            <div class="flex flex-col gap-2">
+              <label class="text-sm font-semibold text-on-surface-variant" for="phone"
+                >Phone Number</label
+              >
+              <input
+                class="h-[48px] px-4 rounded-lg bg-surface-container-lowest border-0 ring-1 ring-outline-variant/20 focus:ring-2 focus:ring-primary text-on-surface"
+                id="phone"
+                name="phone"
+                placeholder="(555) 000-0000"
+                type="tel"
+              />
+            </div>
+          </div>
+        </section>
+        <!-- Contact Preferences -->
+        <section class="space-y-4">
+          <h2 class="text-lg font-semibold text-[#0F172A]">Contact preferences</h2>
+          <div class="bg-surface-container-low rounded-xl p-2 space-y-1">
+            <label
+              class="flex items-center justify-between p-3 hover:bg-surface-container-high rounded-lg cursor-pointer transition-colors"
+            >
+              <span class="text-sm font-medium text-on-surface">Email</span>
+              <input
+                checked=""
+                class="w-5 h-5 rounded text-primary focus:ring-primary border-outline-variant/30"
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="flex items-center justify-between p-3 hover:bg-surface-container-high rounded-lg cursor-pointer transition-colors"
+            >
+              <span class="text-sm font-medium text-on-surface">SMS</span>
+              <input
+                checked=""
+                class="w-5 h-5 rounded text-primary focus:ring-primary border-outline-variant/30"
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="flex items-center justify-between p-3 hover:bg-surface-container-high rounded-lg cursor-pointer transition-colors"
+            >
+              <span class="text-sm font-medium text-on-surface">Phone call</span>
+              <input
+                checked=""
+                class="w-5 h-5 rounded text-primary focus:ring-primary border-outline-variant/30"
+                type="checkbox"
+              />
+            </label>
+          </div>
+        </section>
+        <!-- Notification Preferences -->
+        <section class="space-y-4">
+          <h2 class="text-lg font-semibold text-[#0F172A]">Notification preferences</h2>
+          <div class="space-y-4">
+            <div class="flex items-center justify-between">
+              <div>
+                <p class="text-sm font-semibold text-on-surface">Invoice reminders</p>
+                <p class="text-xs text-on-surface-variant">Get notified when a payment is due</p>
+              </div>
+              <div class="relative inline-block w-12 mr-2 align-middle select-none">
+                <input
+                  checked=""
+                  class="absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer right-6 checked:right-0 checked:border-primary-container transition-all duration-200 ease-in-out"
+                  id="invoice-toggle"
+                  name="toggle"
+                  type="checkbox"
+                />
+                <label
+                  class="block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"
+                  for="invoice-toggle"
+                ></label>
+              </div>
+            </div>
+            <div class="flex items-center justify-between">
+              <div>
+                <p class="text-sm font-semibold text-on-surface">Engagement updates</p>
+                <p class="text-xs text-on-surface-variant">New activity on shared documents</p>
+              </div>
+              <div class="relative inline-block w-12 mr-2 align-middle select-none">
+                <input
+                  checked=""
+                  class="absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer right-6 checked:right-0 checked:border-primary-container transition-all duration-200 ease-in-out"
+                  id="engagement-toggle"
+                  name="toggle"
+                  type="checkbox"
+                />
+                <label
+                  class="block overflow-hidden h-6 rounded-full bg-slate-300 cursor-pointer"
+                  for="engagement-toggle"
+                ></label>
+              </div>
+            </div>
+          </div>
+        </section>
+        <!-- Actions -->
+        <div class="pt-8 flex flex-col space-y-3">
+          <button
+            class="w-full h-[48px] bg-[#1E40AF] text-white font-semibold rounded-lg shadow-lg shadow-blue-900/10 active:scale-[0.98] transition-transform"
+            type="submit"
+          >
+            Save Changes
+          </button>
+          <a
+            class="w-full h-[48px] flex items-center justify-center text-[#475569] font-medium rounded-lg hover:bg-slate-100 transition-colors"
+            href="/portal"
+          >
+            Cancel
+          </a>
+        </div>
+      </form>
+    </main>
+  </body>
+</html>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,10 +1,20 @@
-<header class="sticky top-0 z-50 border-b border-slate-100 bg-white">
-  <div class="mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-6">
-    <a href="/" class="text-lg font-bold tracking-tight text-slate-900">SMD Services</a>
+<header
+  role="banner"
+  class="sticky top-0 z-50 h-14 md:h-16 border-b border-[color:var(--color-border)] bg-white"
+>
+  <div class="mx-auto flex h-full w-full max-w-5xl items-center justify-between px-4 md:px-6">
+    <a
+      href="/"
+      class="text-lg font-bold tracking-tight text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
+      >SMD Services</a
+    >
     <div class="flex items-center gap-5">
-      <a class="text-sm font-medium text-slate-600 hover:text-slate-900" href="/contact">Contact</a>
       <a
-        class="bg-primary px-5 py-2 rounded font-medium text-white transition-opacity hover:opacity-80"
+        class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
+        href="/contact">Contact</a
+      >
+      <a
+        class="inline-flex items-center min-h-11 bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] active:bg-[color:var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 px-5 py-2 rounded font-medium text-white transition-opacity"
         href="/book">Book a Call</a
       >
     </div>

--- a/src/components/SkipToMain.astro
+++ b/src/components/SkipToMain.astro
@@ -1,0 +1,25 @@
+---
+/**
+ * Skip-to-main-content link. Per .stitch/NAVIGATION.md §4 and §9 (accessibility
+ * floor). MUST be the first element inside <body>, before <header>. The
+ * matching <main> element must carry the same `id` (default "main").
+ *
+ * Visible only on keyboard focus; hidden via `sr-only` otherwise. Keeps the
+ * surface chrome-free for sighted users while giving screen-reader and
+ * keyboard users a direct route to page content.
+ */
+
+interface Props {
+  targetId?: string
+  label?: string
+}
+
+const { targetId = 'main', label = 'Skip to main content' } = Astro.props
+---
+
+<a
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:rounded-lg focus:border focus:border-[color:var(--color-border)] focus:text-[color:var(--color-primary)] focus:font-medium"
+  href={`#${targetId}`}
+>
+  {label}
+</a>

--- a/src/components/portal/PortalHeader.astro
+++ b/src/components/portal/PortalHeader.astro
@@ -1,40 +1,76 @@
 ---
 /**
- * Minimal portal top band. Per .stitch/portal-ux-brief.md: no nav tabs, no
- * sidebar. The account menu (sign out, etc.) is rendered via the default slot
- * so the host page controls when it appears.
+ * Minimal portal top band. Per .stitch/NAVIGATION.md §C.1:
  *
- * The showSms prop toggles a "Text Scott" deep link in the header row for
- * surfaces where SMS is the primary contact affordance. The full consultant
- * block (with photo and next touchpoint) lives in ConsultantBlock.astro.
+ * - sticky top-0, h-14 md:h-16 on <header> (not the inner div)
+ * - Client name on the left, stands alone (no logo, no decoration)
+ * - Three-icon contact control on the right: email / SMS / phone. Each
+ *   channel only renders when we have data for it. Clients pick the channel
+ *   that works for them — spec decision: "clients know what they want."
+ * - Default <slot /> for the Sign-out affordance (host page owns it)
+ *
+ * The full consultant block (avatar + role + next-touchpoint) lives in
+ * ConsultantBlock.astro.
  */
 
 interface Props {
   clientName: string
-  showSms?: boolean
-  smsHref?: string
-  smsLabel?: string
+  consultantPhone?: string | null
+  consultantEmail?: string | null
+  consultantFirstName?: string
 }
 
-const { clientName, showSms = false, smsHref, smsLabel } = Astro.props
+const {
+  clientName,
+  consultantPhone = null,
+  consultantEmail = null,
+  consultantFirstName = 'Scott',
+} = Astro.props
+
+const phoneDigits = consultantPhone ? consultantPhone.replace(/[^+\d]/g, '') : null
+const smsHref = phoneDigits ? `sms:${phoneDigits}` : null
+const telHref = phoneDigits ? `tel:${phoneDigits}` : null
+const mailtoHref = consultantEmail ? `mailto:${consultantEmail}` : null
+
+const iconClasses =
+  'inline-flex items-center justify-center w-11 h-11 rounded-lg text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2'
 ---
 
-<header class="w-full bg-[color:var(--color-surface)] border-b border-[color:var(--color-border)]">
-  <div class="max-w-5xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-4">
+<header
+  role="banner"
+  class="sticky top-0 z-50 h-14 md:h-16 w-full bg-[color:var(--color-surface)] border-b border-[color:var(--color-border)]"
+>
+  <div class="max-w-5xl mx-auto h-full px-4 md:px-6 flex items-center justify-between gap-4">
     <p
-      class="text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-secondary)]"
+      class="text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-secondary)] truncate"
     >
       {clientName}
     </p>
-    <div class="flex items-center gap-4">
+    <div class="flex items-center gap-1">
       {
-        showSms && smsHref && smsLabel && (
-          <a
-            class="inline-flex items-center gap-1.5 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
-            href={smsHref}
-          >
-            <span class="material-symbols-outlined text-[18px]">sms</span>
-            {smsLabel}
+        mailtoHref && (
+          <a href={mailtoHref} aria-label={`Email ${consultantFirstName}`} class={iconClasses}>
+            <span class="material-symbols-outlined" aria-hidden="true">
+              mail
+            </span>
+          </a>
+        )
+      }
+      {
+        smsHref && (
+          <a href={smsHref} aria-label={`Text ${consultantFirstName}`} class={iconClasses}>
+            <span class="material-symbols-outlined" aria-hidden="true">
+              sms
+            </span>
+          </a>
+        )
+      }
+      {
+        telHref && (
+          <a href={telHref} aria-label={`Call ${consultantFirstName}`} class={iconClasses}>
+            <span class="material-symbols-outlined" aria-hidden="true">
+              call
+            </span>
           </a>
         )
       }

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css'
+import SkipToMain from '../components/SkipToMain.astro'
 
 interface BreadcrumbItem {
   label: string
@@ -47,65 +48,139 @@ const navItems = [
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>{title}</title>
   </head>
   <body class="min-h-screen bg-slate-50 text-slate-900">
-    <header class="bg-white border-b border-slate-200">
-      <div class={`${maxWidth} mx-auto px-4 py-3 flex items-center justify-between`}>
+    <SkipToMain />
+    <header
+      role="banner"
+      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--color-border)]"
+    >
+      <div class={`${maxWidth} mx-auto h-full px-4 md:px-6 flex items-center justify-between`}>
         <div class="flex items-center gap-3">
           <a
             href="/admin"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
+            class="text-lg font-bold text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
             >SMD Services</a
           >
           <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
         </div>
-        <div class="flex items-center gap-4">
-          {
-            navItems.map((item) => (
-              <a
-                href={item.href}
-                class:list={[
-                  'text-sm transition-colors',
-                  item.match(pathname)
-                    ? 'text-primary font-medium'
-                    : 'text-slate-600 hover:text-slate-900',
-                ]}
-              >
-                {item.label}
-              </a>
-            ))
-          }
-          <span class="text-sm text-slate-400">|</span>
+
+        <!-- Desktop: inline nav tabs + email + sign out -->
+        <div class="hidden md:flex items-center gap-4">
+          <nav aria-label="Primary" class="flex items-center gap-4">
+            {
+              navItems.map((item) => {
+                const active = item.match(pathname)
+                return (
+                  <a
+                    href={item.href}
+                    aria-current={active ? 'page' : undefined}
+                    class:list={[
+                      'inline-flex items-center min-h-11 px-2 -mx-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded',
+                      active
+                        ? 'text-[color:var(--color-primary)] font-medium'
+                        : 'text-slate-600 hover:text-slate-900 active:text-slate-900',
+                    ]}
+                  >
+                    {item.label}
+                  </a>
+                )
+              })
+            }
+          </nav>
+          <span class="text-sm text-slate-300" aria-hidden="true">|</span>
           <span class="text-sm text-slate-600">{session.email}</span>
           <form method="POST" action="/api/auth/logout">
             <button
               type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
+              class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
             >
               Sign out
             </button>
           </form>
         </div>
+
+        <!-- Mobile: <details> menu trigger -->
+        <details class="relative md:hidden">
+          <summary
+            aria-label="Open menu"
+            class="list-none w-11 h-11 flex items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 active:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 cursor-pointer"
+          >
+            <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+          </summary>
+          <div
+            class="absolute right-0 top-12 w-64 bg-white border border-[color:var(--color-border)] rounded-lg shadow-lg p-2 z-50"
+          >
+            <nav aria-label="Primary" class="flex flex-col">
+              {
+                navItems.map((item) => {
+                  const active = item.match(pathname)
+                  return (
+                    <a
+                      href={item.href}
+                      aria-current={active ? 'page' : undefined}
+                      class:list={[
+                        'block px-3 py-2.5 text-sm rounded hover:bg-slate-100 active:bg-slate-100',
+                        active ? 'text-[color:var(--color-primary)] font-medium' : 'text-slate-700',
+                      ]}
+                    >
+                      {item.label}
+                    </a>
+                  )
+                })
+              }
+            </nav>
+            <hr class="my-2 border-[color:var(--color-border)]" />
+            <p class="px-3 py-1.5 text-xs text-slate-500 break-all">{session.email}</p>
+            <form method="POST" action="/api/auth/logout">
+              <button
+                type="submit"
+                class="w-full text-left px-3 py-2.5 text-sm text-slate-700 rounded hover:bg-slate-100 active:bg-slate-100"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+        </details>
       </div>
     </header>
 
-    <main class={`${maxWidth} mx-auto px-4 py-8`}>
+    <main id="main" role="main" class={`${maxWidth} mx-auto px-4 py-8`}>
       {
         breadcrumbs.length > 0 && (
-          <nav class="text-sm text-slate-500 mb-4">
-            {breadcrumbs.map((crumb, i) => (
-              <>
-                {i > 0 && <span class="mx-1">/</span>}
-                {crumb.href ? (
-                  <a href={crumb.href} class="hover:text-primary transition-colors">
-                    {crumb.label}
-                  </a>
-                ) : (
-                  <span class="text-slate-900">{crumb.label}</span>
-                )}
-              </>
-            ))}
+          <nav aria-label="Breadcrumb" class="mb-4">
+            <ol class="flex flex-wrap items-center gap-1 text-sm text-slate-500">
+              {breadcrumbs.map((crumb, i) => (
+                <>
+                  {i > 0 && (
+                    <li aria-hidden="true" class="flex items-center">
+                      <span class="material-symbols-outlined text-base text-slate-300">
+                        chevron_right
+                      </span>
+                    </li>
+                  )}
+                  <li class="max-w-[24ch] md:max-w-none truncate">
+                    {crumb.href ? (
+                      <a
+                        href={crumb.href}
+                        class="hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+                      >
+                        {crumb.label}
+                      </a>
+                    ) : (
+                      <span aria-current="page" class="text-slate-900 font-medium">
+                        {crumb.label}
+                      </span>
+                    )}
+                  </li>
+                </>
+              ))}
+            </ol>
           </nav>
         )
       }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css'
 import JsonLd from '../components/JsonLd.astro'
+import SkipToMain from '../components/SkipToMain.astro'
 
 interface Props {
   title: string
@@ -50,6 +51,7 @@ const ogImageUrl = new URL('/og-image.png', 'https://smd.services')
     <JsonLd />
   </head>
   <body>
+    <SkipToMain />
     <slot />
   </body>
 </html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,7 +8,7 @@ import Footer from '../components/Footer.astro'
 
 <Base title="Page Not Found | SMD Services">
   <Nav />
-  <main class="mx-auto max-w-4xl px-4 py-16 text-center">
+  <main id="main" role="main" class="mx-auto max-w-4xl px-4 py-16 text-center">
     <h1 class="text-3xl font-bold text-slate-900">Page not found</h1>
     <p class="mt-4 text-lg text-slate-600">The page you're looking for doesn't exist.</p>
     <a href="/" class="mt-8 inline-block text-sm font-medium text-primary hover:text-primary/80">

--- a/src/pages/auth/login.astro
+++ b/src/pages/auth/login.astro
@@ -1,5 +1,6 @@
 ---
 import '../../styles/global.css'
+import SkipToMain from '../../components/SkipToMain.astro'
 
 /**
  * Admin login page — email + password form.
@@ -33,71 +34,86 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
     />
     <title>Sign In — SMD Services</title>
   </head>
-  <body class="min-h-screen bg-slate-50 flex items-center justify-center px-4">
-    <div class="w-full max-w-sm">
-      <div class="text-center mb-8">
-        <h1 class="text-2xl font-bold text-slate-900">SMD Services</h1>
-        <p class="text-sm text-slate-500 mt-1">Admin Portal</p>
+  <body class="min-h-screen bg-slate-50">
+    <SkipToMain />
+    <header
+      role="banner"
+      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--color-border)]"
+    >
+      <div class="max-w-md mx-auto h-full flex items-center justify-center px-4">
+        <span class="text-lg font-bold tracking-tight text-[color:var(--color-text-primary)]"
+          >SMD Services</span
+        >
       </div>
+    </header>
+    <main
+      id="main"
+      role="main"
+      class="flex items-start md:items-center justify-center px-4 py-10"
+      style="min-height: calc(100vh - 3.5rem)"
+    >
+      <div class="w-full max-w-sm">
+        <div class="text-center mb-8">
+          <p class="text-sm text-slate-500">Admin sign-in</p>
+        </div>
 
-      <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
-        <h2 class="text-lg font-semibold text-slate-900 mb-6">Sign in</h2>
+        <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+          <h2 class="text-lg font-semibold text-slate-900 mb-6">Sign in</h2>
 
-        {
-          errorMessage && (
-            <div class="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
-              {errorMessage}
+          {
+            errorMessage && (
+              <div class="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+                {errorMessage}
+              </div>
+            )
+          }
+
+          <form method="POST" action="/api/auth/login" class="space-y-4">
+            <div>
+              <label for="email" class="block text-sm font-medium text-slate-700 mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                autocomplete="email"
+                class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+                     focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
+                     placeholder-slate-400"
+                placeholder="you@smd.services"
+              />
             </div>
-          )
-        }
 
-        <form method="POST" action="/api/auth/login" class="space-y-4">
-          <div>
-            <label for="email" class="block text-sm font-medium text-slate-700 mb-1"> Email </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              required
-              autocomplete="email"
-              class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+            <div>
+              <label for="password" class="block text-sm font-medium text-slate-700 mb-1">
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                autocomplete="current-password"
+                class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
-              placeholder="you@smd.services"
-            />
-          </div>
+                placeholder="Enter your password"
+              />
+            </div>
 
-          <div>
-            <label for="password" class="block text-sm font-medium text-slate-700 mb-1">
-              Password
-            </label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              autocomplete="current-password"
-              class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
-                     focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
-                     placeholder-slate-400"
-              placeholder="Enter your password"
-            />
-          </div>
-
-          <button
-            type="submit"
-            class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
+            <button
+              type="submit"
+              class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
                    hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
                    focus:ring-primary focus:ring-offset-2"
-          >
-            Sign in
-          </button>
-        </form>
+            >
+              Sign in
+            </button>
+          </form>
+        </div>
       </div>
-
-      <p class="text-center text-xs text-slate-400 mt-6">
-        &copy; {new Date().getFullYear()} SMD Services
-      </p>
-    </div>
+    </main>
   </body>
 </html>

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -1,5 +1,6 @@
 ---
 import '../../styles/global.css'
+import SkipToMain from '../../components/SkipToMain.astro'
 
 /**
  * Client portal login page — magic link (passwordless) authentication.
@@ -41,65 +42,80 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
     />
     <title>Sign In — SMD Services Portal</title>
   </head>
-  <body class="min-h-screen bg-slate-50 flex items-center justify-center px-4">
-    <div class="w-full max-w-sm">
-      <div class="text-center mb-8">
-        <h1 class="text-2xl font-bold text-slate-900">SMD Services</h1>
-        <p class="text-sm text-slate-500 mt-1">Client Portal</p>
+  <body class="min-h-screen bg-slate-50">
+    <SkipToMain />
+    <header
+      role="banner"
+      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--color-border)]"
+    >
+      <div class="max-w-md mx-auto h-full flex items-center justify-center px-4">
+        <span class="text-lg font-bold tracking-tight text-[color:var(--color-text-primary)]"
+          >SMD Services</span
+        >
       </div>
+    </header>
+    <main
+      id="main"
+      role="main"
+      class="flex items-start md:items-center justify-center px-4 py-10"
+      style="min-height: calc(100vh - 3.5rem)"
+    >
+      <div class="w-full max-w-sm">
+        <div class="text-center mb-8">
+          <p class="text-sm text-slate-500">Client portal sign-in</p>
+        </div>
 
-      <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
-        <h2 class="text-lg font-semibold text-slate-900 mb-2">Sign in</h2>
-        <p class="text-sm text-slate-500 mb-6">
-          Enter your email and we'll send you a link to sign in.
-        </p>
+        <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+          <h2 class="text-lg font-semibold text-slate-900 mb-2">Sign in</h2>
+          <p class="text-sm text-slate-500 mb-6">
+            Enter your email and we'll send you a link to sign in.
+          </p>
 
-        {
-          message && (
-            <div
-              class:list={[
-                'mb-4 px-3 py-2 border rounded text-sm',
-                message.type === 'success'
-                  ? 'bg-green-50 border-green-200 text-green-700'
-                  : 'bg-red-50 border-red-200 text-red-700',
-              ]}
-            >
-              {message.text}
-            </div>
-          )
-        }
+          {
+            message && (
+              <div
+                class:list={[
+                  'mb-4 px-3 py-2 border rounded text-sm',
+                  message.type === 'success'
+                    ? 'bg-green-50 border-green-200 text-green-700'
+                    : 'bg-red-50 border-red-200 text-red-700',
+                ]}
+              >
+                {message.text}
+              </div>
+            )
+          }
 
-        <form method="POST" action="/api/auth/magic-link" class="space-y-4">
-          <div>
-            <label for="email" class="block text-sm font-medium text-slate-700 mb-1"> Email </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              required
-              autocomplete="email"
-              value={prefillEmail}
-              class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+          <form method="POST" action="/api/auth/magic-link" class="space-y-4">
+            <div>
+              <label for="email" class="block text-sm font-medium text-slate-700 mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                autocomplete="email"
+                value={prefillEmail}
+                class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
-              placeholder="your@email.com"
-            />
-          </div>
+                placeholder="your@email.com"
+              />
+            </div>
 
-          <button
-            type="submit"
-            class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
+            <button
+              type="submit"
+              class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
                    hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
                    focus:ring-primary focus:ring-offset-2"
-          >
-            Send sign-in link
-          </button>
-        </form>
+            >
+              Send sign-in link
+            </button>
+          </form>
+        </div>
       </div>
-
-      <p class="text-center text-xs text-slate-400 mt-6">
-        &copy; {new Date().getFullYear()} SMD Services
-      </p>
-    </div>
+    </main>
   </body>
 </html>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -15,7 +15,7 @@ const turnstileSiteKey = Astro.locals.runtime?.env?.PUBLIC_TURNSTILE_SITE_KEY ??
   description="Schedule a conversation about your business. We'll learn how things run, understand what you're trying to accomplish, and share how we can help."
 >
   <Nav />
-  <main>
+  <main id="main" role="main">
     <!-- Hero -->
     <section class="bg-slate-50 px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">

--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -11,7 +11,7 @@ import Footer from '../../../components/Footer.astro'
   description="View, reschedule, or cancel your assessment call with SMD Services."
 >
   <Nav />
-  <main>
+  <main id="main" role="main">
     <section class="bg-slate-50 px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Loading state -->

--- a/src/pages/book/manage/index.astro
+++ b/src/pages/book/manage/index.astro
@@ -8,6 +8,7 @@
  * to the canonical path-based URL.
  */
 export const prerender = false
+import SkipToMain from '../../../components/SkipToMain.astro'
 
 const token = Astro.url.searchParams.get('token')
 if (token) {
@@ -22,17 +23,18 @@ if (token) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Manage Your Booking — SMD Services</title>
   </head>
-  <body
-    style="font-family: 'Inter', sans-serif; background: #f8fafc; display: flex; justify-content: center; padding: 80px 16px;"
-  >
-    <div style="text-align: center;">
-      <h1 style="font-size: 20px; font-weight: 700; color: #0f172a;">Invalid booking link</h1>
-      <p style="margin-top: 12px; color: #64748b;">
-        No booking token found. Check the link in your confirmation email.
-      </p>
-      <a href="/book" style="display: inline-block; margin-top: 24px; color: #1e40af;"
-        >Book a new time</a
-      >
-    </div>
+  <body style="font-family: 'Inter', sans-serif; background: #f8fafc;">
+    <SkipToMain />
+    <main id="main" role="main" style="display: flex; justify-content: center; padding: 80px 16px;">
+      <div style="text-align: center;">
+        <h1 style="font-size: 20px; font-weight: 700; color: #0f172a;">Invalid booking link</h1>
+        <p style="margin-top: 12px; color: #64748b;">
+          No booking token found. Check the link in your confirmation email.
+        </p>
+        <a href="/book" style="display: inline-block; margin-top: 24px; color: #1e40af;"
+          >Book a new time</a
+        >
+      </div>
+    </main>
   </body>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro'
 
 <Base title="Contact | SMD Services" description="Get in touch with SMD Services.">
   <Nav />
-  <main class="px-6 py-20">
+  <main id="main" role="main" class="px-6 py-20">
     <div class="mx-auto max-w-xl">
       <h1 class="text-3xl font-bold text-slate-900">Get in Touch</h1>
       <p class="mt-2 text-lg text-slate-600">

--- a/src/pages/dev/portal-components.astro
+++ b/src/pages/dev/portal-components.astro
@@ -34,9 +34,9 @@ if (import.meta.env.PROD) {
   <body class="min-h-screen bg-[color:var(--color-background)]">
     <PortalHeader
       clientName="Delgado Plumbing"
-      showSms
-      smsHref="sms:+14805550100"
-      smsLabel="Text Scott"
+      consultantPhone="+14805550100"
+      consultantEmail="scott@smd.services"
+      consultantFirstName="Scott"
     >
       <form method="POST" action="/api/auth/logout">
         <button type="submit" class="text-sm text-[color:var(--color-text-muted)]">Sign out</button>

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -17,7 +17,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
   description="Share a few details about your business and what you're working on. We'll review it and reach out to start the conversation on your terms."
 >
   <Nav />
-  <main>
+  <main id="main" role="main">
     <section class="bg-slate-50 px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Hero -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ import Footer from '../components/Footer.astro'
 
 <Base title="SMD Services | Solutions Consulting for Growing Businesses">
   <Nav />
-  <main>
+  <main id="main" role="main">
     <Hero />
     <ProblemCards />
     <HowItWorks />

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -5,6 +5,8 @@ import { listEngagements } from '../../../lib/db/engagements'
 import { listDocuments } from '../../../lib/storage/r2'
 import { getPortalClient } from '../../../lib/portal/session'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
+import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
 
 /**
  * Client portal — document library page.
@@ -19,6 +21,7 @@ const env = Astro.locals.runtime.env
 
 const portalData = await getPortalClient(env.DB, session.userId)
 const clientId = portalData?.client.id
+const clientName = portalData?.client.name ?? ''
 
 interface DocumentEntry {
   name: string
@@ -93,36 +96,27 @@ function formatDate(iso: string): string {
     <title>Documents — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/portal"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >{BRAND_NAME}</a
-          >
-          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+    <SkipToMain />
+    <PortalHeader clientName={clientName}>
+      <form method="POST" action="/api/auth/logout">
+        <button
+          type="submit"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </form>
+    </PortalHeader>
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/portal" class="hover:text-primary transition-colors">Portal</a>
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Documents</span>
-      </nav>
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 py-8">
+      <a
+        href="/portal"
+        aria-label="Home"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        Home
+      </a>
 
       <h2 class="text-xl font-semibold text-slate-900 mb-6">Documents</h2>
 

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -6,6 +6,8 @@ import { getPortalClient } from '../../../lib/portal/session'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listMilestones } from '../../../lib/db/milestones'
 import type { Milestone } from '../../../lib/db/milestones'
+import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
 
 /**
  * Client portal — engagement progress page.
@@ -22,6 +24,7 @@ const env = Astro.locals.runtime.env
 // Resolve client entity from session
 const portalData = await getPortalClient(env.DB, session.userId)
 const entityId = portalData?.client.id ?? null
+const clientName = portalData?.client.name ?? ''
 
 let engagement = null
 let milestones: Milestone[] = []
@@ -68,36 +71,36 @@ function formatDate(iso: string | null): string {
     <title>Engagement Progress — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/portal"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >{BRAND_NAME}</a
-          >
-          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+    <SkipToMain />
+    <PortalHeader
+      clientName={clientName}
+      consultantPhone={(engagement as { consultant_phone?: string | null } | null)
+        ?.consultant_phone ?? null}
+      consultantFirstName={(
+        (engagement as { consultant_name?: string | null } | null)?.consultant_name ?? 'Scott'
+      )
+        .trim()
+        .split(/\s+/)[0] || 'Scott'}
+    >
+      <form method="POST" action="/api/auth/logout">
+        <button
+          type="submit"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </form>
+    </PortalHeader>
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/portal" class="hover:text-primary transition-colors">Portal</a>
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Engagement</span>
-      </nav>
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 py-8">
+      <a
+        href="/portal"
+        aria-label="Home"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        Home
+      </a>
 
       <h2 class="text-xl font-semibold text-slate-900 mb-6">Engagement Progress</h2>
 

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -3,6 +3,7 @@ import '../../styles/global.css'
 import { BRAND_NAME } from '../../lib/config/brand'
 import { getPortalClient } from '../../lib/portal/session'
 import PortalHeader from '../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../components/SkipToMain.astro'
 import ConsultantBlock from '../../components/portal/ConsultantBlock.astro'
 import TimelineEntry from '../../components/portal/TimelineEntry.astro'
 import ActionCard from '../../components/portal/ActionCard.astro'
@@ -240,7 +241,6 @@ const consultant = activeEngagement?.consultant_name
 const consultantFirst = consultant
   ? consultant.name.trim().split(/\s+/)[0] || consultant.name
   : null
-const smsHref = consultant?.phone ? `sms:${consultant.phone.replace(/[^+\d]/g, '')}` : null
 
 const invoiceAmountCents = pendingInvoice ? Math.round(pendingInvoice.amount * 100) : null
 const invoiceDueText = pendingInvoice?.due_date ? `Due ${shortDate(pendingInvoice.due_date)}` : null
@@ -298,11 +298,11 @@ const contextSubtext = consultantFirst
     <title>Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
+    <SkipToMain />
     <PortalHeader
       clientName={client.name}
-      showSms={Boolean(smsHref)}
-      smsHref={smsHref ?? undefined}
-      smsLabel={consultantFirst ? `Text ${consultantFirst}` : undefined}
+      consultantPhone={consultant?.phone ?? null}
+      consultantFirstName={consultantFirst ?? 'Scott'}
     >
       <form method="POST" action="/api/auth/logout">
         <button
@@ -316,7 +316,7 @@ const contextSubtext = consultantFirst
       </form>
     </PortalHeader>
 
-    <main class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
       {
         dashboardError ? (
           <div class="flex flex-col gap-6">

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -8,6 +8,7 @@ import {
   type InvoiceLineItem,
 } from '../../../lib/db/invoices'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
 import MoneyDisplay from '../../../components/portal/MoneyDisplay.astro'
 import ActionCard from '../../../components/portal/ActionCard.astro'
 import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
@@ -195,9 +196,9 @@ const consultantPhone = engagement?.consultant_phone ?? null
 const nextTouchpointAt = engagement?.next_touchpoint_at ?? null
 const nextTouchpointLabel = engagement?.next_touchpoint_label ?? null
 
-// PortalHeader SMS link (mobile thumb-zone affordance)
-const smsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g, '')}` : null
-const smsFirstName = consultantName ? consultantName.trim().split(/\s+/)[0] || consultantName : null
+const consultantFirstName = consultantName
+  ? consultantName.trim().split(/\s+/)[0] || consultantName
+  : 'Scott'
 ---
 
 <!doctype html>
@@ -218,11 +219,11 @@ const smsFirstName = consultantName ? consultantName.trim().split(/\s+/)[0] || c
     <title>Invoice — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
+    <SkipToMain />
     <PortalHeader
       clientName={client.name}
-      showSms={!!smsHref && !isPaid && !!smsFirstName}
-      smsHref={smsHref ?? undefined}
-      smsLabel={smsHref && smsFirstName ? `Text ${smsFirstName}` : undefined}
+      consultantPhone={isPaid ? null : consultantPhone}
+      consultantFirstName={consultantFirstName}
     >
       <form method="POST" action="/api/auth/logout">
         <button
@@ -234,7 +235,15 @@ const smsFirstName = consultantName ? consultantName.trim().split(/\s+/)[0] || c
       </form>
     </PortalHeader>
 
-    <main class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+      <a
+        href="/portal/invoices"
+        aria-label="All invoices"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        All invoices
+      </a>
       <div class="grid grid-cols-1 md:grid-cols-[720px_1fr] gap-8 md:gap-12 items-start">
         <!-- Main column -->
         <section class="flex flex-col gap-8 min-w-0">

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -4,6 +4,8 @@ import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { listInvoicesForEntity, INVOICE_STATUSES } from '../../../lib/db/invoices'
 import type { Invoice } from '../../../lib/db/invoices'
+import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
 
 /**
  * Client portal — invoices page.
@@ -20,6 +22,7 @@ const env = Astro.locals.runtime.env
 // Resolve client entity from session
 const portalData = await getPortalClient(env.DB, session.userId)
 const entityId = portalData?.client.id ?? null
+const clientName = portalData?.client.name ?? ''
 
 let invoices: Awaited<ReturnType<typeof listInvoicesForEntity>> = []
 
@@ -71,36 +74,27 @@ function formatDate(iso: string | null): string {
     <title>Invoices — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a
-            href="/portal"
-            class="text-lg font-bold text-slate-900 hover:text-primary transition-colors"
-            >{BRAND_NAME}</a
-          >
-          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+    <SkipToMain />
+    <PortalHeader clientName={clientName}>
+      <form method="POST" action="/api/auth/logout">
+        <button
+          type="submit"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </form>
+    </PortalHeader>
 
-    <main class="max-w-5xl mx-auto px-4 py-8">
-      <nav class="text-sm text-slate-500 mb-4">
-        <a href="/portal" class="hover:text-primary transition-colors">Portal</a>
-        <span class="mx-1">/</span>
-        <span class="text-slate-900">Invoices</span>
-      </nav>
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 py-8">
+      <a
+        href="/portal"
+        aria-label="Home"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        Home
+      </a>
 
       <h2 class="text-xl font-semibold text-slate-900 mb-6">Invoices</h2>
 

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -1,6 +1,7 @@
 ---
 import '../../../styles/global.css'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
 import MoneyDisplay from '../../../components/portal/MoneyDisplay.astro'
 import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
 import { BRAND_NAME } from '../../../lib/config/brand'
@@ -171,7 +172,6 @@ const pdfHref = hasSow ? `/api/portal/quotes/${quote.id}/sow` : null
 const supersedingQuoteId = isSuperseded ? (superseding?.id ?? null) : null
 
 const consultantPhone = engagement?.consultant_phone ?? null
-const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g, '')}` : null
 ---
 
 <!doctype html>
@@ -192,15 +192,12 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
     <title>Proposal — Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--color-background)]">
+    <SkipToMain />
     <PortalHeader
       clientName={client.name}
-      showSms={!!headerSmsHref && !isSigned && !!consultantFirst}
-      smsHref={headerSmsHref ?? undefined}
-      smsLabel={headerSmsHref && consultantFirst ? `Text ${consultantFirst}` : undefined}
+      consultantPhone={isSigned ? null : consultantPhone}
+      consultantFirstName={consultantFirst ?? 'Scott'}
     >
-      <span class="text-sm text-[color:var(--color-text-secondary)] hidden sm:inline"
-        >{session.email}</span
-      >
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
@@ -211,7 +208,15 @@ const headerSmsHref = consultantPhone ? `sms:${consultantPhone.replace(/[^+\d]/g
       </form>
     </PortalHeader>
 
-    <main class="max-w-[1120px] mx-auto px-4 sm:px-6 py-8 sm:py-12">
+    <main id="main" role="main" class="max-w-[1120px] mx-auto px-4 sm:px-6 py-8 sm:py-12">
+      <a
+        href="/portal/quotes"
+        aria-label="All quotes"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        All quotes
+      </a>
       <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,720px)_340px] gap-8 lg:gap-16">
         <!-- Main column -->
         <section class="min-w-0 space-y-12">

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -4,6 +4,8 @@ import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { listQuotesForEntity } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
+import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
 
 /**
  * Portal quote list — shows all quotes visible to this client.
@@ -60,37 +62,27 @@ const statusLabelMap: Record<string, string> = {
     <title>Proposals — Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
-    <header class="bg-white border-b border-slate-200">
-      <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <a href="/portal" class="text-lg font-bold text-slate-900 hover:text-slate-700"
-            >{BRAND_NAME}</a
-          >
-          <span class="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">Portal</span>
-        </div>
-        <div class="flex items-center gap-4">
-          <span class="text-sm text-slate-600 hidden sm:inline">{session.email}</span>
-          <form method="POST" action="/api/auth/logout">
-            <button
-              type="submit"
-              class="text-sm text-slate-500 hover:text-slate-700 transition-colors"
-            >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-    </header>
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <form method="POST" action="/api/auth/logout">
+        <button
+          type="submit"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </form>
+    </PortalHeader>
 
-    <main class="max-w-5xl mx-auto px-4 py-6 sm:py-8">
-      <!-- Breadcrumb -->
-      <nav class="mb-6">
-        <ol class="flex items-center gap-2 text-sm text-slate-500">
-          <li><a href="/portal" class="hover:text-slate-700">Dashboard</a></li>
-          <li class="text-slate-300">/</li>
-          <li class="text-slate-900 font-medium">Proposals</li>
-        </ol>
-      </nav>
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 py-6 sm:py-8">
+      <a
+        href="/portal"
+        aria-label="Home"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        Home
+      </a>
 
       <h2 class="text-xl sm:text-2xl font-bold text-slate-900 mb-6">Your Proposals</h2>
 

--- a/src/pages/scorecard.astro
+++ b/src/pages/scorecard.astro
@@ -68,7 +68,7 @@ for (const [i, q] of QUESTIONS.entries()) {
   <Nav />
 
   <!-- Progress bar (hidden on landing and results) -->
-  <div id="progress-wrapper" class="fixed left-0 top-16 z-50 hidden w-full">
+  <div id="progress-wrapper" class="fixed left-0 top-14 md:top-16 z-50 hidden w-full">
     <div id="progress-bar" class="h-1.5 w-full bg-slate-200">
       <div
         id="progress-fill"
@@ -83,215 +83,217 @@ for (const [i, q] of QUESTIONS.entries()) {
     </div>
   </div>
 
-  <!-- ============================================================ -->
-  <!-- LANDING -->
-  <!-- ============================================================ -->
-  <section id="landing">
-    <!-- Hero -->
-    <div class="px-6 py-20 text-center sm:py-28">
-      <h1 class="mx-auto max-w-3xl text-4xl font-extrabold text-slate-900 sm:text-5xl">
-        See where your operations stand
-      </h1>
-      <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
-        Answer a few questions about how your business runs. Get an instant, personalized report
-        showing where you're strong and where there's room to grow.
-      </p>
-      <button
-        data-action="start"
-        class="mt-8 inline-block rounded-lg bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
-      >
-        Start your scorecard
-      </button>
+  <main id="main" role="main">
+    <!-- ============================================================ -->
+    <!-- LANDING -->
+    <!-- ============================================================ -->
+    <section id="landing">
+      <!-- Hero -->
+      <div class="px-6 py-20 text-center sm:py-28">
+        <h1 class="mx-auto max-w-3xl text-4xl font-extrabold text-slate-900 sm:text-5xl">
+          See where your operations stand
+        </h1>
+        <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
+          Answer a few questions about how your business runs. Get an instant, personalized report
+          showing where you're strong and where there's room to grow.
+        </p>
+        <button
+          data-action="start"
+          class="mt-8 inline-block rounded-lg bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
+        >
+          Start your scorecard
+        </button>
 
-      <!-- Trust signals -->
-      <div class="mt-8 flex flex-wrap items-center justify-center gap-8">
-        <div class="flex items-center gap-2 text-sm text-slate-500">
-          <span class="material-symbols-outlined text-slate-400">schedule</span>
-          Takes about 3 minutes
-        </div>
-        <div class="flex items-center gap-2 text-sm text-slate-500">
-          <span class="material-symbols-outlined text-slate-400">block</span>
-          No sales pitch
-        </div>
-        <div class="flex items-center gap-2 text-sm text-slate-500">
-          <span class="material-symbols-outlined text-slate-400">bolt</span>
-          Instant results
+        <!-- Trust signals -->
+        <div class="mt-8 flex flex-wrap items-center justify-center gap-8">
+          <div class="flex items-center gap-2 text-sm text-slate-500">
+            <span class="material-symbols-outlined text-slate-400">schedule</span>
+            Takes about 3 minutes
+          </div>
+          <div class="flex items-center gap-2 text-sm text-slate-500">
+            <span class="material-symbols-outlined text-slate-400">block</span>
+            No sales pitch
+          </div>
+          <div class="flex items-center gap-2 text-sm text-slate-500">
+            <span class="material-symbols-outlined text-slate-400">bolt</span>
+            Instant results
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- Dimensions preview -->
-    <div class="bg-slate-50 px-6 py-16">
-      <h2 class="text-center text-2xl font-bold text-slate-900">What we look at</h2>
-      <div class="mx-auto mt-10 grid max-w-4xl grid-cols-2 gap-6 sm:grid-cols-3">
+      <!-- Dimensions preview -->
+      <div class="bg-slate-50 px-6 py-16">
+        <h2 class="text-center text-2xl font-bold text-slate-900">What we look at</h2>
+        <div class="mx-auto mt-10 grid max-w-4xl grid-cols-2 gap-6 sm:grid-cols-3">
+          {
+            DIMENSIONS.map((dim) => (
+              <div class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+                <span class="material-symbols-outlined text-3xl text-primary">{dim.icon}</span>
+                <p class="mt-3 font-semibold text-slate-900">{dim.label}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+
+      <!-- Secondary CTA -->
+      <div class="px-6 py-16 text-center">
+        <p class="text-xl text-slate-700">Ready to see where you stand?</p>
+        <button
+          data-action="start"
+          class="mt-6 inline-block rounded-lg bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+        >
+          Start your scorecard
+        </button>
+      </div>
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- QUIZ -->
+    <!-- ============================================================ -->
+    <section id="quiz" class="hidden">
+      <div class="mx-auto max-w-2xl px-6 pb-24 pt-20">
         {
-          DIMENSIONS.map((dim) => (
-            <div class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-              <span class="material-symbols-outlined text-3xl text-primary">{dim.icon}</span>
-              <p class="mt-3 font-semibold text-slate-900">{dim.label}</p>
+          steps.map((step) => (
+            <div data-step={step.num} class="hidden">
+              {step.sectionHeader && (
+                <p class="text-sm font-medium uppercase tracking-wide text-slate-500">
+                  {step.sectionHeader}
+                </p>
+              )}
+              <p class="mt-4 text-xl font-semibold leading-relaxed text-slate-900 sm:text-2xl">
+                {step.text}
+              </p>
+              <div class="mt-8 space-y-3">
+                {step.options.map((opt) => (
+                  <button
+                    data-answer={opt.value}
+                    class="block w-full cursor-pointer rounded-lg border border-slate-200 px-5 py-4 text-left text-base leading-relaxed text-slate-700 transition-colors hover:bg-slate-50"
+                  >
+                    {opt.text}
+                  </button>
+                ))}
+                {step.type === 'scored' && (
+                  <button
+                    data-answer="-1"
+                    class="block w-full cursor-pointer rounded-lg border border-dashed border-slate-200 px-5 py-3 text-left text-sm text-slate-400 transition-colors hover:bg-slate-50"
+                  >
+                    Doesn't apply to my business
+                  </button>
+                )}
+              </div>
             </div>
           ))
         }
       </div>
+    </section>
+
+    <!-- Quiz navigation (back/next) -->
+    <div
+      id="quiz-nav"
+      class="fixed bottom-0 left-0 hidden w-full border-t border-slate-100 bg-white px-6 py-4"
+    >
+      <div class="mx-auto flex max-w-2xl items-center justify-between">
+        <button id="btn-back" class="text-slate-500 transition-colors hover:text-slate-700"
+          >Back</button
+        >
+        <button
+          id="btn-next"
+          class="rounded-lg bg-primary px-6 py-2.5 font-medium text-white opacity-50 pointer-events-none transition-opacity"
+        >
+          Next
+        </button>
+      </div>
     </div>
 
-    <!-- Secondary CTA -->
-    <div class="px-6 py-16 text-center">
-      <p class="text-xl text-slate-700">Ready to see where you stand?</p>
-      <button
-        data-action="start"
-        class="mt-6 inline-block rounded-lg bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
-      >
-        Start your scorecard
-      </button>
-    </div>
-  </section>
+    <!-- ============================================================ -->
+    <!-- EMAIL GATE -->
+    <!-- ============================================================ -->
+    <section id="email-gate" class="hidden">
+      <div class="flex min-h-[80vh] flex-col items-center justify-center px-6 py-16">
+        <span class="material-symbols-outlined text-5xl text-green-500">check_circle</span>
+        <h2 class="mt-4 text-2xl font-bold text-slate-900 sm:text-3xl">Your report is ready</h2>
+        <p class="mt-2 text-base text-slate-600">Where should we send the full breakdown?</p>
 
-  <!-- ============================================================ -->
-  <!-- QUIZ -->
-  <!-- ============================================================ -->
-  <section id="quiz" class="hidden">
-    <div class="mx-auto max-w-2xl px-6 pb-24 pt-20">
-      {
-        steps.map((step) => (
-          <div data-step={step.num} class="hidden">
-            {step.sectionHeader && (
-              <p class="text-sm font-medium uppercase tracking-wide text-slate-500">
-                {step.sectionHeader}
+        <form
+          id="gate-form"
+          class="mx-auto mt-8 w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+        >
+          <div class="space-y-4">
+            <div>
+              <label for="first_name" class="block text-sm font-medium text-slate-700">
+                First name <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                name="first_name"
+                id="first_name"
+                required
+                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="email" class="block text-sm font-medium text-slate-700">
+                Email <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="email"
+                name="email"
+                id="email"
+                required
+                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="business_name" class="block text-sm font-medium text-slate-700">
+                Business name <span class="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                name="business_name"
+                id="business_name"
+                required
+                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+              />
+            </div>
+            <div>
+              <label for="phone" class="block text-sm font-medium text-slate-700">Phone</label>
+              <input
+                type="tel"
+                name="phone"
+                id="phone"
+                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+              />
+              <p class="mt-1 text-sm text-slate-400">
+                In case you'd rather talk through your results
               </p>
-            )}
-            <p class="mt-4 text-xl font-semibold leading-relaxed text-slate-900 sm:text-2xl">
-              {step.text}
-            </p>
-            <div class="mt-8 space-y-3">
-              {step.options.map((opt) => (
-                <button
-                  data-answer={opt.value}
-                  class="block w-full cursor-pointer rounded-lg border border-slate-200 px-5 py-4 text-left text-base leading-relaxed text-slate-700 transition-colors hover:bg-slate-50"
-                >
-                  {opt.text}
-                </button>
-              ))}
-              {step.type === 'scored' && (
-                <button
-                  data-answer="-1"
-                  class="block w-full cursor-pointer rounded-lg border border-dashed border-slate-200 px-5 py-3 text-left text-sm text-slate-400 transition-colors hover:bg-slate-50"
-                >
-                  Doesn't apply to my business
-                </button>
-              )}
+            </div>
+            <!-- Honeypot -->
+            <div class="absolute -left-[9999px]" aria-hidden="true">
+              <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
             </div>
           </div>
-        ))
-      }
-    </div>
-  </section>
+          <p id="gate-error" class="mt-4 hidden text-sm text-red-600"></p>
+          <button
+            type="submit"
+            class="mt-6 w-full rounded-lg bg-primary py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+          >
+            See my results
+          </button>
+        </form>
+        <p class="mt-4 text-sm text-slate-400">
+          We'll send your detailed PDF report to this email. No spam, ever.
+        </p>
+      </div>
+    </section>
 
-  <!-- Quiz navigation (back/next) -->
-  <div
-    id="quiz-nav"
-    class="fixed bottom-0 left-0 hidden w-full border-t border-slate-100 bg-white px-6 py-4"
-  >
-    <div class="mx-auto flex max-w-2xl items-center justify-between">
-      <button id="btn-back" class="text-slate-500 transition-colors hover:text-slate-700"
-        >Back</button
-      >
-      <button
-        id="btn-next"
-        class="rounded-lg bg-primary px-6 py-2.5 font-medium text-white opacity-50 pointer-events-none transition-opacity"
-      >
-        Next
-      </button>
-    </div>
-  </div>
-
-  <!-- ============================================================ -->
-  <!-- EMAIL GATE -->
-  <!-- ============================================================ -->
-  <section id="email-gate" class="hidden">
-    <div class="flex min-h-[80vh] flex-col items-center justify-center px-6 py-16">
-      <span class="material-symbols-outlined text-5xl text-green-500">check_circle</span>
-      <h2 class="mt-4 text-2xl font-bold text-slate-900 sm:text-3xl">Your report is ready</h2>
-      <p class="mt-2 text-base text-slate-600">Where should we send the full breakdown?</p>
-
-      <form
-        id="gate-form"
-        class="mx-auto mt-8 w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
-      >
-        <div class="space-y-4">
-          <div>
-            <label for="first_name" class="block text-sm font-medium text-slate-700">
-              First name <span class="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              name="first_name"
-              id="first_name"
-              required
-              class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
-            />
-          </div>
-          <div>
-            <label for="email" class="block text-sm font-medium text-slate-700">
-              Email <span class="text-red-500">*</span>
-            </label>
-            <input
-              type="email"
-              name="email"
-              id="email"
-              required
-              class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
-            />
-          </div>
-          <div>
-            <label for="business_name" class="block text-sm font-medium text-slate-700">
-              Business name <span class="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              name="business_name"
-              id="business_name"
-              required
-              class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
-            />
-          </div>
-          <div>
-            <label for="phone" class="block text-sm font-medium text-slate-700">Phone</label>
-            <input
-              type="tel"
-              name="phone"
-              id="phone"
-              class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
-            />
-            <p class="mt-1 text-sm text-slate-400">
-              In case you'd rather talk through your results
-            </p>
-          </div>
-          <!-- Honeypot -->
-          <div class="absolute -left-[9999px]" aria-hidden="true">
-            <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
-          </div>
-        </div>
-        <p id="gate-error" class="mt-4 hidden text-sm text-red-600"></p>
-        <button
-          type="submit"
-          class="mt-6 w-full rounded-lg bg-primary py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
-        >
-          See my results
-        </button>
-      </form>
-      <p class="mt-4 text-sm text-slate-400">
-        We'll send your detailed PDF report to this email. No spam, ever.
-      </p>
-    </div>
-  </section>
-
-  <!-- ============================================================ -->
-  <!-- RESULTS -->
-  <!-- ============================================================ -->
-  <section id="results" class="hidden">
-    <div id="results-content"></div>
-  </section>
+    <!-- ============================================================ -->
+    <!-- RESULTS -->
+    <!-- ============================================================ -->
+    <section id="results" class="hidden">
+      <div id="results-content"></div>
+    </section>
+  </main>
 
   <Footer />
 

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -140,10 +140,10 @@ describe('magic-link: portal login page', () => {
     expect(source).not.toContain('type="password"')
   })
 
-  it('is branded with SMD Services Client Portal', () => {
+  it('is branded with SMD Services and identifies as the client portal sign-in', () => {
     const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
     expect(source).toContain('SMD Services')
-    expect(source).toContain('Client Portal')
+    expect(source).toContain('Client portal sign-in')
   })
 
   it('is not indexed by search engines', () => {


### PR DESCRIPTION
## Summary

- Lands `.stitch/NAVIGATION.md` v1 — the single-source-of-truth navigation spec for marketing, portal, and admin chrome. Five surface classes by auth model, ten archetypes, four appendices with per-class chrome contracts, deterministic injection into Stitch generations, post-generation validator at `~/.agents/skills/nav-spec/validate.py`.
- Retrofits all shipped chrome to conform: new `SkipToMain.astro` component wired through `Base.astro` + `AdminLayout.astro` + every page outside a layout; height classes moved onto `<header>` elements; `PortalHeader.astro` now exposes a three-icon contact control (email / SMS / phone — clients pick the channel that works for them); `AdminLayout.astro` gets a `<details>`-based mobile menu when nav tabs collapse below `md:`; portal detail pages get back affordances; admin breadcrumb separator switched from text `/` to `<chevron_right aria-hidden>`.
- Replaces inline custom headers on portal list pages (`/portal/invoices`, `/portal/quotes`, `/portal/documents`, `/portal/engagement`) with `PortalHeader` + back button per the canonical-parents table. Auth pages get the wordmark-only sticky header per Appendix E (auth-gate).

## Context

NAVIGATION.md v1 was authored via `/nav-spec`, reviewed by parallel IA + Mobile + Implementation specialists, and verified empirically against four live Stitch generations (Phase 7 self-consistency + Phase 8 adversarial on three unseen surface × archetype combos). Phase 0 injection compliance: 93% categorical, 87% strict — within the architecture band that mandates injection-first + required validator. Adversarial verification produced 0 structural violations from taxonomy gaps; only known Stitch blindspots (R1 sticky-vs-fixed, R9 real-face avatars) flagged.

Verification artifacts at `.stitch/designs/v1-verification/` (4 HTMLs + RUN-LOG.md).

## Test plan

- [x] `npm run verify` passes (1077 / 1077 tests; 0 typecheck errors; 0 lint errors; format clean)
- [ ] Spot-check on smd.services: header looks identical (sticky logo + Contact + Book a Call CTA)
- [ ] Spot-check on portal.smd.services/portal: client name left, contact icons right (email/SMS/phone whichever channels available)
- [ ] Spot-check on portal.smd.services/portal/invoices/[id]: back-to-"All invoices" affordance visible above content
- [ ] Spot-check on admin.smd.services/admin (desktop): sticky header, tabs visible
- [ ] Spot-check on admin.smd.services/admin (mobile <768px): menu icon trigger opens `<details>` with nav + email + sign out
- [ ] Tab through any page: skip-to-main link should appear on first focus and jump to `<main>`
- [ ] Visual QA on portal detail right-rail sticky offset (`md:top-20`) — should sit below sticky header without overlap

## Known follow-ups (out of scope)

- `/privacy` and `/terms` pages don't yet exist; footer link to them is intentionally absent
- `scorecard.astro` wizard still uses sticky-bottom nav; the spec defers wizard escape-hatch refactoring to v2
- 404 page back-to-safety link should resolve by subdomain (currently links to `/`); v2 follow-up
- React-components skill integration to consume the same spec for component generation: future phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)