### PR TITLE
feat(nav-spec): migrate to v2 three-layer spec + fix R16 orphan destinations

### DIFF
--- a/.stitch/NAVIGATION.md
+++ b/.stitch/NAVIGATION.md
@@ -1,141 +1,432 @@
 ---
-spec-version: 1
+spec-version: 2
+nav-spec-skill-version: 2.0.0
 design-md-sha: absent
 stitch-project-id: '17873719980790683333'
 phase-0-compliance:
   categorical: '93%'
   strict: '87%'
   date: '2026-04-15'
-enforcement: 'injection-first + required validator (nav-spec/validate.py)'
-approval-state: 'approved (retrofit landed in PR feat/nav-spec-v1)'
+enforcement: 'injection-first + required validator (nav-spec/validate.py R1–R24)'
+approval-state: 'v2 authoring complete; audit findings drive follow-up PRs'
+injection-budgets:
+  session-auth-client/dashboard/mobile/hub-and-spoke: { essential: 482, extended: 287, total: 769 }
+  session-auth-client/list/mobile/master-detail: { essential: 421, extended: 156, total: 577 }
+  session-auth-client/detail/mobile/master-detail: { essential: 437, extended: 218, total: 655 }
+  session-auth-admin/dashboard/desktop/hub-and-spoke-tabs:
+    { essential: 468, extended: 241, total: 709 }
+  public/dashboard/desktop/pyramid: { essential: 395, extended: 112, total: 507 }
+  auth-gate/form/mobile/single-page-form: { essential: 343, extended: 84, total: 427 }
+  token-auth/detail/mobile/master-detail-simplified: { essential: 389, extended: 142, total: 531 }
+revisions:
+  - {
+      from: 1.0,
+      to: 2.0,
+      date: '2026-04-15',
+      kind: 'v1→v2 migration',
+      added:
+        [
+          'Section 1 (Task model)',
+          'Section 3 (Reachability matrix)',
+          'Section 4 (Pattern selection)',
+          'Section 5 (State machine)',
+          'Section 12 (Content taxonomy)',
+        ],
+      renumbered:
+        [
+          'v1 §1+§2 → v2 §2',
+          'v1 §3 → incorporated into v2 §4 pattern map',
+          'v1 §4 → v2 §6',
+          'v1 §5 → v2 §7',
+          'v1 §6 → v2 §8',
+          'v1 §7 → v2 §9',
+          'v1 §8 → v2 §10',
+          'v1 §9 → v2 §11',
+          'v1 §10 → merged into v2 §12',
+          'v1 §11 (refactor checklist) → archived',
+        ],
+    }
 ---
 
-# SMD Services — Navigation Specification
+# SMD Services — Navigation Specification (v2)
 
-Single source of truth for navigation chrome across `smd.services`, `admin.smd.services`, and `portal.smd.services`. Every Stitch-generated screen and every new shipped component must conform. Deviations require a spec-version bump, not a one-off exception.
+Single source of truth for navigation across `smd.services`, `admin.smd.services`, and `portal.smd.services`. Three-layer spec: **Information Architecture**, **Patterns** (anchored to NN/g / Material Design 3 / Apple HIG), and **Chrome**. Every Stitch-generated screen and every new shipped component conforms. Deviations require spec revision, not one-off exceptions.
 
-Companion skill: `~/.agents/skills/nav-spec/`. Spec is consumed by `stitch-design` (via NAV CONTRACT injection) and `stitch-ux-brief` (Phase 7 concept template, Phase 11 strip directive). Post-generation enforcement via `nav-spec/validate.py`.
+Companion skill: `~/.agents/skills/nav-spec/` (version 2.0.0). Spec is consumed by `stitch-design` (via NAV CONTRACT injection) and `stitch-ux-brief` (Phase 7 concept template, Phase 11 strip directive). Post-generation enforcement via `nav-spec/validate.py` (R1–R24).
 
-**v1 status:** spec is authored; approval is held on the refactor checklist in Section 11. Validator is in injection-first + belt-and-suspenders mode per Phase 0 compliance evidence (see `nav-spec/examples/phase-0-compliance-report.md`).
+**v2 rationale:** v1 defined chrome only. Result: pages shipped with consistent sticky headers but portal home had no way to reach list views (`/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement`) except by backtracking from a detail — a gaping IA hole that the skill, its reviewers, and its validator all missed. v2 adds Information Architecture and Patterns as explicit layers above chrome, anchored to established frameworks.
 
 ---
 
-## 1. Information architecture
+## 1. Task model
 
-### Sitemap (by subdomain)
+What users do on each surface class. IA and patterns follow from tasks.
 
-**`smd.services`** (marketing and auth entry — served from apex)
+### 1.1 Surface class: `public`
 
-- `/` — marketing home (public, dashboard archetype)
+**Primary tasks:**
+
+1. Understand what SMD Services does (organic visitor, case-study reader)
+2. Book an assessment (qualified visitor)
+3. Take the self-serve scorecard (prospect evaluating fit)
+4. Contact consultant (ad hoc inquiry)
+
+**Secondary:**
+
+- Read specific landing pages (`/get-started`)
+- Sign in (redirects to `auth-gate`)
+
+### 1.2 Surface class: `auth-gate`
+
+**Primary tasks:**
+
+1. Request a magic link (client) or initiate OAuth (admin)
+2. Verify a magic link (transient)
+
+### 1.3 Surface class: `token-auth`
+
+**Primary tasks:**
+
+1. Manage an existing booking (reschedule, cancel) via `/book/manage/[token]`
+2. (Future) Review/sign a proposal via token deep-link
+3. (Future) Pay an invoice via token deep-link
+
+Entry exclusively via email deep-link. No prior session assumed.
+
+### 1.4 Surface class: `session-auth-client` (portal)
+
+**Primary tasks** (ranked by frequency × criticality):
+
+1. **Pay a pending invoice** — trigger: email received; completion: Stripe payment confirmed; frequency: 1–5 per engagement; criticality: blocking
+2. **Review and sign a proposal** — trigger: email received; completion: SignWell signature; frequency: 1–3 per engagement; criticality: blocking
+3. **See what's happening** — trigger: weekly check-in; completion: scan of Recent Activity; frequency: weekly; criticality: medium
+4. **Find a document** — trigger: user wants a specific deliverable; completion: document open/downloaded; frequency: weekly (active), rare (post); criticality: medium
+5. **Check engagement progress** — trigger: milestone review; completion: status scanned; frequency: weekly; criticality: medium
+6. **Contact consultant** — trigger: ad hoc question; completion: message sent via preferred channel; frequency: variable; criticality: high (trust)
+
+**Secondary tasks:**
+
+- Review past proposals (reference)
+- Review past invoices (accounting)
+- Check scheduled touchpoint
+
+### 1.4.1 Task-to-surface mapping (portal)
+
+| Task                  | Primary surface         | Surfaces touched                                  | Entry point                |
+| --------------------- | ----------------------- | ------------------------------------------------- | -------------------------- |
+| Pay invoice           | `/portal/invoices/[id]` | home → list → detail → Stripe                     | Email, home ActionCard     |
+| Review/sign proposal  | `/portal/quotes/[id]`   | home → list → detail → SignWell                   | Email, home timeline entry |
+| See what's happening  | `/portal`               | home                                              | Login, bookmark            |
+| Find document         | `/portal/documents`     | home → section card → list → document             | Section card on home       |
+| Check progress        | `/portal/engagement`    | home → section card → engagement                  | Section card on home       |
+| Contact consultant    | any                     | three-icon contact control in header + right rail | Header icons               |
+| Review past proposals | `/portal/quotes`        | home → section card → list                        | Section card on home       |
+| Review past invoices  | `/portal/invoices`      | home → section card → list                        | Section card on home       |
+
+### 1.5 Surface class: `session-auth-admin`
+
+**Primary tasks:**
+
+1. Triage clients and their engagements — `/admin/entities`, `/admin/entities/[id]`
+2. Manage assessments — `/admin/assessments/[id]` (accessed via entity detail)
+3. Track engagement progress — `/admin/engagements/[id]` (accessed via entity detail)
+4. Create and send proposals — `/admin/entities/[id]/quotes/[quoteId]`
+5. Follow up on leads and clients — `/admin/follow-ups`
+6. Monitor venture metrics — `/admin/analytics`
+7. Manage integrations — `/admin/settings/google-connect`
+
+Admin IA is **entity-scoped**: most work happens inside `/admin/entities/[id]` rather than at top-level list views.
+
+---
+
+## 2. Sitemap and auth boundary
+
+### 2.1 Sitemap
+
+**`smd.services`** (marketing + auth entry)
+
+- `/` — marketing home (public, dashboard)
 - `/contact` — contact form (public, form)
 - `/book` — booking flow (public, form)
-- `/book/manage/` — query-param redirect handler; renders an inline "invalid link" fallback when no token (public, error)
-- `/book/manage/[token]` — **token-auth**, manage existing booking (token-auth, detail)
-- `/get-started` — onboarding CTA page (public, dashboard)
+- `/book/manage/` — query-param redirect handler; renders "invalid link" fallback when no token (public, error)
+- `/book/manage/[token]` — **token-auth** detail, manage booking
+- `/get-started` — onboarding CTA (public, dashboard)
 - `/scorecard` — self-serve assessment (public, wizard)
-- `/contact` — contact form (public, form)
-- `/404` — shared not-found page (renders in all subdomain contexts; see "Cross-subdomain 404" in Section 7)
+- `/404` — shared not-found, subdomain-aware (error)
 - `/auth/login` — admin OAuth entry (**auth-gate**, form)
 - `/auth/portal-login` — client magic-link request (**auth-gate**, form)
 - `/auth/verify` — magic-link verification (**auth-gate**, transient)
 
 **`admin.smd.services`**
 
-- `/admin` — dashboard (session-auth-admin, dashboard)
-- `/admin/entities` — client list (session-auth-admin, list)
-- `/admin/entities/[id]` — client detail (session-auth-admin, detail)
-- `/admin/entities/[id]/quotes/[quoteId]` — quote detail, nested (session-auth-admin, detail)
-- `/admin/engagements/[id]` — engagement detail (session-auth-admin, detail) — no `/admin/engagements` list; parent is the client detail
-- `/admin/assessments/[id]` — assessment detail (session-auth-admin, detail) — no list; parent is the client detail
-- `/admin/follow-ups` — follow-ups list (session-auth-admin, list)
-- `/admin/analytics` — analytics dashboard (session-auth-admin, dashboard)
-- `/admin/settings/google-connect` — integration settings (session-auth-admin, form)
+- `/admin` — dashboard
+- `/admin/entities` — list (clients)
+- `/admin/entities/[id]` — detail (client)
+- `/admin/entities/[id]/quotes/[quoteId]` — detail (nested: quote under client)
+- `/admin/engagements/[id]` — detail (no list; parent is entity detail)
+- `/admin/assessments/[id]` — detail (no list; parent is entity detail)
+- `/admin/follow-ups` — list
+- `/admin/analytics` — dashboard (analytics)
+- `/admin/settings/google-connect` — form
 
 **`portal.smd.services`**
 
-- `/portal` — dashboard (session-auth-client, dashboard)
-- `/portal/invoices` — list (session-auth-client, list)
-- `/portal/invoices/[id]` — detail (session-auth-client, detail)
-- `/portal/quotes` — list (session-auth-client, list)
-- `/portal/quotes/[id]` — detail (session-auth-client, detail)
-- `/portal/documents` — index (session-auth-client, list)
-- `/portal/engagement` — current engagement summary (session-auth-client, detail)
+- `/portal` — dashboard
+- `/portal/invoices` — list
+- `/portal/invoices/[id]` — detail
+- `/portal/quotes` — list
+- `/portal/quotes/[id]` — detail
+- `/portal/documents` — list
+- `/portal/engagement` — detail (current engagement summary)
 
-**Dev-only (exempt from spec enforcement)**
+**Dev-only** (exempt from spec): `/dev/portal-components`, `/dev/portal-states`.
 
-- `/dev/portal-components`, `/dev/portal-states` — internal component preview harnesses, noindex, not Stitch generation targets
+### 2.2 Surface-class taxonomy (authoritative)
 
-### Auth boundary table
+Classes modeled by **auth model**, not subdomain. Subdomain is secondary; two classes can coexist on one subdomain.
 
-| Surface class         | Auth model                                                   | Base URL                                                                        | Session cookie                                        | Redirect on logout                                |
-| --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
-| `public`              | None                                                         | `smd.services/*` (default marketing)                                            | None                                                  | n/a                                               |
-| `auth-gate`           | Anonymous; surface exists to produce or consume a credential | `smd.services/auth/*`                                                           | None pre-submit; session set on post-success redirect | n/a — surface IS the redirect target after logout |
-| `token-auth`          | Signed URL token in path segment                             | `/book/manage/[token]` (and any future `/proposal/[token]`, `/invoice/[token]`) | None                                                  | n/a — link expiry replaces logout                 |
-| `session-auth-client` | Client cookie session (portal user)                          | `portal.smd.services/*`                                                         | `__Host-portal_session`                               | `smd.services/auth/portal-login`                  |
-| `session-auth-admin`  | Admin cookie session (operator)                              | `admin.smd.services/*`                                                          | `__Host-admin_session`                                | `smd.services/auth/login`                         |
+| Class                 | Definition                                                            | Auth signal             |
+| --------------------- | --------------------------------------------------------------------- | ----------------------- |
+| `public`              | No authentication. Marketing, contact, scorecard.                     | None                    |
+| `auth-gate`           | Anonymous; surface exists to produce/consume a credential. `noindex`. | None pre-submit         |
+| `token-auth`          | Signed URL token grants access without an account.                    | Path-segment token      |
+| `session-auth-client` | Client cookie session (low-privilege).                                | `__Host-portal_session` |
+| `session-auth-admin`  | Operator cookie session (high-privilege).                             | `__Host-admin_session`  |
 
