### PR TITLE
feat(stitch): integrate nav-spec into stitch-ux-brief

### DIFF
--- a/.agents/skills/stitch-ux-brief/SKILL.md
+++ b/.agents/skills/stitch-ux-brief/SKILL.md
@@ -60,6 +60,7 @@ Scan the repo for context:
 - `tailwind.config.*` for palette and type scale
 - Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
 - `.stitch/DESIGN.md` if present (established design system for the venture)
+- `.stitch/NAVIGATION.md` if present (navigation specification — governs chrome in concept prompts and strip passes). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value.
 
 Display an **Intake Summary** table:
 
@@ -70,6 +71,7 @@ Display an **Intake Summary** table:
 | Persona        | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
 | Prior brief    | _path or "none"_                              |
 | Tokens source  | _path to globals.css or config_               |
+| Nav spec       | _spec-version N or "absent"_                  |
 | Venture code   | _resolved from `crane_ventures`_              |
 | Stitch project | _ID or "will create"_                         |
 
@@ -378,6 +380,15 @@ For each concept, write a prompt file to `/tmp/stitch-prompt-<concept>.txt`. The
 
 <Paragraph explaining the concept's structural philosophy. What does it prioritize? What IS the page?>
 
+NAV CONTRACT (REQUIRED):
+[Only if .stitch/NAVIGATION.md exists. Read the matching surface-class
+ appendix + archetype contract from NAVIGATION.md. Concatenate shared
+ sections (a11y, states, anti-patterns). Inject using the template at
+ ~/.agents/skills/nav-spec/references/injection-snippet-template.md.
+ Size budget: ≤600 tokens.
+ If NAVIGATION.md absent: OMIT this entire block. Describe header/footer
+ inline in PAGE STRUCTURE as before (legacy behavior).]
+
 DESIGN SYSTEM (REQUIRED):
 - Platform: Web, mobile-first, 390x844 viewport only (or desktop 1280px)
 - Palette: <hex values from the brief's Appendix>
@@ -388,14 +399,15 @@ DESIGN SYSTEM (REQUIRED):
 - COLOR RULE (intentional): <any harnessed drift — e.g., "muted indigo family for metadata, not neutral slate">
 
 PAGE STRUCTURE:
+[When NAV CONTRACT is present, do NOT describe header/footer/back-button
+ chrome here — the contract owns chrome. PAGE STRUCTURE describes content.]
 
-1. <Minimal header spec>
-2. <Dominant element — the concept's defining feature>
-3. <Supporting elements>
-4. <Consultant/contact block spec>
-5. <What is explicitly absent>
+1. <Dominant element — the concept's defining feature>
+2. <Supporting elements>
+3. <Consultant/contact block spec>
+4. <What is explicitly absent>
 
-Anti-patterns: <per-surface anti-patterns — not a generic list>
+Anti-patterns: <per-surface anti-patterns — from NAVIGATION.md §8 if present, otherwise from the brief>
 
 Mood: <one sentence that captures the intent>
 ```
@@ -539,6 +551,10 @@ Stitch reliably adds default-web chrome that doesn't belong on an authenticated 
 
 Run a **batch edit** across all generated screens with a hardened strip directive. `edit_screens` supports an array of `selectedScreenIds` — pass all of them in one call.
 
+**When `.stitch/NAVIGATION.md` exists:** generate the REMOVE IF PRESENT list from the spec's anti-patterns (§8) + the matching surface-class appendix's "Chrome forbidden" section, rather than hardcoding the list below. Generate the PRESERVE EXACTLY whitelist from the appendix's "Chrome allowed" section. This keeps strip-pass directives in sync with the spec — when the spec evolves, the strip pass follows automatically.
+
+**When `.stitch/NAVIGATION.md` does NOT exist:** use the hardcoded strip directive below (legacy behavior).
+
 **Strip directive template (customize per run):**
 
 ```
