### PR TITLE
Widen engagement scope + add AI & automation as sixth solution category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance for Claude Code agents working in this repository.
 
 **Geography:** Phoenix-based, in-person default for Phase 1 (first 5 clients), remote-capable.
 
-**Positioning:** The client is the hero, we are the guide. Collaborative, objectives-first. The value is enterprise operational discipline applied to businesses that have never had access to it, delivered at speed and pricing that works for their stage. Not "AI-powered" anything. A chef isn't hired for his knife.
+**Positioning:** The client is the hero, we are the guide. Collaborative, objectives-first. The value is enterprise operational discipline applied to businesses that have never had access to it, delivered at speed and pricing that works for their stage. AI & automation is a named capability. We do AI work when AI is the right answer, and we say so plainly. We do not brand the firm, the method, or non-AI engagements as "AI-powered." A chef isn't hired for his knife, but he names the knife when it matters.
 
 ## What This Repo Is For
 
@@ -129,15 +129,26 @@ We use a three-layer model to connect research to delivery:
 
 These are representative, not exhaustive. The assessment listens for whatever comes up.
 
-**3. Five solution categories** (delivery taxonomy):
+**3. Six solution categories** (delivery taxonomy):
 
 - Process design
 - Custom internal tools
 - Systems integration
 - Operational visibility
 - Vendor/platform selection
+- AI & automation
 
 No dollar ranges are attached to solution categories. Pricing comes from scope estimation per engagement.
