### PR TITLE
fix(portal): make invoice rows clickable to match Proposals pattern

### DIFF
--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -114,55 +114,64 @@ function formatDate(iso: string | null): string {
           </div>
         ) : (
           <div class="space-y-3">
-            {invoices.map((inv: Invoice) => (
-              <div class="bg-white rounded-lg border border-slate-200 p-4">
-                <div class="flex items-center justify-between">
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-1">
-                      <p class="text-sm font-medium text-slate-900">
-                        {typeLabels[inv.type] ?? inv.type}
-                      </p>
-                      <span
-                        class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusColorMap[inv.status] ?? 'bg-slate-100 text-slate-600'}`}
-                      >
-                        {INVOICE_STATUSES.find((s) => s.value === inv.status)?.label ?? inv.status}
-                      </span>
-                    </div>
-                    <p class="text-lg font-semibold text-slate-900">{formatCurrency(inv.amount)}</p>
-                    <div class="flex items-center gap-3 mt-1 text-xs text-slate-400">
-                      {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
-                      {inv.paid_at && (
-                        <span class="text-green-600">Paid: {formatDate(inv.paid_at)}</span>
-                      )}
-                    </div>
-                    {inv.description && (
-                      <p class="text-sm text-slate-500 mt-2">{inv.description}</p>
-                    )}
-                  </div>
-                  <div class="flex-shrink-0 ml-4">
-                    {/* Pay Now link for unpaid invoices with Stripe URL */}
-                    {inv.status !== 'paid' &&
-                      inv.stripe_hosted_url &&
-                      inv.stripe_hosted_url !== '#dev-mode' && (
-                        <a
-                          href={inv.stripe_hosted_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="inline-block bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
+            {invoices.map((inv: Invoice) => {
+              const isPayable =
+                inv.status !== 'paid' &&
+                inv.stripe_hosted_url &&
+                inv.stripe_hosted_url !== '#dev-mode'
+              const isPending = inv.status !== 'paid' && inv.stripe_hosted_url === '#dev-mode'
+              return (
+                <a
+                  href={`/portal/invoices/${inv.id}`}
+                  class="block bg-white rounded-lg border border-slate-200 p-4 hover:border-slate-300 hover:shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                >
+                  <div class="flex items-center justify-between">
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2 mb-1">
+                        <p class="text-sm font-medium text-slate-900">
+                          {typeLabels[inv.type] ?? inv.type}
+                        </p>
+                        <span
+                          class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusColorMap[inv.status] ?? 'bg-slate-100 text-slate-600'}`}
                         >
-                          Pay Now
-                        </a>
+                          {INVOICE_STATUSES.find((s) => s.value === inv.status)?.label ??
+                            inv.status}
+                        </span>
+                      </div>
+                      <p class="text-lg font-semibold text-slate-900">
+                        {formatCurrency(inv.amount)}
+                      </p>
+                      <div class="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                        {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
+                        {inv.paid_at && (
+                          <span class="text-green-600">Paid: {formatDate(inv.paid_at)}</span>
+                        )}
+                      </div>
+                      {inv.description && (
+                        <p class="text-sm text-slate-500 mt-2">{inv.description}</p>
                       )}
-                    {/* Show dev-mode indicator when Stripe not configured */}
-                    {inv.status !== 'paid' && inv.stripe_hosted_url === '#dev-mode' && (
-                      <span class="inline-block bg-slate-100 text-slate-500 px-3 py-2 rounded-lg text-xs font-medium">
-                        Payment link pending
-                      </span>
-                    )}
+                    </div>
+                    <div class="flex-shrink-0 ml-4">
+                      {isPayable && (
+                        <span class="inline-flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
+                          Pay
+                        </span>
+                      )}
+                      {isPending && (
+                        <span class="inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-500 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
+                          Payment link pending
+                        </span>
+                      )}
+                      {!isPayable && !isPending && (
+                        <span class="inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-600 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
+                          View Details
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </div>
-            ))}
+                </a>
+              )
+            })}
           </div>
         )
       }

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -458,11 +458,20 @@ describe('invoices: portal view', () => {
     expect(source()).toContain('statusColorMap')
   })
 
-  it('provides Pay Now link opening Stripe hosted URL in new tab', () => {
+  it('links each row to the invoice detail page', () => {
     const code = source()
-    expect(code).toContain('Pay Now')
+    expect(code).toContain('/portal/invoices/${inv.id}')
+  })
+
+  it('shows a Pay affordance for unpaid invoices with a usable Stripe URL', () => {
+    const code = source()
+    // The Stripe URL is still considered when choosing what affordance to render.
     expect(code).toContain('stripe_hosted_url')
-    expect(code).toContain('target="_blank"')
+    expect(code).toMatch(/Pay\b/)
+  })
+
+  it('shows a pending-link indicator when Stripe is not yet configured', () => {
+    expect(source()).toContain('Payment link pending')
   })
 
   it('shows paid date for paid invoices', () => {
@@ -473,6 +482,20 @@ describe('invoices: portal view', () => {
 
   it('handles empty state when no invoices exist', () => {
     expect(source()).toContain('No invoices yet')
+  })
+})
+
+describe('invoices: portal detail view', () => {
+  const source = () => readFileSync(resolve('src/pages/portal/invoices/[id].astro'), 'utf-8')
+
+  it('portal invoice detail page exists', () => {
+    expect(existsSync(resolve('src/pages/portal/invoices/[id].astro'))).toBe(true)
+  })
+
+  it('renders the Stripe hosted URL as the pay CTA when usable', () => {
+    const code = source()
+    expect(code).toContain('stripe_hosted_url')
+    expect(code).toContain('payHref')
   })
 })
 


### PR DESCRIPTION
## Summary

Third and final step of unifying portal list-page interactions. Invoices now wraps the whole row in an anchor to `/portal/invoices/{id}`, matching the Proposals pattern already shipped in #413 for Documents.

- Entire row is clickable
- "Pay" / "Payment link pending" / "View Details" rendered as non-interactive visual affordances inside the row anchor (same pattern as Proposals' "Review & Sign" / "View Details")
- Stripe handoff lives on the invoice detail page (already present via `payHref`) — users take one click more to reach Stripe, matching the Proposals flow

## Pattern now unified across all three list pages

| Page | Row → | Primary affordance |
|------|-------|--------------------|
| Proposals | `/portal/quotes/{id}` | "Review & Sign" (sent) / "View Details" |
| Documents | PDF stream endpoint | "View" (PDF) / "Download" (other) |
| Invoices | `/portal/invoices/{id}` | "Pay" (payable) / "Payment link pending" (dev-mode) / "View Details" (paid) |

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 1140 pass, 2 skipped (+4 new tests)
- [ ] Manual: on `portal.smd.services/invoices`, click anywhere on an invoice row, confirm it lands on `/portal/invoices/{id}`; confirm the "Pay" button on the detail page still handles Stripe handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)