### PR TITLE
fix(portal): Material Symbols font on list pages + remove duplicate Paid badge

### DIFF
--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -93,6 +93,10 @@ function formatDate(iso: string): string {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>Documents — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -68,6 +68,10 @@ function formatDate(iso: string | null): string {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>Engagement Progress — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -71,6 +71,10 @@ function formatDate(iso: string | null): string {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>Invoices — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
@@ -150,12 +154,6 @@ function formatDate(iso: string | null): string {
                     {inv.status !== 'paid' && inv.stripe_hosted_url === '#dev-mode' && (
                       <span class="inline-block bg-slate-100 text-slate-500 px-3 py-2 rounded-lg text-xs font-medium">
                         Payment link pending
-                      </span>
-                    )}
-                    {/* Paid indicator */}
-                    {inv.status === 'paid' && (
-                      <span class="inline-block bg-green-50 text-green-700 px-3 py-2 rounded-lg text-xs font-medium">
-                        Paid
                       </span>
                     )}
                   </div>

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -59,6 +59,10 @@ const statusLabelMap: Record<string, string> = {
       href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>Proposals — Portal — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">


### PR DESCRIPTION
## Summary

- Adds the missing Material Symbols Outlined font import to all four portal list pages (invoices, quotes, documents, engagement). The nav-spec retrofit (#391) added back-button chevrons but missed the font — icons were rendering as literal `chevron_left` text.
- Removes the redundant right-side "Paid" badge on the invoices list. The inline status pill already shows "Paid" next to the invoice type; the second badge on the far right was visual noise.

## Test plan
- [ ] `npm run verify` passes
- [ ] Visit portal.smd.services/portal/invoices — back chevron renders as icon, no duplicate Paid badge
- [ ] Visit portal.smd.services/portal/quotes — back chevron renders as icon
- [ ] Visit portal.smd.services/portal/documents — back chevron renders as icon
- [ ] Visit portal.smd.services/portal/engagement — back chevron renders as icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)