-### Deep-link inventory
+### 2.3 Auth boundary
 
-Every URL reachable from outside the app (email, SMS, saved bookmark):
+| Class               | Base URL                                                                  | Session cookie            | Redirect on logout               |
+| ------------------- | ------------------------------------------------------------------------- | ------------------------- | -------------------------------- |
+| public              | `smd.services/*`                                                          | None                      | n/a                              |
+| auth-gate           | `smd.services/auth/*`                                                     | None → session on success | n/a (surface IS logout target)   |
+| token-auth          | `/book/manage/[token]` (+ future `/proposal/[token]`, `/invoice/[token]`) | None                      | n/a; link expiry                 |
+| session-auth-client | `portal.smd.services/*`                                                   | `__Host-portal_session`   | `smd.services/auth/portal-login` |
+| session-auth-admin  | `admin.smd.services/*`                                                    | `__Host-admin_session`    | `smd.services/auth/login`        |
 
-- `/` and public marketing — organic traffic
-- `/book/manage/[token]` — emailed after booking confirmation (signed token, session-less)
-- `/portal` and `/portal/*` — arrived via `/auth/portal-login` after a magic-link email
-- `/admin` — arrived via `/auth/login` (Google OAuth)
+### 2.4 Surface-class selection when subdomain is ambiguous
 
-Portal detail pages (`/portal/invoices/[id]`, `/portal/quotes/[id]`) always require session auth in the current architecture. If token-auth landings for these ship later, they must route through a distinct URL (e.g., `portal.smd.services/proposal/[token]`) and render `token-auth` chrome per Appendix B — **not** portal chrome. See "Surface-class selection when subdomain is ambiguous" in Section 2.
+Future `portal.smd.services/proposal/[token]` routes will share subdomain with `session-auth-client` but are token-auth. Disambiguation:
 
----
+1. **Valid session cookie** is the primary signal. Present → `session-auth-client` (or admin). Absent but token valid → `token-auth`.
+2. **Token-auth on authenticated subdomain renders distinct chrome** (visible "Viewing via secure link" badge). Prevents a refreshed-tab user from thinking their session persists.
+3. **Middleware carves out token-auth paths before session-auth checks**, else middleware redirects to login.
 
-## 2. Surface-class taxonomy
+### 2.5 Deep-link inventory
 
-Classes are modeled by **auth model**, not subdomain. Subdomain is a secondary attribute; two surface classes can coexist on one subdomain (e.g., `portal.smd.services` can host `session-auth-client` dashboards and `token-auth` proposal landings under distinct URL paths).
-
-| Class                 | One-line definition                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------- |
-| `public`              | No authentication. Addressed to a stranger or first-time visitor. Marketing, contact, scorecard.      |
-| `auth-gate`           | Anonymous; surface exists solely to produce or consume an auth credential. Minimal chrome. `noindex`. |
-| `token-auth`          | Signed URL token grants access without an account. User arrived via an emailed link; token expires.   |
-| `session-auth-client` | Authenticated client with a portal cookie session. Low-privilege; views their own records.            |
-| `session-auth-admin`  | Authenticated operator with an admin cookie session. High-privilege; views all records.               |
-
-### Surface-class selection when subdomain is ambiguous
-
-If the same subdomain hosts multiple surface classes (e.g., a future `portal.smd.services/proposal/[token]`), disambiguation:
-
-1. **Presence of a valid session cookie** is the primary signal. If present → session-auth-client (or admin on admin subdomain). If absent but a URL token is valid → token-auth.
-2. **Token-auth on an authenticated subdomain must render distinct chrome** so an authenticated user who refreshes the tab can tell the session expired. Use a visible "Viewing via secure link" badge in the header band plus the Appendix B token-auth chrome (not Appendix C portal chrome).
-3. **Middleware enforcement:** `src/middleware.ts` must carve out token-auth paths before session-auth checks; otherwise the middleware redirects token-auth users to login.
+| URL                                            | Entry vector                         | Surface class       |
+| ---------------------------------------------- | ------------------------------------ | ------------------- |
+| `/`, other public                              | Organic / direct                     | public              |
+| `/book/manage/[token]`                         | Booking confirmation email           | token-auth          |
+| `/portal/*`                                    | Magic link from `/auth/portal-login` | session-auth-client |
+| `/admin/*`                                     | OAuth from `/auth/login`             | session-auth-admin  |
+| `/portal/quotes/[id]`, `/portal/invoices/[id]` | Email (after portal login)           | session-auth-client |
 
 ---
 
-## 3. Screen archetype taxonomy
+## 3. Reachability matrix
 
-10 archetypes. 9 interactive + 1 transient. See `~/.agents/skills/nav-spec/references/archetype-catalog.md` for full per-archetype contracts.
+The central IA artifact. Declares which destinations are reachable from which surfaces and by what mechanism. Validator rules R16, R18 check code against this matrix.
 
-| Archetype   | Allowed surface classes            | Back                                   | Breadcrumbs                  |
-| ----------- | ---------------------------------- | -------------------------------------- | ---------------------------- |
-| `dashboard` | session-auth-\*, public (landing)  | no                                     | no                           |
-| `list`      | session-auth-\*                    | yes → parent                           | session-auth-admin: 2 levels |
-| `detail`    | all five                           | yes → parent                           | session-auth-admin: 3 levels |
-| `form`      | session-auth-\*, public, auth-gate | cancel+save OR submit-only (auth-gate) | no                           |
-| `wizard`    | session-auth-\*, public            | prev/next                              | no                           |
-| `empty`     | session-auth-\*, token-auth        | inherit                                | inherit                      |
-| `error`     | all five                           | no                                     | no                           |
-| `modal`     | session-auth-\*, token-auth        | close                                  | no                           |
-| `drawer`    | session-auth-\*, token-auth        | close                                  | no                           |
-| `transient` | auth-gate                          | n/a                                    | n/a                          |
+### 3.1 Invariants
 
-`transient` is new: a server-side processing surface with no user-facing chrome (renders only a fallback if the redirect fails). Used by `/auth/verify`.
+- Every surface appears as From ≥1 and To ≥1, with exceptions flagged (Section 3.3, 3.4).
+- Every `dashboard` archetype has Required=Yes rows to every sibling list/detail.
+- Every `detail` archetype has a Required=Yes back to its parent (canonical URL).
+- No dead ends unless flagged Terminal.
+- Mechanisms use canonical names per [reachability-matrix-template.md](../../.agents/skills/nav-spec/references/reachability-matrix-template.md).
+
+### 3.2 Matrix
+
+| From                                             | To                                      | Mechanism                   | Required?                         | Pattern                 |
+| ------------------------------------------------ | --------------------------------------- | --------------------------- | --------------------------------- | ----------------------- |
+| `/` (dashboard)                                  | `/scorecard`                            | Inline CTA                  | Yes                               | Pyramid                 |
+| `/` (dashboard)                                  | `/book`                                 | Primary CTA                 | Yes                               | Pyramid                 |
+| `/` (dashboard)                                  | `/contact`                              | Footer link                 | Yes                               | Pyramid                 |
+| `/` (dashboard)                                  | `/get-started`                          | Inline CTA                  | Yes                               | Pyramid                 |
+| `/scorecard` (wizard)                            | `/book`                                 | Terminal CTA                | Yes                               | Sequential              |
+| `/scorecard` (wizard)                            | `/`                                     | Cancel                      | Yes                               | Sequential              |
+| `/get-started` (dashboard)                       | `/book`                                 | Primary CTA                 | Yes                               | Pyramid                 |
+| `/book` (form)                                   | (external calendar)                     | Submit redirect             | Yes                               | External                |
+| `/book` (form)                                   | `/`                                     | Cancel                      | Yes                               | —                       |
+| `/contact` (form)                                | `/`                                     | Submit → thank-you + Cancel | Yes                               | —                       |
+| `/book/manage/[token]` (token-auth detail)       | `mailto:consultant`                     | Contact icon                | Yes                               | Contact-control         |
+| `/book/manage/[token]` (token-auth detail)       | `sms:consultant`                        | Contact icon                | Yes                               | Contact-control         |
+| `/book/manage/[token]` (token-auth detail)       | `tel:consultant`                        | Contact icon                | Yes                               | Contact-control         |
+| `/book/manage/` (form, no token)                 | `/book`                                 | "Book a call instead" CTA   | Yes                               | Recovery-path           |
+| `/auth/login` (form)                             | `/admin`                                | OAuth → 302                 | Yes                               | —                       |
+| `/auth/portal-login` (form)                      | `/auth/verify`                          | Magic-link submit           | Yes                               | —                       |
+| `/auth/verify` (transient)                       | `/portal`                               | Success redirect            | Yes                               | —                       |
+| `/auth/verify` (transient)                       | `/auth/portal-login`                    | Failure fallback            | Yes                               | Recovery-path           |
+| `/portal` (dashboard)                            | `/portal/quotes`                        | Section card                | Yes                               | Hub-and-spoke           |
+| `/portal` (dashboard)                            | `/portal/invoices`                      | Section card                | Yes                               | Hub-and-spoke           |
+| `/portal` (dashboard)                            | `/portal/documents`                     | Section card                | Yes                               | Hub-and-spoke           |
+| `/portal` (dashboard)                            | `/portal/engagement`                    | Section card                | Yes                               | Hub-and-spoke           |
+| `/portal` (dashboard)                            | `/portal/invoices/[id]`                 | ActionCard                  | Conditional (hasPendingInvoice)   | Dominant-action variant |
+| `/portal` (dashboard)                            | `mailto:<consultant_email>`             | Contact icon                | Conditional (consultant assigned) | Contact-control         |
+| `/portal` (dashboard)                            | `sms:<consultant_phone>`                | Contact icon                | Conditional                       | Contact-control         |
+| `/portal` (dashboard)                            | `tel:<consultant_phone>`                | Contact icon                | Conditional                       | Contact-control         |
+| `/portal` (dashboard)                            | `/api/auth/logout`                      | Logout button               | Yes                               | —                       |
+| `/portal/quotes` (list)                          | `/portal/quotes/[id]`                   | Row click                   | Yes                               | Master-detail           |
+| `/portal/quotes` (list)                          | `/portal`                               | Back button                 | Yes                               | Hub-and-spoke           |
+| `/portal/quotes/[id]` (detail)                   | `/portal/quotes`                        | Back button                 | Yes                               | Master-detail           |
+| `/portal/quotes/[id]` (detail)                   | `<signwell>`                            | Review & Sign CTA           | Conditional (status=sent)         | External                |
+| `/portal/invoices` (list)                        | `/portal/invoices/[id]`                 | Row click                   | Yes                               | Master-detail           |
+| `/portal/invoices` (list)                        | `/portal`                               | Back button                 | Yes                               | Hub-and-spoke           |
+| `/portal/invoices/[id]` (detail)                 | `/portal/invoices`                      | Back button                 | Yes                               | Master-detail           |
+| `/portal/invoices/[id]` (detail)                 | `<stripe>`                              | Pay Now CTA                 | Conditional (status≠paid)         | External                |
+| `/portal/documents` (list)                       | `/api/portal/documents/[key]`           | Row click                   | Yes                               | Master-detail           |
+| `/portal/documents` (list)                       | `/portal`                               | Back button                 | Yes                               | Hub-and-spoke           |
+| `/portal/engagement` (detail)                    | `/portal`                               | Back button                 | Yes                               | Hub-and-spoke           |
+| `/admin` (dashboard)                             | `/admin/entities`                       | Nav tab                     | Yes                               | Hub-and-spoke (tabs)    |
+| `/admin` (dashboard)                             | `/admin/follow-ups`                     | Nav tab                     | Yes                               | Hub-and-spoke (tabs)    |
+| `/admin` (dashboard)                             | `/admin/analytics`                      | Nav tab                     | Yes                               | Hub-and-spoke (tabs)    |
+| `/admin/entities` (list)                         | `/admin/entities/[id]`                  | Row click                   | Yes                               | Master-detail           |
+| `/admin/entities` (list)                         | `/admin`                                | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/entities/[id]` (detail)                  | `/admin/entities`                       | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/entities/[id]` (detail)                  | `/admin/entities/[id]/quotes/[quoteId]` | Related link                | Conditional (quotes exist)        | Nested-doll             |
+| `/admin/entities/[id]` (detail)                  | `/admin/engagements/[id]`               | Related link                | Conditional (engagement exists)   | Nested-doll             |
+| `/admin/entities/[id]` (detail)                  | `/admin/assessments/[id]`               | Related link                | Conditional (assessment exists)   | Nested-doll             |
+| `/admin/entities/[id]/quotes/[quoteId]` (detail) | `/admin/entities/[id]`                  | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/engagements/[id]` (detail)               | `/admin/entities/[id]`                  | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/assessments/[id]` (detail)               | `/admin/entities/[id]`                  | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/follow-ups` (list)                       | `/admin`                                | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/analytics` (dashboard-like)              | `/admin`                                | Breadcrumb                  | Yes                               | Nested-doll             |
+| `/admin/settings/google-connect` (form)          | `/admin`                                | Cancel                      | Yes                               | —                       |
+| `/admin/*` (any)                                 | `/api/auth/logout`                      | Logout button               | Yes                               | —                       |
+| `/404`                                           | `<subdomain-home>`                      | Back-to-safety CTA          | Yes                               | Recovery-path           |
+
+### 3.3 Entry-only surfaces
+
+| Surface                | Entry vector               | Notes                    |
+| ---------------------- | -------------------------- | ------------------------ |
+| `/book/manage/[token]` | Booking confirmation email | Token-auth; cold arrival |
+| `/auth/verify`         | Magic-link email           | Auth-gate transient      |
+
+### 3.4 Terminal surfaces
+
+| Surface                       | Terminal action                              | Notes                                  |
+| ----------------------------- | -------------------------------------------- | -------------------------------------- |
+| `<signwell>` external         | SignWell signing flow                        | External; not part of venture IA       |
+| `<stripe>` external           | Stripe hosted payment                        | External                               |
+| `/auth/verify` (success path) | Auto-redirect to `/portal`                   | Transient; manual fallback link in DOM |
+| `/auth/verify` (failure path) | Auto-redirect to `/auth/portal-login?error=` | Transient; manual fallback link        |
 
 ---
 
