### PR TITLE
fix(portal): unify list heading and card pattern across Proposals / Invoices / Documents

### DIFF
--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -133,27 +133,31 @@ function formatDate(iso: string): string {
             <p class="text-slate-600">Documents will appear here as your engagement progresses.</p>
           </div>
         ) : (
-          <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+          <div class="space-y-3">
             {documents.map((doc) => (
               <a
                 href={`/api/portal/documents/${doc.key}`}
-                class="flex items-center justify-between px-6 py-4 hover:bg-slate-50 transition-colors focus-visible:outline-none focus-visible:bg-slate-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--color-action)]"
+                class="block bg-white rounded-lg border border-slate-200 p-4 hover:border-slate-300 hover:shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
               >
-                <div class="flex items-center gap-3 min-w-0">
-                  <span
-                    class={`material-symbols-outlined text-[20px] ${doc.isPdf ? 'text-red-500' : 'text-slate-400'}`}
-                    aria-hidden="true"
-                  >
-                    {doc.isPdf ? 'picture_as_pdf' : 'description'}
-                  </span>
-                  <div class="min-w-0">
-                    <p class="text-sm font-medium text-slate-900 truncate">{doc.name}</p>
-                    <p class="text-xs text-slate-400">{formatDate(doc.uploaded)}</p>
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-3 min-w-0 flex-1">
+                    <span
+                      class={`material-symbols-outlined text-[20px] ${doc.isPdf ? 'text-red-500' : 'text-slate-400'}`}
+                      aria-hidden="true"
+                    >
+                      {doc.isPdf ? 'picture_as_pdf' : 'description'}
+                    </span>
+                    <div class="min-w-0">
+                      <p class="text-sm font-medium text-slate-900 truncate">{doc.name}</p>
+                      <p class="text-xs text-slate-400">{formatDate(doc.uploaded)}</p>
+                    </div>
+                  </div>
+                  <div class="flex-shrink-0 ml-4">
+                    <span class="inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-600 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
+                      {doc.isPdf ? 'View' : 'Download'}
+                    </span>
                   </div>
                 </div>
-                <span class="text-sm text-primary font-medium shrink-0 ml-4">
-                  {doc.isPdf ? 'View' : 'Download'}
-                </span>
               </a>
             ))}
           </div>

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -64,7 +64,7 @@ const statusLabelMap: Record<string, string> = {
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Proposals — Portal — {BRAND_NAME}</title>
+    <title>Proposals — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <SkipToMain />
@@ -91,7 +91,7 @@ const statusLabelMap: Record<string, string> = {
         Home
       </a>
 
-      <h1 class="text-xl sm:text-2xl font-bold text-slate-900 mb-6">Your Proposals</h1>
+      <h1 class="text-xl font-semibold text-slate-900 mb-6">Proposals</h1>
 
       {
         quotes.length === 0 ? (
@@ -115,11 +115,11 @@ const statusLabelMap: Record<string, string> = {
             </p>
           </div>
         ) : (
-          <div class="space-y-4">
+          <div class="space-y-3">
             {quotes.map((quote: Quote) => (
               <a
                 href={`/portal/quotes/${quote.id}`}
-                class="block bg-white rounded-lg border border-slate-200 p-5 sm:p-6 hover:border-slate-300 hover:shadow-sm transition-all"
+                class="block bg-white rounded-lg border border-slate-200 p-4 hover:border-slate-300 hover:shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
               >
                 <div class="flex flex-col sm:flex-row sm:items-center gap-3">
                   <div class="flex-1 min-w-0">
@@ -150,7 +150,7 @@ const statusLabelMap: Record<string, string> = {
 
                   <div class="flex items-center gap-4">
                     <div class="text-right">
-                      <p class="text-lg font-bold text-slate-900">
+                      <p class="text-lg font-semibold text-slate-900">
                         {formatCurrency(quote.total_price)}
                       </p>
                       <p class="text-xs text-slate-400">Engagement price</p>


### PR DESCRIPTION
## Summary

Complete the portal list-page unification. Previously each page diverged on heading weight, spacing, and card treatment — now they all share the same scaffolding.

**Unified scaffolding:**
- H1: `text-xl font-semibold text-slate-900 mb-6`
- Container: `space-y-3`
- Row card: `block bg-white rounded-lg border border-slate-200 p-4 hover:border-slate-300 hover:shadow-sm transition-all focus-visible:…`
- Primary action: a non-interactive button-style span (`inline-flex px-4 py-2.5 min-h-[44px] rounded-lg`) inside the row anchor

**Heading label simplification** — "Your Proposals" → "Proposals", matching Invoices and Documents.

**Per-file changes:**
- Proposals: h1 copy + h1 classes + container + card padding + price weight + `<title>` normalized
- Documents: switched from divide-y single card to per-card, action becomes button-style span
- Invoices: already canonical from #414, no change needed

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 1140 pass, 2 skipped
- [ ] Manual: visit Proposals / Invoices / Documents and confirm h1 sizing, card spacing, and row card treatment are identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)