### PR TITLE
chore(tooling): commit session skill/command definitions and ignore worktrees

### DIFF
--- a/.agents/skills/analytics/SKILL.md
+++ b/.agents/skills/analytics/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: analytics
+description: Site Traffic Report
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /analytics - Site Traffic Report
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "analytics")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
+
+## Usage
+
+```
+/analytics              # Today + 7-day trend
+/analytics 30           # Last 30 days
+/analytics 2026-02-01   # Specific date
+```
+
+## Arguments
+
+Parse the argument:
+
+- If empty, default to **today + 7-day trend**
+- If a number (e.g., `30`), show the **last N days**
+- If a date (e.g., `2026-02-01`), show that **specific date**
+
+## Constants
+
+These do not change:
+
+- **Account ID:** `ab6cc9362f7e51ba9a610aec1fc3a833`
+- **API Token env var:** `CLOUDFLARE_API_TOKEN`
+- **GraphQL endpoint:** `https://api.cloudflare.com/client/v4/graphql`
+- **Analytics type:** Account-level RUM (Web Analytics), NOT zone-level httpRequests
+
+Zone-level analytics (`httpRequests1dGroups`) will fail with a permissions error. Always use account-level `rumPageloadEventsAdaptiveGroups`.
+
+## Pre-flight
+
+Check that `CLOUDFLARE_API_TOKEN` is set:
+
+```bash
+[ -z "$CLOUDFLARE_API_TOKEN" ] && echo "CLOUDFLARE_API_TOKEN not set" && exit 1
+```
+
+If not set, stop: "CLOUDFLARE_API_TOKEN is not in the environment. Launch with `crane vc` to inject secrets."
+
+## Execution
+
+### 1. Daily Trend (broken out by site)
+
+Query `rumPageloadEventsAdaptiveGroups` at the account level for the date range, grouped by `requestHost` and `date`:
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { rumPageloadEventsAdaptiveGroups(limit: 500, filter: { date_geq: \"START_DATE\", date_leq: \"END_DATE\" }, orderBy: [date_ASC]) { count dimensions { date requestHost } } } } }"
+  }'
+```
+
+Replace `START_DATE` and `END_DATE` based on the parsed argument.
+
+Group the results by `requestHost`. Each unique host gets its own trend section. If there is only one host, display it without the grouping header.
+
+### 2. Top Pages, Referrers, Countries (for the most recent date in the range)
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { topPages: rumPageloadEventsAdaptiveGroups(limit: 15, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost requestPath } } topReferrers: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost refererHost } } topCountries: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost countryName } } } } }"
+  }'
+```
+
+Run both queries in parallel (two Bash tool calls in one message).
+
+Group results by `requestHost`. If only one host exists, omit the grouping header.
+
+### 3. Format Output
+
+**Single site** (omit site header when only one host):
+
+```
+== venturecrane.com Traffic ==
+
+Pageloads (7-day trend):
+  Feb 10:    2
+  Feb 11:    9
+  Feb 12:    0
+  Feb 13:    4
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+  16  /articles/agent-context-management-system/
+   9  /portfolio/
+   ...
+
+Referrers (today):
+  99  venturecrane.com (internal)
+  50  (direct)
+   1  bing.com
+
+Countries (today):
+ 145  US
+   2  SG
+   1  PL
+   ...
+```
+
+**Multiple sites** (group by host with clear separation):
+
+```
+== Venture Crane Traffic ==
+
+--- venturecrane.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+   ...
+
+--- kidexpenses.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   12
+  Feb 15:   18
+  Feb 16:    9  <-- today
+
+Top Pages (today):
+   5  /
+   3  /dashboard/
+   ...
+
+--- Totals ---
+
+  Feb 14:   86
+  Feb 15:  248
+  Feb 16:  159  <-- today
+```
+
+Right-align the numbers for scannability. Flag days with zero traffic (missing from API response) as `0`.
+
+When multiple sites exist, include a **Totals** section at the bottom summing all sites.
+
+## Notes
+
+- Read-only query. RUM data from JavaScript beacon (no bot traffic, but includes operator browsing).
+- Days missing from API response = zero pageloads. Fill as `0` in trend output.
+- Data may lag a few hours for current day. If API errors, show raw error message.
+- Account-level query - new sites with the beacon appear automatically.
+- Fleet machines block the beacon via /etc/hosts. Fleet traffic is not collected.

--- a/.agents/skills/build-log/SKILL.md
+++ b/.agents/skills/build-log/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: build-log
+description: Draft a Build Log Entry
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /build-log - Draft a Build Log Entry
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "build-log")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Draft a short operational update (200-1,000 words) about what shipped, broke, or changed. The founder provides a topic and the agent drafts around it.
+
+## Usage
+
+```
+/build-log "Shipped the new webhook classifier and decommissioned the old monolith"
+/build-log --weekly          # synthesize from last 7 days of handoffs/git
+/build-log --weekly --days 14  # custom lookback window
+```
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- If it starts with `--weekly`, enter **weekly mode**. Check for `--days N` to set the lookback window (default: 7 days).
+- Otherwise, treat the entire argument string as the **topic**. Strip surrounding quotes if present.
+- If `$ARGUMENTS` is empty, stop: "Provide a topic: `/build-log \"what happened\"`"
+
+## Pre-flight
+
+1. **Terminology doc**: Verify `~/dev/vc-web/docs/content/terminology.md` exists. If missing, stop: "Terminology doc not found."
+2. **Venture registry**: Verify `~/dev/crane-console/config/ventures.json` exists. If missing, stop: "Venture registry not found."
+3. **Recent logs**: Read up to 3 most recent files in `~/dev/vc-web/src/content/logs/` for voice consistency.
+
+Read the terminology doc and venture registry on demand when drafting (not pre-loaded into prompt).
+
+Build a list of **stealth ventures** - any venture where `portfolio.showInPortfolio` is `false`. These must not appear in the draft by name, code, or description.
+
+---
+
+## Topic Mode (default)
+
+When the founder provides a topic string:
+
+### 1. Gather lightweight context
+
+- Read the most recent handoff via `crane_context` MCP tool for the current venture (if available)
+- The 3 recent logs from pre-flight are sufficient for voice matching
+
+### 2. Draft the entry
+
+Write a 200-1,000 word build log entry following these rules:
+
+**Structure**: Flexible. No mandatory headings. The content dictates the structure. Common patterns from existing logs include "What We Did" / "What Surprised Us" sections, but these are not required. If nothing genuinely surprising happened, do not manufacture a surprise.
+
+**Voice**: First-person plural ("we") by default. Match the tone of recent logs - operational, direct, honest.
+
+**Genericization** (from terminology doc, Published Content section):
+
+- Replace `crane-*` internal names with functional descriptions (crane-context -> "the context API", crane-mcp -> "the MCP server", etc.)
+- Replace venture codes with generic codes (vc -> alpha, ke -> beta, etc.)
+- Replace "venturecrane" org references with omission or "example-org"
+- Replace specific venture counts with "multiple ventures" or "several projects"
+- Exception: "Venture Crane" in prose is fine (it's the company name on the published site)
+- Exception: External tool names are real (Claude Code, D1, Infisical, Tailscale, etc.)
+
+**Venture names** (three-tier system from terminology doc):
+
+- If the topic is about a specific public venture, use the real venture name in prose and tag the log with the venture-name tag (e.g., `kid-expenses`). The real name adds credibility and connects to the portfolio.
+- If the topic is NOT about a specific venture, genericize public venture names as before ("Project Alpha", etc.) or use "another project" / "a different venture".
+
+**Stealth filtering**: Ventures with `showInPortfolio: false` in the registry must not appear at all - not even in genericized form. If the topic involves a stealth venture, draft around it or stop and tell the Captain: "This topic involves a stealth venture. Revise the topic or confirm you want to proceed."
+
+**Style rules** (from terminology doc):
+
+- No em dashes (use hyphens)
+- No marketing language
+- No throat-clearing openers
+- Real numbers, real tool names, real configs
+- Include setbacks or honest limitations when they exist - but only when they actually exist
+
+### 3. Present and save
+
+Display the draft to the Captain. Ask:
+
+```
+Save as draft? (y/n)
+```
+
+If yes:
+
+1. Generate a slug from the title (lowercase, hyphens, no special chars)
+2. Write to `~/dev/vc-web/src/content/logs/YYYY-MM-DD-slug.md` with today's date
+3. Frontmatter: `title`, `date` (today), `tags` (infer 1-3 from content; if the log is about a specific public venture, include the venture-name tag, e.g., `kid-expenses`), `draft: true`
+4. Report: "Saved draft to {path}. Run `/edit-log {path}` before publishing."
+
+---
+
+## Weekly Mode (`--weekly`)
+
+When invoked with `--weekly`:
+
+### 1. Gather signals across all ventures
+
+For each venture in the registry:
+
+**Handoffs** (primary signal):
+
+```bash
+# Query crane-context for recent handoffs per venture
+```
+
+Use the `crane_context` MCP tool if available, or `crane_notes` to search for recent handoff-tagged notes.
+
+**Git activity** (supporting signal):
+
+```bash
+# Commits in the lookback window
+git log --oneline --since="{N} days ago" --all
+
+# Merged PRs
+gh pr list --state merged --json title,mergedAt --jq '.[] | select(.mergedAt >= "'$(date -v-{N}d +%Y-%m-%d)'")'
+
+# Closed issues
+gh issue list --state closed --json title,closedAt --jq '.[] | select(.closedAt >= "'$(date -v-{N}d +%Y-%m-%d)'")'
+```
+
+**VCMS notes** (supplementary):
+Use `crane_notes` to search for recent notes across ventures.
+
+### 2. Weight and filter
+
+- Handoff summaries carry the most weight. They contain narrative context.
+- Git metadata (commit messages, PR titles) is supporting evidence, not primary material. Do not construct narrative from commit messages alone.
+- If a venture has no handoffs in the lookback period, note it contributed no narrative signal. Do not scrape commits for padding.
+
+### 3. Quality gate
+
+Evaluate the gathered material. If it contains **no genuine setback, surprise, or non-trivial decision**, output:
+
+```
+INSUFFICIENT MATERIAL - The last {N} days produced no narrative-worthy signal. Handoff coverage was sparse and commit messages don't carry enough context for a quality log. Try /build-log "topic" with a specific topic instead.
+```
+
+Stop. Do not draft.
+
+### 4. Draft
+
+If the quality gate passes, draft using the same rules as topic mode (genericization, stealth filtering, style rules, 200-1,000 words).
+
+### 5. Present and save
+
+Same as topic mode step 3.
+
+---
+
+## Notes
+
+- **Topic mode is the 80% case.** The founder knows what happened. The bottleneck is drafting, not signal gathering.
+- **Weekly mode is fragile.** It depends on `/eos` handoffs existing. Sparse handoffs plus raw commit messages produce mediocre drafts. The quality gate prevents publishing low-quality filler.
+- **All logs save as `draft: true`.** Publishing requires `/edit-log` review and Captain approval.
+- **Stealth ventures are never exposed.** The registry's `showInPortfolio` field is the source of truth.

--- a/.agents/skills/calendar-sync/SKILL.md
+++ b/.agents/skills/calendar-sync/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: calendar-sync
 description: Calendar Sync
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /calendar-sync - Calendar Sync
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "calendar-sync")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Create actual session events on Google Calendar from D1 session history. Planned events are never modified or deleted — they represent the work plan and coexist with actuals.
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: code-review
 description: Codebase Review
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /code-review - Codebase Review
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "code-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Deep codebase review with multi-model perspectives. Produces a graded scorecard stored in VCMS and a full report committed to the repo.
 
@@ -112,6 +118,8 @@ Review the codebase across all 7 dimensions listed below. For each dimension:
 - Naming conventions (consistent casing, descriptive names)
 - DRY violations (copy-pasted logic, duplicated patterns)
 - Dead code and unused imports
+- **Dead exports** (HIGH priority): For each worker/package src/ directory, grep for `export` declarations and verify each has at least one importer outside its own file. Exports with zero external importers are dead code shipping in the production bundle. Report each as a finding.
+- **Wiring verification**: When new modules or functions exist, verify they are actually called from a reachable execution path (e.g., a route handler, a CLI entry point), not just exported. Code that compiles but is never invoked is dead code regardless of test coverage.
 
 ### 4. Testing
 - Test framework presence and configuration
@@ -125,6 +133,7 @@ Review the codebase across all 7 dimensions listed below. For each dimension:
 - Check for outdated major versions of key packages (typescript, hono, wrangler, eslint, prettier)
 - Identify unused dependencies (declared but not imported)
 - Evaluate dependency count relative to project complexity
+- **Runtime compatibility** (HIGH priority for Workers): Flag any dependency that uses `eval()`, `new Function()`, or dynamic code generation at runtime. These are prohibited in Cloudflare Workers (workerd) and will throw `EvalError` in production even though they compile and pass tests in Node.js. Known offenders: Ajv (schema compilation), Handlebars (template compilation), some JSON Schema validators. Grep node_modules for patterns if uncertain.
 
 ### 6. Documentation
 - CLAUDE.md completeness (commands, build instructions, architecture notes)
@@ -414,10 +423,10 @@ Concrete thresholds per dimension. The grade is determined by the most severe fi
 
 ### Code Quality
 
-- **A:** Strict TypeScript, consistent error handling, clean naming, no DRY violations, no dead code.
-- **B:** 1-2 minor issues (occasional `any` type, one duplicated pattern).
-- **C:** `strict: false` in tsconfig OR 3+ `any` usages OR inconsistent error handling patterns OR notable DRY violations.
-- **D:** Pervasive `any` usage OR swallowed errors OR significant dead code OR no consistent patterns.
+- **A:** Strict TypeScript, consistent error handling, clean naming, no DRY violations, no dead code, all exports have importers.
+- **B:** 1-2 minor issues (occasional `any` type, one duplicated pattern, 1-2 unused exports).
+- **C:** `strict: false` in tsconfig OR 3+ `any` usages OR inconsistent error handling patterns OR notable DRY violations OR 3+ dead exports.
+- **D:** Pervasive `any` usage OR swallowed errors OR entire dead modules (files with zero importers shipping in bundle) OR no consistent patterns.
 - **F:** No TypeScript strictness, errors silently swallowed throughout, fundamentally inconsistent codebase.
 
 ### Testing
@@ -430,10 +439,10 @@ Concrete thresholds per dimension. The grade is determined by the most severe fi
 
 ### Dependencies
 
-- **A:** No audit vulnerabilities, all major versions current (within 1 major), no unused dependencies.
+- **A:** No audit vulnerabilities, all major versions current (within 1 major), no unused dependencies, no runtime-incompatible dependencies.
 - **B:** Low-severity audit findings only OR 1 major version behind on a key dependency.
 - **C:** Medium-severity audit findings OR 2+ major versions behind OR 3+ unused dependencies.
-- **D:** High-severity audit findings OR severely outdated dependencies (3+ major versions behind).
+- **D:** High-severity audit findings OR severely outdated dependencies (3+ major versions behind) OR runtime-incompatible dependency in a Worker (e.g., Ajv in workerd).
 - **F:** Critical audit vulnerabilities OR dependencies with known exploits in use.
 
 ### Documentation

--- a/.agents/skills/content-scan/SKILL.md
+++ b/.agents/skills/content-scan/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: content-scan
+description: Content Candidate Triage
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /content-scan - Content Candidate Triage
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "content-scan")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Read-only triage tool that scans all ventures for publishable content candidates. Produces a ranked list of article candidates, promotion candidates, and build log gaps. Does NOT draft anything - that's `/build-log`'s job.
+
+## Usage
+
+```
+/content-scan              # Default: 7-day lookback
+/content-scan --days 14    # Custom lookback
+/content-scan --save       # Also save results to VCMS
+```
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- If `--days N` is present, set `LOOKBACK_DAYS` to N. Default: 7.
+- If `--save` is present, set `SAVE_TO_VCMS` to true. Default: false.
+- If `$ARGUMENTS` is empty, use defaults (7 days, no save).
+
+---
+
+## Step 1: Pre-flight
+
+### 1a. Environment check
+
+Verify `CRANE_CONTEXT_KEY` is set in the environment. If not, stop: "CRANE_CONTEXT_KEY not set. Launch with `crane vc`."
+
+### 1b. API health check
+
+Ping crane-context health endpoint. If not `200`, stop: "crane-context API unreachable. Cannot run content scan without handoff data." Do not degrade to git-only mode - handoffs are the primary signal.
+
+### 1c. Load venture registry
+
+Read `~/dev/crane-console/config/ventures.json`. Store as `VENTURE_REGISTRY`.
+
+Build a list of **active ventures** - entries with a non-empty `repos` array. Skip ventures with `"repos": []`.
+
+### 1d. Load content index
+
+Scan `~/dev/vc-web/src/content/` for published content:
+
+- **Articles**: Glob `~/dev/vc-web/src/content/articles/*.md`. Read frontmatter (title, date, tags) from each file.
+- **Build logs**: Glob `~/dev/vc-web/src/content/logs/*.md`. Read frontmatter (title, date, tags, draft) from each file. Exclude files where `draft: true`.
+
+Store these as `ARTICLE_INDEX` and `LOG_INDEX`.
+
+For each venture, count published articles where the venture's name or code appears in tags. Store as `ARTICLE_COUNTS` (e.g., `{ ke: 0, dfg: 0, sc: 0, dc: 0, vc: 12 }`).
+
+---
+
+## Step 2: Short-circuit check
+
+Search VCMS for the most recent `content-scan` note:
+
+```
+crane_notes(tag: "content-scan", limit: 1)
+```
+
+If a note exists, extract its `created_at` timestamp as `LAST_SCAN_DATE`.
+
+Query handoffs created since the last scan. Check if any exist (count > 0).
+
+If **zero** ventures have new handoffs since the last scan:
+
+1. Output: "No new signals since last scan ({LAST_SCAN_DATE}). Skipping."
+2. Record cadence: `crane_schedule(action: "complete", name: "content-scan", result: "skipped", summary: "No new handoffs since last scan", completed_by: "crane-mcp")`
+3. Stop.
+
+---
+
+## Step 3: Gather signals per venture
+
+### 3a. Handoffs (primary signal)
+
+Fetch all handoffs within the lookback window. Group by `venture` field. For each venture, store the `summary` and `created_at` from each handoff.
+
+**Note**: Handoffs created from crane-console sessions carry `venture=vc` even when the work targets another venture. Scan each handoff's `summary` text for venture names and codes (dc, ke, sc, dfg) and cross-reference mentions to associate handoffs with the correct venture when the `venture` field doesn't match.
+
+### 3b. Git activity (metadata only)
+
+Iterate each active venture in the registry. For each venture, for each repo in its `repos` array:
+
+```bash
+# Merged PRs in the lookback window
+gh pr list --repo {ORG}/{REPO} --state merged --json number,title,mergedAt \
+  --jq '.[] | select(.mergedAt >= "'$(date -v-{LOOKBACK_DAYS}d +%Y-%m-%d)'")'
+
+# Closed issues in the lookback window
+gh issue list --repo {ORG}/{REPO} --state closed --json number,title,closedAt \
+  --jq '.[] | select(.closedAt >= "'$(date -v-{LOOKBACK_DAYS}d +%Y-%m-%d)'")'
+```
+
+Store PR titles and counts per venture-repo.
+
+**Selective PR body fetching**: For PRs whose titles contain any of these keywords (case-insensitive): `redesign`, `migrate`, `remove`, `replace`, `decision`, `tradeoff`, `rewrite`, `new` - fetch the full PR body:
+
+```bash
+gh pr view {NUMBER} --repo {ORG}/{REPO} --json body --jq '.body'
+```
+
+**Cap at 5 body fetches per repo.** After 5, stop fetching bodies even if more titles match.
+
+### 3c. Record signal counts
+
+For each venture, record:
+
+- Number of handoffs in window
+- Number of merged PRs in window
+- Number of PR bodies fetched
+
+---
+
+## Step 4: Classify candidates
+
+Evaluate gathered signals using bucket-based assessment. Do not assign numeric scores.
+
+### Article candidates
+
+**Gating question**: Does the material have handoff narrative AND a decision or surprise worth generalizing to readers outside Venture Crane?
+
+For each venture with handoffs in the window, assess:
+
+- **High confidence**: Handoff explicitly describes a design decision, tradeoff, architectural choice, or surprising outcome. The topic generalizes beyond the specific venture.
+- **Medium confidence**: Handoff describes substantive work with some narrative depth, but the generalizable angle is less obvious. May need editorial shaping.
+
+Produce a one-line headline and a "Why" rationale for each candidate.
+
+### Promotion candidates (weekly only)
+
+**Skip this section entirely if `LOOKBACK_DAYS` < 7.**
+
+**Gating question**: Does an existing build log read like a draft article worth promoting?
+
+Filter `LOG_INDEX` to logs that are:
+
+- Older than 14 days (published_date + 14 < today)
+- Longer than 400 words (read the file to count)
+
+For qualifying logs, assess:
+
+- **High confidence**: Log has a substantive "What Surprised Us" section (or equivalent narrative depth) AND no existing article covers the same topic for the same venture.
+- **Medium confidence**: Log has some narrative depth but the article angle needs more development.
+
+### Log candidates
+
+**Gating question**: Did something ship (merged PR with handoff narrative) with no matching build log?
+
+For each venture with merged PRs in the window:
+
+- Check if the venture has any build log published within the lookback window (any log in `LOG_INDEX` with a matching venture tag and a date within the window).
+- If the venture has merged PRs AND handoff narrative in the window but NO log published in the window, flag it as a log gap.
+
+### Suppression rules (never surface as candidates)
+
+- Git-only activity with no handoff narrative (PRs exist but no handoffs mention the work)
+- Routine operational work: dependency updates, config tweaks, linting fixes, formatting changes, CI adjustments
+- Topics already covered by a published article with the same venture context (check `ARTICLE_INDEX` for matching venture tags and similar topics)
+
+### Coverage boost
+
+If a venture has zero published articles (`ARTICLE_COUNTS[code] == 0`), boost its candidates one confidence level:
+
+- Medium -> High
+- Candidates that would otherwise be borderline -> Medium
+
+This integrates the gap signal into the ranking. Do not present it as a separate analysis.
+
+---
+
+## Step 5: Display output
+
+Format and display the results:
+
+```
+CONTENT SCAN - {TODAY} - Last {LOOKBACK_DAYS} days
+================================================================================
+
+ARTICLE CANDIDATES
+--------------------------------------------------------------------
+HIGH  {CODE}  {Headline}
+              Why: {rationale}
+              Source: handoff {date}
+              Note: {venture name} has zero published articles (coverage boost)
+
+MED   {CODE}  {Headline}
+              Why: {rationale}
+              Source: handoff {date}
+
+PROMOTION CANDIDATES (weekly)
+--------------------------------------------------------------------
+HIGH  {CODE}  {log-slug} ({date})
+              Why: {word count} words, substantive surprise section, no article on topic
+              Action: draft article via /build-log
+
+LOG CANDIDATES
+--------------------------------------------------------------------
+      {CODE}  {description} - merged PR, handoff exists, no log
+              Source: PR #{number} merged {date}
+
+COVERAGE GAPS (ventures with zero published articles)
+  {comma-separated list of venture names}
+
+SIGNAL HEALTH
+  {code}  handoffs: {N}   git: {N} PRs     {status}
+  ...
+================================================================================
+```
+
+**Status labels for signal health**:
+
+- `OK` - at least 1 handoff exists
+- `low activity` - handoffs exist but sparse (1 handoff, 0 PRs)
+- `no signal` - zero handoffs and zero PRs
+
+**Section omission rules**:
+
+- If there are no article candidates, omit the ARTICLE CANDIDATES section entirely. Do not show an empty section.
+- If there are no promotion candidates (or lookback < 7), omit the PROMOTION CANDIDATES section.
+- If there are no log candidates, omit the LOG CANDIDATES section.
+- If all ventures have at least one article, omit the COVERAGE GAPS line.
+- SIGNAL HEALTH always displays.
+
+If there are zero candidates across all sections, display:
+
+```
+CONTENT SCAN - {TODAY} - Last {LOOKBACK_DAYS} days
+================================================================================
+
+No publishable candidates found.
+
+SIGNAL HEALTH
+  {code}  handoffs: {N}   git: {N} PRs     {status}
+  ...
+================================================================================
+```
+
+---
+
+## Step 6: Save to VCMS
+
+If `SAVE_TO_VCMS` is true (from `--save` flag), save automatically.
+
+If `SAVE_TO_VCMS` is false, ask: "Save results to VCMS? (y/n)"
+
+If saving:
+
+```
+crane_note(
+  action: "create",
+  title: "Content Scan - {TODAY}",
+  content: "{full output text from Step 5}",
+  tags: ["content-scan"],
+  venture: null
+)
+```
+
+The note is global (no venture), tagged `content-scan` so the short-circuit check in Step 2 can find it.
+
+---
+
+## Step 7: Record cadence
+
+After completing the scan, record in the Cadence Engine:
+
+```
+crane_schedule(
+  action: "complete",
+  name: "content-scan",
+  result: "{result}",
+  summary: "{summary}",
+  completed_by: "crane-mcp"
+)
+```
+
+**Result enum**:
+
+- `success` - API healthy, at least one article-grade candidate found (High or Medium)
+- `warning` - API healthy but zero article-grade candidates (only log gaps or no candidates at all), OR partial API failures during signal gathering
+- `skipped` - short-circuited in Step 2 (already recorded there; do not record again)
+
+**Summary examples**:
+
+- "3 article candidates (1 high, 2 med), 1 log gap, 2 promotions"
+- "No article candidates. 1 log gap across 5 ventures"
+- "Partial failure: ke handoffs unreachable. 1 candidate from vc"
+
+---
+
+## Notes
+
+- **This is a triage tool, not a drafting tool.** It identifies what to write about. Use `/build-log` to draft.
+- **Handoffs are the primary signal.** Git activity confirms something shipped but never justifies a candidate alone.
+- **No VCMS queries during signal gathering.** VCMS is only checked in the short-circuit (Step 2) and optionally for borderline disambiguation. This saves 5+ MCP calls per run.
+- **Promotion scanning is weekly.** Gated behind `LOOKBACK_DAYS >= 7`. Logs don't change daily.
+- **Coverage boost is integrated, not separate.** Ventures with zero articles get +1 confidence level on their candidates rather than appearing in a standalone gap analysis.
+- **Fail fast on API failure.** If crane-context is down, stop. Git-only data produces noise, not signal.
+- **Stealth ventures** (where `portfolio.showInPortfolio` is `false`) are skipped automatically because they have repos but should not produce public content candidates. If a stealth venture's work generates a candidate, omit the venture name and flag it: "Candidate from internal venture - discuss with Captain before proceeding."

--- a/.agents/skills/context-refresh/SKILL.md
+++ b/.agents/skills/context-refresh/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: context-refresh
 description: Enterprise Context Refresh
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /context-refresh - Enterprise Context Refresh
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "context-refresh")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Audit and update all enterprise context: D1 docs, VCMS executive summaries, and venture metadata. Produces a refresh report and records cadence completion.
 

--- a/.agents/skills/critique/SKILL.md
+++ b/.agents/skills/critique/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: critique
 description: Plan Critique & Auto-Revision
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /critique - Plan Critique & Auto-Revision
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "critique")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 This command spawns critic subagents to challenge the current plan or approach in conversation, then auto-revises based on the critique.
 

--- a/.agents/skills/design-brief/SKILL.md
+++ b/.agents/skills/design-brief/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: design-brief
 description: Multi-Agent Design Brief Generator
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /design-brief - Multi-Agent Design Brief Generator
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "design-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
 
@@ -375,10 +381,10 @@ After synthesis, extract the core design reference from the brief into a standar
 1. Read the synthesized `docs/design/brief.md`
 2. Extract: color tokens (with hex values), typography (font stacks, scale), spacing system, surface hierarchy, component inventory, and accessibility notes
 3. Write to `docs/design/design-spec.md` in the **current repo** (wherever the skill runs)
-4. If the current repo is `crane-console`, also write to `docs/design/ventures/{venture_code}/design-spec.md`
+4. If the current repo is `crane-console`, also write to `docs/ventures/{venture_code}/design-spec.md`
 5. The design spec format follows the template at `templates/venture/docs/design/design-spec.md` - structured for agent consumption with token tables, not prose
 
-Tell the user: **"Design spec generated at `docs/design/design-spec.md`. Upload to crane-context with: `infisical run --path /vc -- bash scripts/upload-design-specs.sh`"**
+Tell the user: **"Design spec generated at `docs/design/design-spec.md`. Design specs sync to D1 automatically via GitHub Action when merged to main."**
 
 Do not attempt the API upload from within the skill (no credentials available in skill context).
 

--- a/.agents/skills/docs-refresh/SKILL.md
+++ b/.agents/skills/docs-refresh/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: docs-refresh
+description: Enterprise Docs Refresh
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /docs-refresh - Enterprise Docs Refresh
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "docs-refresh")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Review and update enterprise documentation site content at `crane-console.vercel.app`. Identifies stale pages and enriches them with data from existing sources.
+
+## Arguments
+
+```
+/docs-refresh [scope]
+```
+
+- No argument: Audit mode - lists stale pages, does NOT modify files
+- Venture code (`vc`, `dfg`, `sc`, `ke`, `dc`): Update all 3 pages for one venture
+- Page type (`metrics`, `roadmaps`, `overviews`): Update one page type across all ventures
+- Single page (`vc/metrics`, `dfg/roadmap`): Update one page
+
+## Execution
+
+### Step 1: Audit
+
+Read all files in `docs/ventures/*/`, `docs/company/`, `docs/operations/`. Report line count, TBD count, stale flag (>2 TBDs or <20 lines).
+
+**If no scope provided, STOP after audit. Ask Captain which scope to run.**
+
+### Step 2: Gather Data
+
+For pages in scope, pull from:
+
+- **Overviews**: `config/ventures.json` + `docs/ventures/{code}/design-spec.md` + VCMS exec summaries
+- **Metrics**: BVM stage from ventures.json + VCMS strategy/prd notes + stage-appropriate defaults
+- **Roadmaps**: `gh issue list --repo venturecrane/{code}-console` + `crane_handoffs` + SOD data
+
+### Step 3: Draft
+
+Write updated markdown matching existing good pages (DFG/SC overviews as templates). Use real data. Preserve existing substantive content. Target: overviews 40-70 lines, metrics 25-35 lines, roadmaps 25-40 lines.
+
+### Step 4: Approve
+
+Present drafts to Captain. Show before/after line counts and data sources. **Wait for approval.**
+
+### Step 5: PR
+
+Branch `docs/refresh-{scope}-{date}`, write files, verify `cd site && npm run build`, commit, push, `gh pr create`.
+
+## Notes
+
+- Template variables (`{{portfolio:table}}`) are handled by the build script — don't duplicate that data
+- After merge, Vercel auto-rebuilds the site
+- Quality bar: 0 unjustified TBDs, 20+ lines, real data

--- a/.agents/skills/edit-article/SKILL.md
+++ b/.agents/skills/edit-article/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: edit-article
+description: Editorial Review Agent
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /edit-article - Editorial Review Agent
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "edit-article")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+This command runs an article through two parallel editor agents, applies blocking fixes directly, and reports what changed. Advisory issues are reported but not auto-fixed.
+
+## Arguments
+
+```
+/edit-article <path>
+```
+
+- `path` - path to the article markdown file (required)
+
+Parse the argument: if `$ARGUMENTS` is empty, scan `~/dev/vc-web/src/content/articles/` for files with `draft: true` in their YAML frontmatter. List them and ask the user to pick one using AskUserQuestion. If no drafts found, tell the user: "No draft articles found. Provide a path: `/edit-article <path>`"
+
+If `$ARGUMENTS` is provided, use it as the article path.
+
+## Pre-flight
+
+Before spawning agents, do these checks in order:
+
+1. **Terminology doc**: Resolve `~/dev/vc-web/docs/content/terminology.md`. Read it. If it doesn't exist, stop: "Terminology doc not found at ~/dev/vc-web/docs/content/terminology.md. Cannot run editorial review."
+2. **Venture registry**: Read `~/dev/crane-console/config/ventures.json`. If missing, stop: "Venture registry not found."
+3. **Article file**: Read the file at `path`. If it doesn't exist, stop: "Article not found at {path}."
+4. **Display**: Extract the `title` from the article's YAML frontmatter. Display: `Editing: {title}` and proceed immediately. Do NOT ask for confirmation.
+
+Store file paths for agent delegation:
+
+- Terminology doc path: `~/dev/vc-web/docs/content/terminology.md`
+- Venture registry path: `~/dev/crane-console/config/ventures.json`
+
+Store the full content of the article as `ARTICLE_TEXT` (unique per invocation, must be embedded).
+
+Build a list of **stealth ventures** - any venture where `portfolio.showInPortfolio` is `false`.
+
+Extract **venture-name tags** from the article's frontmatter `tags` field. Recognized venture tags: `kid-expenses`, `durgan-field-guide`, `silicon-crane`, `draft-crane`. Store the matched tags as `ARTICLE_VENTURE_TAGS` (or "None" if no venture tags found).
+
+## Editor Agents (2, launched in parallel)
+
+Launch both agents **in a single message** using the Task tool (`subagent_type: general-purpose`, `model: "sonnet"`).
+
+**CRITICAL**: Both Task tool calls MUST be in a single message to run in true parallel.
+
+---
+
+### Agent 1: Style & Compliance Editor
+
+Prompt:
+
+```
+You are the Style & Compliance Editor. You check articles against the terminology doc and anonymization rules before publish.
+
+## Source Documents
+
+Read these files using the Read tool before starting your review:
+- **Terminology Doc (source of truth):** ~/dev/vc-web/docs/content/terminology.md
+- **Venture Registry:** ~/dev/crane-console/config/ventures.json
+
+## Stealth Ventures (must not appear at all)
+
+{list of ventures with showInPortfolio: false, with their names and codes}
+
+## Article Venture Tags
+
+{ARTICLE_VENTURE_TAGS}
+
+## Article Under Review
+
+{ARTICLE_TEXT}
+
+## Instructions
+
+Read the article line by line. Check every line against the rules below. Report findings with exact quoted text and line numbers.
+
+### BLOCKING checks (must fix before publish)
+
+**Genericization violations - always blocking (regardless of tags):**
+- Any `crane-*` pattern EXCEPT "Venture Crane" (e.g., crane-context, crane-mcp, crane-watch, crane-relay are all internal names that must not appear in published articles)
+- Real org names: "venturecrane" in prose (OK in `sources` frontmatter URLs)
+- Real venture codes used as identifiers: vc, ke, sc, dfg, dc (OK in `sources` frontmatter)
+- Specific venture counts: "5 ventures", "six ventures", or any specific number of ventures (these go stale)
+- Legal entity names
+- Stealth venture names or identifiable details (ventures listed as stealth above)
+
+**Venture name genericization - tag-dependent (see Article Venture Tags above):**
+- If the article IS tagged with a venture name (e.g., tags include `kid-expenses`), that venture's proper name ("Kid Expenses") is ALLOWED in prose. Do not flag it.
+- Other public venture names in a tagged article are ADVISORY - report under "### Advisory", suggest genericizing for focus.
+- If the article has NO venture-name tags, ALL public venture names are ADVISORY - report under "### Advisory", suggest genericizing for readability.
+- Stealth ventures are ALWAYS blocking regardless of tags.
+
+**Terminology violations** - per the terminology doc:
+- "product factory" instead of "development lab"
+- "SQLite" alone without "D1" (should be "D1" or "D1/SQLite" on first reference)
+- "secrets manager" alone without naming "Infisical" on first reference
+- Any other violations of the canonical name table in the terminology doc
+
+**Manufactured experience** - flag these patterns, then evaluate context:
+- Patterns: "we discovered", "we learned", "we realized", "we felt", "we believed", "surprised", "it struck us", "it dawned on", "After X years", "In my experience", "Having spent", "I noticed", "I decided", "I wanted"
+- NOT automatic blockers. For each match, evaluate: does the sentence attribute a subjective human experience the agent couldn't have had?
+  - FINE: "We learned from the build logs that usage dropped 40%" (citing evidence)
+  - BLOCKING: "We learned that simplicity matters" (manufacturing wisdom)
+  - FINE: "We discovered the worker was timing out after checking the error logs" (citing debugging)
+  - BLOCKING: "We discovered that less is more" (manufacturing insight)
+
+**Founder-voice fabrication** - any sentence that puts words in the founder's mouth or manufactures a personal anecdote
+
+### ADVISORY checks (should fix)
+
+- Public venture names per the tag-dependent rules above (suggest genericizing for focus where no matching tag exists)
+- Em dashes (should be hyphens)
+- "I" in articles (only "we" or third person per terminology doc)
+- Throat-clearing openers ("In this article, we will...", "Today we're going to...")
+- Marketing language (superlatives, hype, "revolutionary", "game-changing", etc.)
+- Register mismatch (article should be analytical/explanatory, not terse build-log voice)
+
+### Output Format
+
+Start with `## Style & Compliance Editor`
+
+Then:
+
+```
+
+### Blocking (must fix before publish)
+
+1. Line X: "{exact quoted text}" - {rule violated}. Fix: "{exact replacement text}"
+
+### Advisory (should fix)
+
+1. Line X: "{exact quoted text}" - {issue}. Fix: "{exact replacement text}"
+
+### Clean
+
+- {What was checked and passed}
+
+```
+
+If a section has no findings, write "None" under the heading.
+
+CONSTRAINTS:
+- Quote the EXACT text from the article. Do not paraphrase.
+- Include line numbers. Count from line 1 of the raw file (including frontmatter).
+- Every issue MUST include a Fix with the EXACT replacement text that can be used in a find-and-replace operation. The old text and new text must be copy-pasteable.
+- Do NOT write files. Return your report as your final response message.
+```
+
+---
+
+### Agent 2: Fact Checker
+
+Prompt:
+
+```
+You are the Fact Checker. You cross-reference verifiable claims in articles against real sources.
+
+## Article Under Review
+
+{ARTICLE_TEXT}
+
+## Instructions
+
+You have access to tools. Use them to verify claims in the article against real sources. Work through the verification checklist below IN ORDER.
+
+### Verification Checklist
+
+**1. Venture claims**
+Read the venture registry at ~/dev/crane-console/config/ventures.json. Compare to any count, name, or capability claim in the article. Flag mismatches.
+
+**2. Number verification**
+For any token count, file count, line count, percentage, or other specific number in the article: search build logs at ~/dev/vc-web/src/content/logs/*.md for verification. Flag numbers that don't match.
+
+**3. Status claims**
+For anything described as a "current limitation", "not yet", "doesn't yet", "future work", or similar: search build logs and the codebase for evidence it's been resolved. Flag solved problems presented as current limitations.
+
+**4. Feature claims**
+For anything described as working or shipped: verify the component exists. Check for the worker, endpoint, config file, or package - but do NOT deep-read source code. A quick existence check is sufficient.
+
+**5. Cross-article consistency**
+Read other articles at ~/dev/vc-web/src/content/articles/*.md. Flag contradictions between the article under review and other published articles.
+
+### Scope Constraint
+
+Do NOT read arbitrary source code files to verify technical claims. Stick to the checklist above. Use these sources ONLY:
+- ~/dev/crane-console/config/ventures.json (venture registry)
+- ~/dev/vc-web/src/content/logs/*.md (build logs)
+- ~/dev/vc-web/src/content/articles/*.md (other articles)
+- crane_notes MCP tool (enterprise context)
+- crane_status MCP tool (current issue state)
+- Glob/Grep to check if a file, worker, or endpoint EXISTS (not to read implementation)
+
+If a claim cannot be verified from these sources, flag it as "UNVERIFIED - requires manual confirmation" rather than guessing.
+
+### Classification
+
+**BLOCKING (must fix before publish):**
+- Outdated claims: solved problem presented as current limitation
+- Wrong numbers: counts/percentages that don't match build logs
+- Aspirational-as-shipped: features described as working that are designed-but-not-deployed (aspirational content is fine if clearly labeled as future/planned)
+
+**ADVISORY (should fix):**
+- Architecture descriptions that don't match current code structure
+- Cross-article contradictions
+- Claims you couldn't verify (flag as UNVERIFIED)
+
+### Output Format
+
+Start with `## Fact Checker`
+
+Then:
+
+```
+
+### Blocking (must fix before publish)
+
+1. Line X: "{exact quoted text}" - {what's wrong}. Source: {where you checked}. Fix: "{exact replacement text}"
+
+### Advisory (should fix)
+
+1. Line X: "{exact quoted text}" - {issue}. Source: {where you checked}. Fix: "{exact replacement text}"
+
+### Clean
+
+- {What was checked and passed, with source references}
+
+```
+
+If a section has no findings, write "None" under the heading.
+
+CONSTRAINTS:
+- Quote the EXACT text from the article. Do not paraphrase.
+- Include line numbers. Count from line 1 of the raw file (including frontmatter).
+- Every finding MUST cite the source you checked against.
+- Every issue MUST include a Fix with the EXACT replacement text that can be used in a find-and-replace operation. The old text and new text must be copy-pasteable.
+- Do NOT write files. Return your report as your final response message.
+```
+
+---
+
+## Apply Fixes
+
+Wait for both agents to complete. Then:
+
+### Step 1: Apply blocking fixes
+
+Re-read the article file (it may have changed since pre-flight). For each blocking issue from both editors:
+
+1. Use the Edit tool to find the exact quoted text and replace it with the suggested fix
+2. If the quoted text can't be found (line numbers shifted, text was already fixed, etc.), skip it and note it in the report
+3. Deduplicate - if both editors flagged the same text, apply the fix once
+
+### Step 2: Apply advisory fixes
+
+For advisory issues that have clear, mechanical fixes (em dashes, grammar errors, wrong terminology), apply them the same way. Skip advisory issues that require judgment calls or significant rewriting - list those in the report for human review.
+
+### Step 3: Report
+
+After applying fixes, present:
+
+```
+## Editorial Report: {article title}
+
+### Fixed: {count}
+{list of fixes applied, with before/after quotes}
+
+### Requires Human Review: {count}
+{advisory issues that weren't auto-fixed because they need judgment}
+
+### Clean Checks
+{what passed across both editors}
+```
+
+**If nothing was fixed and nothing needs review**: "Editorial review complete. No issues found."
+
+**If fixes were applied**: End with "Applied {N} fix(es). Re-run `/edit-article` to verify." Do NOT automatically re-run - let the user decide.
+
+---
+
+## Notes
+
+- **Auto-fix**: This command fixes blocking issues and mechanical advisory issues directly in the article file.
+- **Human review**: Advisory issues requiring judgment (rewriting sections, tone adjustments, architectural descriptions) are reported but not auto-fixed.
+- **Re-run to verify**: After fixes, run `/edit-article` again to confirm issues are resolved.
+- **Agent type**: Both editor agents use `subagent_type: general-purpose`, `model: "sonnet"` via the Task tool.
+- **Parallelism**: Both agents launch in a single message for true parallel execution.
+- **No rounds**: Single pass. Re-invoke after fixes to verify.
+- **Terminology doc is the source of truth**: The Style & Compliance Editor checks against it. If the terminology doc is wrong, fix it there - not in the article.

--- a/.agents/skills/edit-log/SKILL.md
+++ b/.agents/skills/edit-log/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: edit-log
+description: Build Log Editorial Review
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /edit-log - Build Log Editorial Review
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "edit-log")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Single-agent editorial review for build logs. Checks genericization and style, auto-fixes blocking issues, reports advisory issues for human judgment.
+
+## Arguments
+
+```
+/edit-log <path>
+```
+
+- `path` - path to the build log markdown file (optional)
+
+Parse the argument: if `$ARGUMENTS` is empty, scan `~/dev/vc-web/src/content/logs/` for files with `draft: true` in their YAML frontmatter. List them and ask the user to pick one using AskUserQuestion. If no drafts found, tell the user: "No draft logs found. Provide a path: `/edit-log <path>`"
+
+If `$ARGUMENTS` is provided, use it as the log path.
+
+## Pre-flight
+
+Before spawning the editor agent, do these checks in order:
+
+1. **Terminology doc**: Read `~/dev/vc-web/docs/content/terminology.md`. If missing, stop: "Terminology doc not found at ~/dev/vc-web/docs/content/terminology.md. Cannot run editorial review."
+2. **Venture registry**: Read `~/dev/crane-console/config/ventures.json`. If missing, stop: "Venture registry not found."
+3. **Log file**: Read the file at `path`. If missing, stop: "Log not found at {path}."
+4. **Existing articles**: Glob `~/dev/vc-web/src/content/articles/*.md` and read their titles and slugs (frontmatter only) for the cross-reference check.
+5. **Display**: Extract the `title` from the log's YAML frontmatter. Display: `Editing: {title}` and proceed immediately. Do NOT ask for confirmation.
+
+Store file paths for agent delegation:
+
+- Terminology doc path: `~/dev/vc-web/docs/content/terminology.md`
+- Venture registry path: `~/dev/crane-console/config/ventures.json`
+
+Store the full content of the log as `LOG_TEXT` (unique per invocation, must be embedded).
+Store the article titles/slugs list as `ARTICLE_INDEX`.
+
+Build a list of **stealth ventures** - any venture where `portfolio.showInPortfolio` is `false`.
+
+Extract **venture-name tags** from the log's frontmatter `tags` field. Recognized venture tags: `kid-expenses`, `durgan-field-guide`, `silicon-crane`, `draft-crane`. Store the matched tags as `LOG_VENTURE_TAGS` (or "None" if no venture tags found).
+
+## Editor Agent
+
+Launch one agent using the Task tool (`subagent_type: general-purpose`, `model: "sonnet"`).
+
+### Agent: Style & Genericization Editor
+
+Prompt:
+
+```
+You are the Style & Genericization Editor for build logs. You check logs against the terminology doc, genericization rules, and style guidelines.
+
+## Source Documents
+
+Read these files using the Read tool before starting your review:
+- **Terminology Doc (source of truth):** ~/dev/vc-web/docs/content/terminology.md
+- **Venture Registry:** ~/dev/crane-console/config/ventures.json
+
+## Stealth Ventures (must not appear at all)
+
+{list of ventures with showInPortfolio: false, with their names and codes}
+
+## Article Index (for cross-reference check)
+
+{ARTICLE_INDEX}
+
+## Log Venture Tags
+
+{LOG_VENTURE_TAGS}
+
+## Build Log Under Review
+
+{LOG_TEXT}
+
+## Instructions
+
+Read the log line by line. Check every line against the rules below. Report findings with exact quoted text and line numbers.
+
+### BLOCKING checks (must fix before publish)
+
+**Genericization violations - always blocking (regardless of tags):**
+- Any `crane-*` pattern EXCEPT "Venture Crane" (e.g., crane-context, crane-mcp, crane-watch, crane-relay - these are internal names)
+- Real org names: "venturecrane" in prose (OK in the site URL venturecrane.com when referring to the published site)
+- Venture codes used as identifiers: vc, ke, sc, dfg, dc (two-letter codes in technical context)
+- Specific venture counts: "5 ventures", "six ventures", or any specific number of ventures
+- Legal entity names, App IDs (e.g., "2619905"), installation IDs
+- Internal hostnames (mac23, mac-mini-1, etc.)
+- Infisical paths (/vc, /ke, /sc, /dfg, /dc)
+- Stealth venture names, codes, descriptions, or identifiable details - even in genericized form
+
+**Venture name genericization - tag-dependent (see Log Venture Tags above):**
+- If the log IS tagged with a venture name (e.g., tags include `kid-expenses`), that venture's proper name ("Kid Expenses") is ALLOWED in prose. Do not flag it.
+- Other public venture names in a tagged log are ADVISORY - report under "### Advisory", suggest genericizing for focus.
+- If the log has NO venture-name tags, ALL public venture names are ADVISORY - report under "### Advisory", suggest genericizing for readability.
+- Stealth ventures are ALWAYS blocking regardless of tags.
+
+**Terminology violations** - per the terminology doc canonical names table:
+- "product factory" instead of "development lab"
+- "SQLite" alone without "D1"
+- "secrets manager" alone without naming "Infisical" on first reference
+- Any other violations of the canonical name table
+
+For each blocking issue, provide:
+- The EXACT genericized replacement per the terminology doc's Published Content section
+- crane-context -> "the context API" or "the context worker"
+- crane-mcp -> "the MCP server" or "the local MCP server"
+- crane-watch -> "the webhook watcher" or "the webhook processor"
+- crane-relay -> "the legacy webhook worker" or "the monolithic worker"
+- Venture codes -> Generic codes (alpha, beta, gamma, etc.)
+- venturecrane org -> Omit or "example-org"
+- Specific counts -> "multiple ventures" or "several projects"
+
+### ADVISORY checks (report but don't auto-fix)
+
+- Public venture names per the tag-dependent rules above (not auto-fixed; suggest genericizing for focus)
+- Em dashes (should be hyphens)
+- Article-register voice: flag analytical or explanatory tone that reads like an article rather than an operational log. Build logs should feel like a field report, not an essay.
+- Numbers that might go stale: specific counts, percentages, or metrics that will become wrong over time
+- Article overlap: search the article index for keyword overlap with the log's content. If found, surface: "This log discusses [topic]. An article on this topic exists at [slug]. Verify consistency."
+
+### NOT checked (explicitly out of scope)
+
+- "I" usage (acceptable in build logs per terminology doc)
+- AI disclosure (BR-006 exempts logs)
+- Fact-checking against other logs (avoids circular checking)
+
+### Output Format
+
+Start with `## Style & Genericization Editor`
+
+Then:
+
+### Blocking (must fix before publish)
+
+1. Line X: "{exact quoted text}" - {rule violated}. Fix: "{exact replacement text}"
+
+### Advisory (should review)
+
+1. Line X: "{exact quoted text}" - {issue}. Suggestion: "{suggested change}"
+
+### Clean
+
+- {What was checked and passed}
+
+If a section has no findings, write "None" under the heading.
+
+CONSTRAINTS:
+- Quote the EXACT text from the log. Do not paraphrase.
+- Include line numbers. Count from line 1 of the raw file (including frontmatter).
+- Every blocking issue MUST include a Fix with the EXACT replacement text that can be used in a find-and-replace operation.
+- Advisory issues include a Suggestion (not a Fix) since they need human judgment.
+- Do NOT write files. Return your report as your final response message.
+```
+
+---
+
+## Apply Fixes
+
+Wait for the agent to complete. Then:
+
+### Step 1: Apply blocking fixes
+
+Re-read the log file (it may have changed since pre-flight). For each blocking issue:
+
+1. Use the Edit tool to find the exact quoted text and replace it with the suggested fix
+2. If the quoted text can't be found (text was already fixed, etc.), skip it and note it in the report
+3. Verify each edit preserves markdown formatting
+
+### Step 2: Report
+
+After applying fixes, present:
+
+```
+## Editorial Report: {log title}
+
+### Fixed: {count}
+{list of fixes applied, with before/after quotes}
+
+### Requires Human Review: {count}
+{advisory issues that need judgment}
+
+### Clean Checks
+{what passed}
+```
+
+**If nothing was fixed and nothing needs review**: "Editorial review complete. No issues found."
+
+**If fixes were applied**: End with "Applied {N} fix(es). Re-run `/edit-log` to verify." Do NOT automatically re-run.
+
+---
+
+## Notes
+
+- **Single agent**: Build logs are 200-1,000 words. One agent with a combined checklist is sufficient.
+- **Auto-fix blocking only**: Genericization violations are mechanical and safe to auto-fix. Advisory issues need human judgment.
+- **Re-run to verify**: After fixes, run `/edit-log` again to confirm issues are resolved.
+- **Agent type**: Uses `subagent_type: general-purpose`, `model: "sonnet"` via the Task tool.
+- **Terminology doc is the source of truth**: If the terminology doc is wrong, fix it there, not in the log.
+- **No fact-checking**: Unlike `/edit-article`, there's no fact checker agent. Build logs are short operational updates, not claims-heavy articles.

--- a/.agents/skills/enterprise-review/SKILL.md
+++ b/.agents/skills/enterprise-review/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: enterprise-review
+description: Cross-Venture Codebase Audit
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /enterprise-review - Cross-Venture Codebase Audit
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "enterprise-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Detects configuration drift, structural drift, and practice drift across all venture repos. Produces a consistency report stored in VCMS.
+
+**Must run from crane-console.** This command is not synced to venture repos.
+
+## Arguments
+
+```
+/enterprise-review [--venture codes]
+```
+
+- `--venture` - Comma-separated venture codes to audit (e.g., `--venture ke,dfg`). If omitted, audits all ventures with repos.
+
+Parse `$ARGUMENTS`:
+
+- If it contains `--venture`, extract the comma-separated codes into `TARGET_VENTURES`.
+- If empty, set `TARGET_VENTURES` to all ventures from `config/ventures.json` that have a repo (codes with a corresponding `~/dev/{code}-console` directory).
+
+## Execution
+
+### Step 1: Verify Context
+
+1. Confirm cwd is within crane-console (check for `config/ventures.json` in repo root).
+2. If not in crane-console, stop: "This command must run from crane-console. It audits cross-venture consistency."
+3. Parse `TARGET_VENTURES`. For each code, verify `~/dev/{code}-console` exists and is a git repo. Skip missing repos with a warning.
+
+Display:
+
+```
+Enterprise Codebase Audit
+Ventures: {list of venture codes being audited}
+```
+
+### Step 2: Bash Data Collection
+
+Run a single Bash command that collects structural snapshots from all target venture repos. This is parsing JSON/YAML, not understanding code semantics - no agents needed.
+
+For each repo at `~/dev/{code}-console`:
+
+```bash
+for CODE in {TARGET_VENTURES}; do
+  REPO="$HOME/dev/${CODE}-console"
+  [ -d "$REPO/.git" ] || continue
+
+  echo "=== $CODE ==="
+
+  # Key dependency versions from package.json (root or first found)
+  echo "-- dependencies --"
+  PKGJSON=$(find "$REPO" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" | head -1)
+  if [ -n "$PKGJSON" ]; then
+    for dep in typescript hono wrangler eslint prettier vitest; do
+      VER=$(jq -r ".dependencies[\"$dep\"] // .devDependencies[\"$dep\"] // \"not found\"" "$PKGJSON" 2>/dev/null)
+      echo "$dep=$VER"
+    done
+  fi
+
+  # TypeScript config
+  echo "-- tsconfig --"
+  TSCONFIG=$(find "$REPO" -maxdepth 2 -name "tsconfig.json" -not -path "*/node_modules/*" | head -1)
+  if [ -n "$TSCONFIG" ]; then
+    jq '{strict: .compilerOptions.strict, target: .compilerOptions.target, module: .compilerOptions.module}' "$TSCONFIG" 2>/dev/null
+  fi
+
+  # ESLint config
+  echo "-- eslint --"
+  ls "$REPO"/.eslintrc* "$REPO"/eslint.config.* 2>/dev/null || echo "none"
+
+  # Prettier config
+  echo "-- prettier --"
+  ls "$REPO"/.prettierrc* "$REPO"/prettier.config.* 2>/dev/null || echo "none"
+
+  # CI workflows
+  echo "-- ci --"
+  ls "$REPO"/.github/workflows/*.yml 2>/dev/null || echo "none"
+
+  # Claude commands present
+  echo "-- commands --"
+  ls "$REPO"/.claude/commands/*.md 2>/dev/null | xargs -I{} basename {} | sort
+
+  echo ""
+done
+```
+
+Store output as `RAW_DATA`.
+
+This should complete in under 30 seconds for all repos. No parallel agents needed.
+
+### Step 3: Claude Analysis Pass
+
+The orchestrator itself (you, not spawned agents) parses `RAW_DATA` and builds the drift report. This is comparison and table-building, not deep code analysis.
+
+Build these sections:
+
+**3a. Version Alignment Table**
+
+Compare key dependency versions across all ventures:
+
+```
+| Dependency | {vc} | {ke} | {dfg} | {sc} | {dc} | Drift? |
+|------------|------|------|-------|------|------|--------|
+| typescript | 5.x  | 5.x  | 5.x   | 5.x  | -    | No     |
+| hono       | 4.x  | 4.x  | -     | -    | -    | No     |
+| wrangler   | 3.x  | 3.x  | 3.x   | 3.x  | -    | No     |
+| eslint     | 9.x  | 8.x  | 9.x   | -    | -    | YES    |
+```
+
+Flag any version where ventures differ by 1+ major version.
+
+**3b. Commands Sync Status**
+
+List which enterprise commands are present/missing per venture:
+
+```
+| Command | {vc} | {ke} | {dfg} | {sc} | {dc} |
+|---------|------|------|-------|------|------|
+| sos.md  |  Y   |  Y   |  Y    |  Y   |  Y   |
+| eos.md  |  Y   |  Y   |  Y    |  N   |  N   |
+```
+
+Flag missing commands. Note: some commands are enterprise-only (like `enterprise-review.md`) and should not be synced.
+
+**3c. Golden Path Compliance**
+
+Pass/fail per venture with tier context:
+
+```
+| Venture | Tier | Failures | Warnings | Status |
+|---------|------|----------|----------|--------|
+| ke      | 1    | 0        | 2        | PASS   |
+| dfg     | 1    | 1        | 3        | FAIL   |
+```
+
+**3d. Drift Hotspots**
+
+Cross-cutting issues that affect multiple ventures or represent enterprise-wide concerns:
+
+- Configuration drift (e.g., "dfg is 2 ESLint majors behind ke")
+- Missing enterprise standards (e.g., "3/5 repos missing security.yml workflow")
+- Practice drift (e.g., "only 2/5 repos have pre-commit hooks configured")
+
+### Step 4: Store and Report
+
+**4a. VCMS Report**
+
+Store concise report in VCMS using `crane_note`:
+
+- Action: `create`
+- Tags: `["code-review", "enterprise"]`
+- Venture: (omit - this is cross-venture)
+- Title: `Enterprise Review - {YYYY-MM-DD}`
+
+Content (under 500 words): date, ventures audited, version alignment summary, top 3-5 drift hotspots, overall consistency assessment.
+
+**4b. Compare with Previous Review**
+
+Search for the most recent enterprise review:
+
+```
+crane_notes tag="code-review" q="Enterprise Review"
+```
+
+If found, compare:
+
+- Which drift items were flagged before and are now resolved?
+- Which are new?
+- Which are persistent (flagged again)?
+
+Note trend in the report.
+
+**4c. Display to User**
+
+Present the full report inline (this is the primary output - no separate file since it lives in VCMS and is only relevant to crane-console).
+
+```
+## Enterprise Codebase Audit - {YYYY-MM-DD}
+
+### Version Alignment
+{table}
+
+### Commands Sync Status
+{table}
+
+### Drift Hotspots
+{numbered list}
+
+### Trend
+{comparison with previous review}
+
+### Recommendation
+{1-3 actionable next steps}
+```
+
+### Step 5: Done
+
+After displaying the report, suggest next steps:
+
+- If commands are out of sync: "Run `sync-commands.sh` to distribute missing commands."
+- If version drift detected: "Consider creating issues to align dependency versions."
+
+Do NOT automatically take any action. Wait for the Captain.
+
+After displaying the report, record the completion in the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "enterprise-review", result: "success", summary: "{N} ventures audited, {findings}", completed_by: "crane-mcp")
+```
+
+---
+
+## Drift Categories
+
+### Configuration Drift
+
+- TypeScript version and tsconfig settings (strict mode, target, module)
+- ESLint version and config format (flat config vs legacy)
+- Prettier version and settings
+- Wrangler version
+- Hono version (for API ventures)
+
+### Structural Drift
+
+- API file structure (routes/, services/, types/ conventions)
+- Claude commands synced vs missing
+- CI workflow files present and consistent
+- CLAUDE.md format and completeness
+
+### Practice Drift
+
+- Pre-commit hooks configured (husky/lint-staged)
+- Branch protection enabled
+- Security workflow present
+- Secret scanning configured (.gitleaks.toml)
+- Test framework configured
+
+---
+
+## Notes
+
+- **Claude-only.** No Codex or Gemini. This is structural comparison, not code analysis.
+- **Not synced.** This command stays in crane-console only. It reads from venture repos but doesn't modify them.
+- **VCMS tags:** `code-review` + `enterprise`. The `code-review` tag groups all review artifacts; the `enterprise` tag distinguishes cross-venture reports from per-venture scorecards.
+- **Speed:** The bash collection step should complete in under 30 seconds. The analysis step is a single Claude pass with no spawned agents.
+- **Prerequisite:** Venture repos must be cloned locally at `~/dev/{code}-console`. Missing repos are skipped with a warning.

--- a/.agents/skills/eos/SKILL.md
+++ b/.agents/skills/eos/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: eos
 description: End of Session Handoff
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /eos - End of Session Handoff
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "eos")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Auto-generate handoff from session context. The agent summarizes - never ask the user.
 

--- a/.agents/skills/go-live/SKILL.md
+++ b/.agents/skills/go-live/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: go-live
+description: Venture Go-Live Process
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /go-live - Venture Go-Live Process
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "go-live")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Launch a venture to production with mandatory secret rotation and readiness checks.
+
+```
+/go-live dc           # launch Draft Crane
+/go-live ke           # launch Kid Expenses
+```
+
+**Do NOT follow `docs/process/secrets-rotation-runbook.md`** - it references decommissioned tooling.
+
+## Step 1: Parse & Validate
+
+Parse `$ARGUMENTS` for a venture code. Then:
+
+1. Read `config/ventures.json`
+2. Find the venture by `code`
+3. If not found, stop: "Unknown venture code. Available: {list codes with status}"
+4. If `portfolio.status` is `"launched"`, stop: "Already launched."
+5. If no argument provided, stop with usage: "/go-live {venture-code}"
+
+## Step 2: Pre-flight Checks (automated)
+
+Run these checks without user input. Report pass/fail for each.
+
+1. **Golden Path compliance** - Read `docs/standards/golden-path.md` compliance dashboard row for this venture. Note Sentry, CI/CD, Monitoring, Docs status. If the venture is missing from the dashboard, flag it as a gap.
+2. **Infisical prod secrets** - Run `infisical secrets --path /{venture} --env prod --silent 2>/dev/null | grep '│' | grep -v 'SECRET NAME' | grep -v '├\|┌\|└' | sed 's/│/|/g' | cut -d'|' -f2 | sed 's/^ *//;s/ *$//'` to extract key names only. **NEVER run bare `infisical secrets` - it displays values in the transcript.**
+3. **Infisical dev secrets** - Same key-names-only extraction for `--env dev`.
+4. **Production worker health** - If the venture has a known health endpoint, `curl` it and confirm 200.
+5. **DNS/custom domain** - If `portfolio.url` is set in ventures.json, verify DNS resolves.
+
+Present results as a checklist. If any critical check fails (no prod secrets, no worker health), stop: "Fix these before proceeding."
+
+## Step 3: Secret Inventory
+
+Agent pulls and displays key names only (NEVER values):
+
+1. Extract key names from Infisical (reuse the key-names-only command from Step 2 - NEVER display values).
+2. Read the **Shared Credentials** table from `docs/infra/secrets-management.md`.
+3. Read the **Revocation Behavior by Type** table from `docs/infra/secrets-management.md`.
+4. Cross-reference: flag any shared credentials and note rotation impact.
+5. Categorize each secret by revocation behavior (immediate vs dual-key vs self-generated).
+
+Present the full inventory, then ask via AskUserQuestion:
+
+**Question:** "Rotate all {N} secrets at their sources, update Infisical (prod AND dev), then confirm."
+
+Include in the question context:
+
+- Shared credentials and which ventures they affect
+- Immediate-revocation secrets (test each one right after rotating)
+- Dual-key/self-generated secrets (can batch)
+
+**Options:**
+
+1. "All rotated and updated in Infisical" - proceed to push
+2. "Skip rotation" - launch without rotating (for ventures where secrets were never exposed in transcripts)
+3. "Cancel" - abort go-live
+
+If cancelled, stop.
+
+## Step 4: Push to Workers (agent-safe)
+
+Push secrets to Cloudflare Workers without exposing values:
+
+```bash
+cd {venture-worker-dir}
+infisical export --format=json --path /{venture} --env prod | npx wrangler secret bulk
+```
+
+No secret values appear in the transcript. If the venture has multiple workers, push to each.
+
+## Step 5: Smoke Test
+
+Run these checks and report pass/fail:
+
+1. **Health endpoint** - `curl` the production health endpoint
+2. **Auth flow** - venture-specific auth check (describe what to test based on the venture's tech stack)
+3. **Sentry** - verify Sentry project exists and is receiving events (if integrated)
+4. **Uptime monitor** - confirm external monitoring is configured
+
+If any fail: "Smoke test failures above. Fix before continuing. Old credentials have NOT been revoked yet."
+
+If all pass, ask via AskUserQuestion:
+
+**Question:** "Smoke tests passed. Revoke old credentials at their source consoles now. Self-generated tokens (like ENCRYPTION_KEY) don't need revocation - rotation was the control."
+
+**Options:**
+
+1. "Old credentials revoked" - proceed to ship
+2. "Cancel" - abort (new credentials remain active, no rollback needed)
+
+## Step 6: Ship
+
+1. Update `config/ventures.json`:
+   - Set `portfolio.status` to `"launched"`
+   - Set `portfolio.showInPortfolio` to `true` (this enables venture name usage in published articles and build logs per terminology.md)
+   - Set `portfolio.url` if provided by user (ask if not already set)
+   - Update `bvmStage` if appropriate
+2. Commit with message: `feat: launch {venture name}`
+3. Run `/portfolio-review` to sync the venture to vc-web's portfolio page
+4. Create handoff via `crane_handoff` MCP tool with summary of what was launched
+
+Report: "{Venture Name} is live. ventures.json updated, portfolio synced, handoff saved."
+
+## Important Notes
+
+- **Transcript cleanup is optional hygiene.** Rotation already invalidated any exposed values. Old transcripts in ~/.claude/ contain dead credentials after rotation.
+- **If smoke tests fail after rotating an immediate-revocation secret** (like OAuth client secrets), the old value is already dead. Fix the issue with the new credential - don't try to rollback.
+- **Shared credentials require coordination.** If GOOGLE_CLIENT_SECRET is rotated for /dc, the old value dies immediately for /ke too. Push to all consuming ventures before revoking.

--- a/.agents/skills/heartbeat/SKILL.md
+++ b/.agents/skills/heartbeat/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: heartbeat
 description: Keep Session Alive
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+backend_only: true
 ---
 
 # /heartbeat - Keep Session Alive

--- a/.agents/skills/nav-spec/README.md
+++ b/.agents/skills/nav-spec/README.md
@@ -1,0 +1,95 @@
+# nav-spec (v2)
+
+Companion to `stitch-design` and `stitch-ux-brief`. Authors and enforces a per-venture three-layer navigation specification: **Information Architecture + Patterns + Chrome**. Anchored to Nielsen Norman Group, Material Design 3, Apple HIG, and Dan Brown's 8 IA principles.
+
+## What it does
+
+- Authors `.stitch/NAVIGATION.md` covering three layers:
+  1. **IA** — task model, sitemap, reachability matrix, state machine, content taxonomy, URL contract, cross-surface context
+  2. **Patterns** — named patterns from established frameworks, per `{surface × archetype}`, with rationale
+  3. **Chrome** — header, back, breadcrumbs, footer, skip-link, states, tap targets, mobile↔desktop transforms, per-surface a11y
+- Runs two distinct audits: **IA audit** (reachability, patterns, taxonomy) and **drift audit** (chrome consistency)
+- Feeds a NAV CONTRACT block (essential + extended) into every Stitch generation via `stitch-design`'s patched pipeline
+- Validates generated HTML and shipped surfaces against 24 deterministic rules (R1–R15 chrome, R16–R24 IA + pattern + a11y)
+
+## v2 change
+
+v1 defined **chrome only**. Result: pages shipped with consistent sticky headers and back buttons, but the portal home had no way to reach list views (`/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement`) except by backtracking from a detail — a gaping IA hole the skill could not catch because none of its reviewers or validator rules checked reachability.
+
+v2 adds the two layers above chrome (IA and Patterns) and 9 new validator rules (R16–R24). The principle: never invent patterns — anchor every choice to a published catalog.
+
+## Who this is for
+
+Ventures using Stitch MCP to generate design artifacts that ship to production (Astro + Tailwind). One spec per venture; shared skill across the portfolio.
+
+## When to run
+
+| Moment                                        | Command                                                                             |
+| --------------------------------------------- | ----------------------------------------------------------------------------------- |
+| First time for a venture (or v1→v2 migration) | `/nav-spec` (author or revise, auto-detected)                                       |
+| After route changes / new surface class       | `/nav-spec --ia-audit`                                                              |
+| Chrome drift check                            | `/nav-spec --drift-audit`                                                           |
+| Updating existing spec                        | `/nav-spec --revise`                                                                |
+| After Stitch model version change             | `/nav-spec --phase-0`                                                               |
+| Validate a single HTML file                   | `python3 validate.py --file X --surface Y --archetype Z --viewport W [--spec path]` |
+
+## Dependencies
+
+- Stitch MCP connected (curl fallback via `STITCH_API_KEY` when MCP is OAuth-broken)
+- Venture has `stitchProjectId` set in `crane-console/config/ventures.json`
+- `.stitch/DESIGN.md` recommended but not required
+- Python 3.8+ for `validate.py`
+
+## Relationship to other skills
+
+- **stitch-design** reads `.stitch/NAVIGATION.md`, requires 5 classification tags (`surface`, `archetype`, `viewport`, `task`, `pattern`), injects essential + extended NAV CONTRACT block, runs `validate.py` post-generation. Graceful-degradation when spec absent.
+- **stitch-ux-brief** reads spec in Phase 1; injects NAV CONTRACT in Phase 7 concept prompts; generates REMOVE/PRESERVE lists from anti-patterns in Phase 11.
+- **react-components** (future) reads the chrome contracts to produce aligned Astro components.
+
+## Key files
+
+- `SKILL.md` — entry point; three-layer model overview; 24-rule summary
+- `workflows/author.md` — 12-phase authoring workflow (task → IA → pattern → chrome → verification)
+- `workflows/ia-audit.md` — reachability, pattern conformance, taxonomy audit
+- `workflows/drift-audit.md` — chrome consistency audit
+- `workflows/revise.md` — update existing spec; supports v1→v2 migration
+- `workflows/phase-0-compliance-test.md` — empirical injection-compliance measurement
+- `workflows/validate.md` — rubric for all 24 rules
+- `references/pattern-catalog.md` — NN/g + Material + HIG + composite patterns
+- `references/ia-principles.md` — Dan Brown's 8 principles
+- `references/archetype-catalog.md` — 10 archetypes × default patterns
+- `references/reachability-matrix-template.md` — central IA artifact template
+- `references/state-machine-template.md` — auth/data/task states
+- `references/content-taxonomy-template.md` — labels, verbs, statuses
+- `references/task-model-template.md` — task elicitation
+- `references/chrome-component-contracts.md` — DOM + Tailwind
+- `references/classification-rubric.md` — 5-tag decision rules
+- `references/injection-snippet-template.md` — NAV CONTRACT block format
+- `references/anti-patterns.md` — 24 anti-patterns (chrome + IA)
+- `validate.py` — implementation of R1–R24
+- `examples/NAVIGATION.md` — gold-standard v2 spec
+- `examples/ia-audit-report.md` — IA audit format
+- `examples/drift-audit-report.md` — chrome drift audit format
+- `examples/phase-0-compliance-report.md` — compliance measurement format
+
+## Philosophy
+
+1. **Three layers, authored top-down.** Tasks before IA. IA before patterns. Patterns before chrome. Inverting this order produces the v1 failure mode.
+2. **Anchor every pattern.** If a pattern doesn't appear in the catalog, the catalog is wrong (add it with citation) or the pattern is invented (replace it). Inventing breaks the rebuild's purpose.
+3. **Five surface classes, by auth model.** `public`, `auth-gate`, `token-auth`, `session-auth-client`, `session-auth-admin`. Subdomain is secondary.
+4. **Authoring is probabilistic; enforcement is deterministic.** The NAV CONTRACT injection is instructional; `validate.py` is truth.
+5. **The reachability matrix is the contract.** R16 enforces it; no surface can orphan a destination without the validator catching it.
+6. **Ground specs in shipped code.** The Implementation reviewer flags any contract requiring a refactor; the user chooses to align the spec or flag the refactor.
+7. **The spec prevents drift on unseen screens.** Self-consistency (Phase 10) is necessary but not sufficient. Adversarial verification with reachability traversal (Phase 11) is the real gate.
+
+## Installation
+
+The skill is a standalone directory at `~/.agents/skills/nav-spec/`. No install step — Claude Code picks it up via directory presence.
+
+Per-venture command wiring: add `/nav-spec` slash command at `<venture>/.claude/commands/nav-spec.md` pointing to this skill. See `examples/` for a sample.
+
+## Versioning
+
+- `nav-spec-skill-version: 2.0.0` (current)
+- Spec-level versioning: each venture's `NAVIGATION.md` tracks its own `spec-version`
+- Compatibility: v1 specs still work with the v2 validator (chrome-only rules apply); migrate with `/nav-spec --revise --migrate-to-v2`

--- a/.agents/skills/nav-spec/SKILL.md
+++ b/.agents/skills/nav-spec/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: nav-spec
+description: "Authors and enforces `.stitch/NAVIGATION.md` — the per-venture three-layer navigation specification (IA + patterns + chrome). Anchors to NN/g, Material Design 3, Apple HIG, and Dan Brown's 8 IA principles. v3 ships as a **challenger, not a chooser**: citation-anchored disqualifier conditions (R25) refuse patterns that contradict the task model, and an authoring-direction lint (R26) prevents Sections 1–4 from ratifying shipped chrome."
+version: 3.0.0
+scope: global
+owner: agent-team
+status: stable
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+depends_on:
+  mcp_tools: [crane_ventures]
+  files:
+    - venture:.stitch/NAVIGATION.md
+    - venture:.stitch/DESIGN.md
+    - global:~/.agents/skills/nav-spec/validate.py
+  commands: [python3]
+---
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+# /nav-spec - Nav Spec Authority (v3)
+
+You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every Stitch generation and shipped surface.
+
+You have seen what happens when navigation is left "open" per surface: chrome that looks consistent but list views that can't be reached except by backtracking from a detail; spec-defined sections orphaned in code; patterns that ratify whatever the designer already shipped. Your output is the thing that stops both the chrome failures (v1), the IA failures (v2), and the pattern-selection laundering failures (v3).
+
+## What changed in v3
+
+v2 added an IA layer and a pattern catalog. It still failed: authors wrote task models while shipped chrome was in memory, then picked patterns that "matched" the chrome the task model had been subtly shaped to support. ss-console's portal home declared cross-section task sequences in Section 1.4.1 ("Pay invoice: home → list → detail → Stripe") and then declared hub-and-spoke in Section 4.4 with the rationale "user returns to hub between tasks" — contradicting the adjacent evidence. No reviewer, no validator rule caught the contradiction.
+
+v3 adds two structural enforcements:
+
+1. **Citation-anchored pattern disqualifiers (R25).** [references/pattern-disqualifiers.md](references/pattern-disqualifiers.md) enumerates disqualifier conditions per catalog pattern, each cited to NN/g / Material 3 / Apple HIG (or tagged `HEURISTIC: UNTESTED`). R25 applies them to the declared pattern against the task-model inputs; the skill becomes a _challenger_ (not a chooser). Overrides require both (a) a defense citing specific task-model input values and (b) ≥2 of 3 Phase 7 reviewer approvals naming the specific disqualifier ID.
+2. **Authoring-direction lint (R26).** Sections 1–4 of `NAVIGATION.md` must not cite `src/components/**` or `*.astro` paths. The IA Architect reviewer catches the sophisticated case (paraphrased shipped chrome).
+
+Additional v3 tightenings:
+
+- Task table requires new columns: `evidence_source` (non-UI artifact) and `return_locus` (task terminus).
+- `return_locus = hub` requires _structural_ evidence (URL literal / interview quote / analytics event), not prose.
+- "Primary" tasks are derived from frequency + criticality, not author-toggled.
+- Evidence-mode front matter: `provisional` (pre-launch, relaxes evidence sourcing) vs. `validated` (production, requires real artifacts). R25 is structural in both modes.
+- Time-bounded provisional-override artifacts: `.stitch/provisional-override-<date>.md` requires named `deferred_validation.event` and `date ≤90 days`. Expired overrides re-fire R25.
+
+## Core responsibilities
+
+1. **Spec authoring** (`/nav-spec`) — produce `.stitch/NAVIGATION.md` with 11 sections + 5 surface-class appendices, covering all three layers.
+2. **IA audit** (`/nav-spec --ia-audit`) — walk the sitemap; flag orphan destinations, dead-ends, label inconsistency, pattern violations, matrix mismatches.
+3. **Drift audit** (`/nav-spec --drift-audit`) — chrome-level audit of shipped code and generated artifacts.
+4. **Spec revision** (`/nav-spec --revise`) — update existing spec; bump spec-version; preserve back-compat.
+5. **Phase 0 compliance test** — empirical injection-effectiveness measurement.
+6. **Validation** (`validate.py`) — post-generation enforcement of all 24 rules (R1–R15 chrome, R16–R24 IA + pattern + a11y) on Stitch output and shipped HTML.
+
+## The three layers
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Layer 1 — Information Architecture                              │
+│   Task model → Sitemap → Reachability matrix                    │
+│   Entry/exit catalogue → State machine                          │
+│   Cross-surface context → URL contract → Content taxonomy       │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 2 — Patterns                                              │
+│   Named patterns from NN/g + Material + HIG                     │
+│   Per {surface × archetype}: which pattern, why, what variants  │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 3 — Chrome                                                │
+│   Header, back, breadcrumbs, footer, skip-link                  │
+│   States, tap targets, mobile↔desktop transforms                │
+│   Per-surface a11y                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Cross-cutting: search strategy, recovery paths, IA-level a11y, analytics hooks.
+
+## Anchoring principle
+
+The skill **does not invent patterns**. Every pattern in a spec must be a specialization of a pattern from [references/pattern-catalog.md](references/pattern-catalog.md), which catalogs:
+
+- **NN/g navigation patterns** — hub-and-spoke, nested-doll, sequential, pyramid, faceted, tag
+- **Material Design 3 navigation components** — top app bar, bottom nav, navigation rail, drawer, tabs, segmented button (with destination-count rules)
+- **Apple HIG patterns** — tab bar, split view, navigation stack, modal
+- **Industry composite patterns** — master-detail, index+preview, modal-on-list, persistent-context workspace, progressive disclosure, command palette
+
+Reviewing the spec against [references/ia-principles.md](references/ia-principles.md) (Dan Brown's 8 principles of IA) is a required Phase 7 deliverable.
+
+## Workflows
+
+| User intent                                     | Workflow                                                           | Primary output                                |
+| ----------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
+| "Create NAVIGATION.md for this venture"         | [author.md](workflows/author.md)                                   | `.stitch/NAVIGATION.md`                       |
+| "Audit IA holes (orphans, dead-ends, taxonomy)" | [ia-audit.md](workflows/ia-audit.md)                               | `examples/ia-audit-report.md`                 |
+| "Audit chrome drift"                            | [drift-audit.md](workflows/drift-audit.md)                         | In-memory drift report                        |
+| "Update existing NAVIGATION.md"                 | [revise.md](workflows/revise.md)                                   | `.stitch/NAVIGATION.md` (bumped spec-version) |
+| "Re-run Phase 0 compliance"                     | [phase-0-compliance-test.md](workflows/phase-0-compliance-test.md) | `examples/phase-0-compliance-report.md`       |
+| "Validate a generated screen"                   | [validate.md](workflows/validate.md)                               | Violation report                              |
+
+## Fail-fast preconditions
+
+Before any workflow except the audits:
+
+1. Resolve the venture's Stitch project ID via `crane_ventures` MCP. Match the current repo to a venture code; read `stitchProjectId`. If null: stop. Tell the user: "No Stitch project configured. Add `stitchProjectId` for this venture in `crane-console/config/ventures.json` first." No fallback discovery.
+2. Check for `.stitch/DESIGN.md`. If absent, warn and pull token inventory from `src/styles/*` or Tailwind config.
+3. Check for `.stitch/NAVIGATION.md`. If present, route to `revise.md`. If absent, route to `author.md`.
+
+## Surface-class taxonomy (authoritative)
+
+Surface classes are modeled by **auth model**, not by subdomain.
+
+| Class                 | Auth                          | Examples (ss-console)                        |
+| --------------------- | ----------------------------- | -------------------------------------------- |
+| `public`              | None                          | Marketing home, scorecard, blog, contact     |
+| `auth-gate`           | Sign-in form (no session yet) | `/auth/login`, `/auth/portal-login`          |
+| `token-auth`          | Signed URL token              | `/portal/proposals/[token]`, `/invoice/[id]` |
+| `session-auth-client` | Cookie session, role=client   | `/portal/*`                                  |
+| `session-auth-admin`  | Cookie session, role=admin    | `/admin/*`                                   |
+
+The subdomain is a secondary attribute. A public page on `portal.*` is still `public` chrome-wise.
+
+## Archetype taxonomy (authoritative)
+
+Ten archetypes: `dashboard`, `list`, `detail`, `form`, `wizard`, `empty`, `error`, `modal`, `drawer`, `transient`.
+
+Each archetype maps to a default pattern from the catalog and inherits the common contract. Full table in [references/archetype-catalog.md](references/archetype-catalog.md).
+
+## Classification (deterministic, required, 5 tags)
+
+Every `stitch-design` or `stitch-ux-brief` invocation targeting a specific screen must carry **five** explicit classification tags:
+
+```
+surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+viewport=<mobile|desktop>
+task=<short-name from venture's task model>
+pattern=<name from pattern-catalog.md>
+```
+
+The pipeline fails fast if any tag is missing or unrecognized. Natural-language inference is explicitly disabled.
+
+The two new tags (`task=`, `pattern=`) are required because chrome alone never determined a pattern — the same chrome can implement different patterns. Tagging makes the choice deterministic and binds every generation to the spec's task model and pattern catalog.
+
+Manual lookup aid: [references/classification-rubric.md](references/classification-rubric.md).
+
+## Injection mechanism
+
+At prompt-enhancement time, `stitch-design` reads `.stitch/NAVIGATION.md`, looks up the matching `{surface, archetype, viewport, task, pattern}` block, assembles an **essential** NAV CONTRACT block (always injected) and an **extended** block (loaded conditionally based on archetype/pattern), and injects them between DESIGN SYSTEM and PAGE STRUCTURE.
+
+Token budget: ≤500 essential, ≤800 essential+extended combined. Canonical format: [references/injection-snippet-template.md](references/injection-snippet-template.md).
+
+Post-generation, `validate.py` parses the returned HTML and runs all 24 rules. Violations fail the generation loudly with specific DOM selectors and suggested fixes. The validator is mandatory, not optional — injection compliance measured in Phase 0 is strong at the categorical level but leaks cosmetic, semantic, and IA-reachability violations.
+
+## Validator coverage (R1–R26)
+
+| #       | Category                | Rule                                                                    | Layer       | Added in |
+| ------- | ----------------------- | ----------------------------------------------------------------------- | ----------- | -------- |
+| R1      | Chrome                  | Header sticky, not fixed                                                | Chrome      | v1       |
+| R2      | Chrome                  | Header bg solid (no blur, no opacity)                                   | Chrome      | v1       |
+| R3      | Chrome                  | No icon before client name                                              | Chrome      | v1       |
+| R4      | Chrome                  | Back not wrapped in breadcrumb nav                                      | Chrome      | v1       |
+| R5      | Chrome                  | Back href is canonical URL                                              | Chrome      | v1       |
+| R6      | Chrome                  | No global nav tabs in header                                            | Chrome      | v1       |
+| R7      | Chrome                  | No sticky-bottom outside dialog                                         | Chrome      | v1       |
+| R8      | Chrome                  | No footer on auth surfaces                                              | Chrome      | v1       |
+| R9      | Chrome                  | No real-face photo placeholders                                         | Chrome      | v1       |
+| R10     | Chrome                  | No marketing CTAs on auth                                               | Chrome      | v1       |
+| R11     | Chrome                  | Header height matches viewport                                          | Chrome      | v1       |
+| R14     | A11y                    | Landmarks present                                                       | A11y        | v1       |
+| R15     | A11y                    | Skip-to-main link wired correctly                                       | A11y        | v1       |
+| R16     | IA                      | Reachability — dashboards link to sibling lists                         | IA          | v2       |
+| R17     | Pattern                 | Pattern conformance — surface implements declared pattern               | Pattern     | v2       |
+| R18     | IA                      | No dead ends                                                            | IA          | v2       |
+| R19     | IA                      | Token-auth handles cold arrival                                         | IA          | v2       |
+| R20     | IA                      | Content taxonomy adherence                                              | IA          | v2       |
+| R21     | IA                      | State machine completeness                                              | IA          | v2       |
+| R22     | A11y                    | Heading hierarchy                                                       | A11y        | v2       |
+| R23     | IA                      | Search affordance present when declared                                 | IA          | v2       |
+| R24     | Pattern                 | Cross-surface context preserved                                         | Pattern     | v2       |
+| **R25** | **Pattern Fitness**     | **Citation-anchored disqualifiers for declared pattern vs. task model** | **Pattern** | **v3**   |
+| **R26** | **Authoring direction** | **Sections 1–4 must not cite `src/components/**`or`\*.astro`\*\*        | **Meta**    | **v3**   |
+
+Severity tiers: **structural** always fails; **semantic** retries once; **cosmetic** warns but passes (configurable per venture).
+
+R25 runs in a spec-only mode via `python3 validate.py --check-pattern-fitness --spec .stitch/NAVIGATION.md` (no HTML file required). R26 runs alongside R25 and whenever `--file` validation is invoked with a v3 spec.
+
+## References
+
+- [pattern-catalog.md](references/pattern-catalog.md) — NN/g + Material + HIG + composite patterns
+- [pattern-disqualifiers.md](references/pattern-disqualifiers.md) — **v3** citation-anchored disqualifier conditions (powers R25)
+- [ia-principles.md](references/ia-principles.md) — Dan Brown's 8 principles
+- [task-model-template.md](references/task-model-template.md) — task elicitation and structure (v3: evidence_source + return_locus)
+- [reachability-matrix-template.md](references/reachability-matrix-template.md) — central IA artifact
+- [state-machine-template.md](references/state-machine-template.md) — auth/data/task states
+- [content-taxonomy-template.md](references/content-taxonomy-template.md) — labels, verbs, statuses
+- [archetype-catalog.md](references/archetype-catalog.md) — 10 archetypes × default patterns
+- [chrome-component-contracts.md](references/chrome-component-contracts.md) — DOM + Tailwind
+- [classification-rubric.md](references/classification-rubric.md) — 5-tag decision rules
+- [injection-snippet-template.md](references/injection-snippet-template.md) — NAV CONTRACT block (essential + extended)
+- [anti-patterns.md](references/anti-patterns.md) — chrome anti-patterns 1–15 + IA anti-patterns 16–24
+
+## Examples
+
+- [examples/NAVIGATION.md](examples/NAVIGATION.md) — gold-standard v3 spec (migrated from ss-console v2)
+- [examples/ia-audit-report.md](examples/ia-audit-report.md) — IA audit format
+- [examples/drift-audit-report.md](examples/drift-audit-report.md) — chrome drift audit format
+- [examples/phase-0-compliance-report.md](examples/phase-0-compliance-report.md) — empirical compliance measurement
+- [examples/pattern-disqualifier-tests/](examples/pattern-disqualifier-tests/) — v3 synthetic regression tests (admin-heavy-switching, mandatory-wizard, deep-content-library)
+- [examples/v3-regression-test.md](examples/v3-regression-test.md) — expected outputs for the v3 regression suite
+
+## Best practices
+
+- **Author in direction: tasks → golden paths → IA → pattern → spec → COMPARE to code.** Sections 1–4 must be authorable as if shipped code did not exist. Phase 5 (chrome contracts) is the first authorized read of shipped components. R26 enforces this at the lint level; the IA Architect reviewer catches paraphrased shipped-chrome claims in §1–4.
+- **Anchor every pattern.** Every pattern in a spec is a specialization of a catalog entry. Every disqualifier in [pattern-disqualifiers.md](references/pattern-disqualifiers.md) cites NN/g / Material 3 / HIG, or carries a `HEURISTIC: UNTESTED` tag. Never invent.
+- **Skill is a challenger, not a chooser.** R25 does not pick the pattern; it refuses patterns whose declared-pattern-vs-task-model disagreement contradicts a cited source. Override requires both (a) a defense citing specific task-model values and (b) ≥2/3 reviewer consensus naming the disqualifier ID.
+- **"Primary" is structural, not declarative.** A task is primary iff `frequency ∈ {high, medium}` OR `criticality = blocking`. The author cannot dodge R25 disqualifiers by relabeling tasks.
+- **`return_locus = hub` requires structural evidence.** Literal URL in a file or SOW, interview quote, or analytics event. Prose intent is insufficient.
+- **Provisional mode relaxes evidence, not R25.** Pre-launch ventures use `evidence-mode: provisional` to cite SOW hypotheses. R25 remains structural. Dismissal requires a time-bounded `.stitch/provisional-override-<date>.md` with a named validation event and date ≤90 days.
+- **Five surface classes, not three or four.** v1 forgot `auth-gate`; v2+ include it explicitly.
+- **The reachability matrix is validator-checkable.** R16 reads the matrix and verifies generated HTML emits the required `<a href>` elements. The matrix is not decorative — it is the contract.
+- **The validator is the enforcement layer.** The injection snippet is instructional; the validator is deterministic. When in conflict, trust the validator.
+- **Spec-version bumps reflect breaking changes.** Additive (new archetype, new pattern, new anti-pattern) lands without bump. Structural (taxonomy redefinition, rule inversion, new required section) bumps.
+- **A11y is woven, not bolted.** It lives in chrome (per-surface) AND IA (cross-surface heading hierarchy, landmark consistency). The Implementation reviewer covers per-surface; the IA architect reviewer covers cross-surface.
+- **Backwards compatibility.** v1 specs validate against R1–R15 only. v2 specs (task/pattern tags, reachability matrix) add R16–R24. v3 specs (evidence-mode, return_locus column, decision log) add R25 and R26. Soft-skip warnings are emitted on stderr when a rule's inputs are missing; the pipeline never fails unexpectedly on a v1 or v2 spec due to a v3 rule.

--- a/.agents/skills/nav-spec/examples/NAVIGATION.md
+++ b/.agents/skills/nav-spec/examples/NAVIGATION.md
@@ -1,0 +1,576 @@
+---
+spec-version: 3
+nav-spec-skill-version: 3.0.0
+evidence-mode: validated
+design-md-sha: <sha-placeholder>
+stitch-project-id: <id-placeholder>
+phase-0-compliance: { categorical: '93%', strict: '87%', date: '2026-04-15' }
+injection-budgets:
+  session-auth-client/dashboard/mobile/persistent-tabs:
+    { essential: 482, extended: 287, total: 769 }
+  session-auth-client/list/mobile/master-detail: { essential: 421, extended: 156, total: 577 }
+  session-auth-client/detail/mobile/master-detail: { essential: 437, extended: 218, total: 655 }
+  session-auth-admin/dashboard/desktop/hub-and-spoke: { essential: 468, extended: 241, total: 709 }
+  public/dashboard/desktop/pyramid: { essential: 395, extended: 112, total: 507 }
+  auth-gate/form/mobile/single-page-form: { essential: 343, extended: 84, total: 427 }
+revisions:
+  - {
+      from: 1.0,
+      to: 2.0,
+      date: '2026-04-15',
+      kind: 'v1→v2 migration',
+      added:
+        [
+          'Section 1 (Task model)',
+          'Section 3 (Reachability matrix)',
+          'Section 4 (Pattern selection)',
+          'Section 5 (State machine)',
+          'Section 12 (Content taxonomy)',
+        ],
+    }
+  - {
+      from: 2.0,
+      to: 3.0,
+      date: '2026-04-16',
+      kind: 'v2→v3 migration',
+      added:
+        [
+          'evidence_source + return_locus columns (§1)',
+          'Section 4 decision log format (chosen / runner_up / defense / reviewer approvals)',
+          'R25 pattern fitness + R26 authoring-direction enforcement',
+        ],
+      pattern-changes:
+        [
+          'session-auth-client/dashboard: hub-and-spoke → persistent-tabs (D1 fired on 2 of top-3 tasks with return_locus=external)',
+        ],
+    }
+---
+
+# ss-console — Navigation Specification (v3)
+
+The authoritative navigation spec for the SMD Services venture (`smd.services`, `portal.smd.services`, `admin.smd.services`). Anchored to Nielsen Norman Group navigation patterns, Material Design 3 navigation components, Apple HIG, and Dan Brown's 8 IA principles.
+
+Sections 1–5 define **IA and patterns** (v2 addition). Sections 6–11 define **chrome** (carried forward from v1 with minor edits). Section 12 defines **content taxonomy** (v2 addition). Appendices A–E provide surface-class overrides.
+
+---
+
+## 1. Task model
+
+### 1.1 Surface class: `public`
+
+#### Primary tasks
+
+1. **Understand what SMD Services does** — visitor arriving organic/referral wants to know the value proposition
+2. **Book an assessment** — qualified visitor ready to explore an engagement
+3. **Read case study / scorecard** — visitor evaluating fit
+
+#### Secondary tasks
+
+- Read blog / articles
+- Sign in to existing portal (redirects to `auth-gate`)
+
+### 1.2 Surface class: `auth-gate`
+
+#### Primary tasks
+
+1. **Sign in with magic link** (client) or email+password (admin)
+
+Entry from: `/auth/login`, `/auth/portal-login`, expiry redirects.
+
+### 1.3 Surface class: `token-auth`
+
+#### Primary tasks
+
+1. **Review and sign a proposal** (via `/portal/proposals/[token]`)
+2. **Pay an invoice** (via `/invoice/[id]`)
+
+Entry exclusively via email deep-link. No prior session assumed.
+
+### 1.4 Surface class: `session-auth-client` (portal)
+
+#### Tasks (v3 — required columns: evidence_source, return_locus, return_locus_evidence)
+
+| Task                 | Frequency | Criticality | Evidence source                                            | return_locus         | return_locus_evidence                                                                                                                                                               |
+| -------------------- | --------- | ----------- | ---------------------------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pay invoice          | high      | blocking    | SOW §4 (deposit schedule); ticket PTL-217                  | external             | vendor URL `https://checkout.stripe.com/*` (SOW §4)                                                                                                                                 |
+| Review/sign proposal | high      | blocking    | SOW §3 (engagement kickoff)                                | external             | vendor URL `https://app.signwell.com/*` (SOW §3)                                                                                                                                    |
+| See what's happening | high      | medium      | interview 2026-03-14 §2 "I just want to know where we are" | hub                  | redirect_to /portal cited: src/pages/portal/index.astro:332 (structural evidence type 1: shipped redirect-equivalent — the dashboard renders at `/portal` and is the login-landing) |
+| Find document        | medium    | medium      | SOW §2.3 (deliverable retention); ticket PTL-138           | last-visited-surface | no auto-return; user stays on document list after download                                                                                                                          |
+| Check progress       | medium    | medium      | interview 2026-03-14 §4                                    | hub                  | redirect_to /portal cited: src/pages/portal/engagement/index.astro:101 (back affordance)                                                                                            |
+| Contact consultant   | variable  | high        | SOW §6 (support commitments); interview 2026-03-14 §5      | external             | mailto/tel/sms schemes (unambiguous vendor terminals)                                                                                                                               |
+
+#### Task-to-surface mapping
+
+| Task                  | Primary surface         | Touched                         | Entry point            |
+| --------------------- | ----------------------- | ------------------------------- | ---------------------- |
+| Pay invoice           | `/portal/invoices/[id]` | home → list → detail → Stripe   | Email, home ActionCard |
+| Review/sign proposal  | `/portal/quotes/[id]`   | home → list → detail → SignWell | Email, home timeline   |
+| See what's happening  | `/portal`               | home                            | Login, bookmark        |
+| Find document         | `/portal/documents`     | home → tab → list → document    | Persistent nav         |
+| Check progress        | `/portal/engagement`    | home → tab → progress           | Persistent nav         |
+| Contact consultant    | any                     | three-icon contact control      | Header + right rail    |
+| Review past proposals | `/portal/quotes`        | home → tab → list               | Persistent nav         |
+| Review past invoices  | `/portal/invoices`      | home → tab → list               | Persistent nav         |
+
+**Note on v3 migration.** Rows 1 and 2 (pay-invoice, review-sign-proposal) declare `return_locus=external` because both tasks terminate at vendor URLs (Stripe, SignWell). With 2 of the top-3-by-frequency tasks exiting externally, R25 D1 disqualifies hub-and-spoke (NN/g definition requires hub return). See §4.4 for the v3 pattern selection.
+
+### 1.5 Surface class: `session-auth-admin`
+
+#### Primary tasks
+
+1. **Triage incoming assessments** — new leads, qualification
+2. **Create and send proposals** — build SOW, send to client
+3. **Issue and manage invoices** — deposit, completion, retainer
+4. **Track engagement progress** — milestones, touchpoints, handoff
+5. **Manage clients** — view history, update notes
+
+---
+
+## 2. Sitemap and auth boundary
+
+### 2.1 Sitemap (abbreviated)
+
+```
+public (smd.services)
+├── /                           dashboard (marketing home)
+├── /scorecard                  detail
+├── /book                       form
+├── /contact                    form
+├── /404, /500                  error
+└── /book/manage/[token]        token-auth detail
+
+auth-gate
+├── /auth/login                 form (admin)
+└── /auth/portal-login          form (client)
+
+token-auth (portal.smd.services)
+├── /portal/proposals/[token]   detail
+└── /invoice/[id]               detail
+
+session-auth-client (portal.smd.services)
+├── /portal                     dashboard
+├── /portal/quotes              list
+├── /portal/quotes/[id]         detail
+├── /portal/invoices            list
+├── /portal/invoices/[id]       detail
+├── /portal/documents           list
+└── /portal/engagement          detail
+
+session-auth-admin (admin.smd.services)
+├── /admin                      dashboard
+├── /admin/assessments          list
+├── /admin/assessments/[id]     detail
+├── /admin/clients              list
+├── /admin/clients/[id]         detail
+├── /admin/quotes               list
+├── /admin/quotes/new           form
+├── /admin/quotes/[id]          detail
+├── /admin/invoices             list
+├── /admin/invoices/new         form
+├── /admin/invoices/[id]        detail
+├── /admin/engagements          list
+├── /admin/engagements/[id]     detail
+└── /admin/engagements/new      wizard
+```
+
+### 2.2 Auth boundary
+
+| Surface class       | Middleware check       | Session cookie        | Redirect on expiry              |
+| ------------------- | ---------------------- | --------------------- | ------------------------------- |
+| public              | none                   | none                  | —                               |
+| auth-gate           | none (render login)    | sets cookie on submit | —                               |
+| token-auth          | token signature verify | none                  | `/auth/portal-login`            |
+| session-auth-client | role=client cookie     | `smd_portal_session`  | `/auth/portal-login?redirect=X` |
+| session-auth-admin  | role=admin cookie      | `smd_admin_session`   | `/auth/login?redirect=X`        |
+
+### 2.3 Deep-link inventory
+
+| URL pattern                 | Surface             | Entry vector        |
+| --------------------------- | ------------------- | ------------------- |
+| `/portal/proposals/[token]` | token-auth          | Email               |
+| `/invoice/[id]`             | token-auth          | Email               |
+| `/book/manage/[token]`      | token-auth          | Confirmation email  |
+| `/portal/quotes/[id]`       | session-auth-client | Email (after login) |
+| `/portal/invoices/[id]`     | session-auth-client | Email (after login) |
+
+---
+
+## 3. Reachability matrix
+
+### 3.1 Invariants
+
+- Every surface appears as From ≥1 and To ≥1.
+- Entry-only and Terminal exceptions flagged explicitly.
+- Every dashboard has Required=Yes rows to every sibling list.
+- Every detail has Required=Yes back to its parent list.
+- No dead ends unless Terminal.
+
+### 3.2 Matrix
+
+| From                                 | To                            | Mechanism             | Required?                         | Pattern                              |
+| ------------------------------------ | ----------------------------- | --------------------- | --------------------------------- | ------------------------------------ |
+| `/` (dashboard)                      | `/scorecard`                  | Inline CTA            | Yes                               | Pyramid                              |
+| `/` (dashboard)                      | `/book`                       | Primary CTA           | Yes                               | Pyramid                              |
+| `/` (dashboard)                      | `/contact`                    | Footer link           | Yes                               | Pyramid                              |
+| `/scorecard` (detail)                | `/book`                       | Primary CTA           | Yes                               | Pyramid                              |
+| `/book` (form)                       | (external calendar)           | Submit redirect       | Yes                               | External                             |
+| `/portal` (dashboard)                | `/portal/quotes`              | Section card          | Yes                               | Hub-and-spoke                        |
+| `/portal` (dashboard)                | `/portal/invoices`            | Section card          | Yes                               | Hub-and-spoke                        |
+| `/portal` (dashboard)                | `/portal/documents`           | Section card          | Yes                               | Hub-and-spoke                        |
+| `/portal` (dashboard)                | `/portal/engagement`          | Section card          | Yes                               | Hub-and-spoke                        |
+| `/portal` (dashboard)                | `/portal/invoices/[id]`       | ActionCard            | Conditional (has pending invoice) | Dominant-action variant              |
+| `/portal` (dashboard)                | `mailto:<consultant_email>`   | Contact icon          | Conditional (consultant assigned) | Contact-control                      |
+| `/portal` (dashboard)                | `sms:<consultant_phone>`      | Contact icon          | Conditional                       | Contact-control                      |
+| `/portal` (dashboard)                | `tel:<consultant_phone>`      | Contact icon          | Conditional                       | Contact-control                      |
+| `/portal` (dashboard)                | `/api/auth/logout`            | Logout button         | Yes                               | —                                    |
+| `/portal/quotes` (list)              | `/portal/quotes/[id]`         | Row click             | Yes                               | Master-detail                        |
+| `/portal/quotes` (list)              | `/portal`                     | Back button           | Yes                               | Hub-and-spoke                        |
+| `/portal/quotes/[id]` (detail)       | `/portal/quotes`              | Back button           | Yes                               | Master-detail                        |
+| `/portal/quotes/[id]` (detail)       | `<signwell>`                  | Review & Sign CTA     | Conditional (status=sent)         | External                             |
+| `/portal/invoices` (list)            | `/portal/invoices/[id]`       | Row click             | Yes                               | Master-detail                        |
+| `/portal/invoices` (list)            | `/portal`                     | Back button           | Yes                               | Hub-and-spoke                        |
+| `/portal/invoices/[id]` (detail)     | `/portal/invoices`            | Back button           | Yes                               | Master-detail                        |
+| `/portal/invoices/[id]` (detail)     | `<stripe>`                    | Pay Now CTA           | Conditional (status≠paid)         | External                             |
+| `/portal/documents` (list)           | `/api/portal/documents/[key]` | Row click             | Yes                               | Master-detail                        |
+| `/portal/documents` (list)           | `/portal`                     | Back button           | Yes                               | Hub-and-spoke                        |
+| `/portal/engagement` (detail)        | `/portal`                     | Back button           | Yes                               | Hub-and-spoke                        |
+| `/admin` (dashboard)                 | `/admin/assessments`          | Nav tab               | Yes                               | Hub-and-spoke (ratified tab variant) |
+| `/admin` (dashboard)                 | `/admin/clients`              | Nav tab               | Yes                               | Hub-and-spoke (tabs)                 |
+| `/admin` (dashboard)                 | `/admin/quotes`               | Nav tab               | Yes                               | Hub-and-spoke (tabs)                 |
+| `/admin` (dashboard)                 | `/admin/invoices`             | Nav tab               | Yes                               | Hub-and-spoke (tabs)                 |
+| `/admin` (dashboard)                 | `/admin/engagements`          | Nav tab               | Yes                               | Hub-and-spoke (tabs)                 |
+| `/portal/proposals/[token]` (detail) | `<signwell>`                  | Review & Sign CTA     | Yes                               | External                             |
+| `/invoice/[id]` (detail)             | `<stripe>`                    | Pay Now CTA           | Yes                               | External                             |
+| `/auth/login` (form)                 | `/admin`                      | Submit → redirect     | Yes                               | —                                    |
+| `/auth/portal-login` (form)          | `/portal`                     | Magic link → redirect | Yes                               | —                                    |
+
+### 3.3 Entry-only surfaces
+
+| Surface                     | Entry vector       | Notes                    |
+| --------------------------- | ------------------ | ------------------------ |
+| `/portal/proposals/[token]` | Email deep-link    | Token-auth; cold arrival |
+| `/invoice/[id]`             | Email deep-link    | Token-auth; cold arrival |
+| `/book/manage/[token]`      | Confirmation email | Token-auth               |
+
+### 3.4 Terminal surfaces
+
+| Surface                     | Terminal action                      | Notes                         |
+| --------------------------- | ------------------------------------ | ----------------------------- |
+| Stripe hosted payment       | External redirect                    | Not part of venture IA        |
+| SignWell signing            | External redirect                    | Not part of venture IA        |
+| Post-signature confirmation | Auto-redirect to `/portal` within 3s | Manual fallback link provided |
+
+---
+
+## 4. Pattern selection
+
+### 4.1 Surface class: `public`
+
+| Archetype | Pattern                                     | Rationale                                     |
+| --------- | ------------------------------------------- | --------------------------------------------- |
+| dashboard | Pyramid (NN/g §1.4) with persistent top nav | Small content set; linear narrative from home |
+| detail    | Single-page detail with inline CTA          | Single long-form; conversion CTA inline       |
+| form      | Single-page form                            | Small field count; no ordering                |
+| error     | Recovery-path                               | Link to `/`                                   |
+
+### 4.2 Surface class: `auth-gate`
+
+| Archetype | Pattern                     | Rationale           |
+| --------- | --------------------------- | ------------------- |
+| form      | Single-page form (centered) | One action: sign in |
+
+### 4.3 Surface class: `token-auth`
+
+| Archetype | Pattern                    | Rationale                                                           |
+| --------- | -------------------------- | ------------------------------------------------------------------- |
+| detail    | Master-detail (simplified) | Cold arrival via email; back target is external; single primary CTA |
+
+### 4.4 `session-auth-client × dashboard` — pattern decision (v3 format)
+
+**Chosen pattern:** persistent-tabs
+**Runner-up pattern:** hub-and-spoke
+**Defense:** Per §1.4, the top-3-by-frequency tasks are pay-invoice, review-sign-proposal, and see-what's-happening. The first two carry `return_locus=external` (Stripe, SignWell); only one returns to the hub. Hub-and-spoke requires hub return as its core premise (NN/g §1.1) — with 2 of 3 high-frequency tasks exiting externally, D1 disqualifies hub-and-spoke on this surface. Persistent-tabs (Material Design 3 §2.2 bottom navigation / §2.5 tabs) satisfies the task model: 4 destinations ≤ 5 (D3 threshold), cross-section switching is high (users move pay-invoice → find-document → check-progress within a session per interview 2026-03-14 §3), and no sequential ordering applies.
+
+**Algorithm inputs (from §1.4 + §3):**
+
+- destination_count: 4 (quotes, invoices, documents, engagement)
+- primary_task_count: 6
+- task_ordering: independent
+- top-3-by-frequency: [pay-invoice external, review-sign-proposal external, see-what's-happening hub]
+- return_locus counts in top-3: { hub: 1, external: 2 }
+
+**Reviewer approvals (Phase 7):** Not applicable — chosen pattern equals the top-scored (surviving) pattern. No override required.
+
+### 4.4.1 `session-auth-client × list` and `session-auth-client × detail`
+
+| Archetype | Pattern           | Rationale                                                  |
+| --------- | ----------------- | ---------------------------------------------------------- |
+| list      | **Master-detail** | List → detail → back; state preserved on return            |
+| detail    | **Master-detail** | Back to parent list; primary action (Sign / Pay) prominent |
+
+**Required elements for persistent-tabs (from pattern-catalog.md §2 + pattern-disqualifiers.md):**
+
+- Persistent nav affordance (bottom nav on mobile / top tabs on desktop) visible on every portal surface
+- 4 labeled destinations: Proposals, Invoices, Documents, Progress
+- `aria-current="page"` on the active tab
+- Tap target ≥ 44px (mobile), minimum Material 3 dimensions
+- Active indicator per Section 8 state colors
+
+### 4.5 Surface class: `session-auth-admin`
+
+| Archetype | Pattern                                     | Rationale                                                                                                                                                        |
+| --------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dashboard | **Hub-and-spoke with ratified tab variant** | 5 top-level sections; Material Design 3 navigation-tabs pattern permits 3–5 destinations at persistent visibility; high switching frequency in operator workflow |
+| list      | Master-detail + Faceted (when count >30)    | Filter needed for large sets                                                                                                                                     |
+| detail    | Nested-doll + Master-detail                 | Multi-level hierarchy uses breadcrumbs                                                                                                                           |
+| wizard    | Sequential (NN/g §1.3)                      | Multi-step intake with mandatory ordering                                                                                                                        |
+
+**Ratification note (Appendix E.1):** Admin nav tabs are the one permitted exception to the global "no nav tabs in header" anti-pattern. Rationale: admin's 5-section scope + high-frequency switching (10–20×/session) + Material's documented destination-count-and-frequency rule. Validator R6 has explicit `surface != "session-auth-admin"` guard.
+
+---
+
+## 5. Navigation state machine
+
+### 5.1 Surface class: `session-auth-client`
+
+#### Auth states
+
+| State           | Detection                                 | Behavior                                         |
+| --------------- | ----------------------------------------- | ------------------------------------------------ |
+| Authenticated   | `Astro.locals.session?.role === 'client'` | Full nav per reachability matrix                 |
+| Expired         | Middleware 401                            | Redirect to `/auth/portal-login?redirect=<path>` |
+| Unauthenticated | No session                                | Redirect to `/auth/portal-login`                 |
+
+#### `/portal` data states
+
+| State                      | Condition                                     | Rendering                                                                                                   |
+| -------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Empty                      | `!activeEngagement`                           | Welcome message, "Your portal will populate when your engagement begins," ConsultantBlock, no section cards |
+| Error                      | DB fetch threw                                | Error card with Retry, ConsultantBlock preserved                                                            |
+| Populated, pending invoice | `pendingInvoice != null`                      | ActionCard dominant, Recent Activity, 4 section cards                                                       |
+| Populated, next touchpoint | `nextTouchpointAt != null && !pendingInvoice` | Touchpoint card, Recent Activity, 4 section cards                                                           |
+| Populated, idle            | else                                          | "Nothing needs your attention right now," Recent Activity, 4 section cards                                  |
+
+#### `/portal/quotes/[id]` task states
+
+| quote.status | Primary CTA              | Body                                                       |
+| ------------ | ------------------------ | ---------------------------------------------------------- |
+| sent         | Review & Sign (SignWell) | Expiry countdown if set                                    |
+| accepted     | —                        | "Signed on <date>"; link to deposit invoice if issued      |
+| declined     | —                        | "You declined this proposal on <date>"; Contact consultant |
+| expired      | —                        | "This proposal expired on <date>"; Contact consultant      |
+
+#### `/portal/invoices/[id]` task states
+
+| invoice.status | Primary CTA                 | Body                         |
+| -------------- | --------------------------- | ---------------------------- |
+| sent           | Pay Now                     | Amount + due date            |
+| overdue        | Pay Now (overdue indicator) | Amount + due date (past)     |
+| paid           | —                           | Paid badge, receipt download |
+| void           | —                           | Voided notice                |
+
+---
+
+## 6. Chrome component contracts
+
+### 6.1 Header band
+
+- Element: `<header role="banner">`, `sticky top-0 z-50`, `h-14 md:h-16`, `bg-white`, `border-b border-[color:var(--color-border)]`.
+- Left: client/workspace name, Inter 500, 13/18, `#475569`.
+- Right: optional contact icons (44×44 each with `aria-label`), utility actions.
+- Forbidden: logo, nav tabs (except admin), hamburger, backdrop-blur, opacity modifiers.
+
+### 6.2 Back affordance
+
+- Element: `<a href="<canonical-URL>" aria-label="<target-name>">` with `chevron_left` icon.
+- Height: 44px.
+- Position: first child of `<main>`, not in header.
+- Forbidden: `href="#"`, `javascript:*`, `history.back()`, breadcrumb wrapper for single link.
+
+### 6.3 Breadcrumbs
+
+- Allowed ONLY on `session-auth-admin` list and detail archetypes.
+- Format: `<nav aria-label="Breadcrumb"><ol>...</ol></nav>` with 2+ items.
+- Separator: `chevron_right` Material icon with `aria-hidden`.
+- Mobile: segment truncation at 24ch.
+
+### 6.4 Section cards (dashboard)
+
+- Element: `<a>` with full-card click area, `min-h-[88px]`, rounded-lg surface, border.
+- Content: icon top-left, label (Plus Jakarta Sans bold), caption (muted).
+- Hover: border lifts to `--color-border-strong`.
+- Focus: 2px ring at 2px offset.
+- Grid: 1 column mobile, 2 columns desktop.
+
+### 6.5 Skip-to-main
+
+- Element: `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>`.
+- Position: first child of `<body>`.
+- Target: `<main id="main" role="main">`.
+
+### 6.6 Footer
+
+- Rendered ONLY on `public` surfaces.
+- 3-column desktop, stacked mobile.
+
+---
+
+## 7. Mobile ↔ desktop transforms
+
+Single breakpoint: **768px** (`md:`). Higher breakpoints only for content-width adjustments, not navigation pattern changes.
+
+| Surface class       | Mobile                                  | Desktop (≥768px)                                            |
+| ------------------- | --------------------------------------- | ----------------------------------------------------------- |
+| public              | Single column, hero stacked             | Two column on home; three column on footer                  |
+| token-auth          | Single column, primary action prominent | Single column max 720px                                     |
+| session-auth-client | Single column; sections stacked         | Two-column grid (main + right rail); section cards 2-across |
+| session-auth-admin  | `<details>` menu dropdown for nav       | Inline nav tabs in header                                   |
+
+---
+
+## 8. State conventions
+
+- Active: `#1E40AF` / `var(--color-primary)`
+- Default: `#475569` / `var(--color-text-secondary)`
+- Hover: `#0F172A` / `var(--color-text-primary)`
+- Focus ring: 2px `#3B82F6` / `var(--color-action)` at 2px offset, keyboard-focus only
+- Disabled: `#94A3B8` / `var(--color-text-muted)`
+- Tap target minimum: 44×44px
+
+---
+
+## 9. Transition contracts
+
+- Back target is canonical absolute URL. Never `#`, `javascript:*`, or `history.back()`.
+- Modal: Esc + click-outside close; focus returns to trigger.
+- Cross-auth-boundary navigation: full page reload (not SPA nav).
+- Post-action redirects (sign, pay) target dashboard with confirmation message.
+
+---
+
+## 10. Anti-patterns (summary)
+
+**Chrome (R1–R15):** fixed-not-sticky, backdrop-blur, icon before client name, breadcrumb-wrapper-single-back, href="#"/history.back(), nav tabs (non-admin), bottom-tab nav, footer on auth, real-face photos, marketing CTAs on auth.
+
+**IA (R16–R24):** orphan destinations, dead-ends, pattern-impersonation, token-auth amnesia, taxonomy drift, state omission, heading hierarchy violation, search missing, cross-surface context loss.
+
+Full list with rationale: [references/anti-patterns.md](../references/anti-patterns.md).
+
+---
+
+## 11. A11y floor
+
+- Landmarks: `<header role="banner">`, `<main role="main" id="main">`, `<nav>` when navigation elements are grouped.
+- Skip-to-main link: first body child, sr-only-until-focused.
+- Heading hierarchy: exactly one `<h1>`; `<h2>` for major sections; no level skipping.
+- `aria-current="page"` on active nav item if nav is rendered.
+- Focus rings: keyboard-only.
+- Icon-only buttons/links: always carry `aria-label`.
+- Tap targets: 44×44px minimum.
+- Keyboard order matches visual order.
+
+---
+
+## 12. Content taxonomy
+
+### 12.1 Object names
+
+| Entity          | Canonical label | Forbidden synonyms             |
+| --------------- | --------------- | ------------------------------ |
+| quote           | Proposal        | Quote, Estimate, Bid, SOW      |
+| invoice         | Invoice         | Bill, Statement                |
+| engagement      | Engagement      | Project, Contract, Job         |
+| milestone       | Milestone       | Phase, Stage, Task, Checkpoint |
+| client (entity) | Client          | Customer, Account              |
+| consultant      | Consultant      | Agent, Staff, Advisor, Rep     |
+| document        | Document        | File, Attachment, Artifact     |
+
+### 12.2 Action verbs
+
+| Action                 | Canonical verb                |
+| ---------------------- | ----------------------------- |
+| View proposal detail   | Review                        |
+| Sign proposal          | Review & Sign                 |
+| Pay invoice            | Pay                           |
+| Download/view document | View (PDF) / Download (other) |
+| Contact consultant     | Contact                       |
+
+### 12.3 Status labels
+
+| Entity  | DB value | Label          | Badge |
+| ------- | -------- | -------------- | ----- |
+| quote   | sent     | Pending Review | blue  |
+| quote   | accepted | Accepted       | green |
+| quote   | declined | Declined       | red   |
+| quote   | expired  | Expired        | amber |
+| invoice | sent     | Sent           | blue  |
+| invoice | paid     | Paid           | green |
+| invoice | overdue  | Overdue        | red   |
+| invoice | void     | Voided         | slate |
+
+### 12.4 Time expressions
+
+| Context          | Format                               |
+| ---------------- | ------------------------------------ |
+| List items       | `Mon D, YYYY` (same year: `Mon D`)   |
+| Relative         | `N days ago` / `Yesterday` / `Today` |
+| Expiry countdown | `Expires in N days`                  |
+| Touchpoint       | `DayName, Mon D at H:MM AM/PM`       |
+
+### 12.5 Empty-state copy
+
+| Surface              | Copy                                                                          |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `/portal/quotes`     | No proposals yet. When we send you one, it will appear here.                  |
+| `/portal/invoices`   | No invoices yet. When we issue one, it will appear here.                      |
+| `/portal/documents`  | Documents will appear here as your engagement progresses.                     |
+| `/portal/engagement` | No active engagement. When your engagement begins, progress will appear here. |
+| `/portal` (idle)     | Nothing needs your attention right now.                                       |
+
+---
+
+## Appendix A — public
+
+Chrome-allowed delta: logo in header, footer present, marketing hero imagery, CTAs addressed to prospects.
+
+Chrome-forbidden delta: back button (home is the top), session-auth chrome.
+
+## Appendix B — auth-gate
+
+Chrome-allowed delta: wordmark-only centered header, single form card.
+
+Chrome-forbidden delta: nav tabs, section cards, Recent Activity, right rail.
+
+## Appendix C — token-auth
+
+Chrome-allowed delta: minimal header with client name (derived from token), primary CTA, optional contact icons.
+
+Chrome-forbidden delta: Sign out button, "welcome back" copy, section cards, session-state UI.
+
+## Appendix D — session-auth-client (portal)
+
+Chrome-allowed delta: three-icon contact control on right of header (mail/sms/tel) conditionally when consultant assigned.
+
+Chrome-forbidden delta: nav tabs.
+
+### D.1 Section card grid requirement (R16)
+
+Portal home MUST render section cards to all four sibling list routes: `/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement`. Specialization of hub-and-spoke required for this venture. Omission is R16 violation.
+
+## Appendix E — session-auth-admin
+
+Chrome-allowed delta: nav tabs in header (5 items), breadcrumbs on list/detail, mobile `<details>` menu dropdown for nav.
+
+### E.1 Admin tabs exception (ratified)
+
+`session-auth-admin` is the ONE permitted exception to the global "no nav tabs in header" rule. Rationale: 5-section scope, high-frequency switching, Material Design 3 navigation-tabs rule (3–5 destinations with frequent switching). Validator R6 has explicit `surface != "session-auth-admin"` guard.
+
+---
+
+## Non-blocking follow-ups
+
+Flagged during v2 migration:
+
+- `/privacy` and `/terms` routes not yet created
+- 404 page subdomain-aware back-link logic not yet implemented
+- Scorecard wizard sticky-bottom nav refactor (Phase 0 semantic compliance)

--- a/.agents/skills/nav-spec/examples/drift-audit-report.md
+++ b/.agents/skills/nav-spec/examples/drift-audit-report.md
@@ -1,0 +1,51 @@
+# Drift audit — ss-console — 2026-04-15
+
+spec-version checked against: _no spec yet (pre-authoring)_
+
+## Live code matrix
+
+| File                                   | Primary chrome                                                                 | Back/breadcrumb                           | Auth level          | Mobile pattern                                            | Shared layout?                |
+| -------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------- | ------------------- | --------------------------------------------------------- | ----------------------------- |
+| `src/components/Nav.astro`             | Sticky header, logo left, Contact + Book CTA right                             | None                                      | Public              | Responsive max-w                                          | Yes — used by marketing pages |
+| `src/components/PortalHeader.astro`    | Minimal band, avatar + client name, optional SMS link on mobile                | None                                      | Session-auth-client | Single-column mobile                                      | Yes — `/portal/*`             |
+| `src/layouts/AdminLayout.astro`        | Top-band header with inline nav tabs + optional breadcrumbs + email + Sign out | Breadcrumbs (optional, hierarchical)      | Session-auth-admin  | No mobile-specific pattern                                | Yes — `/admin/*`              |
+| `src/pages/portal/invoices/[id].astro` | Uses `PortalHeader`                                                            | None — no back affordance, no breadcrumbs | Session-auth-client | Two-column (md breakpoint), action card above fold mobile | Yes                           |
+| `src/pages/portal/quotes/[id].astro`   | Uses `PortalHeader`                                                            | None — login-check only                   | Session-auth-client | Two-column (lg breakpoint), left-main layout              | Yes                           |
+| `src/pages/scorecard.astro`            | Uses `Nav.astro`                                                               | None                                      | Public              | Responsive, no mobile nav                                 | Yes                           |
+
+## Generated artifact matrix
+
+| File                                                | Primary chrome                                         | Back/breadcrumb | Auth level implied | Mobile pattern              |
+| --------------------------------------------------- | ------------------------------------------------------ | --------------- | ------------------ | --------------------------- |
+| `.stitch/designs/portal-v1/home-desktop.html`       | Fixed sticky header (logo + 3 nav tabs)                | None            | Guest (no auth UI) | Bottom-tab nav (4 items)    |
+| `.stitch/designs/portal-v1/proposal-desktop.html`   | Sticky header (logo + status badge)                    | None            | Guest              | No mobile (desktop-primary) |
+| `.stitch/designs/portal-v1/invoice-desktop.html`    | Fixed top header (logo + SMS button)                   | Back link (↵)   | Guest              | No mobile                   |
+| `.stitch/designs/portal-v1/home-mobile-v2.html`     | Minimal header (avatar + client name)                  | None            | Guest              | Centered layout             |
+| `.stitch/designs/portal-v1/invoice-mobile-v2.html`  | Sticky header (arrow_back + "Portal" wordmark + title) | Back only       | Guest              | Sticky-bottom action bar    |
+| `.stitch/designs/portal-v1/proposal-mobile-v2.html` | Sticky header                                          | None            | Guest              | Centered                    |
+| `.stitch/*.html` (scorecard scratch)                | Sticky nav (logo + links + CTA)                        | None            | Guest              | No mobile pattern           |
+
+## Spec compliance matrix
+
+_(Not applicable — no spec exists yet. This audit informs the first spec.)_
+
+## Drift summary (6 bullets)
+
+1. **Three distinct live headers, three live breakpoints.** `Nav.astro` uses `sticky` marketing chrome with logo+CTA. `PortalHeader.astro` is a minimalist band with avatar+name. `AdminLayout` header has inline nav tabs + breadcrumbs + auth affordances. No shared underlying component. Portal uses `md:` breakpoints, invoice detail uses `lg:`. Breakpoint fragmentation is real.
+
+2. **Back navigation is absent from 5 of 6 Stitch portal artifacts.** Deep-link pages (`/portal/invoices/[id]`, `/portal/proposals/[token]`) have no return path. `PortalHeader.astro` in live code has no back affordance either. The first user to hit an invoice via email has no clear way to the dashboard.
+
+3. **Header stickiness inconsistent across Stitch artifacts.** `home-desktop` uses `fixed top-0`. `proposal-desktop` uses `sticky`. `invoice-desktop` uses `fixed`. No clear rule. Each run invents.
+
+4. **Mobile navigation strategy undefined in both code and Stitch output.** `home-desktop.html` has a bottom-tab nav with 4 items (forbidden per our anti-patterns, but shipped). `home-mobile-v2.html` has no mobile nav at all. `scorecard-quiz.html` has a `bottom-0` bar. Portal code has no mobile nav strategy. Scaling Stitch to production requires inventing mobile nav for every screen.
+
+5. **Auth-level presentation missing from every Stitch artifact.** All 6 Stitch portal designs render as "guest" — no sign-out, no user context. Live `PortalHeader.astro` and `AdminLayout` both have logout affordances. Stitch output can't serve as a production template without auth-chrome layered in afterwards.
+
+6. **Token-auth is silently collapsed into "portal."** Proposal landings (`/portal/proposals/[token]`) and invoice landings (`/invoice/[id]`) are token-auth — neither fully public nor session-auth. Current designs and code treat them inconsistently: some have auth-style chrome, some have marketing-style chrome. Spec must carve out a fourth surface class for these.
+
+## Follow-ups
+
+1. **Author NAVIGATION.md v1** (owner: user + nav-spec) — resolves all drift items above by defining the contract.
+2. **Refactor `Nav.astro`, `PortalHeader.astro`, `AdminLayout.astro` to match spec** (owner: user, separate PR, post-spec-approval) — aligns shipped code with the contract. Likely touches breakpoint conventions, back affordances, and the portal/token-auth distinction.
+3. **Regenerate stale portal-v1 designs** (owner: user, optional) — those were produced before the spec and don't benefit from the injection. Keep them as historical reference or regenerate; user's call.
+4. **Revisit admin chrome specifically** (owner: IA reviewer in Phase 4) — the current admin layout has nav tabs, which our default anti-pattern list forbids. Decision needed: align spec to code (admin tabs allowed) or align code to spec (remove tabs from admin).

--- a/.agents/skills/nav-spec/examples/ia-audit-report.md
+++ b/.agents/skills/nav-spec/examples/ia-audit-report.md
@@ -1,0 +1,156 @@
+---
+description: Gold-standard format for the output of `/nav-spec --ia-audit`. A real audit report for ss-console at the end of v1 (April 2026) would have looked like this — and would have flagged the portal-home gap before a human pointed it out.
+---
+
+# IA Audit Report — <venture> — <YYYY-MM-DD>
+
+**Spec version audited against:** `NAVIGATION.md` spec-version=<N>, skill-version=<M>.
+**Code commit:** `<sha>`.
+**Scope:** all surface classes present in `src/pages/**`.
+
+---
+
+## Summary
+
+| Check                                               | Violations | Severity              | Blocks merge? |
+| --------------------------------------------------- | ---------- | --------------------- | ------------- |
+| A — Orphan destinations (IA-O / R16)                | <N>        | structural            | Yes           |
+| B — Dead-end surfaces (IA-D / R18)                  | <N>        | structural            | Yes           |
+| C — Matrix completeness for dashboards (IA-M / R16) | <N>        | structural            | Yes           |
+| D — Detail-to-parent (IA-B / R5)                    | <N>        | structural            | Yes           |
+| E — Pattern conformance (IA-P / R17)                | <N>        | structural            | Yes           |
+| F — Taxonomy adherence (IA-T / R20)                 | <N>        | semantic              | Warn          |
+| G — State handling (IA-S / R21)                     | <N>        | structural / semantic | Mixed         |
+| H — Token-auth cold arrival (IA-TC / R19)           | <N>        | structural            | Yes           |
+| **Total structural**                                | **<N>**    | —                     | —             |
+| **Total semantic**                                  | **<N>**    | —                     | —             |
+
+**Verdict:** <PASS / FAIL>
+
+---
+
+## A. Orphan destinations
+
+Routes that exist in `src/pages/**` but have no matrix row declaring them as a `To`. These routes are only reachable by knowing the URL.
+
+| Route                | Surface class       | Archetype | Notes                                            |
+| -------------------- | ------------------- | --------- | ------------------------------------------------ |
+| `/portal/quotes`     | session-auth-client | list      | No dashboard section card links here             |
+| `/portal/invoices`   | session-auth-client | list      | Reachable only via Recent Activity detail → back |
+| `/portal/documents`  | session-auth-client | list      | Completely orphaned                              |
+| `/portal/engagement` | session-auth-client | detail    | Completely orphaned                              |
+
+**Fixes:**
+
+1. Add 4 matrix rows (Section 3.2 of NAVIGATION.md):
+   ```
+   | `/portal` (dashboard) | `/portal/quotes` | Section card | Yes | Hub-and-spoke |
+   | `/portal` (dashboard) | `/portal/invoices` | Section card | Yes | Hub-and-spoke |
+   | `/portal` (dashboard) | `/portal/documents` | Section card | Yes | Hub-and-spoke |
+   | `/portal` (dashboard) | `/portal/engagement` | Section card | Yes | Hub-and-spoke |
+   ```
+2. Implement section cards on `/portal` that link to each.
+
+---
+
+## B. Dead-end surfaces
+
+Surfaces with no navigation exit in rendered HTML. Not intended terminal surfaces.
+
+| Route                | Surface class | Archetype | Notes |
+| -------------------- | ------------- | --------- | ----- |
+| (none in this audit) |
+
+---
+
+## C. Matrix completeness for dashboards
+
+Dashboards declared in spec that don't emit all required `<a href>` per matrix.
+
+| Dashboard | Missing links                                                                   | Required per matrix |
+| --------- | ------------------------------------------------------------------------------- | ------------------- |
+| `/portal` | `/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement` | Yes (all four)      |
+
+This is the same violation surfaced in Check A, viewed from the dashboard side. Fixing A resolves C.
+
+---
+
+## D. Detail-to-parent
+
+Detail archetypes missing a back affordance to their parent list.
+
+| Route                    | Expected back target | Actual href | Notes |
+| ------------------------ | -------------------- | ----------- | ----- |
+| (all pass in this audit) |
+
+---
+
+## E. Pattern conformance
+
+Surfaces declared with a pattern that fail to implement the pattern's required elements.
+
+| Surface                                | Declared pattern | Missing element                                         |
+| -------------------------------------- | ---------------- | ------------------------------------------------------- |
+| `/portal/quotes/[id]` (status=expired) | master-detail    | No back affordance; expired state shows no recovery CTA |
+
+**Fix:** Render a back button and a "Contact consultant" CTA on expired quotes.
+
+---
+
+## F. Taxonomy adherence
+
+Labels in rendered HTML that don't match the canonical terms in Section 12.
+
+| Location                            | Found      | Canonical   | Severity |
+| ----------------------------------- | ---------- | ----------- | -------- |
+| `/portal/quotes/[id]` email subject | "Quote"    | "Proposal"  | semantic |
+| SOW PDF body copy                   | "Estimate" | "Proposal"  | semantic |
+| Admin nav label                     | "Quotes"   | "Proposals" | semantic |
+
+**Fix:** Update code to use canonical label "Proposal" everywhere. Add R20 to CI if not already.
+
+---
+
+## G. State handling
+
+Surfaces that handle only a subset of declared states.
+
+| Route                | Missing state                                                                  | Severity   |
+| -------------------- | ------------------------------------------------------------------------------ | ---------- |
+| `/portal/engagement` | Empty (no engagement) renders blank — no "when your engagement begins..." copy | structural |
+| `/portal/documents`  | Loading state shows empty list before data arrives                             | semantic   |
+
+**Fixes:**
+
+1. `/portal/engagement` — add explicit `{!engagement && <EmptyState />}` branch.
+2. `/portal/documents` — add skeleton loaders or loading state copy.
+
+---
+
+## H. Token-auth cold arrival
+
+Token-auth surfaces that assume prior session.
+
+| Route                | Violation |
+| -------------------- | --------- |
+| (none in this audit) |
+
+---
+
+## Remediation plan
+
+Ranked by blast radius and effort:
+
+1. **Add section cards to portal home** — fixes A, C. Single PR. High impact. (Addresses April 2026 regression.)
+2. **Fix `/portal/engagement` empty state** — fixes G item 1. Trivial.
+3. **Normalize "Proposal" taxonomy across code, emails, SOW** — fixes F. Cross-cutting; scope with content team.
+4. **Expired-quote back button + CTA** — fixes E. Small PR.
+5. **Loading skeletons on `/portal/documents`** — fixes G item 2. Small PR.
+
+Estimated total remediation: 4 PRs, all low-risk.
+
+---
+
+## Next audit date
+
+Recommended: 2 weeks post-remediation, OR after next IA-affecting change (new route, new surface class, pattern change). Use `/nav-spec --ia-audit` to re-run.

--- a/.agents/skills/nav-spec/examples/pattern-disqualifier-tests/admin-heavy-switching.md
+++ b/.agents/skills/nav-spec/examples/pattern-disqualifier-tests/admin-heavy-switching.md
@@ -1,0 +1,62 @@
+---
+spec-version: 3
+nav-spec-skill-version: 3.0.0
+evidence-mode: validated
+venture: synthetic-admin
+---
+
+# Navigation Spec — synthetic-admin
+
+Regression test for R25 D1 (hub-and-spoke with ≥2 of top-3 tasks having non-hub return_locus).
+
+Expected validator output: R25 structural fire on `session-auth-admin/dashboard` with D1. Surviving patterns include `persistent-tabs`.
+
+## 1. Task model
+
+### 1.1 Surface class: session-auth-admin
+
+| Task                               | Frequency | Criticality | Evidence source                    | return_locus         | return_locus_evidence                                                        |
+| ---------------------------------- | --------- | ----------- | ---------------------------------- | -------------------- | ---------------------------------------------------------------------------- |
+| Review active engagements          | high      | high        | ticket ADM-42 (daily triage)       | last-visited-surface | no auto-return; admin stays on engagement list after review                  |
+| Triage proposals pending signature | high      | blocking    | SOW §2 (SLA requires 24h response) | last-visited-surface | same pattern as engagements                                                  |
+| Run analytics reports              | high      | medium      | ticket ADM-87 (weekly KPI check)   | new-destination      | dashboards at `/admin/analytics/*` are discrete destinations                 |
+| Update consultant roster           | medium    | medium      | ticket ADM-12                      | hub                  | redirect_to /admin cited: SOW §3.1 "return to admin home after roster edits" |
+
+## 2. Sitemap and auth boundary
+
+### 2.1 Sitemap
+
+- `/admin` — dashboard
+- `/admin/entities` — list
+- `/admin/proposals` — list
+- `/admin/analytics` — dashboard
+- `/admin/consultants` — list
+
+## 3. Reachability matrix
+
+### 3.2 Matrix
+
+| From                 | To                   | Mechanism    | Required? | Pattern       |
+| -------------------- | -------------------- | ------------ | --------- | ------------- |
+| `/admin` (dashboard) | `/admin/entities`    | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/proposals`   | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/analytics`   | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/consultants` | Section card | Yes       | Hub-and-spoke |
+
+## 4. Pattern selection
+
+### 4.1 session-auth-admin × dashboard — pattern decision
+
+**Chosen pattern:** hub-and-spoke
+**Runner-up pattern:** persistent-tabs
+**Defense:** The admin dashboard is the natural landing surface; a hub-and-spoke layout gives each section equal weight and matches the sitemap shape.
+
+(Note: this defense is intentionally weak; it does not cite specific input values to override D1, so R25 must fire.)
+
+## 5. Navigation state machine
+
+(omitted for brevity in this regression test)
+
+## 6. Chrome component contracts
+
+(omitted)

--- a/.agents/skills/nav-spec/examples/pattern-disqualifier-tests/deep-content-library.md
+++ b/.agents/skills/nav-spec/examples/pattern-disqualifier-tests/deep-content-library.md
@@ -1,0 +1,71 @@
+---
+spec-version: 3
+nav-spec-skill-version: 3.0.0
+evidence-mode: validated
+venture: synthetic-library
+---
+
+# Navigation Spec — synthetic-library
+
+Regression test for R25 D2 (hub-and-spoke with destination_count > 7).
+
+Expected validator output: R25 structural fire on `session-auth-admin/dashboard` with D2. Surviving patterns include `persistent-tabs` (at desktop viewport; restricted on mobile) or navigation-rail variants (not in the disqualifier catalog — flagged as not enumerated).
+
+## 1. Task model
+
+### 1.1 Surface class: session-auth-admin
+
+| Task                   | Frequency | Criticality | Evidence source                 | return_locus | return_locus_evidence                                                                        |
+| ---------------------- | --------- | ----------- | ------------------------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| Browse content library | high      | high        | ticket LIB-1 (primary use case) | hub          | redirect_to /admin cited: SOW §1 "return to admin home is mandatory between browse sessions" |
+| Tag new uploads        | medium    | medium      | ticket LIB-8                    | hub          | redirect_to /admin cited: SOW §1                                                             |
+| Retire old content     | low       | low         | SOW §7 (retention policy)       | hub          | redirect_to /admin cited: SOW §1                                                             |
+
+## 2. Sitemap and auth boundary
+
+### 2.1 Sitemap
+
+- `/admin` — dashboard
+- `/admin/articles` — list
+- `/admin/videos` — list
+- `/admin/podcasts` — list
+- `/admin/courses` — list
+- `/admin/tags` — list
+- `/admin/authors` — list
+- `/admin/series` — list
+- `/admin/collections` — list
+- `/admin/featured` — list
+
+## 3. Reachability matrix
+
+### 3.2 Matrix
+
+| From                 | To                   | Mechanism    | Required? | Pattern       |
+| -------------------- | -------------------- | ------------ | --------- | ------------- |
+| `/admin` (dashboard) | `/admin/articles`    | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/videos`      | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/podcasts`    | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/courses`     | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/tags`        | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/authors`     | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/series`      | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/collections` | Section card | Yes       | Hub-and-spoke |
+| `/admin` (dashboard) | `/admin/featured`    | Section card | Yes       | Hub-and-spoke |
+
+## 4. Pattern selection
+
+### 4.1 session-auth-admin × dashboard — pattern decision
+
+**Chosen pattern:** hub-and-spoke
+**Runner-up pattern:** drawer
+**Defense:** Content library has 9 top-level sections, each a distinct content type, mapped to the admin home as the common return point.
+
+(Note: 9 > 7. D2 should fire regardless of return-locus evidence — the destination count alone disqualifies hub-and-spoke per NN/g guidance.)
+
+## 5. Navigation state machine
+
+(omitted)
+
+## 6. Chrome component contracts
+
+(omitted)

--- a/.agents/skills/nav-spec/examples/pattern-disqualifier-tests/mandatory-wizard.md
+++ b/.agents/skills/nav-spec/examples/pattern-disqualifier-tests/mandatory-wizard.md
@@ -1,0 +1,57 @@
+---
+spec-version: 3
+nav-spec-skill-version: 3.0.0
+evidence-mode: validated
+venture: synthetic-wizard
+---
+
+# Navigation Spec — synthetic-wizard
+
+Regression test for R25 D5 (persistent-tabs declared on a wizard archetype, where task_ordering=mandatory_sequence contradicts tabs' peer-destination premise).
+
+Expected validator output: R25 structural fire on `public/wizard` with D5. Surviving patterns include `sequential`.
+
+## 1. Task model
+
+### 1.1 Surface class: public
+
+| Task                          | Frequency | Criticality | Evidence source                         | return_locus    | return_locus_evidence                     |
+| ----------------------------- | --------- | ----------- | --------------------------------------- | --------------- | ----------------------------------------- |
+| Complete scorecard assessment | high      | high        | ticket ONB-3 (onboarding funnel metric) | new-destination | lands on results summary after completion |
+
+## 2. Sitemap and auth boundary
+
+### 2.1 Sitemap
+
+- `/scorecard/step-1`
+- `/scorecard/step-2`
+- `/scorecard/step-3`
+- `/scorecard/results`
+
+## 3. Reachability matrix
+
+### 3.2 Matrix
+
+| From                         | To                   | Mechanism   | Required? | Pattern    |
+| ---------------------------- | -------------------- | ----------- | --------- | ---------- |
+| `/scorecard/step-1` (wizard) | `/scorecard/step-2`  | Next button | Yes       | Sequential |
+| `/scorecard/step-2` (wizard) | `/scorecard/step-3`  | Next button | Yes       | Sequential |
+| `/scorecard/step-3` (wizard) | `/scorecard/results` | Submit      | Yes       | Sequential |
+
+## 4. Pattern selection
+
+### 4.1 public × wizard — pattern decision
+
+**Chosen pattern:** persistent-tabs
+**Runner-up pattern:** sequential
+**Defense:** Allowing users to jump between steps via tabs gives them flexibility in how they fill out the scorecard.
+
+(Note: this defense is weak; tabs implicitly allow out-of-order access, contradicting the mandatory sequence declared in §3.)
+
+## 5. Navigation state machine
+
+(omitted)
+
+## 6. Chrome component contracts
+
+(omitted)

--- a/.agents/skills/nav-spec/examples/phase-0-compliance-report.md
+++ b/.agents/skills/nav-spec/examples/phase-0-compliance-report.md
@@ -1,0 +1,154 @@
+# Phase 0 — Stitch injection-compliance report
+
+**Date:** 2026-04-15
+**Stitch project:** `17873719980790683333` (ss — SMD Services)
+**Test scope:** 3 prompts × 2 variants (baseline / injected) = 6 generations
+**Injection snippet:** 453 tokens (well under 600-token budget)
+
+## Test matrix
+
+| Prompt                 | Viewport | Archetype | Baseline                         | Injected                         |
+| ---------------------- | -------- | --------- | -------------------------------- | -------------------------------- |
+| Portal home dashboard  | 390×844  | dashboard | `home-mobile-baseline.html`      | `home-mobile-injected.html`      |
+| Portal invoice detail  | 390×844  | detail    | `invoice-mobile-baseline.html`   | `invoice-mobile-injected.html`   |
+| Portal proposal detail | 1280     | detail    | `proposal-desktop-baseline.html` | `proposal-desktop-injected.html` |
+
+## Results — major-category compliance (what the plan actually cares about)
+
+Forbidden chrome that injection prevented:
+
+| Forbidden pattern                      | Baseline (3 runs)                                                                                                           | Injected (3 runs)                                                        |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Global nav tabs / menu links in header | 2/3 violations (home-mobile has chat + profile icons; proposal-desktop has notifications + help icons)                      | **0/3**                                                                  |
+| Sidebar / hamburger / drawer           | 0/3                                                                                                                         | **0/3**                                                                  |
+| Logo / brand wordmark in header        | 3/3 violations (all three use "Delgado Plumbing" as brand wordmark, proposal-desktop with `text-xl font-extrabold #00288e`) | **0/3** (one minor: water_drop icon decoration on home-mobile)           |
+| Breadcrumb trail                       | 0/3                                                                                                                         | **1/3** (proposal-desktop wraps back in `<nav aria-label="Breadcrumb">`) |
+| Bottom-tab nav                         | 0/3                                                                                                                         | **0/3**                                                                  |
+| Sticky bottom action bar               | 1/3 violation (invoice-mobile-baseline has `fixed bottom-0 w-full` action bar)                                              | **0/3**                                                                  |
+| Footer / copyright / legal links       | 0/3                                                                                                                         | **0/3**                                                                  |
+| Marketing CTAs (book, schedule, etc.)  | 0/3                                                                                                                         | **0/3**                                                                  |
+| Testimonials / pull quotes             | 0/3                                                                                                                         | **0/3**                                                                  |
+| Hero imagery                           | 0/3                                                                                                                         | **0/3**                                                                  |
+| Real face in photo placeholder         | 1/3 violation (proposal-desktop-baseline uses a real headshot via `lh3.googleusercontent.com/aida/...`)                     | **0/3**                                                                  |
+
+**Major-category compliance: 97% (35 of 36 categorical rules honored across injected runs).**
+
+## Results — exact-spec compliance (strict)
+
+Nit-level violations inside the injected runs:
+
+| Run                       | Violation                                                                             | Severity |
+| ------------------------- | ------------------------------------------------------------------------------------- | -------- |
+| home-mobile-injected      | Header uses `fixed top-0` instead of `sticky top-0`                                   | cosmetic |
+| home-mobile-injected      | Added `water_drop` material icon before client name (snippet said "No logo")          | cosmetic |
+| invoice-mobile-injected   | Back link uses `href="#"` instead of hardcoded canonical URL                          | semantic |
+| proposal-desktop-injected | Header uses `bg-white/85 backdrop-blur-md` instead of solid white                     | cosmetic |
+| proposal-desktop-injected | Back button wrapped in `<nav aria-label="Breadcrumb">` (spec said breadcrumbs absent) | semantic |
+
+Strict per-rule compliance: ~87% across the three injected runs.
+
+## Cross-run consistency (the actual thesis)
+
+**Baseline runs (no injection):** three completely different header treatments.
+
+- home-mobile: `sticky top-0 shadow-sm bg-white/80 backdrop-blur-xl`, "Delgado Plumbing" brand + 2 icon buttons
+- invoice-mobile: `sticky top-0 bg-[#faf8ff]` (lavender!), arrow_back + "Portal" + title + spacer
+- proposal-desktop: non-sticky, brand wordmark + notifications/help/avatar photo
+
+Plus invoice-mobile-baseline has a **sticky-bottom action bar** that the other two don't.
+
+**Injected runs:** three structurally consistent headers.
+
+- All three: sticky (or fixed), white bg, border-b, 56/64px height, client name left, Text Scott link right, no secondary nav, no bottom chrome, no footer.
+- Consistency across mobile + desktop: chrome transforms cleanly by height (56 → 64) without diverging in structure.
+
+**This is the first time three ss-console portal surfaces have had consistent chrome across a single generation session.** That's the thesis being validated.
+
+## Decision gate
+
+The plan's gate: ≥90% strict compliance → injection-first with light validator. <90% → validator-first with minimal injection.
+
+Raw strict compliance: **~87%** — slightly below the threshold.
+Major-category compliance: **97%** — well above threshold.
+
+**Recommended verdict: injection-first with a targeted post-generation validator.**
+
+Rationale: every forbidden chrome category (nav tabs, sidebar, hamburger, bottom-tab, marketing, footer) was prevented at 100%. The residual violations are all cosmetic (`fixed` vs `sticky`, translucent vs solid bg, decorative icon on client name) or semantic (placeholder href, breadcrumb wrapper element around a single back button). These are exactly the kind of errors a lightweight HTML-parsing validator can catch deterministically:
+
+1. `fixed top-0` → flag, suggest `sticky top-0`
+2. `<nav aria-label="Breadcrumb">` → flag, suggest removing wrapper
+3. `backdrop-blur-*` class on header → flag, suggest solid background
+4. Icon/SVG sibling before client-name span in header → flag, suggest removing
+5. Back-button `<a href="#">` → flag, require explicit URL
+
+This gives us belt-and-suspenders enforcement: injection handles the high-leverage categorical rules, validator handles the residual cosmetic tail.
+
+## Follow-up — non-compliance category to refine in v2 snippet
+
+The semantic confusion around `<nav aria-label="Breadcrumb">` suggests the injection snippet should be more explicit:
+
+> Back affordance is a single `<a>` or `<button>` element with `aria-label` describing the target. Do not wrap in `<nav>`. Do not use `aria-label="Breadcrumb"`.
+
+Added to the v2 snippet in `references/injection-snippet-template.md`.
+
+## Artifacts
+
+- `/tmp/phase0/home-mobile-baseline.html` (9.5KB) + `.json` response
+- `/tmp/phase0/home-mobile-injected.html` (8.7KB) + `.json` response
+- `/tmp/phase0/invoice-mobile-baseline.html` (10.4KB) + `.json` response
+- `/tmp/phase0/invoice-mobile-injected.html` (9.1KB) + `.json` response
+- `/tmp/phase0/proposal-desktop-baseline.html` (13.9KB) + `.json` response
+- `/tmp/phase0/proposal-desktop-injected.html` (13.7KB) + `.json` response
+
+Injected runs are ~10% smaller than baselines — consistent with less chrome being rendered, as expected.
+
+## Next step
+
+Proceed to skill scaffolding (Task #2). Architecture: injection-first + lightweight validator. Validator ships as a required post-generation step in `stitch-design`'s pipeline, not as a conditional. Workflows/references in the new skill reflect this.
+
+---
+
+## Correction — revised categorical number (2026-04-15, later in same session)
+
+The initial categorical-compliance figure of 97% was based on hand-inspection that missed real-face photo placeholders in injected runs. When the validator's R9 regex was extended from `aida/` → `aida[-/]` to match Stitch's actual `aida-public/...` URL pattern, it caught placeholder photos in `invoice-mobile-injected` and `proposal-desktop-injected` that were previously uncounted.
+
+Revised: **categorical compliance ≈ 93% on injected runs** (still well within the "injection-first + required validator" architecture band). The headline conclusion is unchanged — injection prevents the big categorical failures, but a deterministic validator is required for cosmetic and semantic cleanup.
+
+## Follow-up runs — Phase 7 and Phase 8 verification
+
+On the same day, the full spec was exercised end-to-end against live Stitch generations. See `/Users/scottdurgan/dev/ss-console/.stitch/designs/v1-verification/RUN-LOG.md` for per-run detail.
+
+### Phase 7 — integration check
+
+**Regeneration:** `portal-v1/home-mobile` with the full updated NAV CONTRACT (including three-icon contact control, SVG silhouette rule, strict semantic-precision block).
+
+**Validator result after false-positive fixes:** 1 violation — R1 (fixed-vs-sticky), which is a known Stitch blindspot.
+
+**Specifically preserved in the generation (all adversarial failures in prior runs):**
+
+- Three-icon contact control (mail / sms / tel) implemented correctly
+- Skip-to-main link with matching `<main id="main-content">`
+- SVG silhouette for the consultant avatar — **no real-face placeholder this time**, a direct improvement over Phase 0
+
+### Phase 8 — adversarial verification
+
+Three prompts on unseen `{surface × archetype × viewport}` combos, each generated once and validated:
+
+| Combo                                                     | Violations       | Notes                                                                                    |
+| --------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------- |
+| `session-auth-client / form / mobile` (portal settings)   | 1 (R1)           | No back button (correct for form), three-icon contact control, no footer                 |
+| `session-auth-admin / detail / desktop` (admin audit log) | 1 (R9 real-face) | `sticky top-0`, `hidden md:flex` nav tabs, admin-exception worked, no sidebar, no footer |
+| `public / detail / desktop` (marketing blog)              | 1 (R9 real-face) | Logo + CTA header, footer present (public rule allowed), no breadcrumbs                  |
+
+**Structural violations from taxonomy gaps across all three adversarial runs: 0.**
+
+**Conclusion:** the spec handles unseen combinations correctly. The only residual violations are the two known Stitch blindspots (R1, R9), which the validator catches deterministically every time. This is the drift-prevention thesis being validated.
+
+## Validator improvements from this run
+
+Two validator false-positives were discovered and fixed:
+
+1. **R3** (icon before client name) was truncating the header to 500 chars and flagging ANY material-symbols — including the three-icon contact control on the right side. Fixed to only flag material-symbols/svg/img that appear BEFORE the first visible text element.
+2. **R15** (skip-to-main link) required `href="#main"` or `href="#content"` with specific attribute order. Stitch emits `href="#main-content"` with `class=` before `href=`. Regex broadened to accept any id that has a matching `<main id="...">` element.
+
+Both fixes re-ran against the original Phase 0 HTMLs without regressions.

--- a/.agents/skills/nav-spec/examples/v3-regression-test.md
+++ b/.agents/skills/nav-spec/examples/v3-regression-test.md
@@ -1,0 +1,221 @@
+---
+description: Expected outputs for the v3 regression-test suite. Locked. CI failure if any test deviates from the documented expectation.
+---
+
+# v3 Regression Tests
+
+The v3 skill ships with four test tracks that lock the behavior of R25 (Pattern Fitness) and R26 (Authoring Direction):
+
+1. **Synthetic unit tests** — three handcrafted NAVIGATION.md specs in `examples/pattern-disqualifier-tests/`. Each is designed to fire exactly one disqualifier. Not tuned against any real venture.
+2. **Held-out integration test** — ss-console portal migration to v3. Rubric thresholds MUST NOT be tuned against this test.
+3. **Authoring-direction lint tests** — synthetic NAVIGATION.md fragments that cite `src/components/**` / `*.astro` paths in §1–4 vs. §6.
+4. **Backwards compatibility** — v1 and v2 specs must continue to validate without R25/R26 firing.
+
+Running the full suite:
+
+```bash
+cd ~/.agents/skills/nav-spec
+
+# Track 1 — synthetic units
+for test in admin-heavy-switching mandatory-wizard deep-content-library; do
+  python3 validate.py --check-pattern-fitness \
+    --spec examples/pattern-disqualifier-tests/$test.md
+done
+
+# Track 2 — held-out integration (after ss-console migrates to v3)
+python3 validate.py --check-pattern-fitness \
+  --spec /path/to/ss-console/.stitch/NAVIGATION.md
+
+# Track 3 — R26 lint (uses /tmp fixture)
+python3 validate.py --check-pattern-fitness --spec examples/r26-lint-test.md
+
+# Track 4 — v2 backwards compat (uses existing ss-console v2 spec)
+python3 validate.py --check-pattern-fitness \
+  --spec /path/to/v2-spec/.stitch/NAVIGATION.md
+```
+
+---
+
+## Track 1 — Synthetic unit tests
+
+### 1a. `admin-heavy-switching.md` — D1 on hub-and-spoke
+
+**Input profile.** 4 top-level destinations. Four tasks; the top-3-by-frequency ranked by `(frequency desc, criticality desc)`:
+
+1. `Triage proposals pending signature` — frequency=high, criticality=blocking, return_locus=last-visited-surface
+2. `Review active engagements` — frequency=high, criticality=high, return_locus=last-visited-surface
+3. `Run analytics reports` — frequency=high, criticality=medium, return_locus=new-destination
+
+All three have non-hub `return_locus`. D1 threshold is ≥2 → D1 fires.
+
+**Expected output.**
+
+- `pass: false`
+- `violation_count: 1`
+- Single violation with:
+  - `rule: "R25"`
+  - `selector: "pattern=hub-and-spoke on session-auth-admin/dashboard"`
+  - `severity: "structural"`
+  - message mentions "D1 fired"
+  - message lists 3 tasks by name
+  - surviving patterns list includes `persistent-tabs`
+
+### 1b. `mandatory-wizard.md` — D5 on persistent-tabs
+
+**Input profile.** `public/wizard` archetype (task_ordering=mandatory_sequence by archetype derivation). Declared pattern: persistent-tabs.
+
+D5 threshold: `task_ordering == mandatory_sequence` → D5 fires.
+
+**Expected output.**
+
+- `pass: false`
+- `violation_count: 1`
+- `rule: "R25"`, `selector: "pattern=persistent-tabs on public/wizard"`
+- message mentions "D5 fired" and "task_ordering=mandatory_sequence"
+- surviving patterns list includes `sequential`
+
+### 1c. `deep-content-library.md` — D2 on hub-and-spoke
+
+**Input profile.** 9 top-level destinations. Declared pattern: hub-and-spoke.
+
+D2 threshold: `destination_count > 7` → D2 fires.
+
+**Expected output.**
+
+- `pass: false`
+- `violation_count: 1`
+- `rule: "R25"`, `selector: "pattern=hub-and-spoke on session-auth-admin/dashboard"`
+- message mentions "D2 fired" and "destination_count=9"
+- surviving patterns list includes `persistent-tabs` (at desktop viewport only — for mobile, D3 also fires on persistent-tabs because 9>5; both hub-and-spoke and persistent-tabs fail for mobile; the validator's default viewport is mobile unless overridden, so expect empty or minimal survivor list at default viewport)
+
+---
+
+## Track 2 — Held-out integration test (ss-console portal)
+
+**Pre-condition.** ss-console `.stitch/NAVIGATION.md` migrated to spec-version 3 via `/nav-spec --revise --migrate-to-v3`.
+
+**Expected task-model shape** (after migration, per SOW and vendor URL evidence):
+
+| Task                 | Frequency | return_locus         | evidence                                        |
+| -------------------- | --------- | -------------------- | ----------------------------------------------- |
+| Pay invoice          | high      | external             | vendor URL `https://checkout.stripe.com/*`      |
+| Review/sign proposal | high      | external             | vendor URL `https://app.signwell.com/*`         |
+| See what's happening | high      | hub                  | `src/pages/portal/index.astro:332` (structural) |
+| Find document        | medium    | last-visited-surface | (no auto-return; stays on list)                 |
+| Check progress       | medium    | hub                  | `src/pages/portal/engagement/index.astro:101`   |
+| Contact consultant   | variable  | external             | mailto/sms/tel schemes                          |
+
+Top-3-by-frequency (ranked by frequency desc, criticality desc):
+
+1. Pay invoice — return_locus = **external**
+2. Review/sign proposal — return_locus = **external**
+3. See what's happening — return_locus = hub
+
+Two of top-3 have non-hub return_locus → D1 fires on the declared hub-and-spoke.
+
+**Required outcomes.**
+
+- Phase 4 §4 decision entry for `session-auth-client/dashboard` declares `chosen: hub-and-spoke`, runner-up populated, defense cites migration-era rationale.
+- R25 fires structural with:
+  - `rule: "R25"`
+  - `selector: "pattern=hub-and-spoke on session-auth-client/dashboard"`
+  - message names pay-invoice and review-sign-proposal as the contradicting tasks
+  - `persistent-tabs` appears in surviving patterns
+- The author filed `.stitch/provisional-override-<date>.md` with a concrete validation event (for evidence-mode=provisional) OR switched the declared pattern to persistent-tabs. The test passes in either branch — what matters is that the override path is exercised with cited evidence, not silently ratified.
+- If the author writes a defense citing `return_locus=hub` for pay-invoice with prose evidence ("SOW says client returns to portal"), R25 still fires because the cited structural evidence type is missing.
+
+**What makes this a held-out test.** The disqualifier thresholds in `references/pattern-disqualifiers.md` are authored against NN/g / Material Design 3 / Apple HIG sources only. They are not tuned so that the ss-console portal "comes out right." If future calibration changes are needed, they go into the synthetic tests first, never into ss-console fixtures.
+
+---
+
+## Track 3 — R26 authoring-direction lint
+
+### 3a. Citation in §1 or §2 fires R26
+
+Fixture: a NAVIGATION.md with `src/components/PortalHeader.astro` cited in §1 task model or §2 sitemap.
+
+**Expected output.**
+
+- `rule: "R26"`, `severity: "structural"`
+- `selector: "§1 cites `src/components/PortalHeader.astro`"` or `"§2 cites `src/components/PortalHeader.astro`"`
+- One violation per unique (citation, section); no duplicates for the same citation hit by multiple regex patterns.
+
+### 3b. Citation in §5+ does NOT fire R26
+
+Fixture: same spec, but the `src/components/PortalHeader.astro` citation appears only in §6 (chrome contract).
+
+**Expected output.**
+
+- `pass: true` (no R26 violations)
+
+### 3c. Paraphrased shipped chrome — IA Architect rubric, not R26
+
+R26 is a regex lint. Paraphrase laundering ("the portal currently has a sidebar with four sections") must be caught by the IA Architect reviewer's rubric item in Phase 7 of `author.md`, not by R26. R26 is not expected to fire on paraphrases. This test case validates that the reviewer rubric exists in `workflows/author.md` and names the check explicitly.
+
+---
+
+## Track 4 — Backwards compatibility
+
+### 4a. v2 spec — R25 skipped with stderr warning
+
+**Fixture.** Any existing `.stitch/NAVIGATION.md` with `spec-version: 2`.
+
+**Expected output.**
+
+- stderr contains `R25 skipped — spec is v2.`
+- stdout JSON: `pass: true`, `violation_count: 0`
+- R1–R24 continue to apply (for full-file validation with `--file`).
+
+### 4b. v1 spec — all IA + pattern-fitness rules skipped
+
+**Fixture.** Any `.stitch/NAVIGATION.md` lacking `spec-version:` front matter (defaults to v1).
+
+**Expected output.**
+
+- `pass: true` (assuming the file would pass R1–R15 in v2; no IA/pattern checks run)
+- R16–R26 all skipped.
+
+### 4c. v3 spec with no §4 decisions
+
+**Fixture.** A spec with `spec-version: 3` but §4 is empty (partial migration in progress).
+
+**Expected output.**
+
+- stderr: `R25 skipped — no Section 4 decision entries parsed from spec.`
+- R26 (authoring-direction) still runs against §1–4 text.
+- `pass: true` if §1–4 are clean of shipped-code citations.
+
+---
+
+## R25 override gates — structural tests
+
+These are future-author tests (synthetics not yet shipped in `examples/`): document the expected behavior so the validator's gate logic is pinned by documented expectation.
+
+### 5a. Reclassification attack
+
+Author attempts to demote 2 of 3 non-hub-returning tasks to low frequency. Because R25 operates on top-3-by-frequency (structural), demoted tasks drop out of the top-3 only if genuine lower-frequency tasks rank higher. If fewer than 3 tasks remain at `frequency ≥ medium`, the top-3 still includes the demoted tasks and D1 continues to fire.
+
+Expected: R25 still fires. Validator's disqualifier count is invariant under frequency-relabeling attacks unless the author produces additional higher-frequency tasks with different return_loci (which requires new evidence).
+
+### 5b. Prose-citation attack on return_locus=hub
+
+Author declares `return_locus: hub` with prose evidence `"SOW §3.2 says client returns to portal"`. The validator does not currently enforce the structural-evidence-type rule for `return_locus=hub` at the column-value level (that enforcement lives in the author workflow and Pattern Specialist reviewer rubric, not in validate.py parsing).
+
+**Residual risk noted.** If this proves to be the first override loophole observed, a future R25 extension can parse `return_locus_evidence` and require it to match specific shapes (URL literal, transcript-path:line, analytics event name). For now, the reviewer rubric is the enforcement surface.
+
+### 5c. Reviewer-consensus gate
+
+Author writes defense citing a valid override. Only 1 of 3 reviewers approves with cited disqualifier ID.
+
+Expected: R25 still fires because `<2` reviewer approvals. With 2+ approvals citing the same disqualifier ID, R25 passes.
+
+---
+
+## Exit conditions
+
+- All synthetic unit tests pass (R25 fires with expected disqualifier ID on each).
+- ss-console migration produces the expected R25 fire without rubric tuning.
+- R26 fires only for §1–4 citations; silent on §5+ citations.
+- v1 and v2 specs continue to validate without R25/R26 firing.
+
+If any of these fails in CI after a skill change, the change is rejected.

--- a/.agents/skills/nav-spec/references/anti-patterns.md
+++ b/.agents/skills/nav-spec/references/anti-patterns.md
@@ -1,0 +1,226 @@
+# Anti-patterns
+
+The navigation smells every NAVIGATION.md should explicitly forbid. Each has a rationale — understand it so you can apply judgment when a new anti-pattern emerges, not just copy the list.
+
+## Structural anti-patterns
+
+### 1. Global nav tabs / menu links in the header on authenticated surfaces
+
+**Example:** "Dashboard | Invoices | Proposals | Settings" rendered as a horizontal tab bar in the top band.
+
+**Why forbidden on portal and token-auth:** the client portal has a small, focused surface area; the user is there to check one thing or act on one thing. A tab bar suggests breadth of app, consumes vertical real estate, and imports SaaS-product conventions that don't fit a consulting relationship.
+
+**Why forbidden on admin (usually):** depends on the venture's admin complexity. For ss-console's single-operator admin, a tab bar is overkill. For multi-team admins, a tab bar is allowed but must be specified in the surface-class appendix.
+
+**Exception path:** if the admin truly needs tab-level navigation, define it in Appendix D with explicit tabs, never a free invention by Stitch.
+
+### 2. Sidebar / hamburger / drawer as primary navigation
+
+**Example:** collapsible sidebar with "Home | Invoices | Clients | ..." on desktop; hamburger icon in the header on mobile that opens a slide-out with the same menu.
+
+**Why forbidden:** sidebars are a SaaS-product pattern. This isn't a SaaS product. A sidebar nav signals the wrong relationship (self-serve tool) vs what we're actually building (consulting engagement interface).
+
+**Exception path:** none at the current scope. Re-visit if the admin surface grows past ~15 routes and tabs can't hold them.
+
+### 3. Bottom-tab nav (mobile)
+
+**Example:** fixed bottom bar with 3–5 icons + labels (Home / Invoices / Messages / Profile).
+
+**Why forbidden universally:** mobile apps use bottom-tabs. This is a web surface, not a mobile app. Users expect web-style navigation. Bottom-tabs on mobile web are a conversion-killer on authenticated flows and feel "app-like" in a way that undermines the consulting positioning.
+
+**Exception path:** none.
+
+### 4. Sticky bottom action bar when the primary action is already visible above the fold
+
+**Example:** Pay button visible at y=250 on the invoice detail, plus a duplicated "Pay $4,250" bar stuck to `bottom-0` for "thumb reachability."
+
+**Why forbidden:** duplication signals insecurity — "I put the button twice because I'm not sure you saw it." Either the primary action is above the fold (trust the user) or it isn't (fix the layout). Both can't be true.
+
+**Exception path:** if the content pushes the primary action below the fold on 390×844, the fix is tightening the layout, not adding a second button.
+
+### 5. Footer / copyright / legal links on authenticated surfaces
+
+**Example:** "© 2026 SMDurgan LLC | Privacy | Terms | Contact" at the bottom of `/portal/home`.
+
+**Why forbidden:** the user has already agreed to terms; they have an ongoing relationship. Marketing-site chrome on an authenticated surface signals the wrong relationship. Legal links on authenticated surfaces are almost always out-of-date anyway.
+
+**Exception path:** none.
+
+## Content anti-patterns
+
+### 6. Marketing CTAs on authenticated surfaces
+
+**Example:** "Schedule a call" or "Book a demo" button on `/portal/home`.
+
+**Why forbidden:** the user is already a customer. The CTA is addressed to a stranger. It patronizes the reader.
+
+**Exception path:** a "schedule a check-in" action directed at an existing client is fine if explicit in the page prompt. "Book a demo" is not.
+
+### 7. Testimonials, pull quotes, italicized client-voice text
+
+**Example:** "'Scott transformed our business — Mike Delgado, Delgado Plumbing'" rendered as a pull quote on an invoice landing.
+
+**Why forbidden universally:** marketing chrome. Testimonials live on public marketing pages, nowhere else.
+
+**Exception path:** none.
+
+### 8. Hero imagery / decorative illustrations
+
+**Example:** a large stock-photo-style header image or a geometric illustration atop the portal home.
+
+**Why forbidden on authenticated surfaces:** chrome. Consumes vertical real estate the user wants to use for actual data. Authenticated surfaces are working surfaces; there is no "brand moment" to protect.
+
+**Exception path:** on `public` marketing surfaces, hero imagery is allowed but must be specified in the prompt. Never free invention.
+
+### 9. Real-face photo placeholders
+
+**Example:** `<img src="https://lh3.googleusercontent.com/aida/..." alt="professional headshot of a mature businessman">` as a consultant avatar placeholder.
+
+**Why forbidden universally:** Stitch's training prior is heavy with these. They look real but they're synthetic/stock. They signal "stock photo" aesthetic, which is corrosive to the guide positioning.
+
+**Fix:** a solid-color circle with initials. Always. Never relax this, even "just for this one screen."
+
+### 10. Breadcrumbs on portal
+
+**Example:** "Home > Invoices > Invoice #1042" at the top of the invoice detail.
+
+**Why forbidden on portal:** the portal is shallow (2 levels: dashboard → detail). A breadcrumb trail suggests a deeper hierarchy than exists. The back button is sufficient.
+
+**Exception path:** admin may need breadcrumbs for 3+ level hierarchies (`Clients > Delgado Plumbing > Audit log`). Specify in Appendix D.
+
+## Semantic anti-patterns (mostly caught by the validator)
+
+### 11. `<nav aria-label="Breadcrumb">` wrapping a single back button
+
+**Example:** `<nav aria-label="Breadcrumb"><a href="/home">← Home</a></nav>`
+
+**Why forbidden:** a breadcrumb trail has multiple levels. A single back button is not a breadcrumb — it's a back button. The semantic wrapper lies to assistive tech.
+
+### 12. `fixed top-0` instead of `sticky top-0` on the header
+
+**Why forbidden:** `fixed` takes the header out of document flow. It plays badly with scrolling containers, right rails, and mobile keyboard-opens. `sticky` stays in flow and behaves correctly.
+
+### 13. `backdrop-blur-*` / translucent header background
+
+**Why forbidden:** glassmorphism is a 2021–2023 visual fad. It reads as "trying to look modern" and it's a common Stitch over-render. Solid white headers are cleaner, faster to render, and don't fight the user's reading of the content below.
+
+### 14. Icon decoration before the client name in the header
+
+**Example:** `<span class="material-symbols-outlined">water_drop</span> Delgado Plumbing` — a water drop next to a plumbing client's name.
+
+**Why forbidden:** cute. Also noisy. The client name is identity enough. Decorative icons in the header accumulate over time ("just one more"). Forbid them universally.
+
+### 15. Back href="#" or href="javascript:" or onclick="history.back()"
+
+**Why forbidden:** `#` scrolls to top (broken). `javascript:` breaks right-click context menu (broken). `history.back()` breaks deep-links (user arrived via email, there's nothing to go back to). Always a canonical hardcoded URL.
+
+## IA anti-patterns (v2)
+
+These are the IA-level smells the chrome-only v1 of nav-spec failed to catch. Each maps to a validator rule R16–R24.
+
+### 16. Orphan destination
+
+**Definition:** A route exists in `src/pages/**` (or in deployed code) but no `<a href>` in any navigated surface points to it. The only way to reach it is to know the URL.
+
+**Real example (ss-console v1, April 2026):** `/portal/quotes`, `/portal/invoices`, `/portal/documents`, `/portal/engagement` all existed as list views but none were linked from `/portal`. Users could reach a specific item via Recent Activity then back-navigate to the list — a contortion. This is what triggered nav-spec v2.
+
+**Why forbidden:** orphans break Dan Brown's Front Doors principle (#5). They guarantee that any user not arriving through the bookmarked URL will not find the surface.
+
+**Fix:** Add the link to the reachability matrix; render the affordance on the appropriate hub. Validated by R16.
+
+### 17. Dead-end surface
+
+**Definition:** A surface with no navigation exit other than the browser back button. Not an `error` archetype intentionally pointing to safety; just an oversight.
+
+**Why forbidden:** every surface needs a deliberate next step. Even terminal surfaces (post-purchase, post-sign) need an explicit "Return to home" or auto-redirect with manual fallback.
+
+**Fix:** Add a primary action, back affordance, or sibling link. Validated by R18.
+
+### 18. Pattern-impersonation
+
+**Definition:** A surface that looks like one pattern (e.g., dashboard with section cards) but doesn't implement that pattern's required elements (e.g., the cards link to non-canonical destinations or have no labels).
+
+**Why forbidden:** pattern semantics carry user expectations. Fake patterns confuse users in ways they can't articulate.
+
+**Fix:** Either implement the pattern fully or use a different, simpler control. Validated by R17.
+
+### 19. Token-auth amnesia
+
+**Definition:** A token-auth surface that assumes prior context (logged-in state, prior page, recent actions). Renders broken when arrived-at cold from email.
+
+**Why forbidden:** token-auth is by definition cold-arrival (no prior session). Assumptions about state break front-door (#5).
+
+**Fix:** Render self-contained context — name the entity, name the action, provide the next step without depending on referrer or session. Validated by R19.
+
+### 20. Taxonomy drift
+
+**Definition:** Same concept rendered with different labels across surfaces. "Proposal" on the home, "Quote" on the email, "Estimate" in the PDF.
+
+**Why forbidden:** users must learn three vocabularies for one concept. Trust erodes.
+
+**Fix:** Pick one term in `content-taxonomy-template.md` and use it everywhere. Validated by R20.
+
+### 21. State omission
+
+**Definition:** A surface that handles only the populated state and renders broken (blank, half-rendered, or with affordances to non-existent items) in empty/loading/error states.
+
+**Why forbidden:** every surface has multiple states; designing for only one is incomplete.
+
+**Fix:** Define every state in `state-machine-template.md` and render explicitly for each. Validated by R21.
+
+### 22. Heading hierarchy violation
+
+**Definition:** Multiple `<h1>` on one surface, skipped levels (h1 → h3), or no `<h1>` at all.
+
+**Why forbidden:** screen readers rely on heading hierarchy to convey IA structure. Broken hierarchy = broken IA for non-sighted users.
+
+**Fix:** Single `<h1>` per surface, `<h2>` for major sections, no level skipping. Validated by R22.
+
+### 23. Search affordance missing
+
+**Definition:** A surface declared in the spec to have search, but the rendered HTML has no search input.
+
+**Why forbidden:** if search is in the spec, users expect it. Silent omission = expectation violation.
+
+**Fix:** Render the search input as specified. Validated by R23.
+
+### 24. Cross-surface context loss
+
+**Definition:** A persistent-context pattern (selected client, selected engagement) where the context indicator is missing on one or more surfaces in the workspace.
+
+**Why forbidden:** persistent context only works if it persists. Missing context indicator on any surface breaks the pattern.
+
+**Fix:** Render context indicator (header chip, breadcrumb prefix) on every surface within the workspace scope. Validated by R24.
+
+---
+
+## Classification (machine-readable)
+
+| #   | Anti-pattern                                       | Severity   | Validator rule   | Layer   |
+| --- | -------------------------------------------------- | ---------- | ---------------- | ------- |
+| 1   | Global nav tabs in header (non-admin)              | structural | R6               | Chrome  |
+| 2   | Sidebar / hamburger / drawer nav                   | structural | R6               | Chrome  |
+| 3   | Bottom-tab nav                                     | structural | R7               | Chrome  |
+| 4   | Sticky bottom action bar                           | structural | R7               | Chrome  |
+| 5   | Footer on auth surface                             | structural | R8               | Chrome  |
+| 6   | Marketing CTAs on auth                             | structural | R10              | Chrome  |
+| 7   | Testimonials / pull quotes on auth                 | structural | (content filter) | Chrome  |
+| 8   | Hero imagery on auth                               | structural | (content filter) | Chrome  |
+| 9   | Real-face photo placeholder                        | structural | R9               | Chrome  |
+| 10  | Breadcrumbs on portal                              | structural | R4               | Chrome  |
+| 11  | `<nav aria-label="Breadcrumb">` around single back | semantic   | R4               | Chrome  |
+| 12  | `fixed top-0` on header                            | semantic   | R1               | Chrome  |
+| 13  | `backdrop-blur-*` / translucent header bg          | cosmetic   | R2               | Chrome  |
+| 14  | Icon before client name                            | cosmetic   | R3               | Chrome  |
+| 15  | Back `href="#"` / `history.back()`                 | semantic   | R5               | Chrome  |
+| 16  | Orphan destination                                 | structural | R16              | IA      |
+| 17  | Dead-end surface                                   | structural | R18              | IA      |
+| 18  | Pattern-impersonation                              | structural | R17              | Pattern |
+| 19  | Token-auth amnesia                                 | structural | R19              | IA      |
+| 20  | Taxonomy drift                                     | semantic   | R20              | IA      |
+| 21  | State omission                                     | structural | R21              | IA      |
+| 22  | Heading hierarchy violation                        | semantic   | R22              | A11y    |
+| 23  | Search affordance missing                          | semantic   | R23              | IA      |
+| 24  | Cross-surface context loss                         | structural | R24              | Pattern |
+
+Severity determines retry behavior in the validator: **structural violations always retry**; **semantic violations retry once**; **cosmetic violations warn but pass by default** (can be elevated per venture).

--- a/.agents/skills/nav-spec/references/archetype-catalog.md
+++ b/.agents/skills/nav-spec/references/archetype-catalog.md
@@ -1,0 +1,375 @@
+# Archetype catalog
+
+Ten archetypes. Each archetype maps to one or more named patterns from [pattern-catalog.md](pattern-catalog.md) and defines both IA contract (what the surface must link to) and chrome contract (what it must look like). Every generated or shipped page maps to exactly one archetype.
+
+When a new screen doesn't fit any archetype, either (a) widen an existing archetype by revising the catalog, or (b) add a new one via `/nav-spec --revise --add-archetype`. Never generate an off-catalog archetype silently.
+
+---
+
+## Common contract (inherited by all archetypes)
+
+### Chrome
+
+- **Landmarks:** `<header role="banner">`, `<main role="main" id="main">`.
+- **Skip link:** `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>` as first body child.
+- **Focus rings:** 2px accent color, 2px offset, keyboard-focus only (not mouse).
+- **Icon-only buttons/links:** always carry `aria-label`.
+- **Tap targets:** 44×44px minimum.
+- **Header height:** 56px mobile, 64px desktop.
+- **Header background:** solid (no `backdrop-blur-*`, no opacity modifiers like `bg-white/85`).
+- **Semantic headings:** exactly one `<h1>`; `<h2>` for major sections; no skipping levels.
+
+### IA
+
+- **No dead ends:** every surface has ≥1 navigation exit (primary action, back, or sibling link), unless archetype=terminal.
+- **Front-door assumption:** every surface renders correctly on direct arrival with no prior context (per Dan Brown's Principle 5).
+- **URL is canonical:** back-targets use hardcoded absolute URLs, never `history.back()`.
+
+---
+
+## 1. `dashboard`
+
+### Definition
+
+Landing surface of an authenticated surface class. The user's "home" within that class. Shows overview, pending actions, and entry points to all sibling sections.
+
+### Recommended pattern
+
+**Hub-and-spoke** (primary) — from [pattern-catalog.md §1.1](pattern-catalog.md#11-hub-and-spoke). Optionally combined with:
+
+- **Dominant-action variant** — when the current state has a single actionable priority (e.g., pending invoice)
+- **Recent-activity variant** — time-ordered feed of events alongside entry points
+
+### IA contract
+
+- **MUST link to every sibling list/detail section** in the same surface class (per reachability matrix). This is enforced by validator R16.
+- MUST NOT require the user to drill into a detail to reach a list (the portal-home omission of v1).
+- MAY surface a dominant action (ActionCard) when a specific task is high-priority.
+- MAY include a recent-activity feed as secondary (not replacing entry points).
+
+### Chrome contract
+
+- Header: client/workspace name on left, optional contact controls and utility actions on right. No logo. No nav tabs (admin exception, see Appendix D).
+- **No back button.** The user is already home.
+- **No breadcrumbs.**
+- **Section cards** (primary IA affordance) in a grid: 1 column mobile, 2×N on desktop depending on section count.
+- Right rail on desktop (optional): quick actions, consultant block, status card.
+
+### Allowed surface classes
+
+`session-auth-client`, `session-auth-admin`.
+
+---
+
+## 2. `list`
+
+### Definition
+
+Index of items in a collection. May be filterable, sortable, paginated.
+
+### Recommended pattern
+
+- **Master-detail** (primary) — row-click navigates to detail, detail has back-to-list with state preservation.
+- **Faceted** — when collection size >30 items or multi-dimensional filtering is needed.
+- **Index + preview** — for lightweight detail that benefits from quick scan.
+
+### IA contract
+
+- MUST link to its detail archetype via row-click.
+- MUST link back to its dashboard (hub) via back button.
+- MAY have sibling filters/facets within the surface.
+- Empty state (archetype `empty`) handled when no rows returned.
+
+### Chrome contract
+
+- Header: same minimal band as dashboard.
+- **Back button:** to the parent dashboard. Hardcoded canonical URL. `aria-label` carries destination name.
+- **No breadcrumbs** on portal; breadcrumbs **allowed** on admin (2 levels max).
+- Filter/sort bar directly below header, before the list (if faceted).
+- Item rows: clickable area ≥44px tall, primary label + secondary meta.
+
+### Allowed surface classes
+
+`session-auth-client`, `session-auth-admin`.
+
+---
+
+## 3. `detail`
+
+### Definition
+
+Single-item view. Invoice, proposal, client, audit event.
+
+### Recommended pattern
+
+- **Master-detail** (primary) — back to parent list, state preserved on return.
+- **Nested-doll** — if the detail has sub-sections reachable by drilling (rare on portal, common on admin).
+- **Pyramid** — if sibling prev/next navigation is useful (rare; usually deprioritized in favor of return-to-list).
+
+### IA contract
+
+- MUST link back to its parent list via back button.
+- MAY link to external systems (Stripe, SignWell) via primary action.
+- MUST handle each of its task states (see state-machine-template).
+- MAY include contextual links to related entities (e.g., "View engagement" from invoice).
+
+### Chrome contract
+
+- Header: minimal band.
+- **Back button:** canonical URL to parent list. Label includes parent's name ("All invoices", "All proposals", "Home").
+- **No breadcrumbs** on portal and token-auth; **allowed** on admin for 3+ level hierarchies.
+- Right rail on desktop: consultant/contact block, status summary, related items.
+- Primary action (Pay, Review & Sign) visible above the fold on mobile.
+
+### Allowed surface classes
+
+All four auth classes.
+
+---
+
+## 4. `form`
+
+### Definition
+
+Surface for creating or editing an entity. Fields, validation, submit.
+
+### Recommended pattern
+
+- **Single-page form** (default) — all fields on one surface.
+- **Sequential** (wizard) — if logical ordering is mandatory (see archetype 5).
+
+### IA contract
+
+- Entry from: parent list (New button) or detail (Edit button).
+- Success exit: detail of the created/edited entity.
+- Cancel exit: canonical origin (list or detail, whichever invoked the form).
+- Dirty-state guard on navigation away.
+
+### Chrome contract
+
+- Header: minimal band.
+- **Cancel + Save actions** — not a back button. Cancel returns to the canonical origin.
+- **Dirty-state guard:** if fields have unsaved changes, Cancel triggers a confirm modal.
+- **No breadcrumbs.**
+- Keyboard: `Cmd/Ctrl+S` saves; `Esc` interpreted as Cancel.
+
+### Allowed surface classes
+
+`session-auth-client`, `session-auth-admin`.
+
+---
+
+## 5. `wizard`
+
+### Definition
+
+Multi-step flow with forward/back progress. Onboarding, guided intake, multi-page checkout.
+
+### Recommended pattern
+
+**Sequential** (from [pattern-catalog.md §1.3](pattern-catalog.md#13-sequential-step-by-step)).
+
+### IA contract
+
+- Strict ordering: step N+1 unreachable without completing step N.
+- Cancel exit: the surface that invoked the wizard, with confirm modal if any step has been completed.
+- Success exit: the created entity's detail, or a success confirmation page.
+
+### Chrome contract
+
+- Header: minimal band. **Progress indicator ("Step N of M")** centered or left-aligned within the header, not below.
+- **Previous + Next** buttons in a sticky or in-flow action block. Previous disabled on step 1; Next disabled until current step validates.
+- **Cancel** at far-left of action block or in overflow menu. Triggers confirm modal.
+- **No breadcrumbs.**
+- **No back button in header** — Previous is the back affordance within the wizard.
+
+### Allowed surface classes
+
+`session-auth-client`, `session-auth-admin`.
+
+---
+
+## 6. `empty`
+
+### Definition
+
+Default rendering of a list or detail when there is nothing to show. First-time state.
+
+### Recommended pattern
+
+Inherits from the parent archetype. An empty `list` keeps list-chrome; an empty `detail` keeps detail-chrome.
+
+### IA contract
+
+- MUST provide a clear "what is this" message (Principle of Exemplars).
+- MUST NOT fabricate affordances to items that don't exist.
+- MAY provide a single CTA if adding is the expected next step (rare for portal — most portal empties are "wait for consultant").
+
+### Chrome contract
+
+- Inherits from parent archetype's header (list or detail).
+- **Body:** short "why it's empty" message; optional solid-shape illustration (not real image); optional single CTA.
+- **No marketing copy.** No testimonials, no feature tour.
+
+### Allowed surface classes
+
+All four.
+
+---
+
+## 7. `error`
+
+### Definition
+
+404, 500, 401, validation-failure fallback screens.
+
+### Recommended pattern
+
+**Recovery-path** — minimal chrome with a clear return to safety.
+
+### IA contract
+
+- MUST provide ≥1 navigation exit to a known-good surface.
+- MUST NOT assume valid app state (the user's state is broken).
+- MAY include a contact CTA for persistent failures.
+
+### Chrome contract
+
+- **Header:** minimal band; no back button (the user's history is suspect).
+- **Body:** error type, short human explanation, single primary action that returns to safety:
+  - Authenticated surfaces: "Go to portal home" linking to the surface class's dashboard.
+  - Public surfaces: "Go to home" linking to `/`.
+  - Token-auth: "Contact Scott" CTA.
+- **No support form embedded.** Link to a contact method, don't host the form here.
+
+### Allowed surface classes
+
+All four.
+
+---
+
+## 8. `modal`
+
+### Definition
+
+Overlay for confirmations, pickers, short-form interactions. Single decision or single task.
+
+### Recommended pattern
+
+**Modal** (from [pattern-catalog.md §3.4](pattern-catalog.md#34-modal)).
+
+### IA contract
+
+- MUST preserve the underlying surface's state while open.
+- MUST return focus to the trigger element on close.
+- MAY NOT contain primary navigation (see anti-patterns).
+
+### Chrome contract
+
+- `<dialog>` or `role="dialog"` with `aria-modal="true"` and `aria-labelledby` pointing to a visible title.
+- **Close affordances:** Esc, click-outside on scrim, AND an X button in the top-right. All three work.
+- Focus returns to the triggering element on close.
+- Scrim: `bg-black/50` (50% opacity black).
+- Body scroll locked while open.
+
+### Allowed surface classes
+
+All four.
+
+---
+
+## 9. `drawer`
+
+### Definition
+
+Side panel for secondary actions, filters, or in-context help. Slides in from the edge.
+
+### Recommended pattern
+
+**Drawer** (as implemented in Material Design 3 modal drawer, HIG "full-screen sheet").
+
+### IA contract
+
+- MUST NOT contain primary navigation.
+- Same open/close rules as modal.
+
+### Chrome contract
+
+- Slide direction: right-side on desktop, bottom-sheet on mobile.
+- Width on desktop: 400px standard, max 600px.
+- Height on mobile: 80vh max.
+- Draggable header area on mobile (bottom-sheet affordance).
+- Esc, click-outside, X button all close.
+
+### Allowed surface classes
+
+All four.
+
+---
+
+## 10. `transient`
+
+### Definition
+
+Short-lived surface the user passes through — success confirmation, redirect notice, expired-link notice.
+
+### Recommended pattern
+
+**Recovery-path** when the transient is failure-flavored; **progress indicator** when it's success-flavored.
+
+### IA contract
+
+- MAY be terminal (no navigation away) if it auto-redirects within a short window.
+- MUST render a manual navigation fallback if auto-redirect fails.
+
+### Chrome contract
+
+- Header: present, minimal.
+- Body: short message + manual CTA + (optional) auto-redirect indicator.
+
+### Allowed surface classes
+
+All four.
+
+---
+
+## Archetype lookup table (machine-readable)
+
+| Archetype | Default pattern          | Back         | Breadcrumbs (portal) | Breadcrumbs (admin) | Right rail    | Nav tabs        |
+| --------- | ------------------------ | ------------ | -------------------- | ------------------- | ------------- | --------------- |
+| dashboard | Hub-and-spoke            | no           | no                   | no                  | yes (desktop) | no (admin: yes) |
+| list      | Master-detail            | yes          | no                   | yes (2 levels)      | no            | no (admin: yes) |
+| detail    | Master-detail            | yes          | no                   | yes (3 levels)      | yes (desktop) | no (admin: yes) |
+| form      | Single-page form         | cancel+save  | no                   | no                  | no            | no              |
+| wizard    | Sequential               | prev/next    | no                   | no                  | no            | no              |
+| empty     | inherit from parent      | inherit      | inherit              | inherit             | inherit       | inherit         |
+| error     | Recovery-path            | no           | no                   | no                  | no            | no              |
+| modal     | Modal                    | close button | no                   | no                  | no            | no              |
+| drawer    | Drawer                   | close button | no                   | no                  | no            | no              |
+| transient | Recovery-path / Progress | manual CTA   | no                   | no                  | no            | no              |
+
+**Anti-pattern shorthand:** breadcrumbs are never rendered on portal (session-auth-client). Admin breadcrumbs are for list and detail only, capped at the item's hierarchical depth. Modals and drawers never carry primary navigation.
+
+---
+
+## Pattern specialization per archetype (summary)
+
+For each archetype, the pattern from the catalog may be specialized with venture-specific variants:
+
+```markdown
+### Archetype: dashboard
+
+Pattern: Hub-and-spoke (NN/g §1.1)
+Variant: Dominant-action + Recent-activity feed
+Rationale: Portal tasks are bounded (Pay invoice, Sign proposal, Browse
+documents, Check progress); user returns to home between tasks;
+time-ordered timeline surfaces actionable state at a glance.
+Required elements:
+
+- Section cards to every sibling list (R16)
+- ActionCard when condition `hasPendingInvoice` holds
+- Recent-activity timeline (≤5 entries)
+- Right-rail consultant block on desktop
+```
+
+This specialization is recorded in the venture's `NAVIGATION.md` Section 4 (Patterns).

--- a/.agents/skills/nav-spec/references/chrome-component-contracts.md
+++ b/.agents/skills/nav-spec/references/chrome-component-contracts.md
@@ -1,0 +1,200 @@
+# Chrome component contracts
+
+Each chrome piece has a DOM template and a Tailwind class template. Specs reference these contracts rather than redefining them per surface class. Deviations live in surface-class appendices.
+
+## Header band
+
+**DOM:**
+
+```html
+<header
+  role="banner"
+  class="sticky top-0 z-50 bg-white border-b border-[#E2E8F0] h-14 md:h-16 px-4 md:px-6 flex items-center justify-between"
+>
+  <div class="flex items-center">
+    <span class="text-[13px] leading-[18px] font-medium text-[#475569]"
+      ><!-- client/workspace name --></span
+    >
+  </div>
+  <div class="flex items-center gap-4">
+    <!-- optional: Text Scott SMS link, settings gear, etc. -->
+    <a href="sms:+..." class="text-[13px] leading-[18px] font-medium text-[#1E40AF]">Text Scott</a>
+  </div>
+</header>
+```
+
+**Rules:**
+
+- `sticky top-0`, never `fixed top-0`
+- `bg-white`, never translucent or `backdrop-blur-*`
+- Height: `h-14` (56px) on mobile, `h-16` (64px) on desktop via `md:h-16`
+- `border-b border-[#E2E8F0]` — exact hex, not `border-slate-200` (close but not exact)
+- Left: client name only. No logo. No icon. No decoration.
+- Right: optional single quick-action link. Never two. Never icons without labels.
+
+## Back affordance (detail archetypes)
+
+**DOM:**
+
+```html
+<a
+  href="/portal/invoices"
+  aria-label="All invoices"
+  class="inline-flex items-center gap-1 w-11 h-11 text-[#475569] hover:text-[#0F172A] focus-visible:ring-2 focus-visible:ring-[#3B82F6] focus-visible:ring-offset-2 rounded-lg"
+>
+  <span class="material-symbols-outlined">chevron_left</span>
+  <span class="text-[13px] font-medium">All invoices</span>
+</a>
+```
+
+**Rules:**
+
+- Single `<a>` or `<button>`. **Never wrap in `<nav>`.** Never use `aria-label="Breadcrumb"`.
+- Target: hardcoded canonical URL string. Never `#`, `javascript:`, or `history.back()`.
+- Tap target: 44×44 minimum (`w-11 h-11` = 44px).
+- Positioned below the header band, within the main content area, not inside the header itself (prevents crowding).
+- Label text: the destination's name ("All invoices", "Home", "Back to clients"). Not "Back" in isolation.
+
+## Breadcrumbs (admin only)
+
+**DOM:**
+
+```html
+<nav aria-label="Breadcrumb" class="mb-4">
+  <ol class="flex items-center gap-2 text-[13px] text-[#475569]">
+    <li><a href="/admin/clients" class="hover:text-[#0F172A]">Clients</a></li>
+    <li aria-hidden="true">
+      <span class="material-symbols-outlined text-base">chevron_right</span>
+    </li>
+    <li><a href="/admin/clients/123" class="hover:text-[#0F172A]">Delgado Plumbing</a></li>
+    <li aria-hidden="true">
+      <span class="material-symbols-outlined text-base">chevron_right</span>
+    </li>
+    <li><span aria-current="page" class="font-medium text-[#0F172A]">Audit log</span></li>
+  </ol>
+</nav>
+```
+
+**Rules:**
+
+- **Admin only.** Never on portal. Never on token-auth. Never on public.
+- 2 levels max on `list` archetype; 3 levels max on `detail` archetype.
+- Last item is the current page with `aria-current="page"`; rendered as a `<span>`, not an `<a>`.
+- Separator: `<chevron_right>` with `aria-hidden="true"`; never use `/` or `>` as text (screen readers will read them literally).
+- Truncation: each label capped at 24ch on mobile; full label on desktop. Use `text-overflow: ellipsis` via `truncate` class with explicit `max-w-[24ch]`.
+
+## Footer (public only)
+
+**DOM:**
+
+```html
+<footer class="bg-white border-t border-[#E2E8F0] mt-16">
+  <div
+    class="max-w-7xl mx-auto px-6 py-8 flex flex-col md:flex-row justify-between gap-4 text-[13px] text-[#475569]"
+  >
+    <span>© 2026 SMDurgan LLC. All rights reserved.</span>
+    <nav aria-label="Legal" class="flex gap-4">
+      <a href="/privacy" class="hover:text-[#0F172A]">Privacy</a>
+      <a href="/terms" class="hover:text-[#0F172A]">Terms</a>
+      <a href="/contact" class="hover:text-[#0F172A]">Contact</a>
+    </nav>
+  </div>
+</footer>
+```
+
+**Rules:**
+
+- **Public surface class only.** Never rendered on authenticated or token-auth surfaces.
+- Legal links in a `<nav aria-label="Legal">`. Not free-floating `<a>` elements.
+- Copyright on left, legal links on right (flex-row on desktop, flex-col on mobile with copyright first).
+
+## Skip-to-main link (all surfaces)
+
+**DOM:**
+
+```html
+<a
+  href="#main"
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] bg-white px-4 py-2 rounded-lg border border-[#E2E8F0] text-[#1E40AF] font-medium"
+>
+  Skip to main content
+</a>
+```
+
+**Rules:**
+
+- First element inside `<body>`, before `<header>`.
+- Hidden visually by default (`sr-only`); revealed on keyboard focus (`focus:not-sr-only`).
+- Matching `id="main"` on the `<main>` element.
+
+## State classes (all interactive elements)
+
+```
+Default:     text-[#475569]
+Hover:       hover:text-[#0F172A]
+Active link: text-[#1E40AF]   + aria-current="page"
+Focus ring:  focus-visible:ring-2 focus-visible:ring-[#3B82F6] focus-visible:ring-offset-2
+Disabled:    disabled:text-[#94A3B8] disabled:cursor-not-allowed
+```
+
+Tap-target padding when the rendered element is visually smaller than 44px: wrap or pad to `w-11 h-11` (44×44) minimum, or use `p-3` (12px × 4 = 48px — works for 24px icons).
+
+## Right rail (detail, dashboard — desktop)
+
+**DOM:**
+
+```html
+<div class="flex flex-col lg:flex-row gap-8 lg:gap-12">
+  <div class="flex-1 lg:max-w-[75%]">
+    <!-- primary content -->
+  </div>
+  <aside class="w-full lg:w-[300px] lg:sticky lg:top-[80px] lg:self-start space-y-6">
+    <!-- consultant block, status, related links -->
+  </aside>
+</div>
+```
+
+**Rules:**
+
+- Desktop only (collapses to stacked on mobile via `flex-col lg:flex-row`).
+- Width: ~300px fixed or 25% max of container.
+- `<aside>` element, not `<div>` — semantic.
+- `lg:sticky lg:top-[80px]` so the rail stays visible under the sticky header (header is 64px + 16px buffer = 80px top offset).
+
+## Consultant block (portal surfaces)
+
+**DOM:**
+
+```html
+<section class="bg-white border border-[#E2E8F0] rounded-lg p-6 flex items-start gap-4">
+  <div
+    class="w-12 h-12 rounded-full bg-[#1E40AF] text-white flex items-center justify-center font-semibold"
+    aria-hidden="true"
+  >
+    SD
+  </div>
+  <div class="flex-1">
+    <h3 class="text-base font-semibold text-[#0F172A]">Scott Durgan</h3>
+    <p class="text-sm text-[#475569]">Primary consultant</p>
+    <a
+      href="sms:+..."
+      class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-[#1E40AF]"
+    >
+      <span class="material-symbols-outlined text-base">chat</span>
+      Text Scott
+    </a>
+  </div>
+</section>
+```
+
+**Rules:**
+
+- Photo placeholder: solid-color circle with white initials. Never a real photo. Never an illustration of a person.
+- Color: primary hex; or per-appendix override.
+- Initials: 2 letters max, capitalized.
+
+## Mobile-desktop transform
+
+For each chrome piece above, the mobile ↔ desktop transform is explicit via Tailwind's responsive modifiers. The convention across this skill: **`md:` is the only breakpoint used for chrome transforms**. That's 768px. Avoid `lg:` (1024px) and `sm:` (640px) for chrome — they are allowed for content layout but not for chrome structure.
+
+Violating this creates the "breakpoint fragmentation" flagged in the ss-console drift audit.

--- a/.agents/skills/nav-spec/references/classification-rubric.md
+++ b/.agents/skills/nav-spec/references/classification-rubric.md
@@ -1,0 +1,206 @@
+# Classification rubric
+
+Every Stitch generation must carry **five** tags: `surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`. The pipeline fails fast if any is missing. This rubric is the manual lookup for users constructing prompts; it is not a runtime classifier.
+
+The two new tags (`task=` and `pattern=`) bind the generation to the venture's task model and selected pattern from `pattern-catalog.md`. They are required because chrome alone never determined a navigation pattern — the same chrome can implement different patterns. Tagging makes the choice deterministic.
+
+---
+
+## Tag format
+
+Case-sensitive. Lowercase values. Hyphens, not underscores. Multi-word values use `-` (no quoting needed in shell).
+
+```
+surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+viewport=<mobile|desktop>
+task=<short-name-from-task-model>
+pattern=<pattern-name-from-catalog>
+```
+
+Example prompt prefix:
+
+```
+/stitch-design target=portal-home surface=session-auth-client archetype=dashboard \
+  viewport=mobile task=see-whats-happening pattern=hub-and-spoke
+```
+
+---
+
+## Decision tree — surface class
+
+1. **Is the URL publicly linkable without auth?**
+   - Yes → node 2.
+   - No → node 3.
+
+2. **Does the URL contain a signed token or opaque identifier as a path segment** (e.g., `/portal/proposals/[token]`, `/invoice/[id]`)?
+   - Yes → `token-auth`.
+   - No → node 2a.
+
+2a. **Is the page itself a sign-in / sign-up form** (e.g., `/auth/login`, `/auth/portal-login`)?
+
+- Yes → `auth-gate`.
+- No → `public`.
+
+3. **Does the route require admin role?**
+   - Yes → `session-auth-admin`.
+   - No → `session-auth-client`.
+
+---
+
+## Decision tree — archetype
+
+1. **Is this the landing for an authenticated surface class** (a "home")?
+   - Yes → `dashboard`.
+   - No → node 2.
+
+2. **Does the page show a list of items?**
+   - Yes → `list`.
+   - No → node 3.
+
+3. **Does the page show a single item's details?**
+   - Yes → `detail`.
+   - No → node 4.
+
+4. **Is the page an input form for creating/editing one entity?**
+   - Yes, single-page → `form`.
+   - Yes, multi-step → `wizard`.
+   - No → node 5.
+
+5. **Is this an overlay or panel?**
+   - Overlay centered → `modal`.
+   - Slide-in from edge → `drawer`.
+   - No → node 6.
+
+6. **Is this an error or empty state?**
+   - Error (404/500/401/etc.) → `error`.
+   - Empty list/detail → `empty`.
+   - Short-lived pass-through → `transient`.
+   - Otherwise → STOP. Run `/nav-spec --revise --add-archetype`.
+
+---
+
+## Decision tree — viewport
+
+Two values: `mobile` (390×844 reference) and `desktop` (1280 reference).
+
+- If user prompt specifies → use it.
+- If not → ask. Do not default. Explicit classification forces mobile-first thinking.
+- For both viewports → run two generations.
+
+---
+
+## Decision tree — task
+
+Look up the venture's task model (Section 1 of NAVIGATION.md). Each surface has 1–3 primary tasks. Pick the one this generation is designed to support.
+
+If the surface supports multiple tasks (a dashboard supports several), pick the one that anchors this particular Stitch generation — the user's stated focus.
+
+If you can't name the task without consulting the spec, the spec is incomplete OR the surface lacks a clear task. Stop and reconcile.
+
+Examples (ss-console portal):
+
+| Surface                               | Likely task tag                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `/portal`                             | `see-whats-happening`, `pay-pending-invoice` (state-dependent), `contact-consultant` |
+| `/portal/quotes`                      | `review-past-proposals`                                                              |
+| `/portal/quotes/[id]` (status=sent)   | `review-and-sign-proposal`                                                           |
+| `/portal/invoices`                    | `review-past-invoices`                                                               |
+| `/portal/invoices/[id]` (status=sent) | `pay-pending-invoice`                                                                |
+| `/portal/documents`                   | `find-document`                                                                      |
+| `/portal/engagement`                  | `check-progress`                                                                     |
+
+---
+
+## Decision tree — pattern
+
+Look up the surface's archetype in [archetype-catalog.md](archetype-catalog.md) — each archetype has a recommended pattern. If the venture's spec specializes that pattern (e.g., dashboard with dominant-action variant), use the specialized name.
+
+Common patterns by archetype:
+
+| Archetype | Default pattern (catalog reference)     |
+| --------- | --------------------------------------- |
+| dashboard | `hub-and-spoke` (NN/g §1.1)             |
+| list      | `master-detail` or `faceted`            |
+| detail    | `master-detail` or `nested-doll`        |
+| form      | `single-page-form`                      |
+| wizard    | `sequential` (NN/g §1.3)                |
+| empty     | inherits from parent                    |
+| error     | `recovery-path`                         |
+| modal     | `modal`                                 |
+| drawer    | `drawer`                                |
+| transient | `recovery-path` or `progress-indicator` |
+
+If the venture's pattern selection diverges from the default, the venture spec must justify it. If the prompt's `pattern=` tag doesn't match the spec's selection for the surface, the pipeline fails.
+
+---
+
+## Disambiguation — common edge cases
+
+### A "detail" page with an inline form
+
+`/portal/invoices/[id]` shows the invoice and has a Pay button that opens payment fields inline (no navigation).
+
+Classification: `detail`. The form is content. `task=pay-pending-invoice`, `pattern=master-detail`.
+
+### A "list" with a prominent filter drawer
+
+`/admin/audit-log` with a slide-in filter panel.
+
+Classification: `list` for the main page, `drawer` if generating the filter panel separately.
+
+### Dashboard + list
+
+`/admin/home` shows metric cards and a recent-activity list.
+
+Classification: `dashboard`. Lists embedded in dashboards are content; the archetype is determined by the surface's role.
+
+### Public marketing page with a form
+
+`/contact` with a contact form.
+
+Classification: either `public` + `detail` (form is one section of a larger page) OR `public` + `form` (form IS the page). Use `form` when it's the primary purpose.
+
+### Token-auth landing → session-auth after action
+
+`/portal/proposals/[token]` where accepting signs the client in.
+
+Classification: two different pages. `/portal/proposals/[token]` is `token-auth` + `detail`. Post-acceptance redirect target is `session-auth-client` + `dashboard`.
+
+### Same URL, different chrome by role
+
+`/invoice/[id]` — logged-in user gets session chrome, anonymous gets token-auth chrome.
+
+Classification: two generations, one per surface class. The implementation branches at render; design specs for each path are independent.
+
+---
+
+## Fallback when classification is ambiguous
+
+```
+Cannot classify target. Add these tags to your prompt:
+  surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+  archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+  viewport=<mobile|desktop>
+  task=<short-name>     (look up Section 1 of NAVIGATION.md)
+  pattern=<name>        (look up Section 4 of NAVIGATION.md or pattern-catalog.md)
+
+Run /nav-spec --classify-help to see the decision rubric.
+```
+
+Never guess. Never infer from natural language. Probabilistic classification is the drift the system is designed to prevent.
+
+---
+
+## Test cases
+
+| Prompt                                        | Correct classification                                                                                           |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| "Portal home dashboard, mobile"               | `surface=session-auth-client archetype=dashboard viewport=mobile task=see-whats-happening pattern=hub-and-spoke` |
+| "Invoice detail page, mobile" (authenticated) | `surface=session-auth-client archetype=detail viewport=mobile task=pay-pending-invoice pattern=master-detail`    |
+| "Invoice link from email" (deep-link)         | `surface=token-auth archetype=detail viewport=<ask> task=pay-pending-invoice pattern=master-detail`              |
+| "Admin clients list"                          | `surface=session-auth-admin archetype=list viewport=<ask> task=manage-clients pattern=master-detail`             |
+| "New engagement intake wizard"                | `surface=session-auth-admin archetype=wizard viewport=<ask> task=create-engagement pattern=sequential`           |
+| "Marketing home page"                         | `surface=public archetype=dashboard viewport=<ask> task=convert-visitor pattern=hub-and-spoke`                   |
+| "Portal sign-in"                              | `surface=auth-gate archetype=form viewport=<ask> task=sign-in pattern=single-page-form`                          |
+| "404 page on portal"                          | `surface=session-auth-client archetype=error viewport=<ask> task=recover pattern=recovery-path`                  |

--- a/.agents/skills/nav-spec/references/content-taxonomy-template.md
+++ b/.agents/skills/nav-spec/references/content-taxonomy-template.md
@@ -1,0 +1,225 @@
+---
+description: Template for the Content Taxonomy section of NAVIGATION.md. Declares the canonical terms for objects, actions, states, and dates. Validator rule R20 checks labels in generated HTML against this taxonomy.
+---
+
+# Content Taxonomy
+
+Labels are half of IA. If `/portal/quotes` is titled "Your Proposals" but the email says "Your Quote," users are navigating two products. The taxonomy section declares the canonical term for every object, action, status, and time expression, and the validator (R20) enforces consistent usage.
+
+---
+
+## What the taxonomy covers
+
+### Object names
+
+The user-visible name for each entity in the product. One name per object, used everywhere.
+
+| Entity (DB term) | Client-facing label (canonical) | Synonyms to avoid                               |
+| ---------------- | ------------------------------- | ----------------------------------------------- |
+| quote            | Proposal                        | Quote, Estimate, Bid, SOW (the PDF is separate) |
+| invoice          | Invoice                         | Bill, Statement                                 |
+| engagement       | Engagement                      | Project, Contract, Job                          |
+| milestone        | Milestone                       | Phase, Stage, Task, Checkpoint                  |
+| client (entity)  | Client                          | Customer, Account                               |
+| consultant       | Consultant                      | Agent, Staff, Advisor, Rep                      |
+| document         | Document                        | File, Attachment, Artifact                      |
+
+### Action verbs
+
+Consistent verbs for actions on objects.
+
+| Action                 | Canonical verb                                            | Synonyms to avoid                |
+| ---------------------- | --------------------------------------------------------- | -------------------------------- |
+| View a proposal detail | Review                                                    | Read, Look at, Open              |
+| Sign a proposal        | Sign                                                      | Accept, Approve, Execute         |
+| Pay an invoice         | Pay                                                       | Settle, Remit, Fund              |
+| Download a document    | View (for PDFs, opens in browser) / Download (for others) | Get, Fetch, Save                 |
+| Contact consultant     | Contact                                                   | Reach out, Message, Get in touch |
+
+### Status labels
+
+User-facing status terms. DB values are separate from what the UI shows.
+
+| Entity  | DB value | User-facing label         | Badge color |
+| ------- | -------- | ------------------------- | ----------- |
+| quote   | sent     | Pending Review            | blue        |
+| quote   | accepted | Accepted                  | green       |
+| quote   | declined | Declined                  | red         |
+| quote   | expired  | Expired                   | amber       |
+| invoice | sent     | Sent (or Due, contextual) | blue        |
+| invoice | paid     | Paid                      | green       |
+| invoice | overdue  | Overdue                   | red         |
+| invoice | void     | Voided                    | slate       |
+
+### Time expressions
+
+Canonical date and time formats, consistent across surfaces.
+
+| Context                 | Format                               | Example                     |
+| ----------------------- | ------------------------------------ | --------------------------- |
+| Short date (list items) | `Mon D, YYYY`                        | Apr 15, 2026                |
+| Short date (same year)  | `Mon D`                              | Apr 15                      |
+| Relative for recent     | `N days ago` / `Yesterday` / `Today` | 3 days ago                  |
+| Expiry countdown        | `Expires in N days` / `Expired`      | Expires in 5 days           |
+| Touchpoint              | `DayName, Mon D at H:MM AM/PM`       | Thursday, Apr 18 at 2:30 PM |
+| ISO (forms, data attrs) | `YYYY-MM-DD`                         | 2026-04-15                  |
+
+### Numeric formats
+
+| Context                               | Format              | Example     |
+| ------------------------------------- | ------------------- | ----------- |
+| Project price (marketing / proposals) | `$N,NNN` (no cents) | $5,250      |
+| Invoice amount                        | `$N,NNN.CC`         | $2,625.00   |
+| Small quantities                      | no units in label   | 3 proposals |
+
+### Empty-state copy
+
+Canonical phrasing for empty states.
+
+| Surface                                      | Canonical copy                                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------------------- |
+| `/portal/quotes` empty                       | "No proposals yet. When we send you one, it will appear here."                  |
+| `/portal/invoices` empty                     | "No invoices yet. When we issue one, it will appear here."                      |
+| `/portal/documents` empty                    | "Documents will appear here as your engagement progresses."                     |
+| `/portal/engagement` empty                   | "No active engagement. When your engagement begins, progress will appear here." |
+| `/portal` empty + no pending + no touchpoint | "Nothing needs your attention right now."                                       |
+
+### Error-state copy
+
+| Context                        | Canonical copy                                      |
+| ------------------------------ | --------------------------------------------------- |
+| Portal dashboard fetch failure | "Something went wrong loading your portal." + Retry |
+| 404 portal route               | "This page doesn't exist. Go to the portal home."   |
+| 401 portal                     | "Your session expired. Please sign in again."       |
+
+---
+
+## Template structure
+
+In `.stitch/NAVIGATION.md`:
+
+```markdown
+## 10. Content taxonomy
+
+### 10.1 Object names
+
+| Entity | Canonical label | Forbidden synonyms   |
+| ------ | --------------- | -------------------- |
+| quote  | Proposal        | Quote, Estimate, Bid |
+
+| ...
+
+### 10.2 Action verbs
+
+| Action               | Canonical verb |
+| -------------------- | -------------- |
+| View proposal detail | Review         |
+
+| ...
+
+### 10.3 Status labels
+
+| Entity | DB value | Label | Badge color |
+| ------ | -------- | ----- | ----------- |
+
+| ...
+
+### 10.4 Time expressions
+
+| Context | Format |
+| ------- | ------ |
+
+| ...
+
+### 10.5 Empty-state copy
+
+| Surface | Copy |
+| ------- | ---- |
+
+| ...
+
+### 10.6 Error-state copy
+
+| Context | Copy |
+| ------- | ---- |
+
+| ...
+```
+
+---
+
+## Rules for using the taxonomy
+
+1. **One canonical label per concept.** If a PM or designer proposes a new term, either add it to the taxonomy (with the old term listed as a forbidden synonym) or reject it. Don't ship both.
+2. **Code may use DB terms; UI must use taxonomy.** The DB column is `quote_id`; the UI says "Proposal." Accept this divergence; do not rename DB columns to match UI.
+3. **Consistency across surfaces.** Email subject lines, PDF contents, notification copy, and UI must all use the taxonomy. This is audit-checkable.
+4. **Clarity over brevity.** "Pending Review" is longer than "Sent" but communicates the client's required action. The taxonomy favors clarity.
+5. **No clever variations.** "Pending review" on one surface and "Awaiting your review" on another = drift. Pick one and use it everywhere.
+
+---
+
+## Validator coverage (R20)
+
+Rule R20 performs a shallow text match:
+
+- Scans generated HTML for any status label from the taxonomy
+- Flags occurrences of `synonyms to avoid` in user-visible positions (h1, h2, p, span, button, a, badge)
+- Flags action verbs that don't match the canonical form (e.g., "Accept Proposal" button when canonical is "Review & Sign")
+- Checks empty-state copy presence when an empty-state rendering is detected
+
+False positives are possible with polysemous terms (e.g., "contract" might appear in an unrelated context). The validator reports severity `semantic` (not `structural`) for taxonomy violations so they can be reviewed without blocking.
+
+---
+
+## Example — ss-console
+
+```markdown
+## 10. Content taxonomy
+
+### 10.1 Object names
+
+| Entity     | Label      | Avoid                     |
+| ---------- | ---------- | ------------------------- |
+| quote      | Proposal   | Quote, Estimate, Bid, SOW |
+| invoice    | Invoice    | Bill, Statement           |
+| engagement | Engagement | Project, Contract         |
+| client     | Client     | Customer, Account         |
+| consultant | Consultant | Agent, Staff, Advisor     |
+
+### 10.2 Action verbs
+
+| Action                 | Verb                          |
+| ---------------------- | ----------------------------- |
+| View proposal detail   | Review                        |
+| Sign proposal          | Review & Sign (composite CTA) |
+| Pay invoice            | Pay                           |
+| Download/view document | View (PDF) / Download (other) |
+
+### 10.3 Status labels
+
+| Entity  | DB       | Label          | Badge |
+| ------- | -------- | -------------- | ----- |
+| quote   | sent     | Pending Review | blue  |
+| quote   | accepted | Accepted       | green |
+| quote   | declined | Declined       | red   |
+| quote   | expired  | Expired        | amber |
+| invoice | sent     | Sent           | blue  |
+| invoice | paid     | Paid           | green |
+| invoice | overdue  | Overdue        | red   |
+
+### 10.4 Time expressions
+
+| Context    | Format                             |
+| ---------- | ---------------------------------- |
+| List items | `Mon D, YYYY` (same year: `Mon D`) |
+| Touchpoint | `DayName, Mon D at H:MM AM/PM`     |
+
+### 10.5 Empty-state copy
+
+| Surface              | Copy                                                                          |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `/portal/quotes`     | No proposals yet. When we send you one, it will appear here.                  |
+| `/portal/invoices`   | No invoices yet. When we issue one, it will appear here.                      |
+| `/portal/documents`  | Documents will appear here as your engagement progresses.                     |
+| `/portal/engagement` | No active engagement. When your engagement begins, progress will appear here. |
+```

--- a/.agents/skills/nav-spec/references/ia-principles.md
+++ b/.agents/skills/nav-spec/references/ia-principles.md
@@ -1,0 +1,126 @@
+---
+description: Dan Brown's Eight Principles of Information Architecture and how nav-spec applies them. Use as the review rubric in Phase 7 of the authoring workflow.
+---
+
+# IA Principles
+
+Dan Brown's eight principles, from _Eight Principles of Information Architecture_ (ASIS&T Bulletin, 2010), are the canonical framework for evaluating an IA. `nav-spec` uses them as the rubric for the IA architect reviewer in Phase 7 of the authoring workflow.
+
+Each principle below has a one-sentence definition (the source), an application guide (how `nav-spec` applies it), and a check (what question the reviewer asks of a spec).
+
+---
+
+## 1. Principle of Objects
+
+> "Treat content as a living, breathing thing with a lifecycle, behaviors, and attributes."
+
+**Application.** Before writing an IA, name the _objects_ (entities) the venture manipulates — Proposal, Invoice, Engagement, Client, Consultant, Milestone. Each object has:
+
+- **Attributes** — fields users see and act on
+- **Lifecycle states** — draft, sent, accepted, paid, expired, archived
+- **Behaviors** — what can be done to it, and by whom
+
+The IA map is derived from objects, not from pages. "Pages" are views of objects in particular states.
+
+**Check:** Does the spec's task model and sitemap cleanly decompose into objects, object-states, and object-actions? Are state transitions reflected in URL/IA?
+
+---
+
+## 2. Principle of Choices
+
+> "Create pages that offer meaningful choices to users, keeping the range of choices available focused on a particular task."
+
+**Application.** Each surface in the IA has a small, focused choice set. If a surface presents >7 equally-weighted next actions, it's likely two surfaces masquerading as one. Split.
+
+**Check:** For every surface in the reachability matrix, list the primary + secondary choices. If the list is long or unranked, the surface is overloaded.
+
+---
+
+## 3. Principle of Disclosure
+
+> "Show only enough information to help people understand what kinds of information they'll find as they dig deeper."
+
+**Application.** The IA uses progressive disclosure. Dashboards surface summaries; detail surfaces carry the full payload. Lists show title + status + one number; detail shows the rest.
+
+**Check:** Does the spec define what each surface discloses vs. withholds? Are list items restrained (no full-payload rendering on the index)?
+
+---
+
+## 4. Principle of Exemplars
+
+> "Describe the contents of categories by showing examples of the contents."
+
+**Application.** Labels in the IA show what's inside by example when text alone is ambiguous. "Documents (SOW, meeting notes, deliverables)" is more useful than "Documents" in isolation.
+
+**Check:** Does the taxonomy carry exemplars where labels are ambiguous? Category names should resolve to concrete mental models.
+
+---
+
+## 5. Principle of Front Doors
+
+> "Assume at least half of the website's visitors will come through some page other than the home page."
+
+**Application.** Every surface must work as a front door. Token-auth landings, email deep-links, search-engine entries, bookmarked detail pages — none should assume the user arrived via a linear path. Every surface has self-explanatory title, context, and exits.
+
+**Check:** For every surface, answer: "If the user arrives here cold with no prior context, do they know where they are, what this is, and what they can do next?" If not, the surface fails front-door.
+
+---
+
+## 6. Principle of Multiple Classifications
+
+> "Offer users several different classification schemes to browse the site's content."
+
+**Application.** Users have different mental models. The IA supports multiple entry paths to the same object:
+
+- By time (Recent Activity)
+- By type (Invoices, Proposals, Documents)
+- By status (Pending, Accepted, Expired — filter facets)
+- By context (Engagement-scoped)
+
+**Check:** Can every object be reached by ≥2 classification schemes? Are multiple paths designed, not accidental?
+
+---
+
+## 7. Principle of Focused Navigation
+
+> "Don't mix apples, oranges, and aardvarks in your navigation scheme."
+
+**Application.** Each navigation affordance groups semantically related items. Don't mix "Proposals, Invoices, Documents" (object-kind) with "Account, Help, Log out" (utilities) in the same visual group. Use sections, dividers, or separate chrome regions.
+
+**Second application (v3).** Focused navigation also governs pattern selection: the chosen pattern must support the primary task sequences the user performs, not the designer's aesthetic preference. A pattern that forces cross-section traversal through a hub when the task model declares external termini is unfocused — it serves the hub's sense of place over the user's task. R25 (see [pattern-disqualifiers.md](pattern-disqualifiers.md)) operationalizes this: disqualifiers fire when a declared pattern contradicts the task model's declared `return_locus` distribution. Phase 7's IA architect reviewer should treat pattern ↔ task-model coherence as an application of this principle.
+
+**Check:** Does each navigation affordance have a single semantic category? Are utilities separated from object-navigation? Does the chosen pattern (§4 of the spec) match the `return_locus` distribution of the top-3-by-frequency tasks?
+
+---
+
+## 8. Principle of Growth
+
+> "Assume the content you have today is a small fraction of the content you will have tomorrow."
+
+**Application.** The IA is designed for 10x the current content without restructuring. Patterns (hub-and-spoke, faceted) scale; hardcoded nav lists don't. Labels are category-level, not item-level. URLs use stable slugs that survive renames.
+
+**Check:** If this venture triples its destinations (new engagement types, new object classes), does the IA absorb them without rewrite? Or does it collapse?
+
+---
+
+## Review checklist
+
+When running the IA architect reviewer in Phase 7 of `author.md`, the reviewer evaluates the draft against all eight principles and reports pass/fail per principle with specific evidence:
+
+```
+## IA principles review
+
+1. **Objects** — <pass/fail> — <evidence>
+2. **Choices** — <pass/fail> — <evidence>
+3. **Disclosure** — <pass/fail> — <evidence>
+4. **Exemplars** — <pass/fail> — <evidence>
+5. **Front doors** — <pass/fail> — <evidence>
+6. **Multiple classifications** — <pass/fail> — <evidence>
+7. **Focused navigation** — <pass/fail> — <evidence>
+8. **Growth** — <pass/fail> — <evidence>
+
+## Critical fixes (ranked)
+...
+```
+
+A spec with 3+ principle failures is returned to Phase 3 (IA model) before proceeding. A spec with 1–2 failures can proceed after decision-round fixes in Phase 8.

--- a/.agents/skills/nav-spec/references/injection-snippet-template.md
+++ b/.agents/skills/nav-spec/references/injection-snippet-template.md
@@ -1,0 +1,223 @@
+# Injection snippet template
+
+Canonical NAV CONTRACT block injected between DESIGN SYSTEM and PAGE STRUCTURE in every `stitch-design` prompt. v2 splits the block into **essential** (always injected) and **extended** (loaded only when archetype/pattern requires).
+
+Total token budget: ≤800 tokens combined when both essential and extended are loaded; ≤500 when essential only.
+
+---
+
+## Essential block (always injected)
+
+This block is required for every Stitch generation. Replaces the v1 single-block format.
+
+```
+NAV CONTRACT — ESSENTIAL (REQUIRED — do not invent beyond this block):
+
+# Classification
+Surface class: <surface-class> — <one-line description>.
+Archetype: <archetype>.
+Viewport: <viewport, e.g., "mobile 390x844">.
+Task: <task name from venture task model>.
+Pattern: <pattern name from pattern-catalog.md, e.g., "hub-and-spoke">.
+
+# IA contract (REQUIRED links)
+This surface MUST link to the following destinations (per reachability matrix):
+<list of {To, Mechanism} rows from matrix where From = this surface and Required ∈ {Yes, Conditional}>
+
+# Chrome allowed (inclusive)
+<Chrome-allowed list for {surface, archetype, viewport}, from spec appendix>
+
+# Chrome FORBIDDEN
+<Chrome-forbidden list from anti-patterns, filtered to surface class>
+
+# State colors (exact hex)
+- Active: <hex> | Default: <hex> | Hover: <hex>
+- Focus ring: 2px <hex> at 2px offset, keyboard-focus only
+- Disabled: <hex> | Tap target minimum: 44x44px
+
+# Transition
+<Back target URL (canonical, hardcoded, not # or history.back) — for detail/list/form/wizard/empty/error>
+<Modal close rules — for modal/drawer>
+
+# A11y floor
+- <header role="banner">, <main role="main" id="main">
+- Skip-to-main <a> sr-only-until-focused, first body child, href="#main"
+- Single <h1>; <h2> for major sections; no level skipping
+- aria-label on every icon-only button
+- Focus rings keyboard-only
+
+# Semantic precision (Phase 0 drift targets)
+- Header: `sticky top-0`, NOT `fixed top-0`.
+- Header bg: solid `bg-white`. No `backdrop-blur-*`, no opacity modifiers.
+- Client name stands alone in header — no preceding icon/emoji/SVG.
+- Back: single <a> or <button>, never wrapped in <nav>, never aria-label="Breadcrumb" for a single link.
+- Back href: hardcoded canonical URL.
+
+If any element below in PAGE STRUCTURE conflicts with this block, THIS BLOCK WINS.
+```
+
+---
+
+## Extended block (loaded conditionally)
+
+The extended block is added when:
+
+- The archetype requires it (dashboard always loads "IA — sibling list completeness")
+- The pattern requires it (sequential always loads "Sequential — step ordering")
+- The state machine has non-default behaviors (any surface with declared task states)
+- The taxonomy has terms relevant to the prompt (any surface that renders status badges)
+
+Format:
+
+```
+NAV CONTRACT — EXTENDED (REQUIRED for this archetype/pattern):
+
+# Pattern requirements: <pattern name>
+<Required elements list, copied from pattern-catalog.md>
+
+# State machine
+<Auth state behavior>
+<Data state behavior for this surface>
+<Task state behavior if relevant>
+
+# Content taxonomy (relevant labels)
+<Object labels: from taxonomy>
+<Action verbs: from taxonomy>
+<Status labels with required casing/colors>
+<Empty-state copy if applicable>
+
+# Cross-surface context
+<If this surface participates in persistent-context pattern: declare context indicator and where it renders>
+```
+
+---
+
+## Substitution at prompt-enhancement time
+
+`stitch-design`'s pipeline does these lookups:
+
+1. Read classification tags from prompt: `surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`.
+2. Open `.stitch/NAVIGATION.md`.
+3. Build essential block:
+   - Surface description: from Section 3 (surface-class taxonomy).
+   - IA contract: filter Section 3 (reachability matrix) by `From = current surface`; render rows where `Required = Yes` or `Conditional`.
+   - Chrome allowed: Section 6 chrome contracts, filtered by archetype, overridden by surface appendix.
+   - Chrome forbidden: Section 9 anti-patterns, filtered by surface class.
+   - State colors: Section 7 state conventions.
+   - Transition: Section 8, filtered by archetype.
+   - A11y floor: Section 10.
+4. Build extended block IF:
+   - Archetype is `dashboard` → always load IA — sibling list completeness from matrix.
+   - Pattern is in `{sequential, master-detail, faceted, persistent-context}` → load pattern requirements from pattern-catalog.md.
+   - Surface has declared task states → load state machine entry from Section 5.
+   - Surface renders status badges → load taxonomy from Section 11.
+5. Concatenate essential + extended (with separator) and inject between DESIGN SYSTEM and PAGE STRUCTURE.
+
+Keep substitution simple: string concatenation with placeholders, no templating engine.
+
+---
+
+## Size budget tracking
+
+For each `{surface, archetype, viewport, pattern}` combo, measure the assembled block size and record it in NAVIGATION.md front matter:
+
+```yaml
+injection-budgets:
+  session-auth-client/dashboard/mobile/hub-and-spoke: { essential: 482, extended: 287, total: 769 }
+  session-auth-client/list/mobile/master-detail: { essential: 421, extended: 156, total: 577 }
+  ...
+```
+
+If any combo exceeds 800 tokens, shorten the surface-class appendix rather than the semantic-precision section. The latter is load-bearing per Phase 0 measurements.
+
+If essential alone exceeds 500 tokens, that's a sign the surface class has too many forbidden chrome items — refactor the spec.
+
+---
+
+## Versioning and compatibility
+
+- Semantic-precision section is the most volatile (drifts as Stitch evolves). Bump spec-version when it materially changes.
+- IA contract section is stable per spec-version (changes only when reachability matrix changes).
+- Chrome allowed/forbidden are stable per spec-version.
+
+When the spec moves from v1 to v2:
+
+- v1 specs lacked task and pattern tags. The pipeline still accepts v1 specs and falls back to legacy injection (essential block without IA contract section).
+- v2-aware ventures benefit from full injection.
+
+---
+
+## Example — assembled essential block (portal home, mobile)
+
+```
+NAV CONTRACT — ESSENTIAL (REQUIRED — do not invent beyond this block):
+
+# Classification
+Surface class: session-auth-client — Authenticated client portal user. Cookie session. Hosted on portal.smd.services.
+Archetype: dashboard.
+Viewport: mobile 390x844.
+Task: see-whats-happening.
+Pattern: hub-and-spoke (with dominant-action and recent-activity variants).
+
+# IA contract (REQUIRED links)
+This surface MUST link to:
+- /portal/quotes (Section card, Required)
+- /portal/invoices (Section card, Required)
+- /portal/documents (Section card, Required)
+- /portal/engagement (Section card, Required)
+- /portal/invoices/[id] (ActionCard, Conditional: when has pending invoice)
+- mailto:<consultant_email> (Contact icon, Conditional: when consultant assigned)
+- sms:<consultant_phone> (Contact icon, Conditional)
+- tel:<consultant_phone> (Contact icon, Conditional)
+
+# Chrome allowed
+- Top band: sticky, bg-white, h-14 (mobile), border-b border-[color:var(--color-border)]
+  - Left: client name only (Inter 500, 13/18, #475569)
+  - Right: optional contact icons (mail/sms/tel) and Sign out icon
+- Section card grid: 1 column on mobile, 2 columns on desktop, between hero and Recent Activity
+- Recent Activity timeline: ≤5 entries, time-ordered, with artifact links
+- Right rail (desktop only): ActionCard or status card + ConsultantBlock
+- ConsultantBlock: solid initials circle (no real face), name, role, contact icons
+
+# Chrome FORBIDDEN
+- Logo or brand mark in header
+- Nav tabs or hamburger menu in header
+- Breadcrumbs anywhere
+- Bottom-tab nav
+- Footer with copyright/legal
+- Marketing CTAs ("Schedule a call", "Get started", "Learn more")
+- Real-face photos (Unsplash, googleusercontent/aida, etc.)
+- bg-white/85, backdrop-blur-*, fixed top-0
+
+# State colors
+- Active: #1E40AF | Default: #475569 | Hover: #0F172A
+- Focus ring: 2px #3B82F6 at 2px offset, keyboard-focus only
+- Disabled: #94A3B8 | Tap target: 44x44px minimum
+
+# Transition
+- Direct arrival; no back affordance on this dashboard.
+- Section card click → navigate to list URL.
+- ActionCard click → navigate to /portal/invoices/[id].
+
+# A11y floor
+- <header role="banner">, <main role="main" id="main">
+- Skip-to-main <a> sr-only-until-focused, first body child
+- Single <h1>: "Your engagement is in flight." (or state-appropriate)
+- <h2>: "Recent activity"
+- aria-label on icon-only buttons
+- Focus rings keyboard-only
+
+# Semantic precision
+- Header sticky top-0, not fixed.
+- Header bg solid white.
+- Client name stands alone (no leading icon).
+- No back button on dashboard.
+
+If PAGE STRUCTURE conflicts with this block, THIS BLOCK WINS.
+```
+
+---
+
+## Reference implementation
+
+The 2026-04-15 ss-console run used a ~450-token v1 template for Phase 0. v2 essential is ~480 tokens; extended adds 200–300 tokens depending on surface complexity. Total stays within 800-token budget for all measured combos.

--- a/.agents/skills/nav-spec/references/pattern-catalog.md
+++ b/.agents/skills/nav-spec/references/pattern-catalog.md
@@ -1,0 +1,487 @@
+---
+description: Named navigation patterns drawn from Nielsen Norman Group, Material Design 3, Apple Human Interface Guidelines, and other established design systems. nav-spec chooses from this catalog; it never invents.
+---
+
+# Pattern Catalog
+
+Every navigation choice in a venture's `NAVIGATION.md` must be a specialization of a pattern from this catalog. Inventing a new pattern without rationale against these is a violation of the `nav-spec` principle of **anchoring**.
+
+When a pattern is selected, record:
+
+- **Pattern name** (from this catalog, verbatim)
+- **Source** (NN/g, Material, HIG, or industry convention)
+- **Rationale** (why this pattern fits this `{surface × archetype}`)
+- **Variant** (if a subpattern is being applied)
+- **Required elements** (what this pattern mandates — copied into the spec's chrome contract)
+
+If two patterns are combined (e.g., "hub-and-spoke within a persistent-context workspace"), record both and describe how they compose.
+
+---
+
+## 1. Structural patterns (NN/g taxonomy)
+
+These describe how destinations relate to each other.
+
+### 1.1 Hub-and-spoke
+
+> Central surface (the hub) links to several peer destinations (spokes). User returns to the hub between tasks. Spokes do not link to each other directly.
+
+**Source:** Nielsen Norman Group — "Hub and Spoke: A Better Option for Mobile Navigation" (Mobile UX research).
+
+**Use when:**
+
+- The product has 3–7 top-level tasks that users switch between
+- Users tend to complete one task then return to orientation before starting another
+- Mobile-first: preserves simplicity without a persistent bottom nav
+
+**Don't use when:**
+
+- Users need to rapidly switch between sections mid-task (prefer tabs/bottom nav)
+- > 7 top-level destinations (prefer drawer or rail)
+
+**Required elements:**
+
+- Hub surface (typically a dashboard archetype) with visible entry points to every top-level spoke
+- Each spoke has a back affordance targeting the canonical hub URL (not `history.back()`)
+- No sibling-to-sibling links between spokes in the base nav
+
+**Common variants:**
+
+- **Hub with dominant action** — hub additionally surfaces a single contextually primary action (e.g., "Pay invoice" card on portal home)
+- **Hub with recent activity** — hub surfaces a time-ordered list of recent events alongside entry points
+
+**Reference implementations:** iOS Settings app (first-level), typical SaaS client portals, Gmail's folder view on mobile.
+
+---
+
+### 1.2 Nested doll (hierarchical)
+
+> Destinations organized as a strict tree. User drills in and uses back/breadcrumbs to ascend. Each level contains its children and nothing else.
+
+**Source:** Nielsen Norman Group — "Mobile Navigation Patterns."
+
+**Use when:**
+
+- Content has a clear parent-child relationship
+- Destination count is large but organized by category
+- Desktop admin consoles with section > subsection > detail
+
+**Don't use when:**
+
+- Users need to jump between distant branches (prefer faceted or tag)
+- Hierarchy is artificial — forcing a tree creates false affordances
+
+**Required elements:**
+
+- Every non-root surface carries either a back affordance OR breadcrumbs
+- Breadcrumbs reflect the actual parent chain, not a synthetic one
+- Ascent from a leaf must be possible in one action (click on parent in breadcrumb, or back button)
+
+**Common variants:**
+
+- **Breadcrumb-dominant** — ascent is via breadcrumbs, no standalone back button
+- **Back-dominant** — ascent is via back button; breadcrumbs absent (portal convention)
+
+---
+
+### 1.3 Sequential (step-by-step)
+
+> Linear flow with explicit forward/back. Each step depends on the previous. Progress indicator shows position.
+
+**Source:** Nielsen Norman Group — "Wizard Design Pattern."
+
+**Use when:**
+
+- Task has mandatory ordering (onboarding, multi-step form, checkout)
+- Users shouldn't be able to skip ahead without consequence
+- Completion state matters ("you finished step 3 of 7")
+
+**Don't use when:**
+
+- Steps are independent (prefer single form with sections)
+- Users need to revise any step at any time (prefer single-page form)
+
+**Required elements:**
+
+- Progress indicator showing N of M
+- Previous button (except on step 1)
+- Next/Submit button
+- Cancel affordance returning to parent context with confirmation if data entered
+- Dirty-state guard on navigation away
+
+**Common variants:**
+
+- **Linear wizard** — strict sequence
+- **Branching wizard** — step selection depends on prior answers
+
+---
+
+### 1.4 Pyramid (pagewise)
+
+> List or collection where each item links prev/next among siblings and up to the parent. Think article series or a photo gallery.
+
+**Source:** Nielsen Norman Group — "Mobile Navigation Patterns."
+
+**Use when:**
+
+- Content is a sibling set with meaningful order (chronological, alphabetical, category-internal)
+- Users benefit from iteration (read article 1, then 2, then 3)
+
+**Don't use when:**
+
+- Siblings have no meaningful order
+- The content is bite-sized and the list view is sufficient
+
+**Required elements:**
+
+- Parent (list) link, typically as a back affordance
+- Previous sibling link (if applicable)
+- Next sibling link (if applicable)
+- Position indicator (e.g., "2 of 12")
+
+---
+
+### 1.5 Faceted
+
+> A large index filtered by orthogonal dimensions (facets). User selects filter/sort values; results update. URL captures filter state so results are shareable.
+
+**Source:** Nielsen Norman Group — "Filters vs. Facets," Endeca research.
+
+**Use when:**
+
+- The index has >30 items
+- Users search by multiple independent properties (status, date, type, assignee)
+- Results are worth sharing (filter state in URL)
+
+**Don't use when:**
+
+- The index has <10 items (a simple list is better)
+- Facets are highly correlated (overlap confuses filtering)
+
+**Required elements:**
+
+- Filter chips or sidebar showing active facets
+- Clear state preservation in URL
+- "Clear all" affordance
+- Result count visible
+- Empty-state handling when filters eliminate all results
+
+**Common variants:**
+
+- **Inline facets** (chips above list)
+- **Sidebar facets** (collapsible left rail on desktop)
+- **Bottom-sheet facets** (mobile, invoked from a filter button)
+
+---
+
+### 1.6 Tag (flat)
+
+> All destinations are siblings at a single level. No hierarchy.
+
+**Source:** Nielsen Norman Group — "Mobile Navigation Patterns."
+
+**Use when:**
+
+- The product has ≤5 top-level destinations
+- All destinations are used with similar frequency
+- No meaningful grouping exists
+
+**Don't use when:**
+
+- > 5 destinations (creates cognitive load)
+- Destinations have meaningful hierarchy (prefer nested-doll or hub-and-spoke)
+
+**Required elements:**
+
+- A persistent nav (tab bar, bottom nav, or navigation rail) with all top-level destinations visible
+- Active-state indication via `aria-current="page"`
+
+---
+
+## 2. Material Design 3 navigation components
+
+Material specifies which component to use based on destination count and device class.
+
+### 2.1 Top app bar
+
+> The persistent band at the top of every surface. Contains title, contextual actions, and optionally a navigation icon.
+
+**Source:** Material Design 3 — Top app bar guidelines.
+
+**Always used.** Every surface has a top app bar unless it's a fullscreen task (camera, media playback, transient modal).
+
+**Variants:**
+
+- **Center-aligned** — title centered; best for simple hierarchy
+- **Small** — default; title left-aligned
+- **Medium/Large** — title wraps to second row; use for detail surfaces where context matters
+
+### 2.2 Bottom navigation bar
+
+> Fixed band at the bottom of mobile screens showing 3–5 top-level destinations.
+
+**Source:** Material Design 3 — Bottom navigation.
+
+**Use when:**
+
+- Mobile viewport
+- 3–5 top-level destinations
+- Users switch frequently between sections
+
+**Don't use when:**
+
+- Desktop viewport (prefer rail or drawer)
+- <3 or >5 destinations
+- Sections are hub-and-spoke (bottom nav forces flat thinking)
+
+**Required elements:**
+
+- All destinations labeled
+- Active state obvious (filled icon, color, indicator line)
+- `role="navigation"` and `aria-label`
+
+### 2.3 Navigation rail
+
+> Narrow vertical strip on the side of tablet/desktop showing 3–7 top-level destinations.
+
+**Source:** Material Design 3 — Navigation rail.
+
+**Use when:**
+
+- Viewport ≥600px wide
+- 3–7 top-level destinations
+- Alternative to bottom nav at larger sizes
+
+### 2.4 Navigation drawer
+
+> Side panel (typically left) listing 5+ top-level destinations. May be persistent (always visible on desktop) or modal (slides in from edge on mobile).
+
+**Source:** Material Design 3 — Navigation drawer.
+
+**Use when:**
+
+- > 5 top-level destinations
+- Destinations benefit from grouping or dividers
+- Desktop: persistent drawer; mobile: modal drawer invoked from menu icon
+
+**Don't use when:**
+
+- <5 destinations (prefer tabs, rail, or bottom nav)
+- Destinations are hub-and-spoke (drawer hides the hub relationship)
+
+### 2.5 Tabs
+
+> Horizontal bar of ≤5 categories within a single destination. NOT for top-level app navigation.
+
+**Source:** Material Design 3 — Tabs.
+
+**Use when:**
+
+- Within a detail surface, for related content categories (Activity / History / Payments on an invoice detail)
+- Categories are peers that share context
+
+**Don't use when:**
+
+- Switching changes the surface (that's nav, not tabs)
+- > 5 categories
+
+### 2.6 Segmented button
+
+> A button group selecting between views/filters within a single destination.
+
+**Source:** Material Design 3 — Segmented button.
+
+**Use when:**
+
+- ≤4 mutually exclusive view modes (e.g., Day / Week / Month)
+- Switching doesn't cause navigation
+
+---
+
+## 3. Apple Human Interface Guidelines
+
+For native iOS/iPadOS feel when relevant.
+
+### 3.1 Tab bar
+
+> Fixed bottom bar with 2–5 top-level destinations.
+
+**Source:** Apple HIG — Tab bars.
+
+**Use when:** Same rules as Material's bottom navigation, with iOS visual conventions.
+
+### 3.2 Split view
+
+> Master-detail layout on tablet/desktop: list on the left, detail on the right. Both always visible.
+
+**Source:** Apple HIG — Split views.
+
+**Use when:**
+
+- Viewport ≥768px
+- Detail depends on a current selection from the list
+- Mail, messaging, file browsers
+
+**Don't use when:**
+
+- Mobile viewport (collapse to stacked list-then-detail with back)
+
+### 3.3 Navigation stack
+
+> Drill-down sequence with automatic back button showing parent title.
+
+**Source:** Apple HIG — Navigation bars and Navigation stacks.
+
+**Use when:** Hierarchical content on iOS/iPadOS native feel.
+
+### 3.4 Modal
+
+> Focused task presented over the current surface, dismissible with close button or swipe-down.
+
+**Source:** Apple HIG — Modality.
+
+**Required elements:**
+
+- Escape (Esc key) closes
+- Click-outside closes
+- Close button visible
+- Focus returns to the trigger element on close
+- Body scroll locked while open
+
+---
+
+## 4. Industry-standard composite patterns
+
+These are widely adopted compositions of the above.
+
+### 4.1 Master-detail
+
+> List (master) and detail views. Mobile: stacked — tap list item to navigate to detail, back to list. Desktop: split-view.
+
+**Composes:** Nested doll + Split view.
+
+**Required elements:**
+
+- List has stable sort
+- Detail has back-to-list affordance with canonical URL
+- Selection state preserved on return (scroll position, highlighted item)
+
+### 4.2 Index + preview
+
+> List with inline preview pane. Clicking an item updates the preview without navigating.
+
+**Composes:** Master-detail + Progressive disclosure.
+
+**Use when:**
+
+- Detail is lightweight and doesn't need its own URL
+- User benefits from scanning multiple items quickly
+
+### 4.3 Overlay / modal-on-list
+
+> List view where "open" uses a modal overlay instead of navigating.
+
+**Composes:** Modal + list archetype.
+
+**Use when:**
+
+- Detail is short-lived (confirm, compose, quick-edit)
+- Preserving list scroll/filter state is important
+
+### 4.4 Persistent-context workspace
+
+> A selected entity (client, tenant, project) persists across navigation. All subsequent surfaces operate within that context. Context is visible in chrome and in URL.
+
+**Composes:** Hub-and-spoke or nested-doll, scoped to a current entity.
+
+**Use when:**
+
+- Multi-tenant admin consoles
+- Project-scoped tools (Linear, Jira, Notion)
+
+**Required elements:**
+
+- Context selector/switcher
+- Context visible in header
+- Context in URL path (e.g., `/admin/clients/<id>/...`)
+- Context-switch invalidates in-flight state
+
+### 4.5 Progressive disclosure
+
+> Show summary by default; expand to reveal detail on demand. Accordion, "show more" link, expanded card.
+
+**Source:** Nielsen Norman Group — Progressive Disclosure.
+
+**Use when:**
+
+- Detail is nice-to-have, not always needed
+- Page would be overwhelming with everything expanded
+- Common actions first, secondary actions behind a menu
+
+### 4.6 Command palette / search-first
+
+> Global search (typically invoked with `Cmd+K`) acts as primary navigation. Users navigate by typing.
+
+**Use when:**
+
+- Product has many destinations
+- Power users benefit from keyboard-first nav
+- Linear, Notion, VS Code
+
+**Required elements:**
+
+- Keyboard shortcut to invoke (platform-appropriate)
+- Fuzzy match with ranking
+- Recent items surfaced
+- Destinations and actions both searchable
+
+---
+
+## 5. Selecting a pattern
+
+For each `{surface class × archetype}` in the venture, the author chooses ONE primary pattern from this catalog, names a runner-up, and defends the choice against task-model inputs.
+
+**Pattern selection is governed by disqualifiers, not by a free-form decision table.** See [pattern-disqualifiers.md](pattern-disqualifiers.md) for the citation-anchored disqualifier conditions that the validator (rule R25) applies to every declared pattern against the task-model inputs (`return_locus`, `destination_count`, `task_ordering`, etc.).
+
+Workflow:
+
+1. Draft the task model per [task-model-template.md](task-model-template.md) — including the required `evidence_source` and `return_locus` columns.
+2. For the target `{surface × archetype}`, propose a pattern from this catalog.
+3. Run `python3 ~/.agents/skills/nav-spec/validate.py --check-pattern-fitness --spec .stitch/NAVIGATION.md` against the draft.
+4. If R25 fires, either switch to a surviving pattern or mount an override (cited input values + ≥2-of-3 reviewer consensus; see [workflows/author.md](../workflows/author.md) Phase 4).
+
+The decision guide below remains as a hint for the initial proposal only. **It is not authoritative** — pattern-disqualifiers.md is. Patterns flagged here as "start with" may still be disqualified by R25 given specific task-model inputs.
+
+Initial-proposal hints (non-authoritative):
+
+| Situation                                                                               | Start with                             |
+| --------------------------------------------------------------------------------------- | -------------------------------------- |
+| 3–7 top-level destinations, mobile-first, task-centered, hub is the common return point | Hub-and-spoke                          |
+| Strict tree of content with depth ≥3                                                    | Nested doll                            |
+| Task with mandatory order                                                               | Sequential                             |
+| Index with ≥30 items, filterable                                                        | Faceted                                |
+| ≤5 top-level destinations, frequent switching between sections                          | Persistent-tabs (bottom nav / tab bar) |
+| >5 top-level destinations                                                               | Drawer (mobile) / Rail (desktop)       |
+| Category within a detail                                                                | Tabs (inside detail)                   |
+| Mutually exclusive views of the same data                                               | Segmented button                       |
+| Detail that shouldn't leave list context                                                | Modal-on-list                          |
+| Scoped-by-entity admin tool                                                             | Persistent-context workspace           |
+| Heavy-keyboard power-user tool                                                          | Command palette                        |
+
+If nothing in the catalog fits, stop and question the design — not invent. Re-read the task model; most "novel" patterns are specializations of entries above.
+
+---
+
+## 6. Anti-patterns (do not use)
+
+These patterns appear repeatedly in misaligned designs and are forbidden unless explicitly ratified by the venture with rationale:
+
+- **Hamburger menu as primary nav on desktop** (NN/g research: reduces discoverability)
+- **Both bottom nav AND drawer** (redundancy that confuses)
+- **Tabs that change the URL beyond a hash fragment** (that's navigation, not tabs)
+- **Breadcrumbs that synthesize from category tags** (not a real hierarchy)
+- **Back button using `history.back()`** (breaks for deep-linked arrivals)
+- **Infinite scroll as the only navigation** (loss of place, no URL for specific items)
+- **Carousels as primary navigation** (low discoverability, accessibility issues)
+
+See also: [anti-patterns.md](anti-patterns.md) for chrome-level anti-patterns.

--- a/.agents/skills/nav-spec/references/pattern-disqualifiers.md
+++ b/.agents/skills/nav-spec/references/pattern-disqualifiers.md
@@ -1,0 +1,246 @@
+---
+description: Citation-anchored disqualifier conditions for each pattern in pattern-catalog.md. Read by validator rule R25. Every disqualifier cites a primary source (NN/g, Material Design 3, Apple HIG) or carries a HEURISTIC UNTESTED tag.
+---
+
+# Pattern Disqualifiers
+
+The rule the skill enforces: **a pattern is disqualified for a given `{surface × archetype}` when its primary-source description is contradicted by the task model's declared inputs.** This is not a score, not a weight, not a heuristic table — it is a yes/no check against a cited source. If no catalog entry anchors a check, it carries the `HEURISTIC: UNTESTED` tag and is advisory only.
+
+Read by validator rule R25 (`validate.py::check_pattern_disqualifiers`). Phase 4 of `workflows/author.md` runs `validate.py --check-pattern-fitness` against the draft spec before the four-reviewer pass.
+
+## How a disqualifier is written
+
+Each disqualifier is a tuple of:
+
+- **ID** — `D1`, `D2`, ... unique across this document. IDs are stable; new disqualifiers append.
+- **Predicate** — an expression over task-model inputs (`return_locus`, `destination_count`, `task_ordering`, `index_size`, `max_tree_depth`, `viewport`) that the validator can evaluate mechanically.
+- **Rationale** — one sentence tying the predicate to the anchor's description.
+- **Anchor citation** — specific source, section, and (where possible) quoted text.
+
+Patterns without a disqualifier for a given input are silent on that input. The validator fires R25 only when an explicit disqualifier evaluates to true.
+
+## Task-model input vocabulary
+
+These terms appear across disqualifiers and are sourced from the task model (Section 1 of `NAVIGATION.md`):
+
+- `return_locus` ∈ {hub, last-visited-surface, external, new-destination}
+- `top-3-by-frequency` — the three tasks with the highest `frequency` values (ranked desc; ties broken by `criticality`). Stable against author reclassification (no `primary`/`secondary` flag to toggle).
+- `destination_count` — count of top-level siblings in the sitemap under this surface class
+- `task_ordering` ∈ {independent, mandatory_sequence, parallel}
+- `index_size` — maximum collection size on list archetypes declared in Section 3
+- `max_tree_depth` — longest ancestor chain declared in Section 3's reachability matrix
+- `viewport` ∈ {mobile, desktop} — from the classification tag
+
+---
+
+## hub-and-spoke
+
+**Anchor.** Nielsen Norman Group — Raluca Budiu, _Navigation You Can Stick With_, NN/g 2018; cross-referenced in NN/g _Mobile Navigation Patterns_ article series. Pattern also codified as "Hub-and-Spoke" in NN/g Mobile UX research (2015–2020).
+
+**Source description (quoted).**
+
+> "In a hub-and-spoke layout, the home page serves as a hub and links out to various sections of the site (the spokes). Users return to the hub to navigate between sections." — NN/g, Mobile Navigation Patterns
+
+**Disqualified when:**
+
+### D1. ≥2 of the top-3-by-frequency tasks declare `return_locus ∈ {external, last-visited-surface, new-destination}`
+
+**Rationale.** The NN/g description explicitly requires that users "return to the hub to navigate between sections." If two or more of the most-frequent tasks terminate elsewhere (external vendor, prior surface, a new destination), the hub is not the common return point the pattern requires.
+
+**Anchor citation.** NN/g _Mobile Navigation Patterns_ — "Hub-and-spoke navigation works when users tend to complete one task, then return to the home screen before beginning another." Contradicted by ≥2-of-3 non-hub return loci.
+
+**Note on counting.** "Top-3-by-frequency" ranks tasks by the `frequency` column in Section 1's task table, descending. This is stable against the author demoting a task's nominal "primary" label — there is no primary flag; frequency alone determines inclusion.
+
+### D2. `destination_count > 7`
+
+**Rationale.** NN/g guidance caps hub affordance count before the hub loses its landing function. Above 7 destinations, the hub becomes a dense index — users scan rather than orient, and the pattern's core value (quick re-orientation between tasks) degrades.
+
+**Anchor citation.** NN/g _Hub-and-Spoke_ guidance: "The pattern works best with a small number of peer destinations (typically 3–7)." Above the upper bound, NN/g recommends drawer or navigation rail instead.
+
+---
+
+## persistent-tabs
+
+This entry covers both Material Design 3's bottom navigation bar (mobile) and top tabs / tab bar (desktop), and Apple HIG's Tab Bar component. Disqualifiers differ by viewport.
+
+**Anchor.**
+
+- Material Design 3 — _Bottom navigation_ component specification. `https://m3.material.io/components/navigation-bar/guidelines`
+- Material Design 3 — _Primary navigation tabs_. `https://m3.material.io/components/tabs/guidelines`
+- Apple Human Interface Guidelines — _Tab bars_. `https://developer.apple.com/design/human-interface-guidelines/tab-bars`
+
+**Source descriptions (quoted).**
+
+> "Navigation bars offer a persistent and convenient way to switch between primary destinations in an app. Use three to five destinations that are of equal importance." — Material Design 3, Bottom navigation
+
+> "Use a tab bar to organize information in your app at a high level. A tab bar appears at the bottom of the screen and lets people quickly switch among the main sections of your app." — Apple HIG, Tab bars
+
+**Disqualified when:**
+
+### D3. `destination_count > 5` AND `viewport = mobile`
+
+**Rationale.** Material 3 caps bottom navigation at 5 destinations. Beyond 5, Material 3 recommends navigation drawer.
+
+**Anchor citation.** Material Design 3 _Bottom navigation_ — "Use three to five destinations." Apple HIG _Tab bars_ — "Avoid displaying more than five tabs at the top level."
+
+### D4. `destination_count > 7` AND `viewport = desktop`
+
+**Rationale.** Desktop top-tab patterns tolerate more destinations than mobile bottom-nav but still degrade above ~7 when tab labels begin to truncate or wrap. Above 7, Material 3 recommends navigation rail or drawer.
+
+**Anchor citation.** Material Design 3 _Primary tabs_ — "Primary tabs should represent a small number of related destinations."
+
+### D5. `task_ordering = mandatory_sequence`
+
+**Rationale.** Tabs imply peer destinations with independent access order. A mandatory sequence (wizard) requires ordered progression; exposing all steps as tabs contradicts the pattern's premise of free navigation.
+
+**Anchor citation.** Material Design 3 _Tabs_ guidelines — "Tabs organize content into categories at the same level of hierarchy, allowing users to switch between them." HIG _Tab bars_ — "Don't use a tab bar to present a set of sequential steps."
+
+---
+
+## sequential
+
+**Anchor.** Nielsen Norman Group — _Wizard Design Pattern_ / _Multistep forms_. Also codified in Apple HIG _Multistep Tasks_ and Material 3 _Stepper_ component.
+
+**Source description (quoted).**
+
+> "A wizard is a linear, step-by-step form that leads users through a complex task or process." — NN/g, Wizards: Definition and Usability Guidelines
+
+**Disqualified when:**
+
+### D6. `task_ordering ≠ mandatory_sequence`
+
+**Rationale.** The sequential pattern's defining property is that steps must be completed in order. Without that constraint, sequential is pure friction — use hub-and-spoke (for independent tasks) or nested-doll (for hierarchical browsing).
+
+**Anchor citation.** NN/g _Wizard Design_ — "Wizards are appropriate only when the task has a mandatory sequence and each step depends on the previous."
+
+---
+
+## nested-doll
+
+**Anchor.** Nielsen Norman Group — _Mobile Navigation Patterns_ — "Nested Doll" (hierarchical / drill-down).
+
+**Source description (quoted).**
+
+> "In the nested-doll navigation, the user moves in and out of increasingly specific content, along a single path." — NN/g, Mobile Navigation Patterns
+
+**Disqualified when:**
+
+### D7. `max_tree_depth < 3`
+
+**Rationale.** Nested-doll's value is in traversing deep hierarchies. A tree with depth <3 (hub → section → item) has only two meaningful levels and is better served by hub-and-spoke (for ≤7 siblings) or faceted (for large flat indexes).
+
+**Anchor citation.** NN/g — "The nested-doll pattern is best for deep content hierarchies where users need to drill in several levels."
+
+---
+
+## faceted
+
+**Anchor.** Nielsen Norman Group — _Filters vs. Facets_; _Faceted Search/Browse Interfaces_.
+
+**Source description (quoted).**
+
+> "Faceted navigation provides users multiple filter dimensions that can be combined to narrow a large content set." — NN/g, Filters vs. Facets
+
+**Disqualified when:**
+
+### D8. `index_size < 30` — `HEURISTIC: UNTESTED`
+
+**Rationale.** Faceted navigation's overhead (filter UI, facet counts, filter state management) is justified only when the index is large enough that scanning is impractical. Below ~30 items, a sortable list with inline filters is typically sufficient.
+
+**Anchor citation.** NN/g _Filters vs. Facets_ discusses when faceted search is appropriate but does not cite a specific numeric threshold. The `<30` threshold is a heuristic drawn from common industry practice (Amazon, Booking, Zillow all surface facets only at scale) but is NOT anchored to a published number. Tag: `HEURISTIC: UNTESTED`.
+
+---
+
+## pyramid
+
+**Anchor.** Nielsen Norman Group — _Mobile Navigation Patterns_ — "Pyramid Pattern" (previous/next within a siblings set, with index above).
+
+**Source description (quoted).**
+
+> "The pyramid pattern allows users to navigate between siblings in a linear set without returning to the index." — NN/g, Mobile Navigation Patterns
+
+**Disqualified when:**
+
+### D9. Siblings have no canonical ordering (`task_ordering ∈ {independent, parallel}`) AND `destination_count > 5` — `HEURISTIC: UNTESTED`
+
+**Rationale.** Pyramid's previous/next affordance is useful when siblings form an ordered sequence (chapters of a book, steps of an article series). Without ordering, "next" is arbitrary; above ~5 siblings, the ordering becomes opaque.
+
+**Anchor citation.** NN/g describes the pyramid pattern qualitatively. No numeric threshold for destination_count is published. Tag: `HEURISTIC: UNTESTED`.
+
+---
+
+## persistent-context / workspace
+
+Composite pattern: a global scoping control (entity selector) combined with a pattern nested underneath it. Used in admin tools where all operations are scoped to a selected entity across the session.
+
+**Anchor.** Not a named NN/g / Material / HIG pattern. Industry composite, documented with a HEURISTIC tag.
+
+**Disqualified when:**
+
+### D10. `entity_scope = false` — `HEURISTIC: UNTESTED`
+
+**Rationale.** Persistent-context assumes users operate on one entity across a session. Without entity-scoping, the global scoping control is dead weight.
+
+**Anchor citation.** No primary source. Tag: `HEURISTIC: UNTESTED`.
+
+---
+
+## Worked example — ss-console portal `session-auth-client/dashboard`
+
+Declared pattern in `.stitch/NAVIGATION.md` §4.4 (v2): `hub-and-spoke with dominant-action + recent-activity variants`.
+
+Task-model inputs from §1.4.1 (task model, v3-migrated):
+
+| Task                 | Frequency | return_locus         | return_locus_evidence                                                                      |
+| -------------------- | --------- | -------------------- | ------------------------------------------------------------------------------------------ |
+| pay-invoice          | high      | external             | vendor URL: `https://checkout.stripe.com/*` (cited SOW §4)                                 |
+| review-sign-proposal | high      | external             | vendor URL: `https://app.signwell.com/*` (cited SOW §3)                                    |
+| see-whats-happening  | high      | hub                  | redirect_to /portal cited at src/pages/portal/index.astro:332 (structural evidence type 1) |
+| find-document        | medium    | last-visited-surface | no auto-return implemented                                                                 |
+| check-progress       | medium    | hub                  | redirect_to /portal cited at src/pages/portal/engagement/index.astro:101                   |
+| contact-consultant   | low       | external             | mailto/tel/sms schemes                                                                     |
+
+Top-3-by-frequency: pay-invoice, review-sign-proposal, see-whats-happening.
+
+- pay-invoice: `return_locus = external` ✗
+- review-sign-proposal: `return_locus = external` ✗
+- see-whats-happening: `return_locus = hub` ✓
+
+Count of top-3 with `return_locus ≠ hub`: **2**. D1 threshold is `≥2`. **D1 fires.**
+
+D2 check: `destination_count = 4` (quotes, invoices, documents, engagement). D2 threshold is `>7`. D2 does not fire.
+
+**R25 output:**
+
+```
+R25 Pattern disqualifier fired on session-auth-client/dashboard
+  Declared pattern: hub-and-spoke
+  Disqualifier: D1 (NN/g Mobile Navigation Patterns) —
+    2 of the top-3-by-frequency tasks (pay-invoice, review-sign-proposal)
+    have return_locus=external, not hub
+  Surviving patterns evaluated:
+    - persistent-tabs: D3 false (destination_count=4 ≤ 5), D4 n/a (viewport=mobile),
+      D5 false (task_ordering=independent) → SURVIVES
+    - nested-doll: D7 fires (max_tree_depth=2) → DISQUALIFIED
+    - faceted: D8 fires (index_size < 30 across sections) → DISQUALIFIED (HEURISTIC)
+    - sequential: D6 fires (task_ordering=independent) → DISQUALIFIED
+  Surviving patterns: persistent-tabs
+```
+
+Override paths (per R25 spec):
+
+- (a) Defense + ≥2/3 reviewer consensus — defense must cite specific return_locus values that a disqualifier miscounted. In this case the miscounting claim is hard: Stripe and SignWell URLs are unambiguous external terminals.
+- (b) Switch declared pattern to `persistent-tabs`.
+- (c) In provisional mode only: file `.stitch/provisional-override-<date>.md` with deferred validation event + date ≤90 days.
+
+---
+
+## Amending this document
+
+New disqualifiers append at the end with the next D-number. Existing IDs never change (R25 may reference them in violations recorded in prior spec versions).
+
+When a disqualifier tagged `HEURISTIC: UNTESTED` becomes anchored (e.g., a new NN/g article codifies the threshold), remove the tag and update the citation. Keep a brief change log at the bottom of this file.
+
+## Change log
+
+- 2026-04-16 — initial v3 authoring. D1–D10 established. D8, D9, D10 carry HEURISTIC: UNTESTED tags pending better sourcing.

--- a/.agents/skills/nav-spec/references/reachability-matrix-template.md
+++ b/.agents/skills/nav-spec/references/reachability-matrix-template.md
@@ -1,0 +1,164 @@
+---
+description: Template for the Reachability Matrix section of NAVIGATION.md. This is the central IA artifact — it declares which destinations are reachable from which surfaces, and by what mechanism. Validator rule R16 checks code against this matrix.
+---
+
+# Reachability Matrix
+
+The reachability matrix is the IA's central deliverable. It declares, explicitly and exhaustively, which navigation transitions exist between surfaces and how they're mechanized. Orphan destinations and dead-end surfaces are visible as missing rows.
+
+This matrix is validator-checkable (R16–R18). If the matrix says a dashboard links to `/portal/invoices`, the validator confirms the dashboard's HTML emits `<a href="/portal/invoices">`.
+
+---
+
+## Template structure
+
+In `.stitch/NAVIGATION.md`, the matrix follows the Task Model and Sitemap sections.
+
+```markdown
+## 3. Reachability matrix
+
+### 3.1 Invariants
+
+- Every surface in the sitemap appears as a "From" at least once AND a "To" at least once.
+  - Exception: entry-only surfaces (token-auth landings from email) have no "To" from internal surfaces; flag with **Entry-only**.
+  - Exception: terminal surfaces (confirm + redirect to external) may have no "To"; flag with **Terminal**.
+- Every `dashboard` archetype has "To" rows for every sibling list route in its surface class.
+- Every `detail` archetype has a "To" row back to its parent list.
+- Every surface has at least one "To" row (no dead ends) unless flagged **Terminal**.
+
+### 3.2 Matrix
+
+| From                             | To                      | Mechanism                         | Required?       | Pattern ref             |
+| -------------------------------- | ----------------------- | --------------------------------- | --------------- | ----------------------- |
+| `/portal` (dashboard)            | `/portal/invoices`      | Section card                      | Yes             | Hub-and-spoke           |
+| `/portal` (dashboard)            | `/portal/quotes`        | Section card                      | Yes             | Hub-and-spoke           |
+| `/portal` (dashboard)            | `/portal/documents`     | Section card                      | Yes             | Hub-and-spoke           |
+| `/portal` (dashboard)            | `/portal/engagement`    | Section card                      | Yes             | Hub-and-spoke           |
+| `/portal` (dashboard)            | `/portal/invoices/[id]` | ActionCard (when invoice pending) | Conditional     | Dominant-action variant |
+| `/portal/invoices` (list)        | `/portal/invoices/[id]` | Row click                         | Yes             | Master-detail           |
+| `/portal/invoices` (list)        | `/portal`               | Back button                       | Yes             | Hub-and-spoke           |
+| `/portal/invoices/[id]` (detail) | `/portal/invoices`      | Back button (canonical URL)       | Yes             | Master-detail           |
+| `/portal/invoices/[id]` (detail) | `<stripe>`              | Pay Now CTA                       | Yes (if unpaid) | External                |
+| ...                              |                         |                                   |                 |                         |
+
+### 3.3 Entry-only surfaces
+
+| Surface                        | Entry vector    | Notes                                |
+| ------------------------------ | --------------- | ------------------------------------ |
+| `/portal/proposals/[token]`    | Email deep-link | Token-auth; no prior session assumed |
+| `/invoice/[id]` (public token) | Email deep-link | Token-auth; no prior session assumed |
+
+### 3.4 Terminal surfaces
+
+| Surface                          | Terminal action       | Notes                  |
+| -------------------------------- | --------------------- | ---------------------- |
+| `/portal/quotes/[id]` after sign | Redirect to `/portal` | Post-signature         |
+| Stripe hosted payment            | External              | Not part of venture IA |
+```
+
+---
+
+## Field definitions
+
+- **From** — canonical route (Astro path format, `[param]` preserved) plus archetype in parentheses.
+- **To** — same format. If external, wrap in angle brackets (e.g., `<stripe>`, `<signwell>`, `<email>`).
+- **Mechanism** — the named control that creates the link:
+  - Section card, entry card, action card, row click, back button, breadcrumb, inline link, CTA, modal close, context switcher, form submit, redirect, SMS deep-link, email deep-link, etc.
+  - Name mechanisms consistently. A "section card" is a specific pattern; don't also call it an "entry tile."
+- **Required?** — `Yes` (must always render), `Conditional` (with the condition named, e.g., "when invoice pending"), or `No` (optional affordance).
+- **Pattern ref** — one of the patterns from [pattern-catalog.md](pattern-catalog.md) that this link implements.
+
+---
+
+## Invariants (validator rules)
+
+Validator rule R16 enforces each of the following on generated HTML:
+
+1. **Dashboard completeness** — for every row where From is `dashboard` archetype and Required is `Yes`, the dashboard's HTML must emit an `<a href>` whose href matches the `To` route.
+2. **Detail-to-parent** — for every row where From is `detail` archetype and Mechanism is `back button`, the detail's HTML must emit a back-affordance `<a href>` whose href matches the `To` route.
+3. **No dead ends** — every surface that appears as a "From" must have at least one row with Required=Yes; surfaces flagged Terminal are exempt.
+4. **No orphan destinations** — for every route in `src/pages/**/index.astro` or `src/pages/**/[param].astro` with the same surface class, there must exist at least one row where `To` matches the route.
+
+Orphan destinations (item 4) are caught by walking `src/pages/` at audit time and diffing against the matrix.
+
+---
+
+## Mechanism naming conventions
+
+Mechanism is a free-text field, but naming should be consistent across a spec. Recommended canonical names:
+
+| Canonical            | Use                                                         |
+| -------------------- | ----------------------------------------------------------- |
+| **Section card**     | Dashboard entry to a section's list view                    |
+| **Action card**      | Dashboard dominant-action affordance (pending invoice)      |
+| **Entry card**       | Non-hub surface linking to a related area                   |
+| **Row click**        | Index row click navigating to detail                        |
+| **Back button**      | Single-affordance ascent using canonical URL                |
+| **Breadcrumb**       | Multi-level ascent via full parent chain                    |
+| **Inline link**      | Contextual in-prose or in-body link                         |
+| **CTA**              | Primary call-to-action button                               |
+| **Contact icon**     | Email / SMS / phone icon in chrome                          |
+| **Context switcher** | Selector that changes a persistent context (client, tenant) |
+| **Tab**              | Category switch within a detail surface (not navigation)    |
+| **Modal open**       | Open a modal overlay                                        |
+| **Modal close**      | Close and return to trigger surface                         |
+| **Redirect**         | Auto-navigation post-action                                 |
+| **Email deep-link**  | Arrival via email URL                                       |
+| **SMS deep-link**    | Arrival via SMS URL                                         |
+
+If none of these fit, invent a new mechanism name AND document it in this file so future specs use the same term.
+
+---
+
+## Conditional logic
+
+When a mechanism is conditional (e.g., "ActionCard renders only when an invoice is pending"), the condition must be stated in the Mechanism or Required column, not hidden in prose elsewhere in the spec. Validators treat conditional mechanisms as "render when condition holds; absence is allowed otherwise."
+
+Example:
+
+```
+| `/portal` | `/portal/invoices/[pending-id]` | ActionCard (only when `invoices.some(i => i.status === 'sent' || i.status === 'overdue')`) | Conditional | Dominant-action |
+```
+
+---
+
+## Keeping the matrix current
+
+The matrix must be maintained as the IA changes:
+
+- Adding a new route → add rows for every surface that should link to it and every surface it should return to
+- Removing a route → remove all rows referencing it
+- Restructuring a section → delete+recreate rows rather than partially editing
+
+The `/nav-spec --ia-audit` workflow reads `src/pages/**` and diffs against the matrix. A route added to the code without a matrix update surfaces as an orphan destination. A matrix row pointing to a non-existent route surfaces as a broken link.
+
+---
+
+## Example — ss-console portal (abbreviated)
+
+```markdown
+### 3.2 Matrix
+
+| From                             | To                            | Mechanism                                   | Required?                 | Pattern                       |
+| -------------------------------- | ----------------------------- | ------------------------------------------- | ------------------------- | ----------------------------- |
+| `/portal` (dashboard)            | `/portal/quotes`              | Section card                                | Yes                       | Hub-and-spoke                 |
+| `/portal` (dashboard)            | `/portal/invoices`            | Section card                                | Yes                       | Hub-and-spoke                 |
+| `/portal` (dashboard)            | `/portal/documents`           | Section card                                | Yes                       | Hub-and-spoke                 |
+| `/portal` (dashboard)            | `/portal/engagement`          | Section card                                | Yes                       | Hub-and-spoke                 |
+| `/portal` (dashboard)            | `/portal/invoices/[id]`       | ActionCard (condition: has pending invoice) | Conditional               | Dominant-action               |
+| `/portal` (dashboard)            | `mailto:consultant@...`       | Contact icon                                | Conditional               | Contact-control               |
+| `/portal` (dashboard)            | `sms:+1...`                   | Contact icon                                | Conditional               | Contact-control               |
+| `/portal` (dashboard)            | `tel:+1...`                   | Contact icon                                | Conditional               | Contact-control               |
+| `/portal` (dashboard)            | `/api/auth/logout`            | Logout button                               | Yes                       | —                             |
+| `/portal/quotes` (list)          | `/portal/quotes/[id]`         | Row click                                   | Yes                       | Master-detail                 |
+| `/portal/quotes` (list)          | `/portal`                     | Back button                                 | Yes                       | Hub-and-spoke                 |
+| `/portal/quotes/[id]` (detail)   | `/portal/quotes`              | Back button                                 | Yes                       | Master-detail                 |
+| `/portal/quotes/[id]` (detail)   | `<signwell>`                  | Review & Sign CTA                           | Conditional (status=sent) | External                      |
+| `/portal/invoices` (list)        | `/portal/invoices/[id]`       | Row click                                   | Yes                       | Master-detail                 |
+| `/portal/invoices` (list)        | `/portal`                     | Back button                                 | Yes                       | Hub-and-spoke                 |
+| `/portal/invoices/[id]` (detail) | `/portal/invoices`            | Back button                                 | Yes                       | Master-detail                 |
+| `/portal/invoices/[id]` (detail) | `<stripe>`                    | Pay Now CTA                                 | Conditional (status≠paid) | External                      |
+| `/portal/documents` (list)       | `/api/portal/documents/[key]` | Row click (download/view)                   | Yes                       | Master-detail (external view) |
+| `/portal/documents` (list)       | `/portal`                     | Back button                                 | Yes                       | Hub-and-spoke                 |
+| `/portal/engagement` (detail)    | `/portal`                     | Back button                                 | Yes                       | Hub-and-spoke                 |
+```

--- a/.agents/skills/nav-spec/references/state-machine-template.md
+++ b/.agents/skills/nav-spec/references/state-machine-template.md
@@ -1,0 +1,155 @@
+---
+description: Template for the Navigation State Machine section of NAVIGATION.md. Declares how navigation changes in each auth, data, and task state. Validator rule R21 checks state-aware rendering.
+---
+
+# Navigation State Machine
+
+Navigation is not static. Auth expires, data is empty or errored, tasks transition. The state machine section of the spec declares _how navigation changes in each state_ so these are designed, not improvised.
+
+The state machine is authored per surface class. Within a class, each surface has state-specific navigation rules.
+
+---
+
+## Three dimensions of state
+
+### Auth state
+
+| State               | Description                            | Nav impact                                             |
+| ------------------- | -------------------------------------- | ------------------------------------------------------ |
+| **Authenticated**   | Valid session cookie                   | Full nav                                               |
+| **Expired**         | Cookie present but session expired     | Redirect to login with `?redirect=<current>`           |
+| **Unauthenticated** | No session                             | Redirect to login (or token-auth entry for deep-links) |
+| **Token-valid**     | Signed token (for token-auth surfaces) | Restricted nav: only the action tied to the token      |
+| **Token-expired**   | Signed token but expired/revoked       | Surface with "This link has expired" and recovery path |
+
+### Data state
+
+| State         | Description              | Nav impact                                                                                    |
+| ------------- | ------------------------ | --------------------------------------------------------------------------------------------- |
+| **Empty**     | Query returned no rows   | Empty-state chrome; onboarding or explanation copy; no list affordances to non-existent items |
+| **Loading**   | Async data fetch pending | Skeleton or spinner; chrome present but affordances disabled                                  |
+| **Populated** | Data present             | Full nav with item affordances                                                                |
+| **Error**     | Fetch failed             | Error-state chrome with recovery (Retry, contact support, back to safe surface)               |
+
+### Task state
+
+Each surface has task-specific states that change what nav does:
+
+| Surface                 | Task state | Nav impact                                                                    |
+| ----------------------- | ---------- | ----------------------------------------------------------------------------- |
+| `/portal/quotes/[id]`   | `sent`     | Review & Sign CTA visible; back button to list                                |
+| `/portal/quotes/[id]`   | `accepted` | CTA hidden; Deposit invoice link visible if issued                            |
+| `/portal/quotes/[id]`   | `declined` | CTA hidden; message "You declined this proposal on <date>"; no forward action |
+| `/portal/quotes/[id]`   | `expired`  | CTA hidden; message "This proposal expired on <date>"; contact consultant CTA |
+| `/portal/invoices/[id]` | `sent`     | Pay Now CTA prominent                                                         |
+| `/portal/invoices/[id]` | `paid`     | Paid badge; receipt download; no CTA                                          |
+| `/portal/invoices/[id]` | `overdue`  | Pay Now CTA with overdue indicator                                            |
+
+---
+
+## Template structure
+
+In `.stitch/NAVIGATION.md`:
+
+```markdown
+## 5. Navigation state machine
+
+### 5.1 Surface class: <name>
+
+#### Auth states
+
+| State           | Detection                           | Navigation behavior                                         |
+| --------------- | ----------------------------------- | ----------------------------------------------------------- |
+| Authenticated   | Valid session cookie via middleware | Full nav per reachability matrix                            |
+| Expired         | Middleware rejects cookie           | Redirect to `/auth/portal-login?redirect=<encoded current>` |
+| Unauthenticated | No cookie                           | Redirect to `/auth/portal-login`                            |
+
+#### Data states per surface
+
+##### `/portal`
+
+| State                                             | Condition                                                | Rendering                                                                                |
+| ------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Empty                                             | No engagement exists                                     | Welcome headline, "Your portal will populate when engagement begins," single contact CTA |
+| Populated, no pending invoice, no next touchpoint | `activeEngagement && !pendingInvoice && !nextTouchpoint` | Status pill "In flight"; Recent Activity; section cards                                  |
+| Populated, pending invoice                        | `pendingInvoice != null`                                 | ActionCard; Recent Activity; section cards                                               |
+| Populated, next touchpoint                        | `nextTouchpointAt != null`                               | Touchpoint card; Recent Activity; section cards                                          |
+| Error                                             | DB fetch threw                                           | Error card with Retry; Consultant block preserved                                        |
+
+##### `/portal/invoices`
+
+| State     | Condition        | Rendering                                                                                |
+| --------- | ---------------- | ---------------------------------------------------------------------------------------- |
+| Empty     | No invoices      | "No invoices yet. When invoices are created for your engagement, they will appear here." |
+| Populated | Invoices present | Standard list with status badges, amounts, Pay Now CTAs                                  |
+| Error     | Fetch threw      | Error state; back to home available                                                      |
+
+...
+
+#### Task states per surface
+
+##### `/portal/quotes/[id]`
+
+| Task state | Source                    | Nav behavior                                     |
+| ---------- | ------------------------- | ------------------------------------------------ |
+| sent       | quote.status = 'sent'     | Review & Sign CTA; countdown if expires_at set   |
+| accepted   | quote.status = 'accepted' | Signed badge; deposit invoice link if exists     |
+| declined   | quote.status = 'declined' | Declined message; no forward action; contact CTA |
+| expired    | quote.status = 'expired'  | Expired message; contact CTA                     |
+```
+
+---
+
+## Invariants
+
+- **Empty is not error.** An empty list has a single clear "you haven't done X yet" message; an error has a "something went wrong, try again" message. Don't conflate.
+- **Error states have recovery.** Every error renders ≥1 action: Retry, navigate to safe surface, or contact support. No pure dead-ends.
+- **Loading does not hide chrome.** Header, back affordance, and landmarks render during loading. Only the data area uses skeletons.
+- **Auth state transitions preserve intent.** Expiry mid-session redirects to login with a `?redirect=` param. Post-login, the user lands on their original destination.
+- **Cross-auth-boundary is a full page reload.** SPA-style navigation across auth boundaries can leak state. Navigating from `session-auth-client` to `public` uses a full page reload.
+
+---
+
+## Validator coverage (R21)
+
+Rule R21 checks:
+
+- For every surface in the state machine, the generated HTML handles each declared state, OR declares which state was generated in a `data-nav-state` attribute on `<main>`
+- Empty states include a non-empty help message (not a blank screen)
+- Error states include a recovery affordance
+- Loading states, if present, preserve chrome landmarks
+
+---
+
+## Example — ss-console session-auth-client
+
+```markdown
+### 5.1 Surface class: session-auth-client
+
+#### Auth states
+
+| State           | Detection                                 | Nav behavior                                     |
+| --------------- | ----------------------------------------- | ------------------------------------------------ |
+| Authenticated   | `Astro.locals.session?.role === 'client'` | Full nav; reachability matrix applies            |
+| Expired         | Middleware 401                            | Redirect to `/auth/portal-login?redirect=<path>` |
+| Unauthenticated | No session                                | Redirect to `/auth/portal-login`                 |
+
+#### `/portal` states
+
+| State                       | Condition                                     | Rendering                                                                | Key chrome                                                                        |
+| --------------------------- | --------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Empty                       | `!activeEngagement`                           | Welcome message; "Your portal will populate when your engagement begins" | Header, skip-link, ConsultantBlock (if consultant assigned), section cards hidden |
+| Error                       | DB threw                                      | Error card; Retry                                                        | Header, skip-link, ConsultantBlock                                                |
+| Populated + pending invoice | `pendingInvoice != null`                      | ActionCard dominant; Recent Activity; section cards                      | Full                                                                              |
+| Populated + touchpoint      | `nextTouchpointAt != null && !pendingInvoice` | Touchpoint card; Recent Activity; section cards                          | Full                                                                              |
+| Populated + idle            | else                                          | "Nothing needs your attention right now"; Recent Activity; section cards | Full                                                                              |
+
+#### `/portal/quotes/[id]` task states
+
+| quote.status | Primary CTA              | Body state                                                 |
+| ------------ | ------------------------ | ---------------------------------------------------------- |
+| sent         | Review & Sign (SignWell) | Expiry countdown if set                                    |
+| accepted     | —                        | "Signed on <date>"; link to deposit invoice if issued      |
+| declined     | —                        | "You declined this proposal on <date>"; Contact consultant |
+| expired      | —                        | "This proposal expired on <date>"; Contact consultant      |
+```

--- a/.agents/skills/nav-spec/references/task-model-template.md
+++ b/.agents/skills/nav-spec/references/task-model-template.md
@@ -1,0 +1,155 @@
+---
+description: Template and guidance for authoring the Task Model section of NAVIGATION.md. Tasks drive IA; do not author IA before authoring tasks. v3 adds two required columns (evidence_source, return_locus) and a structural definition of "primary".
+---
+
+# Task Model
+
+The Task Model is the first layer of the spec. It answers: _what is the user trying to accomplish on this surface, and where does that task terminate?_ IA, patterns, and chrome all follow from tasks.
+
+Common failure mode: skipping straight to sitemaps and wireframes. The resulting IA works for the designer's mental model but not the user's actual workflow. Authoring tasks first forces the designer to name the workflow before naming the surface.
+
+**v3 change.** Every task carries two new required columns — `evidence_source` and `return_locus` — so the pattern disqualifier rule R25 can evaluate task profiles mechanically. "Primary" is no longer an author-controlled label; it is derived structurally from `frequency` and `criticality`. See [§ Primary definition](#primary-definition) below.
+
+---
+
+## Template structure
+
+In `.stitch/NAVIGATION.md`, the Task Model section goes at the top of the spec, immediately after the front matter and before the sitemap.
+
+```markdown
+## 1. Task model
+
+### 1.1 Surface class: <surface-class-name>
+
+#### Tasks
+
+| Task                 | Frequency | Criticality | Trigger                              | Completion                            | Evidence source                                              | return_locus         | return_locus_evidence                                                                         |
+| -------------------- | --------- | ----------- | ------------------------------------ | ------------------------------------- | ------------------------------------------------------------ | -------------------- | --------------------------------------------------------------------------------------------- |
+| Pay invoice          | high      | blocking    | Consultant sends invoice email       | Stripe payment confirmed              | SOW §4.2 (deposit schedule); ticket PTL-217                  | external             | vendor URL `https://checkout.stripe.com/*` (SOW §4)                                           |
+| Review/sign proposal | high      | blocking    | Consultant sends proposal email      | SignWell signature captured           | SOW §3.1 (engagement kickoff)                                | external             | vendor URL `https://app.signwell.com/*` (SOW §3)                                              |
+| See what's happening | high      | medium      | User logs in to check status         | User views recent activity feed       | Interview 2026-03-14 §2 ("I just want to know where we are") | hub                  | redirect_to /portal (cited: src/pages/portal/index.astro:332 — the feed renders at `/portal`) |
+| Find document        | medium    | medium      | User recalls receiving a deliverable | User has document open                | SOW §2.3 (deliverable retention)                             | last-visited-surface | no auto-return implemented (after download, user stays on document list)                      |
+| Check progress       | medium    | medium      | User wants milestone status          | User sees milestone list              | Interview 2026-03-14 §4                                      | hub                  | redirect_to /portal cited: src/pages/portal/engagement/index.astro:101                        |
+| Contact consultant   | variable  | high        | Ad-hoc question                      | Message delivered via email/SMS/phone | SOW §6 (support commitments); provisional:interview-only     | external             | mailto/tel/sms schemes (unambiguous vendor terminals)                                         |
+
+#### Task-to-surface mapping
+
+| Task        | Primary surface         | Surfaces touched                                            | Entry point                 |
+| ----------- | ----------------------- | ----------------------------------------------------------- | --------------------------- |
+| Pay invoice | `/portal/invoices/[id]` | /portal → /portal/invoices → /portal/invoices/[id] → Stripe | Email link; home ActionCard |
+| ...         |
+```
+
+---
+
+## Required columns (v3)
+
+### `frequency`
+
+One of: `high` / `medium` / `low` / `variable`. Drives pattern selection (R25 top-3-by-frequency).
+
+- `high` — user performs this task ≥ weekly during active engagement.
+- `medium` — weekly to monthly.
+- `low` — rare or one-time.
+- `variable` — genuinely unpredictable (e.g., "contact consultant"). Ranked as `medium` for R25 purposes unless a criticality override applies.
+
+### `criticality`
+
+One of: `blocking` / `high` / `medium` / `low`.
+
+- `blocking` — engagement cannot proceed without the task completing.
+- `high` — user considers this a primary reason for using the product.
+- `medium` — expected functionality.
+- `low` — convenience or administrative.
+
+### `evidence_source` (v3, required)
+
+The artifact that justifies the task's inclusion at the declared frequency/criticality. The rule: **"I looked at the portal and saw X" is not an evidence source.** Accepted values include:
+
+- `SOW §<N.M>` — venture contract or scope document with section reference
+- `ticket <ID>` — support ticket or client email thread
+- `analytics <event-name>` — instrumented analytics event with observed rate
+- `interview <path-or-ID> §<n>` — user interview transcript with section/line reference
+- `provisional:SOW-scope` — pre-launch, SOW scope hypothesis; requires evidence-mode: provisional in front matter
+- `provisional:design-hypothesis` — pre-launch, stated product goal; requires evidence-mode: provisional
+- `provisional:interview-only` — interview data only, no SOW confirmation yet
+
+Provisional evidence is acceptable in `evidence-mode: provisional` specs; in `evidence-mode: validated`, only non-provisional sources pass R25 structural validation.
+
+### `return_locus` (v3, required)
+
+Where the task terminates. Drives R25 disqualifier D1 for hub-and-spoke. One of:
+
+- `hub` — the task ends at the dashboard/hub surface of the surface class (e.g., `/portal`).
+- `last-visited-surface` — the task ends at whatever surface the user was on before starting it (no canonical landing).
+- `external` — the task ends at a surface outside the venture's IA (vendor URL, `mailto:`, etc.).
+- `new-destination` — the task ends at a venture surface that is neither the hub nor a prior one (e.g., a detail page the user did not start from).
+
+### `return_locus_evidence` (v3, required for `return_locus = hub`)
+
+Structural evidence — not prose — justifying the `hub` claim. Accepted evidence types:
+
+1. **Shipped or designed redirect path.** Cite a specific file:line or SOW section that contains the hub URL as a literal string.
+   - Example: `redirect_to /portal cited: src/pages/api/stripe/return.ts:12`
+   - Example: `redirect_to /portal cited: SOW §5.3 "After payment, client returns to https://portal.smd.services/"`
+2. **Interview quote.** Cite a transcript path and line with a user statement about returning to the hub.
+   - Example: `interview transcripts/2026-03-14-alice.md:45 "I always go back to the main page after paying"`
+3. **Analytics event.** Cite an instrumented event that fires on hub arrival post-task.
+   - Example: `analytics.portal_return_after_payment`
+
+For `return_locus ∈ {external, last-visited-surface, new-destination}`, prose citation is sufficient (the terminal surface is typically an unambiguous vendor URL or default behavior).
+
+---
+
+## Primary definition
+
+**"Primary" is derived structurally, not author-declared.** The validator computes:
+
+```
+primary(task) := frequency(task) ∈ {high, medium} OR criticality(task) = blocking
+```
+
+The author cannot toggle a task's primary status without changing its frequency or criticality values. This closes a v2 failure mode where the author could demote tasks to avoid disqualifier thresholds.
+
+**R25's disqualifier counting uses `top-3-by-frequency`, not `primary`:** for thresholds like "≥2 primary tasks with non-hub return_locus," the count operates on the three tasks with the highest frequency-rank (ties broken by criticality). This is stable against author reclassification.
+
+---
+
+## How to elicit tasks
+
+Tasks are derived from non-UI sources: user research, support tickets, contracts, session recordings, analytics, or (failing those) the product owner's articulated reason the product exists.
+
+**Forbidden.** Do not author the task model by reading `src/components/**`, `.astro` bodies, or shipped HTML. R26 (authoring-direction lint) fires if Sections 1–4 cite those paths; the IA Architect reviewer fires on paraphrased shipped-chrome claims (e.g., "the portal currently has a sidebar"). If the only available evidence is shipped chrome, declare `evidence-mode: provisional` and use `provisional:*` sources.
+
+Good elicitation questions:
+
+1. **"What does a good session look like for the user?"** — captures golden-path tasks
+2. **"What goes wrong, and how do they get unstuck?"** — captures recovery tasks
+3. **"What does the user do once a week? Once a month? Once ever?"** — captures frequency tiers
+4. **"What would the user stop using the product for?"** — captures criticality
+5. **"What does the user do that isn't in the product but should be?"** — captures IA gaps
+6. **"Where does this task end?"** — elicits `return_locus` directly. If the user says "I go back to the home page," ask what specifically brought them there (redirect? bookmark? manual nav?) — that specificity feeds `return_locus_evidence`.
+
+If the venture has no user research, the author drafts tasks from domain knowledge and CLAUDE.md, flags them as `provisional:*`, and sets `evidence-mode: provisional` in the front matter.
+
+---
+
+## Naming tasks
+
+Tasks are named as **verb + object**. "Pay invoice," "Review proposal," "Check engagement progress," "Contact consultant." Never "View invoice page" — that's a navigation, not a task.
+
+Tasks are named from the user's perspective. "Review and sign proposal" is correct; "Accept proposal submission" is the system's perspective.
+
+---
+
+## What the task model produces downstream
+
+The Task Model constrains:
+
+- **The reachability matrix (§3)** — every primary task's path through the IA must be a row.
+- **Pattern selection (§4)** — frequency + return_locus drive R25's pattern disqualifier evaluation.
+- **Chrome contract (§6)** — criticality drives affordance prominence.
+- **State machine (§5)** — each task has pre/in-progress/completed states.
+- **Content taxonomy (§12)** — verbs and object names come from task names.
+
+Downstream sections must not contradict the task model. If they do, the task model is wrong (re-author) or the design diverged (reconcile). R25 enforces the pattern ↔ task-model consistency directly.

--- a/.agents/skills/nav-spec/validate.py
+++ b/.agents/skills/nav-spec/validate.py
@@ -1,0 +1,1672 @@
+#!/usr/bin/env python3
+"""validate.py — post-generation navigation validator (v2).
+
+Enforces the 24 rules documented in workflows/validate.md against HTML files.
+Chrome rules (R1–R15) are self-contained. IA + pattern + a11y rules (R16–R24)
+read `.stitch/NAVIGATION.md` for context.
+
+Usage:
+  python3 validate.py --file generated.html \
+      --surface session-auth-client \
+      --archetype dashboard \
+      --viewport mobile \
+      --task see-whats-happening \
+      --pattern hub-and-spoke \
+      --spec .stitch/NAVIGATION.md
+
+Output: JSON violation report. Exit 0 = pass, 1 = violations found.
+
+For v1 specs (no reachability matrix, no task/pattern tags), the validator
+falls back to chrome-only rules (R1–R15). Pass --spec pointing to a v1 file
+and omit --task / --pattern.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Violation:
+    rule: str
+    selector: str
+    severity: str  # "cosmetic" | "semantic" | "structural"
+    message: str
+    fix: str
+
+
+SURFACE_AUTHENTICATED = {"session-auth-client", "session-auth-admin", "token-auth"}
+SURFACE_ALL = SURFACE_AUTHENTICATED | {"public", "auth-gate"}
+
+TOKEN_EQUIVALENCES = {
+    "border": {
+        "literal": {"#e2e8f0", "#E2E8F0"},
+        "var": "var(--color-border)",
+        "tailwind": "slate-200",
+    },
+    "text-default": {
+        "literal": {"#475569"},
+        "var": "var(--color-text-secondary)",
+        "tailwind": "slate-600",
+    },
+    "text-bold": {
+        "literal": {"#0f172a", "#0F172A"},
+        "var": "var(--color-text-primary)",
+        "tailwind": "slate-900",
+    },
+    "primary": {
+        "literal": {"#1e40af", "#1E40AF"},
+        "var": "var(--color-primary)",
+        "tailwind": "blue-800",
+    },
+    "focus": {
+        "literal": {"#3b82f6", "#3B82F6"},
+        "var": "var(--color-action)",
+        "tailwind": "blue-500",
+    },
+    "disabled": {
+        "literal": {"#94a3b8", "#94A3B8"},
+        "var": "var(--color-text-muted)",
+        "tailwind": "slate-400",
+    },
+}
+
+
+def accepts_border_token(class_str: str) -> bool:
+    if any(h in class_str for h in TOKEN_EQUIVALENCES["border"]["literal"]):
+        return True
+    if TOKEN_EQUIVALENCES["border"]["var"] in class_str:
+        return True
+    if f"border-{TOKEN_EQUIVALENCES['border']['tailwind']}" in class_str:
+        return True
+    return False
+
+
+def find_header_block(html: str) -> tuple[str, str] | None:
+    m = re.search(r"<header\b([^>]*)>", html, re.IGNORECASE)
+    if not m:
+        return None
+    attrs = m.group(1)
+    cls = re.search(r'class="([^"]*)"', attrs)
+    return (m.group(0), cls.group(1) if cls else "")
+
+
+# ============================================================================
+# Spec parsing (v2 — reads NAVIGATION.md to power R16, R20, R21, R23, R24)
+# ============================================================================
+
+@dataclass
+class SpecContext:
+    """Parsed context from NAVIGATION.md needed by the IA + pattern-fitness rules.
+
+    v2 fields (matrix, taxonomy, state, search, context) unchanged.
+    v3 adds: evidence_mode, primary_tasks, pattern_decisions, provisional_overrides,
+    section_1_to_4_text (for R26 authoring-direction lint).
+    """
+    spec_version: int = 1
+    matrix_rows: list[dict] = None  # [{from, archetype, to, mechanism, required, pattern}]
+    taxonomy_objects: dict = None   # {canonical: [forbidden_synonyms]}
+    taxonomy_verbs: dict = None     # {action_key: canonical_verb}
+    taxonomy_statuses: dict = None  # {entity.dbvalue: label}
+    state_declarations: dict = None # {route: [state_name, ...]}
+    search_declared: set = None     # {route, ...}
+    context_pattern_surfaces: set = None  # {surface_class, ...}
+    entry_only_surfaces: set = None
+    terminal_surfaces: set = None
+
+    # v3 fields
+    evidence_mode: str = "validated"   # "provisional" | "validated"
+    provisional_review_date: str = ""  # YYYY-MM-DD (iff evidence_mode=provisional)
+    # primary_tasks per surface_class:
+    #   {surface_class: [{task, frequency, criticality, evidence_source,
+    #                     return_locus, return_locus_evidence}, ...]}
+    tasks_by_surface: dict = None
+    # pattern_decisions per {surface_class, archetype}:
+    #   {(surface_class, archetype): {chosen, runner_up, defense,
+    #                                 reviewer_approvals: [...], override_cited_values: [...]}}
+    pattern_decisions: dict = None
+    # provisional_overrides from .stitch/provisional-override-*.md artifacts:
+    #   [{disqualifier_overridden, declared_pattern, surviving_patterns,
+    #     override_rationale, deferred_validation: {event, date, artifact}}]
+    provisional_overrides: list = None
+    # Section 1–4 combined text for R26 lint
+    section_1_to_4_text: str = ""
+
+    def __post_init__(self):
+        self.matrix_rows = self.matrix_rows or []
+        self.taxonomy_objects = self.taxonomy_objects or {}
+        self.taxonomy_verbs = self.taxonomy_verbs or {}
+        self.taxonomy_statuses = self.taxonomy_statuses or {}
+        self.state_declarations = self.state_declarations or {}
+        self.search_declared = self.search_declared or set()
+        self.context_pattern_surfaces = self.context_pattern_surfaces or set()
+        self.entry_only_surfaces = self.entry_only_surfaces or set()
+        self.terminal_surfaces = self.terminal_surfaces or set()
+        self.tasks_by_surface = self.tasks_by_surface or {}
+        self.pattern_decisions = self.pattern_decisions or {}
+        self.provisional_overrides = self.provisional_overrides or []
+
+
+def parse_spec(spec_path: Path) -> SpecContext:
+    """Parse NAVIGATION.md for v2 rule inputs. Defensive — returns empty ctx
+    on any parse failure so the validator falls back to chrome-only rules.
+    """
+    ctx = SpecContext()
+    try:
+        text = spec_path.read_text(encoding="utf-8")
+    except OSError:
+        return ctx
+
+    # Spec version from front matter
+    fm_match = re.search(r'^---\s*\n(.*?)\n---\s*\n', text, re.DOTALL)
+    if fm_match:
+        fm = fm_match.group(1)
+        sv = re.search(r'^spec-version:\s*(\d+)', fm, re.MULTILINE)
+        if sv:
+            ctx.spec_version = int(sv.group(1))
+
+    if ctx.spec_version < 2:
+        return ctx  # v1 specs lack the sections below
+
+    # Reachability matrix (Section 3.2)
+    # Match table rows: | From | To | Mechanism | Required? | Pattern |
+    matrix_section = re.search(
+        r'###\s+3\.2\s+Matrix\s*\n(.*?)(?=\n##\s|\n###\s+3\.3|\Z)',
+        text,
+        re.DOTALL,
+    )
+    if matrix_section:
+        for line in matrix_section.group(1).split("\n"):
+            m = re.match(
+                r'^\|\s*`?([^|`]+)`?\s*(?:\(([^)]+)\))?\s*\|\s*`?([^|`]+)`?\s*'
+                r'\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|',
+                line.strip()
+            )
+            if m:
+                from_route = m.group(1).strip()
+                from_archetype = (m.group(2) or "").strip()
+                to_route = m.group(3).strip()
+                mechanism = m.group(4).strip()
+                required = m.group(5).strip()
+                pattern = m.group(6).strip()
+                # Skip header rows
+                if from_route.lower() in {"from", "---"}:
+                    continue
+                ctx.matrix_rows.append({
+                    "from": from_route,
+                    "archetype": from_archetype,
+                    "to": to_route,
+                    "mechanism": mechanism,
+                    "required": required,
+                    "pattern": pattern,
+                })
+
+    # Entry-only and terminal surfaces (Section 3.3, 3.4)
+    eo = re.search(
+        r'###\s+3\.3\s+Entry-only[^\n]*\n(.*?)(?=\n##\s|\n###\s+3\.4|\Z)',
+        text, re.DOTALL,
+    )
+    if eo:
+        for line in eo.group(1).split("\n"):
+            m = re.match(r'^\|\s*`?([^|`]+)`?\s*\|', line.strip())
+            if m and m.group(1).strip().lower() not in {"surface", "---"}:
+                ctx.entry_only_surfaces.add(m.group(1).strip())
+
+    ts = re.search(
+        r'###\s+3\.4\s+Terminal[^\n]*\n(.*?)(?=\n##\s|\Z)',
+        text, re.DOTALL,
+    )
+    if ts:
+        for line in ts.group(1).split("\n"):
+            m = re.match(r'^\|\s*`?([^|`]+)`?\s*\|', line.strip())
+            if m and m.group(1).strip().lower() not in {"surface", "---"}:
+                ctx.terminal_surfaces.add(m.group(1).strip())
+
+    # Content taxonomy (Section 12)
+    # Object names
+    obj_section = re.search(
+        r'###\s+(?:10|12)\.1\s+Object[^\n]*\n(.*?)(?=\n###|\n##|\Z)',
+        text, re.DOTALL,
+    )
+    if obj_section:
+        for line in obj_section.group(1).split("\n"):
+            m = re.match(
+                r'^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|',
+                line.strip(),
+            )
+            if m:
+                canonical = m.group(2).strip()
+                avoid_raw = m.group(3).strip()
+                if canonical.lower() in {"label", "canonical label", "---"}:
+                    continue
+                if avoid_raw and avoid_raw != "—":
+                    synonyms = [s.strip() for s in re.split(r"[,/]", avoid_raw) if s.strip()]
+                    ctx.taxonomy_objects[canonical] = synonyms
+
+    # Status labels
+    status_section = re.search(
+        r'###\s+(?:10|12)\.3\s+Status[^\n]*\n(.*?)(?=\n###|\n##|\Z)',
+        text, re.DOTALL,
+    )
+    if status_section:
+        for line in status_section.group(1).split("\n"):
+            m = re.match(
+                r'^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|',
+                line.strip(),
+            )
+            if m:
+                entity = m.group(1).strip()
+                db_val = m.group(2).strip()
+                label = m.group(3).strip()
+                if entity.lower() in {"entity", "---"}:
+                    continue
+                ctx.taxonomy_statuses[f"{entity}.{db_val}"] = label
+
+    # State machine declarations (Section 5) — capture which routes have declared states
+    sm_section = re.search(
+        r'##\s+5\.\s+Navigation state machine(.*?)(?=\n##\s+\d+|\Z)',
+        text, re.DOTALL,
+    )
+    if sm_section:
+        for m in re.finditer(
+            r'#####?\s+(`?[/\w\[\]-]+`?)\s*(?:states|[^\n]*)\n',
+            sm_section.group(1),
+        ):
+            route = m.group(1).strip("`")
+            # Gather state names mentioned nearby
+            start = m.end()
+            nxt = re.search(r'#####?\s+', sm_section.group(1)[start:])
+            end = start + nxt.start() if nxt else len(sm_section.group(1))
+            block = sm_section.group(1)[start:end]
+            states = []
+            for sm in re.finditer(
+                r'\|\s*(Empty|Error|Loading|Populated[^|]*|sent|accepted|declined|expired|paid|overdue)\s*\|',
+                block, re.IGNORECASE,
+            ):
+                states.append(sm.group(1).strip())
+            if states:
+                ctx.state_declarations[route] = states
+
+    # Persistent-context pattern detection — scan Section 4 (Patterns)
+    pattern_section = re.search(
+        r'##\s+4\.\s+(?:Pattern|Patterns)[^\n]*\n(.*?)(?=\n##\s|\Z)',
+        text, re.DOTALL,
+    )
+    if pattern_section:
+        for m in re.finditer(
+            r'surface[\s-]+class:\s*([\w-]+).*?pattern:[^\n]*persistent-context',
+            pattern_section.group(1), re.IGNORECASE | re.DOTALL,
+        ):
+            ctx.context_pattern_surfaces.add(m.group(1).strip())
+
+    # Search declared — scan for "search" references in any section
+    if re.search(r'\bsearch\s+(?:strategy|input|affordance)\b', text, re.IGNORECASE):
+        # Coarse detection: if the spec says any surface has search, the
+        # validator asks for explicit route-level search declaration. Parse
+        # "Search present on: <routes>" if present; otherwise treat as a
+        # cross-cutting hint not route-specific (no per-surface R23 check).
+        search_block = re.search(
+            r'###?\s+Search(?:\s+strategy)?\s*\n(.*?)(?=\n##|\n###)',
+            text, re.DOTALL | re.IGNORECASE,
+        )
+        if search_block:
+            for m in re.finditer(r'`(/[\w\[\]/-]+)`', search_block.group(1)):
+                ctx.search_declared.add(m.group(1))
+
+    # ========================================================================
+    # v3 parsing — evidence mode, task columns, pattern decisions
+    # ========================================================================
+    if ctx.spec_version >= 3:
+        _parse_v3_fields(text, ctx, spec_path)
+
+    return ctx
+
+
+def _parse_v3_fields(text: str, ctx: SpecContext, spec_path: Path) -> None:
+    """Populate v3-specific fields on ctx. Defensive; silently tolerates
+    missing or malformed sections to keep the validator running."""
+    # --- Front-matter: evidence-mode, provisional-review-date ---
+    fm_match = re.search(r'^---\s*\n(.*?)\n---\s*\n', text, re.DOTALL)
+    if fm_match:
+        fm = fm_match.group(1)
+        em = re.search(r'^evidence-mode:\s*(\w+)', fm, re.MULTILINE)
+        if em:
+            ctx.evidence_mode = em.group(1).strip()
+        prd = re.search(r'^provisional-review-date:\s*([\d-]+)', fm, re.MULTILINE)
+        if prd:
+            ctx.provisional_review_date = prd.group(1).strip()
+
+    # --- Section 1–4 combined text for R26 lint ---
+    # Capture everything between "## 1." and "## 5." (or EOF).
+    s14 = re.search(
+        r'^##\s+1\.\s.*?(?=^##\s+5\.\s|\Z)',
+        text, re.DOTALL | re.MULTILINE,
+    )
+    if s14:
+        ctx.section_1_to_4_text = s14.group(0)
+
+    # --- Task tables per surface class (Section 1.N) ---
+    # Match "### 1.N Surface class: <name>" blocks up to the next "### 1." or "## 2."
+    # Tolerate `backtick-wrapped` surface-class names.
+    surface_blocks = re.finditer(
+        r'^###\s+1\.\d+\s+Surface\s+class:\s*`?([\w-]+)`?[^\n]*\n(.*?)(?=^###\s+1\.\d+|^##\s+\d+\.|\Z)',
+        text, re.DOTALL | re.MULTILINE,
+    )
+    for sb in surface_blocks:
+        surface_class = sb.group(1).strip().strip("`")
+        block = sb.group(2)
+        tasks = _parse_task_table(block)
+        if tasks:
+            ctx.tasks_by_surface[surface_class] = tasks
+
+    # --- Section 4.N pattern decisions ---
+    sec4 = re.search(
+        r'##\s+4\.\s+(?:Pattern|Patterns)[^\n]*\n(.*?)(?=\n##\s+\d+\.|\Z)',
+        text, re.DOTALL,
+    )
+    if sec4:
+        sec4_body = sec4.group(1)
+        # Enumerate each "### 4.N ..." heading along with the block that follows.
+        heading_positions = [
+            (m.start(), m.end(), m.group(0))
+            for m in re.finditer(r'^###\s+4\.\d+[^\n]*$', sec4_body, re.MULTILINE)
+        ]
+        for idx, (h_start, h_end, heading_line) in enumerate(heading_positions):
+            if idx + 1 < len(heading_positions):
+                block_end = heading_positions[idx + 1][0]
+            else:
+                block_end = len(sec4_body)
+            block = sec4_body[h_end:block_end]
+
+            # Try to extract surface × archetype from the HEADING line itself
+            hdr = re.search(
+                r'\b(public|auth-gate|token-auth|session-auth-client|session-auth-admin)\b'
+                r'[^\n]*?\b(dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient)\b',
+                heading_line, re.IGNORECASE,
+            )
+            # Fallback: look inside the body
+            if not hdr:
+                hdr = re.search(
+                    r'\b(public|auth-gate|token-auth|session-auth-client|session-auth-admin)\b'
+                    r'[^\n]*?\b(dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient)\b',
+                    block, re.IGNORECASE,
+                )
+            if not hdr:
+                continue
+            surface_class = hdr.group(1).lower()
+            archetype = hdr.group(2).lower()
+
+            chosen = _extract_field(block, r'Chosen\s+pattern')
+            runner_up = _extract_field(block, r'Runner[-\s]up(?:\s+pattern)?')
+            defense = _extract_field(block, r'Defense', multiline=True)
+
+            # Reviewer approvals — lines like "Reviewer approval: IA-architect D1 ..."
+            approvals = []
+            for m in re.finditer(
+                r'(?:Reviewer\s+approval|Approval)\s*(?:\(([^)]+)\))?\s*:\s*([^\n]+)',
+                block, re.IGNORECASE,
+            ):
+                approval_text = (m.group(1) or "") + " " + m.group(2)
+                # Parse which disqualifier IDs the approval cites
+                cited_ds = re.findall(r'\bD\d+\b', approval_text)
+                approvals.append({
+                    "reviewer": (m.group(1) or "unknown").strip(),
+                    "text": m.group(2).strip(),
+                    "cited_disqualifiers": cited_ds,
+                })
+
+            # Override-cited values — any "return_locus for X is Y" assertions
+            override_values = []
+            for m in re.finditer(
+                r'return_locus\s+for\s+([\w-]+)\s+is\s+(\w[-\w]*)',
+                block, re.IGNORECASE,
+            ):
+                override_values.append({
+                    "task": m.group(1).strip(),
+                    "claimed_locus": m.group(2).strip().lower(),
+                })
+
+            ctx.pattern_decisions[(surface_class, archetype)] = {
+                "chosen": (chosen or "").lower().strip(),
+                "runner_up": (runner_up or "").lower().strip(),
+                "defense": defense or "",
+                "reviewer_approvals": approvals,
+                "override_cited_values": override_values,
+            }
+
+    # --- Provisional override artifacts ---
+    # Look in the spec file's parent directory for provisional-override-*.md
+    try:
+        parent = spec_path.parent
+        for path in parent.glob("provisional-override-*.md"):
+            override = _parse_provisional_override(path)
+            if override:
+                ctx.provisional_overrides.append(override)
+    except Exception:
+        pass  # silent; validator still runs
+
+
+def _parse_task_table(block: str) -> list[dict]:
+    """Parse a task table from a surface-class block in Section 1.
+
+    Expected columns (in any order): Task, Frequency, Criticality, Trigger,
+    Completion, Evidence source, return_locus, return_locus_evidence.
+
+    Returns [{task, frequency, criticality, evidence_source, return_locus,
+    return_locus_evidence}, ...].
+    """
+    tasks = []
+    # Find the first table in the block (heuristic: first line starting with | that
+    # contains "Task" case-insensitively).
+    lines = block.split("\n")
+    header_idx = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith("|") and re.search(r"\btask\b", line, re.IGNORECASE):
+            header_idx = i
+            break
+    if header_idx is None:
+        return tasks
+
+    # Parse header cells — normalize whitespace to underscores for exact lookup
+    def _normalize_header(s: str) -> str:
+        s = s.strip().strip("`_*").strip().lower()
+        # Replace any run of whitespace/underscore with a single underscore
+        return re.sub(r'[_\s]+', '_', s)
+
+    header_cells = [_normalize_header(c) for c in lines[header_idx].strip().strip("|").split("|")]
+
+    COL_MAP = {
+        "task": "task",
+        "frequency": "frequency",
+        "criticality": "criticality",
+        "trigger": "trigger",
+        "completion": "completion",
+        "evidence_source": "evidence_source",
+        "return_locus": "return_locus",
+        "return_locus_evidence": "return_locus_evidence",
+    }
+    col_keys = [COL_MAP.get(c) for c in header_cells]
+
+    # Skip separator row if present
+    start = header_idx + 1
+    if start < len(lines) and re.match(r"^\s*\|[\s|:-]+\|\s*$", lines[start]):
+        start += 1
+
+    for line in lines[start:]:
+        if not line.strip().startswith("|"):
+            break  # end of table
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < len(col_keys):
+            continue
+        entry = {}
+        for i, cell in enumerate(cells[:len(col_keys)]):
+            if col_keys[i]:
+                entry[col_keys[i]] = cell
+        if entry.get("task"):
+            # Normalize common fields to lowercase
+            for k in ("frequency", "criticality", "return_locus"):
+                if k in entry:
+                    entry[k] = entry[k].lower()
+            tasks.append(entry)
+    return tasks
+
+
+def _extract_field(block: str, field_pattern: str, multiline: bool = False) -> str:
+    """Extract value of a bold-labeled field like **Chosen pattern:** <value>.
+    Handles both `**Chosen pattern:** value` and `**Chosen pattern**: value`.
+    If multiline=True, capture until the next **bold field** or blank line.
+    """
+    # Accept the colon either inside or outside the bold tags.
+    if multiline:
+        m = re.search(
+            rf'\*\*\s*{field_pattern}\s*:?\s*\*\*\s*:?\s*(.+?)(?=\n\s*\*\*|\n\n|\Z)',
+            block, re.DOTALL | re.IGNORECASE,
+        )
+    else:
+        m = re.search(
+            rf'\*\*\s*{field_pattern}\s*:?\s*\*\*\s*:?\s*([^\n]+)',
+            block, re.IGNORECASE,
+        )
+    return m.group(1).strip() if m else ""
+
+
+def _parse_provisional_override(path: Path) -> dict | None:
+    """Parse a .stitch/provisional-override-<date>.md artifact's front matter."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    fm = re.search(r'^---\s*\n(.*?)\n---', text, re.DOTALL)
+    if not fm:
+        return None
+    body = fm.group(1)
+
+    def field(name: str) -> str:
+        m = re.search(rf'^{name}:\s*(.+?)$', body, re.MULTILINE | re.IGNORECASE)
+        return m.group(1).strip() if m else ""
+
+    # deferred_validation is a nested block; parse inline
+    dv_block = re.search(
+        r'^deferred_validation:\s*\n((?:[ \t]+[^\n]+\n?)+)', body, re.MULTILINE,
+    )
+    deferred = {}
+    if dv_block:
+        for m in re.finditer(r'^[ \t]+(\w+):\s*(.+?)$', dv_block.group(1), re.MULTILINE):
+            deferred[m.group(1).lower()] = m.group(2).strip()
+
+    return {
+        "path": str(path),
+        "disqualifier_overridden": field("disqualifier_overridden"),
+        "declared_pattern": field("declared_pattern").lower(),
+        "surviving_patterns": field("surviving_patterns"),
+        "override_rationale": field("override_rationale"),
+        "deferred_validation": deferred,
+    }
+
+
+# ============================================================================
+# Chrome rules (R1–R15) — preserved verbatim from v1
+# ============================================================================
+
+def check_chrome(html: str, surface: str, archetype: str, viewport: str) -> list[Violation]:
+    violations: list[Violation] = []
+    header = find_header_block(html)
+
+    # R1 — Header sticky, not fixed
+    if header:
+        _, hclass = header
+        if re.search(r'\bfixed\s+top-0\b|\bfixed\b(?=[^"]*\btop-0\b)', hclass):
+            violations.append(Violation(
+                rule="R1",
+                selector="<header>",
+                severity="semantic",
+                message="Header uses `fixed top-0` instead of `sticky top-0`.",
+                fix="Replace `fixed top-0` with `sticky top-0`. Fixed removes header from document flow.",
+            ))
+
+    # R2 — Solid header bg
+    if header and surface != "public":
+        _, hclass = header
+        if re.search(r"backdrop-blur-", hclass):
+            violations.append(Violation(
+                rule="R2",
+                selector="<header>",
+                severity="cosmetic",
+                message="Header uses `backdrop-blur-*` (glassmorphism).",
+                fix="Replace with solid `bg-white`.",
+            ))
+        if re.search(r"bg-[a-z0-9\-]+/\d+", hclass):
+            violations.append(Violation(
+                rule="R2b",
+                selector="<header>",
+                severity="cosmetic",
+                message="Header background uses opacity modifier (e.g., `bg-white/85`).",
+                fix="Use solid `bg-white` (no opacity suffix).",
+            ))
+
+    # R3 — Client name stands alone
+    if header and surface in SURFACE_AUTHENTICATED:
+        hstart = html.find("<header")
+        hend = html.find("</header>", hstart) if hstart >= 0 else -1
+        if hstart >= 0 and hend > hstart:
+            hinner = html[hstart:hend]
+            first_text_match = re.search(r">\s*([A-Za-z][^<]{2,})<", hinner)
+            first_text_pos = first_text_match.start() if first_text_match else len(hinner)
+            prefix = hinner[:first_text_pos]
+            if re.search(r'<span[^>]*class="[^"]*material-symbols-[a-z]+', prefix) \
+               or re.search(r"<svg\b", prefix) \
+               or re.search(r"<img\b", prefix):
+                violations.append(Violation(
+                    rule="R3",
+                    selector="<header> first child (before client name)",
+                    severity="cosmetic",
+                    message="Header contains an icon, image, or SVG decoration before the client name.",
+                    fix="Remove decorative element. Client name stands alone.",
+                ))
+
+    # R4 — Back not wrapped in breadcrumb nav
+    breadcrumb_navs = re.findall(
+        r'<nav[^>]+aria-label="Breadcrumb"[^>]*>(.*?)</nav>',
+        html,
+        re.DOTALL | re.IGNORECASE,
+    )
+    for nav_inner in breadcrumb_navs:
+        count = len(re.findall(r"<a\b|<button\b", nav_inner))
+        allows_breadcrumbs = (surface == "session-auth-admin" and archetype in {"list", "detail"})
+        if not allows_breadcrumbs and count >= 1:
+            violations.append(Violation(
+                rule="R4",
+                selector='<nav aria-label="Breadcrumb">',
+                severity="semantic",
+                message="Back affordance wrapped in breadcrumb nav on a surface where breadcrumbs are forbidden.",
+                fix="Unwrap. Use `<a>` or `<button>` with `aria-label`.",
+            ))
+        elif allows_breadcrumbs and count == 1:
+            violations.append(Violation(
+                rule="R4b",
+                selector='<nav aria-label="Breadcrumb">',
+                severity="semantic",
+                message="Breadcrumb nav wraps a single link — this is a back button, not a breadcrumb.",
+                fix="Unwrap. Breadcrumbs require multiple levels.",
+            ))
+
+    # R5 — Back href is canonical
+    if archetype == "detail":
+        back_anchors = re.findall(
+            r'<a[^>]+href="([^"]*)"[^>]*>.*?(?:chevron_left|arrow_back).*?</a>',
+            html,
+            re.DOTALL,
+        )
+        for href in back_anchors:
+            if href.strip() in {"#", "javascript:void(0)", "javascript:"}:
+                violations.append(Violation(
+                    rule="R5",
+                    selector=f'<a href="{href}">',
+                    severity="semantic",
+                    message=f"Back link uses placeholder `href=\"{href}\"`.",
+                    fix="Use a hardcoded canonical URL string. Never `#`, `javascript:`, or `history.back()`.",
+                ))
+        if re.search(r"onclick=\"history\.back\(\)\"", html):
+            violations.append(Violation(
+                rule="R5b",
+                selector="onclick=history.back()",
+                severity="semantic",
+                message="Back uses `history.back()`.",
+                fix="Replace with hardcoded canonical URL. Deep-links have no history to return to.",
+            ))
+
+    # R6 — No global nav tabs
+    if header and surface != "session-auth-admin":
+        hstart = html.find("<header")
+        hend = html.find("</header>", hstart) if hstart >= 0 else -1
+        if hstart >= 0 and hend > hstart:
+            hinner = html[hstart:hend]
+            if re.search(r'role="tablist"|role="tab"', hinner):
+                violations.append(Violation(
+                    rule="R6",
+                    selector="<header> (role=tablist/tab)",
+                    severity="structural",
+                    message="Header contains tablist/tab roles — global nav tabs forbidden.",
+                    fix="Remove. Secondary navigation below the header.",
+                ))
+            anchors = re.findall(r"<a\b[^>]*>([^<]+)</a>", hinner)
+            nav_like = [a for a in anchors if a.strip() and len(a.strip().split()) <= 3]
+            contact_verbs = {"email", "text", "call", "sms", "phone"}
+            contact_like = [a for a in nav_like if any(v in a.strip().lower().split() for v in contact_verbs)]
+            effective_tab_count = len(nav_like) - len(contact_like)
+            if effective_tab_count >= 3:
+                violations.append(Violation(
+                    rule="R6b",
+                    selector="<header> (3+ short-text non-contact links)",
+                    severity="structural",
+                    message=f"Header has {effective_tab_count} short-text non-contact links — looks like a nav tab bar.",
+                    fix="Remove nav-tab-style links from header.",
+                ))
+
+    # R7 — No sticky-bottom outside dialog
+    bottom_sticky = re.search(r'class="[^"]*\b(?:fixed|sticky)\s+bottom-0\b', html)
+    if bottom_sticky and surface in SURFACE_ALL:
+        surrounding = html[max(0, bottom_sticky.start() - 200):bottom_sticky.end()]
+        if "<dialog" not in surrounding and 'role="dialog"' not in surrounding:
+            violations.append(Violation(
+                rule="R7",
+                selector="element with `fixed bottom-0` or `sticky bottom-0`",
+                severity="structural",
+                message="Sticky-bottom outside dialog (bottom-tab nav or duplicated action bar).",
+                fix="Remove. Primary action above the fold via document flow.",
+            ))
+
+    # R8 — No footer on auth
+    if surface in SURFACE_AUTHENTICATED:
+        if re.search(r"<footer\b", html):
+            violations.append(Violation(
+                rule="R8",
+                selector="<footer>",
+                severity="structural",
+                message="Footer on authenticated surface.",
+                fix="Remove footer.",
+            ))
+
+    # R9 — No real-face photos
+    real_face_srcs = re.findall(r'<img[^>]+src="([^"]+)"', html)
+    for src in real_face_srcs:
+        if (re.search(r"googleusercontent\.com/aida[-/]", src)
+                or "unsplash.com" in src
+                or "pexels.com" in src):
+            violations.append(Violation(
+                rule="R9",
+                selector=f'<img src="{src[:60]}...">',
+                severity="structural",
+                message="Image uses real-face photo placeholder source.",
+                fix="Replace with solid-color initials circle.",
+            ))
+            break
+
+    # R10 — No marketing CTAs on auth
+    if surface in SURFACE_AUTHENTICATED:
+        marketing_patterns = [
+            r"\b(?:schedule|book)\s+(?:a\s+)?(?:call|demo|meeting|consultation)\b",
+            r"\bget\s+started\b",
+            r"\blearn\s+more\b",
+            r"\bsign\s+up\s+(?:now|today|free)\b",
+        ]
+        for pat in marketing_patterns:
+            if re.search(pat, html, re.IGNORECASE):
+                violations.append(Violation(
+                    rule="R10",
+                    selector=f"text match: {pat}",
+                    severity="structural",
+                    message="Marketing CTA on authenticated surface.",
+                    fix="Remove. User is already a customer.",
+                ))
+                break
+
+    # R11 — Header height matches viewport
+    if header:
+        _, hclass = header
+        expected_mobile = {"h-14", "h-[56px]"}
+        expected_desktop_any = {"h-16", "h-[64px]", "md:h-16", "md:h-[64px]"}
+        has_h_class = re.search(r"\bh-\[?\d+(?:px)?\]?\b", hclass) or re.search(r"\bmd:h-\[?\d+(?:px)?\]?\b", hclass)
+        if has_h_class:
+            if viewport == "mobile" and not any(cls in hclass for cls in expected_mobile):
+                if not re.search(r"\b(?:h-14|h-\[56px\])\b", hclass):
+                    violations.append(Violation(
+                        rule="R11",
+                        selector="<header>",
+                        severity="cosmetic",
+                        message="Header height does not match 56px (mobile).",
+                        fix="Use `h-14` on mobile.",
+                    ))
+            if viewport == "desktop" and not any(cls in hclass for cls in expected_desktop_any):
+                if not re.search(r"\b(?:h-16|h-\[64px\]|md:h-16|md:h-\[64px\])\b", hclass):
+                    violations.append(Violation(
+                        rule="R11",
+                        selector="<header>",
+                        severity="cosmetic",
+                        message="Header height does not match 64px (desktop).",
+                        fix="Use `h-16` or `md:h-16` on desktop.",
+                    ))
+
+    # R14 — Landmarks
+    if not re.search(r"<header\b[^>]*role=\"banner\"|<header\b", html):
+        violations.append(Violation(
+            rule="R14a",
+            selector="<header>",
+            severity="semantic",
+            message="No <header> landmark found.",
+            fix="Wrap top band in `<header role=\"banner\">`.",
+        ))
+    if not re.search(r"<main\b", html):
+        violations.append(Violation(
+            rule="R14b",
+            selector="<main>",
+            severity="semantic",
+            message="No <main> landmark found.",
+            fix="Wrap primary content in `<main role=\"main\">`.",
+        ))
+
+    # R15 — Skip-to-main
+    skip_link_match = re.search(
+        r'<a\b(?=[^>]*\bclass="[^"]*sr-only)[^>]*\bhref="#([a-zA-Z][\w-]*)"',
+        html,
+    )
+    if not skip_link_match:
+        violations.append(Violation(
+            rule="R15",
+            selector="skip-to-main link",
+            severity="semantic",
+            message="No skip-to-main link detected.",
+            fix='Prepend `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>` before <header>. <main> must carry matching `id`.',
+        ))
+    else:
+        target_id = skip_link_match.group(1)
+        if not re.search(rf'<main\b[^>]*id="{re.escape(target_id)}"', html):
+            violations.append(Violation(
+                rule="R15b",
+                selector=f'<main id="{target_id}">',
+                severity="semantic",
+                message=f'Skip-link targets #{target_id} but no <main id="{target_id}"> exists.',
+                fix=f'Add `id="{target_id}"` to <main>.',
+            ))
+
+    return violations
+
+
+# ============================================================================
+# IA, Pattern, A11y rules (R16–R24) — NEW in v2
+# ============================================================================
+
+# Pattern required-elements map. Expandable. Keys are pattern names from
+# pattern-catalog.md; values are predicates that return a list of violations
+# given the HTML and classification context.
+
+PATTERN_REQUIRED_ELEMENTS: dict[str, list[tuple[str, str]]] = {
+    # pattern name → list of (description, regex-that-should-match)
+    "sequential": [
+        ("Progress indicator (Step N of M)", r"[Ss]tep\s+\d+\s+of\s+\d+"),
+        ("Previous button", r"<button[^>]*>\s*(?:Previous|Back|Prev)\s*<|>\s*(?:Previous|Back|Prev)\s*</"),
+        ("Next button", r"<button[^>]*>\s*(?:Next|Continue|Submit)\s*<|>\s*(?:Next|Continue|Submit)\s*</"),
+    ],
+    "modal": [
+        ("aria-modal=\"true\"", r'aria-modal="true"'),
+        ("Close button", r'<button[^>]*aria-label="(?:Close|Dismiss)"|×|&times;'),
+    ],
+    "drawer": [
+        ("aria-label or aria-labelledby", r'aria-label(?:ledby)?="[^"]+"'),
+    ],
+    # Hub-and-spoke and master-detail are primarily checked via R16
+    # (reachability matrix); no extra per-element checks here.
+}
+
+
+def check_ia(html: str, surface: str, archetype: str, viewport: str,
+             task: str | None, pattern: str | None,
+             ctx: SpecContext, current_route: str | None = None
+             ) -> list[Violation]:
+    violations: list[Violation] = []
+
+    if ctx.spec_version < 2:
+        # v1 spec: skip all IA rules (no matrix, no taxonomy)
+        return violations
+
+    # -------- R16 — Reachability matrix enforcement --------
+    # Filter matrix rows by surface class to avoid cross-surface false positives.
+    # Map surface class to the canonical dashboard root path. If --route is
+    # provided, prefer literal match.
+    SURFACE_DASHBOARD_ROOT = {
+        "public": "/",
+        "session-auth-client": "/portal",
+        "session-auth-admin": "/admin",
+    }
+    if archetype == "dashboard":
+        if current_route:
+            allowed_froms = {current_route}
+        else:
+            root = SURFACE_DASHBOARD_ROOT.get(surface)
+            allowed_froms = {root} if root else set()
+
+        required_tos = set()
+        for row in ctx.matrix_rows:
+            if row["archetype"].lower() != "dashboard":
+                continue
+            if row["required"].lower() not in {"yes", "y"}:
+                continue
+            # Filter by surface — only check rows where From matches our
+            # current surface's dashboard root.
+            if allowed_froms and row["from"] not in allowed_froms:
+                continue
+            required_tos.add(row["to"])
+
+        for to in required_tos:
+            # Skip external protocols/tokens, contact mechanisms, and API
+            # endpoints (actions like logout, not destinations).
+            if to.startswith("<") or to.startswith("mailto:") or to.startswith("sms:") \
+               or to.startswith("tel:") or to.startswith("/api/"):
+                continue
+            pattern_to = re.escape(to).replace(r"\[id\]", r"[^\"]+")
+            if not re.search(rf'href="{pattern_to}"', html):
+                violations.append(Violation(
+                    rule="R16",
+                    selector=f'missing <a href="{to}">',
+                    severity="structural",
+                    message=f'Dashboard must link to sibling list `{to}` per reachability matrix, but no matching <a href> found.',
+                    fix=f'Add `<a href="{to}">` as a section card on the dashboard. Matrix row declares Required=Yes.',
+                ))
+
+    # -------- R17 — Pattern conformance --------
+    if pattern:
+        reqs = PATTERN_REQUIRED_ELEMENTS.get(pattern, [])
+        for description, pattern_regex in reqs:
+            if not re.search(pattern_regex, html, re.IGNORECASE):
+                violations.append(Violation(
+                    rule="R17",
+                    selector=f"pattern={pattern}",
+                    severity="structural",
+                    message=f'Pattern "{pattern}" requires: {description}, but not found in output.',
+                    fix=f'Implement {description} per pattern-catalog.md, or change the pattern declaration.',
+                ))
+
+    # -------- R18 — No dead ends --------
+    # A surface has ≥1 exit: <a href>, <button> with handler, form, or back.
+    if archetype not in {"error"}:  # error surfaces handled separately
+        has_link = bool(re.search(r'<a\b[^>]+href="[^"#]+', html))
+        has_button = bool(re.search(r"<button\b", html))
+        has_form = bool(re.search(r"<form\b", html))
+        if not (has_link or has_button or has_form):
+            # Check if surface is declared Terminal
+            is_terminal = any(current_route and current_route in ts
+                              for ts in ctx.terminal_surfaces)
+            if not is_terminal:
+                violations.append(Violation(
+                    rule="R18",
+                    selector="<main>",
+                    severity="structural",
+                    message="Surface has no navigation exit (no links, buttons, or forms).",
+                    fix="Add a primary action, back affordance, or sibling link.",
+                ))
+    elif archetype == "error":
+        # Error must have recovery
+        recovery_patterns = [
+            r"\b(?:[Rr]etry|[Tt]ry again|[Gg]o (?:to )?home|[Bb]ack (?:to )?(?:home|portal))\b",
+            r"<a[^>]+href=\"/\"",
+            r"<button[^>]*>(?:[^<]*(?:retry|reload|home))",
+        ]
+        if not any(re.search(p, html) for p in recovery_patterns):
+            violations.append(Violation(
+                rule="R18",
+                selector="error surface",
+                severity="structural",
+                message="Error archetype has no recovery affordance (Retry, Go home, or Contact).",
+                fix="Add a recovery CTA linking to a known-good surface.",
+            ))
+
+    # -------- R19 — Token-auth cold arrival --------
+    if surface == "token-auth":
+        cold_violations = [
+            (r"[Ww]elcome back", "prior-session-implying copy ('welcome back')"),
+            (r"[Cc]ontinue where you left off", "prior-session-implying copy ('continue where you left off')"),
+            (r"<button[^>]*>\s*Sign\s*out", "sign-out button on token-auth surface"),
+        ]
+        for pat, desc in cold_violations:
+            if re.search(pat, html):
+                violations.append(Violation(
+                    rule="R19",
+                    selector=f"text/element: {desc}",
+                    severity="structural",
+                    message=f"Token-auth surface assumes prior session: {desc}.",
+                    fix="Render self-contained context. Token-auth is cold-arrival by definition.",
+                ))
+
+    # -------- R20 — Content taxonomy adherence --------
+    if ctx.taxonomy_objects:
+        # Extract visible text from key positions (crude — h1/h2/h3/button/a/span)
+        visible_text_matches = re.findall(
+            r'<(?:h[1-6]|button|a|span|div|p|td)[^>]*>([^<]+)</(?:h[1-6]|button|a|span|div|p|td)>',
+            html,
+        )
+        full_visible = " ".join(t.strip() for t in visible_text_matches)
+        for canonical, synonyms in ctx.taxonomy_objects.items():
+            for syn in synonyms:
+                # Case-insensitive whole-word match
+                if re.search(rf"\b{re.escape(syn)}\b", full_visible, re.IGNORECASE):
+                    # Don't report if the canonical term also appears (may be intentional contrast)
+                    if not re.search(rf"\b{re.escape(canonical)}\b", full_visible, re.IGNORECASE):
+                        violations.append(Violation(
+                            rule="R20",
+                            selector=f'text match "{syn}"',
+                            severity="semantic",
+                            message=f'Forbidden synonym "{syn}" used; canonical term is "{canonical}".',
+                            fix=f'Replace "{syn}" with "{canonical}" per taxonomy.',
+                        ))
+                        break  # one violation per canonical, avoid noise
+
+    # -------- R21 — State machine completeness --------
+    # Heuristic: if the HTML renders no visible content (<main> essentially empty),
+    # an empty or error state was probably intended but not rendered.
+    main_match = re.search(r"<main\b[^>]*>(.*?)</main>", html, re.DOTALL)
+    if main_match:
+        main_inner = main_match.group(1)
+        # Strip tags to check if there's any text content
+        stripped = re.sub(r"<[^>]+>", "", main_inner).strip()
+        if len(stripped) < 10:
+            violations.append(Violation(
+                rule="R21",
+                selector="<main>",
+                severity="structural",
+                message="<main> has no visible text content — state rendering likely missing.",
+                fix="Render explicit empty/error state with copy per state-machine-template.md.",
+            ))
+
+    # -------- R22 — Heading hierarchy --------
+    h1_count = len(re.findall(r"<h1\b", html, re.IGNORECASE))
+    if h1_count == 0:
+        violations.append(Violation(
+            rule="R22a",
+            selector="<h1>",
+            severity="semantic",
+            message="No <h1> element found.",
+            fix="Add a single <h1> as the surface's primary heading.",
+        ))
+    elif h1_count > 1:
+        violations.append(Violation(
+            rule="R22a",
+            selector="<h1>",
+            severity="semantic",
+            message=f"{h1_count} <h1> elements; each surface should have exactly one.",
+            fix="Demote secondary <h1>s to <h2>.",
+        ))
+    # Check for level skipping (h1 → h3 without h2)
+    levels_present = set()
+    for m in re.finditer(r"<h([1-6])\b", html, re.IGNORECASE):
+        levels_present.add(int(m.group(1)))
+    if 1 in levels_present and 3 in levels_present and 2 not in levels_present:
+        violations.append(Violation(
+            rule="R22b",
+            selector="heading hierarchy",
+            severity="semantic",
+            message="Heading hierarchy skips level: <h1> and <h3> present but no <h2>.",
+            fix="Use <h2> for major sections between <h1> and <h3>.",
+        ))
+
+    # -------- R23 — Search affordance --------
+    if current_route and current_route in ctx.search_declared:
+        if not re.search(r'<input[^>]+type="search"|<input[^>]+role="searchbox"', html):
+            violations.append(Violation(
+                rule="R23",
+                selector="search input",
+                severity="semantic",
+                message=f'Spec declares search on `{current_route}` but no search input found.',
+                fix='Add `<input type="search">` or update spec to remove search declaration.',
+            ))
+
+    # -------- R24 — Cross-surface context --------
+    if surface in ctx.context_pattern_surfaces:
+        # Require a context indicator in header (e.g., client chip, breadcrumb prefix)
+        header = find_header_block(html)
+        if header:
+            hstart = html.find("<header")
+            hend = html.find("</header>", hstart) if hstart >= 0 else -1
+            hinner = html[hstart:hend] if hend > hstart else ""
+            # Look for a context-indicator pattern: span/chip with data-context attribute,
+            # or a persistent workspace name display
+            has_context = bool(
+                re.search(r'data-context="[^"]+"', hinner) or
+                re.search(r'<(?:span|div|nav)[^>]*class="[^"]*(?:context|workspace|tenant|client-chip)[^"]*"', hinner)
+            )
+            if not has_context:
+                violations.append(Violation(
+                    rule="R24",
+                    selector="<header> context indicator",
+                    severity="structural",
+                    message=f"Surface class `{surface}` uses persistent-context pattern but no context indicator in header.",
+                    fix='Add a context indicator (chip, label, or breadcrumb prefix) showing the current workspace entity.',
+                ))
+
+    return violations
+
+
+# ============================================================================
+# v3 rules: R25 (pattern fitness) and R26 (authoring-direction lint)
+# ============================================================================
+
+# Pattern disqualifier conditions mirrored from references/pattern-disqualifiers.md.
+# Each entry: pattern name → list of (disqualifier_id, predicate_fn, message_fn,
+# citation, heuristic_untested).
+#
+# predicate_fn takes (profile, archetype, viewport) and returns True iff the
+# disqualifier fires. profile is a dict of task-model inputs derived from the
+# spec + surface class.
+
+def _disq_hub_and_spoke_d1(profile, archetype, viewport):
+    """D1: ≥2 of the top-3-by-frequency tasks have return_locus ≠ hub."""
+    tasks = profile.get("tasks", [])
+    if not tasks:
+        return False, None
+    # Rank by frequency (high > medium > low/variable); ties broken by criticality
+    # (blocking > high > medium > low).
+    FREQ = {"high": 3, "medium": 2, "variable": 2, "low": 1}
+    CRIT = {"blocking": 4, "high": 3, "medium": 2, "low": 1}
+    ranked = sorted(
+        tasks,
+        key=lambda t: (
+            -FREQ.get((t.get("frequency") or "").lower(), 0),
+            -CRIT.get((t.get("criticality") or "").lower(), 0),
+            t.get("task", ""),
+        ),
+    )
+    top3 = ranked[:3]
+    non_hub = [t for t in top3 if (t.get("return_locus") or "").lower() != "hub"]
+    if len(non_hub) >= 2:
+        names = ", ".join(t.get("task", "?") for t in non_hub)
+        return True, f"top-3-by-frequency includes {len(non_hub)} tasks with non-hub return_locus: {names}"
+    return False, None
+
+
+def _disq_hub_and_spoke_d2(profile, archetype, viewport):
+    dc = profile.get("destination_count", 0)
+    if dc > 7:
+        return True, f"destination_count={dc} exceeds 7 (NN/g hub cap)"
+    return False, None
+
+
+def _disq_persistent_tabs_d3(profile, archetype, viewport):
+    dc = profile.get("destination_count", 0)
+    if dc > 5 and viewport == "mobile":
+        return True, f"destination_count={dc} exceeds 5 (Material 3 bottom-nav cap on mobile)"
+    return False, None
+
+
+def _disq_persistent_tabs_d4(profile, archetype, viewport):
+    dc = profile.get("destination_count", 0)
+    if dc > 7 and viewport == "desktop":
+        return True, f"destination_count={dc} exceeds 7 (HIG tab-bar practical cap on desktop)"
+    return False, None
+
+
+def _disq_persistent_tabs_d5(profile, archetype, viewport):
+    if (profile.get("task_ordering") or "").lower() == "mandatory_sequence":
+        return True, "task_ordering=mandatory_sequence contradicts tabs' peer-destination premise"
+    return False, None
+
+
+def _disq_sequential_d6(profile, archetype, viewport):
+    if (profile.get("task_ordering") or "").lower() != "mandatory_sequence":
+        return True, f"task_ordering={profile.get('task_ordering', 'unspecified')} is not mandatory_sequence"
+    return False, None
+
+
+def _disq_nested_doll_d7(profile, archetype, viewport):
+    mtd = profile.get("max_tree_depth", 0)
+    if mtd < 3:
+        return True, f"max_tree_depth={mtd} is <3 (nested-doll requires deep hierarchy)"
+    return False, None
+
+
+def _disq_faceted_d8(profile, archetype, viewport):
+    idx = profile.get("index_size", 0)
+    if idx < 30:
+        return True, f"index_size={idx} is <30 (HEURISTIC)"
+    return False, None
+
+
+PATTERN_DISQUALIFIERS = {
+    "hub-and-spoke": [
+        ("D1", _disq_hub_and_spoke_d1,
+         "NN/g Mobile Navigation Patterns — requires hub return",
+         False),
+        ("D2", _disq_hub_and_spoke_d2,
+         "NN/g Hub-and-Spoke guidance — 3–7 destinations",
+         False),
+    ],
+    "persistent-tabs": [
+        ("D3", _disq_persistent_tabs_d3,
+         "Material Design 3 Bottom navigation — 3–5 destinations on mobile",
+         False),
+        ("D4", _disq_persistent_tabs_d4,
+         "Apple HIG Tab bars — practical cap on desktop",
+         False),
+        ("D5", _disq_persistent_tabs_d5,
+         "Material 3 Tabs — peer destinations, not sequential steps",
+         False),
+    ],
+    "sequential": [
+        ("D6", _disq_sequential_d6,
+         "NN/g Wizard Design — requires mandatory sequence",
+         False),
+    ],
+    "nested-doll": [
+        ("D7", _disq_nested_doll_d7,
+         "NN/g Mobile Navigation Patterns — nested-doll for deep hierarchies",
+         False),
+    ],
+    "faceted": [
+        ("D8", _disq_faceted_d8,
+         "NN/g Filters vs. Facets (heuristic threshold)",
+         True),  # HEURISTIC: UNTESTED
+    ],
+}
+
+
+def _build_task_profile(ctx: SpecContext, surface: str, archetype: str,
+                        current_route: str | None) -> dict:
+    """Derive a task profile (the inputs to disqualifier predicates) from the
+    parsed spec context for the given surface + archetype."""
+    tasks = ctx.tasks_by_surface.get(surface, [])
+
+    # destination_count — count of distinct "To" routes in matrix from the
+    # surface's dashboard archetype that are Required=Yes and section-card-like.
+    SURFACE_DASHBOARD_ROOT = {
+        "public": "/",
+        "session-auth-client": "/portal",
+        "session-auth-admin": "/admin",
+    }
+    root = SURFACE_DASHBOARD_ROOT.get(surface)
+    destinations = set()
+    for row in ctx.matrix_rows:
+        if row.get("from") != root:
+            continue
+        if row.get("archetype", "").lower() != "dashboard":
+            continue
+        if row.get("required", "").lower() not in {"yes", "y"}:
+            continue
+        to = row.get("to", "")
+        if to.startswith("<") or to.startswith("mailto:") or to.startswith("sms:") \
+           or to.startswith("tel:") or to.startswith("/api/"):
+            continue
+        destinations.add(to)
+
+    # max_tree_depth — longest ancestor chain expressible from matrix
+    depth = 1
+    for row in ctx.matrix_rows:
+        slashes = row.get("to", "").count("/")
+        if slashes > depth:
+            depth = slashes
+
+    # task_ordering — if the spec declares any wizard archetype in matrix, treat
+    # the evaluated surface/archetype as independent unless it IS a wizard.
+    ordering = "independent"
+    if archetype == "wizard":
+        ordering = "mandatory_sequence"
+
+    # index_size — not currently declared in spec; default 0.
+    # (A future spec field could capture this.)
+    index_size = 0
+
+    return {
+        "tasks": tasks,
+        "destination_count": len(destinations),
+        "max_tree_depth": depth,
+        "task_ordering": ordering,
+        "index_size": index_size,
+    }
+
+
+def _evaluate_disqualifiers_for(pattern: str, profile: dict, archetype: str,
+                                 viewport: str) -> list[dict]:
+    """Return list of fired disqualifier dicts for the given pattern."""
+    fired = []
+    rules = PATTERN_DISQUALIFIERS.get(pattern, [])
+    for d_id, pred, citation, heuristic in rules:
+        is_fired, detail = pred(profile, archetype, viewport)
+        if is_fired:
+            fired.append({
+                "id": d_id,
+                "citation": citation,
+                "heuristic_untested": heuristic,
+                "detail": detail or "",
+            })
+    return fired
+
+
+def _surviving_patterns(profile: dict, archetype: str, viewport: str) -> list[str]:
+    """Return the list of catalog patterns whose disqualifiers do NOT fire
+    (ignoring HEURISTIC disqualifiers)."""
+    survivors = []
+    for pat in PATTERN_DISQUALIFIERS:
+        fired = [
+            d for d in _evaluate_disqualifiers_for(pat, profile, archetype, viewport)
+            if not d["heuristic_untested"]
+        ]
+        if not fired:
+            survivors.append(pat)
+    return survivors
+
+
+def _override_satisfies_disqualifier(decision: dict, fired_d: dict,
+                                      profile: dict) -> tuple[bool, str]:
+    """Check whether the author's defense plus reviewer approvals form a
+    sufficient override for a specific fired disqualifier.
+
+    Returns (accepted, reason_or_failure_message).
+    """
+    d_id = fired_d["id"]
+
+    # Gate 1: defense must cite specific input values that would make the
+    # disqualifier not fire. For D1, the override must claim at least one
+    # top-3 task's return_locus is actually hub (with structural evidence).
+    cited_values = decision.get("override_cited_values", [])
+    if d_id == "D1":
+        hub_claims = [v for v in cited_values if v.get("claimed_locus") == "hub"]
+        if not hub_claims:
+            return False, "defense does not cite any return_locus=hub reclassification for D1"
+    elif d_id in {"D2", "D3", "D4"}:
+        # Overrides for destination-count thresholds must cite a specific recount
+        if "destination_count" not in (decision.get("defense", "") or ""):
+            return False, f"defense does not cite a destination_count recount for {d_id}"
+    else:
+        # For others, require ANY value citation
+        if not cited_values and "return_locus" not in (decision.get("defense", "") or ""):
+            return False, f"defense does not cite specific input values for {d_id}"
+
+    # Gate 2: ≥2 of 3 reviewers must explicitly approve the override and cite
+    # the disqualifier ID.
+    approvals = decision.get("reviewer_approvals", [])
+    matching = [a for a in approvals if d_id in a.get("cited_disqualifiers", [])]
+    if len(matching) < 2:
+        return False, (
+            f"only {len(matching)} of 3 reviewers approved override of {d_id}; "
+            f"need ≥2 with cited disqualifier ID"
+        )
+
+    return True, f"override accepted: defense cites values + {len(matching)} reviewer approvals for {d_id}"
+
+
+def _override_satisfied_by_provisional(ctx: SpecContext, fired_d: dict,
+                                        pattern: str) -> tuple[bool, str]:
+    """Check if any filed provisional-override artifact covers this fire."""
+    import datetime
+    today = datetime.date.today()
+    for override in ctx.provisional_overrides:
+        if override.get("disqualifier_overridden") != fired_d["id"]:
+            continue
+        if override.get("declared_pattern") != pattern.lower():
+            continue
+        dv = override.get("deferred_validation", {})
+        date_str = dv.get("date", "")
+        try:
+            date = datetime.date.fromisoformat(date_str)
+        except ValueError:
+            return False, f"provisional-override at {override['path']} has invalid date"
+        if date < today:
+            return False, f"provisional-override at {override['path']} expired ({date})"
+        if not dv.get("event"):
+            return False, f"provisional-override at {override['path']} lacks deferred_validation.event"
+        return True, f"covered by {override['path']} (valid until {date})"
+    return False, "no provisional-override artifact covers this disqualifier"
+
+
+def check_authoring_direction(ctx: SpecContext) -> list[Violation]:
+    """R26: Sections 1–4 must not cite src/components/** or *.astro paths.
+
+    This is the trivial-case catch for authoring-direction inversion. The
+    sophisticated-case catch is the IA Architect reviewer's rubric item.
+    """
+    violations: list[Violation] = []
+    text = ctx.section_1_to_4_text
+    if not text:
+        return violations  # nothing parsed; quietly skip
+
+    # Find any citation-shaped reference to a component file in §1–4.
+    # Patterns are ORed; de-dupe by (citation, section) to avoid redundant fires
+    # when a single citation matches multiple patterns.
+    forbidden_patterns = [
+        (r'`(src/components/[^`\s]+)`', "src/components/ path"),
+        (r'`([^`\s]+\.astro)`', "*.astro file path"),
+        (r'\bsrc/components/[\w/.-]+\b', "src/components/ path"),
+    ]
+    seen = set()
+    for pattern, kind in forbidden_patterns:
+        for m in re.finditer(pattern, text):
+            citation = m.group(1) if m.lastindex else m.group(0)
+            citation = citation.strip("` ")
+            # Find which section the hit is in
+            hit_pos = m.start()
+            section_match = None
+            for sec in re.finditer(r'^##\s+([1-4])\.\s', text, re.MULTILINE):
+                if sec.start() < hit_pos:
+                    section_match = sec.group(1)
+            sec_label = f"§{section_match}" if section_match else "§1–4"
+            key = (citation, sec_label)
+            if key in seen:
+                continue
+            seen.add(key)
+            violations.append(Violation(
+                rule="R26",
+                selector=f"{sec_label} cites `{citation}`",
+                severity="structural",
+                message=(
+                    f"Authoring-direction violation: Sections 1–4 cite shipped "
+                    f"code ({kind}: `{citation}`). Task model and pattern "
+                    f"selection must be authorable before shipped code existed."
+                ),
+                fix=(
+                    f"Remove the `{citation}` reference from Sections 1–4. If "
+                    f"the claim relies on shipped code, source it from a "
+                    f"contract, ticket, interview, or analytics event instead. "
+                    f"Chrome contracts (§6) may cite shipped components freely."
+                ),
+            ))
+    return violations
+
+
+def check_pattern_disqualifiers(ctx: SpecContext, surface: str | None = None,
+                                 archetype: str | None = None,
+                                 viewport: str | None = None) -> list[Violation]:
+    """R25: Pattern fitness check. Runs citation-anchored disqualifiers against
+    the declared pattern per {surface × archetype}. Returns violations for
+    each fired disqualifier without a valid override.
+
+    If surface/archetype are provided, check only that combo. Otherwise iterate
+    all decisions in the spec.
+    """
+    violations: list[Violation] = []
+
+    # v2 specs have no pattern_decisions; emit a soft skip warning to stderr
+    if ctx.spec_version < 3:
+        if ctx.spec_version >= 2:
+            print(
+                "R25 skipped — spec is v2. Run `/nav-spec --revise --migrate-to-v3` "
+                "to enable Pattern Fitness checks.",
+                file=sys.stderr,
+            )
+        return violations
+
+    if not ctx.pattern_decisions:
+        print(
+            "R25 skipped — no Section 4 decision entries parsed from spec.",
+            file=sys.stderr,
+        )
+        return violations
+
+    # Select which decisions to evaluate
+    targets = []
+    for (sc, at), decision in ctx.pattern_decisions.items():
+        if surface and sc != surface:
+            continue
+        if archetype and at != archetype:
+            continue
+        targets.append((sc, at, decision))
+
+    for sc, at, decision in targets:
+        pat = decision.get("chosen", "")
+        if not pat:
+            continue
+        if pat not in PATTERN_DISQUALIFIERS:
+            # Unknown pattern — not our concern (catalog may have composite
+            # patterns we don't model); skip silently.
+            continue
+
+        profile = _build_task_profile(ctx, sc, at, None)
+        viewport_local = viewport or "mobile"  # default when unspecified
+        fired = _evaluate_disqualifiers_for(pat, profile, at, viewport_local)
+        # Structural disqualifiers (not HEURISTIC) drive structural R25
+        structural_fires = [f for f in fired if not f["heuristic_untested"]]
+
+        if not structural_fires:
+            continue
+
+        survivors = _surviving_patterns(profile, at, viewport_local)
+
+        for fired_d in structural_fires:
+            # Try override paths
+            accepted_by_defense, defense_msg = _override_satisfies_disqualifier(
+                decision, fired_d, profile,
+            )
+            if accepted_by_defense:
+                continue
+
+            if ctx.evidence_mode == "provisional":
+                accepted_by_override, ov_msg = _override_satisfied_by_provisional(
+                    ctx, fired_d, pat,
+                )
+                if accepted_by_override:
+                    continue
+            else:
+                ov_msg = ""
+
+            # No override accepted → fire R25
+            survivors_str = ", ".join(survivors) if survivors else "(none)"
+            msg = (
+                f"Pattern `{pat}` disqualified on {sc}/{at}: {fired_d['id']} "
+                f"fired — {fired_d['detail']} (anchor: {fired_d['citation']}). "
+                f"Surviving patterns: {survivors_str}. "
+                f"Defense gate: {defense_msg}."
+            )
+            if ctx.evidence_mode == "provisional" and ov_msg:
+                msg += f" Provisional override: {ov_msg}."
+
+            # Emit remediation checklist once per fire to stderr
+            print(
+                f"\n--- R25 remediation checklist for {sc}/{at} ({fired_d['id']}) ---\n"
+                f"1. Surfaces to change: enumerate routes whose chrome would change if "
+                f"pattern switches from `{pat}` to {survivors[0] if survivors else '(surviving pattern)'}.\n"
+                f"2. Chrome diff scope: what DOM + Tailwind changes per surface.\n"
+                f"3. URL migration: what routes stay, what redirects are needed.\n"
+                f"4. Validation metric: analytics event or measurement to confirm the switch works.\n"
+                f"---",
+                file=sys.stderr,
+            )
+
+            violations.append(Violation(
+                rule="R25",
+                selector=f"pattern={pat} on {sc}/{at}",
+                severity="structural",
+                message=msg,
+                fix=(
+                    f"Choose one: (a) revise §4 defense to cite specific input "
+                    f"values overriding {fired_d['id']} AND obtain ≥2/3 reviewer "
+                    f"approvals citing {fired_d['id']}, (b) switch declared "
+                    f"pattern to a surviving pattern ({survivors_str}), or "
+                    f"(c) in evidence-mode: provisional, file "
+                    f".stitch/provisional-override-<date>.md per the schema in "
+                    f"references/task-model-template.md."
+                ),
+            ))
+    return violations
+
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+def check(html: str, surface: str, archetype: str, viewport: str,
+          task: str | None = None, pattern: str | None = None,
+          spec_path: Path | None = None, current_route: str | None = None
+          ) -> list[Violation]:
+    violations = check_chrome(html, surface, archetype, viewport)
+
+    if spec_path and spec_path.exists():
+        ctx = parse_spec(spec_path)
+        if ctx.spec_version >= 2:
+            violations.extend(check_ia(html, surface, archetype, viewport,
+                                       task, pattern, ctx, current_route))
+        if ctx.spec_version >= 3:
+            # R25 runs per {surface, archetype}; limit to the invocation's
+            # surface/archetype to avoid cross-surface false positives.
+            violations.extend(check_pattern_disqualifiers(
+                ctx, surface=surface, archetype=archetype, viewport=viewport,
+            ))
+            # R26 runs once per spec, not per file
+            violations.extend(check_authoring_direction(ctx))
+
+    return violations
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="nav-spec v3 validator (R1–R26)"
+    )
+    # --file is required for chrome/IA validation; NOT required when
+    # --check-pattern-fitness is used (spec-only mode).
+    ap.add_argument("--file", default=None,
+                    help="HTML file to validate (required unless --check-pattern-fitness)")
+    ap.add_argument("--surface",
+                    choices=["public", "auth-gate", "token-auth",
+                             "session-auth-client", "session-auth-admin"],
+                    help="Surface class (required unless --check-pattern-fitness)")
+    ap.add_argument("--archetype",
+                    choices=["dashboard", "list", "detail", "form", "wizard",
+                             "empty", "error", "modal", "drawer", "transient"],
+                    help="Archetype (required unless --check-pattern-fitness)")
+    ap.add_argument("--viewport", choices=["mobile", "desktop"],
+                    help="Viewport (required unless --check-pattern-fitness)")
+    ap.add_argument("--task", default=None,
+                    help="Task name from venture task model (optional; required by R17 for some patterns)")
+    ap.add_argument("--pattern", default=None,
+                    help="Pattern name from pattern-catalog.md (optional; required by R17)")
+    ap.add_argument("--spec", default=None,
+                    help="Path to NAVIGATION.md (required by R16, R20, R21, R23, R24, R25, R26)")
+    ap.add_argument("--route", default=None,
+                    help="Current route (optional; used by R18 terminal check and R23)")
+    ap.add_argument("--check-pattern-fitness", action="store_true",
+                    dest="check_pattern_fitness",
+                    help="Run R25 + R26 against the spec only (no HTML required). "
+                         "Iterates all Section 4 pattern decisions in the spec.")
+    args = ap.parse_args()
+
+    # Spec-only mode: R25 (per decision) + R26 (authoring direction lint)
+    if args.check_pattern_fitness:
+        if not args.spec:
+            print(json.dumps({"error": "--check-pattern-fitness requires --spec"}), file=sys.stderr)
+            return 1
+        spec_path = Path(args.spec)
+        if not spec_path.exists():
+            print(json.dumps({"error": f"Spec not found: {args.spec}"}), file=sys.stderr)
+            return 1
+        ctx = parse_spec(spec_path)
+        violations: list[Violation] = []
+        violations.extend(check_pattern_disqualifiers(
+            ctx, surface=args.surface, archetype=args.archetype, viewport=args.viewport,
+        ))
+        violations.extend(check_authoring_direction(ctx))
+        report = {
+            "mode": "pattern-fitness",
+            "spec": args.spec,
+            "spec_version": ctx.spec_version,
+            "evidence_mode": ctx.evidence_mode,
+            "nav_spec_skill_version": "3.0.0",
+            "pass": len(violations) == 0,
+            "violation_count": len(violations),
+            "structural_count": sum(1 for v in violations if v.severity == "structural"),
+            "semantic_count": sum(1 for v in violations if v.severity == "semantic"),
+            "violations": [
+                {"rule": v.rule, "selector": v.selector, "severity": v.severity,
+                 "message": v.message, "fix": v.fix}
+                for v in violations
+            ],
+        }
+        print(json.dumps(report, indent=2))
+        return 0 if report["pass"] else 1
+
+    # Standard per-file validation mode
+    missing = [n for n in ("file", "surface", "archetype", "viewport")
+               if getattr(args, n) in (None, "")]
+    if missing:
+        print(json.dumps({"error": f"Missing required args: {', '.join('--' + m for m in missing)}"}),
+              file=sys.stderr)
+        return 1
+
+    try:
+        with open(args.file, "r", encoding="utf-8") as f:
+            html = f.read()
+    except FileNotFoundError:
+        print(json.dumps({"error": f"File not found: {args.file}"}), file=sys.stderr)
+        return 1
+    except OSError as e:
+        print(json.dumps({"error": f"Cannot read {args.file}: {e}"}), file=sys.stderr)
+        return 1
+
+    spec_path = Path(args.spec) if args.spec else None
+    violations = check(html, args.surface, args.archetype, args.viewport,
+                       args.task, args.pattern, spec_path, args.route)
+
+    report = {
+        "file": args.file,
+        "surface": args.surface,
+        "archetype": args.archetype,
+        "viewport": args.viewport,
+        "task": args.task,
+        "pattern": args.pattern,
+        "spec": args.spec,
+        "nav_spec_skill_version": "3.0.0",
+        "pass": len(violations) == 0,
+        "violation_count": len(violations),
+        "structural_count": sum(1 for v in violations if v.severity == "structural"),
+        "semantic_count": sum(1 for v in violations if v.severity == "semantic"),
+        "cosmetic_count": sum(1 for v in violations if v.severity == "cosmetic"),
+        "violations": [
+            {"rule": v.rule, "selector": v.selector, "severity": v.severity,
+             "message": v.message, "fix": v.fix}
+            for v in violations
+        ],
+    }
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/nav-spec/workflows/author.md
+++ b/.agents/skills/nav-spec/workflows/author.md
@@ -1,0 +1,350 @@
+---
+description: Produce `.stitch/NAVIGATION.md` from scratch for a venture. Twelve phases. Authors tasks → IA → patterns → chrome top-down; compares to shipped code only AFTER the spec is drafted. v3 adds the evidence-mode gate, structural return_locus columns, and the R25 Pattern Fitness + R26 authoring-direction checks.
+---
+
+# Author NAVIGATION.md (v3)
+
+Full-fidelity authoring workflow. Run this once per venture; thereafter use [revise.md](revise.md) for updates, [ia-audit.md](ia-audit.md) for IA checks, and [drift-audit.md](drift-audit.md) for chrome drift checks.
+
+v1's nine-phase workflow started with chrome. v2 inverted the order (tasks first). v3 closes the v2 loophole where the author could write the task model while shipped chrome was in memory and then "deterministically" confirm the incumbent pattern. The v3 rule: **Sections 1–4 must be authorable before shipped code existed.** R26 enforces this at the lint level; Phase 4 adds an algorithmic pattern-fitness check (R25) against the task model; Phase 7 reviewers confirm the evidence is non-UI-sourced.
+
+## Authoring direction (v3)
+
+| Phase                                           | May read shipped code?                                                                                                                                         |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 (Intake)                                      | Route paths from `src/pages/` FILENAMES only. No `.astro` body reads.                                                                                          |
+| 2 (Task model)                                  | NO. Source from contracts, tickets, interviews, analytics. UI-sourced evidence is forbidden — use `evidence-mode: provisional` if that's all that's available. |
+| 3 (IA model)                                    | NO. Derive matrix + state machine from task model, not from shipped chrome.                                                                                    |
+| 4 (Pattern selection)                           | NO. Run R25 algorithmically against task-model inputs.                                                                                                         |
+| 5 (Chrome contracts)                            | YES. Chrome must align with shipped components; diff to shipped code is expected.                                                                              |
+| 6 (Save draft v1)                               | YES. Artifact on disk.                                                                                                                                         |
+| 7 (Parallel reviewers)                          | YES for Implementation reviewer; NO for IA architect when evaluating §1–4.                                                                                     |
+| 8+ (Decision rounds, integration, verification) | YES.                                                                                                                                                           |
+
+R26 is the lint that enforces this; it runs on every save and fires if §1–4 cite `src/components/**` or `*.astro` paths. The IA Architect reviewer catches the sophisticated case (paraphrased shipped chrome without a file citation).
+
+---
+
+## Phase 1 — Intake
+
+Gather context before drafting any layer. Read-rules per the authoring-direction table above.
+
+1. Resolve venture code from the current repo via `crane_ventures`. Read `stitchProjectId`. If null, stop — see SKILL.md fail-fast.
+2. **Enumerate route paths from `src/pages/` FILENAMES only** (no `.astro` body reads). Group by surface class (use the 5-class taxonomy — don't fold `auth-gate` into `public`).
+3. Check `.stitch/DESIGN.md`. If absent, warn; pull token inventory from `src/styles/*` or Tailwind config.
+4. Load the venture's `CLAUDE.md` for voice, business-model context, forbidden patterns.
+5. Reference Phase 0 compliance report if present at `examples/phase-0-compliance-report.md`. If not, run `phase-0-compliance-test.md` before proceeding.
+6. **Detect evidence mode.** Read the venture's `CLAUDE.md` and any status documents. If the venture is pre-launch (no shipped product, no real users), default `evidence-mode: provisional`. If the venture has live users and collects analytics / support tickets, default `evidence-mode: validated`. The author may override.
+
+Display an **Intake Summary** table:
+
+| Field                     | Value                                                                  |
+| ------------------------- | ---------------------------------------------------------------------- |
+| Venture                   | code + name                                                            |
+| Stitch project            | ID                                                                     |
+| Surface classes present   | list (all 5 classes, check each)                                       |
+| Routes per surface class  | path inventory (FILENAMES only, no body reads)                         |
+| Tokens source             | path                                                                   |
+| DESIGN.md status          | present / absent                                                       |
+| Phase 0 compliance        | % categorical / % strict, or "not run"                                 |
+| Evidence mode (v3)        | provisional \| validated — with detection reasoning                    |
+| Shipped chrome components | list paths (for Phase 5 comparison only, NOT for Phases 2–4 authoring) |
+
+Ask: **"Does this capture the intake? Anything to correct before authoring?"** Wait for confirmation.
+
+---
+
+## Phase 2 — Task model (IA layer 1; v3 evidence-sourcing rules)
+
+Before any IA structure, author the task model per surface class. v3 tightens v2's elicitation rules: every primary task requires a cited evidence artifact, and every task declares `return_locus`. "I looked at the portal and saw X" is forbidden as evidence.
+
+For each surface class present in the venture, fill the v3 task table per [references/task-model-template.md](../references/task-model-template.md) with the required columns:
+
+| Task | Frequency | Criticality | Evidence source | return_locus | return_locus_evidence |
+
+**Required columns:**
+
+- `Frequency` ∈ {high, medium, low, variable}
+- `Criticality` ∈ {blocking, high, medium, low}
+- `Evidence source` — a cited non-UI artifact. Accepted: `SOW §N.M`, `ticket <ID>`, `analytics <event>`, `interview <path>§<n>`, or `provisional:<type>` (requires evidence-mode = provisional).
+- `return_locus` ∈ {hub, last-visited-surface, external, new-destination}
+- `return_locus_evidence` — structural evidence for `return_locus=hub` (literal URL, interview quote, or analytics event). Prose citation is sufficient only for non-hub return_loci.
+
+**Elicitation order (v3):**
+
+- Read `CLAUDE.md` and `docs/**` for product intent and business-model context.
+- Read any user-interview transcripts, support tickets, or analytics dumps.
+- Read contracts (SOW, engagement letters) for required deliverables and task cadence.
+- **Do NOT read `src/components/**`or`.astro` bodies to elicit tasks.\*\* The filename inventory from Phase 1 is enough; body reads bias the task model toward incumbent chrome.
+- For pre-launch ventures with no user research: draft from SOW scope and product goals, cite each as `provisional:SOW-scope` or `provisional:design-hypothesis`, and declare `evidence-mode: provisional` in the front matter.
+
+**"Primary" is derived, not author-declared.** A task is primary iff `frequency ∈ {high, medium}` OR `criticality = blocking`. The validator computes this mechanically; the author cannot toggle.
+
+**Output.** Section 1 of `NAVIGATION.md`. Show the draft and ask: "Do these tasks match how you think about this product? Is any cited evidence missing or weak?"
+
+---
+
+## Phase 3 — IA model (NEW — IA layers 2–7)
+
+With tasks in hand, author the IA:
+
+1. **Sitemap** — route inventory grouped by surface class (Section 2 of spec)
+2. **Auth boundary table** — which routes require which auth (Section 2b)
+3. **Reachability matrix** — the central IA artifact (Section 3)
+   - Use [references/reachability-matrix-template.md](../references/reachability-matrix-template.md)
+   - Every surface appears as From ≥1 time and To ≥1 time (exceptions: entry-only, terminal)
+   - Every dashboard has rows to every sibling list
+   - Every detail has a row back to its parent list
+4. **Entry/exit catalogue** — how users arrive (email, SMS, bookmark, direct URL) and where each surface exits
+5. **State persistence** — what persists across navigation (filters, scroll, selection, dirty forms)
+6. **Cross-surface context** — does a selected entity (client, engagement) persist? How is it indicated?
+7. **URL/routing contract** — canonical URL structure, redirect strategy for renamed routes, deep-link durability
+
+**Output:** Sections 2, 3 of `NAVIGATION.md`. Show the reachability matrix as a rendered table. Ask: "Review this matrix — any missing rows (orphan destinations) or wrong rows (dead-ends, wrong mechanisms)?"
+
+---
+
+## Phase 4 — Pattern selection with v3 Pattern Fitness (R25)
+
+For every `{surface class × archetype}` combination, author a decision entry in Section 4. The v3 format is structured: chosen pattern, runner-up pattern, defense citing specific task-model input values, and (if a disqualifier is overridden) reviewer-approval citations.
+
+### 4a. Propose a pattern
+
+Pick a candidate pattern from [references/pattern-catalog.md](../references/pattern-catalog.md). Record:
+
+- Pattern name (verbatim from catalog)
+- Source (NN/g / Material / HIG / composite)
+- Runner-up pattern (the second-best catalog entry for this surface)
+- Defense citing specific task-model values (see 4c below)
+- Required elements (copied from catalog)
+
+### 4b. Run the Pattern Fitness check
+
+Run:
+
+```
+python3 ~/.agents/skills/nav-spec/validate.py --check-pattern-fitness \
+    --spec .stitch/NAVIGATION.md
+```
+
+This invokes R25 (disqualifier check) and R26 (authoring-direction lint). Expected outcomes:
+
+- **R25 passes:** proceed.
+- **R25 fires:** the chosen pattern is disqualified per a citation-anchored rule in [references/pattern-disqualifiers.md](../references/pattern-disqualifiers.md). The validator names the disqualifier ID (e.g., D1), the citation, and the surviving patterns. Resolve per 4c.
+- **R26 fires:** Sections 1–4 cite shipped code. Edit out the citation (re-source the claim from contracts / tickets / interviews / analytics) or move the citation to Section 6+ (chrome contracts).
+
+### 4c. Defending an override
+
+If R25 fires but the author believes the chosen pattern is correct, the defense in Section 4's decision block must:
+
+1. **Cite specific input values** that would make the disqualifier not fire. Example for D1: "return_locus for pay-invoice is actually `hub` (not `external`) because Stripe redirects back to /portal after payment, cited at `src/pages/api/stripe/return.ts:12` (structural evidence type 1)."
+2. **Use structural evidence for `return_locus=hub` claims** (URL literal, interview quote, or analytics event). Prose intent is insufficient.
+3. **Obtain ≥2 of 3 reviewer approvals** in Phase 7, each citing the specific disqualifier ID being overridden (e.g., "I approve override of D1 because the cited redirect path satisfies NN/g's hub-return requirement").
+
+If either defense or reviewer consensus is missing, R25 continues to fire and the decision cannot ship. The author's other options:
+
+- **Switch to a surviving pattern** per the validator's output.
+- **In `evidence-mode: provisional` only:** file `.stitch/provisional-override-<YYYY-MM-DD>.md` per the schema in [references/task-model-template.md](../references/task-model-template.md). Requires a named `deferred_validation.event` and `date ≤ 90 days` from filing.
+
+### 4d. Compose patterns
+
+Patterns compose. For example, `session-auth-client × dashboard` might declare `persistent-tabs` (primary) + `dominant-action variant` (conditional ActionCard) + `recent-activity variant` (timeline feed). Document each; R25 evaluates only the primary pattern.
+
+### 4e. State machine
+
+Also in this phase, author the **Navigation state machine** (Section 5): auth states, data states, task states per surface class using [references/state-machine-template.md](../references/state-machine-template.md).
+
+**Output.** Section 4 (Patterns with decision entries) + Section 5 (State machine). Show the pattern decisions and ask: **"Are the cited task-model input values correct? (Not: does the pattern look right.)"** The challenge should be to the _inputs_, not the _output_ — the algorithm's job is to make the output deterministic given the inputs.
+
+---
+
+## Phase 5 — Chrome contracts (Layer 3, unchanged from v1 in scope)
+
+Now, and only now, author chrome:
+
+1. **Chrome component contracts** (Section 6): header, back, breadcrumbs, footer, skip-link — DOM + Tailwind per [references/chrome-component-contracts.md](../references/chrome-component-contracts.md)
+2. **Mobile↔desktop transforms** (Section 7): per surface class, what changes at the 768px breakpoint
+3. **State conventions** (Section 8): active, hover, focus, disabled — hex values pulled from DESIGN.md
+4. **Transition contracts** (Section 9): back-target canonical URLs, modal close rules, cross-auth-boundary = full reload
+5. **Anti-patterns** (Section 10): chrome and IA anti-patterns per surface class, pulled from [references/anti-patterns.md](../references/anti-patterns.md)
+6. **A11y floor** (Section 11): landmarks, skip-link, aria-current, focus rings with hex, semantic heading hierarchy
+7. **Content taxonomy** (Section 12): object names, action verbs, status labels, time/numeric formats using [references/content-taxonomy-template.md](../references/content-taxonomy-template.md)
+
+**Output:** Sections 6–12 of `NAVIGATION.md`. Plus the five surface-class appendices (A public, B auth-gate, C token-auth, D session-auth-client, E session-auth-admin) each stating deltas from the parent spec.
+
+---
+
+## Phase 6 — Save draft v1
+
+Save `.stitch/NAVIGATION.md`. Bump `spec-version` to the next value (1 for first author, 2 if migrating a v1 spec, etc.). Show the user a diff-summary of what was generated.
+
+Front matter must include:
+
+```yaml
+---
+spec-version: <N>
+nav-spec-skill-version: 2.0.0
+design-md-sha: <SHA of DESIGN.md, or "absent">
+stitch-project-id: <ID>
+phase-0-compliance: { categorical: '%', strict: '%', date: 'YYYY-MM-DD' }
+injection-budgets:
+  <surface/archetype/viewport/pattern>: { essential: N, extended: N, total: N }
+---
+```
+
+---
+
+## Phase 7 — Parallel three-reviewer pass
+
+Spawn three agents in a single message via the Task tool using `subagent_type: general-purpose`. Each reviewer gets the draft + Phase 0 report + CLAUDE.md + drift-audit results (from Phase 8 if already run) + pattern-catalog.md + ia-principles.md.
+
+v2 reviewer rubrics are upgraded:
+
+### IA architect reviewer (v3)
+
+> You are a senior Information Architect who has designed navigation systems at Figma, Linear, and Stripe. You are reviewing a venture's navigation spec for completeness and rigor, with specific attention to Dan Brown's 8 IA principles, the reachability matrix, AND whether Sections 1–4 could have been authored before any shipped code existed.
+
+**Rubric:**
+
+1. Evaluate the spec against each of Dan Brown's 8 principles (Objects, Choices, Disclosure, Exemplars, Front Doors, Multiple Classifications, Focused Navigation, Growth). Pass/fail per principle with evidence.
+2. Reachability matrix completeness — is every surface a From and a To? Are all dashboards linking to all sibling lists? Are entry-only / terminal surfaces correctly flagged?
+3. Task model coverage — does every declared task have a surface mapping?
+4. State machine completeness — does every surface handle auth, data, and task states?
+5. Content taxonomy — is it exhaustive, consistent, canonical-label-only?
+6. Cross-surface context — if persistent-context pattern is used, is it applied consistently?
+7. **Authoring direction (v3).** Sections 1–4 must be writable as if shipped code did not exist. For each claim in Sections 1–4, ask: "could this sentence have been written before any code existed, using only contracts / tickets / interviews / analytics?" Any sentence whose truth depends on shipped UI state — present-tense claims about existing UI ("the portal currently has…", "the sidebar shows…"), paraphrases of shipped chrome, or URL paths cited without an independent source — fails this rubric item. Return the offending sentences verbatim.
+8. **Focused Navigation + Pattern Fitness coherence (v3).** Per the updated "Focused Navigation" application in [references/ia-principles.md](../references/ia-principles.md), the chosen pattern must match the `return_locus` distribution of the top-3-by-frequency tasks. If Section 4's decision disagrees with what §1 evidence would suggest (i.e., R25 would fire), flag as an IA principle failure.
+
+### Pattern specialist reviewer (v3)
+
+> You are a design-systems specialist who has shipped pattern libraries at Shopify, Atlassian, or IBM. You know NN/g, Material Design 3, Apple HIG, and Dan Brown deeply. You are reviewing a venture's pattern selections against established catalogs AND against the disqualifier conditions in `references/pattern-disqualifiers.md`.
+
+**Rubric:**
+
+1. For each `{surface × archetype}` pattern selection: is it present in the catalog? Is the rationale valid?
+2. Are any patterns invented (not in the catalog)? If so, flag.
+3. Does the pattern's required-elements list match the chrome contract in Section 6?
+4. Are composite patterns (e.g., hub-and-spoke + dominant-action) documented explicitly?
+5. Do destination counts match pattern constraints (e.g., Material bottom nav = 3–5 destinations; not 7)?
+6. Are anti-patterns flagged correctly (no hamburger on desktop, no tabs changing URL, no invented patterns)?
+7. **Runner-up explicitly named (v3).** Does Section 4 name a runner-up pattern for every decision? A specific named catalog entry, not "considered alternatives." Missing runner-up = failed review.
+8. **Value-cited defense (v3).** For every override of an R25 disqualifier, does the defense cite specific task-model input VALUES (not prose)? Acceptable: "return_locus for pay-invoice is /portal, not external, because…" Unacceptable: "hub-and-spoke feels right for our users."
+9. **Override approval gate (v3).** When reviewing a §4 decision whose defense overrides an R25 disqualifier, you are one of the 3 voters on the ≥2-of-3 reviewer-consensus gate. Your rubric response for that decision MUST either explicitly approve the override citing the disqualifier ID (e.g., "I approve override of D1 on hub-and-spoke because the cited redirect path satisfies NN/g's hub-return requirement") OR explicitly decline with a reason. Do not equivocate.
+
+### Implementation reviewer (v2)
+
+> You are a senior Astro+Tailwind engineer reviewing a proposed spec against the venture's existing component shapes. You think about class lists, semantic HTML, keyboard traversal, and whether a contract can be implemented without refactoring working components.
+
+**Rubric:**
+
+1. Diff the proposed chrome contracts against shipped components (`Nav.astro`, `PortalHeader.astro`, `AdminLayout.astro`, etc.). Flag any contract that would require component refactor, with refactor scope.
+2. A11y floor — per-surface landmarks, focus rings, skip-to-main, icon-only button labels.
+3. Cross-surface a11y — heading hierarchy consistency, tab order across surfaces, consistent landmark semantics.
+4. Injection budget — does every `{surface, archetype, viewport, pattern}` combo stay within 800 tokens?
+5. Validator rule coverage — are R16–R24 inputs (reachability matrix, taxonomy, state machine) complete enough for the validator to run?
+
+### Output format (all three)
+
+```
+## Overall assessment
+[2–3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Principles/pattern scorecard (IA and Pattern reviewers only)
+<per-principle or per-pattern pass/fail with evidence>
+
+## Decisions needed from user
+<items requiring human judgment>
+```
+
+**IMPORTANT:** launch all three in a single message for parallel execution.
+
+---
+
+## Phase 8 — Decision rounds
+
+Surface the Decisions-needed items from the reviewers. Filter to the 3–5 that materially change the spec. Present each with your recommendation and rationale. Wait for the user's answers.
+
+Typical v2 decisions:
+
+- "Dashboard surface declares hub-and-spoke; Implementation reviewer flags no section cards in current `/portal/index.astro`. Add section cards to the spec (and to code) or choose a different pattern?"
+- "Pattern specialist flags drawer on admin as Material anti-pattern (destination count too low). Switch admin to tabs (current) or keep drawer?"
+- "IA architect flags orphan destination `/portal/settings` exists in code but not in matrix. Add to matrix + dashboard section cards, or remove from code?"
+- "Taxonomy says 'Proposal' everywhere but 2 shipped pages say 'Quote.' Update code, or accept shipped inconsistency?"
+
+---
+
+## Phase 9 — Final spec saved
+
+Apply reviewer fixes and user decisions. Save `.stitch/NAVIGATION.md`. Ensure `spec-version` correct. Show summary of shifts from draft.
+
+---
+
+## Phase 10 — Integration-check regeneration (chrome-level)
+
+Pick one existing surface (recommended: the venture's primary dashboard, mobile). Regenerate with the new injection snippet live.
+
+- Extract HTML download URL from Stitch response
+- Download HTML
+- Run `validate.py` with the surface's full classification (5 tags)
+- Pass = zero violations against the predicted spec
+- Fail = do not proceed; tune the spec and repeat
+
+This proves the spec is **self-consistent**. Phase 11 proves it **prevents drift**.
+
+---
+
+## Phase 11 — Adversarial verification (NEW coverage)
+
+### 11a — Chrome adversarial (as in v1)
+
+Generate three prompts the spec author has NOT seen with full 5-tag classification. Run validator on each. Pass = validator reports zero chrome-rule violations.
+
+### 11b — IA reachability traversal (NEW in v2)
+
+Walk the actual codebase (`src/pages/**`) and verify the reachability matrix matches live code:
+
+1. For every route in `src/pages/**/index.astro` (and `[id].astro`), look up the matrix.
+2. For every matrix row where `From` is a dashboard and `Required=Yes`, grep the dashboard's HTML for `<a href="{To}">`. If missing, the spec's pattern isn't implemented — real failure mode.
+3. For every matrix row where `From` is a detail and `Mechanism=Back button`, grep for a back affordance with href={To}.
+4. Surface orphan destinations: routes not listed as `To` in any matrix row.
+5. Surface dead-ends: surfaces listed as `From` with no Required=Yes outbound rows.
+
+This is the step that would have caught the April 2026 portal-home gap. If any violation, return to Phase 3 (IA model) and fix.
+
+### 11c — Pattern conformance (NEW in v2)
+
+For each declared pattern in Section 4, verify its required-elements list is satisfied by the shipped or generated HTML. Spot-check 2–3 surfaces per pattern.
+
+---
+
+## Phase 12 — Write-back to consuming skills
+
+Only run if the venture is the first v2-adopter globally. Otherwise skip (consuming skills already updated for v2).
+
+Edits required:
+
+- `~/.agents/skills/stitch-design/SKILL.md` — classification now requires 5 tags (task, pattern added); pipeline step 1b fail-fast text updated; step 3 NAV CONTRACT block uses essential + extended format per [injection-snippet-template.md](../references/injection-snippet-template.md); step 3b validator now runs R1–R24.
+- `~/.agents/skills/stitch-design/workflows/text-to-design.md` and `edit-design.md` — 5-tag reference.
+- `~/.agents/skills/stitch-design/examples/enhanced-prompt.md` — add v2 example showing 5-tag classification and essential+extended NAV CONTRACT.
+- `.agents/skills/stitch-ux-brief/SKILL.md` (per-venture) — Phase 1 check for NAVIGATION.md updated to detect spec-version; Phase 7 concept-prompt template uses 5 tags; Phase 11 strip directive driven by chrome-forbidden list; Phase 12 RUN-LOG records `nav-spec-skill-version` and `spec-version`.
+
+All edits are guarded by `hasNavigationMd && specVersion >= 2` — v1 specs still work with v1-compatible injection (chrome-only).
+
+Produce a PR with these edits on a separate branch. Title: `feat(stitch): nav-spec v2 — IA + patterns + chrome three-layer injection`.
+
+---
+
+## Final output
+
+Tell the user:
+
+- Where `.stitch/NAVIGATION.md` lives and its spec-version
+- Phase 10 integration-check result
+- Phase 11 adversarial + reachability traversal results
+- Phase 11b — any IA violations found (orphans, dead-ends)
+- Whether the write-back PR was produced or skipped
+- Next step: run `/stitch-design` or `/stitch-ux-brief` — NAV CONTRACT (v2) is now injected automatically for any 5-tag prompt

--- a/.agents/skills/nav-spec/workflows/drift-audit.md
+++ b/.agents/skills/nav-spec/workflows/drift-audit.md
@@ -1,0 +1,132 @@
+---
+description: Standalone chrome-level drift audit. Scans shipped code and generated artifacts for chrome inconsistencies. Distinct from ia-audit (which covers reachability and patterns).
+---
+
+# Drift Audit (chrome)
+
+Chrome-level consistency audit. Scans shipped code and generated artifacts; flags inconsistencies across headers, back affordances, breadcrumbs, footers, skip-links, state colors, and mobile↔desktop transforms.
+
+Output: an in-memory drift report or saved to `.stitch/drift-audit-<YYYY-MM-DD>.md`. Format in [examples/drift-audit-report.md](../examples/drift-audit-report.md).
+
+---
+
+## When to run this (vs ia-audit)
+
+| Audit                         | Measures                                       | When to run                                                        |
+| ----------------------------- | ---------------------------------------------- | ------------------------------------------------------------------ |
+| `/nav-spec --drift-audit`     | Chrome consistency across pages and artifacts  | After multiple Stitch generations, before pattern roundtrip review |
+| `/nav-spec --ia-audit`        | IA reachability, pattern conformance, taxonomy | After route changes, before shipping IA-affecting work             |
+| `/nav-spec --validate <file>` | Single-file rule check (R1–R24)                | Post-generation, CI                                                |
+
+Drift audit is retrospective — it measures what has shipped. ia-audit is structural — it measures whether what shipped matches the spec.
+
+---
+
+## Audit steps
+
+### 1. Locate artifacts
+
+- `src/layouts/*.astro` — every layout
+- `src/components/**/*{Nav,Header,Footer,Sidebar,Layout}*.astro` — shared chrome components
+- `src/pages/**/*.astro` — note pages that bypass the layout and render own chrome
+- `.stitch/designs/**/*.html` — prior Stitch output (categorize by generation date if possible)
+
+### 2. Extract chrome features per artifact
+
+For each file, record:
+
+| Field                                | Values                                                                     |
+| ------------------------------------ | -------------------------------------------------------------------------- |
+| Surface class (inferred or declared) | public / auth-gate / token-auth / session-auth-client / session-auth-admin |
+| Archetype (inferred)                 | dashboard / list / detail / ...                                            |
+| Header pattern                       | sticky / fixed / absent                                                    |
+| Header background                    | solid white / translucent / colored                                        |
+| Header height                        | 56 / 64 / other                                                            |
+| Client-name decoration               | none / leading icon / leading SVG / logo mark                              |
+| Back affordance                      | present / absent / history.back() / href="#" / canonical URL               |
+| Breadcrumbs                          | none / single-link / multi-level                                           |
+| Nav tabs in header                   | none / 2 / 3+                                                              |
+| Bottom-tab nav                       | present / absent                                                           |
+| Sticky bottom action bar             | present / absent                                                           |
+| Footer                               | present / absent                                                           |
+| Skip-to-main                         | present (correct target) / present (wrong target) / absent                 |
+| Mobile pattern                       | flex / hidden / collapsed                                                  |
+| Breakpoint                           | 768 / 1024 / other                                                         |
+
+### 3. Build two matrices
+
+**Live code matrix** (rows = shipped files):
+
+```
+| File | Surface | Archetype | Header | Back | Breadcrumbs | Mobile | Layout? |
+```
+
+**Generated artifact matrix** (rows = .stitch/designs/\* files):
+
+```
+| File | Surface (inferred) | Archetype | Header | Back | Breadcrumbs | Mobile |
+```
+
+### 4. Identify drift clusters
+
+Group files by surface class. Within each cluster, count the distinct values for each chrome feature. If >1 distinct value exists (excluding genuine per-archetype variation), that feature has drift.
+
+Example outputs:
+
+```
+## Drift summary
+
+### session-auth-client (portal)
+- **Header pattern:** 2 distinct values across 7 files
+  - `sticky top-0`: 4 files (post-PR #391 retrofit)
+  - `fixed top-0`: 3 files (pre-retrofit — /portal/dev/*, /portal/legacy/*)
+  - Drift: files not yet retrofitted
+
+- **Header client-name decoration:** 3 distinct values
+  - none (correct per spec): 5 files
+  - leading water-drop icon: 1 file (portal/demo-v2.html, Stitch drift)
+  - leading logo: 1 file (portal/legacy/invoice.astro — pre-PR #375)
+
+- **Back affordance (detail archetypes):** 2 distinct values
+  - `<a href="/portal/invoices">`: 2 files (canonical, correct)
+  - `<a href="#">` and `onclick="history.back()"`: 1 file (Stitch artifact not yet reconciled)
+```
+
+### 5. Score drift severity
+
+- **Structural drift:** fixed-vs-sticky, nav-tabs-present, bottom-tab-nav, footer-on-auth. Count and list.
+- **Semantic drift:** back-href-canonical-vs-hash, breadcrumb-wrapper, landmark-absence.
+- **Cosmetic drift:** header-height-off-by-pixels, backdrop-blur, opacity modifiers.
+
+### 6. Output the drift summary
+
+4–6 bullets that are specific, file-referenced, and lead the eye to the biggest deltas. Not a complete list — ammunition for Phase 3 of `author.md` (or for `revise.md` when the spec already exists).
+
+Example bullets:
+
+- Portal headers split: 4 sticky (post-retrofit), 3 fixed (pre-retrofit)
+- 2 of 7 portal detail pages lack a back affordance; remaining 5 use canonical URLs (correct)
+- 3 Stitch artifacts in `.stitch/designs/portal-v1/` use `backdrop-blur-sm` — confirms Phase 0 strict-compliance leakage
+- 1 portal list page uses history.back() — this is the Stitch-artifact version, shipped version was fixed in PR #391
+- No drift on mobile breakpoint (consistent 768px)
+- Admin nav tabs consistent across all admin routes (ratified exception in spec Appendix D)
+
+---
+
+## Output artifacts
+
+### Option 1 — In-memory (default)
+
+Drift audit is run as a phase within `author.md` Phase 8 (was Phase 2 in v1). Output is consumed by the author workflow and not persisted.
+
+### Option 2 — Standalone run
+
+When invoked directly (`/nav-spec --drift-audit`), save output to `.stitch/drift-audit-<YYYY-MM-DD>.md`. Keep historical audits for measuring drift change over time.
+
+---
+
+## Exit criteria
+
+Drift audit does not fail/pass. It produces an inventory. Humans decide which drift matters — the spec is the declaration.
+
+However, if the audit is run after `validate.py` has run on the same artifacts, the drift audit should find a strict subset of what validate.py found (drift audit measures presence across files; validate.py measures per-file conformance). Any drift not caught by validate.py is a signal that a new validator rule may be needed.

--- a/.agents/skills/nav-spec/workflows/ia-audit.md
+++ b/.agents/skills/nav-spec/workflows/ia-audit.md
@@ -1,0 +1,172 @@
+---
+description: Standalone IA audit. Walks the sitemap and reachability matrix; flags orphan destinations, dead-end surfaces, taxonomy drift, pattern-impersonation, state omissions. This is the audit nav-spec v1 could not run because v1 had no IA layer.
+---
+
+# IA Audit
+
+Produces `examples/ia-audit-report.md` in the venture's skill output directory. Reads `.stitch/NAVIGATION.md` + `src/pages/**` and measures whether the code matches the spec's IA contract.
+
+This is distinct from the drift audit (chrome consistency across generated and shipped artifacts). IA audit measures: _are destinations reachable?_ _do patterns hold?_ _are labels consistent?_
+
+---
+
+## Prerequisites
+
+- `.stitch/NAVIGATION.md` exists with spec-version ≥ 2 (has reachability matrix).
+- Venture codebase available at current working directory.
+- Route inventory in `src/pages/**`.
+
+If spec-version = 1: stop. Tell user to run `/nav-spec --revise` first to add IA layer.
+
+---
+
+## Audit steps
+
+### 1. Parse the spec
+
+Extract from `.stitch/NAVIGATION.md`:
+
+- Reachability matrix rows (Section 3.2)
+- Entry-only surfaces (Section 3.3)
+- Terminal surfaces (Section 3.4)
+- Pattern selections per `{surface × archetype}` (Section 4)
+- State machine declarations (Section 5)
+- Content taxonomy: object names, action verbs, status labels (Section 12)
+
+### 2. Walk the code
+
+Enumerate:
+
+- Every route under `src/pages/**/*.astro`
+- For each route, identify its surface class (from middleware / path pattern)
+- For each route, extract visible `<a href="...">` elements and their text content
+- Identify forms, buttons, and other navigation-triggering elements
+
+Record: `code_routes = set(routes)`, `code_links[route] = list[(href, text)]`.
+
+### 3. Run IA checks
+
+For each check, produce a violation list with `route`, `rule`, `severity`, `message`, `fix`.
+
+#### Check A — Orphan destinations (rule IA-O)
+
+For every route in `code_routes`, is there at least one row in the matrix where `To = route`?
+
+- If no: orphan. Severity `structural`.
+- Exception: routes flagged as entry-only in matrix Section 3.3 can have no internal `To`.
+
+Output:
+
+```
+## Orphan destinations
+- /portal/settings (session-auth-client, form) — no matrix row references this route
+  Fix: add matrix row from /portal to /portal/settings (section card or menu), OR remove /portal/settings if not needed
+```
+
+#### Check B — Dead-end surfaces (rule IA-D)
+
+For every route in `code_routes`, does it have at least one Required=Yes outbound row?
+
+- If no and not flagged as terminal: dead-end. Severity `structural`.
+
+#### Check C — Matrix completeness for dashboards (rule IA-M)
+
+For every matrix row where `From = dashboard archetype` and `Required=Yes`, does `code_links[From]` contain an `<a href>` matching `To`?
+
+- If no: missing affordance. Severity `structural`.
+- This catches the April 2026 ss-console portal-home gap.
+
+#### Check D — Detail-to-parent (rule IA-B)
+
+For every matrix row where `From` is detail archetype and `Mechanism = Back button`, does `code_links[From]` contain an `<a href>` matching `To` AND is it inside a back-affordance pattern (chevron_left icon, aria-label with parent name)?
+
+- If missing: broken ascent. Severity `structural`.
+
+#### Check E — Pattern conformance (rule IA-P)
+
+For each declared pattern in Section 4, spot-check the surface's HTML for the pattern's required elements (from pattern-catalog.md).
+
+Example: `/portal` declares `hub-and-spoke with dominant-action variant`. Required elements:
+
+- Section cards to every sibling list → Check A catches this
+- ActionCard rendered conditionally when `hasPendingInvoice` → parse conditional and confirm code has the matching branch
+- Recent-activity feed → confirm presence
+
+Partial implementation (e.g., 3 section cards but matrix says 4) is a pattern violation even if Check A passes for the 3 that exist.
+
+#### Check F — Taxonomy adherence (rule IA-T)
+
+Scan rendered HTML text content across all routes. For every entity, action, status declared in Section 12 taxonomy:
+
+- Flag occurrences of "forbidden synonyms" (e.g., "Quote" when canonical is "Proposal")
+- Flag action-verb drift (e.g., "Accept" button when canonical verb for proposals is "Review & Sign")
+- Flag status-label drift
+
+Severity: `semantic` (not `structural` — these rarely break functionality but erode trust).
+
+#### Check G — State handling (rule IA-S)
+
+For each route with a declared state machine entry in Section 5:
+
+- Grep code for the empty-state, error-state, and loading-state rendering branches
+- If a declared state has no code branch: violation
+
+Severity `structural` for empty and error states (these always exist in practice); `semantic` for loading states.
+
+#### Check H — Token-auth cold arrival (rule IA-TC)
+
+For every route with surface class `token-auth`:
+
+- Parse the page's frontmatter / script
+- Check: does the page access `Astro.locals.session`? If yes, violation — token-auth surfaces must not assume session exists
+- Check: does the page render a "welcome back" or similar that implies prior session?
+
+---
+
+### 4. Produce report
+
+Save to `examples/ia-audit-report.md` (or `.stitch/ia-audit-<YYYY-MM-DD>.md` within the venture). Format in [examples/ia-audit-report.md](../examples/ia-audit-report.md).
+
+Summary table at top:
+
+| Check                                | Violations | Severity   |
+| ------------------------------------ | ---------- | ---------- |
+| A — Orphan destinations              | 4          | structural |
+| B — Dead-end surfaces                | 0          | —          |
+| C — Matrix completeness (dashboards) | 4          | structural |
+| D — Detail-to-parent                 | 0          | —          |
+| E — Pattern conformance              | 1          | structural |
+| F — Taxonomy adherence               | 3          | semantic   |
+| G — State handling                   | 2          | structural |
+| H — Token-auth cold arrival          | 0          | —          |
+| **Total**                            | **14**     | —          |
+
+Then detailed sections per check.
+
+---
+
+## Exit criteria
+
+IA audit passes if:
+
+- 0 structural violations
+- ≤5 semantic violations (configurable threshold per venture)
+
+If structural violations exist, the audit fails loud — these are IA bugs. The report lists each with a specific fix; pursuing them is the remediation work.
+
+---
+
+## Recommended usage
+
+- Before each nav-spec revision (catches divergence since last spec)
+- Weekly during active IA changes
+- After adding a new route or new surface class
+- Before shipping a design system update that touches navigation
+
+---
+
+## Relationship to Phase 11b of author workflow
+
+Phase 11b of `author.md` runs a subset of these checks (A, C, D, E) as the adversarial-verification step. The standalone `ia-audit` workflow runs all eight checks and produces a persisted report.
+
+Both are valuable. The standalone audit is run regularly; Phase 11b is a gate during initial spec authoring.

--- a/.agents/skills/nav-spec/workflows/phase-0-compliance-test.md
+++ b/.agents/skills/nav-spec/workflows/phase-0-compliance-test.md
@@ -1,0 +1,94 @@
+---
+description: Empirical measurement of whether prompt injection is honored by Stitch. Must run before authoring the first NAVIGATION.md for a venture, or when Stitch's underlying model version changes.
+---
+
+# Phase 0 — Injection compliance test
+
+Measures compliance empirically. Informs whether injection alone is sufficient (rare) or whether a validator is required (always, given measurements to date).
+
+## Why this exists
+
+Per the critique in the originating plan file: LLM design generators have strong training priors. A constraint block is a hint, not a guarantee. Before committing to injection-first enforcement, measure reality. Skip this step and the first NAVIGATION.md ships to production on faith.
+
+## Protocol
+
+### Step 1 — Draft a minimal injection snippet
+
+A short, high-constraint version of the canonical NAV CONTRACT block. Target 400–500 tokens. Focus on the forbidden list, state hex values, and the "this block wins" override. See `references/injection-snippet-template.md` for the template; trim appendix-specific content for Phase 0.
+
+### Step 2 — Pick three representative prompts
+
+Pick one prompt per major surface/archetype combination the venture actually uses. For ss-console the canonical triad is:
+
+- `home-mobile` (portal home dashboard, 390×844)
+- `invoice-mobile` (portal invoice detail, 390×844)
+- `proposal-desktop` (portal proposal detail, 1280)
+
+Each prompt should include DESIGN SYSTEM and PAGE STRUCTURE sections, but NOT a nav spec — leave nav "open" the way Stitch has historically seen it.
+
+### Step 3 — Fire 6 generations in parallel
+
+Three base prompts × two variants (baseline vs injected) = 6 runs. Use the Stitch MCP if connected; curl fallback if not (see `stitch-ux-brief/SKILL.md` for the curl pattern — `https://stitch.googleapis.com/mcp`, `X-Goog-Api-Key` header, `STITCH_API_KEY` from Infisical `/vc` path).
+
+Python runner template at `/tmp/phase0-runner.py` (from the ss-console Phase 0 run). Adapt prompts and project ID.
+
+### Step 4 — Download HTML for all six
+
+Extract `htmlCode.downloadUrl` from each response, curl each to `/tmp/phase0/<label>.html`.
+
+### Step 5 — Compliance scoring
+
+Two scoring passes:
+
+**Major-category compliance** — did injection prevent categorically-forbidden chrome? For each injected run, score 0 or 1 for each of:
+
+- No global nav tabs / menu links in header
+- No sidebar / hamburger / drawer
+- No logo / brand wordmark in header
+- No breadcrumb trail
+- No bottom-tab nav
+- No sticky bottom action bar
+- No footer / copyright / legal links
+- No marketing CTAs (book, schedule, etc.)
+- No testimonials / pull quotes
+- No hero imagery
+- No real-face photo placeholder (check for `googleusercontent.com/aida/` or similar)
+
+Total: 11 categories. Score = categorical compliance percentage.
+
+**Strict compliance** — for each injected run, score against every rule in the injection snippet (header sticky-not-fixed, border color exact, 56/64px height, client-name-only, back button wrapping semantics, etc.). Record specific violations.
+
+### Step 6 — Decision
+
+| Outcome               | Architecture                                                                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Major-category ≥ 95%  | Injection-first + **required** lightweight validator                                                                        |
+| Major-category 80–95% | Injection-first + **required** strict validator (this is the common case)                                                   |
+| Major-category < 80%  | Validator-first with minimal injection (~150 tokens forbidden-list only); injection is a hint, validator is the enforcement |
+
+The validator is always present. The scoring determines how much of the work injection versus validator does.
+
+### Step 7 — Write the report
+
+Save to `examples/phase-0-compliance-report.md` (copy from `/tmp/phase0/COMPLIANCE-REPORT.md`). Include:
+
+- Test matrix and scores
+- Specific violations from strict pass → become validator rules
+- Recommended architecture decision
+- Date (for re-runs when Stitch updates)
+
+### Step 8 — Re-run cadence
+
+Re-run Phase 0 when:
+
+- Stitch's model version changes (Gemini 3 Pro → Gemini 3.1 Pro has happened)
+- The injection snippet structure is substantively revised
+- Validator rules are under-catching violations that feel like they should be catchable via injection
+
+## ss-console reference run
+
+See `examples/phase-0-compliance-report.md` for the 2026-04-15 ss-console measurement:
+
+- Major-category: 97%
+- Strict: ~87%
+- Decision: injection-first + required validator covering 5 specific residual violation types

--- a/.agents/skills/nav-spec/workflows/revise.md
+++ b/.agents/skills/nav-spec/workflows/revise.md
@@ -1,0 +1,189 @@
+---
+description: Update an existing `.stitch/NAVIGATION.md`. Versioning-aware. Runs a focused reviewer pass on the delta. Supports v1→v2 migration.
+---
+
+# Revise NAVIGATION.md
+
+Use when:
+
+- Venture introduces a new surface class or archetype
+- A pattern selection changes (e.g., switching from hub-and-spoke to drawer on admin)
+- The reachability matrix gains or loses routes
+- The content taxonomy grows (new entity, new status label)
+- A drift audit surfaces code-spec mismatch that should resolve in the spec's favor
+- **Migrating from v1 (chrome-only) to v2 (three-layer)**
+
+---
+
+## Arguments
+
+```
+/nav-spec --revise [--add-surface-class X] [--add-archetype Y] [--add-pattern Z]
+                   [--align-to-code <path>] [--migrate-to-v2] [--migrate-to-v3]
+```
+
+---
+
+## Change classification
+
+| Classification      | Examples                                                                                                                                                                        | Spec-version bump   | Reviewer pass                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------- |
+| **Additive**        | New archetype, new forbidden pattern, new matrix row                                                                                                                            | minor (1.0 → 1.1)   | Optional                              |
+| **Structural**      | Taxonomy redefinition, rule inversion, surface-class reshape, chrome contract change for existing archetype                                                                     | major (1.x → 2.0)   | Required                              |
+| **Corrective**      | Aligning spec to shipped code, fixing a wrong contract                                                                                                                          | major               | Required (Implementation-focused)     |
+| **Pattern change**  | Changing declared pattern for a `{surface × archetype}`                                                                                                                         | major               | Required (Pattern specialist focused) |
+| **v1→v2 migration** | Adding IA layer (task model, matrix, state machine, taxonomy) to a v1 chrome-only spec                                                                                          | major (bump to 2.0) | Required (full three-reviewer pass)   |
+| **v2→v3 migration** | Adding evidence_source + return_locus columns (§1), pattern-decision-log format (§4), evidence-mode front matter; enabling R25 Pattern Fitness + R26 authoring-direction checks | major (bump to 3.0) | Required (full three-reviewer pass)   |
+
+---
+
+## Steps
+
+1. **Load current spec.** Read `.stitch/NAVIGATION.md`. Note `spec-version` and `nav-spec-skill-version` in front matter.
+
+2. **Detect v1→v2 migration case.** If spec-version is 1 and skill is 2.0+, the spec must be migrated. Run the full v2 authoring workflow (Phases 2–5) to add:
+   - Section 1: Task model
+   - Section 3: Reachability matrix
+   - Section 4: Pattern selection (annotate each `{surface × archetype}`)
+   - Section 5: State machine
+   - Section 12: Content taxonomy
+
+   Preserve Sections 6–11 (chrome contracts) from v1 with minor format adjustments.
+
+3. **Classify the change.** Use the table above. For additive changes, may skip reviewer pass if the addition is obvious and low-risk. For anything else, reviewer pass is required.
+
+4. **Run scoped drift audit and ia-audit.** Both audits narrowed to the affected surface(s) or archetypes. This grounds the revision in real code/artifact state.
+
+5. **Draft the delta.** Edit only the affected sections. Do not rewrite unchanged sections. Preserve history in the front matter's `revisions:` log:
+
+   ```yaml
+   revisions:
+     - {
+         from: 1.0,
+         to: 2.0,
+         date: '2026-04-15',
+         kind: 'v1→v2 migration',
+         added: ['Section 1', 'Section 3', 'Section 4', 'Section 5', 'Section 12'],
+       }
+     - { from: 2.0, to: 2.1, date: '2026-05-20', kind: 'additive', added: ['archetype: transient'] }
+   ```
+
+6. **Focused reviewer pass** (if required). Subset of the three reviewers, parallel:
+   - Additive → skip (unless the addition is a new pattern, then include Pattern specialist)
+   - Structural → full three
+   - Corrective → Implementation-focused (single reviewer)
+   - Pattern change → Pattern specialist + IA architect
+   - v1→v2 migration → full three
+
+   Same output format as `author.md` Phase 7.
+
+7. **Decision round** (if reviewers surfaced any). Same format as `author.md` Phase 8.
+
+8. **Apply edits.** Bump `spec-version`. Update front matter with new `design-md-sha` if DESIGN.md changed; update `nav-spec-skill-version` if rev'd.
+
+9. **Version-impact check.** For each existing generation under `.stitch/designs/**/*.html`, run `validate.py` against the new spec. Count non-compliant files. Do not auto-regenerate; surface for user decision.
+
+10. **Integration-check regeneration** on one affected surface (if the change is structural, corrective, pattern change, or migration). Same as `author.md` Phase 10.
+
+11. **IA audit re-run** (if change affected Sections 1–5). Same as `author.md` Phase 11b.
+
+12. **Save and report.** Write new version. Summarize:
+    - Spec-version N → M
+    - What changed (sections touched)
+    - Non-compliant existing designs count
+    - IA audit result (violations caught)
+    - Next steps (e.g., "run `/nav-spec --ia-audit` and fix the 4 orphan destinations")
+
+---
+
+## v2→v3 migration details
+
+When migrating a v2 spec to v3, order of operations matters:
+
+### Order
+
+1. **Add v3 front matter.** Insert `evidence-mode: validated` (or `provisional` for pre-launch). If provisional, add `provisional-review-date: <YYYY-MM-DD>` (≤6 months out).
+2. **Expand Section 1 task tables** per surface class to include `evidence_source` and `return_locus` columns. Cite a non-UI artifact per task; use `provisional:<type>` values only in provisional mode. Prose citation is sufficient for non-hub `return_locus` values; `return_locus=hub` requires structural evidence (URL literal, interview quote, or analytics event).
+3. **Rewrite Section 4 pattern selections** into the v3 decision-log format:
+   - `**Chosen pattern:** <name>`
+   - `**Runner-up pattern:** <name>`
+   - `**Defense:** <prose; if overriding R25, cite specific task-model values>`
+   - (If override) Reviewer-approval lines from Phase 7 citing the specific disqualifier IDs.
+4. **Run `validate.py --check-pattern-fitness --spec .stitch/NAVIGATION.md`** to fire R25 against the updated spec. Any R25 violations surface latent design debt from v2 (patterns that contradict the task model's declared return_locus distribution). Resolve per author.md Phase 4c: defense + reviewer approvals, switch to a surviving pattern, or file a provisional-override artifact.
+5. **Run R26 lint** (runs automatically alongside R25). If §1–4 cite `src/components/**` or `*.astro`, remove or move those citations to §6+ (chrome contracts).
+6. **Bump spec-version to 3.0** and `nav-spec-skill-version: 3.0.0`.
+7. **Preserve v2's spec-version history** in `revisions:` front matter. Add a new entry summarizing what changed.
+
+### What typically surfaces in v2→v3 migration
+
+- Pattern-task-model disagreements — v2 specs were susceptible to the "pattern ratifies shipped chrome" failure. v3 R25 surfaces any case where the task model's evidence contradicts the chosen pattern.
+- Prose `return_locus=hub` claims that lack structural evidence — v2 had no such requirement; v3 requires URL literal / interview / analytics event.
+- Authoring-direction citations in Sections 1–4 — v2 author.md licensed `src/pages/` scans; v3 forbids them. Move citations to §6+ or re-source from non-UI artifacts.
+
+Document each of these in the migration's revisions entry.
+
+### Output
+
+After v3 migration:
+
+- Spec-version bumped to 3.0
+- `nav-spec-skill-version: 3.0.0` in front matter
+- R25 + R26 passing (or override artifacts filed in provisional mode)
+- Pattern decisions in §4 use the structured format
+- Any pattern-level changes flagged in the `revisions` entry
+
+---
+
+## v1→v2 migration details
+
+When migrating a v1 spec to v2, order of operations matters:
+
+### Order
+
+1. Run v2 authoring Phase 2 (Task model) against the existing venture
+2. Run v2 authoring Phase 3 (IA model — sitemap, reachability matrix, etc.)
+3. Run v2 authoring Phase 4 (Pattern selection — annotate each surface with its pattern)
+4. Run v2 authoring Phase 5 (Chrome — verify v1 contracts still hold, adjust as needed)
+5. Preserve v1's spec-version history in `revisions:` front matter
+6. Run Phase 11b IA reachability traversal — this is the step that falsifies v1 chrome-only assumptions
+7. If R16–R24 violations found, fix the code first (don't adjust the spec to match broken code unless you're consciously ratifying a shipped reality)
+
+After v1→v2 migration, consider whether v2→v3 migration is also warranted (running them back-to-back is fine).
+
+### What typically surfaces in v1→v2 migration
+
+- Orphan destinations — v1 may have declared "no primary nav on portal header" without verifying sibling-list reachability. This is the v1 failure mode.
+- Missing task model — v1 never captured why each surface exists
+- Invented pattern names — v1 chrome contracts may have been authored without reference to a catalog; v2 requires anchoring to NN/g/Material/HIG
+- Taxonomy drift — v1 lacked a taxonomy section, so labels drifted freely
+
+Document each of these in the migration's revisions entry.
+
+### Output
+
+After migration:
+
+- Spec-version bumped to 2.0 (or higher if prior revisions occurred)
+- `nav-spec-skill-version: 2.0.0` in front matter
+- IA audit report: `examples/ia-audit-<YYYY-MM-DD>.md`
+- Summary of violations found and whether they were fixed in code (separate PR) or ratified in the spec
+
+---
+
+## Spec-version bump guidance
+
+- **Minor (N.0 → N.1):** additive change. Existing generations stay valid. Existing skill consumers can continue.
+- **Major (N.x → (N+1).0):** structural, corrective, pattern change, or v1→v2 migration. Existing generations are at-risk; flag for review. Existing consumer skills must handle the new version (they already should — all nav-spec-aware skills graceful-degrade).
+
+---
+
+## When NOT to revise
+
+Don't run `revise` to silence a Stitch drift. First ask: "Is this drift a Stitch failure, or a spec gap?"
+
+- If Stitch drifted against a clear spec rule, the validator should have caught it — fix the validator (add rule or refine existing one).
+- If the spec rule was ambiguous, revise the spec with the clarification.
+- If the code is right and the spec is wrong, revise the spec (corrective).
+- If both are wrong, fix both.
+
+Never revise _away_ the spec's contract because one Stitch generation disagreed. The spec is the source of truth; drift is the input, not the output.

--- a/.agents/skills/nav-spec/workflows/validate.md
+++ b/.agents/skills/nav-spec/workflows/validate.md
@@ -1,0 +1,296 @@
+---
+description: Post-generation validator rubric. Documents all 24 rules (R1–R15 chrome, R16–R24 IA + pattern + a11y). validate.py implements; this file specifies.
+---
+
+# Validation Rubric
+
+`validate.py` enforces 24 rules on generated HTML and shipped surfaces. This document is the authoritative rubric; `validate.py` implements it.
+
+Violations are reported with:
+
+- `rule` — identifier (R1–R24)
+- `selector` — DOM selector or description of where the violation was found
+- `severity` — `cosmetic` | `semantic` | `structural`
+- `message` — human-readable description
+- `fix` — concrete suggested remediation
+
+The validator exits 0 (pass) when violation_count is 0, and 1 (fail) otherwise. Severity affects retry behavior in the `stitch-design` pipeline:
+
+- `structural` → always retries, up to 2 attempts
+- `semantic` → retries once
+- `cosmetic` → warns; passes by default; elevates per-venture configurable
+
+---
+
+## Invocation
+
+```bash
+python3 validate.py \
+  --file /path/to/generated.html \
+  --surface <public|auth-gate|token-auth|session-auth-client|session-auth-admin> \
+  --archetype <dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient> \
+  --viewport <mobile|desktop> \
+  --task <task-name>          # optional; required for R17 pattern check when surface has tasks
+  --pattern <pattern-name>    # optional; required for R17
+  --spec <path-to-NAVIGATION.md>  # required for R16, R20, R21, R23, R24
+```
+
+Output: JSON report to stdout.
+
+---
+
+## Chrome rules (R1–R15 — unchanged from v1)
+
+### R1 — Header sticky, not fixed
+
+**Severity:** semantic
+**Selector:** `<header>`
+**Check:** Header class list contains `sticky top-0` or equivalent; does NOT contain `fixed top-0`.
+**Fix:** Replace `fixed top-0` with `sticky top-0`. Fixed removes header from document flow.
+
+### R2 — Header bg solid
+
+**Severity:** cosmetic (R2a), cosmetic (R2b)
+**Applies when:** surface != `public`
+**Check:** Header class list does not contain `backdrop-blur-*` (R2a) or `bg-*/\d+` opacity modifier (R2b).
+**Fix:** Use solid `bg-white` or `bg-[color:var(--color-surface)]`.
+
+### R3 — No icon before client name
+
+**Severity:** cosmetic
+**Applies when:** surface in `SURFACE_AUTHENTICATED`
+**Check:** No `<span class="material-symbols-*">`, `<svg>`, or `<img>` appears in the header before the first visible text node.
+**Fix:** Remove the decorative element. Client name stands alone.
+
+### R4 — Back not wrapped in breadcrumb nav
+
+**Severity:** semantic
+**Check:** No `<nav aria-label="Breadcrumb">` wrapping a single link on surfaces where breadcrumbs are forbidden (R4), OR wrapping a single link on surfaces where breadcrumbs ARE allowed (R4b — that's a back button, not breadcrumbs).
+**Fix:** Unwrap. Use `<a>` or `<button>` with `aria-label` describing target.
+
+### R5 — Back href is canonical
+
+**Severity:** semantic
+**Applies when:** archetype == `detail`
+**Check:** Back-chevron anchor's href is not `#`, `javascript:*`, or `onclick="history.back()"`.
+**Fix:** Hardcoded canonical URL (e.g., `/portal/invoices`).
+
+### R6 — No global nav tabs in header
+
+**Severity:** structural
+**Applies when:** surface != `session-auth-admin` (admin has ratified exception)
+**Check:** Header does not contain `role="tablist"`/`role="tab"` (R6); header does not contain 3+ short-text non-contact links (R6b — heuristic for nav-tab bar).
+**Fix:** Remove. Secondary navigation below the header.
+
+### R7 — No sticky-bottom outside dialog
+
+**Severity:** structural
+**Check:** No element with `fixed bottom-0` or `sticky bottom-0` outside a `<dialog>` or `role="dialog"`.
+**Fix:** Remove. Primary action above the fold via document flow.
+
+### R8 — No footer on auth surfaces
+
+**Severity:** structural
+**Applies when:** surface in `SURFACE_AUTHENTICATED`
+**Check:** No `<footer>` element.
+**Fix:** Remove.
+
+### R9 — No real-face photos
+
+**Severity:** structural
+**Check:** No `<img>` with src matching `googleusercontent.com/aida[-/]`, `unsplash.com`, `pexels.com`, or similar stock-photo domains.
+**Fix:** Replace with initials circle.
+
+### R10 — No marketing CTAs on auth
+
+**Severity:** structural
+**Applies when:** surface in `SURFACE_AUTHENTICATED`
+**Check:** No text match of "schedule a call", "book a demo", "get started", "learn more", "sign up now/today/free".
+**Fix:** Remove. User is a customer.
+
+### R11 — Header height matches viewport
+
+**Severity:** cosmetic
+**Check:** Header class contains `h-14` (mobile) or `h-16`/`md:h-16` (desktop).
+**Fix:** Set correct height.
+
+### R14 — Landmarks present
+
+**Severity:** semantic
+**Check:** `<header>` (R14a) and `<main>` (R14b) elements exist.
+**Fix:** Add landmark elements.
+
+### R15 — Skip-to-main wired
+
+**Severity:** semantic
+**Check:** First-body `<a class="sr-only focus:not-sr-only ..." href="#<id>">` exists (R15), AND `<main id="<id>">` matches (R15b).
+**Fix:** Add skip link at body top; add matching `id` on `<main>`.
+
+---
+
+## IA rules (R16–R24 — NEW in v2)
+
+### R16 — Reachability matrix enforcement
+
+**Severity:** structural
+**Layer:** IA
+**Applies when:** archetype in `{dashboard, list, detail, form, wizard, empty, error, transient}`
+**Requires:** `--spec` argument
+
+**Check:** Parse NAVIGATION.md reachability matrix (Section 3.2). For each row where `From` matches the current surface and `Required = Yes`, verify the generated HTML emits an `<a href>` whose href matches the row's `To`.
+
+- Exception: `Conditional` rows with a stated condition — the validator evaluates whether the condition holds (via heuristic: for `hasPendingInvoice`, check for an ActionCard structure; for `consultantAssigned`, check for a ConsultantBlock structure). If the condition holds, the link is required.
+- Dashboards with no sibling lists in the matrix are exempt (but then the archetype is probably wrong — flag with R18).
+
+**Fix:** Add `<a href="{To}">` to the surface's HTML. If the surface should not link to `{To}`, update the matrix.
+
+**Rationale:** Catches the April 2026 ss-console failure mode. Before this rule, a dashboard could render polished chrome while orphan-ing every sibling list; the validator would pass. R16 guarantees that's impossible going forward.
+
+### R17 — Pattern conformance
+
+**Severity:** structural
+**Layer:** Pattern
+**Applies when:** `--pattern` is provided
+**Requires:** `--spec` argument
+
+**Check:** Look up the pattern's required elements in `pattern-catalog.md` (the validator has a built-in mapping). For the declared pattern, verify the HTML contains each required element.
+
+Examples:
+
+- `pattern=hub-and-spoke` → requires ≥1 entry-point element per sibling list (checked via R16)
+- `pattern=master-detail` → requires back affordance on detail (checked via R5), row-click on list
+- `pattern=sequential` → requires progress indicator ("Step N of M") + Previous + Next buttons
+- `pattern=modal` → requires close button (X), Esc handler, click-outside handler, `aria-modal="true"`
+
+**Fix:** Implement the pattern's required elements, or change the pattern declaration.
+
+### R18 — No dead ends
+
+**Severity:** structural
+**Layer:** IA
+
+**Check:** Surface has ≥1 navigation exit in rendered HTML. Exit = `<a href>`, `<button>` with handler (form submit, modal trigger), primary action, or back affordance.
+
+- Exception: surfaces declared as `Terminal` in Section 3.4 of the spec.
+- Error archetype surfaces must have ≥1 exit (Retry, Go home, Contact support).
+
+**Fix:** Add a navigation exit (primary action, back affordance, or sibling link).
+
+### R19 — Token-auth cold arrival
+
+**Severity:** structural
+**Layer:** IA
+**Applies when:** surface == `token-auth`
+
+**Check:** Generated HTML does not:
+
+- Render "Welcome back", "Continue where you left off", or similar prior-session-assuming copy
+- Reference user session state (pattern heuristic; limited to text scan)
+- Display a chrome element requiring session (sign out button)
+
+**Fix:** Render self-contained context. Token-auth is cold-arrival by definition.
+
+### R20 — Content taxonomy adherence
+
+**Severity:** semantic
+**Layer:** IA
+**Requires:** `--spec` argument
+
+**Check:** Parse NAVIGATION.md Section 12 (Content taxonomy). For every entity with declared canonical label and forbidden synonyms:
+
+- Scan rendered text (h1, h2, p, span, button, a, badge, div with class including "title"/"label"/"status").
+- Flag forbidden synonyms in user-visible positions.
+- Flag action verbs that don't match canonical form.
+- Flag status labels that don't match declared format.
+
+**Fix:** Replace with canonical label.
+
+### R21 — State machine completeness
+
+**Severity:** structural (empty/error), semantic (loading)
+**Layer:** IA
+**Requires:** `--spec` argument
+
+**Check:** For each surface declared in Section 5 (state machine), the rendered HTML includes a `data-nav-state="<state>"` attribute on `<main>` OR the rendering clearly matches one of the declared states:
+
+- Empty state: contains non-empty help message describing the empty condition
+- Error state: contains recovery affordance (Retry, Go home, or Contact CTA)
+- Loading state: preserves chrome landmarks even while data is unresolved
+
+**Fix:** Render explicit state handling with appropriate copy and affordances.
+
+### R22 — Heading hierarchy
+
+**Severity:** semantic
+**Layer:** A11y
+
+**Check:**
+
+- Exactly one `<h1>` per surface (R22a)
+- No skipping levels (e.g., h1 → h3 without h2) (R22b)
+- All major sections use `<h2>` (not `<div class="section-title">`)
+
+**Fix:** Adjust heading levels to form a linear hierarchy.
+
+### R23 — Search affordance
+
+**Severity:** semantic
+**Layer:** IA
+**Applies when:** spec declares search on this surface
+**Requires:** `--spec` argument
+
+**Check:** If NAVIGATION.md declares search for the surface (inside cross-cutting "search strategy"), generated HTML contains `<input type="search">` or `<input ... role="searchbox">`.
+
+**Fix:** Render search input per spec, OR remove search declaration from spec.
+
+### R24 — Cross-surface context
+
+**Severity:** structural
+**Layer:** Pattern
+**Applies when:** spec declares persistent-context pattern on this surface class
+**Requires:** `--spec` argument
+
+**Check:** If surface class uses persistent-context pattern (e.g., admin with selected client), every surface within the workspace scope renders the context indicator (header chip, breadcrumb prefix, etc.).
+
+**Fix:** Render context indicator per spec.
+
+---
+
+## CI integration
+
+Recommended CI step:
+
+```yaml
+- name: Validate navigation (chrome + IA)
+  run: |
+    for file in .stitch/designs/**/*.html; do
+      python3 ~/.agents/skills/nav-spec/validate.py \
+        --file "$file" \
+        --surface "$(yq .surface "${file%.html}.meta.yaml")" \
+        --archetype "$(yq .archetype "${file%.html}.meta.yaml")" \
+        --viewport "$(yq .viewport "${file%.html}.meta.yaml")" \
+        --task "$(yq .task "${file%.html}.meta.yaml")" \
+        --pattern "$(yq .pattern "${file%.html}.meta.yaml")" \
+        --spec .stitch/NAVIGATION.md
+    done
+```
+
+For shipped `src/pages/**` files, the spec-version-aware Astro build hook runs the validator in a pre-build step and fails the build on structural violations.
+
+---
+
+## False-positive handling
+
+The validator is deterministic. False positives happen when:
+
+- The spec doesn't match shipped conventions (R16 wrong because the matrix is wrong)
+- A pattern's required elements differ from the catalog default (R17 wrong because the surface specializes)
+- A taxonomy term has legitimate polysemy (R20 wrong because "contract" appeared in an unrelated context)
+
+Remediation:
+
+- Update the spec first, not the validator. The validator reflects the spec.
+- If the catalog default is wrong, update `pattern-catalog.md` (cite a source for the change).
+- For polysemous taxonomy terms, narrow the rule to specific DOM positions (buttons, headings) rather than broad text scans.
+
+Never disable a rule to pass a generation. The failing rule is telling you something.

--- a/.agents/skills/new-venture/SKILL.md
+++ b/.agents/skills/new-venture/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: new-venture
+description: Set Up a New Venture
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /new-venture - Set Up a New Venture
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-venture")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+This command walks through setting up a new venture with Crane infrastructure.
+
+## Prerequisites (Manual)
+
+Before running this command, the user must have completed:
+
+1. Created a GitHub organization (github.com/organizations/new)
+2. Installed "Crane Relay" GitHub App on the org
+3. Noted the installation ID from GitHub App settings
+
+## Execution
+
+### Step 1: Gather Information
+
+Ask the user for:
+
+- **Venture code** (2-3 lowercase letters, e.g., `dc`)
+- **Venture display name** (e.g., "Draft Crane")
+- **GitHub org** (e.g., `draftcrane`)
+- **GitHub App installation ID** (numeric)
+
+Confirm all values before proceeding.
+
+### Step 2: Read the Checklist
+
+Read the full setup checklist for reference:
+
+```bash
+cat docs/process/new-venture-setup-checklist.md
+```
+
+This is the canonical checklist. Follow it step by step.
+
+### Step 3: Run the Setup Script
+
+The script automates most of the process:
+
+```bash
+./scripts/setup-new-venture.sh {venture-code} {github-org} {installation-id}
+```
+
+**Dry run first** to preview what will happen:
+
+```bash
+DRY_RUN=true ./scripts/setup-new-venture.sh {venture-code} {github-org} {installation-id}
+```
+
+The script handles:
+
+- GitHub repo creation and structure
+- Standard labels and project board
+- Venture registry (`config/ventures.json`) - single source of truth
+- crane-context venture registry
+- crane-watch installation ID
+- upload-doc-to-context-worker.sh scope mapping
+- crane-mcp rebuild (INFISICAL_PATHS derived from ventures.json)
+- Cloudflare worker deployments
+- Fleet cloning
+- .infisical.json copy to new repo
+
+### Step 4: Manual Follow-ups
+
+After the script completes, walk through remaining manual steps from the checklist:
+
+1. **Venture-specific secrets** (Phase 3.5) - add venture-specific secrets (shared secrets like CRANE_CONTEXT_KEY and CRANE_ADMIN_KEY are synced automatically by the setup script)
+2. **Seed documentation** - upload PRD/project instructions to crane-context
+3. **Verify** - run `crane {venture-code}` and `/sos` in the new repo
+4. **Code quality** (Phase 4.5) - testing scaffold, CI/CD, pre-commit hooks
+5. **Monitoring** (Phase 4.6) - Sentry, uptime checks
+6. **PWA setup** (Phase 4.7) - manifest, service worker, icons, iOS meta tags. Framework-specific: Serwist for Next.js, @vite-pwa/astro for Astro. See `docs/standards/golden-path.md` PWA section and `docs/process/new-venture-setup-checklist.md` Phase 4.7 for step-by-step.
+
+### Step 5: Update CLAUDE.md
+
+Update `CLAUDE.md` in crane-console to reference the new venture in the Secrets Management section if not already there.
+
+### Step 6: Verification
+
+Run through Phase 5 of the checklist:
+
+- [ ] `crane {venture-code}` launches without errors
+- [ ] `/sos` creates session and shows correct context
+- [ ] Documentation is cached and accessible
+- [ ] GitHub issues are displayed
+- [ ] `/eos` creates handoff successfully
+
+## Reference Files
+
+- **Checklist:** `docs/process/new-venture-setup-checklist.md`
+- **Script:** `scripts/setup-new-venture.sh`
+- **Venture registry:** `config/ventures.json` (single source of truth for ventures and INFISICAL_PATHS)
+- **Context worker registry:** `workers/crane-context/src/constants.ts`
+- **Secrets docs:** `docs/infra/secrets-management.md`

--- a/.agents/skills/platform-audit/SKILL.md
+++ b/.agents/skills/platform-audit/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: platform-audit
+description: Platform Audit
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /platform-audit - Platform Audit
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "platform-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+End-to-end senior-engineer audit of the crane operating system. Catches sprawl, dead code, incomplete migrations, and accumulated cruft before they compound. Produces a kill / fix / invest list a Captain can act on.
+
+## Scope
+
+**In scope (the support OS):**
+
+- `workers/` (crane-context, crane-mcp-remote, crane-watch)
+- `packages/` (crane-mcp, crane-test-harness)
+- `.agents/skills/`, `.agents/agents/`, `.claude/settings.json` hooks
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` instruction files
+- The MCP tool surface (local + remote)
+- D1 schemas in `workers/crane-context/migrations/`
+- `docs/` tree
+- `crane_docs` uploaded documents (via `crane_doc_audit`)
+- `MEMORY.md` and satellite files
+- `scripts/` shell scripts
+- `.github/workflows/`
+
+**Out of scope:**
+
+- Individual venture product codebases (vc-web, dc-marketing, dfg-console, sc-console, kidexpenses) - those are `/code-review` or `/enterprise-review`.
+- Anything outside the crane-console repo.
+
+## Process
+
+### 1. Recon (inline, cheap)
+
+- `ls` of `workers/`, `packages/`, `scripts/`, `.agents/`, `docs/`, `.github/workflows/`
+- Count skills, migrations, scripts, workflows
+- `git log --oneline -20` for recent activity
+
+### 2. Spawn 6 parallel Explore agents
+
+Launch all six in a single message. Each gets a focused brief and reports under 1500 words. Each must end with kill / fix / keep lists with file paths and line numbers.
+
+| #   | Domain                    | Look for                                                                                                                                                                                                                                           |
+| --- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Workers & packages**    | God files (>500 LOC), dead exports, duplication across workers (esp. GitHub signature validation, HTTP clients, auth), layer violations, `console.log` in production paths, test pathology (over-mocking, test files larger than source)           |
+| 2   | **Skills, agents, hooks** | Skill overlap (lifecycle / review / editorial clusters), AGENTS.md vs GEMINI.md drift, settings.json deny/allow precedence, skill bloat (SKILL.md >10KB), CLAUDE.md content that should be in fetched docs                                         |
+| 3   | **MCP tool surface**      | Schema token cost at session start, action-enum sprawl in single tools (red flag: tool with >5 actions), dead tools (grep for usage), local-vs-remote MCP drift                                                                                    |
+| 4   | **D1 datastores**         | Dead tables (defined in schema, never written), schema sprawl (tables with 25+ columns), missing indices on hot paths, vague `meta_json`/`details_json` columns, migration history smells (drop-and-rebuild patterns, missing baseline migrations) |
+| 5   | **Documentation**         | Stale subdirs (>30 days), contradictions (same fact in 3 places with 3 versions), fragmented bootstrap instructions, `crane_docs` manifest health, `MEMORY.md` sprawl, orphaned handoffs                                                           |
+| 6   | **Scripts & ops**         | Bootstrap script overlap, incomplete migrations (find legacy + new running in parallel), dead scripts (verify with grep), failing GitHub Actions workflows (root cause, not just "it's red")                                                       |
+
+### 3. Synthesize as a senior-engineer report
+
+Required sections:
+
+- **TL;DR** - 3-4 sentences
+- **Critical / fix this week** - 5-10 items max with file:line refs and exact fixes
+- **Inventory** - sized table
+- **Findings by domain** - condensed (don't repeat the deep-dive agent reports verbatim)
+- **Cross-cutting themes** - patterns across domains (incomplete migrations, inline duplication, god files, hardcoded indexes, etc.)
+- **Kill list / Fix list / Invest list**
+- **Risk assessment**
+- **What was deliberately not audited**
+
+### 4. Save the report
+
+Write to `docs/reviews/{YYYY-MM-DD}-platform-audit.md`. Use the actual current date.
+
+### 5. Compare to the prior audit
+
+Find the most recent prior audit: `ls -t docs/reviews/*-platform-audit.md`. If one exists, surface:
+
+- **Still on the list** - items that haven't been addressed (this is the most important section)
+- **New** - sprawl that accumulated since last audit
+- **Resolved** - progress
+
+If no prior audit exists on disk, check branch `audit/platform-audit-skill-and-report` for the original 2026-04-11 report: `git show audit/platform-audit-skill-and-report:docs/reviews/2026-04-11-platform-audit.md`
+
+### 6. Record completion
+
+Log to the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "Platform Audit", result: "success", summary: "{grade or headline}", completed_by: "crane-mcp")
+```
+
+### 7. Offer to act on findings
+
+Ask the Captain whether to:
+
+1. File the critical-list items as GitHub issues (with appropriate labels)
+2. Open a PR for the mechanical kill-list deletions
+3. Drill into any specific finding
+
+## Honesty bar
+
+Be unflinching. Name files, line numbers, and specific anti-patterns. Acknowledge what's well-built - but the point is to catch problems early, not to write a flattering report. The Captain wants the version a senior team would deliver in an out-brief.
+
+## Rules
+
+- Must run from crane-console only.
+- All GitHub issues this session target venturecrane/crane-console. Targeting a different repo? STOP.
+- Never write the report to the previous audit's filename - always use today's date.
+- Do NOT execute the kill list automatically. Always ask first.
+- Use `model: "sonnet"` for Explore agents. Reserve opus for the synthesis step.

--- a/.agents/skills/portfolio-review/SKILL.md
+++ b/.agents/skills/portfolio-review/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: portfolio-review
+description: Portfolio Status Review
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /portfolio-review - Portfolio Status Review
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "portfolio-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Review and update venture portfolio data. Collects live signals, compares against current records, and presents changes for Captain approval.
+
+## Status Taxonomy
+
+| Status     | BVM Stages                  | Badge  | Criteria                                                                    |
+| ---------- | --------------------------- | ------ | --------------------------------------------------------------------------- |
+| `building` | IDEATION, DESIGN, PROTOTYPE | gray   | Code exists. No production deployment serving real users.                   |
+| `beta`     | MARKET TEST                 | yellow | Production URL returns HTTP 200. Real users have access (even invite-only). |
+| `live`     | SCALE, MAINTAIN             | green  | Generally available. No invite gate. Active users.                          |
+| `paused`   | PIVOT/KILL                  | orange | Development stopped. Under evaluation. Captain decides.                     |
+| `sunset`   | post-KILL                   | muted  | Shut down. Historical record.                                               |
+| `internal` | any                         | blue   | Studio tooling. Not a user-facing product.                                  |
+
+### Transition Evidence
+
+- `building` -> `beta`: Production URL returns HTTP 200 AND at least one non-founder user has access
+- `beta` -> `live`: Invite gate removed. In beta 2+ weeks with no critical bugs
+- Any -> `paused`/`sunset`: Captain explicitly decides (never automated)
+
+## Execution
+
+### Step 1: Collect Signals
+
+For each venture in `config/ventures.json` (all ventures, regardless of `showInPortfolio`):
+
+1. **Real development activity** - For each repo, fetch the last 30 days of commits on main:
+
+   ```
+   gh api "repos/{org}/{repo}/commits?sha=main&since={30-days-ago-ISO}&per_page=100" --jq '.[] | {date: .commit.committer.date, message: .commit.message | split("\n")[0]}'
+   ```
+
+   Classify each commit as **real development** or **automated/infrastructure**. Automated commits match patterns like:
+   - `chore: sync enterprise commands`
+   - `chore: sync *` (any sync from another repo)
+   - npm audit fix / security fix commits
+   - Dependabot version bumps
+
+   Report: total commits, real dev commits, last real dev commit date + message.
+
+2. **Session history** - Use `crane_schedule(action: "session-history", days: 30)` to get session counts per venture. This shows where Captain time is actually going.
+
+3. **Merged PR velocity** - For each repo, count PRs merged in the last 30 days:
+
+   ```
+   gh api "repos/{org}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100" --jq '[.[] | select(.merged_at != null and .merged_at > "{30-days-ago-ISO}")] | length'
+   ```
+
+4. **Open issues and PRs** - Use `gh api repos/{org}/{repo}` for open issue count and `gh api repos/{org}/{repo}/pulls` for open PR count.
+
+5. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status.
+
+6. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions.
+
+### Step 1b: Classify Venture Activity
+
+Based on collected signals, classify each venture's activity level:
+
+| Classification   | Criteria                                                                   |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Active**       | Sessions in last 30d AND real dev commits in last 14d                      |
+| **Low activity** | Real dev commits in last 30d but no sessions (e.g., one-off maintenance)   |
+| **Parked**       | Zero sessions AND zero real dev commits in last 30d (only automated syncs) |
+
+This classification is for reporting only - it does not automatically change venture status.
+
+### Step 2: Detect Drift
+
+Compare collected signals against current portfolio data. Flag:
+
+- Status says `live` or `beta` but URL returns non-200 or is missing
+- Status says `building` but URL is healthy (might be ready for `beta`)
+- Venture classified as **parked** for a `building` venture - note but do not auto-promote to `paused` (Captain decision)
+- BVM stage in VCMS doesn't match `bvmStage` in ventures.json
+- `portfolio.url` being removed but URL still returns HTTP 200
+- Open PR count > 20 (PR accumulation warning)
+- Open issue count growing with no sessions (backlog drift)
+
+### Step 2b: Collect Code Health
+
+For each venture, search VCMS for the most recent `code-review` scorecard:
+
+```
+crane_notes tag="code-review" venture="{VENTURE_CODE}" limit=1
+```
+
+Extract the overall grade and review date. If no scorecard exists, mark as "-". If the review is older than 30 days, mark the grade with "(stale)".
+
+### Step 3: Present Review Table
+
+First, show where time is going:
+
+```
+### Where the Time Is Going
+
+| | Sessions (30d) | Merged PRs | Real Dev Commits | Activity | Focus |
+|---|---|---|---|---|---|
+| Venture Crane (platform) | 27 | 71 | 85 | Active | Calendar, fleet, docs |
+| SMD Services | 19 | 57 | 64 | Active | Greenfield build |
+| Draft Crane | 6 | 36 | 33 | Active | Design system overhaul |
+| Kid Expenses | 0 | 5 | 3 | Parked | One-off maintenance |
+```
+
+Then the status review:
+
+```
+### Honest Status Assessment
+
+| Venture | Status | Proposed | BVM Stage | Code Health | Last Real Dev | Activity | Signals |
+|---------|--------|----------|-----------|-------------|---------------|----------|---------|
+| Kid Expenses | building | building | PROTOTYPE | B (stale) | Mar 15 | Parked | 54 issues, 15 PRs |
+| Draft Crane | building | building | PROTOTYPE | B | 2d ago | Active | 21 issues, 6 PRs |
+```
+
+"Last Real Dev" must be the date of the last non-automated commit. Never use `pushed_at` or include automated syncs in this column.
+
+If any drift was detected, display it prominently:
+
+```
+### Drift Detected
+- Silicon Crane: Parked (0 sessions, 0 real dev commits in 30d)
+- crane-console: 27 open PRs - cleanup pass needed
+```
+
+### Step 4: Captain Approval
+
+Ask the Captain:
+
+**"Approve these portfolio statuses?"**
+
+Options:
+
+- **"Approve all"** - Accept all proposed statuses as shown
+- **"Review individually"** - Walk through each venture one by one
+- **"Skip"** - No changes this review
+
+If "Review individually": for each venture, show current vs proposed status and ask Captain to confirm or override.
+
+### Step 5: Publish Updates
+
+After Captain approves:
+
+**Step A: Update crane-console**
+
+1. Update `config/ventures.json`:
+   - Set `lastPortfolioReview` to today's date (YYYY-MM-DD)
+   - Update any portfolio fields the Captain changed (status, bvmStage, description, url, etc.)
+2. Commit: `chore: portfolio review {date}`
+3. Push to main
+
+**Step B: Update vc-web**
+
+1. Read the updated `config/ventures.json`
+2. Update `vc-web/src/data/ventures.ts`:
+   - Sync venture statuses, descriptions, techStack, and URLs
+   - Update `lastReviewed` date
+   - Only include ventures where `showInPortfolio: true`
+3. Commit: `chore: sync portfolio data from review {date}`
+4. Push to main
+
+These are independent git operations. If Step B fails, report it and the Captain can re-run. `ventures.json` is the source of truth; `ventures.ts` is a derivative.
+
+After both git pushes complete, record the completion in the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "portfolio-review", result: "success", summary: "Portfolio reviewed and published")
+```
+
+### Step 6: Align VCMS (if needed)
+
+If any BVM stage or description changed, update the corresponding VCMS executive summary using `crane_note` MCP tool with action `update`.
+
+## Notes
+
+- Never auto-promote to `paused` or `sunset` - those are Captain-only decisions
+- Signals are ephemeral - collected live, displayed once, not persisted
+- `config/ventures.json` is the single source of truth for portfolio data
+- `vc-web/src/data/ventures.ts` is a derivative that can be regenerated anytime
+- **Never use GitHub's `pushed_at` field for activity reporting.** It reflects pushes to any branch (including fleet dispatch and automated syncs) and is misleading. Always use main branch commit history with automated commits filtered out.
+- **"Last commit" must mean "last real development commit."** Automated syncs, Dependabot bumps, and CI-triggered commits do not count as development activity.
+- The report should answer: "Is time allocation aligned with venture priority?" not just "what happened in git?"

--- a/.agents/skills/prd-review/SKILL.md
+++ b/.agents/skills/prd-review/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: prd-review
 description: Multi-Agent PRD Review
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /prd-review - Multi-Agent PRD Review
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "prd-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 This command orchestrates a 6-agent PRD review process with configurable rounds. It reads existing source documents, runs structured critique rounds with parallel agents, and synthesizes the output into a production-ready PRD.
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: ship
 description: Ship to Production
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /ship - Ship to Production
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ship")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Commit, push, PR, CI, merge, and confirm deployment - all in one shot. Follows enterprise rules (branch, PR, CI) but executes the full pipeline without stopping.
 

--- a/.agents/skills/skill-audit/SKILL.md
+++ b/.agents/skills/skill-audit/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: skill-audit
+description: Monthly skill health report. Walks every SKILL.md, parses frontmatter, computes staleness via git log, detects schema gaps, and surfaces the deprecation queue. Run this once a month to keep the skill library healthy.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  mcp_tools:
+    - crane_skill_audit
+    - crane_schedule
+---
+
+# /skill-audit - Monthly Skill Health Report
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Run a repo-wide audit of every SKILL.md in the enterprise and global skill libraries. The report surfaces schema gaps, stale skills, and skills that have passed their sunset date.
+
+## Usage
+
+```
+/skill-audit
+```
+
+No arguments required. The audit runs across all scopes by default.
+
+## What it checks
+
+| Section               | What it surfaces                                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Inventory**         | Total skill count, broken down by scope, status, and owner                                                            |
+| **Schema gaps**       | Skills missing one or more required frontmatter fields (`name`, `description`, `version`, `scope`, `owner`, `status`) |
+| **Staleness**         | Skills whose `SKILL.md` has not been touched in git for more than 180 days                                            |
+| **Deprecation queue** | Skills with `status: deprecated` that have a `sunset_date` set - sorted soonest-first                                 |
+
+Reference drift (broken `depends_on.mcp_tools`, `depends_on.files`, `depends_on.commands`) is NOT included in this tool - it requires invoking the `skill-review` CLI which cross-checks against live manifests. Run `/skill-review --all` for reference-drift details.
+
+## Workflow
+
+### Step 1: Run the audit
+
+Call the MCP tool:
+
+```
+crane_skill_audit()
+```
+
+Default parameters:
+
+- `scope`: `all` (enterprise + global)
+- `stale_threshold_days`: 180
+- `include_deprecated`: true
+
+You can narrow the scope:
+
+```
+crane_skill_audit(scope: "enterprise", stale_threshold_days: 90)
+```
+
+### Step 2: Interpret the report
+
+**Inventory** - Review the totals. A healthy library has no skills in `unknown` status. Skills in `draft` for more than 30 days should be reviewed.
+
+**Schema gaps** - Each entry names the skill and the missing fields. Schema gaps should be fixed before the skill is marked `stable`. Open a PR to fill them.
+
+**Staleness** - Skills not touched in 180+ days may be outdated. Review each:
+
+- If the skill is still accurate: touch the file (whitespace-only commit) to reset the clock.
+- If the skill is obsolete: run `/skill-deprecate <name>` to begin the retirement process.
+
+**Deprecation queue** - Skills sorted by days until sunset. Skills with `days_until_sunset <= 0` are past their sunset date. Bring these to the Captain for a removal directive. Removal is always a separate PR.
+
+### Step 3: Record completion
+
+After reviewing the report and taking any required actions, record the audit as complete:
+
+```
+crane_schedule(
+  action: "complete",
+  name: "skill-audit",
+  result: "success",
+  summary: "<one-line summary, e.g. '18 skills audited, 2 stale flagged, 0 schema gaps'>"
+)
+```
+
+## Cadence
+
+This skill is on a monthly cadence (`schedule_items` name: `skill-audit`). It surfaces in the `/sos` briefing when due.
+
+## Notes
+
+- Staleness is derived from `git log -1 --format=%cI -- <path>`. Files never committed show as `last_touched: unknown` and are treated as maximally stale.
+- Skills with `backend_only: true` still appear in the audit - they just have no dispatcher parity requirement.
+- This tool does not modify any SKILL.md. It is read-only.

--- a/.agents/skills/skill-deprecate/SKILL.md
+++ b/.agents/skills/skill-deprecate/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+> ⚠️ **Captain-gated.** This skill requires explicit Captain confirmation before any changes are made.
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-deprecate")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+# /skill-deprecate - Captain-Gated Skill Sunset
+
+Formal deprecation flow for enterprise skills. Marks a skill for retirement with a 90-day grace period. The skill remains invocable throughout the grace period - this is NOT deletion.
+
+## When to Use
+
+Invoke `/skill-deprecate` when ALL of the following are true:
+
+- A skill has had zero invocations for 90+ days AND has been identified by `/skill-audit` as a deprecation candidate
+- Functionality has been fully merged into another skill, making the original redundant
+- A dependency (MCP tool, external service, file) the skill requires has been removed
+- An explicit Captain directive names the skill for sunset
+
+Do NOT invoke based on a single low-usage period or minor staleness. The audit surfaces candidates; the Captain decides.
+
+## Arguments
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+| Argument       | Required | Description                                        |
+| -------------- | -------- | -------------------------------------------------- |
+| `<skill-name>` | Yes      | Matches the directory name under `.agents/skills/` |
+| `--reason`     | No       | If omitted, agent will ask interactively           |
+| `--migration`  | No       | If omitted, agent will ask interactively           |
+
+## Preconditions (Fail-Fast)
+
+Run all checks before any changes. Stop and report if any fail.
+
+1. **Captain confirmation** - Ask in chat: "This will deprecate `<name>`. Confirm you're the Captain authorizing this deprecation? (yes/no)". Do not proceed until the Captain replies "yes" in the chat interface.
+
+2. **Skill exists** - Verify `.agents/skills/<name>/SKILL.md` is present. If missing, stop: "No skill found at `.agents/skills/<name>/SKILL.md`."
+
+3. **Not already deprecated** - Read current frontmatter. If `status` is already `deprecated`, stop: "`<name>` is already deprecated (since `<deprecation_date>`). Nothing to do."
+
+4. **Scope reminder** - Before proceeding, state to the Captain: "Per `guardrails.md`, deprecation is NOT removal. The skill remains invocable during the 90-day grace period. Removal requires a separate Captain directive after the sunset date."
+
+## Phases
+
+### Phase 1 - Gather Context
+
+Read the target SKILL.md. Extract current frontmatter (`version`, `status`, `description`).
+
+If `--reason` was not provided, ask:
+
+> "What's the deprecation reason? (1-2 sentences)"
+
+If `--migration` was not provided, ask:
+
+> "What should callers use instead? (migration path, or 'no direct replacement')"
+
+Once both are collected, echo everything back for confirmation:
+
+```
+About to deprecate: <name>
+Reason:    <reason>
+Migration: <migration>
+Sunset:    <today + 90 days>
+
+Proceed? (yes/no)
+```
+
+Do not advance to Phase 2 until the Captain confirms.
+
+### Phase 2 - Update Frontmatter
+
+Get today's date:
+
+```bash
+date +%Y-%m-%d
+```
+
+Get the sunset date (90 days out):
+
+```bash
+date -v+90d +%Y-%m-%d   # macOS
+# or: date -d '+90 days' +%Y-%m-%d   # Linux
+```
+
+Bump these fields in the target SKILL.md frontmatter:
+
+```yaml
+status: deprecated
+deprecation_date: YYYY-MM-DD # today
+sunset_date: YYYY-MM-DD # today + 90 days
+deprecation_notice: '<reason>. Migration: <migration>'
+```
+
+Bump `version` MINOR (e.g., `1.0.0` → `1.1.0`, `2.3.1` → `2.4.0`). This is a status change, not a breaking change.
+
+### Phase 3 - Inject Sunset Banner
+
+Insert the following block immediately after the closing `---` of the frontmatter and before the `# /<name>` heading in the target SKILL.md body:
+
+```markdown
+> ⚠️ **DEPRECATED** — Sunset: YYYY-MM-DD (90 days from deprecation).
+> Reason: <reason>
+> Migration: <migration>
+> Invocations during the grace period still work. Removal requires a separate Captain directive after the sunset date.
+```
+
+If a banner already exists at that position (e.g., a prior warning blockquote), replace it rather than prepending a second one.
+
+### Phase 4 - Log the Deprecation
+
+Append to `docs/skills/deprecated.md` (append-only - never edit existing entries):
+
+```markdown
+## <skill-name> (deprecated YYYY-MM-DD)
+
+- **Reason**: <reason>
+- **Migration**: <migration>
+- **Sunset date**: YYYY-MM-DD
+- **Deprecated by**: Captain (<session_id from crane_sos if available, otherwise omit>)
+```
+
+### Phase 5 - Branch, Commit, PR
+
+```bash
+# Create branch
+git checkout -b deprecate/<skill-name>-YYYY-MM-DD
+
+# Stage only the two modified files
+git add .agents/skills/<skill-name>/SKILL.md
+git add docs/skills/deprecated.md
+
+# Commit
+git commit -m "chore(skills): deprecate <skill-name> with 90-day sunset"
+
+# Push and open PR
+gh pr create \
+  --title "chore(skills): deprecate <skill-name>" \
+  --body "$(cat <<'EOF'
+## Skill Deprecation: <skill-name>
+
+**Reason:** <reason>
+
+**Migration:** <migration>
+
+**Sunset date:** YYYY-MM-DD
+
+The skill remains invocable during the 90-day grace period. This PR does NOT delete any files. Removal is a separate Captain-authorized PR after the sunset date.
+
+Changes:
+- `.agents/skills/<skill-name>/SKILL.md` — status, deprecation fields, sunset banner
+- `docs/skills/deprecated.md` — deprecation log entry
+EOF
+)"
+```
+
+Do NOT merge automatically. The PR goes through normal review.
+
+## What This Skill Does NOT Do
+
+- Delete any files
+- Remove the skill from `config/skill-owners.json` (owner stays until removal)
+- Skip or delegate the Captain confirmation
+- Bypass CI or merge the PR automatically
+- Affect invocability during the grace period
+
+## After Sunset
+
+Once `sunset_date` has passed, `/skill-audit` will flag the skill in the "Deprecation queue" section. The Captain then decides in a separate session:
+
+- **Delete** - new PR to remove the skill directory, dispatcher, and `skill-owners.json` entry
+- **Extend** - run `/skill-deprecate` again with a new sunset date (or edit manually)
+- **Reverse** - flip `status` back to `stable`, remove the banner and deprecation fields
+
+Removal is always a separate Captain-authorized PR. `guardrails.md` forbids removing features without a directive.
+
+## Cross-References
+
+- `docs/skills/governance.md` - lifecycle model (draft → stable → deprecated → removed)
+- `docs/skills/deprecated.md` - append-only deprecation log
+- `crane_doc('global', 'guardrails.md')` - feature-removal rules that govern this flow

--- a/.agents/skills/skill-review/SKILL.md
+++ b/.agents/skills/skill-review/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: skill-review
+description: Lint a skill or all skills in the repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  files:
+    - crane-console:config/skill-owners.json
+    - crane-console:config/mcp-tool-manifest.json
+    - crane-console:docs/skills/governance.md
+---
+
+# /skill-review
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Lint a skill directory (or all skills) against the governance schema defined in `docs/skills/governance.md`. Surfaces violations as structured output and exits non-zero in strict mode if any errors are found.
+
+## Behavior
+
+The skill delegates to the CLI at `packages/crane-mcp/src/cli/skill-review.ts`. It is the creation/change gate — run it before flipping `status: stable` and opening a PR. CI runs it in advisory mode on every PR that touches `.agents/skills/**`.
+
+### Invocation
+
+```bash
+# Review a single skill
+npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
+
+# Review all skills (advisory — exits 0 regardless of findings)
+npm run skill-review -w @venturecrane/crane-mcp -- --all
+
+# Review all skills, block on errors (CI strict mode)
+npm run skill-review -w @venturecrane/crane-mcp -- --all --strict
+
+# Machine-readable JSON output
+npm run skill-review -w @venturecrane/crane-mcp -- --all --json
+
+# Custom MCP tool manifest path
+npm run skill-review -w @venturecrane/crane-mcp -- --all --manifest config/mcp-tool-manifest.json
+```
+
+### Flags
+
+| Flag                | Default                         | Description                                                                |
+| ------------------- | ------------------------------- | -------------------------------------------------------------------------- |
+| `--path <dir>`      | -                               | Review a single skill directory. Mutually exclusive with `--all`.          |
+| `--all`             | -                               | Review every skill in `.agents/skills/`. Mutually exclusive with `--path`. |
+| `--strict`          | advisory (exit 0)               | Exit 1 if any `error` violations are found.                                |
+| `--json`            | human-readable                  | Emit machine-readable JSON report.                                         |
+| `--manifest <path>` | `config/mcp-tool-manifest.json` | Path to MCP tool manifest used for `mcp_tools` validation.                 |
+
+## Rule Categories
+
+Five rule categories are checked. Each violation has a `severity` of `error`, `warning`, or `info`.
+
+### 1. Frontmatter Conformance (`frontmatter.*`)
+
+Validates the YAML frontmatter block at the top of each `SKILL.md`.
+
+Required fields: `name`, `description`, `version`, `scope`, `owner`, `status`.
+
+Violation examples:
+
+```
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+
+ERROR [frontmatter.name-mismatch] .agents/skills/foo/SKILL.md: name "bar" does not match directory name "foo"
+  Fix: Set `name: foo` in frontmatter to match the skill directory.
+
+ERROR [frontmatter.invalid-semver] .agents/skills/foo/SKILL.md: version "1.0" is not valid semver (expected MAJOR.MINOR.PATCH)
+  Fix: Set version to a semver string, e.g. `version: 1.0.0`.
+
+ERROR [frontmatter.invalid-scope] .agents/skills/foo/SKILL.md: scope "vc" is invalid. Must be enterprise, global, or venture:<code>
+  Fix: Set scope to one of: `enterprise`, `global`, or `venture:<lowercase-code>` (e.g. `venture:ss`).
+
+ERROR [frontmatter.invalid-status] .agents/skills/foo/SKILL.md: status "beta" is invalid. Must be one of: draft, stable, deprecated
+  Fix: Set status to `draft`, `stable`, or `deprecated`.
+
+ERROR [frontmatter.unknown-owner] .agents/skills/foo/SKILL.md: owner "unknown-team" is not a known key in config/skill-owners.json
+  Fix: Add the skill under an existing owner key (captain, agent-team) in config/skill-owners.json, or add a new owner key.
+```
+
+### 2. Dispatcher Parity (`dispatcher.*`)
+
+Unless `backend_only: true` is set, every skill must have a matching `.claude/commands/<name>.md` command dispatcher.
+
+Violation example:
+
+```
+ERROR [dispatcher.missing-command-file] .agents/skills/foo/SKILL.md: No dispatcher found at .claude/commands/foo.md
+  Fix: Create .claude/commands/foo.md, or set `backend_only: true` in frontmatter if this skill has no slash command.
+```
+
+### 3. Reference Validity (`references.*`)
+
+Validates entries in `depends_on.mcp_tools`, `depends_on.files`, and `depends_on.commands`.
+
+- `mcp_tools`: each name must appear in `config/mcp-tool-manifest.json` (errors if manifest exists).
+- `files`: each entry must be scope-prefixed (`crane-console:`, `venture:`, or `global:`). Unprefixed paths are an error. `crane-console:` paths are resolved from repo root. `venture:` paths require `CRANE_VENTURE_SAMPLE_REPO` env var (warning if unset). `global:` paths expand `~/` and check local filesystem; in CI (`CI=true`) they emit a warning instead of an error.
+- `commands`: checked via `which <cmd>`. Missing commands are warnings, not errors.
+
+Violation examples:
+
+```
+ERROR [references.unknown-mcp-tool] .agents/skills/foo/SKILL.md: MCP tool "crane_missing" not found in config/mcp-tool-manifest.json
+  Fix: Remove the tool reference, add it to the manifest, or check for a typo in the tool name.
+
+ERROR [references.file-missing-scope-prefix] .agents/skills/foo/SKILL.md: File path missing scope prefix (expected `crane-console:`, `venture:`, or `global:`): "docs/foo.md"
+  Fix: Prefix the file path with `crane-console:`, `venture:`, or `global:` to indicate where the file lives.
+
+ERROR [references.broken-crane-console-file] .agents/skills/foo/SKILL.md: crane-console file not found: "docs/missing.md"
+  Fix: Create the file at docs/missing.md relative to the repo root, or remove the reference.
+
+WARNING [references.venture-file-unverified] .agents/skills/foo/SKILL.md: venture file reference ".stitch/DESIGN.md" not verified — CRANE_VENTURE_SAMPLE_REPO is not set
+  Fix: Set CRANE_VENTURE_SAMPLE_REPO to a local venture repo path to enable validation, or verify the path manually.
+
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "missing-cli" not found on PATH
+  Fix: Install "missing-cli" or remove it from depends_on.commands if it is optional.
+```
+
+### 4. Structural Lint (`structure.*`)
+
+The SKILL.md body (text after the closing `---`) must:
+
+1. Have a top-level `#` heading that starts with `/<name>` (e.g. `# /skill-review` or `# /skill-review - Title`).
+2. Contain at least one second-level section named `## Phases`, `## Workflow`, or `## Behavior`.
+
+Violation examples:
+
+```
+ERROR [structure.missing-h1-heading] .agents/skills/foo/SKILL.md: Body has no top-level # heading
+  Fix: Add a `# /foo` heading as the first heading in the SKILL.md body.
+
+ERROR [structure.heading-mismatch] .agents/skills/foo/SKILL.md: First # heading "Foo" does not start with "/foo"
+  Fix: Change the first heading to `# /foo` or `# /foo - Description`.
+
+ERROR [structure.missing-workflow-section] .agents/skills/foo/SKILL.md: Body is missing a workflow section (## Phases, ## Workflow, or ## Behavior)
+  Fix: Add a `## Phases`, `## Workflow`, or `## Behavior` section describing how the skill executes.
+```
+
+### 5. Deprecation Sanity (`deprecation.*`)
+
+If `status: deprecated`, both `deprecation_date` and `sunset_date` must be present, parseable as ISO dates, and `sunset_date` must be strictly after `deprecation_date`.
+
+Violation examples:
+
+```
+ERROR [deprecation.missing-deprecation-date] .agents/skills/foo/SKILL.md: status is deprecated but deprecation_date is missing
+  Fix: Add `deprecation_date: YYYY-MM-DD` to frontmatter.
+
+ERROR [deprecation.missing-sunset-date] .agents/skills/foo/SKILL.md: status is deprecated but sunset_date is missing
+  Fix: Add `sunset_date: YYYY-MM-DD` to frontmatter (typically deprecation_date + 90 days).
+
+ERROR [deprecation.sunset-before-deprecation] .agents/skills/foo/SKILL.md: sunset_date "2025-01-01" must be after deprecation_date "2025-03-01"
+  Fix: Set sunset_date to a date strictly after deprecation_date.
+```
+
+## Output Formats
+
+### Human-readable (default)
+
+```
+Reviewed 3 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" not found on PATH
+  Fix: Install "jq" or remove it from depends_on.commands if it is optional.
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "skills_reviewed": 3,
+  "total_violations": 2,
+  "by_severity": { "error": 1, "warning": 1, "info": 0 },
+  "violations": [
+    {
+      "rule": "frontmatter.missing-field",
+      "severity": "error",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Missing required field: owner",
+      "fix": "Add `owner: <team>` to frontmatter. See docs/skills/governance.md."
+    },
+    {
+      "rule": "references.missing-command",
+      "severity": "warning",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Command \"jq\" not found on PATH",
+      "fix": "Install \"jq\" or remove it from depends_on.commands if it is optional."
+    }
+  ]
+}
+```
+
+## Adding a New Skill
+
+Follow the workflow in `docs/skills/governance.md`:
+
+1. Scaffold the skill directory at `.agents/skills/<name>/SKILL.md`.
+2. Fill in all required frontmatter fields (start with `status: draft`).
+3. Ensure `config/skill-owners.json` has the owning key.
+4. Create `.claude/commands/<name>.md` unless `backend_only: true`.
+5. Run `/skill-review --path .agents/skills/<name>` until zero errors.
+6. Flip to `status: stable` and open a PR.
+
+## Reference
+
+Full governance spec: `docs/skills/governance.md`
+
+CLI source: `packages/crane-mcp/src/cli/skill-review.ts`

--- a/.agents/skills/sos/SKILL.md
+++ b/.agents/skills/sos/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: sos
 description: Start of Session
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /sos - Start of Session
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "sos")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 1. Call `crane_sos` MCP tool (returns formatted briefing).
 2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.

--- a/.agents/skills/sprint/SKILL.md
+++ b/.agents/skills/sprint/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: sprint
 description: Sequential sprint execution of GitHub issues on separate branches
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
-# Sprint
+# /sprint - Sequential sprint execution
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "sprint")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Takes a set of pre-selected GitHub issue numbers, builds an optimal wave-based execution plan, and implements them sequentially on separate branches. The prior step (human or planning agent) selects which issues go into the sprint. This skill handles execution.
 

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: status
 description: Show Session Status
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+backend_only: true
 ---
 
 # /status - Show Session Status

--- a/.agents/skills/stitch-design/README.md
+++ b/.agents/skills/stitch-design/README.md
@@ -1,0 +1,50 @@
+# Stitch Design Skill
+
+Teaches agents to generate high-fidelity, consistent UI designs and maintain project-level design systems using Stitch.
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill stitch-design --global
+```
+
+## What It Does
+
+Enables professional-grade UI/UX design workflows through Stitch MCP:
+
+1. **Prompt Enhancement**: Transforms rough intent into structured, high-fidelity prompts with professional terminology and design system context.
+2. **Design System Synthesis**: Analyzes existing Stitch projects to create and maintain a `.stitch/DESIGN.md` "source of truth".
+3. **Iterative Generation**: Selects the best generation or editing workflow (`edit_screens`, `generate_variants`) based on user intent.
+4. **Asset Management**: Synchronizes remote designs by downloading HTML and screenshots to the project's `.stitch/designs` directory.
+
+## Prerequisites
+
+- Stitch MCP Server access
+- A project `projectId` (can be discovered via `list_projects`)
+
+## Example Prompt
+
+```text
+Design a premium landing page for a mountain resort with a focus on serene luxury and glassmorphism.
+```
+
+## Skill Structure
+
+```
+stitch-design/
+├── SKILL.md           — Core instructions & Prompt Pipeline
+├── README.md          — This file
+├── workflows/         — Specialized pipelines (Text-to-UI, Edit, MD)
+├── references/        — UI/UX keywords & Technical Mappings
+└── examples/          — Gold-standard references (Solace Mindfulness)
+```
+
+## Works With
+
+- **`react:components` skill**: Hand-off generated designs for frontend implementation.
+- **`stitch-loop` skill**: Provides the `DESIGN.md` context for autonomous building loops.
+- **Multi-agent workflows**: Refines prompts before passing design tasks to specialized agents.
+
+## Learn More
+
+See [SKILL.md](./SKILL.md) for complete instructions.

--- a/.agents/skills/stitch-design/SKILL.md
+++ b/.agents/skills/stitch-design/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: stitch-design
+description: Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (.stitch/DESIGN.md), and high-fidelity screen generation/editing via Stitch MCP.
+version: 1.1.0
+scope: global
+owner: agent-team
+status: stable
+allowed-tools:
+  - 'StitchMCP'
+  - 'Read'
+  - 'Write'
+---
+
+# /stitch-design - Stitch Design Expert
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "stitch-design")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+You are an expert Design Systems Lead and Prompt Engineer specializing in the **Stitch MCP server**. Your goal is to help users create high-fidelity, consistent, and professional UI designs by bridging the gap between vague ideas and precise design specifications.
+
+## Core Responsibilities
+
+1.  **Prompt Enhancement** — Transform rough intent into structured prompts using professional UI/UX terminology and design system context.
+2.  **Design System Synthesis** — Analyze existing Stitch projects to create `.stitch/DESIGN.md` "source of truth" documents.
+3.  **Workflow Routing** — Intelligently route user requests to specialized generation or editing workflows.
+4.  **Consistency Management** — Ensure all new screens leverage the project's established visual language.
+5.  **Asset Management** — Automatically download generated HTML and screenshots to the `.stitch/designs` directory.
+
+---
+
+## 🚀 Workflows
+
+Based on the user's request, follow one of these workflows:
+
+| User Intent                       | Workflow                                              | Primary Tool                             |
+| :-------------------------------- | :---------------------------------------------------- | :--------------------------------------- |
+| "Design a [page]..."              | [text-to-design](workflows/text-to-design.md)         | `generate_screen_from_text` + `Download` |
+| "Edit this [screen]..."           | [edit-design](workflows/edit-design.md)               | `edit_screens` + `Download`              |
+| "Create/Update .stitch/DESIGN.md" | [generate-design-md](workflows/generate-design-md.md) | `get_screen` + `Write`                   |
+
+---
+
+## 🎨 Prompt Enhancement Pipeline
+
+Before calling any Stitch generation or editing tool, you MUST enhance the user's prompt.
+
+### 1. Resolve Project ID (fail-fast)
+
+Before any Stitch tool call, resolve the venture's persistent project:
+
+1. Call `crane_ventures` MCP tool. Match the current repo to a venture. Use its `stitch_project_id`.
+2. If `null` or lookup fails: **STOP.** Tell the user: "No Stitch project configured for this venture. Add `stitchProjectId` to `config/ventures.json` in crane-console first."
+
+**No fallback to `list_projects`. No auto-creation.** Project IDs are explicit config, not discovered at runtime.
+
+### 1a. Analyze Context
+
+- **Design System**: Check for `.stitch/DESIGN.md`. If it exists, incorporate its tokens (colors, typography). If not, suggest the `generate-design-md` workflow.
+- **Navigation Spec**: Check for `.stitch/NAVIGATION.md`. If it exists, nav-contract injection is available (see step 1b and step 3). If not, proceed without — the skill gracefully degrades. Consider suggesting `/nav-spec` if the user is generating portal or admin surfaces.
+- **Freshness check**: Before generating, compare `design-spec.md` freshness (via `crane_doc` metadata) against `.stitch/DESIGN.md`. If the spec is newer, warn and suggest running the sync-design-spec workflow first.
+
+### 1b. Classification tags (when NAVIGATION.md present)
+
+If `.stitch/NAVIGATION.md` exists, read its `spec-version` frontmatter to determine the required tag set:
+
+**spec-version >= 3** — the user prompt MUST carry **five** classification tags:
+
+```
+surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+viewport=<mobile|desktop>
+task=<short-name from venture's task model, NAVIGATION.md §1>
+pattern=<name from pattern-catalog.md, NAVIGATION.md §4>
+```
+
+If any of the five tags is missing: **STOP.** Tell the user: "NAVIGATION.md v3+ is present — add `surface=`, `archetype=`, `viewport=`, `task=`, and `pattern=` tags so the nav contract can be injected. Run `/nav-spec --classify-help` for the decision rubric."
+
+**spec-version < 3 (legacy)** — the user prompt MUST carry **three** classification tags (`surface=`, `archetype=`, `viewport=`). The `task=` and `pattern=` tags do not apply to legacy specs.
+
+If `.stitch/NAVIGATION.md` does NOT exist, skip this step entirely. No tags required.
+
+### 2. Refine UI/UX Terminology
+
+Consult [Design Mappings](references/design-mappings.md) to replace vague terms.
+
+- Vague: "Make a nice header"
+- Professional: "Sticky navigation bar with glassmorphism effect and centered logo"
+
+### 3. Structure the Final Prompt
+
+Format the enhanced prompt for Stitch like this:
+
+```markdown
+[Overall vibe, mood, and purpose of the page]
+
+**NAV CONTRACT (REQUIRED):**
+[Only if .stitch/NAVIGATION.md exists — inject the nav contract block here.
+Built from the classification tags: read the matching surface-class appendix
+
+- archetype contract from NAVIGATION.md, concatenate with shared sections
+  (a11y, states, anti-patterns). Template at
+  ~/.agents/skills/nav-spec/references/injection-snippet-template.md.
+  When spec-version >= 3, populate Task and Pattern in the Classification
+  section from the venture's task model (§1) and pattern catalog (§4).
+  Size budget: ≤500 essential, ≤800 essential+extended combined.
+  If NAVIGATION.md absent, omit this block entirely.]
+
+**DESIGN SYSTEM (REQUIRED):**
+
+- Platform: [Web/Mobile], [Desktop/Mobile]-first
+- Palette: [Primary Name] (#hex for role), [Secondary Name] (#hex for role)
+- Styles: [Roundness description], [Shadow/Elevation style]
+
+**PAGE STRUCTURE:**
+
+1. **[Content area 1]:** [Description]
+2. **[Content area 2]:** [Description]
+3. **[Content area 3]:** [Description]
+```
+
+When NAV CONTRACT is present, do NOT describe navigation/header/footer chrome in PAGE STRUCTURE — the contract owns chrome. PAGE STRUCTURE describes content only.
+
+### 3b. Post-generation validation (when NAVIGATION.md present)
+
+After every `generate_screen_from_text` or `edit_screens` call, if `.stitch/NAVIGATION.md` exists, run the nav validator:
+
+```bash
+python3 ~/.agents/skills/nav-spec/validate.py \
+  --file <path-to-generated-html> \
+  --surface <surface-tag> \
+  --archetype <archetype-tag> \
+  --viewport <viewport-tag> \
+  --task <task-tag> \
+  --pattern <pattern-tag>
+```
+
+When spec-version < 3, omit `--task` and `--pattern` (the validator soft-skips R25/R26 when those inputs are missing).
+
+If the validator reports structural violations: retry once with the violation report appended to the prompt ("The previous output violated these nav rules: ... please regenerate"). On second failure: surface to the user ("Validator flagged N violations. Accept anyway, regenerate, or adjust?").
+
+If `.stitch/NAVIGATION.md` does NOT exist, skip validation.
+
+### 4. Present AI Insights
+
+After any tool call, always surface the `outputComponents` (Text Description and Suggestions) to the user.
+
+---
+
+## 📚 References
+
+- [Tool Schemas](references/tool-schemas.md) — How to call Stitch MCP tools.
+- [Design Mappings](references/design-mappings.md) — UI/UX keywords and atmosphere descriptors.
+- [Prompting Keywords](references/prompt-keywords.md) — Technical terms Stitch understands best.
+- **VCMS:** `crane_notes(q: 'stitch')` — Full API reference and enterprise best practices.
+- **Nav Spec:** `~/.agents/skills/nav-spec/` — Navigation specification skill. Produces `.stitch/NAVIGATION.md`; provides the injection template and validator consumed by steps 1b, 3, and 3b above.
+
+---
+
+## 💡 Best Practices
+
+- **Iterative Polish**: Prefere `edit_screens` for targeted adjustments over full re-generation.
+- **Semantic First**: Name colors by their role (e.g., "Primary Action") as well as their appearance.
+- **Atmosphere Matters**: Explicitly set the "vibe" (Minimalist, Vibrant, Brutalist) to guide the generator.

--- a/.agents/skills/stitch-design/examples/DESIGN.md
+++ b/.agents/skills/stitch-design/examples/DESIGN.md
@@ -1,0 +1,23 @@
+---
+# The "Solace" Design System
+This is a comprehensive design language for a mindfulness and wellness application.
+
+## 🎨 Color Palette
+- **Primary**: Deep Ocean Blue (#1a365d) - for critical navigation and CTAs.
+- **Secondary**: Calm Slate (#718096) - for subtexts and secondary buttons.
+- **Background**: Soft Mist (#f7fafc) - for main page content.
+- **Accent**: Serene Emerald (#38a169) - for positive feedback and completion states.
+
+## 🔡 Typography
+- **Heading**: Montserrat, Bold - for titles and hero section headlines.
+- **Body**: Inter, Regular - for descriptions and general content.
+- **Size**: 16px as base, 48px for H1.
+
+## 📐 Components
+- **Buttons**: Rounded (12px), subtle hover shadow (4px blur).
+- **Cards**: Minimal border (1px, #e2e8f0), soft shadow (8px elevation).
+- **Navigation**: Clean, top-aligned, centered menu items.
+
+---
+
+💡 **Tip**: When calling `generate_screen_from_text`, include the tokens above to ensure the new screen matches this design system.

--- a/.agents/skills/stitch-design/examples/enhanced-prompt.md
+++ b/.agents/skills/stitch-design/examples/enhanced-prompt.md
@@ -1,0 +1,81 @@
+# Example: Prompt Enhancement
+
+## User Input (Vague)
+
+> "Make a landing page for my fitness app called 'Pulse'. Use red and black. It should have a place for features and a hero section."
+
+---
+
+## Enhanced Prompt (Stitch-Optimized)
+
+**Overall Purpose**: A high-energy, modern landing page for 'Pulse', a fitness tracking application. The vibe is powerful, motivating, and high-performance.
+
+**DESIGN SYSTEM (REQUIRED):**
+
+- **Primary Color**: Racing Red (#e11d48) for CTA buttons and active states.
+- **Secondary Color**: Deep Obsidian (#0f172a) for background and text containers.
+- **Typography**: Bold, condensed sans-serif headings (e.g., Impact or Inter Tight) to convey speed and strength.
+- **Style**: Hard edges with sharp, minimal borders; high contrast; dark mode by default.
+
+**PAGE STRUCTURE:**
+
+1. **Header**: Minimalist navigation with Pulse logo (left) and "Start Training" primary button (right).
+2. **Hero Section**: Large, emotive fitness photography background. Headline: "Elevate Every Beat." Sub-headline: "Track, analyze, and crush your fitness goals with Pulse." Primary red CTA: "Get Started".
+3. **Feature Grid**: Three-column layout highlighting:
+   - **Real-time Tracking**: Live stats from your wearable.
+   - **AI Coaching**: Personalized workouts based on your performance.
+   - **Community Challenges**: Compete with friends and stay motivated.
+4. **Social Proof Section**: Subtle slider showing "Trusted by 500,000+ athletes".
+5. **Footer**: Quick links (Training, Pricing, Support), social icons, and legal.
+
+---
+
+💡 **Tip**: Notice how the enhanced prompt adds specific hex codes, defines the typography "vibe", and breaks the page into a logical numbered structure. This gives Stitch much clearer instructions.
+
+---
+
+# Example: Prompt Enhancement with NAV CONTRACT
+
+When `.stitch/NAVIGATION.md` exists for the venture and the user provides classification tags, the prompt gains a NAV CONTRACT block between the vibe statement and the DESIGN SYSTEM.
+
+## User Input
+
+> "Design the invoice detail page for the client portal. surface=session-auth-client archetype=detail viewport=mobile task=pay-invoice pattern=nested-doll"
+
+(The `task=` and `pattern=` tags are required when NAVIGATION.md spec-version >= 3. For legacy specs, only surface/archetype/viewport are needed.)
+
+## Enhanced Prompt (with NAV CONTRACT injected)
+
+**NAV CONTRACT (REQUIRED — do not invent beyond this block):**
+
+Surface class: session-auth-client (portal.smd.services, authenticated).
+Archetype: detail (has back button, no breadcrumbs, no bottom nav).
+Viewport: mobile 390x844.
+
+Chrome allowed (inclusive list; nothing else):
+
+- Top band (sticky, NOT fixed): bg-white, 1px border-b #e2e8f0, h-14 on `<header>`. Left: client name (Inter 500, 13/18, #475569). Right: three-icon contact control (email/sms/tel, each 44x44 with aria-label).
+- Back affordance inside `<main>`: chevron_left + "All invoices", href="/portal/invoices" (hardcoded). 44x44 tap target.
+- Bottom chrome: NONE. Footer: NONE.
+
+Chrome FORBIDDEN: global nav tabs, sidebar, hamburger, logo in header, breadcrumbs, bottom-tab nav, copyright row, marketing CTAs, real-face photos.
+
+If any above conflicts with PAGE STRUCTURE below, THIS BLOCK WINS.
+
+**DESIGN SYSTEM (REQUIRED):**
+
+- Platform: Web, mobile-first, 390x844
+- Palette: Primary #1E40AF, Text #475569, Bold #0F172A, Border #E2E8F0
+- Typography: Inter 400/500/600
+- Shape: 8px rounded
+
+**PAGE STRUCTURE:**
+
+1. Invoice summary: amount ($4,250), due date (Apr 18), status pill
+2. Line items table
+3. Pay button (primary CTA, above fold)
+4. Consultant contact card (SVG silhouette, never real photo)
+
+---
+
+💡 **Tip**: The NAV CONTRACT separates _chrome_ from _content_. PAGE STRUCTURE no longer describes the header, footer, or back button — those are owned by the contract. If Stitch drifts on chrome, the post-generation validator (`validate.py`) catches it deterministically.

--- a/.agents/skills/stitch-design/references/design-mappings.md
+++ b/.agents/skills/stitch-design/references/design-mappings.md
@@ -1,0 +1,45 @@
+# Design Mappings & Descriptors
+
+Use these mappings to transform vague user requests into precise, high-fidelity design instructions.
+
+## UI/UX Keyword Refinement
+
+| Vague Term        | Enhanced Professional Terminology                                            |
+| :---------------- | :--------------------------------------------------------------------------- |
+| "menu at the top" | "sticky navigation bar with logo and list items"                             |
+| "big photo"       | "high-impact hero section with full-width imagery"                           |
+| "list of things"  | "responsive card grid with hover states and subtle elevations"               |
+| "button"          | "primary call-to-action button with micro-interactions"                      |
+| "form"            | "clean form with labeled input fields, validation states, and submit button" |
+| "picture area"    | "hero section with focal-point image or video background"                    |
+| "sidebar"         | "collapsible side navigation with icon-label pairings"                       |
+| "popup"           | "modal dialog with overlay and smooth entry animation"                       |
+
+## Atmosphere & "Vibe" Descriptors
+
+Add these adjectives to set the mood and aesthetic philosophy:
+
+| Basic Vibe      | Enhanced Design Description                                                                    |
+| :-------------- | :--------------------------------------------------------------------------------------------- |
+| "Modern"        | "Clean, minimal, with generous whitespace and high-contrast typography."                       |
+| "Professional"  | "Sophisticated, trustworthy, utilizing subtle shadows and a restricted, premium palette."      |
+| "Fun / Playful" | "Vibrant, organic, with rounded corners, bold accent colors, and bouncy micro-animations."     |
+| "Dark Mode"     | "Electric, high-contrast accents on deep slate or near-black backgrounds."                     |
+| "Luxury"        | "Elegant, spacious, with fine lines, serif headers, and a focus on high-fidelity photography." |
+| "Tech / Cyber"  | "Futuristic, neon accents, glassmorphism effects, and technological monospaced typography."    |
+
+## Geometry & Shape Translation
+
+Convert technical values into physical descriptions for Stitch:
+
+- **Pill-shaped**: Used for `rounded-full` elements (buttons, tags).
+- **Softly rounded**: Used for `rounded-xl` (12px) or `rounded-2xl` (16px) containers.
+- **Sharp/Precise**: Used for `rounded-none` or `rounded-sm` elements.
+- **Glassmorphism**: Semi-transparent surfaces with background blur and thin borders.
+
+## Depth & Elevation
+
+- **Flat**: No shadows, focus on color blocking and borders.
+- **Whisper-soft**: Diffused, light shadows for subtle lift.
+- **Floating**: High-offset, soft shadows for elements that appear high above the surface.
+- **Inset**: Inner shadows for pressable or nested elements.

--- a/.agents/skills/stitch-design/references/prompt-keywords.md
+++ b/.agents/skills/stitch-design/references/prompt-keywords.md
@@ -1,0 +1,129 @@
+# UI/UX Keywords Reference
+
+Progressive disclosure reference for common UI terminology and adjective palettes.
+
+## Component Keywords
+
+### Navigation
+
+- navigation bar, nav menu, header
+- breadcrumbs, tabs, sidebar
+- hamburger menu, dropdown menu
+- back button, close button
+
+### Content Containers
+
+- hero section, hero banner
+- card, card grid, tile
+- modal, dialog, popup
+- accordion, collapsible section
+- carousel, slider
+
+### Forms
+
+- input field, text input
+- dropdown, select menu
+- checkbox, radio button
+- toggle switch
+- date picker, time picker
+- search bar, search input
+- submit button, form actions
+
+### Calls to Action
+
+- primary button, secondary button
+- ghost button, text link
+- floating action button (FAB)
+- icon button
+
+### Feedback
+
+- toast notification, snackbar
+- alert banner, warning message
+- loading spinner, skeleton loader
+- progress bar, step indicator
+
+### Layout
+
+- grid layout, flexbox
+- sidebar layout, split view
+- sticky header, fixed footer
+- full-width, contained width
+- centered content, max-width container
+
+## Adjective Palettes
+
+### Minimal / Clean
+
+- minimal, clean, uncluttered
+- generous whitespace, breathing room
+- subtle, understated, refined
+- simple, focused, distraction-free
+
+### Professional / Corporate
+
+- sophisticated, polished, trustworthy
+- corporate, business-like, formal
+- subtle shadows, clean lines
+- structured, organized, hierarchical
+
+### Playful / Fun
+
+- vibrant, colorful, energetic
+- rounded corners, soft edges
+- bold, expressive, dynamic
+- friendly, approachable, warm
+
+### Premium / Luxury
+
+- elegant, luxurious, high-end
+- dramatic, bold contrasts
+- sleek, modern, cutting-edge
+- exclusive, boutique, curated
+
+### Dark Mode
+
+- dark theme, night mode
+- high-contrast accents
+- soft glows, subtle highlights
+- deep backgrounds, muted surfaces
+
+### Organic / Natural
+
+- earthy tones, natural colors
+- warm, inviting, cozy
+- textured, tactile, handcrafted
+- flowing, organic shapes
+
+## Color Role Terminology
+
+### Backgrounds
+
+- page background, canvas
+- surface color, card background
+- overlay, scrim
+
+### Text
+
+- primary text, heading color
+- secondary text, body copy
+- muted text, placeholder
+- inverse text (on dark backgrounds)
+
+### Accents
+
+- primary accent, brand color
+- secondary accent, highlight
+- success, error, warning colors
+- hover state, active state
+
+## Shape Descriptions
+
+| Technical      | Natural Language           |
+| -------------- | -------------------------- |
+| `rounded-none` | sharp, squared-off edges   |
+| `rounded-sm`   | slightly softened corners  |
+| `rounded-md`   | gently rounded corners     |
+| `rounded-lg`   | generously rounded corners |
+| `rounded-xl`   | very rounded, pillow-like  |
+| `rounded-full` | pill-shaped, circular      |

--- a/.agents/skills/stitch-design/references/tool-schemas.md
+++ b/.agents/skills/stitch-design/references/tool-schemas.md
@@ -1,0 +1,90 @@
+# Stitch MCP Tool Schemas
+
+Use these examples to format your tool calls to the Stitch MCP server correctly.
+
+---
+
+## 🏗️ Project Management
+
+### `list_projects`
+
+Lists all Stitch projects accessible to you.
+
+```json
+// No parameters needed
+{}
+```
+
+### `get_project`
+
+Retrieves details of a specific project.
+
+```json
+{
+  "name": "projects/4044680601076201931"
+}
+```
+
+### `create_project`
+
+Creates a new Stitch project.
+
+```json
+{
+  "title": "My New App"
+}
+```
+
+---
+
+## 🎨 Design Generation
+
+### `generate_screen_from_text`
+
+Generates a new screen from a text description.
+
+```json
+{
+  "projectId": "4044680601076201931",
+  "prompt": "A modern landing page for a coffee shop with a hero section, menu, and contact form. Use warm brown tones (#4b2c20) and a clean sans-serif font.",
+  "deviceType": "DESKTOP" // Options: MOBILE, DESKTOP, TABLET
+}
+```
+
+### `edit_screens`
+
+Edits existing screens with a text prompt.
+
+```json
+{
+  "projectId": "4044680601076201931",
+  "selectedScreenIds": ["98b50e2ddc9943efb387052637738f61"],
+  "prompt": "Change the background color to white (#ffffff) and make the call-to-action button larger."
+}
+```
+
+---
+
+## 🖼️ Screen Management
+
+### `list_screens`
+
+Lists all screens within a project.
+
+```json
+{
+  "projectId": "4044680601076201931"
+}
+```
+
+### `get_screen`
+
+Retrieves details of a specific screen.
+
+```json
+{
+  "projectId": "4044680601076201931",
+  "screenId": "98b50e2ddc9943efb387052637738f61",
+  "name": "projects/4044680601076201931/screens/98b50e2ddc9943efb387052637738f61"
+}
+```

--- a/.agents/skills/stitch-design/workflows/edit-design.md
+++ b/.agents/skills/stitch-design/workflows/edit-design.md
@@ -1,0 +1,53 @@
+---
+description: Edit an existing design screen using Stitch MCP.
+---
+
+# Workflow: Edit-Design
+
+Make targeted changes to an already generated design.
+
+## Steps
+
+### 1. Identify the Screen
+
+Resolve `projectId` using the fail-fast Project ID Resolution from SKILL.md step 1. Then use `list_screens` to find the target `screenId`.
+
+### 2. Formulate the Edit Prompt
+
+Be specific about the changes you want to make. Do not just say "fix it".
+
+- **Location**: "Change the color of the [primary button] in the [hero section]..."
+- **Visuals**: "...to a darker blue (#004080) and add a subtle shadow."
+- **Structure**: "Add a secondary button next to the primary one with the text 'Learn More'."
+- **Nav preservation**: If `.stitch/NAVIGATION.md` exists and the screen has spec-conforming chrome, include "Preserve the existing header, back affordance, and footer exactly as rendered" in the edit prompt. Do not let edits re-invent chrome that the nav contract already owns.
+
+### 3. Apply the Edit
+
+Call the `mcp_StitchMCP_edit_screens` tool.
+
+```json
+{
+  "projectId": "...",
+  "selectedScreenIds": ["..."],
+  "prompt": "[Your target edit prompt]"
+}
+```
+
+### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the user.
+
+### 5. Download Design Assets
+
+After editing, download the updated HTML and screenshot urls from `outputComponents` to the `.stitch/designs` directory, overwriting previous versions to ensure the local files reflect the latest edits.
+
+### 6. Verify and Repeat
+
+- Check the output screen to see if the changes were applied correctly.
+- If more polish is needed, repeat the process with a new specific prompt.
+
+## Tips
+
+- **Keep it focused**: One edit at a time is often better than a long list of changes.
+- **Reference components**: Use professional terms like "navigation bar", "hero section", "footer", "card grid".
+- **Mention colors**: Use hex codes for precise color matching.

--- a/.agents/skills/stitch-design/workflows/generate-design-md.md
+++ b/.agents/skills/stitch-design/workflows/generate-design-md.md
@@ -1,0 +1,75 @@
+---
+description: Analyze a Stitch project and synthesize its design system into a .stitch/DESIGN.md file.
+---
+
+# Workflow: Generate .stitch/DESIGN.md
+
+Create a "source of truth" for your project's design language to ensure consistency across all future screens.
+
+## 📥 Retrieval
+
+To analyze a Stitch project, you must retrieve metadata and assets using the Stitch MCP tools:
+
+1.  **Project lookup**: Resolve `projectId` using the fail-fast Project ID Resolution from SKILL.md step 1 (via `crane_ventures`).
+2.  **Screen lookup**: Use `list_screens` for that `projectId` to find representative screens (e.g., "Home", "Main Dashboard").
+3.  **Metadata fetch**: Call `get_screen` for the target screen to get `screenshot.downloadUrl` and `htmlCode.downloadUrl`.
+4.  **Asset download**: Use `read_url_content` to fetch the HTML code.
+
+## 🧠 Analysis & Synthesis
+
+### 1. Identify Identity
+
+- Capture Project Title and Project ID.
+
+### 2. Define Atmosphere
+
+- Analyze the HTML and screenshot to capture the "vibe" (e.g., "Airy," "Professional," "Vibrant").
+
+### 3. Map Color Palette
+
+- Extract exact hex codes and assign functional roles (e.g., "Primary Action: #2563eb").
+
+### 4. Translate Geometry
+
+- Convert Tailwind/CSS values into descriptive language (e.g., `rounded-full` → "Pill-shaped").
+
+### 5. Document Depth
+
+- Describe shadow styles and layering (e.g., "Soft, diffused elevation").
+
+## 📝 Output Structure
+
+Create a `.stitch/DESIGN.md` file in the project directory with this structure:
+
+```markdown
+# Design System: [Project Title]
+
+**Project ID:** [Insert Project ID Here]
+
+## 1. Visual Theme & Atmosphere
+
+(Description of mood and aesthetic philosophy)
+
+## 2. Color Palette & Roles
+
+(Descriptive Name + Hex Code + Role)
+
+## 3. Typography Rules
+
+(Font families, weights, and usage)
+
+## 4. Component Stylings
+
+- **Buttons:** Shape, color, behavior
+- **Containers:** Roundness, elevation
+
+## 5. Layout Principles
+
+(Whitespace strategy and grid alignment)
+```
+
+## 💡 Best Practices
+
+- **Be Precise**: Always include hex codes in parentheses.
+- **Be Descriptive**: Use natural language like "Deep Ocean Blue" instead of just "Blue".
+- **Be Functional**: Explain _why_ an element is used.

--- a/.agents/skills/stitch-design/workflows/sync-design-spec.md
+++ b/.agents/skills/stitch-design/workflows/sync-design-spec.md
@@ -1,0 +1,44 @@
+---
+description: Sync design-spec.md changes into .stitch/DESIGN.md and the Stitch cloud design system.
+---
+
+# Workflow: Sync Design Spec to Stitch
+
+When `design-spec.md` is updated, propagate changes to the Stitch derivative files.
+
+## When to Run
+
+- After any PR that modifies `docs/design/ventures/{code}/design-spec.md` in crane-console
+- After running `/design-brief` which regenerates design-spec.md
+- When the pre-generation freshness check (SKILL.md step 1a) detects drift
+- When the schedule engine flags `design-system-review` as due
+
+## Steps
+
+### 1. Load Both Files
+
+- Read the canonical `design-spec.md` via `crane_doc('{code}', 'design-spec.md')`
+- Read the current `.stitch/DESIGN.md` from the venture repo
+
+### 2. Diff and Update
+
+- Compare token values (colors, typography, spacing, component patterns) between the two files
+- Update `.stitch/DESIGN.md` with any changed values from design-spec.md
+- Preserve Stitch-specific formatting and sections that don't exist in design-spec.md (e.g., atmosphere descriptions, prompt-optimized language)
+- Keep the Project ID in the DESIGN.md header unchanged
+
+### 3. Push to Stitch Cloud
+
+- Resolve `projectId` using the fail-fast resolution (SKILL.md step 1)
+- Call `update_design_system` with the updated designMd content
+- Verify with `list_design_systems`
+
+### 4. Commit
+
+- Commit the updated `.stitch/DESIGN.md` to the venture repo
+- PR title: `chore: sync design system from design-spec.md`
+
+## Tips
+
+- Only sync tokens that actually changed - don't regenerate the entire DESIGN.md
+- If the design-spec.md has major structural changes (new component patterns, new color zones), consider regenerating DESIGN.md from scratch using the `generate-design-md` workflow instead

--- a/.agents/skills/stitch-design/workflows/text-to-design.md
+++ b/.agents/skills/stitch-design/workflows/text-to-design.md
@@ -1,0 +1,61 @@
+---
+description: Generate new screens from a text prompt using Stitch MCP.
+---
+
+# Workflow: Text-to-Design
+
+Transform a text description into a high-fidelity design screen.
+
+## Steps
+
+### 1. Enhance the User Prompt
+
+Before calling the Stitch MCP tool, apply the [Prompt Enhancement Pipeline](../SKILL.md#prompt-enhancement-pipeline).
+
+- Identify the platform (Web/Mobile) and page type.
+- Incorporate any existing project design system from `.stitch/DESIGN.md`.
+- If `.stitch/NAVIGATION.md` exists: require classification tags per pipeline step 1b (3 tags for legacy specs, 5 tags including `task=` and `pattern=` for spec-version >= 3). Build and inject the NAV CONTRACT block per step 3.
+- Use specific [Design Mappings](../references/design-mappings.md) and [Prompting Keywords](../references/prompt-keywords.md).
+
+### 2. Identify the Project
+
+Use the fail-fast Project ID Resolution from SKILL.md step 1: look up `stitch_project_id` via `crane_ventures`, stop if null.
+
+### 3. Generate the Screen
+
+Call the `mcp_StitchMCP_generate_screen_from_text` tool with the enhanced prompt.
+
+```json
+{
+  "projectId": "...",
+  "prompt": "[Your Enhanced Prompt]",
+  "deviceType": "DESKTOP" // or MOBILE
+}
+```
+
+### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the user.
+
+### 5. Validate Navigation (if NAVIGATION.md present)
+
+If `.stitch/NAVIGATION.md` exists, run the nav validator per pipeline step 3b before downloading. On structural violations, retry once with the violations appended. On second failure, surface to user.
+
+### 6. Download Design Assets
+
+After generation (and validation if applicable), download the HTML and screenshot urls from `outputComponents` to the `.stitch/designs` directory.
+
+- **Naming**: Use the screen ID or a descriptive slug for the filename.
+- **Tools**: Use `curl -o` via `run_command` or similar.
+- **Directory**: Ensure `.stitch/designs` exists.
+
+### 7. Review and Refine
+
+- If the result is not exactly as expected, use the [edit-design](edit-design.md) workflow to make targeted adjustments.
+- Do NOT re-generate from scratch unless the fundamental layout is wrong.
+
+## Tips
+
+- **Be structural**: Break the page down into header, hero, features, and footer in your prompt.
+- **Specify colors**: Use hex codes for precision.
+- **Set the tone**: Explicitly mention if the design should be minimal, professional, or vibrant.

--- a/.agents/skills/stitch-ux-brief/SKILL.md
+++ b/.agents/skills/stitch-ux-brief/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: stitch-ux-brief
 description: Stitch UX Brief & Generation
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /stitch-ux-brief - Stitch UX Brief & Generation
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "stitch-ux-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona), then commissions Stitch to generate three structurally distinct concepts at a single surface + viewport, iterates a winner with the user, expands to the full matrix of surfaces and viewports, and strips default-web gold-plating. Final artifacts land in `.stitch/` in the current venture repo.
 
@@ -60,7 +66,7 @@ Scan the repo for context:
 - `tailwind.config.*` for palette and type scale
 - Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
 - `.stitch/DESIGN.md` if present (established design system for the venture)
-- `.stitch/NAVIGATION.md` if present (navigation specification — governs chrome in concept prompts and strip passes). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value.
+- `.stitch/NAVIGATION.md` if present (navigation specification — governs chrome in concept prompts and strip passes). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value. When present and `spec-version >= 3`, each concept must include `task=` and `pattern=` tags per-screen (sourced from the spec's task model in §1 and pattern catalog in §4) in addition to the standard surface/archetype/viewport tags.
 
 Display an **Intake Summary** table:
 
@@ -385,7 +391,9 @@ NAV CONTRACT (REQUIRED):
  appendix + archetype contract from NAVIGATION.md. Concatenate shared
  sections (a11y, states, anti-patterns). Inject using the template at
  ~/.agents/skills/nav-spec/references/injection-snippet-template.md.
- Size budget: ≤600 tokens.
+ When spec-version >= 3, the Classification section must include Task
+ (from §1 task model) and Pattern (from §4 pattern catalog) for this
+ concept's primary screen. Size budget: ≤500 essential, ≤800 combined.
  If NAVIGATION.md absent: OMIT this entire block. Describe header/footer
  inline in PAGE STRUCTURE as before (legacy behavior).]
 

--- a/.agents/skills/update/SKILL.md
+++ b/.agents/skills/update/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: update
 description: Update Session Context
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+backend_only: true
 ---
 
 # /update - Update Session Context

--- a/.agents/skills/work-plan/SKILL.md
+++ b/.agents/skills/work-plan/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: work-plan
 description: Work Planning
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /work-plan - Work Planning
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "work-plan")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Generate a rolling N-day work schedule with Google Calendar events per venture.
 

--- a/.claude/commands/nav-spec.md
+++ b/.claude/commands/nav-spec.md
@@ -1,6 +1,6 @@
 ---
 name: nav-spec
-description: Author or revise `.stitch/NAVIGATION.md` — the navigation specification that eliminates chrome drift across Stitch-generated screens and live code.
+description: Author or revise `.stitch/NAVIGATION.md` — the per-venture three-layer navigation specification (IA + patterns + chrome) that eliminates drift across Stitch-generated screens and live code.
 ---
 
 # /nav-spec - Navigation Specification
@@ -12,9 +12,10 @@ Invokes the `nav-spec` skill (`~/.agents/skills/nav-spec/`). Produces or revises
 ```
 /nav-spec                        # Author (first time) or check status (if spec exists)
 /nav-spec --revise [flags]       # Update existing spec
-/nav-spec --audit                # Run drift audit only, no authoring
+/nav-spec --drift-audit          # Run chrome drift audit only
+/nav-spec --ia-audit             # Run IA audit (orphans, dead-ends, pattern violations)
 /nav-spec --phase-0              # Re-run Phase 0 injection compliance test
-/nav-spec --classify-help        # Show classification decision rubric
+/nav-spec --classify-help        # Show classification decision rubric (5 tags)
 ```
 
 ### Revise flags
@@ -32,16 +33,32 @@ Invokes the `nav-spec` skill (`~/.agents/skills/nav-spec/`). Produces or revises
    - Absent + no flags → `workflows/author.md`
    - Present + `--revise` → `workflows/revise.md`
    - Present + no flags → status summary + suggest next action
-   - `--audit` → `workflows/audit.md`
+   - `--drift-audit` → `workflows/drift-audit.md`
+   - `--ia-audit` → `workflows/ia-audit.md`
    - `--phase-0` → `workflows/phase-0-compliance-test.md`
 3. Produces artifacts:
    - `.stitch/NAVIGATION.md` (primary output)
-   - `.stitch/drift-audit-<YYYY-MM-DD>.md` (audit runs)
+   - `.stitch/drift-audit-<YYYY-MM-DD>.md` (drift audit runs)
+   - IA audit report (ia-audit runs)
    - Phase 0 compliance report copied to the skill's `examples/` folder for reuse
 
-## After first run
+## Classification (v3)
 
-On first successful author, the command produces a **separate PR** with edits to `stitch-design` and `stitch-ux-brief` that consume the new spec via graceful-degradation guards. This PR lands after the NAVIGATION.md itself — never bundled.
+v3 requires 5 classification tags per screen generation:
+
+```
+surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+viewport=<mobile|desktop>
+task=<short-name from venture's task model>
+pattern=<name from pattern-catalog.md>
+```
+
+`task=` and `pattern=` are required because chrome alone never determines a pattern. Run `/nav-spec --classify-help` for the decision rubric.
+
+## Integration
+
+The `stitch-design` and `stitch-ux-brief` skills consume `.stitch/NAVIGATION.md` via graceful-degradation guards. When the spec is present, nav contracts are injected into Stitch prompts and the validator runs post-generation. When absent, both skills fall back to legacy behavior with zero behavior change. v3 rules (R25, R26) soft-skip when their inputs are missing, so v1/v2 specs remain compatible.
 
 ## Execution
 

--- a/.claude/commands/platform-audit.md
+++ b/.claude/commands/platform-audit.md
@@ -1,0 +1,100 @@
+# /platform-audit - Platform Audit
+
+End-to-end senior-engineer audit of the crane operating system. Catches sprawl, dead code, incomplete migrations, and accumulated cruft before they compound. Produces a kill / fix / invest list a Captain can act on.
+
+## Scope
+
+**In scope (the support OS):**
+
+- `workers/` (crane-context, crane-mcp-remote, crane-watch)
+- `packages/` (crane-mcp, crane-test-harness)
+- `.agents/skills/`, `.agents/agents/`, `.claude/settings.json` hooks
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` instruction files
+- The MCP tool surface (local + remote)
+- D1 schemas in `workers/crane-context/migrations/`
+- `docs/` tree
+- `crane_docs` uploaded documents (via `crane_doc_audit`)
+- `MEMORY.md` and satellite files
+- `scripts/` shell scripts
+- `.github/workflows/`
+
+**Out of scope:**
+
+- Individual venture product codebases (vc-web, dc-marketing, dfg-console, sc-console, kidexpenses) - those are `/code-review` or `/enterprise-review`.
+- Anything outside the crane-console repo.
+
+## Process
+
+### 1. Recon (inline, cheap)
+
+- `ls` of `workers/`, `packages/`, `scripts/`, `.agents/`, `docs/`, `.github/workflows/`
+- Count skills, migrations, scripts, workflows
+- `git log --oneline -20` for recent activity
+
+### 2. Spawn 6 parallel Explore agents
+
+Launch all six in a single message. Each gets a focused brief and reports under 1500 words. Each must end with kill / fix / keep lists with file paths and line numbers.
+
+| #   | Domain                    | Look for                                                                                                                                                                                                                                           |
+| --- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Workers & packages**    | God files (>500 LOC), dead exports, duplication across workers (esp. GitHub signature validation, HTTP clients, auth), layer violations, `console.log` in production paths, test pathology (over-mocking, test files larger than source)           |
+| 2   | **Skills, agents, hooks** | Skill overlap (lifecycle / review / editorial clusters), AGENTS.md vs GEMINI.md drift, settings.json deny/allow precedence, skill bloat (SKILL.md >10KB), CLAUDE.md content that should be in fetched docs                                         |
+| 3   | **MCP tool surface**      | Schema token cost at session start, action-enum sprawl in single tools (red flag: tool with >5 actions), dead tools (grep for usage), local-vs-remote MCP drift                                                                                    |
+| 4   | **D1 datastores**         | Dead tables (defined in schema, never written), schema sprawl (tables with 25+ columns), missing indices on hot paths, vague `meta_json`/`details_json` columns, migration history smells (drop-and-rebuild patterns, missing baseline migrations) |
+| 5   | **Documentation**         | Stale subdirs (>30 days), contradictions (same fact in 3 places with 3 versions), fragmented bootstrap instructions, `crane_docs` manifest health, `MEMORY.md` sprawl, orphaned handoffs                                                           |
+| 6   | **Scripts & ops**         | Bootstrap script overlap, incomplete migrations (find legacy + new running in parallel), dead scripts (verify with grep), failing GitHub Actions workflows (root cause, not just "it's red")                                                       |
+
+### 3. Synthesize as a senior-engineer report
+
+Required sections:
+
+- **TL;DR** - 3-4 sentences
+- **Critical / fix this week** - 5-10 items max with file:line refs and exact fixes
+- **Inventory** - sized table
+- **Findings by domain** - condensed (don't repeat the deep-dive agent reports verbatim)
+- **Cross-cutting themes** - patterns across domains (incomplete migrations, inline duplication, god files, hardcoded indexes, etc.)
+- **Kill list / Fix list / Invest list**
+- **Risk assessment**
+- **What was deliberately not audited**
+
+### 4. Save the report
+
+Write to `docs/reviews/{YYYY-MM-DD}-platform-audit.md`. Use the actual current date.
+
+### 5. Compare to the prior audit
+
+Find the most recent prior audit: `ls -t docs/reviews/*-platform-audit.md`. If one exists, surface:
+
+- **Still on the list** - items that haven't been addressed (this is the most important section)
+- **New** - sprawl that accumulated since last audit
+- **Resolved** - progress
+
+If no prior audit exists on disk, check branch `audit/platform-audit-skill-and-report` for the original 2026-04-11 report: `git show audit/platform-audit-skill-and-report:docs/reviews/2026-04-11-platform-audit.md`
+
+### 6. Record completion
+
+Log to the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "Platform Audit", result: "success", summary: "{grade or headline}", completed_by: "crane-mcp")
+```
+
+### 7. Offer to act on findings
+
+Ask the Captain whether to:
+
+1. File the critical-list items as GitHub issues (with appropriate labels)
+2. Open a PR for the mechanical kill-list deletions
+3. Drill into any specific finding
+
+## Honesty bar
+
+Be unflinching. Name files, line numbers, and specific anti-patterns. Acknowledge what's well-built - but the point is to catch problems early, not to write a flattering report. The Captain wants the version a senior team would deliver in an out-brief.
+
+## Rules
+
+- Must run from crane-console only.
+- All GitHub issues this session target venturecrane/crane-console. Targeting a different repo? STOP.
+- Never write the report to the previous audit's filename - always use today's date.
+- Do NOT execute the kill list automatically. Always ask first.
+- Use `model: "sonnet"` for Explore agents. Reserve opus for the synthesis step.

--- a/.claude/commands/skill-audit.md
+++ b/.claude/commands/skill-audit.md
@@ -1,0 +1,50 @@
+---
+name: skill-audit
+description: Monthly skill health report. Audits all SKILL.md files for schema gaps, staleness, and deprecation queue status.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-audit - Monthly Skill Health Report
+
+Invoke the `crane_skill_audit` MCP tool and walk through the report.
+
+## How to run
+
+```
+/skill-audit
+```
+
+This command:
+
+1. Calls `crane_skill_audit()` with default parameters (`scope: all`, `stale_threshold_days: 180`, `include_deprecated: true`).
+2. Displays the structured report with sections for inventory, schema gaps, staleness, and the deprecation queue.
+3. Prompts you to review any flagged items.
+4. Records completion via `crane_schedule(action: "complete", name: "skill-audit", ...)`.
+
+## What to expect
+
+The report contains four sections:
+
+- **Inventory** - Total skills by scope, status, and owner.
+- **Schema gaps** - Skills missing required frontmatter fields. Each entry shows which fields are missing.
+- **Staleness** - Skills not touched in git for more than 180 days, sorted worst-first.
+- **Deprecation queue** - Skills with `status: deprecated`, sorted by days until sunset.
+
+Reference drift checking (broken MCP tool / file / command references) is not included here. Run `/skill-review --all` separately for that.
+
+## Options
+
+You can customize the audit:
+
+```
+crane_skill_audit(scope: "enterprise")          # enterprise skills only
+crane_skill_audit(stale_threshold_days: 90)     # tighter staleness window
+crane_skill_audit(include_deprecated: false)    # exclude deprecated from counts
+```
+
+## Full workflow
+
+See `.agents/skills/skill-audit/SKILL.md` for the complete step-by-step workflow including how to act on each report section and record completion.

--- a/.claude/commands/skill-deprecate.md
+++ b/.claude/commands/skill-deprecate.md
@@ -1,0 +1,29 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-deprecate
+
+Captain-gated skill sunset flow. Marks a skill as deprecated, injects a warning banner, logs it to `docs/skills/deprecated.md`, and opens a PR for review. Does not delete the skill.
+
+## Usage
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+## Execution
+
+Follow the full skill specification at `.agents/skills/skill-deprecate/SKILL.md`.
+
+Key points:
+
+- Requires explicit Captain confirmation in chat before any changes are made
+- Fails fast if the skill does not exist or is already deprecated
+- 90-day grace period: the skill stays invocable until a separate removal PR
+- Never merges automatically

--- a/.claude/commands/skill-review.md
+++ b/.claude/commands/skill-review.md
@@ -1,0 +1,72 @@
+---
+name: skill-review
+description: Lint a skill or the entire repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-review
+
+Lint a skill directory or all skills against the schema in `docs/skills/governance.md`.
+
+## Usage
+
+```
+/skill-review [skill-name] [--strict]
+```
+
+- `/skill-review` - review all skills in advisory mode (always exits 0)
+- `/skill-review sos` - review the `sos` skill only
+- `/skill-review --strict` - review all skills, exit 1 on errors
+- `/skill-review sos --strict` - review `sos`, exit 1 on errors
+
+## What the Agent Does
+
+When you invoke `/skill-review`, the agent runs:
+
+```bash
+# Single skill
+npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
+
+# All skills
+npm run skill-review -w @venturecrane/crane-mcp -- --all [--strict] [--json]
+```
+
+The CLI builds from TypeScript, runs all five checks against each `SKILL.md`, then prints a human-readable report (or JSON with `--json`).
+
+## Output
+
+Human-readable (default):
+
+```
+Reviewed 12 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" not found on PATH
+  Fix: Install "jq" or remove it from depends_on.commands if it is optional.
+```
+
+JSON (with `--json`):
+
+```json
+{
+  "skills_reviewed": 12,
+  "total_violations": 2,
+  "by_severity": { "error": 1, "warning": 1, "info": 0 },
+  "violations": [...]
+}
+```
+
+## Exit Codes
+
+- Default (advisory): always exits 0
+- `--strict`: exits 1 if any `error`-severity violations are found
+
+## Reference
+
+Full governance spec and rule definitions: `docs/skills/governance.md`
+
+CLI source: `packages/crane-mcp/src/cli/skill-review.ts`

--- a/.claude/commands/stitch-design.md
+++ b/.claude/commands/stitch-design.md
@@ -1,0 +1,22 @@
+---
+name: stitch-design
+description: Unified entry point for Stitch design work. Handles prompt enhancement, design system synthesis, and high-fidelity screen generation via Stitch MCP.
+version: 1.0.0
+scope: global
+owner: agent-team
+status: stable
+---
+
+# /stitch-design - Stitch Design Expert
+
+Thin dispatcher for the `stitch-design` skill. The full workflow lives at `~/.agents/skills/stitch-design/SKILL.md` (mirrored from `crane-console/.agents/skills/stitch-design/` via `syncGlobalSkills`).
+
+## Usage
+
+```
+/stitch-design [description of what you want to design]
+```
+
+When invoked, the skill guides you through: prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (`.stitch/DESIGN.md`), and high-fidelity screen generation or editing via Stitch MCP.
+
+See the full SKILL.md for workflow details, Stitch MCP fallback patterns, and the companion `/nav-spec` integration.

--- a/.gemini/commands/platform-audit.toml
+++ b/.gemini/commands/platform-audit.toml
@@ -1,0 +1,103 @@
+description = "Platform Audit"
+
+prompt = """
+
+End-to-end senior-engineer audit of the crane operating system. Catches sprawl, dead code, incomplete migrations, and accumulated cruft before they compound. Produces a kill / fix / invest list a Captain can act on.
+
+## Scope
+
+**In scope (the support OS):**
+
+- `workers/` (crane-context, crane-mcp-remote, crane-watch)
+- `packages/` (crane-mcp, crane-test-harness)
+- `.agents/skills/`, `.agents/agents/`, `.claude/settings.json` hooks
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` instruction files
+- The MCP tool surface (local + remote)
+- D1 schemas in `workers/crane-context/migrations/`
+- `docs/` tree
+- `crane_docs` uploaded documents (via `crane_doc_audit`)
+- `MEMORY.md` and satellite files
+- `scripts/` shell scripts
+- `.github/workflows/`
+
+**Out of scope:**
+
+- Individual venture product codebases (vc-web, dc-marketing, dfg-console, sc-console, kidexpenses) - those are `/code-review` or `/enterprise-review`.
+- Anything outside the crane-console repo.
+
+## Process
+
+### 1. Recon (inline, cheap)
+
+- `ls` of `workers/`, `packages/`, `scripts/`, `.agents/`, `docs/`, `.github/workflows/`
+- Count skills, migrations, scripts, workflows
+- `git log --oneline -20` for recent activity
+
+### 2. Spawn 6 parallel Explore agents
+
+Launch all six in a single message. Each gets a focused brief and reports under 1500 words. Each must end with kill / fix / keep lists with file paths and line numbers.
+
+| #   | Domain                    | Look for                                                                                                                                                                                                                                           |
+| --- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Workers & packages**    | God files (>500 LOC), dead exports, duplication across workers (esp. GitHub signature validation, HTTP clients, auth), layer violations, `console.log` in production paths, test pathology (over-mocking, test files larger than source)           |
+| 2   | **Skills, agents, hooks** | Skill overlap (lifecycle / review / editorial clusters), AGENTS.md vs GEMINI.md drift, settings.json deny/allow precedence, skill bloat (SKILL.md >10KB), CLAUDE.md content that should be in fetched docs                                         |
+| 3   | **MCP tool surface**      | Schema token cost at session start, action-enum sprawl in single tools (red flag: tool with >5 actions), dead tools (grep for usage), local-vs-remote MCP drift                                                                                    |
+| 4   | **D1 datastores**         | Dead tables (defined in schema, never written), schema sprawl (tables with 25+ columns), missing indices on hot paths, vague `meta_json`/`details_json` columns, migration history smells (drop-and-rebuild patterns, missing baseline migrations) |
+| 5   | **Documentation**         | Stale subdirs (>30 days), contradictions (same fact in 3 places with 3 versions), fragmented bootstrap instructions, `crane_docs` manifest health, `MEMORY.md` sprawl, orphaned handoffs                                                           |
+| 6   | **Scripts & ops**         | Bootstrap script overlap, incomplete migrations (find legacy + new running in parallel), dead scripts (verify with grep), failing GitHub Actions workflows (root cause, not just "it's red")                                                       |
+
+### 3. Synthesize as a senior-engineer report
+
+Required sections:
+
+- **TL;DR** - 3-4 sentences
+- **Critical / fix this week** - 5-10 items max with file:line refs and exact fixes
+- **Inventory** - sized table
+- **Findings by domain** - condensed (don't repeat the deep-dive agent reports verbatim)
+- **Cross-cutting themes** - patterns across domains (incomplete migrations, inline duplication, god files, hardcoded indexes, etc.)
+- **Kill list / Fix list / Invest list**
+- **Risk assessment**
+- **What was deliberately not audited**
+
+### 4. Save the report
+
+Write to `docs/reviews/{YYYY-MM-DD}-platform-audit.md`. Use the actual current date.
+
+### 5. Compare to the prior audit
+
+Find the most recent prior audit: `ls -t docs/reviews/*-platform-audit.md`. If one exists, surface:
+
+- **Still on the list** - items that haven't been addressed (this is the most important section)
+- **New** - sprawl that accumulated since last audit
+- **Resolved** - progress
+
+If no prior audit exists on disk, check branch `audit/platform-audit-skill-and-report` for the original 2026-04-11 report: `git show audit/platform-audit-skill-and-report:docs/reviews/2026-04-11-platform-audit.md`
+
+### 6. Record completion
+
+Log to the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "Platform Audit", result: "success", summary: "{grade or headline}", completed_by: "crane-mcp")
+```
+
+### 7. Offer to act on findings
+
+Ask the Captain whether to:
+
+1. File the critical-list items as GitHub issues (with appropriate labels)
+2. Open a PR for the mechanical kill-list deletions
+3. Drill into any specific finding
+
+## Honesty bar
+
+Be unflinching. Name files, line numbers, and specific anti-patterns. Acknowledge what's well-built - but the point is to catch problems early, not to write a flattering report. The Captain wants the version a senior team would deliver in an out-brief.
+
+## Rules
+
+- Must run from crane-console only.
+- All GitHub issues this session target venturecrane/crane-console. Targeting a different repo? STOP.
+- Never write the report to the previous audit's filename - always use today's date.
+- Do NOT execute the kill list automatically. Always ask first.
+- Use `model: "sonnet"` for Explore agents. Reserve opus for the synthesis step.
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage/
 
 # Performance
 .lighthouseci/
+
+# Ephemeral agent worktrees (created by EnterWorktree tool)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Cleans up the pre-existing uncommitted agent tooling that has been sitting on disk across several sessions. Prior handoffs noted this as "intentionally untouched"; this PR gets the tree clean.

**What's in here:**
- 15 modified `.agents/skills/*/SKILL.md` — adds frontmatter (version, scope, owner, status) + a preamble to call `crane_skill_invoked()` so skill-audit can track usage
- 30+ new skill/command definitions (`analytics`, `build-log`, `content-scan`, `docs-refresh`, `edit-article`, `edit-log`, `enterprise-review`, `go-live`, `nav-spec`, `new-venture`, `platform-audit`, `portfolio-review`, `skill-audit`, `skill-deprecate`, `skill-review`, `stitch-design`)
- New `.claude/commands/*.md` slash shims
- New `.gemini/commands/platform-audit.toml`
- `.gitignore` now excludes `.claude/worktrees/` — ephemeral agent scratch directory that shouldn't be tracked

**Intentionally not committed:**
- `.claude/handoff.md` — session-managed by `/eos`, leaving for the next end-of-session cycle
- `docs/reviews/code-review-2026-04-16.md` — going in a separate PR as the `/code-review` artifact

## Test plan

- [x] `npm run typecheck` — 0 errors (no code changes)
- [x] `npm test` — passes (no code changes)
- [x] Gitleaks — clean
- [ ] Sanity-check that `.claude/worktrees/` doesn't accidentally break any tooling that expects it tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)