-## 4. Chrome component contracts (defaults)
+## 4. Pattern selection
 
-Chrome pieces default to shapes in `~/.agents/skills/nav-spec/references/chrome-component-contracts.md`. Surface-class appendices override.
+Every `{surface class × archetype}` selects a named pattern from [pattern-catalog.md](../../.agents/skills/nav-spec/references/pattern-catalog.md). No pattern is invented; all choices specialize a catalog entry.
 
-### Default header band
+### 4.1 Surface class: `public`
+
+| Archetype                       | Pattern                                     | Rationale                                                                  |
+| ------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------- |
+| dashboard (`/`, `/get-started`) | Pyramid (NN/g §1.4) with persistent top nav | Small content set; linear narrative from home; visitors move through story |
+| wizard (`/scorecard`)           | Sequential (NN/g §1.3)                      | Multi-step scorecard with mandatory ordering                               |
+| form (`/book`, `/contact`)      | Single-page form                            | Small field count; no step ordering                                        |
+| error (`/404`)                  | Recovery-path                               | Single CTA back to subdomain home                                          |
+
+### 4.2 Surface class: `auth-gate`
+
+| Archetype                                  | Pattern                                      | Rationale                                               |
+| ------------------------------------------ | -------------------------------------------- | ------------------------------------------------------- |
+| form (`/auth/login`, `/auth/portal-login`) | Single-page form (centered, wordmark header) | One action: sign in                                     |
+| transient (`/auth/verify`)                 | Recovery-path + auto-redirect                | Server-side processing; fallback link if redirect fails |
+
+### 4.3 Surface class: `token-auth`
+
+| Archetype                       | Pattern                                    | Rationale                                                                                          |
+| ------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| detail (`/book/manage/[token]`) | Master-detail simplified + Contact-control | Cold email arrival; no back target; three-icon contact control is the primary secondary affordance |
+
+### 4.4 Surface class: `session-auth-client` (portal)
+
+| Archetype                                                                     | Pattern                                                                                   | Rationale                                                                                                                                               |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dashboard (`/portal`)                                                         | **Hub-and-spoke** (NN/g §1.1) + **Dominant-action variant** + **Recent-activity variant** | Bounded task set (6 primary tasks); user returns to hub between tasks; mobile-first; ActionCard surfaces contextually urgent task when state demands it |
+| list (`/portal/quotes`, `/portal/invoices`, `/portal/documents`)              | Master-detail                                                                             | Back to hub; row click to detail                                                                                                                        |
+| detail (`/portal/quotes/[id]`, `/portal/invoices/[id]`, `/portal/engagement`) | Master-detail with right-rail ActionCard / ConsultantBlock on desktop                     | Primary action (Sign / Pay) prominent; consultant and status alongside                                                                                  |
+
+**Required elements for hub-and-spoke (from catalog §1.1):**
+
+- Hub surface with visible entry points to every spoke → Section cards on `/portal` to all 4 sibling lists (enforced by R16)
+- Each spoke has back affordance to canonical hub URL → Back button with href=`/portal` (enforced by R5, R16)
+- No sibling-to-sibling links in base nav (e.g., no link from `/portal/quotes` to `/portal/invoices`)
+
+### 4.5 Surface class: `session-auth-admin`
+
+| Archetype                                                              | Pattern                                                                  | Rationale                                                                                                                                                   |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dashboard (`/admin`, `/admin/analytics`)                               | **Hub-and-spoke with ratified tab variant** (Material 3 navigation-tabs) | 3 top-level sections (Entities, Follow-ups, Analytics); high switching frequency; Material's destination-count-and-frequency rule justifies persistent tabs |
+| list (`/admin/entities`, `/admin/follow-ups`)                          | Master-detail + Faceted (filter bar)                                     | Potentially large lists; filter useful                                                                                                                      |
+| detail (`/admin/entities/[id]`, nested quotes/engagements/assessments) | Nested-doll + Persistent-context workspace                               | 3-level hierarchy; `/admin/entities/[id]` is the workspace context; nested surfaces inherit it                                                              |
+| form (`/admin/settings/*`)                                             | Single-page form                                                         | Config editing                                                                                                                                              |
+
+**Admin nav tabs exception (ratified, see Appendix D.2):** `session-auth-admin` is the ONE permitted exception to "no nav tabs in header." Rationale: 3 top-level sections + Dashboard, high-frequency switching in operator workflow, Material 3 permits 3–7 at persistent visibility. Validator R6 has `surface != "session-auth-admin"` guard.
+
+---
+
+## 5. Navigation state machine
+
+How navigation changes per auth state, data state, and task state. Validator R21 checks state-aware rendering.
+
+### 5.1 Surface class: `session-auth-client`
+
+#### Auth states
+
+| State           | Detection                     | Behavior                                 |
+| --------------- | ----------------------------- | ---------------------------------------- |
+| Authenticated   | Valid `__Host-portal_session` | Full nav per matrix                      |
+| Expired         | Middleware 401                | 302 `/auth/portal-login?redirect=<path>` |
+| Unauthenticated | No session                    | 302 `/auth/portal-login`                 |
+
+#### `/portal` data states
+
+| State                       | Condition                                     | Rendering                                                                                                   |
+| --------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Empty                       | `!activeEngagement`                           | Welcome message; "Your portal will populate when your engagement begins"; ConsultantBlock; no section cards |
+| Error                       | DB fetch threw                                | Error card + Retry; ConsultantBlock preserved                                                               |
+| Populated + pending invoice | `pendingInvoice != null`                      | ActionCard dominant; Recent Activity; 4 section cards                                                       |
+| Populated + next touchpoint | `nextTouchpointAt != null && !pendingInvoice` | Touchpoint card; Recent Activity; 4 section cards                                                           |
+| Populated + idle            | else                                          | "Nothing needs your attention right now"; Recent Activity; 4 section cards                                  |
+
+#### `/portal/quotes/[id]` task states
+
+| quote.status | Primary CTA   | Body                                                       |
+| ------------ | ------------- | ---------------------------------------------------------- |
+| sent         | Review & Sign | Expiry countdown if set                                    |
+| accepted     | —             | "Signed on <date>"; link to deposit invoice if issued      |
+| declined     | —             | "You declined this proposal on <date>"; Contact consultant |
+| expired      | —             | "This proposal expired on <date>"; Contact consultant      |
+
+#### `/portal/invoices/[id]` task states
+
+| invoice.status | Primary CTA              | Body                         |
+| -------------- | ------------------------ | ---------------------------- |
+| sent           | Pay Now                  | Amount + due date            |
+| overdue        | Pay Now (with indicator) | Amount + due date past       |
+| paid           | —                        | Paid badge; receipt download |
+| void           | —                        | Voided notice                |
+
+### 5.2 Surface class: `session-auth-admin`
+
+#### Auth states
+
+| State           | Detection                                 | Behavior                          |
+| --------------- | ----------------------------------------- | --------------------------------- |
+| Authenticated   | Valid `__Host-admin_session` + role=admin | Full nav                          |
+| Expired         | 401                                       | 302 `/auth/login?redirect=<path>` |
+| Unauthenticated | No session                                | 302 `/auth/login`                 |
+
+#### Per-surface data states
+
+Admin uses consistent empty + error + populated states across list/detail. Pattern: empty list → "No <entities> yet"; error → error card + Retry; populated → data rendering per surface.
+
+---
+
+## 6. Chrome component contracts
+
+### 6.1 Default header band
 
 ```html
 <header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
@@ -146,28 +437,29 @@ Chrome pieces default to shapes in `~/.agents/skills/nav-spec/references/chrome-
 </header>
 ```
 
-**Height class placement:** `h-14 md:h-16` MUST be on the `<header>` element, not on an inner wrapper. The validator checks the `<header>`'s class list only. Inner-div `py-*` produces a different computed height and fails validation.
+**Height class placement:** `h-14 md:h-16` MUST be on `<header>` itself. Validator checks header's class list only.
 
-**Width wrapper:** `max-w-5xl mx-auto` lives on the inner `<div>`, inside `<header>`. The outer `<header>` is full-bleed so the bottom border spans the viewport.
+**Width wrapper:** `max-w-5xl mx-auto` on inner `<div>`. Outer `<header>` is full-bleed so border spans viewport.
 
-### Token acceptance forms
+### 6.2 Token acceptance forms
 
-The spec uses literal hex (`#e2e8f0`) in examples. The validator and the Stitch injection accept these equivalent forms for every token:
+Validator accepts any equivalent form for color tokens:
 
-| Token        | Literal hex | CSS variable                  | Tailwind named color |
-| ------------ | ----------- | ----------------------------- | -------------------- |
-| Border       | `#e2e8f0`   | `var(--color-border)`         | `slate-200`          |
-| Text default | `#475569`   | `var(--color-text-secondary)` | `slate-600`          |
-| Text bold    | `#0f172a`   | `var(--color-text-primary)`   | `slate-900`          |
-| Primary      | `#1e40af`   | `var(--color-primary)`        | `blue-800`           |
-| Focus ring   | `#3b82f6`   | `var(--color-action)`         | `blue-500`           |
+| Token        | Literal hex | CSS variable                  | Tailwind    |
+| ------------ | ----------- | ----------------------------- | ----------- |
+| Border       | `#e2e8f0`   | `var(--color-border)`         | `slate-200` |
+| Text default | `#475569`   | `var(--color-text-secondary)` | `slate-600` |
+| Text bold    | `#0f172a`   | `var(--color-text-primary)`   | `slate-900` |
+| Primary      | `#1e40af`   | `var(--color-primary)`        | `blue-800`  |
+| Focus ring   | `#3b82f6`   | `var(--color-action)`         | `blue-500`  |
 
-Astro components should prefer the CSS-var form. Stitch generations emit literal hex. Validator accepts any.
+Astro components prefer CSS-var form. Stitch generations emit literal hex. Validator accepts any.
 
-### Default back affordance (detail archetypes)
+### 6.3 Default back affordance (detail archetypes)
 
 ```html
-<a href="<canonical-parent-url>" aria-label="<parent-label>" class="inline-flex items-center gap-1 w-11 h-11 text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded-lg">
+<a href="<canonical-parent-url>" aria-label="<parent-label>"
+   class="inline-flex items-center gap-1 w-11 h-11 text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded-lg">
   <span class="material-symbols-outlined">chevron_left</span>
   <span class="text-[13px] font-medium"><parent-label></span>
 </a>
@@ -175,11 +467,28 @@ Astro components should prefer the CSS-var form. Stitch generations emit literal
 
 Positioned inside `<main>`, above content, never inside `<header>`.
 
-### Breadcrumbs
+### 6.4 Section cards (dashboard hub-and-spoke)
 
-Admin only, depth ≥ 2.
+```html
+<a href="<sibling-route>" aria-label="<sibling-label>"
+   class="block rounded-lg border border-[color:var(--color-border)] bg-white p-4 min-h-[88px] hover:border-[color:var(--color-border-strong)] transition-colors focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+  <div class="flex items-start gap-3">
+    <span class="material-symbols-outlined text-[color:var(--color-primary)]" aria-hidden="true"><icon></span>
+    <div>
+      <p class="font-['Plus_Jakarta_Sans'] font-bold text-[color:var(--color-text-primary)]"><label></p>
+      <p class="text-sm text-[color:var(--color-text-secondary)] mt-1"><caption></p>
+    </div>
+  </div>
+</a>
+```
 
-### Skip-to-main link (all surfaces, no exceptions)
+Grid: 1 column mobile, 2 columns desktop (via `grid md:grid-cols-2 gap-3`).
+
+### 6.5 Breadcrumbs
+
+Admin only. Depth ≥ 2. Separator: `<span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>`. Segment truncation at 24ch on mobile via `truncate max-w-[24ch]`.
+
+### 6.6 Skip-to-main link (all surfaces)
 
 ```html
 <a
@@ -194,240 +503,307 @@ First element in `<body>`, before `<header>`. `<main id="main">` is the target.
 
 ---
 
-## 5. Mobile ↔ desktop transforms
+## 7. Mobile ↔ desktop transforms
 
