### PR TITLE
fix(portal): remove remaining Pattern B fabrications (#398, #419)

### DIFF
--- a/docs/reviews/code-review-2026-04-17.md
+++ b/docs/reviews/code-review-2026-04-17.md
@@ -1,0 +1,440 @@
+# Complete Code Review - 2026-04-17
+
+Scope: full repository review of SMD Services, with extra attention on client-facing AI slop, fabricated commitments, tenant scoping, test quality, deployment hygiene, and Golden Path readiness.
+
+Reviewer: Codex
+
+## Verdict
+
+Overall grade: C
+
+The project is healthier than the previous 2026-04-16 review in some areas: `npm run verify` passes, `react` is now declared, worker dry-run checks exist in CI, and several prior Pattern A/B strings have been removed. The remaining issues are still serious. The highest-risk problems are not syntax or build failures. They are product integrity issues: client-facing pages still synthesize promises and line items from non-authoritative fields, portal data access still relies too much on entity-only scoping, and tests often lock in implementation strings instead of verifying behavior.
+
+This is the exact shape of AI slop in a production codebase: plausible copy, TODO-backed fallbacks, and brittle tests that make unfinished work look complete.
+
+## Scorecard
+
+| Area                            | Grade | Notes                                                                                                        |
+| ------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ |
+| Client-facing content integrity | D     | Multiple live portal and SOW paths still fabricate or infer commitments.                                     |
+| Tenant isolation                | C     | User lookup improved, but entity-only portal DAL and time-entry DAL still leave avoidable cross-tenant risk. |
+| Test quality                    | C-    | Good volume, weak assertions. Several tests bless unsafe implementation details.                             |
+| Build and CI                    | B-    | `npm run verify` passes, but warning noise and generated artifacts hide real problems.                       |
+| Deployment hygiene              | C     | Social-listening worker verifies but does not deploy. Runtime binding/config warnings remain.                |
+| Dependency/security hygiene     | C     | Audit fails on moderate dev-tool advisories with no current fix.                                             |
+| Documentation and agent context | C-    | Agent guidance is partly stale and still contains old client-facing template commitments.                    |
+| Architecture maintainability    | C     | Large route files mix data access, business rules, UI, and copy.                                             |
+
+## Verification Run
+
+Commands run:
+
+```bash
+npm audit --audit-level=moderate
+npm run verify
+```
+
+Results:
+
+- `npm run verify` passed.
+- Tests: 40 files, 39 passed, 1 skipped; 1152 passed, 2 skipped.
+- `npm audit --audit-level=moderate` failed with 5 moderate advisories through the `yaml` package in `@astrojs/check`/language-server tooling. No fix is currently available from npm audit.
+- Build and typecheck produce warnings that should not be ignored: generated `coverage/` and `.claude/worktrees/` files are included in checks, the Cloudflare adapter warns about the expected `SESSION` binding, and `src/pages/404.astro` reads request headers while prerendering.
+
+## Critical Findings
+
+### 1. Portal quotes still render derived deliverables from line items
+
+File: `src/pages/portal/quotes/[id].astro:77-93`
+
+The portal quote page prefers authored deliverables, then falls back to line items:
+
+```ts
+const deliverables: DeliverableRow[] =
+  authoredDeliverables.length > 0
+    ? authoredDeliverables
+    : lineItems.map((item) => ({
+        title: getProblemLabel(item.problem),
+        body: item.description ?? '',
+      }))
+```
+
+This is still Pattern B. Line items are pricing/problem data, not authored client-facing deliverables. The inline comment says the fallback is temporary, but the page is live and client-facing. The test suite also blesses the fallback at `tests/quotes-authored-content.test.ts:439-443`, so CI currently protects the unsafe behavior.
+
+Required fix:
+
+- Remove the fallback from client-visible quote rendering.
+- Backfill existing quotes with authored deliverables or mark legacy quotes with an explicit non-client-rendering state.
+- Replace the test with a negative assertion that client-visible quote pages never derive deliverables from line items.
+
+### 2. Signed quote next-step copy is synthesized from `scope_summary`
+
+File: `src/pages/portal/quotes/[id].astro:150-157`
+
+The signed-state next step uses authored `next_touchpoint_label` when present, but otherwise builds a new client-facing promise from `engagement.scope_summary`:
+
+```ts
+engagement?.scope_summary ? `Kickoff next: ${engagement.scope_summary}.` : null
+```
+
+`scope_summary` is not an authored next-step field. This turns a summary into operational commitment copy. That is Pattern A/B hybrid behavior.
+
+Required fix:
+
+- Render only explicit, reviewed next-step copy.
+- If `next_touchpoint_label` is missing, render nothing or an explicit internal/admin state. Do not compose a promise from `scope_summary`.
+
+### 3. Portal dashboard fabricates next-check-in promises
+
+File: `src/pages/portal/index.astro:272-277` and `src/pages/portal/index.astro:403-416`
+
+When no authored touchpoint exists, the portal promises that the consultant will reach out:
+
+```ts
+;`${consultantFirst} will reach out to schedule the next check-in.`
+```
+
+and:
+
+```astro
+{consultantFirst} will reach out to schedule the next touchpoint.
+```
+
+These are client-facing future behavior promises with no authored engagement data behind them.
+
+Required fix:
+
+- Remove both fallbacks.
+- Require `next_touchpoint_label` or `next_touchpoint_at` for any next-step copy.
+- If no next touchpoint is authored, render a neutral status only.
+
+### 4. Invoice detail page invents invoice line-item descriptions
+
+File: `src/pages/portal/invoices/[id].astro:84-97`
+
+If no invoice line items exist, the page displays:
+
+```ts
+description: invoice.description ?? engagement?.scope_summary ?? 'Engagement work'
+```
+
+`Engagement work` is fabricated invoice content. `scope_summary` is also not necessarily authored as invoice line-item copy. This is especially risky because invoices are payment-facing records.
+
+Required fix:
+
+- Require invoice line items before an invoice can be sent.
+- Remove the fallback row from client-visible rendering.
+- Add a send gate and a behavior test that a sent invoice without line items fails before client exposure.
+
+### 5. Invoice payment CTA can point to a nonexistent endpoint
+
+File: `src/pages/portal/invoices/[id].astro:113-120`, rendered at `src/pages/portal/invoices/[id].astro:324-334` and `src/pages/portal/invoices/[id].astro:506-520`
+
+When `stripe_hosted_url` is absent or `#dev-mode`, the page falls back to:
+
+```ts
+const payHref = stripeUrl ?? `/api/invoices/${invoice.id}/pay`
+```
+
+No matching route exists. A repo search only finds the TODO and the fallback. Tests at `tests/invoices.test.ts:495-499` only check that `payHref` exists, not that the link works.
+
+Required fix:
+
+- Do not render a payment CTA unless a real hosted payment URL exists, or implement the server route behind the CTA.
+- Add a route existence or integration test for the payment CTA path.
+
+## High Findings
+
+### 6. SOW template still contains hardcoded post-signing and stabilization commitments
+
+File: `src/lib/pdf/sow-template.tsx:538-553` and `src/lib/pdf/sow-template.tsx:590-594`
+
+The PDF still hardcodes future behavior:
+
+- Start date confirmation after deposit clears.
+- Stabilization period after handoff.
+- Deposit invoice after signing.
+- Kickoff date confirmation after deposit clears.
+
+The previous fixed-duration phrases were removed, but the template still contains universal commitments. Per `CLAUDE.md:47-66`, post-signing promises must come from authored engagement data or an explicitly reviewed source file.
+
+Required fix:
+
+- Move SOW terms and next-step copy into authored SOW fields, or document a Captain-approved template decision that these commitments apply to every engagement.
+- Update tests to reject generic post-signing promise templates unless those terms are sourced from reviewed SOW data.
+
+### 7. SOW design documentation still preserves old fixed-timeframe commitments
+
+File: `docs/templates/sow-template.md:299-303` and `docs/templates/sow-template.md:331-333`
+
+The template documentation still says:
+
+- Confirm start date within 1 business day.
+- A 2-week stabilization period follows handoff.
+- Confirm kickoff date within one business day.
+
+This conflicts with current code and the no-fabricated-content rule. Because agents use repo docs as context, stale template docs can reintroduce bad commitments.
+
+Required fix:
+
+- Update the template docs to match the current content standard.
+- Add a docs scan for fixed timeframes in client-facing templates.
+
+### 8. Portal entity resolution fetches client entity without org scope
+
+File: `src/lib/portal/session.ts:33-45`
+
+The user lookup is scoped by `userId` and `orgId`, but the entity fetch is not:
+
+```ts
+SELECT * FROM entities WHERE id = ?
+```
+
+If `users.entity_id` is ever stale, migrated incorrectly, or compromised, the portal can resolve an entity outside the session org. The comment says org scope prevents cross-org access, but the second query does not enforce that.
+
+Required fix:
+
+- Change the entity query to `WHERE id = ? AND org_id = ?`.
+- Add a regression test with a user whose `entity_id` points to a different org.
+
+### 9. Portal quote and invoice DAL intentionally avoids org scoping
+
+Files:
+
+- `src/lib/db/quotes.ts:410-445`
+- `src/lib/db/invoices.ts:298-334`
+- `tests/portal-quotes.test.ts:16-45`
+
+The DAL comments explicitly say portal functions are scoped by `entity_id (NOT org_id)`. The tests assert that `orgId` is not accepted or used. Entity IDs are expected to be unique, but this is a weak tenant boundary for a multi-tenant admin/portal system.
+
+Required fix:
+
+- Pass `session.orgId` into portal quote and invoice DAL functions.
+- Scope by both `entity_id` and `org_id`.
+- Replace tests that prohibit `orgId` with tests that require it.
+
+### 10. Portal dashboard follow-up queries drop org scope after finding the engagement
+
+File: `src/pages/portal/index.astro:91-132`
+
+The active engagement query scopes by `entity_id` and `org_id`, but follow-up invoice and milestone queries use only `engagement_id`. The quote list uses only `entity_id`.
+
+Required fix:
+
+- Add `AND org_id = ?` to invoice, milestone, and quote queries.
+- Bind `session.orgId` in every portal query, not just the first one.
+
+### 11. Time-entry DAL can update and delete by raw ID
+
+Files:
+
+- `src/lib/db/time-entries.ts:53-89`
+- `src/lib/db/time-entries.ts:131-197`
+- `src/pages/api/admin/time-entries/[id].ts:43-87`
+
+The API verifies the parent engagement belongs to the admin org before update/delete, which reduces practical risk. The DAL still exposes unsafe primitives:
+
+- `getTimeEntry(db, id)` with no org scope.
+- `updateTimeEntry(db, id, data)` with `UPDATE time_entries SET ... WHERE id = ?`.
+- `deleteTimeEntry(db, id)` with `DELETE FROM time_entries WHERE id = ?`.
+- `recalculateActualHours(db, engagementId)` with no org scope on the engagement update.
+
+Required fix:
+
+- Thread `orgId` through every time-entry DAL function.
+- Scope reads, writes, deletes, and actual-hours recalculation by org.
+- Replace string-inspection tests in `tests/time-entries.test.ts` with behavior tests that prove cross-org IDs cannot be changed.
+
+### 12. Turnstile configuration can silently disable bot protection or break forms
+
+Files:
+
+- `wrangler.toml:31-36`
+- `src/pages/book.astro:10`
+- `src/pages/book.astro:508-606`
+- `src/lib/booking/turnstile.ts:35-43`
+- `src/pages/api/booking/reserve.ts:56-65`
+- `src/pages/api/intake.ts:39-47`
+
+`PUBLIC_TURNSTILE_SITE_KEY` is set to an empty string in `wrangler.toml`. The client skips the widget when that value is empty. The server skips verification only when `TURNSTILE_SECRET_KEY` is missing; if the secret is present and the public key is empty, submissions fail with missing token. If both are absent, production can accept submissions without Turnstile.
+
+Required fix:
+
+- Make Turnstile configuration explicit per environment.
+- Fail startup/build or render an admin-visible configuration error when one key exists without the other.
+- Do not let production silently bypass verification because a secret is missing.
+
+## Medium Findings
+
+### 13. Social-listening worker is verified but not deployed
+
+Files:
+
+- `.github/workflows/verify.yml:53-63`
+- `.github/workflows/deploy.yml:54-85`
+
+CI dry-run builds four workers, including `workers/social-listening`. Deployment only deploys job-monitor, new-business, and review-mining. If social-listening is a real worker, changes can pass CI and never reach production.
+
+Required fix:
+
+- Add install and deploy steps for `workers/social-listening`, or remove it from verify if it is intentionally dormant.
+
+### 14. Lint/typecheck include generated and worktree artifacts
+
+Files:
+
+- `eslint.config.js:18-29`
+- `eslint.config.js:44-46`
+- `tsconfig.json:6`
+
+`npm run verify` passes but emits warning noise from generated `coverage/` files and `.claude/worktrees/`. Real source warnings are mixed into generated-output warnings. `no-unused-vars` and `no-explicit-any` are warnings, not errors.
+
+Required fix:
+
+- Ignore `coverage/**` and `.claude/worktrees/**` in lint, format, and typecheck.
+- After the noise is removed, promote unused vars and explicit `any` to errors for source files.
+
+### 15. SOW PDF rendering tests are skipped
+
+File: `tests/sow-render.test.ts:58-68`
+
+Both SOW PDF render tests are skipped. The comment says build and live deployment validate rendering, but there is no automated test asserting a valid PDF for contractual documents.
+
+Required fix:
+
+- Add a compatible render smoke test, even if it runs in a narrower environment than full Vitest.
+- At minimum, cover the API route that returns the PDF bytes and assert PDF shape, response type, and non-empty content.
+
+### 16. Tests frequently inspect source strings instead of behavior
+
+Examples:
+
+- `tests/portal-quotes.test.ts:16-45` asserts unsafe lack of `orgId`.
+- `tests/quotes-authored-content.test.ts:439-443` asserts a fallback exists instead of proving it is safe.
+- `tests/invoices.test.ts:495-499` checks that `payHref` exists, not that it points to a real route.
+- `tests/time-entries.test.ts:36-80` checks substrings in DAL source instead of behavior.
+
+Required fix:
+
+- Replace source-text tests with route/DAL behavior tests.
+- For client-facing content, test rendered output and provenance.
+- For tenant scoping, use cross-org fixture rows and assert denial.
+
+### 17. Large route files concentrate business logic and copy
+
+Largest examples:
+
+- `src/pages/admin/entities/[id]/quotes/[quoteId].astro` - 1004 lines
+- `src/pages/admin/engagements/[id].astro` - 909 lines
+- `src/pages/book.astro` - 842 lines
+- `src/pages/admin/entities/[id].astro` - 811 lines
+- `src/pages/portal/quotes/[id].astro` - 603 lines
+- `src/pages/portal/invoices/[id].astro` - 550 lines
+
+These files mix SQL, authorization assumptions, view-model assembly, client copy, UI, and inline browser scripts. That structure makes fabricated copy and inconsistent scoping more likely.
+
+Required fix:
+
+- Move portal/admin view-model construction into testable library modules.
+- Keep Astro pages focused on rendering.
+- Centralize client-facing copy resolvers with provenance requirements.
+
+### 18. Agent guidance is stale enough to mislead future agents
+
+File: `CLAUDE.md:17-28`
+
+The file still says this is not a product codebase and that there is no app to build yet. The repository now contains a real Astro app with admin, portal, booking, quotes, invoices, SOW generation, auth, D1, KV, R2, and Workers.
+
+Required fix:
+
+- Update agent guidance to describe the actual application surface.
+- Keep the no-fabricated-content rules, but remove stale repo-purpose statements.
+
+### 19. Cloudflare session binding warning remains unresolved
+
+Files:
+
+- `wrangler.toml:58-61`
+- `src/middleware.ts:103-107`
+
+The app code uses `env.SESSIONS`, and `wrangler.toml` binds `SESSIONS`. Build output warns that the Cloudflare adapter expects a `SESSION` binding for Astro sessions. This might be benign if Astro sessions are not used, but the warning appears on every build and can hide real deployment warnings.
+
+Required fix:
+
+- Confirm whether Astro adapter sessions are enabled or needed.
+- Either configure the adapter to stop requesting `SESSION`, or add the expected binding intentionally.
+
+### 20. `404.astro` reads request headers while prerendering
+
+Build warning:
+
+```text
+Astro.request.headers was used when rendering the route src/pages/404.astro.
+```
+
+Required fix:
+
+- If 404 needs request headers, make it server-rendered.
+- If it does not, remove the request-header dependency.
+
+## Low Findings
+
+### 21. Root Cloudflare worker types are pinned to an old date
+
+File: `tsconfig.json:3-5`
+
+The root type config still uses `@cloudflare/workers-types/2023-07-01` even though `package.json` installs `@cloudflare/workers-types` version `^4.20260417.1`.
+
+Required fix:
+
+- Use the current package-provided types path unless there is a documented reason to pin.
+
+### 22. Open issues appear stale after fixes
+
+Observed issue state:
+
+- Issue #409 is still open, but `package.json:23-33` now declares `react` and `npm run verify` passes.
+- Issue #399 is still open, but the milestone DAL appears to have been improved since the prior review.
+- Issue #404 remains partially open because worker checks and Wrangler versions improved, but root worker types remain stale.
+
+Required fix:
+
+- Reconcile open code-review issues against current code.
+- Close fixed issues with evidence and split remaining acceptance criteria into smaller issues.
+
+## Existing Strengths
+
+- The repo has a single `npm run verify` Golden Path that runs typecheck, worker typecheck, format check, lint, build, and tests.
+- The test suite is broad enough to catch many regressions once assertions are made behavior-first.
+- Prior audit fixes did remove several fixed-duration and generic consultant fallbacks.
+- Auth middleware consistently attaches sessions and renews sessions through a shared helper.
+- D1 queries are parameterized in the reviewed surfaces.
+
+## Recommended Fix Order
+
+1. Remove all remaining client-facing fabricated content in quotes, invoices, portal dashboard, and SOW PDF.
+2. Add org scoping to portal client resolution, quote/invoice DAL, dashboard queries, invoice line items, and time-entry DAL.
+3. Replace tests that bless unsafe source strings with behavior tests for provenance and tenant isolation.
+4. Fix the broken invoice payment CTA and Turnstile production config behavior.
+5. Clean lint/typecheck inputs so generated artifacts and old worktrees do not hide real warnings.
+6. Reconcile deployment CI with actual worker inventory.
+7. Update stale agent guidance and SOW template documentation.
+
+## Issue Coverage Notes
+
+Likely overlaps with existing issues:
+
+- #398: Pattern A/B violations.
+- #399: DAL tenant scoping.
+- #404: platform hygiene.
+- #409: React dependency, likely fixed in code.
+- #362: invoice payment endpoint TODO, referenced from source.
+
+New or not cleanly covered:
+
+- Turnstile production config mismatch.
+- Social-listening worker verified but not deployed.
+- Tests that explicitly protect unsafe no-org-scope and fallback behaviors.
+- Stale agent guidance saying this is not an app codebase.
+
+I did not create VCMS notes or GitHub issues during this review. Repo guidance requires explicit approval for VCMS writes, and issue creation should be done after deciding whether to update existing issues or split new ones.

--- a/src/lib/portal/states.ts
+++ b/src/lib/portal/states.ts
@@ -130,8 +130,9 @@ export function resolveInvoiceState(
  *   6. `default` — render the sign surface
  *
  * nextStepText is the engagement-specific "what happens next" copy, pulled
- * from engagement.scope_summary / next_touchpoint_label by the caller. When
- * missing we fall back to a generic kickoff sentence.
+ * from engagement.next_touchpoint_label by the caller. When missing we
+ * render no next-step copy — we never synthesize client-facing
+ * commitments from non-authoritative fields (CLAUDE.md #398).
  */
 export function resolveProposalState(
   quote: QuoteLike,

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -270,11 +270,13 @@ const touchpointText: string | null = (() => {
 })()
 
 const contextHeadline = activeEngagement ? 'Engagement in flight.' : 'Welcome.'
-const contextSubtext = consultantFirst
-  ? touchpointText
+// Only render a check-in sentence when an authored touchpoint exists. We
+// never synthesize consultant outreach copy — that is uncontracted future
+// behavior per CLAUDE.md's no-fabricated-content policy (#398).
+const contextSubtext =
+  consultantFirst && touchpointText
     ? `Next check-in ${touchpointText} with ${consultantFirst}.`
-    : `${consultantFirst} will reach out to schedule the next check-in.`
-  : null
+    : null
 ---
 
 <!doctype html>
@@ -410,11 +412,6 @@ const contextSubtext = consultantFirst
                 <p class="mt-5 text-base leading-6 text-[color:var(--color-text-secondary)]">
                   Nothing needs your attention right now.
                 </p>
-                {consultantFirst && (
-                  <p class="mt-2 text-[13px] leading-[18px] text-[color:var(--color-text-muted)]">
-                    {consultantFirst} will reach out to schedule the next touchpoint.
-                  </p>
-                )}
               </section>
             )
           }

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -2,11 +2,7 @@
 import '../../../styles/global.css'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
-import {
-  getInvoiceForEntity,
-  listLineItemsForInvoice,
-  type InvoiceLineItem,
-} from '../../../lib/db/invoices'
+import { getInvoiceForEntity, listLineItemsForInvoice } from '../../../lib/db/invoices'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
 import SkipToMain from '../../../components/SkipToMain.astro'
@@ -50,7 +46,13 @@ if (!invoice) {
   return Astro.redirect('/portal')
 }
 
-// Load line items; if none exist, we render a single fallback row below.
+// Line items drive the "What's included" section. We never fabricate
+// invoice content — no generic placeholder rows, no borrow from
+// scope_summary or invoice.description. See CLAUDE.md "No fabricated
+// client-facing content" (#398). A sent invoice without line items
+// renders no breakdown; the Total line still renders. Admin send-gate
+// should prevent this state reaching a client, but the page degrades
+// cleanly if it does.
 const lineItems = await listLineItemsForInvoice(env.DB, invoice.id)
 
 // Load engagement for scope fallback + consultant attribution.
@@ -81,21 +83,6 @@ const lineItemsTotalCents = lineItems.reduce((sum, li) => sum + li.amount_cents,
 // Show the invoice's own amount as Total so rounding always matches the CTA.
 const totalCents = amountCents
 
-// Fallback line item when none are stored for this invoice.
-const displayLineItems: InvoiceLineItem[] =
-  lineItems.length > 0
-    ? lineItems
-    : [
-        {
-          id: 'fallback',
-          invoice_id: invoice.id,
-          description: invoice.description ?? engagement?.scope_summary ?? 'Engagement work',
-          amount_cents: amountCents,
-          sort_order: 0,
-          created_at: invoice.created_at,
-        },
-      ]
-
 // Consultant first name is needed early so we can thread it into the state
 // resolver's next-step copy. Null when the engagement has no consultant.
 const consultantFirstEarly = engagement?.consultant_name
@@ -110,14 +97,16 @@ const isCardExpired = surface.state === 'card_expired'
 const isLinkExpired = surface.state === 'expired'
 const isErrorState = isDeclined || isCardExpired || isLinkExpired
 
-// CTA: prefer Stripe hosted URL when present and usable, otherwise a server
-// endpoint placeholder. The server endpoint is out of scope for this PR.
+// CTA is gated on a real Stripe hosted URL. When it is missing or the
+// dev-mode sentinel, we render a non-link "Payment link pending" state
+// instead of a link to a nonexistent server route (#419 removed the
+// previous `/api/invoices/[id]/pay` fallback, which 404'd). Minting the
+// checkout session on demand is a separate server feature.
 const stripeUrl =
   invoice.stripe_hosted_url && invoice.stripe_hosted_url !== '#dev-mode'
     ? invoice.stripe_hosted_url
     : null
-// TODO(#362): wire /api/invoices/[id]/pay to mint a Stripe checkout session.
-const payHref = stripeUrl ?? `/api/invoices/${invoice.id}/pay`
+const isPayable = stripeUrl !== null
 
 // Formatting
 const formatDueCaption = (iso: string | null): string | null => {
@@ -319,25 +308,31 @@ const consultantFirstName: string | null = consultantName
               )
             }
             {
-              !isPaid && !isLinkExpired && (
-                <>
-                  <a
-                    href={payHref}
-                    class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-                  >
-                    {isDeclined
-                      ? 'Try again'
-                      : isCardExpired
-                        ? 'Update payment method'
-                        : 'Pay invoice'}
-                    <span class="material-symbols-outlined text-[20px]">arrow_forward</span>
-                  </a>
-                  <div class="mt-3 flex items-center gap-2 text-[13px] text-[color:var(--color-text-muted)]">
-                    <span class="material-symbols-outlined text-[16px]">lock</span>
-                    <span>Secure payment via Stripe</span>
+              !isPaid &&
+                !isLinkExpired &&
+                (isPayable ? (
+                  <>
+                    <a
+                      href={stripeUrl!}
+                      class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                    >
+                      {isDeclined
+                        ? 'Try again'
+                        : isCardExpired
+                          ? 'Update payment method'
+                          : 'Pay invoice'}
+                      <span class="material-symbols-outlined text-[20px]">arrow_forward</span>
+                    </a>
+                    <div class="mt-3 flex items-center gap-2 text-[13px] text-[color:var(--color-text-muted)]">
+                      <span class="material-symbols-outlined text-[16px]">lock</span>
+                      <span>Secure payment via Stripe</span>
+                    </div>
+                  </>
+                ) : (
+                  <div class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-surface-muted)] text-[color:var(--color-text-secondary)] text-base font-semibold">
+                    Payment link pending
                   </div>
-                </>
-              )
+                ))
             }
           </div>
 
