### PR TITLE
fix(portal): render document icons via Material Symbols

### DIFF
--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -137,8 +137,11 @@ function formatDate(iso: string): string {
             {documents.map((doc) => (
               <div class="flex items-center justify-between px-6 py-4">
                 <div class="flex items-center gap-3 min-w-0">
-                  <span class={`text-lg ${doc.isPdf ? 'text-red-500' : 'text-slate-400'}`}>
-                    {doc.isPdf ? '&#128196;' : '&#128462;'}
+                  <span
+                    class={`material-symbols-outlined text-[20px] ${doc.isPdf ? 'text-red-500' : 'text-slate-400'}`}
+                    aria-hidden="true"
+                  >
+                    {doc.isPdf ? 'picture_as_pdf' : 'description'}
                   </span>
                   <div class="min-w-0">
                     <p class="text-sm font-medium text-slate-900 truncate">{doc.name}</p>


### PR DESCRIPTION
## Summary

- Portal Documents page rendered literal `&#128196;` / `&#128462;` text because Astro JSX expressions do not decode HTML entities
- Replaced the emoji entities with Material Symbols icons (`picture_as_pdf` / `description`), matching the convention already used for chevron/logout/arrow_forward on sibling portal pages

## Screenshot context

The bug shows on `portal.smd.services/documents` — the icon column displays the raw string `&#128196;` in red next to "Statement of Work (SOW)".

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 1135 pass, 2 skipped, 0 fail
- [x] `prettier --check` on touched file — clean
- [ ] Manual: load `portal.smd.services/documents` after deploy, confirm PDF/document icons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)