### PR TITLE
chore(test): add vitest coverage thresholds (#403)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "wrangler pages dev dist",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,5 +19,42 @@ export default defineConfig({
         external: ['@venturecrane/crane-test-harness', /node:/],
       },
     },
+    coverage: {
+      provider: 'v8',
+      // Thresholds are set at the 2026-04-16 baseline (rounded down 1-2 pts)
+      // to act as a regression guardrail, not an aspirational target.
+      // Branches/functions are the meaningful signals; lines/statements are
+      // dragged down by .astro templates which v8 instruments but cannot
+      // exercise in a unit-test environment.
+      //
+      // To raise thresholds: run `npm run test:coverage`, note new numbers,
+      // bump here, and open a PR. Never set a threshold you can't currently
+      // meet.
+      thresholds: {
+        lines: 22,
+        branches: 67,
+        functions: 52,
+        statements: 22,
+      },
+      exclude: [
+        // Test files themselves
+        'tests/**',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        // Astro page templates — v8 instruments them but unit tests cannot
+        // exercise their request/response lifecycle, leading to misleading
+        // zero-coverage numbers.
+        'src/pages/**/*.astro',
+        'src/components/**/*.astro',
+        // Generated and build artifacts
+        '.astro/**',
+        'dist/**',
+        // DB migrations — SQL-only, nothing to instrument
+        'migrations/**',
+        // Config files
+        '*.config.*',
+        '.claude/worktrees/**',
+      ],
+    },
   },
 })


### PR DESCRIPTION
## Summary

- Installs `@vitest/coverage-v8@3.2.4` (matches vitest 3.2.4)
- Adds `coverage` block to `vitest.config.ts` with v8 provider, thresholds, and exclude list
- Adds `npm run test:coverage` script (not wired into `verify` — keep verify fast)

## Baseline numbers (2026-04-16, 1,120 tests / 37 files)

| Metric | Raw baseline | Threshold set |
|---|---|---|
| lines | 22.67% | 22 |
| branches | 67.54% | 67 |
| functions | 52.80% | 52 |
| statements | 22.67% | 22 |

Lines/statements are low because v8 instruments `.astro` templates that unit tests cannot exercise in a non-request context. Branches and functions are the meaningful regression guardrails for the TS lib layer.

## Threshold bump policy

Run `npm run test:coverage`, note the new numbers, round down 1-2 pts, update thresholds in `vitest.config.ts`, open a PR.

## CI follow-up (out of scope here)

Add `npm run test:coverage` as a CI step (separate from `verify`) so threshold failures block PRs. Recommended as a follow-up issue.

Closes #403