### PR TITLE
fix(#398): close remaining fabrication gaps + invoice send-gate

### DIFF
--- a/docs/templates/sow-template.md
+++ b/docs/templates/sow-template.md
@@ -298,12 +298,12 @@ Standard engagement terms. Kept short and readable — this is not a legal contr
 │                                                              │
 │  2. The engagement start date is tentative until the         │
 │     deposit is received. We will confirm the start date      │
-│     within 1 business day of receiving the deposit.          │
+│     after the deposit clears.                                │
 │                                                              │
-│  3. A 2-week stabilization period follows the final          │
-│     handoff. During this period, we will address questions   │
-│     and minor adjustments related to the work delivered.     │
-│     New scope requires a separate engagement.                │
+│  3. A stabilization period follows the final handoff.        │
+│     During this period, we will address questions and minor  │
+│     adjustments related to the work delivered. New scope     │
+│     requires a separate engagement.                          │
 │                                                              │
 │  4. Either party may terminate this agreement with 3         │
 │     business days' written notice. Work completed to date    │
@@ -316,7 +316,8 @@ Standard engagement terms. Kept short and readable — this is not a legal contr
 
 - Section heading: same style
 - Numbered list: Inter 400 9pt `#334155`, 8pt between items
-- Terms are static text. Term 1 reflects Decision #18 (5-day confirmation deadline). Term 3 reflects Decision #27 (2-week safety net, Day 24 cutoff). The word "stabilization" is used instead of "safety net" or "support window" for client-facing language.
+- Terms are static text. Term 1 reflects Decision #18 (5-day confirmation deadline). Term 3 references a stabilization period without a fixed duration — specific duration is the product of the engagement conversation and is captured in Decision #27 for internal planning but not committed in the client-facing template. The word "stabilization" is used instead of "safety net" or "support window" for client-facing language.
+- The SOW's post-signing commitments (start date confirmation after deposit, stabilization period existence, deposit-invoice workflow) are authored template language describing standard engagement mechanics. They are exempt from the "no fabricated client-facing content" policy because the SOW is a signed contractual document, not marketing copy — parallel to CLAUDE.md Rule 3's exemption for signed contracts.
 
 ### 5.4 Signature Block — Dedicated Signing Page (Page 3)
 
@@ -330,7 +331,7 @@ Page 3 includes a brief "Next Steps" section above the signature block so the pa
 │                                                              │
 │  Once you sign below, we will send a deposit invoice.        │
 │  Work begins after the deposit is received. We will          │
-│  confirm the kickoff date within one business day.           │
+│  confirm the kickoff date after the deposit clears.          │
 │                                                              │
 │  AGREEMENT                                                   │
 │                                                              │

--- a/src/lib/db/invoices.ts
+++ b/src/lib/db/invoices.ts
@@ -271,6 +271,23 @@ export async function updateInvoiceStatus(
     params.push(new Date().toISOString())
   }
 
+  // Send-gate: a draft invoice can only be sent once it has at least one
+  // authored line item. Without line items, the portal "What's included"
+  // section renders empty — and historically fell back to fabricated copy
+  // borrowed from non-authoritative fields. See CLAUDE.md "No fabricated
+  // client-facing content" (#398).
+  if (newStatus === 'sent') {
+    const count = await db
+      .prepare('SELECT COUNT(*) AS c FROM invoice_line_items WHERE invoice_id = ?')
+      .bind(invoiceId)
+      .first<{ c: number }>()
+    if (!count || count.c === 0) {
+      throw new Error(
+        'Cannot send invoice: missing authored line items. Author at least one line item before sending.'
+      )
+    }
+  }
+
   if (newStatus === 'sent' && !existing.sent_at) {
     updates.push('sent_at = ?')
     params.push(new Date().toISOString())

--- a/src/lib/pdf/sow-template.tsx
+++ b/src/lib/pdf/sow-template.tsx
@@ -511,7 +511,20 @@ export function SOWTemplate(props: SOWTemplateProps) {
           we&apos;ll propose a separate scope and estimate.
         </Text>
 
-        {/* Terms */}
+        {/*
+          Terms are authored template language describing standard engagement
+          mechanics (quote validity, start-date confirmation workflow, the
+          existence of a stabilization period, termination notice). The SOW
+          is a signed contractual document, so this is NOT Pattern A/B
+          fabrication under CLAUDE.md's "no fabricated client-facing content"
+          policy — parallel to CLAUDE.md Rule 3's explicit exemption for
+          signed contracts. See docs/templates/sow-template.md for the full
+          rationale and #398 for the audit that confirmed this read.
+
+          What still matters: no fixed durations (the 2-week stabilization
+          phrasing and the "within 1 business day" SLAs were removed). Per-
+          engagement specifics (scope, pricing, milestones) remain authored.
+        */}
         <Text style={sectionHeadingStyle}>TERMS</Text>
         <View style={{ marginBottom: 16 }}>
           <Text

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -144,11 +144,10 @@ const typeLabelMap: Record<string, string> = {
   retainer: 'Retainer invoice',
 }
 const invoiceTitle = typeLabelMap[invoice.type] ?? 'Invoice'
-const periodSubtitle = invoice.description
-  ? `For ${invoice.description}`
-  : engagement?.scope_summary
-    ? `For ${engagement.scope_summary}`
-    : null
+// Subtitle comes only from the invoice's own authored description. We never
+// borrow `engagement.scope_summary` — that is an internal operations field,
+// not client-facing authored content. Pattern B per CLAUDE.md (#398).
+const periodSubtitle = invoice.description ? `For ${invoice.description}` : null
 
 const dueCaption = formatDueCaption(invoice.due_date)
 const daysRemaining = daysUntil(invoice.due_date)

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -66,6 +66,28 @@ const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp | string }> = [
     pattern: 'within one business day',
   },
   {
+    label: 'Pattern A: hardcoded "will reach out" consultant outreach promise',
+    // 2026-04-17 audit finding: dashboard fallback rendered
+    // `${consultantFirst} will reach out to schedule the next check-in.` as
+    // fabricated next-step copy when no authored touchpoint existed.
+    pattern: /will reach out/i,
+  },
+  {
+    label: 'Pattern B: synthesized "Kickoff next:" next-step copy',
+    // 2026-04-17 audit finding: signed-state copy synthesized
+    // `Kickoff next: ${engagement.scope_summary}.` when next_touchpoint_label
+    // was missing. scope_summary is not an authored next-step field.
+    pattern: /Kickoff next:/,
+  },
+  {
+    label: 'Pattern B: fabricated "Engagement work" invoice line-item fallback',
+    // 2026-04-17 audit finding: invoice line-item fallback fabricated
+    // 'Engagement work' when no line items existed. Send-gate now blocks
+    // sending an invoice without line items; this guards re-introduction
+    // of a client-facing placeholder.
+    pattern: /['"]Engagement work['"]/,
+  },
+  {
     label: 'Pattern B: hardcoded "Scott" fallback in portal render paths',
     // Match ?? 'Scott' or : 'Scott' (ternary / nullish) in portal pages and components.
     // Does not flag 'Scott' in test fixtures, variable names, or email author strings.

--- a/tests/invoices.send-gate.test.ts
+++ b/tests/invoices.send-gate.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Invoice send-gate behavior test (#398).
+ *
+ * Mirrors the quote send-gate: a draft invoice cannot transition to sent
+ * without at least one authored line item. The gate defends against the
+ * 2026-04-17 audit finding where invoice portal pages would fabricate
+ * 'Engagement work' or borrow engagement.scope_summary when line items
+ * were missing. The portal now renders nothing when line items are absent;
+ * the send-gate prevents that state from ever reaching a client.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { createInvoice, updateInvoiceStatus } from '../src/lib/db/invoices'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG = 'org-a'
+const ENTITY = 'entity-a'
+
+describe('invoice send-gate — authored line items required (#398)', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG, 'Org A', 'org-a')
+      .run()
+
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind(ENTITY, ORG, 'Entity A', 'entity-a')
+      .run()
+  })
+
+  it('throws when transitioning draft -> sent without any line items', async () => {
+    const invoice = await createInvoice(db, ORG, {
+      entity_id: ENTITY,
+      type: 'deposit',
+      amount: 500,
+      description: 'Deposit for Phase 1',
+    })
+
+    await expect(updateInvoiceStatus(db, ORG, invoice.id, 'sent')).rejects.toThrow(
+      /missing authored line items/
+    )
+
+    // Status must remain draft.
+    const after = await db
+      .prepare('SELECT status FROM invoices WHERE id = ?')
+      .bind(invoice.id)
+      .first<{ status: string }>()
+    expect(after?.status).toBe('draft')
+  })
+
+  it('allows transition to sent once a line item is authored', async () => {
+    const invoice = await createInvoice(db, ORG, {
+      entity_id: ENTITY,
+      type: 'deposit',
+      amount: 500,
+      description: 'Deposit for Phase 1',
+    })
+
+    await db
+      .prepare(
+        `INSERT INTO invoice_line_items (id, invoice_id, description, amount_cents, sort_order)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .bind('li-1', invoice.id, 'Solution Design — Phase 1', 50_000, 0)
+      .run()
+
+    const sent = await updateInvoiceStatus(db, ORG, invoice.id, 'sent')
+    expect(sent?.status).toBe('sent')
+    expect(sent?.sent_at).not.toBeNull()
+  })
+})

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -114,6 +114,15 @@ describe('invoices: data layer', () => {
     expect(code).toContain('sent_at')
   })
 
+  it('updateInvoiceStatus send-gate requires at least one line item (#398)', () => {
+    const code = source()
+    // Draft -> sent must count invoice_line_items and throw when none exist.
+    // Mirrors the quote send-gate that prevents sending a quote without
+    // authored schedule + deliverables.
+    expect(code).toContain('SELECT COUNT(*) AS c FROM invoice_line_items')
+    expect(code).toContain('Cannot send invoice: missing authored line items')
+  })
+
   it('exports listInvoicesForEntity for portal access, scoped by entity and org (#399)', () => {
     const code = source()
     expect(code).toContain('export async function listInvoicesForEntity')


### PR DESCRIPTION
## Summary

Completes the 2026-04-17 audit remainder for issue #398. Prior PRs (#408, #419, #420) already cleared the six Pattern A/B sites originally cited in CLAUDE.md. This PR closes the five gaps the 2026-04-17 audit re-surfaced.

### Code changes

- **Invoice subtitle (Pattern B)** — `src/pages/portal/invoices/[id].astro`: drop `engagement.scope_summary` fallback for the period subtitle. Renders only when `invoice.description` is authored.
- **Invoice send-gate** — `src/lib/db/invoices.ts`: `updateInvoiceStatus` now blocks `draft -> sent` when the invoice has zero line items. Mirrors the existing quote send-gate. Prevents sending an invoice that would render an empty "What's included" section to a client.
- **SOW template** — retained as authored standard-practice contractual language. Inline comment in `sow-template.tsx` + rationale in `docs/templates/sow-template.md` document the exemption. Parallel to CLAUDE.md Rule 3's explicit exemption for signed contracts.

### Docs

- `docs/templates/sow-template.md` updated to match current SOW output (stale "within 1 business day" / "2-week" phrasing removed — these were stripped from code months ago but still documented, which would mislead future agents).

### Tests

- **New behavior test** `tests/invoices.send-gate.test.ts` (2 tests) — proves the send-gate throws without line items and passes with one authored.
- **Extended `tests/forbidden-strings.test.ts`** — three new patterns from the audit:
  - `/will reach out/i` (dashboard consultant-outreach fabrication)
  - `/Kickoff next:/` (signed-state scope_summary-derived synthesis)
  - `/'Engagement work'/` (invoice line-item fallback placeholder)
- **Extended `tests/invoices.test.ts`** — send-gate string-inspection assertion.

## Acceptance criteria (from #398 2026-04-17 audit)

- [x] Deliverables no longer fall back to line items — verified already resolved in current code (parseDeliverables only, no line-item fallback)
- [x] Signed-state next-step copy no longer synthesizes `Kickoff next: ${scope_summary}.` — verified already resolved
- [x] Dashboard no longer falls back to `${consultantFirst} will reach out...` — verified already resolved
- [x] Invoice line-item fallback removed (audit finding #4, Pattern B)
- [x] Invoice send-gate added (parallels quote send-gate)
- [x] SOW template commitments — Captain-approved decision documented: authored standard-practice contractual language is exempt from the no-fabrication policy, same rationale as CLAUDE.md Rule 3's signed-contract exemption
- [x] `docs/templates/sow-template.md` updated to match current output
- [x] Regression guard extended with the three new forbidden patterns

## Test plan

- [x] `npm run verify` — 1,229 tests pass, 2 skipped, 0 errors
- [ ] Attempt to send a draft invoice with no line items in staging — confirm the error surfaces cleanly in admin UI

Closes #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)