@@ -547,6 +563,10 @@ CONTEXT RESET: This is an authenticated <surface type> surface. The person viewi
 Your job: remove everything that was added as gold-plating or default web chrome, and touch nothing else. Do NOT redesign. Do NOT rebalance layouts. Do NOT reword preserved copy. Only remove.
 
 REMOVE IF PRESENT:
+[If NAVIGATION.md present: enumerate from §8 anti-patterns + surface-class
+ appendix "Chrome forbidden" list. Each item is a concrete selector or
+ description of what to remove.]
+[If absent, use the legacy list:]
 1. Global navigation tabs or menus
 2. Testimonial paragraphs, pull quotes, italicized client-voice sentences
 3. Copyright lines
@@ -557,6 +577,9 @@ REMOVE IF PRESENT:
 8. Stickied bottom bars duplicating a visible primary action
 
 PRESERVE EXACTLY:
+[If NAVIGATION.md present: enumerate from the surface-class appendix
+ "Chrome allowed" list. Each item is a concrete element description.]
+[If absent:]
 <Whitelist every element that should remain — the primary action, the amount display, every named section, the consultant block, all inline artifacts, the minimal header, every link that was explicit in the original prompt>
 
 REPLACEMENT RULE: Do not replace what you remove. If removing creates empty space, leave it empty. The page ends where content ends.
@@ -602,6 +625,7 @@ Write a short log to `.stitch/designs/<target>-v1/RUN-LOG.md` capturing:
 - Winning concept
 - Decisions made by the user
 - Known drifts / over-strips
+- **nav-spec-version**: record the `spec-version` from `.stitch/NAVIGATION.md` front matter (or "absent" if no spec present). This anchors the generation to a specific spec version for future compatibility checks.
 - Next follow-ups
 
 Update `crane-console/config/ventures.json` with the `stitchProjectId` if it was created during this run.

--- a/.claude/commands/design-brief.md
+++ b/.claude/commands/design-brief.md
@@ -370,10 +370,10 @@ After synthesis, extract the core design reference from the brief into a standar
 1. Read the synthesized `docs/design/brief.md`
 2. Extract: color tokens (with hex values), typography (font stacks, scale), spacing system, surface hierarchy, component inventory, and accessibility notes
 3. Write to `docs/design/design-spec.md` in the **current repo** (wherever the skill runs)
-4. If the current repo is `crane-console`, also write to `docs/design/ventures/{venture_code}/design-spec.md`
+4. If the current repo is `crane-console`, also write to `docs/ventures/{venture_code}/design-spec.md`
 5. The design spec format follows the template at `templates/venture/docs/design/design-spec.md` - structured for agent consumption with token tables, not prose
 
-Tell the user: **"Design spec generated at `docs/design/design-spec.md`. Upload to crane-context with: `infisical run --path /vc -- bash scripts/upload-design-specs.sh`"**
+Tell the user: **"Design spec generated at `docs/design/design-spec.md`. Design specs sync to D1 automatically via GitHub Action when merged to main."**
 
 Do not attempt the API upload from within the skill (no credentials available in skill context).
 

--- a/.claude/commands/stitch-ux-brief.md
+++ b/.claude/commands/stitch-ux-brief.md
@@ -58,15 +58,15 @@ Scan the repo for context:
 
 Display an **Intake Summary** table:
 
-| Field | Value |
-| --- | --- |
-| Target | _e.g., `client-portal`_ |
-| Authentication | _logged-in / prospect / public_ |
-| Persona | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
-| Prior brief | _path or "none"_ |
-| Tokens source | _path to globals.css or config_ |
-| Venture code | _resolved from `crane_ventures`_ |
-| Stitch project | _ID or "will create"_ |
+| Field          | Value                                         |
+| -------------- | --------------------------------------------- |
+| Target         | _e.g., `client-portal`_                       |
+| Authentication | _logged-in / prospect / public_               |
+| Persona        | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
+| Prior brief    | _path or "none"_                              |
+| Tokens source  | _path to globals.css or config_               |
+| Venture code   | _resolved from `crane_ventures`_              |
+| Stitch project | _ID or "will create"_                         |
 
 Present the table and ask: **"Does this capture the intake? Anything to correct before I draft?"**
 
