### PR TITLE
fix(wrangler): keep_vars=true — stop wiping dashboard-set secrets

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,6 +15,19 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
+# Preserve env vars and secrets set outside wrangler.toml (via
+# `wrangler pages secret put`, the Cloudflare dashboard, or direct API
+# writes) across subsequent `wrangler pages deploy` runs.
+#
+# Without this, every CI deploy treats wrangler.toml as authoritative and
+# silently erodes anything not declared here — which is how every
+# dashboard-set secret (RESEND_API_KEY, ANTHROPIC_API_KEY,
+# LEAD_INGEST_API_KEY, etc.) ended up reaching the Astro SSR runtime as
+# empty strings after #178 introduced the first `[vars]` block.
+#
+# See: https://developers.cloudflare.com/workers/wrangler/configuration/
+keep_vars = true
+
 # ---------- Public env vars ----------
 # Canonical origins for outbound links and webhook callbacks.
 # All email links and webhook callbacks are built from these env vars — never


### PR DESCRIPTION
## Root cause

Every \`wrangler pages deploy\` was silently eroding dashboard-set secrets. On-page diagnostic (PR #440) confirmed ALL secrets reach the Astro SSR runtime as empty strings (\`typeof \"string\"\`, \`length: 0\`), while plain-text vars bound via wrangler.toml \`[vars]\` come through correctly.

This has been broken since #178 (Apr 7) introduced the first \`[vars]\` block to wrangler.toml. Hidden because:
- \`src/lib/email/resend.ts\` falls back to \`console.log\` when \`RESEND_API_KEY\` is missing — email delivery has been silently off
- Other secret-gated paths fail in ways that look like unrelated 401/timeout errors

## Fix

\`keep_vars = true\` at the top of wrangler.toml. Documented [here](https://developers.cloudflare.com/workers/wrangler/configuration/).

## What this PR does NOT do

This is the structural fix only. The currently-empty secret values still need to be re-set via \`wrangler pages secret put\` (once each) before they become non-empty at runtime. Playbook in the post-merge follow-up.

## Test plan

- [x] \`npm run build\` clean
- [ ] After deploy, before any secret re-setting: diagnostic on \`/admin/generators/new_business\` still shows secrets at length 0 (expected — keep_vars preserves but does not create)
- [ ] After re-setting \`LEAD_INGEST_API_KEY\` via \`wrangler pages secret put\`: diagnostic shows length > 0; Run-now enables
- [ ] Verify Resend and Anthropic secrets after re-setting them: email delivery resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)