### PR TITLE
chore(generators): remove temp env diagnostic

### DIFF
--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -281,19 +281,6 @@ const runDisabledReason = !runWorkerUrl
   : !runHasKey
     ? 'LEAD_INGEST_API_KEY is not bound to this Pages deployment'
     : ''
-
-// TEMP diagnostic (REMOVE once Run-now works) — distinguishes undefined vs
-// empty string vs both-broken by comparing to a known-working secret.
-const envDiag = {
-  lead_type: typeof env.LEAD_INGEST_API_KEY,
-  lead_len: (env.LEAD_INGEST_API_KEY ?? '').length,
-  resend_type: typeof env.RESEND_API_KEY,
-  resend_len: (env.RESEND_API_KEY ?? '').length,
-  anthropic_type: typeof env.ANTHROPIC_API_KEY,
-  anthropic_len: (env.ANTHROPIC_API_KEY ?? '').length,
-  worker_url_type: typeof runWorkerUrl,
-  worker_url_len: (runWorkerUrl ?? '').length,
-}
 ---
 
 <AdminLayout
@@ -406,10 +393,6 @@ const envDiag = {
           </p>
         )
       }
-      <pre
-        class="mt-2 text-xs font-mono bg-slate-50 text-slate-600 rounded p-2 overflow-x-auto">
-env diagnostic (TEMP): {JSON.stringify(envDiag, null, 2)}
-      </pre>
     </div>
   </section>
 


### PR DESCRIPTION
Diagnostic from #440 served its purpose — confirmed secrets were empty at runtime, which led to re-setting via `wrangler pages secret put`. LEAD_INGEST + SIGNWELL pair now bound. Run-now works. Removing the temp `<pre>` block.

Remaining empty Pages secrets (not in Infisical, must be retrieved from each service dashboard before re-setting): RESEND_API_KEY, ANTHROPIC_API_KEY, STRIPE_API_KEY, STRIPE_WEBHOOK_SECRET, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, BOOKING_ENCRYPTION_KEY, TURNSTILE_SECRET_KEY, GOOGLE_PLACES_API_KEY, OUTSCRAPER_API_KEY, SERPAPI_API_KEY. Covered in a follow-up.