@@ -82,93 +82,125 @@ Write a v1 brief to `.stitch/<target>-ux-brief.md` (create the directory if need
 # <Title> — UX Redesign Brief (v1)
 
 ## Context
+
 <2-4 paragraphs: venture positioning, what this surface is for, why we're redesigning>
 
 ## Scope of this Stitch pass
+
 <surfaces + viewports to be generated>
 
 ## Visit modes
+
 <5-ish modes: action responder, status checker, etc. Be specific to this surface>
 
 ## Objectives, ranked
+
 1. ... 2. ... 3. ... 4. ... 5. ...
 
 ## Entry points (with email context)
+
 <each entry point, with the subject line and CTA from the email that triggers it>
 
 ## Design principles
+
 <3-5 principles that constrain Stitch without dictating layout>
 
 ## Three concepts requested (structurally distinct, not visual variations)
+
 A — <axis>
 B — <axis>
 C — <axis>
 
 ## Worked example (fidelity reference)
+
 <one concept × one surface × one viewport, with inline type specs>
 
 ## Above-fold specs for B and C
+
 <matching A's format>
 
 ## What must be preserved
+
 <typography, palette, shape, voice>
 
 ## What is open
+
 <layout, hierarchy, flow — full creative freedom>
 
 ## Anti-patterns (do not produce)
+
 <bullet list of explicit no-gos>
 
 ## Mobile spec
+
 <390×844, thumb zone, tap target, no hover, no horizontal scroll>
 
 ## Desktop spec
+
 <1280px, right-rail placement, eye-level action>
 
 ## Contact affordance spec
+
 <primary channel, fallback, SLA — operational commitment, not copy>
 
 ## Copy samples (tone calibration)
+
 <5-6 lines showing the voice in concrete context>
 
 ## Error states (must design)
+
 <per-surface error list — each includes named human + next step>
 
 ## Activity timeline schema
+
 <if the surface has time-series data, define the event shape>
 
 ## Money rule
+
 <dollar figures only, never bars or percentages, if applicable>
 
 ## Photo placeholder rule
+
 <harder than "neutral placeholder" — use initials-in-circle or solid shape; never real faces>
 
 ## Accessibility floor
+
 <WCAG 2.2 AA, focus rings with hex, landmarks, tap targets>
 
 ## Success criteria
+
 **Primary acceptance test:** <one measurable design constraint — e.g., "on 390×844, [Pay invoice] button top edge at y ≤ 700px, no scroll">
 
 Secondary: <2-4 testable criteria>
 
 ## Follow-ups (scheduled, not gaps)
+
 <real priorities scheduled after this pass, each with a target window>
 
 ## Data available
+
 <data fields the design can use; ask for flag if design needs data we don't capture>
 
 ## Constraints
+
 <stack, viewports, scope limits>
 
 ## Approver
+
 <name — Stitch output reviewed before any iteration>
 
 ## Appendix: Hard design tokens
+
 ### Color
+
 <hex block — use exact values from globals.css or tailwind config>
+
 ### Typography
+
 <family, weights, sizes, line-heights, tracking>
+
 ### Spacing and shape
+
 <rounded, padding, rhythm, tap target, breakpoints>
 ```
 
@@ -187,6 +219,7 @@ Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via t
 > You are a senior product manager at a [venture type] firm. You review UX briefs for client-facing surfaces. You are direct, critical, and do not validate work you find weak.
 
 **Focus:**
+
 - Are user objectives correctly framed and ranked?
 - Are lifecycle states complete? What failure states are missing (declined, paused, expired, disputed, cancelled, overdue)?
 - Are success criteria measurable? Name the primary metric.
@@ -204,6 +237,7 @@ Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via t
 > You are a senior UX designer with deep experience using AI design tools — Stitch, v0, Magic Patterns, Figma Make. You know what makes them produce generic output vs considered work.
 
 **Focus:**
+
 - Are design tokens described precisely enough? Vague tokens ("muted violet") produce inconsistent runs across concepts. Require hex.
 - Is mobile-first a slogan or a constraint? Specific viewport, thumb zone, tap targets, no-hover rules.
 - Will three runs produce structurally distinct concepts, or three visual variations of the same layout? Commission structural divergence with explicit axis names.
@@ -218,12 +252,14 @@ Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via t
 > You are <NAME>, <AGE>. You own <BUSINESS>. <BACKGROUND: years, team, revenue>. You are not <disqualifying tech trait> but you run a real business with real software. <SPOUSE/PARTNER> handles <ROLE>. You just <TRIGGERING EVENT>. Someone handed you a document that describes people like you — how you use [target surface], what you need from it. Tell them if it sounds right. Call out patronizing language. Flag missing things they don't know about your actual life. Talk plainly. Swear if you want. Don't bullet-point at the top; talk first, then summarize.
 
 **Focus:**
+
 - Does this sound like real me, or like someone who's never talked to someone in my role?
 - What's patronizing? Soft? Over-explained?
 - What's missing about my actual life? (spouse access, SMS vs email, what I'd show my advisor)
 - What would I actually do on this surface vs what they think I'd do?
 
 **Persona discipline:**
+
 - Specific name, age, business details. "A business owner in the 30-55 age range" does not work. "Mike Delgado, 52, plumbing HVAC, 9 employees, $1.8M revenue, wife Elena does books" does.
 - Give the persona permission to push back on the brief's description of them. The most common persona finding: the brief describes the user in ways no user would recognize.
 
@@ -398,11 +434,13 @@ View the three PNGs. Compare.
 **Question to answer, rigorously:** Are the three concepts structurally distinct, or have they collapsed into visual variations of the same layout?
 
 Signal of structural divergence:
+
 - Height ratios differ noticeably (e.g., one concept is ~60% the height of the others)
 - Information hierarchy differs (what dominates the viewport is genuinely different)
 - The "what IS the page?" answer differs per concept
 
 Signal of collapse:
+
 - All three are the same layout with different colors or card treatments
 - The heights are within 10% of each other
 - The dominant element is the same across all three
@@ -469,6 +507,7 @@ Download the updated preview. Present to user. Confirm the iteration landed befo
 Generate the remaining surfaces × viewports for the winning concept.
 
 Typical matrix:
+
 - Remaining surfaces (2 at minimum — e.g., deep-link invoice landing, deep-link proposal landing) × 2 viewports (mobile, desktop) = 4 new screens
 - Plus the desktop variant of the primary surface = 1 more
 


### PR DESCRIPTION
## Summary

- Patches `stitch-ux-brief/SKILL.md` to consume `.stitch/NAVIGATION.md` when present — graceful-degradation, zero behavior change for ventures without a nav spec.
- Phase 1 adds nav-spec status to intake table. Phase 7 injects NAV CONTRACT block into concept prompts (chrome separated from content). Phase 11 generates strip-pass REMOVE/PRESERVE lists from the spec's anti-patterns + surface-class appendix. Phase 12 records `nav-spec-version` in RUN-LOG.
- Companion change: `stitch-design` (global skill, not in this repo) was also patched locally with classification tag checking (step 1b), NAV CONTRACT injection (step 3), and post-generation validator invocation (step 3b).

## Test plan
- [x] Skill file only — no code changes, no verify needed
- [ ] Confirm next `/stitch-ux-brief` run on ss-console picks up NAVIGATION.md v1 and injects NAV CONTRACT into Phase 7 concepts
- [ ] Confirm `/stitch-ux-brief` on a venture WITHOUT NAVIGATION.md (e.g., ke-console) behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)