### PR TITLE
chore(ci): drop social-listening from verify dry-run (#13)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,5 +59,8 @@ jobs:
       - name: Build Review Mining Worker
         run: cd workers/review-mining && npm ci && npx wrangler deploy --dry-run --outdir=dist
 
-      - name: Build Social Listening Worker
-        run: cd workers/social-listening && npm ci && npx wrangler deploy --dry-run --outdir=dist
+      # NOTE: workers/social-listening is not built or deployed here. It has
+      # never been deployed to prod — CI-verifying undeployed code creates
+      # false confidence and masks drift. See venture-tracked issue for
+      # Pipeline 4 first-deploy (secrets provisioning, dry-run via /run,
+      # digest-routing review). Re-add the build step when that issue ships.


### PR DESCRIPTION
## Summary

Panel review (2026-04-17) confirmed via git history that \`workers/social-listening\` has never been deployed to prod. CI dry-run was creating false confidence without validating runtime behavior.

Remove the \`Build Social Listening Worker\` step from \`verify.yml\`. Pipeline 4 will be brought online via a dedicated first-deploy tracked in a separate issue — secrets provisioning (Reddit OAuth, Resend, lead-ingest), dry-run via the \`/run\` endpoint, and digest-routing review. Re-add the build step when that ships.

No impact on the three live workers (\`job-monitor\`, \`new-business\`, \`review-mining\`).

## Test plan

- [x] Verify workflow file still valid YAML
- [x] Other three worker build steps untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)