### PR TITLE
chore: ignore generated dirs + skip middleware cookie read on static routes (#14a, #20)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 .claude/
 wrangler.toml
+coverage/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,15 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['**/dist/**', '**/node_modules/**', '**/.wrangler/**', '**/.astro/**'],
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/.wrangler/**',
+      '**/.astro/**',
+      // Generated / ephemeral artifacts — ignored so real source warnings
+      // surface instead of drowning in noise (#14a from 2026-04-17 audit).
+      'coverage/**',
+      '.claude/worktrees/**',
+    ],
   }
 )

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -93,18 +93,29 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const isPortalApiRoute = pathname.startsWith('/api/portal')
   const isProtectedRoute = isAdminRoute || isAdminApiRoute || isPortalRoute || isPortalApiRoute
 
-  // Always try to resolve session from cookie (even on unprotected routes)
-  // so endpoints like /api/auth/google/connect can read locals.session
-  const cookieHeader = context.request.headers.get('cookie')
-  const token = parseSessionToken(cookieHeader)
+  // Resolve session from cookie only on routes that can actually use it.
+  // Marketing pages are prerendered and reading request headers during
+  // prerender triggers a build-time warning (#20). Restricting the cookie
+  // read to routes that have a session use case (admin/portal surfaces,
+  // auth flows, API endpoints including /api/auth/google/connect) eliminates
+  // the warning and avoids pointless work on public static paths.
+  const isAuthRoute = pathname.startsWith('/auth')
+  const isApiRoute = pathname.startsWith('/api/')
+  const needsSession = isProtectedRoute || isAuthRoute || isApiRoute
 
-  if (token) {
-    const env = context.locals.runtime.env
-    const sessionData = await validateSession(env.DB, env.SESSIONS, token)
-    if (sessionData) {
-      context.locals.session = sessionData
-      // Renew session (sliding window) — fire and forget
-      renewSession(env.DB, env.SESSIONS, token, sessionData).catch(() => {})
+  let token: string | null = null
+  if (needsSession) {
+    const cookieHeader = context.request.headers.get('cookie')
+    token = parseSessionToken(cookieHeader)
+
+    if (token) {
+      const env = context.locals.runtime.env
+      const sessionData = await validateSession(env.DB, env.SESSIONS, token)
+      if (sessionData) {
+        context.locals.session = sessionData
+        // Renew session (sliding window) — fire and forget
+        renewSession(env.DB, env.SESSIONS, token, sessionData).catch(() => {})
+      }
     }
   }
 

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -130,6 +130,28 @@ describe('middleware: portal rewrite preserved (regression)', () => {
   })
 })
 
+describe('middleware: session resolution gating (#20)', () => {
+  const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('only reads the cookie header on routes that can use a session', () => {
+    const code = source()
+    // Marketing pages are prerendered; reading request headers during
+    // prerender triggers a build warning. The cookie read must be gated
+    // behind a `needsSession` check so static pages stay clean.
+    expect(code).toContain('const needsSession =')
+    expect(code).toMatch(/if\s*\(\s*needsSession\s*\)/)
+  })
+
+  it('needsSession includes protected, auth, and API routes', () => {
+    const code = source()
+    // All three classes can legitimately consume locals.session:
+    // - protected (admin/portal) require it
+    // - auth routes read it (e.g. renewal flows)
+    // - API routes include /api/auth/google/connect etc.
+    expect(code).toContain('isProtectedRoute || isAuthRoute || isApiRoute')
+  })
+})
+
 describe('middleware: admin login host guard', () => {
   const source = () => readFileSync(resolve('src/pages/api/auth/login.ts'), 'utf-8')
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["@cloudflare/workers-types/2023-07-01"]
   },
-  "exclude": ["workers", "dist", ".astro"]
+  "exclude": ["workers", "dist", ".astro", "coverage", ".claude/worktrees"]
 }


### PR DESCRIPTION
## Summary

Bundled panel-approved hygiene fixes from the 2026-04-17 audit.

**#14a — generated-dir ignores.** Added \`coverage/**\` and \`.claude/worktrees/**\` to eslint config, tsconfig excludes, and prettier ignore. Signal-to-noise cleanup so real source warnings surface in verify output.

**#20 — 404 prerender warning.** Root cause was \`src/middleware.ts\` reading the cookie header on every request including during prerender. Gated the cookie read behind a \`needsSession\` check (protected routes + auth + API). Marketing pages and /404 skip the read entirely — warning eliminated and unnecessary work avoided.

Does NOT touch warn→error promotion (#14b). That's scoped separately per panel recommendation: measure violation count on real source first, then promote incrementally on auth/session/DAL paths.

## Test plan

- [x] \`npm run verify\` passes (1177 tests, 2 skipped)
- [x] \`npm run build\` no longer emits \`Astro.request.headers was used when rendering src/pages/404.astro\` — confirmed in build output
- [x] Regression test in \`tests/middleware.test.ts\` asserts the \`needsSession\` gate stays in place

## Files

- \`eslint.config.js\` — ignores
- \`tsconfig.json\` — excludes
- \`.prettierignore\` — coverage/
- \`src/middleware.ts\` — cookie-read gating
- \`tests/middleware.test.ts\` — regression guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)