### PR TITLE
fix(portal): allow SOW revision keys under orgs/ prefix

### DIFF
--- a/src/pages/api/portal/documents/[...key].ts
+++ b/src/pages/api/portal/documents/[...key].ts
@@ -66,8 +66,13 @@ export const GET: APIRoute = async ({ locals, params }) => {
     })
   }
 
-  // Path traversal protection: key must start with org prefix
-  if (!key.startsWith(`${session.orgId}/`)) {
+  // Path traversal protection: key must be scoped to this org.
+  // Two conventions exist in R2:
+  //   - Engagement docs:   `{orgId}/engagements/{id}/...`
+  //   - SOW revisions:     `orgs/{orgId}/quotes/{qid}/sow/...` (see getSowRevisionSignedKey)
+  const orgPrefix = `${session.orgId}/`
+  const orgsScopedPrefix = `orgs/${session.orgId}/`
+  if (!key.startsWith(orgPrefix) && !key.startsWith(orgsScopedPrefix)) {
     return new Response(JSON.stringify({ error: 'Forbidden' }), {
       status: 403,
       headers: { 'Content-Type': 'application/json' },
@@ -91,7 +96,11 @@ export const GET: APIRoute = async ({ locals, params }) => {
   const isEngagementDoc = engagementIds.some((id) =>
     key.startsWith(`${session.orgId}/engagements/${id}/`)
   )
-  const isQuoteDoc = quoteIds.some((qid) => key.startsWith(`${session.orgId}/quotes/${qid}/`))
+  const isQuoteDoc = quoteIds.some(
+    (qid) =>
+      key.startsWith(`${session.orgId}/quotes/${qid}/`) ||
+      key.startsWith(`orgs/${session.orgId}/quotes/${qid}/`)
+  )
 
   if (!isEngagementDoc && !isQuoteDoc) {
     return new Response(JSON.stringify({ error: 'Forbidden' }), {

--- a/tests/portal-docs.test.ts
+++ b/tests/portal-docs.test.ts
@@ -127,6 +127,14 @@ describe('portal: document download route', () => {
     expect(code).toContain('listEngagements')
   })
 
+  it('accepts SOW revision keys under the orgs/{orgId}/quotes/ prefix', () => {
+    // SOW revisions are stored at `orgs/{orgId}/quotes/{qid}/sow/...` per
+    // getSowRevisionSignedKey(). The handler must not reject these as off-org.
+    const code = source()
+    expect(code).toContain('orgs/${session.orgId}/')
+    expect(code).toContain('orgs/${session.orgId}/quotes/${qid}/')
+  })
+
   it('streams document from R2', () => {
     expect(source()).toContain('streamDocument')
   })


### PR DESCRIPTION
## Summary

- Portal SOW "View" links 403'd in production because `/api/portal/documents/[...key]` rejected any key not starting with `{orgId}/`. SOW revisions are stored at `orgs/{orgId}/quotes/{quoteId}/sow/...` (per `getSowRevisionSignedKey`).
- Extended the handler's org-prefix allowlist and `isQuoteDoc` check to recognize the `orgs/` convention in addition to the bare `{orgId}/` one used for engagement docs.
- Added a regression test (tests/portal-docs.test.ts).

## Observed bug

Clicking "View" on the Documents tab's SOW row hit:
```
portal.smd.services/api/portal/documents/orgs/01JQFK0000SMDSERVICES000/quotes/e53d9c63-.../sow/.../signed.pdf
```
and returned `{"error":"Forbidden"}`. Post-fix, the same key is accepted when the quote is tied to an engagement the authenticated client owns.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 1136 pass, 2 skipped (+1 new regression test)
- [ ] Manual: click "View" on the SOW row in `portal.smd.services/documents`, confirm PDF streams inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)