-**Single breakpoint for chrome:** `md:` (768px). Content layouts may use `sm:` / `lg:` / `xl:`; **chrome never does, with one named exception (right-rail sticky).**
+Single chrome breakpoint: `md:` (768px). Content layouts may use `sm:` / `lg:` / `xl:`. Chrome never does, with one named exception (right-rail sticky).
 
-### Transforms per chrome piece
+### 7.1 Per chrome piece
 
-| Chrome                                 | Mobile (<768)                                                         | Desktop (≥768)                                |
-| -------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------- |
-| Header height                          | `h-14` (56px) on `<header>`                                           | `md:h-16` (64px) on `<header>`                |
-| Header padding x                       | `px-4` on inner div                                                   | `md:px-6` on inner div                        |
-| Header max-width                       | full bleed (no wrapper constraint below md)                           | `md:max-w-5xl md:mx-auto` on inner div        |
-| Back affordance                        | in-flow, left of content, inside `<main>`                             | same                                          |
-| Admin nav tabs (Appendix D)            | `hidden`, collapsed into user menu                                    | `md:flex`, inline                             |
-| Admin user menu trigger (Appendix D)   | icon button, right of header                                          | `md:hidden` (email + Sign out visible inline) |
-| ActionCard (portal detail, Appendix C) | **above** `<main>` content                                            | inside right rail                             |
-| Right rail (portal detail, dashboard)  | stacks below (collapsed)                                              | `md:` (see below)                             |
-| Breadcrumbs                            | segment truncation at 24ch                                            | full labels                                   |
-| Safe-area bottom                       | `pb-[max(1rem,env(safe-area-inset-bottom))]` on `<main>` or container | n/a                                           |
+| Chrome                     | Mobile (<768)                                | Desktop (≥768)            |
+| -------------------------- | -------------------------------------------- | ------------------------- |
+| Header height              | `h-14` (56px)                                | `md:h-16` (64px)          |
+| Header padding x           | `px-4` (inner div)                           | `md:px-6`                 |
+| Header max-width           | full bleed                                   | `md:max-w-5xl md:mx-auto` |
+| Back affordance            | in-flow inside `<main>`                      | same                      |
+| Section cards grid         | 1 column                                     | `md:grid-cols-2`          |
+| Admin nav tabs             | `hidden`, collapsed into menu                | `md:flex`, inline         |
+| Admin user menu trigger    | icon button                                  | `md:hidden`               |
+| ActionCard (portal detail) | above `<main>` content                       | in right rail             |
+| Right rail (portal)        | stacks below                                 | `md:` (see 7.2)           |
+| Breadcrumbs                | truncation at 24ch                           | full labels               |
+| Safe-area bottom           | `pb-[max(1rem,env(safe-area-inset-bottom))]` | n/a                       |
 
-### Right-rail stickiness (named exception)
+### 7.2 Right-rail stickiness (named exception)
 
-The right rail is the **only** chrome piece that may use `lg:` classes. Live shipped portal code uses `md:` for the rail, and the spec ratifies this after reviewing the evidence:
-
-- Permitted class pattern on `<aside>` elements inside `<main>`: `md:w-[340px] md:sticky md:top-20 md:self-start`
-- Forbidden on all other chrome elements: `sm:`, `lg:`, `xl:` classes anywhere in `<header>`, `<footer>`, nav elements, or back affordances.
-
-Rail top offset is `md:top-20` (80px), which clears the 64px sticky header + 16px buffer. If header height changes, rail offset must update in lockstep.
-
----
-
-## 6. State conventions
-
-Pulled from `src/styles/global.css`. Hex values authoritative.
-
-| State                        | Hex                         | CSS var                  | Tailwind name (equivalent) |
-| ---------------------------- | --------------------------- | ------------------------ | -------------------------- |
-| Primary / active link        | `#1e40af`                   | `--color-primary`        | `blue-800`                 |
-| Primary hover                | `#1e3a8a`                   | `--color-primary-hover`  | `blue-900`                 |
-| Default text                 | `#475569`                   | `--color-text-secondary` | `slate-600`                |
-| Bold text / hover on default | `#0f172a`                   | `--color-text-primary`   | `slate-900`                |
-| Disabled text                | `#94a3b8`                   | `--color-text-muted`     | `slate-400`                |
-| Border                       | `#e2e8f0`                   | `--color-border`         | `slate-200`                |
-| Focus ring                   | `#3b82f6` @ 2px, 2px offset | `--color-action`         | `blue-500`                 |
-| Error                        | `#ef4444`                   | `--color-error`          | `red-500`                  |
-| Success / paid               | `#10b981`                   | `--color-complete`       | `emerald-500`              |
-| Attention                    | `#f59e0b`                   | `--color-attention`      | `amber-500`                |
-| Meta (timeline dates)        | `#6366f1`                   | `--color-meta`           | `indigo-500`               |
-
-### Touch-state parity (critical for mobile)
-
-Every `hover:` utility on an interactive element MUST be paired with a matching `focus-visible:` utility (keyboard users) AND an `active:` utility (pressed state on touch). Without `active:`, touch devices exhibit "stuck hover" — a tapped element stays in hover state until another element is tapped.
-
-**Canonical interactive-element class pattern:**
+Right rail is the ONE chrome piece permitted to use `md:` stickiness classes on `<aside>`:
 
 ```
-text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2
+md:w-[340px] md:sticky md:top-20 md:self-start
 ```
 
-Apply this pattern to every chrome link, button, and CTA.
-
-### Tap target enforcement
-
-Tap target minimum: 44×44px. Every interactive chrome element declares an explicit `min-h-11 min-w-11` (or `w-11 h-11` for icon-only, or `min-h-11` + negative horizontal margins when the ink is text). This is load-bearing; do not omit.
-
-### aria-current
-
-Active nav item carries `aria-current="page"` and the active hex. The validator checks for this on any rendered nav.
+`md:top-20` (80px) clears 64px sticky header + 16px buffer. If header height changes, rail offset must update in lockstep.
 
 ---
 
-## 7. Transition contracts
+## 8. State conventions
 
-### Back-target resolution
+From `src/styles/global.css`.
 
-All back buttons and cancel buttons resolve to a **hardcoded canonical URL string**. Never `#`, `javascript:`, or `history.back()`. Token-auth leaves (which have no parent) have **no back button** at all.
+| State            | Hex                         | CSS var                  | Tailwind      |
+| ---------------- | --------------------------- | ------------------------ | ------------- |
+| Primary / active | `#1e40af`                   | `--color-primary`        | `blue-800`    |
+| Primary hover    | `#1e3a8a`                   | `--color-primary-hover`  | `blue-900`    |
+| Default text     | `#475569`                   | `--color-text-secondary` | `slate-600`   |
+| Bold text        | `#0f172a`                   | `--color-text-primary`   | `slate-900`   |
+| Disabled         | `#94a3b8`                   | `--color-text-muted`     | `slate-400`   |
+| Border           | `#e2e8f0`                   | `--color-border`         | `slate-200`   |
+| Focus ring       | `#3b82f6` @ 2px, 2px offset | `--color-action`         | `blue-500`    |
+| Error            | `#ef4444`                   | `--color-error`          | `red-500`     |
+| Success / paid   | `#10b981`                   | `--color-complete`       | `emerald-500` |
+| Attention        | `#f59e0b`                   | `--color-attention`      | `amber-500`   |
+| Meta (timeline)  | `#6366f1`                   | `--color-meta`           | `indigo-500`  |
 
-### Canonical parents (authoritative; every shipped dynamic route enumerated)
+### 8.1 Touch-state parity (critical for mobile)
 
-| From                                    | Back target            | Label                                              |
-| --------------------------------------- | ---------------------- | -------------------------------------------------- |
-| `/portal/invoices/[id]`                 | `/portal/invoices`     | "All invoices"                                     |
-| `/portal/quotes/[id]`                   | `/portal/quotes`       | "All quotes"                                       |
-| `/portal/engagement`                    | `/portal`              | "Home"                                             |
-| `/portal/documents/[id]` (future)       | `/portal/documents`    | "All documents"                                    |
-| `/admin/entities/[id]`                  | `/admin/entities`      | "All clients"                                      |
-| `/admin/entities/[id]/quotes/[quoteId]` | `/admin/entities/[id]` | "<Client name>"                                    |
-| `/admin/engagements/[id]`               | `/admin/entities/[id]` | "<Client name>" (engagement is scoped to a client) |
-| `/admin/assessments/[id]`               | `/admin/entities/[id]` | "<Client name>" (same pattern)                     |
-| `/admin/settings/google-connect`        | `/admin`               | "Dashboard"                                        |
-| `/admin/follow-ups`                     | `/admin`               | "Dashboard"                                        |
-| `/admin/analytics`                      | `/admin`               | "Dashboard"                                        |
-| `/contact` submit/cancel                | `/`                    | "Home"                                             |
-| `/book` cancel                          | `/`                    | "Home"                                             |
-| `/get-started`                          | `/`                    | "Home"                                             |
-| `/scorecard`                            | `/`                    | "Home"                                             |
+Every `hover:` MUST pair with `focus-visible:` AND `active:`. Without `active:`, touch devices exhibit "stuck hover."
 
-No fallback row. Every new dynamic route must add a row during spec revision.
+Canonical interactive pattern:
 
-### Modal / drawer close
+```
+text-[#475569] hover:text-[#0f172a] active:text-[#0f172a]
+focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2
+```
 
-Esc closes. Click-outside (scrim) closes. X button closes. Focus returns to the triggering element.
+Apply to every chrome link, button, and CTA.
 
-### Cross-auth-boundary transitions (full enumeration)
+### 8.2 Tap target enforcement
 
-| From                | To                            | Mechanism                                                                 | Clears cookie?                 |
-| ------------------- | ----------------------------- | ------------------------------------------------------------------------- | ------------------------------ |
-| public              | auth-gate (`/auth/*`)         | `<a href="smd.services/auth/...">` (same origin)                          | no                             |
-| auth-gate           | session-auth-client           | 302 to `portal.smd.services/portal` + Set-Cookie                          | sets `__Host-portal_session`   |
-| auth-gate           | session-auth-admin            | 302 to `admin.smd.services/admin` + Set-Cookie                            | sets `__Host-admin_session`    |
-| session-auth-client | auth-gate (logout)            | form POST to `/api/auth/logout` → 302 to `smd.services/auth/portal-login` | clears `__Host-portal_session` |
-| session-auth-admin  | auth-gate (logout)            | form POST to `/api/auth/logout` → 302 to `smd.services/auth/login`        | clears `__Host-admin_session`  |
-| session-auth-\*     | public (marketing link click) | `<a>` with target subdomain origin                                        | no                             |
-| session-auth-admin  | session-auth-client           | not supported; operator must log out and re-login                         | n/a                            |
-| token-auth          | anywhere (via link click)     | `<a>` with explicit origin; token does not follow                         | n/a                            |
+Minimum 44×44px. Every interactive chrome element declares `min-h-11 min-w-11` or `w-11 h-11` (icon-only) or `min-h-11` + negative horizontal margins (text). Load-bearing; do not omit.
 
-All cross-subdomain transitions are **full page loads**; no client-side routing across origins.
+### 8.3 `aria-current`
 
-### Post-login redirects (also table rows above)
-
-- Client magic-link verify success → 302 `portal.smd.services/portal`
-- Admin OAuth success → 302 `admin.smd.services/admin`
-- Any auth-gate failure → 302 back to same auth-gate page with `?error=<code>`
-
-### Cross-subdomain 404
-
-`src/pages/404.astro` is a shared not-found page that renders in all three subdomain contexts. Current implementation has no layout, so it ships chrome-less — which is actually acceptable per the spec's `error` archetype rules (minimal header, back-to-safety link). Target link resolves by subdomain:
-
-- On `smd.services` → `/`
-- On `portal.smd.services` → `/portal`
-- On `admin.smd.services` → `/admin`
-
-Middleware detects host and sets `Astro.locals.homeUrl`; 404 page reads it for the back-to-safety link.
+Active nav item carries `aria-current="page"`. Validator checks on any rendered nav.
 
 ---
 
-## 8. Anti-patterns (forbidden by default)
+## 9. Transition contracts
 
-See `~/.agents/skills/nav-spec/references/anti-patterns.md` for rationale.
+### 9.1 Back-target resolution
 
-| Anti-pattern                                       | Forbidden by default on                            | Exceptions                            |
-| -------------------------------------------------- | -------------------------------------------------- | ------------------------------------- |
-| Global nav tabs in header                          | public, session-auth-client, token-auth, auth-gate | Admin (see Appendix D.2)              |
-| Sidebar / hamburger / drawer as primary nav        | all                                                | none                                  |
-| Bottom-tab nav on mobile                           | all                                                | none                                  |
-| Sticky-bottom action bar on viewport               | all                                                | See escape hatches below              |
-| Footer                                             | auth-gate, session-auth-\*, token-auth             | Public (Appendix A)                   |
-| Marketing CTAs on auth surface                     | session-auth-\*, token-auth, auth-gate             | none                                  |
-| Testimonials / pull quotes                         | all                                                | Public marketing (explicit in prompt) |
-| Hero imagery on auth surface                       | session-auth-\*, token-auth, auth-gate             | Public marketing (explicit)           |
-| Real-face photo placeholders                       | all                                                | none; see consultant-block rule below |
-| Breadcrumbs on non-admin                           | public, auth-gate, session-auth-client, token-auth | Admin only                            |
-| `<nav aria-label="Breadcrumb">` around single link | all                                                | none                                  |
-| `fixed top-0` on header                            | all                                                | none; always `sticky top-0`           |
-| `backdrop-blur-*` / translucent header bg          | session-auth-\*, token-auth, auth-gate             | Public hero bands (explicit)          |
-| Icon before client name in header                  | session-auth-\*, token-auth                        | none                                  |
-| Back `href="#"` / `javascript:` / `history.back()` | all                                                | none                                  |
+All back buttons and cancel buttons resolve to a **hardcoded canonical URL string**. Never `#`, `javascript:`, or `history.back()`. Token-auth leaves have NO back button.
 