+
+**AI & automation sub-capabilities** (for agent reference when authoring copy or scoping engagements, not a list to publish verbatim):
+
+- AI strategy conversations and readiness assessment
+- AI tool selection and rollout
+- Custom AI and agent implementations
+- Team training and enablement on AI tools
+- Non-AI workflow automation (scripts, integrations that don't require AI)
+
+**Taxonomy divergence note.** The six-category taxonomy above is the marketing and doctrinal source of truth. Internal lead-generation code still operates on the earlier five-category list (`tests/extraction-prompt.test.ts`, `src/lib/enrichment/review-synthesis.ts`, `src/lead-gen/prompts/job-qualification-prompt.ts`, `docs/collateral/lead-automation-blueprint.md`). Closing that gap is tracked as a follow-on issue. Agents editing either side of the divergence must not silently change the other. Doctrine changes here do not retroactively rewrite extraction prompts, and lead-gen changes there do not dictate the external taxonomy.
 
 ### Pain Clusters by Vertical
 
@@ -161,10 +172,12 @@ These suggest where to lead the conversation, not which problems to look for. Th
 | Training         | Hands-on walkthrough, practice, deliver "how to" docs, identify internal champion |
 | Handoff + polish | Handle feedback, adjust based on real use, final handoff                          |
 
+**Phases scale per engagement.** Every engagement includes every phase. What changes is how heavy each one is. Training may be a three-day program or a single "on Tuesdays you click this button." Implementation may be a multi-week build or a one-afternoon script. Scope determines depth, not presence.
+
 ### Pricing
 
 - **Internal rate:** $175/hr at launch, then $200/hr after first case study, then $250/hr, then $300/hr with volume
-- **Engagement range:** $5,000-$15,000+ depending on scope
+- **Engagement range:** scoped per engagement. Smallest engagements (targeted automation scripts, AI pilots) start around $2,500. Below that, assessment overhead exceeds delivery value. Largest engagements have no fixed ceiling. Nothing published externally.
 - **Paid Assessment:** $250, applied toward engagement if they proceed. First 3 assessments free.
 - **Retainer (post-delivery):** $200-500/mo for ongoing support and optimization. Model holds but we define the details after the first delivery.
 - **No dollar amounts published externally.** Client sees a project price, not hourly rate.
@@ -186,7 +199,7 @@ We are in the **pre-launch phase**. Nothing has been sold yet. The immediate pri
 
 - [ ] Assessment call script (structured conversation guide, objectives-first)
 - [ ] Proposal/SOW template (what gets sent after the assessment, reflecting full solution range)
-- [ ] Pricing framework (scope estimation across all 5 solution categories)
+- [ ] Pricing framework (scope estimation across all 6 solution categories)
 - [ ] One-pager / leave-behind (physical or PDF for networking, guide positioning)
 
 ### Priority 2: Go-to-Market
@@ -199,7 +212,7 @@ We are in the **pre-launch phase**. Nothing has been sold yet. The immediate pri
 
 ### Priority 3: Delivery Readiness
 
-- [ ] Tool and solution matrix (across all 5 solution categories, including custom internal tools and integrations)
+- [ ] Tool and solution matrix (across all 6 solution categories, including custom internal tools, integrations, and AI & automation)
 - [ ] SOP templates (reusable frameworks filled in per client)
 - [ ] Client onboarding checklist (what we need from them before Day 1)
 - [ ] Quality checklist templates (reusable across engagements)

--- a/docs/adr/decision-stack.md
+++ b/docs/adr/decision-stack.md
@@ -145,16 +145,16 @@ Don't ask for revenue directly. Look for: 3+ years in business, consistent payro
 
 **Decision: Synthesis of all Layer 1 decisions**
 
-|                        |                                                                                                                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Revenue**            | $750k-$5M (expansion to $10M after 5+ engagements)                                                                                                                    |
-| **Geography**          | Phoenix metro (Phase 1), in-person default for assessments                                                                                                            |
-| **Years in business**  | 3+                                                                                                                                                                    |
-| **Verticals**          | Home services, professional services, contractor/trades (problem-qualified, not vertical-gated)                                                                       |
-| **Pain profile**       | 2-3 problems surfaced during assessment mapping to the six solution categories in CLAUDE.md (process design, custom internal tools, systems integration, operational visibility, vendor/platform selection, AI & automation)  |
-| **Psychographics**     | Owner knows something isn't working, will invest to change it, makes decisions without committee                                                                      |
-| **Disqualifiers**      | Not owner, scope exceeds single phase, no champion, no tech baseline, in crisis                                                                                       |
-| **Where to find them** | BNI, Phoenix Chamber, PHCC, ACCA, ASCPA, accountant referrals, Vistage, EO                                                                                            |
+|                        |                                                                                                                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Revenue**            | $750k-$5M (expansion to $10M after 5+ engagements)                                                                                                                                                                           |
+| **Geography**          | Phoenix metro (Phase 1), in-person default for assessments                                                                                                                                                                   |
+| **Years in business**  | 3+                                                                                                                                                                                                                           |
+| **Verticals**          | Home services, professional services, contractor/trades (problem-qualified, not vertical-gated)                                                                                                                              |
+| **Pain profile**       | 2-3 problems surfaced during assessment mapping to the six solution categories in CLAUDE.md (process design, custom internal tools, systems integration, operational visibility, vendor/platform selection, AI & automation) |
+| **Psychographics**     | Owner knows something isn't working, will invest to change it, makes decisions without committee                                                                                                                             |
+| **Disqualifiers**      | Not owner, scope exceeds single phase, no champion, no tech baseline, in crisis                                                                                                                                              |
+| **Where to find them** | BNI, Phoenix Chamber, PHCC, ACCA, ASCPA, accountant referrals, Vistage, EO                                                                                                                                                   |
 
 ---
 

--- a/docs/adr/decision-stack.md
+++ b/docs/adr/decision-stack.md
@@ -151,7 +151,7 @@ Don't ask for revenue directly. Look for: 3+ years in business, consistent payro
 | **Geography**          | Phoenix metro (Phase 1), in-person default for assessments                                                                                                            |
 | **Years in business**  | 3+                                                                                                                                                                    |
 | **Verticals**          | Home services, professional services, contractor/trades (problem-qualified, not vertical-gated)                                                                       |
-| **Pain profile**       | 2-3 problems surfaced during assessment mapping to solution capability areas (process design, tools & systems, data & visibility, customer pipeline, team operations) |
+| **Pain profile**       | 2-3 problems surfaced during assessment mapping to the six solution categories in CLAUDE.md (process design, custom internal tools, systems integration, operational visibility, vendor/platform selection, AI & automation)  |
 | **Psychographics**     | Owner knows something isn't working, will invest to change it, makes decisions without committee                                                                      |
 | **Disqualifiers**      | Not owner, scope exceeds single phase, no champion, no tech baseline, in crisis                                                                                       |
 | **Where to find them** | BNI, Phoenix Chamber, PHCC, ACCA, ASCPA, accountant referrals, Vistage, EO                                                                                            |
@@ -250,7 +250,7 @@ Every engagement is different. The assessment identifies the problems; the solut
 - Never publish a dollar amount on the website or marketing materials
 - Never share the hourly rate with clients — they see a project price
 - The assessment call is the pricing conversation — "we'll design a solution and send you a scope and price"
-- Typical engagement range at launch rate: $5,000-$15,000+ depending on scope
+- Engagement range: scoped per engagement. Smallest engagements start around $2,500 at launch rate; below that, assessment overhead exceeds delivery value. Largest have no fixed ceiling. Nothing published externally. See CLAUDE.md solution taxonomy as source of truth for the categories being scoped.
 
 _The value is not the hours. The value is an experienced team that can see the problems the owner can't, make decisions fast, and implement in days. The rate is internal math — the client pays for outcomes._
 

--- a/docs/collateral/outreach-plan.md
+++ b/docs/collateral/outreach-plan.md
@@ -133,6 +133,12 @@ Once channels are open, the weekly cadence looks like:
 
 **ROI hook:** "If your team is copying data between three spreadsheets and two apps, that's not a people problem. The tools just aren't connected."
 
+### AI & Automation
+
+> We help growing businesses figure out what to actually do with AI. Sometimes the answer is an AI tool. Sometimes it's a simple automation. Sometimes it's neither. Either way we talk it through before anyone writes a check.
+
+**ROI hook:** "Most owners we talk to have been pitched five AI things this year. We help you tell which one is worth the time and which one would have been a better spreadsheet formula."
+
 ---
 
 ## Tracking
@@ -177,7 +183,7 @@ The value proposition for the chair: you bring a practical session their members
 Keep it practical. No slides if you can help it.
 
 1. Open with a question: "What's the one thing in your business that would break if you took two weeks off?"
-2. Walk through 2-3 of the five solution categories with real examples (anonymized client stories when available)
+2. Walk through 2-3 of the six solution categories (process design, custom internal tools, systems integration, operational visibility, vendor/platform selection, AI & automation) with real examples (anonymized client stories when available)
 3. Give each person one concrete thing to look at this week
 4. Close with an open offer: "If any of this sounds familiar, we start with a conversation. No charge for that."
 

--- a/docs/pm/prd.md
+++ b/docs/pm/prd.md
@@ -36,7 +36,7 @@ The product being specified is an internal operations platform and client-facing
 The value is two-sided:
 
 - **For the admin:** It replaces a fragile combination of spreadsheets, email threads, and memory that cannot scale past 2-3 concurrent engagements and does not project the operational maturity the business is selling.
-- **For the client:** It delivers the professional experience the engagement promises before a single deliverable is in their hands. As one target client put it: "A $5,000-$9,000 engagement should come with a client experience that matches it. The portal is a trust signal. It either reinforces the price or undermines it. There is no neutral."
+- **For the client:** It delivers the professional experience the engagement promises before a single deliverable is in their hands. As one target client put it: "Any engagement, from a focused automation script to a full implementation, should come with a client experience that matches it. The portal is a trust signal. It either reinforces the price or undermines it. There is no neutral."
 
 The MVP must be live and functional before the first assessment call. That is the forcing function. Everything else sequences from that constraint.
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,6 +7,7 @@
       <p class="mt-1 text-sm text-slate-500">&copy; 2026 SMDurgan, LLC. Phoenix, Arizona.</p>
     </div>
     <nav class="flex items-center gap-6">
+      <a class="text-sm text-slate-500 hover:text-slate-900" href="/ai">AI</a>
       <a class="text-sm text-slate-500 hover:text-slate-900" href="/contact">Contact</a>
       <a
         class="rounded bg-primary px-5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-80"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,6 +11,10 @@
     <div class="flex items-center gap-5">
       <a
         class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
+        href="/ai">AI</a
+      >
+      <a
+        class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
         href="/contact">Contact</a
       >
       <a

--- a/src/components/WhatYouGet.astro
+++ b/src/components/WhatYouGet.astro
@@ -4,6 +4,7 @@ const items = [
   'Tool selection, configuration, and integration',
   'Custom internal tools and dashboards built for how you work',
   'System integrations that eliminate manual data entry',
+  'AI tools and automation scripts where they cut real work from your day',
   'Vendor evaluation and selection when off-the-shelf fits better',
   'Data migration and setup',
   'Hands-on team training and walkthrough',

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -1,0 +1,80 @@
+---
+export const prerender = false
+
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import CtaButton from '../components/CtaButton.astro'
+---
+
+<Base
+  title="AI & Automation | SMD Services"
+  description="AI strategy, tool selection, custom automation, and team training for growing businesses. Sometimes the answer is AI. Sometimes it's something simpler. Let's figure out which."
+>
+  <Nav />
+  <main id="main" role="main">
+    <section class="relative overflow-hidden px-6 pb-32 pt-24">
+      <div class="mx-auto max-w-4xl text-center">
+        <h1
+          class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-slate-900 md:text-7xl"
+        >
+          AI and Automation for Growing Businesses.
+        </h1>
+        <p class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-slate-600">
+          Some of what you're hearing about AI is useful. A lot of it is noise. We help you sort it
+          out and build what fits how your business actually works.
+        </p>
+        <CtaButton href="/book">Book a Call</CtaButton>
+      </div>
+    </section>
+
+    <section class="bg-slate-50 px-6 py-24">
+      <div class="mx-auto max-w-4xl">
+        <h2 class="mb-12 text-center text-3xl font-bold text-slate-900 sm:text-4xl">
+          What Working With Us Looks Like
+        </h2>
+        <div class="space-y-10 text-lg leading-relaxed text-slate-700">
+          <p>
+            <span class="font-semibold text-slate-900">A conversation first.</span> We walk through
+            what you're trying to do, what's slowing you down, and whether AI is the right answer or
+            whether something simpler would serve you better.
+          </p>
+          <p>
+            <span class="font-semibold text-slate-900">The right tool, not the loudest one.</span> Dozens
+            of AI tools are marketed at businesses your size every month. We help you tell which
+            ones actually fit your work and which are solving someone else's problem.
+          </p>
+          <p>
+            <span class="font-semibold text-slate-900">Built for how your team already works.</span>
+            If we build something custom, whether it's an AI assistant, a script that cleans up a recurring
+            task, or an integration between tools, it fits into how your team already operates instead
+            of asking them to change.
+          </p>
+          <p>
+            <span class="font-semibold text-slate-900">Training your team to use it.</span> A tool nobody
+            uses is worse than no tool at all. We make sure your team can actually run what we build
+            after we're gone.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="px-6 py-24">
+      <div class="mx-auto max-w-3xl text-center">
+        <h2 class="mb-8 text-3xl font-bold text-slate-900 sm:text-4xl">
+          Is AI Actually the Right Answer?
+        </h2>
+        <p class="text-lg leading-relaxed text-slate-700">
+          Sometimes yes. Other times the answer is a simple script, a better process, or just
+          getting two of your tools to talk to each other. And sometimes the answer is not yet.
+          That's the conversation. If you walk out of it thinking AI isn't where you should spend
+          money this quarter, that's a win too. Clarity is the point.
+        </p>
+      </div>
+    </section>
+
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -36,14 +36,14 @@ import CtaButton from '../components/CtaButton.astro'
         </h2>
         <div class="space-y-10 text-lg leading-relaxed text-slate-700">
           <p>
-            <span class="font-semibold text-slate-900">A conversation first.</span> We walk through
-            what you're trying to do, what's slowing you down, and whether AI is the right answer or
-            whether something simpler would serve you better.
+            <span class="font-semibold text-slate-900">A conversation first.</span> We walk through what
+            you're trying to do and where things are getting stuck. Then we figure out together whether
+            AI is the right answer or whether something simpler would serve you better.
           </p>
           <p>
             <span class="font-semibold text-slate-900">The right tool, not the loudest one.</span> Dozens
-            of AI tools are marketed at businesses your size every month. We help you tell which
-            ones actually fit your work and which are solving someone else's problem.
+            of AI tools are marketed at businesses your size every month. We help you tell which ones
+            actually fit your work and which are solving someone else's problem.
           </p>
           <p>
             <span class="font-semibold text-slate-900">Built for how your team already works.</span>
@@ -53,8 +53,8 @@ import CtaButton from '../components/CtaButton.astro'
           </p>
           <p>
             <span class="font-semibold text-slate-900">Training your team to use it.</span> A tool nobody
-            uses is worse than no tool at all. We make sure your team can actually run what we build
-            after we're gone.
+            uses is worse than no tool at all. We make sure your team can actually run what we build after
+            we're gone.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Two pre-launch strategic shifts land together in doctrine and on the marketing site.

- **Widen the net.** Engagement range moves from \$5k-\$15k+ to "scoped per engagement, no ceiling" with a named internal floor (~\$2.5k) below which assessment overhead eats the delivery. Five engagement phases stay, they scale per engagement (training can be a three-day program or a single Tuesday button-click).
- **Lean into AI.** AI & automation joins the solution taxonomy as the sixth category. The prior `"Not 'AI-powered' anything"` positioning line is repointed rather than deleted — the guide persona still refuses to use AI as marketing varnish, but AI is now a named deliverable. New `/ai` marketing page takes the honest-broker posture: sometimes AI is the answer, sometimes it isn't, clarity is the point.

## What's in this PR

**Doctrine (`76cd184`)**
- `CLAUDE.md` — positioning line, solution taxonomy (5 → 6), engagement range, phase-scaling note, taxonomy divergence disclosure
- `docs/adr/decision-stack.md` — mirrors the pricing and taxonomy edits; points to CLAUDE.md as source of truth
- `docs/pm/prd.md` — persona quote generalized off \$5-9k
- `docs/collateral/outreach-plan.md` — AI & Automation messaging block added; Vistage session script updated to 6 categories

**Marketing site components (`01fa904`)**
- `Nav.astro` + `Footer.astro` — \`/ai\` link added before Contact
- `WhatYouGet.astro` — outcome-voiced AI & automation bullet

**New `/ai` page (`0c1667c`)**
- Four sections (hero / what it looks like / is AI the right answer / reused FinalCta). Reuses Base layout, Nav, Footer, FinalCta, CtaButton. No new components.
- Copy follows the tone standard: collaborative "we" voice, no dollar amounts, no fixed timeframes, no em dashes or AI-polish register, owner-respectful.

**Prettier cleanup (`6368117`)** — formatting only.

## Taxonomy divergence (intentional, documented, follow-on filed)

The marketing/doctrine taxonomy now names six categories. Internal lead-gen code (`tests/extraction-prompt.test.ts`, `src/lib/enrichment/review-synthesis.ts`, `src/lead-gen/prompts/job-qualification-prompt.ts`, `docs/collateral/lead-automation-blueprint.md`) still operates on the five-category list. This is flagged in `CLAUDE.md` under **Taxonomy divergence note**. A follow-on issue will align lead-gen to the six-category taxonomy so AI-signal inbound doesn't get misclassified.

## IA trade-off (acknowledged, not overridden)

Putting `/ai` in the nav elevates one of six categories to peer-with-Contact. Critics in plan review flagged this; Captain chose nav placement over a `/services` hub. Mitigation in this PR: `WhatYouGet` stays comprehensive so the non-AI buyer still sees their work reflected on the homepage. Trigger to revisit: conversion mix skewing too AI-heavy after ~10 inbound conversations.

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings, 29 hints
- [x] `npm run lint` — clean on changed files
- [x] `npm run build` — succeeds, `/ai` renders
- [x] Pre-push `npm test` hook — 1223 passed, 2 skipped, 0 failures
- [x] Scoped greps for \`\$5,000-\$15,000\` / \`\$5,000-\$9,000\` / \`five solution\` / \`5 solution\` / \`'AI-powered' anything\` in `CLAUDE.md` + `docs/` — zero hits
- [ ] Visual check on preview at 320/360/375/768/1024 viewports before merge
- [ ] Copy read-through on `/ai` before merge

## Follow-ons to file (tracked separately)

1. Lead-gen taxonomy 5 → 6 (extraction prompt + review-synthesis + job-qualification + lead-automation-blueprint)
2. Proposal/SOW templates scale for small engagements (current templates are sized for \$15k+)
3. Scorecard tool category alignment (may reference old five-category taxonomy)
4. Mobile nav disclosure if three-item nav clips on narrow viewports (watch-item — not verified yet because I skipped local dev-server visual check to avoid port contention with a parallel agent)

## Notes

- Built in `.claude/worktrees/widen-scope-add-ai` to decouple from a parallel agent working `fix/398` + `fix/399` on the same repo.
- Originating plan: `~/.claude/plans/regarding-2-lightweight-engagement-nested-puppy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)