### PR TITLE
fix(portal): drop 'Your X' framing + drift-prevention test

### DIFF
--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -73,7 +73,7 @@ function formatDate(iso: string | null): string {
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Engagement Progress — {BRAND_NAME}</title>
+    <title>Progress — {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-slate-50">
     <SkipToMain />
@@ -106,7 +106,7 @@ function formatDate(iso: string | null): string {
         Home
       </a>
 
-      <h1 class="text-xl font-semibold text-slate-900 mb-6">Engagement Progress</h1>
+      <h1 class="text-xl font-semibold text-slate-900 mb-6">Progress</h1>
 
       {
         !engagement ? (

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -269,13 +269,11 @@ const touchpointText: string | null = (() => {
   })
 })()
 
-const contextHeadline = activeEngagement
-  ? 'Your engagement is in flight.'
-  : 'Welcome to your portal.'
+const contextHeadline = activeEngagement ? 'Engagement in flight.' : 'Welcome.'
 const contextSubtext = consultantFirst
   ? touchpointText
     ? `Next check-in ${touchpointText} with ${consultantFirst}.`
-    : `${consultantFirst} will reach out to schedule your next check-in.`
+    : `${consultantFirst} will reach out to schedule the next check-in.`
   : null
 ---
 

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -92,7 +92,7 @@ const deliverables: DeliverableRow[] =
         body: item.description ?? '',
       }))
 
-const engagementTitle = deliverables[0]?.title ?? 'Your engagement'
+const engagementTitle = deliverables[0]?.title ?? 'Engagement'
 const engagementSubtitle =
   deliverables.length > 1
     ? `A focused scope across ${deliverables.length} work areas tailored to your operation.`

--- a/tests/portal-list-consistency.test.ts
+++ b/tests/portal-list-consistency.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Regression guard for the unified portal list scaffolding established by
+ * PRs #413–#415. The three list pages — Proposals, Invoices, Documents —
+ * must share the same h1 class, list container spacing, and row-card
+ * treatment so they stay visually consistent as copy/content changes.
+ *
+ * If this test fails, the fix is either to update the other pages to match
+ * or to update this test plus the scaffolding intentionally.
+ */
+
+const CANONICAL_H1_CLASS = 'text-xl font-semibold text-slate-900 mb-6'
+const CANONICAL_LIST_CONTAINER = 'space-y-3'
+const CANONICAL_ROW_CARD =
+  'block bg-white rounded-lg border border-slate-200 p-4 hover:border-slate-300 hover:shadow-sm transition-all'
+
+const PAGES = [
+  { name: 'Proposals', path: 'src/pages/portal/quotes/index.astro' },
+  { name: 'Invoices', path: 'src/pages/portal/invoices/index.astro' },
+  { name: 'Documents', path: 'src/pages/portal/documents/index.astro' },
+] as const
+
+describe('portal list pages: unified scaffolding', () => {
+  for (const page of PAGES) {
+    const source = () => readFileSync(resolve(page.path), 'utf-8')
+
+    describe(page.name, () => {
+      it('uses the canonical h1 class', () => {
+        expect(source()).toContain(CANONICAL_H1_CLASS)
+      })
+
+      it('uses space-y-3 for the list container', () => {
+        expect(source()).toContain(CANONICAL_LIST_CONTAINER)
+      })
+
+      it('uses the canonical row-card anchor class', () => {
+        expect(source()).toContain(CANONICAL_ROW_CARD)
+      })
+
+      it('does not use a "Your X" heading', () => {
+        const code = source()
+        // Only h1 tags are in scope — body copy may still address the user.
+        expect(code).not.toMatch(/<h1[^>]*>\s*Your\s/i)
+      })
+    })
+  }
+})

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -104,8 +104,8 @@ describe('portal quotes: dashboard', () => {
   it('shows active engagement context', () => {
     const code = source()
     expect(code).toContain('activeEngagement')
-    // Guide voice: "Your engagement is in flight." replaces "Current Engagement".
-    expect(code).toMatch(/engagement is in flight/i)
+    // Guide voice: "Engagement in flight." replaces "Current Engagement".
+    expect(code).toMatch(/engagement in flight/i)
   })
 
   it('surfaces completed milestones in the timeline', () => {


### PR DESCRIPTION
## Summary

Closes the remaining loose threads from the portal list-page unification sprint.

**Copy changes (apply the "name the item" rule consistently):**
- `/portal/engagement` h1 "Engagement Progress" → "Progress" (matches tab label; `<title>` normalized)
- Home hero prose: "Your engagement is in flight." → "Engagement in flight."; "Welcome to your portal." → "Welcome."
- Home sub-context: "...schedule your next check-in." → "...schedule the next check-in."
- Quote detail `engagementTitle` fallback: "Your engagement" → "Engagement"

**Drift-prevention test (`tests/portal-list-consistency.test.ts`):**
- Asserts Proposals / Invoices / Documents share the canonical h1 class, list container, and row-card anchor class
- Asserts no list page renders a `<h1>Your X</h1>`

Body copy that addresses the user conversationally ("Documents will appear here as your engagement progresses.", Stripe payment text, etc.) is intentionally untouched — this pass targets labels and status messages.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 1152 pass, 2 skipped (+12 new)
- [ ] Manual: eyeball the hero/heading copy on `/portal`, `/portal/engagement`, and the three list pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)