@@ -351,7 +346,7 @@ const consultantFirstName: string | null = consultantName
             <div class="mt-4 border-t border-[color:var(--color-border)]"></div>
             <ul class="flex flex-col">
               {
-                displayLineItems.map((li) => (
+                lineItems.map((li) => (
                   <li class="flex justify-between items-baseline gap-6 py-5 border-b border-[color:var(--color-border)]/60">
                     <span class="text-[15px] leading-[22px] text-[color:var(--color-text-primary)] max-w-[480px]">
                       {li.description}
@@ -503,22 +498,39 @@ const consultantFirstName: string | null = consultantName
                     </div>
                   </div>
                 )}
-                <ActionCard
-                  pillLabel={
-                    isDeclined ? 'Try again' : isCardExpired ? 'Update payment method' : pillLabel
-                  }
-                  amountCents={amountCents}
-                  amountLabel="Remaining balance"
-                  ctaLabel={
-                    isDeclined
-                      ? 'Try again'
-                      : isCardExpired
-                        ? 'Update payment method'
-                        : 'Pay invoice'
-                  }
-                  ctaHref={payHref}
-                  ctaSubtext="Secure payment via Stripe."
-                />
+                {isPayable ? (
+                  <ActionCard
+                    pillLabel={
+                      isDeclined ? 'Try again' : isCardExpired ? 'Update payment method' : pillLabel
+                    }
+                    amountCents={amountCents}
+                    amountLabel="Remaining balance"
+                    ctaLabel={
+                      isDeclined
+                        ? 'Try again'
+                        : isCardExpired
+                          ? 'Update payment method'
+                          : 'Pay invoice'
+                    }
+                    ctaHref={stripeUrl!}
+                    ctaSubtext="Secure payment via Stripe."
+                  />
+                ) : (
+                  <section
+                    class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-6 sm:p-8"
+                    aria-label="Payment link pending"
+                  >
+                    <span class="inline-flex items-center rounded-full bg-[color:var(--color-surface-muted)] px-3 py-1 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-muted)]">
+                      Payment link pending
+                    </span>
+                    <div class="mt-5">
+                      <MoneyDisplay amountCents={amountCents} size="display" />
+                      <p class="mt-2 text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[color:var(--color-text-muted)]">
+                        Remaining balance
+                      </p>
+                    </div>
+                  </section>
+                )}
               </>
             )
           }

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -8,14 +8,9 @@ import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
 import { getQuoteForEntity, parseSchedule, parseDeliverables } from '../../../lib/db/quotes'
-import type { LineItem, ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
+import type { ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
 import { resolveProposalState } from '../../../lib/portal/states'
-import {
-  PROBLEM_LABELS,
-  LEGACY_PROBLEM_LABELS,
-} from '../../../portal/assessments/extraction-schema'
-import type { ProblemId, LegacyProblemId } from '../../../portal/assessments/extraction-schema'
 
 /**
  * Portal quote detail — C-hybrid proposal landing.
@@ -54,15 +49,8 @@ const sowState = await getSOWStateForQuote(env.DB, session.orgId, quote.id)
 const activeSignatureRequest = sowState.openSignatureRequest
 const downloadableRevision = sowState.downloadableRevision
 
-const lineItems: LineItem[] = JSON.parse(quote.line_items)
-
 const formatDate = (d: string) =>
   new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-
-const getProblemLabel = (problem: string) =>
-  PROBLEM_LABELS[problem as ProblemId] ??
-  LEGACY_PROBLEM_LABELS[problem as LegacyProblemId] ??
-  problem
 
 const depositPctDisplay = Math.round(quote.deposit_pct * 100)
 const balancePctDisplay = 100 - depositPctDisplay
@@ -74,23 +62,14 @@ const paymentSplitText = isThreeMilestone
   ? `${depositPctDisplay}% at signing, balance across milestones.`
   : `${depositPctDisplay}% at signing, ${balancePctDisplay}% at completion.`
 
-// Deliverables prefer the authored `quotes.deliverables` rows. If none have
-// been authored we fall back to deriving from line items so legacy quotes
-// (pre-#377) keep rendering a list. The send-gate added in this issue
-// prevents NEW quotes from going out without authored deliverables; the
-// fallback exists only for the migration window. TODO(#377-followon):
-// once existing quotes have been backfilled or marked, drop the fallback
-// and require authored deliverables on every visible quote.
-const authoredDeliverables: DeliverableRow[] = parseDeliverables(quote)
+// Deliverables come exclusively from the authored `quotes.deliverables`
+// rows. Line items are pricing/problem data — not authored client-facing
+// deliverables — so we never derive the visible list from them. The
+// send-gate (#377) prevents quotes from going out without authored
+// deliverables; legacy quotes missing them render without a deliverables
+// section rather than with fabricated content.
+const deliverables: DeliverableRow[] = parseDeliverables(quote)
 const schedule: ScheduleRow[] = parseSchedule(quote)
-
-const deliverables: DeliverableRow[] =
-  authoredDeliverables.length > 0
-    ? authoredDeliverables
-    : lineItems.map((item) => ({
-        title: getProblemLabel(item.problem),
-        body: item.description ?? '',
-      }))
 
 const engagementTitle = deliverables[0]?.title ?? 'Engagement'
 const engagementSubtitle =
@@ -148,13 +127,11 @@ const superseding = await env.DB.prepare(
   .first<SupersedingRow>()
 
 // Build the concrete "what happens next" string for signed quotes. Render
-// authored copy verbatim — do not prepend fixed phrases. If neither field is
-// set the resolver returns null and the caller renders nothing.
-const nextStepText: string | null = engagement?.next_touchpoint_label
-  ? engagement.next_touchpoint_label
-  : engagement?.scope_summary
-    ? `Kickoff next: ${engagement.scope_summary}.`
-    : null
+// authored copy verbatim — do not synthesize client-facing commitments from
+// non-authoritative fields. When `next_touchpoint_label` is absent the page
+// renders no next-step copy. `scope_summary` is an internal operations
+// field, not authored client-facing next-step language.
+const nextStepText: string | null = engagement?.next_touchpoint_label ?? null
 
 const surface = resolveProposalState(quote, Astro.url.searchParams, consultantFirst, nextStepText)
 
@@ -333,39 +310,39 @@ const consultantPhone = engagement?.consultant_phone ?? null
             </div>
           </div>
 
-          <!-- What you'll get -->
-          <div class="pt-2">
-            <div class="h-px bg-[color:var(--color-border)] mb-8"></div>
-            <h2
-              class="font-['Plus_Jakarta_Sans'] font-bold text-[22px] leading-[28px] text-[color:var(--color-text-primary)] mb-6"
-            >
-              What you'll get
-            </h2>
-            <ul class="space-y-5">
-              {
-                deliverables.map((d) => (
-                  <li class="flex items-start gap-4">
-                    <span
-                      class="material-symbols-outlined text-[color:var(--color-meta)] mt-0.5"
-                      style="font-variation-settings: 'FILL' 1"
-                    >
-                      check_circle
-                    </span>
-                    <div class="min-w-0">
-                      <p class="text-base font-semibold text-[color:var(--color-text-primary)]">
-                        {d.title}
-                      </p>
-                      {d.body && (
-                        <p class="mt-1 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
-                          {d.body}
+          <!-- What you'll get — rendered only when deliverables are authored. -->
+          {
+            deliverables.length > 0 && (
+              <div class="pt-2">
+                <div class="h-px bg-[color:var(--color-border)] mb-8" />
+                <h2 class="font-['Plus_Jakarta_Sans'] font-bold text-[22px] leading-[28px] text-[color:var(--color-text-primary)] mb-6">
+                  What you'll get
+                </h2>
+                <ul class="space-y-5">
+                  {deliverables.map((d) => (
+                    <li class="flex items-start gap-4">
+                      <span
+                        class="material-symbols-outlined text-[color:var(--color-meta)] mt-0.5"
+                        style="font-variation-settings: 'FILL' 1"
+                      >
+                        check_circle
+                      </span>
+                      <div class="min-w-0">
+                        <p class="text-base font-semibold text-[color:var(--color-text-primary)]">
+                          {d.title}
                         </p>
-                      )}
-                    </div>
-                  </li>
-                ))
-              }
-            </ul>
-          </div>
+                        {d.body && (
+                          <p class="mt-1 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
+                            {d.body}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          }
 
           <!-- How we'll work (only when authored — never synthesized; #377) -->
           {

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -492,10 +492,31 @@ describe('invoices: portal detail view', () => {
     expect(existsSync(resolve('src/pages/portal/invoices/[id].astro'))).toBe(true)
   })
 
-  it('renders the Stripe hosted URL as the pay CTA when usable', () => {
+  it('gates the pay CTA on a real Stripe hosted URL', () => {
     const code = source()
+    // The detail page must only link to Stripe when stripe_hosted_url is
+    // present and not the dev-mode sentinel. A missing URL must render a
+    // non-link "Payment link pending" state, not a link to a server route.
     expect(code).toContain('stripe_hosted_url')
-    expect(code).toContain('payHref')
+    expect(code).toContain('isPayable')
+    expect(code).toContain('Payment link pending')
+  })
+
+  it('does not link to a nonexistent /api/invoices/[id]/pay route (#419)', () => {
+    const code = source()
+    // The previous fallback rendered a clickable link to /api/invoices/[id]/pay,
+    // which never existed. This regression guard ensures we never reintroduce it.
+    expect(code).not.toMatch(/\/api\/invoices\/\$\{[^}]*\}\/pay/)
+    expect(code).not.toContain('payHref')
+  })
+
+  it('renders invoice line items without any fabricated fallback (#398)', () => {
+    const code = source()
+    // The page must never invent invoice line-item copy. No "Engagement work",
+    // no borrow from scope_summary, no fallback row synthesized from invoice.description.
+    expect(code).not.toContain('Engagement work')
+    expect(code).not.toContain('displayLineItems')
+    expect(code).not.toMatch(/scope_summary\s*\?\?/)
   })
 })
 

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -135,6 +135,21 @@ describe('portal quotes: dashboard', () => {
     expect(code).not.toContain('/hr')
     expect(code).not.toContain('hourly')
   })
+
+  it('never fabricates consultant "will reach out" promises (#398)', () => {
+    const code = source()
+    // Two prior instances rendered "will reach out to schedule the next
+    // check-in / touchpoint" when no authored touchpoint existed. Those
+    // are uncontracted future-behavior promises and must not reappear.
+    expect(code).not.toMatch(/will reach out/i)
+  })
+
+  it('gates next-check-in subtext on an authored touchpoint', () => {
+    const code = source()
+    // The subtext renders only when both consultantFirst and touchpointText
+    // exist. No fallback phrasing when either is missing.
+    expect(code).toContain('consultantFirst && touchpointText')
+  })
 })
 
 describe('portal quotes: quote list page', () => {
@@ -219,11 +234,15 @@ describe('portal quotes: quote detail page', () => {
     expect(source()).toContain('getPortalClient')
   })
 
-  it('displays scope with problem descriptions only', () => {
+  it('displays scope via authored deliverables only (not line items) (#398)', () => {
     const code = source()
-    expect(code).toContain('lineItems')
-    expect(code).toContain('getProblemLabel')
-    expect(code).toContain('item.description')
+    // Deliverables now come exclusively from parseDeliverables(quote). The
+    // page does not read or iterate line_items for client-facing scope
+    // rendering. Problem labels are no longer used as deliverable titles.
+    expect(code).toContain('parseDeliverables')
+    expect(code).toContain('deliverables.map')
+    expect(code).not.toContain('getProblemLabel')
+    expect(code).not.toMatch(/lineItems\.map/)
   })
 
   it('does NOT show hours column in scope table', () => {

--- a/tests/quotes-authored-content.test.ts
+++ b/tests/quotes-authored-content.test.ts
@@ -436,10 +436,21 @@ describe('portal proposal page: render gating', () => {
     expect(code).not.toMatch(/Week 1.*Week 2.*Week 3/s)
   })
 
-  it('prefers authored deliverables and falls back to line items only when missing', () => {
+  it('never derives deliverables from line items (#398)', () => {
     const code = source()
-    expect(code).toContain('authoredDeliverables.length > 0')
-    expect(code).toContain('? authoredDeliverables')
+    // Deliverables come exclusively from parseDeliverables(quote). The page
+    // must not construct deliverable rows from line_items — line items are
+    // pricing/problem data, not authored client-facing content.
+    expect(code).not.toMatch(/lineItems\.map\(\s*\(?\s*item/)
+    expect(code).not.toContain('authoredDeliverables')
+    expect(code).not.toContain('getProblemLabel')
+  })
+
+  it('gates the deliverables section on deliverables.length > 0', () => {
+    const code = source()
+    // Parallel to the schedule section gate — empty = render nothing, not
+    // an empty section header.
+    expect(code).toContain('deliverables.length > 0')
   })
 
   it('iterates schedule rows by label and body, not hardcoded week numbers', () => {
@@ -447,6 +458,15 @@ describe('portal proposal page: render gating', () => {
     expect(code).toContain('schedule.map')
     expect(code).toContain('row.label')
     expect(code).toContain('row.body')
+  })
+
+  it('never synthesizes "Kickoff next: {scope_summary}" next-step copy (#398)', () => {
+    const code = source()
+    // scope_summary is an internal operations field, not authored next-step
+    // language. The previous synthesis turned it into a client-facing
+    // commitment. Only authored next_touchpoint_label feeds nextStepText.
+    expect(code).not.toContain('Kickoff next:')
+    expect(code).not.toMatch(/engagement\.scope_summary\s*\?/)
   })
 })
 


### PR DESCRIPTION
## Summary

The 2026-04-17 external code review found five client-facing fabrication paths still live after the 2026-04-15 audit. This PR removes the mechanisms — not just the loudest strings — so the portal cannot synthesize commitments from non-authoritative fields.

- **Proposal detail** (\`src/pages/portal/quotes/[id].astro\`) — drop the \`lineItems.map\` fallback that derived deliverables from pricing data. Drop the \`Kickoff next: \${scope_summary}\` synthesis. Gate the "What you'll get" section on \`deliverables.length > 0\`.
- **Dashboard** (\`src/pages/portal/index.astro\`) — drop both "\${consultantFirst} will reach out to schedule the next check-in / touchpoint" fallbacks.
- **Invoice detail** (\`src/pages/portal/invoices/[id].astro\`) — drop the \`'Engagement work'\` fallback line item and the \`scope_summary\`/\`invoice.description\` borrow.
- **Invoice Pay CTA** (\`src/pages/portal/invoices/[id].astro\`) — gate on a real Stripe hosted URL; render a non-link "Payment link pending" state when absent instead of linking to \`/api/invoices/[id]/pay\`, a route that does not exist.

Closes #419. Advances #398 (the SOW template hardcoded commitments are called out separately in the issue comment; those need a Captain decision on whether the terms are universal).

## Test plan

- [x] \`npm run verify\` passes (1158 passed, 2 skipped)
- [x] Tests that previously blessed the fallbacks are replaced with negative assertions:
  - \`tests/quotes-authored-content.test.ts\` — asserts no line-items→deliverables derivation, no \`Kickoff next:\` synthesis
  - \`tests/invoices.test.ts\` — asserts no \`/api/invoices/[id]/pay\` link, no fabricated line-item strings
  - \`tests/portal-quotes.test.ts\` — asserts no "will reach out" fallbacks in dashboard
- [ ] Manual smoke on preview: a signed quote renders without "Kickoff next" when no touchpoint is authored; an invoice without a Stripe URL shows "Payment link pending" (not a dead link); dashboard with no touchpoint shows no subtext.

## Not in this PR

- SOW template hardcoded post-signing commitments (finding #6) — kept open on #398 pending Captain decision on whether these terms should be universal or move to authored fields.
- \`docs/templates/sow-template.md\` stale timeframe language (finding #7).
- Tenant scoping findings (#8-#11) — tracked on #399 and shipping in a separate PR.
- Turnstile config, worker deploy, 404 prerender — separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)