### PR TITLE
fix(portal): make document rows clickable to match Proposals pattern

### DIFF
--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -135,7 +135,10 @@ function formatDate(iso: string): string {
         ) : (
           <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
             {documents.map((doc) => (
-              <div class="flex items-center justify-between px-6 py-4">
+              <a
+                href={`/api/portal/documents/${doc.key}`}
+                class="flex items-center justify-between px-6 py-4 hover:bg-slate-50 transition-colors focus-visible:outline-none focus-visible:bg-slate-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--color-action)]"
+              >
                 <div class="flex items-center gap-3 min-w-0">
                   <span
                     class={`material-symbols-outlined text-[20px] ${doc.isPdf ? 'text-red-500' : 'text-slate-400'}`}
@@ -148,13 +151,10 @@ function formatDate(iso: string): string {
                     <p class="text-xs text-slate-400">{formatDate(doc.uploaded)}</p>
                   </div>
                 </div>
-                <a
-                  href={`/api/portal/documents/${doc.key}`}
-                  class="text-sm text-primary hover:text-primary/80 font-medium transition-colors shrink-0 ml-4"
-                >
+                <span class="text-sm text-primary font-medium shrink-0 ml-4">
                   {doc.isPdf ? 'View' : 'Download'}
-                </a>
-              </div>
+                </span>
+              </a>
             ))}
           </div>
         )


### PR DESCRIPTION
## Summary

- Normalize the interaction pattern across portal list pages. Proposals wraps the whole row in an anchor; Documents only made the small "View" text clickable.
- Documents now matches Proposals: the entire row is the link, "View" / "Download" becomes a non-interactive visual affordance. Added hover + focus-visible states.
- Larger tap target, better mobile ergonomics, single interaction model for list rows.

## Out of scope

Invoices list has no detail-link at all (only an external Stripe "Pay Now" for unpaid rows). That's a separate interaction question — not touched here.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test tests/portal-docs.test.ts` — 30 pass
- [ ] Manual: on `portal.smd.services/documents`, click anywhere on the row (not just the "View" text) and confirm the PDF opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)