-### Sticky-bottom escape hatches (for long forms on mobile)
+### 9.2 Canonical parents (authoritative)
 
-Sticky-bottom action bars that stick to the viewport (`fixed bottom-0`, `sticky bottom-0` with a `fixed` ancestor) are **forbidden**. For long forms or wizards where the primary CTA would fall below the fold on 390×844:
+| From                                    | Back target            | Label           |
+| --------------------------------------- | ---------------------- | --------------- |
+| `/portal/invoices/[id]`                 | `/portal/invoices`     | "All invoices"  |
+| `/portal/quotes/[id]`                   | `/portal/quotes`       | "All proposals" |
+| `/portal/engagement`                    | `/portal`              | "Home"          |
+| `/admin/entities/[id]`                  | `/admin/entities`      | "All clients"   |
+| `/admin/entities/[id]/quotes/[quoteId]` | `/admin/entities/[id]` | "<Client name>" |
+| `/admin/engagements/[id]`               | `/admin/entities/[id]` | "<Client name>" |
+| `/admin/assessments/[id]`               | `/admin/entities/[id]` | "<Client name>" |
+| `/admin/follow-ups`                     | `/admin`               | "Dashboard"     |
+| `/admin/analytics`                      | `/admin`               | "Dashboard"     |
+| `/admin/settings/google-connect`        | `/admin`               | "Dashboard"     |
+| `/contact`, `/book`                     | `/`                    | "Home"          |
+| `/get-started`                          | `/`                    | "Home"          |
+| `/scorecard`                            | `/`                    | "Home"          |
 
-1. **Primary CTA at the natural end of `<main>`** (inside document flow). Preferred.
-2. **Wizard split** — break the form into steps so each step's CTA fits above the fold. Required for forms ≥ 6 fields on mobile.
-3. **Duplicate CTA at top and bottom of `<main>`** (both in document flow). Acceptable for public-facing forms (contact, book) where the form length is outside the designer's control.
-4. **`sticky bottom-0` scoped to a scrollable container inside `<main>`** — permitted only inside `modal` and `drawer` archetypes. Not a header-level escape.
+No fallback row. Every new dynamic route must add a row during revision.
 
-### Consultant block photo placeholder
+### 9.3 Modal / drawer close
 
-Defers to `.stitch/portal-ux-brief.md § Photo placeholder rule`. Current rule: **neutral SVG silhouette**, never initials, never real photos. The spec in Section 4 and `chrome-component-contracts.md` is superseded by the portal-ux-brief on this specific element.
+Esc closes. Click-outside (scrim) closes. X button closes. Focus returns to trigger.
 
----
+### 9.4 Cross-auth-boundary
 
-## 9. Accessibility floor
+| From                | To                  | Mechanism                                         | Cookie?                        |
+| ------------------- | ------------------- | ------------------------------------------------- | ------------------------------ |
+| public              | auth-gate           | `<a>` same origin                                 | —                              |
+| auth-gate           | session-auth-client | 302 + Set-Cookie                                  | sets `__Host-portal_session`   |
+| auth-gate           | session-auth-admin  | 302 + Set-Cookie                                  | sets `__Host-admin_session`    |
+| session-auth-client | auth-gate (logout)  | POST → 302 `/auth/portal-login`                   | clears `__Host-portal_session` |
+| session-auth-admin  | auth-gate (logout)  | POST → 302 `/auth/login`                          | clears `__Host-admin_session`  |
+| session-auth-\*     | public              | `<a>` with target origin                          | —                              |
+| token-auth          | anywhere            | `<a>` with explicit origin; token does not follow | —                              |
 
-- **Landmarks on every page:** `<header role="banner">`, `<main role="main" id="main">`, `<footer role="contentinfo">` (public only).
-- **Skip-to-main link** first in `<body>` (no exceptions; see Section 4).
-- **Keyboard order matches visual order.** No positive `tabindex` values.
-- **Focus rings** on keyboard focus only (`focus-visible:`); no always-on rings.
-- **aria-label** on every icon-only button, link, or control.
-- **`aria-current="page"`** on the active nav item if any nav is rendered.
-- **Tap target** ≥ 44×44px on touch surfaces. Enforce via `min-h-11` or `w-11 h-11`.
-- **Touch-state parity** (Section 6) — `hover:` paired with `focus-visible:` and `active:`.
-- **Safe-area insets (mobile):** pages whose last interactive element is near the bottom apply `pb-[max(1rem,env(safe-area-inset-bottom))]` to `<main>` or the page container. Public footers apply the inset inside `<footer>`.
-- **Contrast:** body text `#475569` on `#ffffff` = 8.6:1, bold `#0f172a` = 19.0:1 (WCAG 2.2 AAA).
-- **No autoplay media, no carousels on auth surfaces.**
+All cross-subdomain transitions are full page loads (no client-side routing across origins).
 
----
+### 9.5 Cross-subdomain 404
 
-## 10. Content rules
+`src/pages/404.astro` renders in all three subdomain contexts. Back-to-safety link resolves by subdomain via middleware-set `Astro.locals.homeUrl`:
 
-- **Nav labels**: sentence case ("Text Scott", "All invoices"). Not Title Case. Not ALL CAPS.
-- **Mobile breadcrumb truncation**: each segment caps at 24ch via `truncate max-w-[24ch]`. Full label on desktop.
-- **Icon + label pairing**: icon-only buttons must have `aria-label`; icon + visible-text buttons must not duplicate the label as `aria-label` (redundant to screen readers).
-- **Status pills**: sentence case ("Paid", "Due Friday"). Colors via state-token table. Never three attention colors in one view (use exactly one attention color per surface).
-- **Date format in chrome**: "Apr 18" (short) in back labels / breadcrumbs; never "04/18" or ISO format.
-- **Contact channel labels**: "Email Scott", "Text Scott", "Call Scott" (sentence case, action verb + name).
+- `smd.services` → `/`
+- `portal.smd.services` → `/portal`
+- `admin.smd.services` → `/admin`
 
 ---
 
-## 11. Refactor checklist (prerequisites for v1 approval)
+## 10. Anti-patterns
 
-Per user decision, v1 of this spec is held until the following retrofits land. All are spec-conformance refactors against shipped code; none change user-visible behavior materially.
+See `~/.agents/skills/nav-spec/references/anti-patterns.md` for rationale and validator cross-refs.
 
-### Blocking (v1 held until complete)
+### 10.1 Chrome anti-patterns (R1–R15)
 
-| #   | File / Scope                                                                 | Change                                                                                                                        | Est. LOC          |
-| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| 1   | New `src/components/SkipToMain.astro`                                        | Create reusable component per Section 4 contract                                                                              | 10                |
-| 2   | Every layout + every page outside a layout                                   | Insert `<SkipToMain />` as first child of `<body>`                                                                            | ~15 insertions    |
-| 3   | Every `<main>` element                                                       | Add `id="main"`                                                                                                               | ~15               |
-| 4   | `src/components/Nav.astro`                                                   | Move `h-16` from inner div to `<header>`; add mobile `h-14`                                                                   | 3                 |
-| 5   | `src/components/portal/PortalHeader.astro`                                   | Replace `py-4` with `h-14 md:h-16` on `<header>`; add `sticky top-0 z-50`                                                     | 3                 |
-| 6   | `src/layouts/AdminLayout.astro`                                              | Replace `py-3` with `h-14 md:h-16` on `<header>`; add `sticky top-0 z-50`; add mobile user-menu transform per D.1-mobile      | ~40               |
-| 7   | `src/pages/portal/invoices/[id].astro`, `src/pages/portal/quotes/[id].astro` | Add back affordance inside `<main>` per canonical-parents table                                                               | ~6 per file = 12  |
-| 8   | `src/layouts/AdminLayout.astro`                                              | Breadcrumb separator: replace text `/` with `<span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>` | 3                 |
-| 9   | `~/.agents/skills/nav-spec/validate.py`                                      | Guard R6b with `surface != "session-auth-admin"`; expand token regex to accept CSS-var, slate-N, and literal hex forms        | 10                |
-| 10  | Portal + Token-auth headers                                                  | Implement three-icon contact control (email/SMS/phone) per Appendix B/C                                                       | ~15 per component |
+| Anti-pattern                                       | Forbidden on                                       | Exceptions                   |
+| -------------------------------------------------- | -------------------------------------------------- | ---------------------------- |
+| Global nav tabs in header                          | public, session-auth-client, token-auth, auth-gate | Admin (Appendix D.2)         |
+| Sidebar / hamburger / drawer primary nav           | all                                                | none                         |
+| Bottom-tab nav on mobile                           | all                                                | none                         |
+| Sticky-bottom action bar on viewport               | all                                                | See 10.3                     |
+| Footer                                             | auth-gate, session-auth-\*, token-auth             | Public (Appendix A)          |
+| Marketing CTAs                                     | session-auth-\*, token-auth, auth-gate             | none                         |
+| Testimonials / pull quotes                         | all                                                | Public marketing (explicit)  |
+| Hero imagery                                       | session-auth-\*, token-auth, auth-gate             | Public (explicit)            |
+| Real-face photo placeholders                       | all                                                | none                         |
+| Breadcrumbs on non-admin                           | public, auth-gate, session-auth-client, token-auth | Admin only                   |
+| `<nav aria-label="Breadcrumb">` around single link | all                                                | none                         |
+| `fixed top-0` on header                            | all                                                | none                         |
+| `backdrop-blur-*` / translucent header             | session-auth-\*, token-auth, auth-gate             | Public hero bands (explicit) |
+| Icon before client name in header                  | session-auth-\*, token-auth                        | none                         |
+| Back `href="#"` / `javascript:` / `history.back()` | all                                                | none                         |
 
-**Total estimated scope:** ~120 LOC across ~10 files.
+### 10.2 IA anti-patterns (R16–R24, new in v2)
 
-### Non-blocking (v2 follow-ups, tracked separately)
+| Anti-pattern                | Validator | Notes                                                                      |
+| --------------------------- | --------- | -------------------------------------------------------------------------- |
+| Orphan destination          | R16       | Route exists in `src/pages/**` but no matrix row → no navigated affordance |
+| Dead-end surface            | R18       | No nav exit; not flagged Terminal                                          |
+| Pattern-impersonation       | R17       | Declared pattern's required elements not rendered                          |
+| Token-auth amnesia          | R19       | Token surface assumes prior session                                        |
+| Taxonomy drift              | R20       | "Quote" rendered when canonical is "Proposal", etc.                        |
+| State omission              | R21       | Surface handles only populated state                                       |
+| Heading hierarchy violation | R22       | Multiple `<h1>`, skipped levels                                            |
+| Search affordance missing   | R23       | Declared search not rendered                                               |
+| Cross-surface context loss  | R24       | Persistent-context pattern broken on a workspace surface                   |
 
-- Right-rail offset update when admin + portal headers become sticky — may require QA visual check of `md:top-20` being correct across all detail pages
-- `<aside>` semantic audit for right-rail elements (ensure `<aside>` not `<div>`)
-- `.stitch/designs/portal-v1/` artifact regeneration under the new spec (optional; existing artifacts are historical)
-- `/privacy` and `/terms` marketing pages — currently linked from Appendix A footer but not shipped; either create minimal pages or remove links from footer
+### 10.3 Sticky-bottom escape hatches
 
