### PR TITLE
fix(deps): declare react as explicit dependency (#409)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "ics": "^3.11.0",
+        "react": "^19.2.5",
         "wrangler": "^4.78.0"
       },
       "devDependencies": {
@@ -8106,11 +8107,10 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "ics": "^3.11.0",
+    "react": "^19.2.5",
     "wrangler": "^4.78.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Root cause

`react` was used directly by `src/lib/pdf/scorecard-template.tsx` and `src/lib/pdf/sow-template.tsx` but was only a transitive peer dep of `@formepdf/react` — not declared in `package.json`. Rollup failed to resolve the import locally; CI passed only because `@astrojs/cloudflare` silently externalizes unresolved imports in its build mode.

## Fix

Added `react@^19.2.5` to `dependencies` (not `devDependencies` — the PDF templates run server-side at the CF edge).

## Verification

- `npm run build` now succeeds cleanly
- `npm run verify` passes (1118 tests, 0 failures)
- `tests/build-output.test.ts` passes (3 tests — was already passing pre-fix since `dist/` existed from prior runs, but confirms no regression)

Closes #409