-Once all 10 blocking items are merged, bump front matter to `spec-version: 1` (remove `-pending` suffix) and mark approval state as `approved`.
+For long forms where the primary CTA would fall below 390×844 fold:
+
+1. **Primary CTA at natural end of `<main>`** (document flow). Preferred.
+2. **Wizard split** — break form into steps. Required for ≥6 fields on mobile.
+3. **Duplicate CTA top and bottom** (both in document flow). Acceptable for public forms.
+4. **`sticky bottom-0` scoped to scrollable container inside `<main>`** — permitted only in `modal` and `drawer`.
+
+### 10.4 Consultant block photo placeholder
+
+Defers to `.stitch/portal-ux-brief.md § Photo placeholder rule`. Current rule: **neutral SVG silhouette**; never initials, never real photos.
+
+---
+
+## 11. A11y floor
+
+- Landmarks: `<header role="banner">`, `<main role="main" id="main">`, `<footer role="contentinfo">` (public only).
+- Skip-to-main link first in `<body>` (no exceptions).
+- **Heading hierarchy: exactly one `<h1>`; `<h2>` for major sections; no level skipping** (R22).
+- Keyboard order matches visual order. No positive `tabindex`.
+- Focus rings on keyboard focus only (`focus-visible:`); no always-on rings.
+- `aria-label` on every icon-only button, link, or control.
+- `aria-current="page"` on active nav item.
+- Tap targets ≥ 44×44px.
+- Touch-state parity (Section 8.1).
+- Safe-area insets on mobile bottom (Section 7.1).
+- Contrast: body `#475569` on `#ffffff` = 8.6:1; bold `#0f172a` = 19:1 (WCAG 2.2 AAA).
+- No autoplay media, no carousels on auth surfaces.
+
+---
+
+## 12. Content taxonomy
+
+Labels, verbs, statuses, time expressions, and empty-state copy. Validator R20 checks rendered text against canonical terms.
+
+### 12.1 Object names
+
+| Entity          | Canonical label | Forbidden synonyms               |
+| --------------- | --------------- | -------------------------------- |
+| quote           | Proposal        | Quote, Estimate, Bid, SOW        |
+| invoice         | Invoice         | Bill, Statement                  |
+| engagement      | Engagement      | Project, Contract, Job           |
+| milestone       | Milestone       | Phase, Stage, Task, Checkpoint   |
+| entity (client) | Client          | Customer, Account                |
+| consultant      | Consultant      | Agent, Staff, Advisor, Rep       |
+| document        | Document        | File, Attachment, Artifact       |
+| assessment      | Assessment      | Audit, Evaluation, Review (noun) |
+| follow-up       | Follow-up       | Task, Ticket, Reminder           |
+
+### 12.2 Action verbs
+
+| Action                 | Canonical verb                | Forbidden                |
+| ---------------------- | ----------------------------- | ------------------------ |
+| View proposal detail   | Review                        | Read, Look at, Open      |
+| Sign proposal          | Review & Sign (composite CTA) | Accept, Approve, Execute |
+| Pay invoice            | Pay                           | Settle, Remit, Fund      |
+| Download/view document | View (PDF) / Download (other) | Get, Fetch, Save         |
+| Contact consultant     | Contact                       | Reach out, Message       |
+| Book a call            | Book a Call                   | Schedule, Reserve        |
+
+### 12.3 Status labels
+
+| Entity     | DB value   | Label          | Badge color |
+| ---------- | ---------- | -------------- | ----------- |
+| quote      | draft      | Draft          | slate       |
+| quote      | sent       | Pending Review | blue        |
+| quote      | accepted   | Accepted       | emerald     |
+| quote      | declined   | Declined       | red         |
+| quote      | expired    | Expired        | amber       |
+| invoice    | draft      | Draft          | slate       |
+| invoice    | sent       | Sent           | blue        |
+| invoice    | paid       | Paid           | emerald     |
+| invoice    | overdue    | Overdue        | red         |
+| invoice    | void       | Voided         | slate       |
+| engagement | scheduled  | Scheduled      | slate       |
+| engagement | active     | In flight      | blue        |
+| engagement | handoff    | Handoff        | amber       |
+| engagement | safety_net | Safety net     | amber       |
+| engagement | completed  | Completed      | emerald     |
+| engagement | cancelled  | Cancelled      | red         |
+
+### 12.4 Time expressions
+
+| Context                | Format                               | Example                     |
+| ---------------------- | ------------------------------------ | --------------------------- |
+| List items, same year  | `Mon D`                              | Apr 15                      |
+| List items, prior year | `Mon D, YYYY`                        | Apr 15, 2025                |
+| Relative               | `N days ago` / `Yesterday` / `Today` | 3 days ago                  |
+| Expiry countdown       | `Expires in N days` / `Expired`      | Expires in 5 days           |
+| Touchpoint             | `DayName, Mon D at H:MM AM/PM`       | Thursday, Apr 18 at 2:30 PM |
+| ISO (internal)         | `YYYY-MM-DD`                         | 2026-04-15                  |
+
+### 12.5 Numeric formats
+
+| Context                               | Format              | Example     |
+| ------------------------------------- | ------------------- | ----------- |
+| Project price (marketing / proposals) | `$N,NNN` (no cents) | $5,250      |
+| Invoice amount                        | `$N,NNN.CC`         | $2,625.00   |
+| Small counts                          | no units            | 3 proposals |
+
+### 12.6 Empty-state copy
+
+| Surface              | Canonical copy                                                                |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `/portal/quotes`     | No proposals yet. When we send you one, it will appear here.                  |
+| `/portal/invoices`   | No invoices yet. When we issue one, it will appear here.                      |
+| `/portal/documents`  | Documents will appear here as your engagement progresses.                     |
+| `/portal/engagement` | No active engagement. When your engagement begins, progress will appear here. |
+| `/portal` (idle)     | Nothing needs your attention right now.                                       |
+| `/admin/entities`    | No clients yet.                                                               |
+| `/admin/follow-ups`  | No follow-ups due.                                                            |
+
+### 12.7 Error-state copy
+
+| Context                        | Canonical copy                                      |
+| ------------------------------ | --------------------------------------------------- |
+| Portal dashboard fetch failure | "Something went wrong loading your portal." + Retry |
+| 404 on portal                  | "This page doesn't exist. Go to the portal home."   |
+| 401 on portal                  | "Your session expired. Please sign in again."       |
+| Admin DB error                 | "Something went wrong loading <section>." + Retry   |
+
+### 12.8 Content rules (carried from v1 §10)
+
+- Nav labels: sentence case ("Text Scott", "All invoices"). Not Title Case. Not ALL CAPS.
+- Breadcrumb mobile truncation: 24ch per segment via `truncate max-w-[24ch]`.
+- Icon-only buttons: `aria-label` required. Icon + visible text: do not duplicate as `aria-label` (redundant to screen readers).
+- Status pills: sentence case. Colors per 12.3. Never three attention colors in one view.
+- Date format in chrome: "Apr 18" short, never "04/18" or ISO.
+- Contact channel labels: "Email Scott", "Text Scott", "Call Scott" (sentence case, action verb + name).
 
 ---
 
 # Appendix A — `public` (marketing)
 
-Base URL: `smd.services`. Visitor is a stranger or first-time prospect; goal is clear communication of offering.
+Base URL: `smd.services`. Visitor is a stranger or first-time prospect.
 
 ## A.1 Chrome allowed
 
@@ -457,9 +833,9 @@ Base URL: `smd.services`. Visitor is a stranger or first-time prospect; goal is 
 </header>
 ```
 
-**Delta vs default header:** logo wordmark (only surface class where a logo appears) + one text link + one CTA button.
+**Delta:** logo wordmark (only surface class with a logo) + one text link + one CTA button.
 
-### Footer (public only)
+### Footer
 
 ```html
 <footer role="contentinfo" class="bg-white border-t border-[#e2e8f0] mt-16">
@@ -478,38 +854,30 @@ Base URL: `smd.services`. Visitor is a stranger or first-time prospect; goal is 
 </footer>
 ```
 
-**`/privacy` and `/terms` are not shipped as of v1.** Footer omits them until pages exist. Re-add when ready (tracked in non-blocking follow-ups).
-
 ### Hero imagery
 
-Allowed on `/`, `/get-started`, `/scorecard` — must be explicitly specified in the page prompt. Stock headshots forbidden (validator R9).
+Allowed on `/`, `/get-started`, `/scorecard` — must be explicitly specified in the page prompt. Stock headshots forbidden (R9).
 
-## A.2 Chrome forbidden on public
+## A.2 Chrome forbidden
 
-Universal anti-patterns from Section 8, plus:
-
-- Sidebar / hamburger / drawer as primary nav
-- Bottom-tab nav
-- Sticky-bottom action bar (the header CTA is sufficient for marketing)
-- Testimonials on non-`/` pages
-- `backdrop-blur-*` / translucent header bg (marketing can use solid hero bands; header is always solid white)
+Universal anti-patterns, plus: sidebar / hamburger, bottom-tab nav, sticky-bottom action bar, testimonials on non-`/` pages, `backdrop-blur-*` on header.
 
 ## A.3 Archetype-specific notes
 
-- `dashboard` = the marketing home `/`. The public landing.
-- `form` = `/contact`, `/book`. Cancel returns to `/`.
-- `wizard` = `/scorecard`, `/get-started`. Multi-step with progress indicator in header band.
-- `error` = `/404` (on `smd.services` context). Back-to-safety returns to `/`.
+- `dashboard` = `/`, `/get-started`. Public landing.
+- `form` = `/contact`, `/book`. Cancel → `/`.
+- `wizard` = `/scorecard`. Multi-step; progress indicator in header band.
+- `error` = `/404`. Back-to-safety → subdomain home (see Section 9.5).
 
 ---
 
 # Appendix B — `token-auth`
 
-Base URL examples: `smd.services/book/manage/[token]`. Future: `portal.smd.services/proposal/[token]`, `portal.smd.services/invoice/[token]`. No account; token encodes identity.
+Base URL examples: `smd.services/book/manage/[token]`. Future: `portal.smd.services/proposal/[token]`, `/invoice/[token]`. No account; token encodes identity.
 
 ## B.1 Chrome allowed
 
-### Header (three-icon contact control, per user rule: "clients know what they want")
+### Header (three-icon contact control)
 
 ```html
 <header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
@@ -530,30 +898,30 @@ Base URL examples: `smd.services/book/manage/[token]`. Future: `portal.smd.servi
 </header>
 ```
 
-**Delta vs default:** no logo; recipient name left; **three contact channels on the right** (email / SMS / phone), each 44×44, each with `aria-label`. Client picks the channel that works for them; every channel works on every device. `<mailto:>`, `<sms:>`, and `<tel:>` handle fallbacks automatically per OS/browser.
+**Delta:** no logo; recipient name left; three contact channels right, each 44×44, each with `aria-label`. Client picks the channel. `<mailto:>`, `<sms:>`, `<tel:>` handle fallbacks per OS/browser.
 
 ### Back affordance
 
-**Absent.** Token-auth pages are leaf surfaces; user arrived from a link.
+**Absent.** Token-auth leaves have no parent destination.
 
-## B.2 Chrome forbidden on token-auth
+## B.2 Chrome forbidden
 
-Universal anti-patterns from Section 8. Additionally:
+Universal anti-patterns. Additionally:
 
-- Links to authenticated surfaces (`/portal`, `/admin`) — user has no session
+- Links to authenticated surfaces (`/portal`, `/admin`) — no session
 - "Sign up" / "Create account" CTAs — not the job of token-auth
 
 ## B.3 Archetype-specific notes
 
 - `detail` — primary; managing a booking, viewing a proposal/invoice
-- `form` — reschedule via token; submit-only (no cancel affordance — user closes tab)
-- `empty`, `error` — the three-icon contact control is the only recovery path
+- `form` — reschedule via token; submit-only
+- `empty`, `error` — three-icon contact control is the only recovery
 
 ---
 
 # Appendix C — `session-auth-client` (portal)
 
-Base URL: `portal.smd.services`. Authenticated client viewing their own records. The working surface this spec's rigor was tuned against.
+Base URL: `portal.smd.services`. Authenticated client.
 
 ## C.1 Chrome allowed
 
@@ -579,11 +947,11 @@ Base URL: `portal.smd.services`. Authenticated client viewing their own records.
 </header>
 ```
 
-Shipped component: `src/components/portal/PortalHeader.astro`. Refactor item #5 in Section 11 aligns shipped component to this contract.
+Shipped component: `src/components/portal/PortalHeader.astro`.
 
 ### Back affordance (detail archetypes)
 
-Default contract from Section 4. Positioned inside `<main>` above content.
+Default contract from Section 6. Inside `<main>` above content.
 
 ### Right rail (detail + dashboard, `md:` and up)
 
@@ -593,41 +961,45 @@ Default contract from Section 4. Positioned inside `<main>` above content.
 </aside>
 ```
 
-Width 340px ratifies live shipped portal code. `md:top-20` (80px) clears the 64px sticky header + 16px buffer.
+`md:top-20` (80px) clears 64px sticky header + 16px buffer.
 
 ### Mobile stack order (detail archetype)
 
-On mobile (<`md:`), the ActionCard moves **above** `<main>` content — the primary CTA must be above the fold. Order: `<header>` → `<main>` → back button → **ActionCard** → main content body → ConsultantBlock → related links.
-
-On desktop (`md:` and up), ActionCard lives in the right rail.
+`<header>` → `<main>` → back button → **ActionCard** → main content body → ConsultantBlock → related links. Primary CTA above the fold on mobile.
 
 ### ConsultantBlock
 
-Shipped component: `src/components/portal/ConsultantBlock.astro`. Photo placeholder treatment is the **SVG silhouette** defined in `.stitch/portal-ux-brief.md § Photo placeholder rule`. The nav-spec defers to the UX brief on this element specifically (do not substitute initials).
+Shipped: `src/components/portal/ConsultantBlock.astro`. Photo placeholder: SVG silhouette per `.stitch/portal-ux-brief.md`.
 
-## C.2 Chrome forbidden on session-auth-client
+### C.1.1 Section card grid requirement (R16)
 
-Universal anti-patterns. Especially:
+Portal home (`/portal`) MUST render section cards to all four sibling list routes: `/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement`. This is the specialization of hub-and-spoke required for this venture. Omission triggers R16 violation.
 
-- **Breadcrumbs** — never; portal is shallow (≤2 levels)
-- **Global nav tabs** — portal is narrow; no tab bar
-- **Sticky-bottom action bar** — primary action is in ActionCard above the fold
-- **Logo in header** — client name identifies context
+Grid: 1 column mobile (`grid-cols-1`), 2 columns desktop (`md:grid-cols-2`). Placement: in the main column, between hero/eyebrow and Recent Activity.
+
+## C.2 Chrome forbidden
+
+Universal anti-patterns. Additionally:
+
+- Breadcrumbs — never
+- Global nav tabs — never (portal is narrow)
+- Sticky-bottom action bar — primary action in ActionCard above the fold
+- Logo in header — client name identifies context
 
 ## C.3 Archetype-specific notes
 
-- `dashboard` = `/portal`. No back. Two-column on `md:`. ActionCard above timeline on mobile.
+- `dashboard` = `/portal`. No back. Section cards + Recent Activity + right rail (desktop).
 - `list` = `/portal/invoices`, `/portal/quotes`, `/portal/documents`. Back → `/portal`. Filter bar below header.
-- `detail` = `/portal/*/[id]`. Back → canonical parent. ActionCard above main on mobile, in right rail on `md:`.
-- `form` — rare on portal; none currently live. Cancel → origin.
+- `detail` = `/portal/*/[id]`, `/portal/engagement`. Back → canonical parent. ActionCard mobile-above / desktop-rail.
+- `form` — rare; none currently live. Cancel → origin.
 - `empty` — inside list views; no CTA (user doesn't create these records).
-- `error` — three-icon contact control is the recovery.
+- `error` — three-icon contact control is recovery.
 
 ---
 
 # Appendix D — `session-auth-admin`
 
-Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA than portal; nav tabs allowed as a ratified exception.
+Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA; nav tabs allowed.
 
 ## D.1 Chrome allowed
 
@@ -641,7 +1013,7 @@ Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA tha
       <span class="text-xs bg-[#f1f5f9] text-[#475569] px-2 py-0.5 rounded">Admin</span>
     </div>
     <div class="flex items-center gap-4">
-      <!-- nav tabs per D.2, rendered hidden md:flex -->
+      <!-- nav tabs per D.2 -->
       <span class="text-sm text-[#94a3b8]" aria-hidden="true">|</span>
       <span class="text-sm text-[#475569]"><operator email></span>
       <form method="POST" action="/api/auth/logout">
@@ -652,7 +1024,7 @@ Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA tha
 </header>
 ```
 
-### Mobile header (<`md:`)
+### Mobile header (<`md:`) — `<details>` dropdown
 
 ```html
 <header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:hidden">
@@ -668,7 +1040,7 @@ Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA tha
       <div class="absolute right-0 top-12 w-64 bg-white border border-[#e2e8f0] rounded-lg shadow-lg p-2 z-50">
         <nav aria-label="Primary" class="flex flex-col">
           <a href="/admin" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Dashboard</a>
-          <a href="/admin/entities" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Entities</a>
+          <a href="/admin/entities" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Clients</a>
           <a href="/admin/follow-ups" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Follow-ups</a>
           <a href="/admin/analytics" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Analytics</a>
         </nav>
@@ -683,7 +1055,7 @@ Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA tha
 </header>
 ```
 
-Below `md:`, tabs + email + Sign out collapse into a `<details>` menu triggered by an icon button. This is a **ratified menu-trigger pattern** (not a general hamburger) — it exists specifically to collapse the admin-only tab bar below `md:`. The pattern is scoped to admin; no other surface class gets a menu trigger.
+Ratified menu-trigger pattern; scoped to admin; no other surface class gets a menu trigger.
 
 ### D.2 Admin nav tabs (ratified exception)
 
@@ -693,46 +1065,43 @@ Below `md:`, tabs + email + Sign out collapse into a `<details>` menu triggered 
      class={`text-sm transition-colors min-h-11 inline-flex items-center px-2 -mx-2 rounded focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 ${active ? "text-[#1e40af] font-medium" : "text-[#475569] hover:text-[#0f172a] active:text-[#0f172a]"}`}>
     Dashboard
   </a>
-  <!-- Entities, Follow-ups, Analytics — same pattern -->
+  <!-- Clients, Follow-ups, Analytics — same pattern -->
 </nav>
 ```
 
-Rationale for exception: admin has 4 top-level sections with distinct IA (Entities, Follow-ups, Analytics, plus Dashboard). Tab bar is clearest IA for a single-operator surface. Cap at 5 tabs; if a 6th appears, revisit via `/nav-spec --revise`.
+Cap at 5 tabs. Current count: 4 (Dashboard, Clients, Follow-ups, Analytics). If a 6th appears, revisit via `/nav-spec --revise`.
 
 ### D.3 Breadcrumbs
 
-Admin is the only surface class rendering breadcrumbs. Live `AdminLayout.astro` ships an optional breadcrumb prop; keep it. Format per `chrome-component-contracts.md` (use `<chevron_right aria-hidden="true">`, not `/` text).
+Admin only. Format: `<nav aria-label="Breadcrumb"><ol>...</ol></nav>` with 2+ items. Separator: `<span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>`.
 
-Depth caps:
-
-- `list`: 2 levels
-- `detail`: 3 levels
+Depth caps: list = 2, detail = 3.
 
 ### D.4 Back vs breadcrumbs
 
-If the page has breadcrumbs, it does **not** also have a back button. If no breadcrumbs (e.g., admin dashboard), no back either — the nav tabs/menu is the navigation.
+If breadcrumbs present → no back button. Admin dashboard: no breadcrumbs, no back (nav tabs ARE the navigation).
 
-## D.5 Chrome forbidden on session-auth-admin
+## D.5 Chrome forbidden
 
-Universal anti-patterns, **except** nav tabs (D.2 exception) and the mobile `<details>` menu (D.1 exception). Additionally:
+Universal anti-patterns, **except** nav tabs (D.2) and mobile `<details>` menu (D.1). Additionally:
 
 - Sidebar (permanent) — no
-- Right rail — no (data-dense; 3-column is cramped)
+- Right rail — no (data-dense; 3-column cramped)
 - Footer — no (authenticated)
-- Marketing CTAs, testimonials, hero imagery — obviously forbidden
+- Marketing CTAs, testimonials, hero imagery — forbidden
 
 ## D.6 Archetype-specific notes
 
-- `dashboard` = `/admin`. Grid of metric cards.
-- `list` = `/admin/entities`, `/admin/follow-ups`. Filter bar. 2-level breadcrumbs acceptable.
-- `detail` = `/admin/*/[id]`. 3-level breadcrumbs. No back button (breadcrumbs carry the affordance).
-- `form` = `/admin/settings/*`, `/admin/*/[id]/edit`. Cancel + Save. 2-level breadcrumbs.
+- `dashboard` = `/admin`, `/admin/analytics`. Grid of metric cards. Nav tabs for primary navigation.
+- `list` = `/admin/entities`, `/admin/follow-ups`. Filter bar; 2-level breadcrumbs.
+- `detail` = `/admin/entities/[id]`, nested quotes/engagements/assessments. 3-level breadcrumbs. Persistent-context pattern (client is the workspace scope).
+- `form` = `/admin/settings/*`. Cancel + Save. 2-level breadcrumbs.
 
 ---
 
 # Appendix E — `auth-gate`
 
-Base URLs: `smd.services/auth/login`, `/auth/verify`, `/auth/portal-login`. Anonymous surface; exists to produce or consume an auth credential. All pages in this class carry `<meta name="robots" content="noindex, nofollow">`.
+Base URLs: `smd.services/auth/login`, `/auth/verify`, `/auth/portal-login`. Anonymous; produces/consumes credential. `<meta name="robots" content="noindex, nofollow">`.
 
 ## E.1 Chrome allowed
 
@@ -746,38 +1115,48 @@ Base URLs: `smd.services/auth/login`, `/auth/verify`, `/auth/portal-login`. Anon
 </header>
 ```
 
-**Delta vs default:** wordmark centered (not linked — no destination is safe from an auth-gate); no Contact, no Book a Call, no nav, no contact icons. Narrower max-width to focus the form.
+**Delta:** wordmark centered (not linked — no safe destination from auth-gate); no Contact/Book a Call/nav/contact icons. Narrower max-width.
 
 ### No footer, no back affordance
 
-Auth-gate has no parent destination and no legal chrome. Post-success redirects happen server-side (Section 7's cross-auth-boundary table).
+Auth-gate has no parent destination and no legal chrome. Post-success redirects are server-side (Section 9.4).
 
 ## E.2 Chrome forbidden
 
 Universal anti-patterns. Additionally:
 
-- Contact link / Book a Call CTA — wrong audience; users are trying to sign in
-- Footer with legal links — if legal is required by an OAuth consent screen, it's rendered by the OAuth provider, not by this surface
+- Contact / Book a Call — wrong audience
+- Footer with legal — if OAuth legal is required, OAuth provider renders it
 - Links to authenticated surfaces — session doesn't exist yet
-- Links to marketing pages — distracting mid-auth
+- Links to marketing — distracting mid-auth
 
 ## E.3 Archetype-specific notes
 
-- `form` — `/auth/login` (admin OAuth), `/auth/portal-login` (client magic-link). Submit-only (no cancel). Errors render inline via `?error=` query param.
-- `transient` — `/auth/verify`. Server-side processing + redirect. Renders a fallback error only if the redirect fails. No header required (server sends a bare HTML document with a `<noscript>` fallback link).
+- `form` — `/auth/login` (admin OAuth), `/auth/portal-login` (client magic-link). Submit-only. Errors via `?error=` query param.
+- `transient` — `/auth/verify`. Server-side processing + redirect. Bare HTML + `<noscript>` fallback.
 
 ## E.4 Post-auth transitions
 
-Enumerated in Section 7 cross-auth-boundary table. Summary:
+See Section 9.4. Summary:
 
 - Admin OAuth success → 302 `admin.smd.services/admin`
 - Client magic-link verify success → 302 `portal.smd.services/portal`
-- Any failure → 302 back to same auth-gate with `?error=<code>`
+- Failure → 302 back to same auth-gate with `?error=<code>`
 
 ---
 
 ## Revision history
 
-| spec-version | Date       | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Approver |
-| ------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| 1            | 2026-04-15 | Initial spec authored via `/nav-spec`. Grounded in Phase 0 compliance run (categorical 93%, strict 87%) and drift audit of shipped code. Approves: admin nav tabs as documented exception (D.2), admin mobile `<details>` menu (D.1-mobile), ratified live portal right-rail `md:` + 340px + `md:top-20`, SVG silhouette for ConsultantBlock (defers to portal-ux-brief), three-icon contact control in portal and token-auth headers (per user: "clients know what they want"). Introduces `auth-gate` surface class (Appendix E) for `/auth/*` pages and `transient` archetype for `/auth/verify`. All 10 Section 11 retrofit items shipped in PR feat/nav-spec-v1; verify pipeline green (1077 tests pass). | Captain  |
+| Version | Date       | Change                                                                                                                                                                                                                                                                                                                                                           |
+| ------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.0     | 2026-04-15 | Initial v1 spec authored (chrome-only). Retrofit shipped in PR #391.                                                                                                                                                                                                                                                                                             |
+| 2.0     | 2026-04-15 | v1→v2 migration: added Sections 1 (Task model), 3 (Reachability matrix), 4 (Pattern selection), 5 (State machine), 12 (Content taxonomy). Renumbered v1 Sections 4–10 → v2 Sections 6–11. Archived v1 Section 11 (refactor checklist — all 10 items shipped in PR #391). Anchored all pattern choices to NN/g / Material 3 / Apple HIG per `pattern-catalog.md`. |
+
+## Non-blocking follow-ups
+
+Tracked for future revisions:
+
+- `/privacy` and `/terms` marketing pages — currently absent; Appendix A footer references were removed in v1 and stay removed
+- Scorecard wizard sticky-bottom nav refactor (Phase 0 semantic compliance improvement)
+- Right-rail `md:top-20` offset QA across admin detail pages (if admin gets a right rail)
+- `.stitch/designs/portal-v1/` artifact regeneration under v2 (optional; artifacts are historical)

--- a/.stitch/ia-audit-2026-04-15.md
+++ b/.stitch/ia-audit-2026-04-15.md
@@ -1,0 +1,166 @@
+# IA Audit Report — ss-console — 2026-04-15
+
+**Spec audited against:** `.stitch/NAVIGATION.md` spec-version=2, skill-version=2.0.0.
+**Code commit:** `3842ee1` (main).
+**Scope:** all surface classes present in `src/pages/**`.
+**Invocation:** `/nav-spec --ia-audit` (first run after v1→v2 migration).
+
+---
+
+## Summary
+
+| Check                                        | Violations | Severity   | Blocks merge? |
+| -------------------------------------------- | ---------- | ---------- | ------------- |
+| A — Orphan destinations (R16)                | 4          | structural | **Yes**       |
+| B — Dead-end surfaces (R18)                  | 0          | —          | —             |
+| C — Matrix completeness for dashboards (R16) | 4          | structural | **Yes**       |
+| D — Detail-to-parent (R5)                    | 0          | —          | —             |
+| E — Pattern conformance (R17)                | 1          | structural | **Yes**       |
+| F — Taxonomy adherence (R20)                 | 0          | —          | —             |
+| G — State handling (R21)                     | 0          | —          | —             |
+| H — Token-auth cold arrival (R19)            | 0          | —          | —             |
+
+**Total structural violations:** 9 (A, C, E overlap — unique issues: 5).
+**Verdict:** **FAIL** (structural violations present).
+
+---
+
+## A. Orphan destinations
+
+Routes that exist in `src/pages/**` but have no `<a href>` from any navigated surface that would expose them.
+
+| Route                | Surface class       | Archetype | Problem                                                                                                                        |
+| -------------------- | ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `/portal/quotes`     | session-auth-client | list      | Not linked from `/portal`. Only reachable via a specific quote shown in Recent Activity (detail → back → list — a contortion). |
+| `/portal/invoices`   | session-auth-client | list      | Same pattern. Only reachable via a specific invoice Recent Activity entry.                                                     |
+| `/portal/documents`  | session-auth-client | list      | Completely orphaned. No entry point from the hub.                                                                              |
+| `/portal/engagement` | session-auth-client | detail    | Completely orphaned.                                                                                                           |
+
+**Evidence:** grep of `src/pages/portal/index.astro`:
+
+```
+✗ href="/portal/quotes" not found
+✗ href="/portal/invoices" not found
+✗ href="/portal/documents" not found
+✗ href="/portal/engagement" not found
+```
+
+**Root cause:** portal home was authored with a hub-and-spoke _intent_ (dashboard + ActionCard + Recent Activity + ConsultantBlock) but the hub-and-spoke _required element_ — section cards linking to every spoke — was never implemented. v1 of the spec did not declare this requirement; v2 does (Appendix C.1.1).
+
+**Fix:** Add a 2×2 section card grid to `/portal`:
+
+| Card      | Icon         | Destination        |
+| --------- | ------------ | ------------------ |
+| Proposals | description  | /portal/quotes     |
+| Invoices  | receipt_long | /portal/invoices   |
+| Documents | folder       | /portal/documents  |
+| Progress  | timeline     | /portal/engagement |
+
+Implementation: `src/pages/portal/index.astro`, insert grid in main column between hero/headline and Recent Activity divider. Each card is a full-click `<a>` with `min-h-[88px]`, `aria-label`, icon + Plus Jakarta Sans bold label + muted caption, rounded-lg border, focus ring per Section 8 state colors.
+
+---
+
+## B. Dead-end surfaces
+
+No dead-ends found. Every surface in `src/pages/**` has at least one navigation exit.
+
+---
+
+## C. Matrix completeness for dashboards
+
+Dashboards declared in spec that don't emit all required `<a href>` per matrix.
+
+| Dashboard | Missing required links (Required=Yes)                                           |
+| --------- | ------------------------------------------------------------------------------- |
+| `/portal` | `/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement` |
+
+This is the same set as Check A, viewed from the dashboard side. Fixing A resolves C.
+
+`/admin` and `/admin/analytics` pass this check (nav tabs render all required destinations via `AdminLayout.astro`).
+
+---
+
+## D. Detail-to-parent
+
+All detail archetypes have correct back affordances with canonical URLs:
+
+- `/portal/invoices/[id]` → `href="/portal/invoices"` with `chevron_left` ✓
+- `/portal/quotes/[id]` → `href="/portal/quotes"` with `chevron_left` ✓
+- `/portal/engagement` → `href="/portal"` with `chevron_left` ✓
+- Admin detail pages use breadcrumbs via `AdminLayout.astro` (allowed per Appendix D.3) ✓
+
+---
+
+## E. Pattern conformance
+
+Surfaces declared with a pattern that fail to implement the pattern's required elements.
+
+| Surface               | Declared pattern                                           | Missing element                                                                                                                                                                                                                     |
+| --------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/portal` (dashboard) | Hub-and-spoke + dominant-action + recent-activity variants | **Entry points to every spoke** — required by hub-and-spoke's required-elements list (pattern-catalog.md §1.1). Currently only the ActionCard (conditional spoke) and Recent Activity (timeline, not entry points) are implemented. |
+
+Same root cause as A/C. The hub-and-spoke pattern requires section cards as the primary affordance; portal home implements the variants (ActionCard, Recent Activity) but not the base required element.
+
+---
+
+## F. Taxonomy adherence
+
+Scanned rendered text across portal surfaces for forbidden synonyms per Section 12.1:
+
+- No occurrences of "Quote" where canonical is "Proposal" in user-visible positions
+- No occurrences of "Bill" where canonical is "Invoice"
+- No occurrences of "Customer" where canonical is "Client"
+
+v1 retrofit (PR #391) standardized labels as part of the shipped-chrome alignment.
+
+**Note:** DB column names (`quote_id`, etc.) are allowed per Section 12 guidance; only user-visible positions are enforced.
+
+---
+
+## G. State handling
+
+Portal surfaces with declared state machine entries (Section 5.1) all render explicit state branches:
+
+- `/portal` — handles empty, error, populated-pending, populated-touchpoint, populated-idle ✓
+- `/portal/quotes/[id]` — handles sent, accepted, declined, expired ✓
+- `/portal/invoices/[id]` — handles sent, overdue, paid, void ✓
+- `/portal/invoices`, `/portal/quotes` — empty state copy matches Section 12.6 ✓
+- `/portal/documents`, `/portal/engagement` — empty state copy matches ✓
+
+---
+
+## H. Token-auth cold arrival
+
+`/book/manage/[token]` does not render "welcome back" copy, does not reference a session cookie, does not render a Sign out button. ✓
+
+No other token-auth routes exist yet (future proposal/invoice tokens will share this rubric).
+
+---
+
+## Remediation plan
+
+Ranked by blast radius (all structural, all blocking):
+
+### PR target — `feat(portal): add section cards to home (fix R16 violations)`
+
+1. **Add section card grid to `/portal`** (resolves A, C, E)
+   - Single file edit: `src/pages/portal/index.astro`
+   - Insert `<section>` with 4 `<a>` cards between hero/headline and Recent Activity divider
+   - Grid: `grid-cols-1 md:grid-cols-2 gap-3`
+   - Each card per Appendix C chrome contract (Section 6.4)
+   - Compute card captions from existing queries:
+     - Proposals: "N proposals" / "1 pending review" when a proposal with status=sent exists
+     - Invoices: "N invoices" / "1 due" when pending invoice exists (else "M paid")
+     - Documents: "N documents" / "View files"
+     - Progress: "X of Y milestones" or "View progress"
+   - Accessibility: `aria-label` on each card with destination + status caption combined
+2. **Update NAVIGATION.md Appendix C.1.1** — mark section card grid as implemented (change "required but not yet rendered" note to "implemented as of PR #X")
+3. **Re-run validator** — confirm all 4 R16 violations resolved
+
+Estimated scope: ~80 LOC in `src/pages/portal/index.astro` + 1 small doc edit.
+
+---
+
+## Next audit date
+
+Recommended: 2 weeks post-remediation to measure drift in any new Stitch output produced in that window. Use `/nav-spec --ia-audit` to re-run.

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -456,6 +456,114 @@ const contextSubtext = consultantFirst
             }
           </div>
 
+          <!--
+            Section cards — hub-and-spoke primary affordance per
+            NAVIGATION.md Appendix C.1.1 (R16). Without these, the four
+            sibling list routes are orphaned and only reachable by
+            backtracking from a detail.
+          -->
+          <nav
+            aria-label="Portal sections"
+            class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-8 md:mb-10"
+          >
+            <a
+              href="/portal/quotes"
+              aria-label="Proposals — review and sign"
+              class="block rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4 min-h-[88px] hover:border-[#cbd5e1] hover:shadow-sm transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            >
+              <div class="flex items-start gap-3">
+                <span
+                  class="material-symbols-outlined text-[color:var(--color-primary)] text-[24px] shrink-0"
+                  aria-hidden="true">description</span
+                >
+                <div class="min-w-0">
+                  <p
+                    class="font-['Plus_Jakarta_Sans'] font-bold text-[15px] leading-[20px] text-[color:var(--color-text-primary)]"
+                  >
+                    Proposals
+                  </p>
+                  <p
+                    class="text-[13px] leading-[18px] text-[color:var(--color-text-secondary)] mt-0.5"
+                  >
+                    Review and sign
+                  </p>
+                </div>
+              </div>
+            </a>
+            <a
+              href="/portal/invoices"
+              aria-label="Invoices — view and pay"
+              class="block rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4 min-h-[88px] hover:border-[#cbd5e1] hover:shadow-sm transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            >
+              <div class="flex items-start gap-3">
+                <span
+                  class="material-symbols-outlined text-[color:var(--color-primary)] text-[24px] shrink-0"
+                  aria-hidden="true">receipt_long</span
+                >
+                <div class="min-w-0">
+                  <p
+                    class="font-['Plus_Jakarta_Sans'] font-bold text-[15px] leading-[20px] text-[color:var(--color-text-primary)]"
+                  >
+                    Invoices
+                  </p>
+                  <p
+                    class="text-[13px] leading-[18px] text-[color:var(--color-text-secondary)] mt-0.5"
+                  >
+                    View and pay
+                  </p>
+                </div>
+              </div>
+            </a>
+            <a
+              href="/portal/documents"
+              aria-label="Documents — engagement files"
+              class="block rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4 min-h-[88px] hover:border-[#cbd5e1] hover:shadow-sm transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            >
+              <div class="flex items-start gap-3">
+                <span
+                  class="material-symbols-outlined text-[color:var(--color-primary)] text-[24px] shrink-0"
+                  aria-hidden="true">folder</span
+                >
+                <div class="min-w-0">
+                  <p
+                    class="font-['Plus_Jakarta_Sans'] font-bold text-[15px] leading-[20px] text-[color:var(--color-text-primary)]"
+                  >
+                    Documents
+                  </p>
+                  <p
+                    class="text-[13px] leading-[18px] text-[color:var(--color-text-secondary)] mt-0.5"
+                  >
+                    Engagement files
+                  </p>
+                </div>
+              </div>
+            </a>
+            <a
+              href="/portal/engagement"
+              aria-label="Progress — milestones and status"
+              class="block rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4 min-h-[88px] hover:border-[#cbd5e1] hover:shadow-sm transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            >
+              <div class="flex items-start gap-3">
+                <span
+                  class="material-symbols-outlined text-[color:var(--color-primary)] text-[24px] shrink-0"
+                  aria-hidden="true">flag</span
+                >
+                <div class="min-w-0">
+                  <p
+                    class="font-['Plus_Jakarta_Sans'] font-bold text-[15px] leading-[20px] text-[color:var(--color-text-primary)]"
+                  >
+                    Progress
+                  </p>
+                  <p
+                    class="text-[13px] leading-[18px] text-[color:var(--color-text-secondary)] mt-0.5"
+                  >
+                    Milestones and status
+                  </p>
+                </div>
+              </div>
+            </a>
+          </nav>
+
           <div
             class="mt-8 md:mt-0 pt-8 md:pt-0 border-t md:border-t-0 border-[color:var(--color-border)]"
           >


### PR DESCRIPTION
## Summary

- Migrates `.stitch/NAVIGATION.md` from v1 (chrome-only) to v2 three-layer spec: IA + Patterns + Chrome, anchored to NN/g / Material 3 / HIG / Dan Brown's 8 IA principles
- Runs IA audit (`.stitch/ia-audit-2026-04-15.md`); catches the 4 R16 orphan-destination violations on `/portal` that v1's reviewers and validator could not detect
- Fixes the violations by adding a 2×2 section card grid to `/portal` linking to `/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement`

## Why

v1 defined navigation as chrome only. Shipped code had consistent sticky headers and back buttons, but the portal home had no way to reach list views except by backtracking from a detail shown in Recent Activity — a gaping IA hole. The v1 skill's three reviewers, 15 validator rules, and adversarial verification all missed it because none checked reachability.

v2 rebuild of the nav-spec skill (shipped separately) adds:

- **IA layer** — task model, sitemap, reachability matrix, state machine, content taxonomy, URL contract
- **Patterns layer** — named patterns from established frameworks, specialized per `{surface × archetype}`
- **Chrome layer** — preserved from v1 with minor format normalization
- **9 new validator rules** (R16–R24) — reachability, pattern conformance, no dead-ends, token-auth cold arrival, taxonomy, state completeness, heading hierarchy, search, cross-surface context

This PR applies v2 to ss-console and proves the skill catches the regression by surfacing R16 violations against the current code. The fix — section cards — is the hub-and-spoke pattern's required element per `pattern-catalog.md §1.1`.

## Scope

- **NAVIGATION.md** — complete rewrite, spec-version bumped 1 → 2, all v1 chrome content preserved and renumbered
- **ia-audit-2026-04-15.md** — first run of `/nav-spec --ia-audit`, captures 4 R16 structural violations + verification that admin breadcrumbs, portal back affordances, taxonomy, and state handling all pass
- **src/pages/portal/index.astro** — adds 4 section card grid per Appendix C.1.1 chrome contract; no other changes

## Test plan

- [x] `npm run verify` passes (0 errors, 0 warnings — expected hints unchanged from main)
- [x] `npm run format:check` passes
- [x] grep confirms all 4 required `/portal/*` hrefs now present on portal home
- [x] Existing portal detail back affordances and admin breadcrumbs unchanged
- [ ] Visual QA on preview: section cards render with correct icons, labels, hover state, focus ring on mobile (390×844) and desktop (≥768px)
- [ ] Accessibility: keyboard-tab order through cards, `aria-label` read correctly, focus visible

## Follow-ups (not blocking)

Tracked in NAVIGATION.md § Non-blocking follow-ups:
- `/privacy` and `/terms` marketing pages (currently absent)
- Scorecard wizard sticky-bottom nav refactor
- Right-rail `md:top-20` QA across admin detail (if admin gets a right rail)
- `.stitch/designs/portal-v1/` artifact regeneration under v2 (historical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)