### PR TITLE
feat(portal): list-row registry + R7 enforcement

### DIFF
--- a/.agents/skills/stitch-design/SKILL.md
+++ b/.agents/skills/stitch-design/SKILL.md
@@ -151,6 +151,10 @@ Mappings cover arbitrary typography (`text-[Npx]` → scale tokens), raw Tailwin
 
 Skip if `docs/style/UI-PATTERNS.md` absent.
 
+### 3c-bis. Portal list-row primitive check (UI-PATTERNS R7)
+
+When the target surface is a portal list index (`src/pages/portal/*/index.astro`), the generated output MUST render iterated rows through `src/components/portal/PortalListItem.astro` — not fresh `<a class="block bg-white ...">` markup. Helpers (`formatDate`, `formatCurrency`, `statusColorMap`, `statusLabelMap`, `typeLabels`) MUST come from `src/lib/portal/formatters.ts` and `src/lib/portal/status.ts`. The presence + no-local-redef assertions in `tests/forbidden-strings.test.ts` fail CI on any regeneration that re-rolls inline markup or local formatters. See `docs/style/UI-PATTERNS.md` R7 for the full contract.
+
 ### 3d. Hallucination strip pass
 
 After normalize, strip elements Stitch produced despite the UI CONTRACT forbidding them:

--- a/docs/style/UI-PATTERNS.md
+++ b/docs/style/UI-PATTERNS.md
@@ -351,6 +351,94 @@ Audit flagged 32 arbitrary sizes in this file and 27 in `portal/invoices/[id].as
 
 ---
 
+## Rule 7 — Shared primitives for repeated patterns
+
+**Rule.** When the same visual element appears on multiple surfaces, it
+renders through a shared component. The component is the enforcement; prose
+rules about "use tokens" and "match the design system" do not survive
+multiple generations of AI-authored screens without a code contract behind
+them.
+
+**Why.** AI generators (Stitch today, possibly others later) produce each
+screen in isolation. Tokens unify colors and spacing; nothing unifies
+element _shape_. Without a shared primitive, list-row markup diverges on
+every regeneration — different status pills, date formats, CTA positions —
+even when every surface "uses the design system." The 2026-04-17 portal
+screenshots (proposals vs. invoices vs. documents) are the canonical
+example.
+
+**Authority.** Shopify Polaris component system, IBM Carbon design system,
+Atlassian Design System — all treat named components as the source of
+truth, not token conformance. "Every surface should have a consistent
+look" is an aspiration; "every surface must import the same component" is
+a contract.
+
+**Anti-pattern.** Every portal list surface (before this rule) hand-rolled:
+
+```tsx
+<a href={...} class="block bg-white rounded-lg border border-slate-200 p-stack ...">
+  <div class="flex items-center justify-between gap-stack">
+    <span class={`inline-block px-2.5 py-0.5 rounded-full text-xs ${statusColorMap[status]}`}>
+      {statusLabelMap[status]}
+    </span>
+    {/* ... */}
+  </div>
+</a>
+```
+
+Each surface chose slightly different class orderings, different pill
+tints, different date formats, different CTAs (chevron / button /
+icon-circle). Class reorder evasion means a "no forbidden markup string"
+test cannot defend this.
+
+**Correct pattern.**
+
+```tsx
+import PortalListItem from '../../../components/portal/PortalListItem.astro'
+import { resolveInvoiceTone, resolveInvoiceLabel } from '../../../lib/portal/status'
+
+{
+  invoices.map((inv) => (
+    <PortalListItem
+      variant="status"
+      href={`/portal/invoices/${inv.id}`}
+      tone={resolveInvoiceTone(inv.status)}
+      toneLabel={resolveInvoiceLabel(inv.status)}
+      title={typeLabel[inv.type]}
+      amountCents={Math.round(inv.amount * 100)}
+      metaCaption={resolveMetaCaption(inv)}
+    />
+  ))
+}
+```
+
+**Registered primitives (portal).**
+
+- [`src/components/portal/PortalListItem.astro`](../../src/components/portal/PortalListItem.astro) — card-shell list row; `variant: 'status' | 'document'`.
+- [`src/components/portal/StatusPill.astro`](../../src/components/portal/StatusPill.astro) — tone-based pill; consumes `Tone` from `status.ts`.
+- [`src/components/portal/MoneyDisplay.astro`](../../src/components/portal/MoneyDisplay.astro) — dollar-figure renderer (pre-existing).
+- [`src/lib/portal/formatters.ts`](../../src/lib/portal/formatters.ts) — `formatShortDate`, `formatRelativeDueCaption`, `formatCentsToCurrency`.
+- [`src/lib/portal/status.ts`](../../src/lib/portal/status.ts) — `Tone` type, per-entity `resolveInvoiceTone/Label`, `resolveQuoteTone/Label`.
+
+**Source-of-truth contract.**
+
+- Portal surfaces: import from `src/lib/portal/status.ts` and `src/lib/portal/formatters.ts`.
+- Admin surfaces: import from `src/lib/ui/status-badge.ts` (raw Tailwind classes; pre-existing; stays un-migrated).
+- Shared / cross-surface code (e.g., email notifications, cross-context reports): add a new helper when the first such caller appears. Do not mix imports.
+
+**Detection.** Two assertion families in [`tests/forbidden-strings.test.ts`](../../tests/forbidden-strings.test.ts) under the heading "Portal list-row registry":
+
+1. **Presence.** Every `src/pages/portal/*/index.astro` (except `engagement/index.astro`, which is a detail surface) that iterates via `.map(` must render through `<PortalListItem>`. Defeats class-reorder evasion because presence is required, not absence.
+2. **No local helper redefinition.** No `const formatDate`, `const formatCurrency`, `const statusColorMap`, `const statusLabelMap`, `const typeLabels` in portal list-index files.
+
+The test auto-enrolls new portal list-index files. Exceptions are an explicit `LIST_INDEX_ALLOWLIST` array (commented rationale required).
+
+**Escape hatch.** Add the file path to `LIST_INDEX_ALLOWLIST` with an inline comment explaining why the surface genuinely cannot use the primitive (e.g., "milestone rail is a vertical-timeline, not a list row"). Cap: **≤3 allowlist entries globally**. Exceeding the cap means the primitive is wrong — extend its variants or split, don't allowlist around.
+
+**When to split.** `PortalListItem` is one component with two variants today. Split into `PortalStatusListItem` + `PortalDocumentListItem` only when more than ~5 conditionals key on `variant`, or when a third variant is needed. Don't pre-split.
+
+---
+
 ## Enforcement
 
 - **Grep / AST rules** in the `nav-spec/validate.py` extension or a sibling validator: redundancy detector (Rule 2), inline typography detector (Rule 5), inline spacing detector (Rule 6), multi-primary detector (Rule 3), heading-skip detector (Rule 4), pill-context detector (Rule 1).

--- a/src/components/portal/PortalListItem.astro
+++ b/src/components/portal/PortalListItem.astro
@@ -1,0 +1,125 @@
+---
+/**
+ * The portal list row. One component, two variants:
+ *
+ *   variant='status'   — proposals, invoices. Pill + title + money + meta.
+ *   variant='document' — documents. Icon + title + eyebrow. No money, no pill.
+ *
+ * This is the ONLY place list-row markup should exist on portal surfaces.
+ * Enforced by `tests/forbidden-strings.test.ts` — any `.map(` inside a
+ * portal index page must render through <PortalListItem>.
+ *
+ * Card shell is inlined (no separate _PortalListRow.astro) because splitting
+ * didn't earn its keep for two callers. If document and status layouts
+ * diverge materially in the future, split then.
+ *
+ * The whole card is a link. The chevron/trailing-icon indicates
+ * interactivity; no redundant "View details" button (UI-PATTERNS R2:
+ * one signal per fact).
+ */
+
+import MoneyDisplay from './MoneyDisplay.astro'
+import StatusPill from './StatusPill.astro'
+import type { Tone } from '../../lib/portal/status'
+
+type StatusProps = {
+  variant: 'status'
+  href: string
+  tone: Tone
+  toneLabel: string
+  title: string
+  amountCents: number
+  metaCaption?: string | null
+  trailingCaption?: string | null
+}
+
+type DocumentProps = {
+  variant: 'document'
+  href: string
+  icon: string
+  title: string
+  eyebrow?: string | null
+  trailingIcon: 'open_in_new' | 'download'
+  /** If true, link opens in a new tab. */
+  external?: boolean
+}
+
+type Props = StatusProps | DocumentProps
+
+const props = Astro.props as Props
+
+const shellClass = [
+  'block bg-[color:var(--color-surface)]',
+  'rounded-[var(--radius-card)] border border-[color:var(--color-border)]',
+  'p-card',
+  'transition-colors',
+  'hover:border-[color:var(--color-text-muted)]',
+  'focus-visible:outline-none',
+  'focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2',
+].join(' ')
+---
+
+{
+  props.variant === 'status' ? (
+    <a href={props.href} class={shellClass}>
+      <div class="flex items-center gap-stack min-h-[44px]">
+        <div class="flex-1 min-w-0 flex flex-col gap-row">
+          <div class="flex items-center gap-row flex-wrap">
+            <StatusPill tone={props.tone} label={props.toneLabel} />
+            <span class="text-heading text-[color:var(--color-text-primary)] truncate">
+              {props.title}
+            </span>
+          </div>
+          <div class="flex items-baseline gap-row flex-wrap">
+            <MoneyDisplay amountCents={props.amountCents} size="h2" />
+            {props.metaCaption && (
+              <span class="text-caption text-[color:var(--color-text-muted)]">
+                {props.metaCaption}
+              </span>
+            )}
+            {props.trailingCaption && (
+              <span class="text-caption text-[color:var(--color-attention)]">
+                {props.trailingCaption}
+              </span>
+            )}
+          </div>
+        </div>
+        <span
+          class="material-symbols-outlined text-[color:var(--color-text-muted)] flex-shrink-0"
+          aria-hidden="true"
+        >
+          chevron_right
+        </span>
+      </div>
+    </a>
+  ) : (
+    <a
+      href={props.href}
+      class={shellClass}
+      {...(props.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+    >
+      <div class="flex items-center gap-stack min-h-[44px]">
+        <span
+          class="flex-shrink-0 w-10 h-10 rounded-lg bg-[color:var(--color-primary)]/10 flex items-center justify-center text-[color:var(--color-primary)]"
+          aria-hidden="true"
+        >
+          <span class="material-symbols-outlined">{props.icon}</span>
+        </span>
+        <div class="flex-1 min-w-0 flex flex-col gap-row">
+          <span class="text-heading text-[color:var(--color-text-primary)] truncate">
+            {props.title}
+          </span>
+          {props.eyebrow && (
+            <span class="text-label uppercase text-[color:var(--color-meta)]">{props.eyebrow}</span>
+          )}
+        </div>
+        <span
+          class="material-symbols-outlined text-[color:var(--color-text-muted)] flex-shrink-0"
+          aria-hidden="true"
+        >
+          {props.trailingIcon}
+        </span>
+      </div>
+    </a>
+  )
+}

--- a/src/components/portal/StatusPill.astro
+++ b/src/components/portal/StatusPill.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * Tone-based status pill. The only place pill markup should exist on portal
+ * surfaces. Consumes TONE_CLASS from src/lib/portal/status.ts so a tone
+ * change (e.g., 'warning' shifts color) propagates everywhere at once.
+ *
+ * Accessibility: a pill is a visual affordance for a fact that is already
+ * available in the DOM (the status field). It does not need aria-label
+ * when its text content matches the fact.
+ */
+
+import { TONE_CLASS, type Tone } from '../../lib/portal/status'
+
+interface Props {
+  tone: Tone
+  label: string
+  /**
+   * `compact` is the default (table/list rows). `base` is the larger pill
+   * used on detail pages where the pill is the primary status signal.
+   */
+  size?: 'compact' | 'base'
+  class?: string
+}
+
+const { tone, label, size = 'compact', class: klass = '' } = Astro.props
+
+const sizeClass = size === 'base' ? 'px-3 py-1 text-caption' : 'px-2.5 py-0.5 text-[11px] leading-4'
+
+const toneClass = TONE_CLASS[tone]
+---
+
+<span
+  class={`inline-flex items-center font-medium rounded-full whitespace-nowrap ${sizeClass} ${toneClass} ${klass}`}
+>
+  {label}
+</span>

--- a/src/lib/portal/formatters.ts
+++ b/src/lib/portal/formatters.ts
@@ -1,0 +1,63 @@
+/**
+ * Portal-facing formatters. Centralized so no list/detail surface redefines
+ * its own formatDate/formatCurrency variant (the pattern that produced the
+ * three-different-date-formats drift this registry is fixing).
+ *
+ * Money rendering: use `<MoneyDisplay amountCents={N}>` as the default.
+ * Only fall back to `formatCentsToCurrency` when a string is required
+ * (e.g., interpolation into a title attribute or aria-label).
+ */
+
+/**
+ * Short date: "Apr 13, 2026" / "Apr 13" when within the current year.
+ * Returns an empty string for invalid ISO input so callers can chain without
+ * guarding.
+ */
+export function formatShortDate(iso: string | null | undefined): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const now = new Date()
+  const sameYear = d.getFullYear() === now.getFullYear()
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  })
+}
+
+/**
+ * Due caption: "Due Monday, April 20" for a future date; "Overdue — was
+ * Monday, April 20" for past. Used on invoice list rows + the detail
+ * action card.
+ */
+export function formatRelativeDueCaption(iso: string | null | undefined): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  const long = d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  })
+  const now = Date.now()
+  const diffMs = d.getTime() - now
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays < 0) return `Overdue — was ${long}`
+  if (diffDays === 0) return `Due today`
+  return `Due ${long}`
+}
+
+/**
+ * Cents → "$5,250" string. Whole dollars, no decimal places, en-US locale.
+ * Prefer <MoneyDisplay /> for rendered output; use this only when a plain
+ * string is required.
+ */
+export function formatCentsToCurrency(amountCents: number): string {
+  const dollars = Math.round(amountCents / 100)
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(dollars)
+}

--- a/src/lib/portal/status.ts
+++ b/src/lib/portal/status.ts
@@ -1,0 +1,112 @@
+/**
+ * Portal status resolution — per-entity tone + label + class lookups.
+ *
+ * Source of truth for status rendering on all portal surfaces. Admin uses
+ * src/lib/ui/status-badge.ts (raw Tailwind hex-family classes); portal uses
+ * this module (semantic var(--color-*) tokens). They remain separate by
+ * design — the portal is the drift surface and stays tone-based.
+ *
+ * Contract (UI-PATTERNS.md R7):
+ *   - Portal surfaces: import from src/lib/portal/status.ts
+ *   - Admin surfaces: import from src/lib/ui/status-badge.ts
+ *   - Shared/cross-surface: new helper when first needed; don't mix.
+ *
+ * Status → tone → label tables (argue with these assignments, not with the
+ * enum):
+ *
+ * Invoice:
+ *   draft   → neutral → "Draft"    (internal only; never portal-visible)
+ *   sent    → info    → "Sent"
+ *   paid    → success → "Paid"
+ *   overdue → danger  → "Overdue"
+ *   void    → neutral → "Void"     (internal only; never portal-visible)
+ *
+ * Quote:
+ *   draft      → neutral → "Draft"           (internal only)
+ *   sent       → info    → "Pending Review"  (client-facing: action required)
+ *   accepted   → success → "Accepted"
+ *   declined   → danger  → "Declined"
+ *   expired    → warning → "Expired"
+ *   superseded → neutral → "Superseded"      (internal only)
+ *
+ * Engagement (portal progress surface — future use):
+ *   scheduled  → info    → "Scheduled"
+ *   active     → success → "Active"
+ *   handoff    → info    → "Handoff"
+ *   safety_net → warning → "Stabilization"
+ *   completed  → success → "Completed"
+ *   cancelled  → neutral → "Cancelled"
+ */
+
+export type Tone = 'info' | 'success' | 'danger' | 'warning' | 'neutral'
+
+export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'void'
+export type QuoteStatus = 'draft' | 'sent' | 'accepted' | 'declined' | 'expired' | 'superseded'
+
+const INVOICE_TONE: Record<InvoiceStatus, Tone> = {
+  draft: 'neutral',
+  sent: 'info',
+  paid: 'success',
+  overdue: 'danger',
+  void: 'neutral',
+}
+
+const INVOICE_LABEL: Record<InvoiceStatus, string> = {
+  draft: 'Draft',
+  sent: 'Sent',
+  paid: 'Paid',
+  overdue: 'Overdue',
+  void: 'Void',
+}
+
+const QUOTE_TONE: Record<QuoteStatus, Tone> = {
+  draft: 'neutral',
+  sent: 'info',
+  accepted: 'success',
+  declined: 'danger',
+  expired: 'warning',
+  superseded: 'neutral',
+}
+
+const QUOTE_LABEL: Record<QuoteStatus, string> = {
+  draft: 'Draft',
+  sent: 'Pending Review',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  expired: 'Expired',
+  superseded: 'Superseded',
+}
+
+export function resolveInvoiceTone(status: string): Tone {
+  return INVOICE_TONE[status as InvoiceStatus] ?? 'neutral'
+}
+
+export function resolveInvoiceLabel(status: string): string {
+  return INVOICE_LABEL[status as InvoiceStatus] ?? status
+}
+
+export function resolveQuoteTone(status: string): Tone {
+  return QUOTE_TONE[status as QuoteStatus] ?? 'neutral'
+}
+
+export function resolveQuoteLabel(status: string): string {
+  return QUOTE_LABEL[status as QuoteStatus] ?? status
+}
+
+/**
+ * Tone → class map, consumed by StatusPill. Uses semantic tokens only.
+ * Not exported as part of the public API — consumers pass a Tone; only
+ * StatusPill renders the pill.
+ *
+ * The alpha-channel backgrounds (e.g., `bg-[color:var(--color-primary)]/10`)
+ * give the pill a tinted surface without hard-coding a separate color
+ * variable per tone. Text color uses the same semantic role at full
+ * saturation for AA contrast against the tinted background.
+ */
+export const TONE_CLASS: Record<Tone, string> = {
+  info: 'bg-[color:var(--color-primary)]/10 text-[color:var(--color-primary)]',
+  success: 'bg-[color:var(--color-complete)]/10 text-[color:var(--color-complete)]',
+  danger: 'bg-[color:var(--color-error)]/10 text-[color:var(--color-error)]',
+  warning: 'bg-[color:var(--color-attention)]/10 text-[color:var(--color-attention)]',
+  neutral: 'bg-[color:var(--color-surface-muted,#f1f5f9)] text-[color:var(--color-text-secondary)]',
+}

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -7,7 +7,9 @@ import { getPortalClient } from '../../../lib/portal/session'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
+import PortalListItem from '../../../components/portal/PortalListItem.astro'
 import SkipToMain from '../../../components/SkipToMain.astro'
+import { formatShortDate } from '../../../lib/portal/formatters'
 
 /**
  * Client portal — document library page.
@@ -43,7 +45,6 @@ const documents: DocumentEntry[] = []
 let engagement = null
 
 if (clientId) {
-  // Get active engagement (or most recent one)
   const engagements = await listEngagements(env.DB, session.orgId, clientId)
   engagement =
     engagements.find((e) => e.status !== 'completed' && e.status !== 'cancelled') ??
@@ -51,7 +52,6 @@ if (clientId) {
     null
 
   if (engagement) {
-    // List engagement documents from R2
     const prefix = `${session.orgId}/engagements/${engagement.id}/docs/`
     const r2Objects = await listDocuments(env.STORAGE, prefix)
 
@@ -66,7 +66,6 @@ if (clientId) {
       })
     }
 
-    // Include SOW PDF from the quote if available
     if (engagement.quote_id) {
       const sowState = await getSOWStateForQuote(env.DB, session.orgId, engagement.quote_id)
       const revision = sowState.downloadableRevision
@@ -84,14 +83,6 @@ if (clientId) {
   }
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
 /**
  * File-type icon mapping. Purely visual affordance derived from the
  * filename extension — not client-facing authored content.
@@ -105,6 +96,11 @@ function iconFor(name: string, isPdf: boolean): string {
   if (/\.(pptx?|keynote)$/.test(lower)) return 'slideshow'
   if (/\.(zip|tar|gz|7z)$/.test(lower)) return 'folder_zip'
   return 'description'
+}
+
+function resolveEyebrow(doc: DocumentEntry): string {
+  const shared = `Shared ${formatShortDate(doc.uploaded)}`
+  return doc.category ? `${doc.category} · ${shared}` : shared
 }
 ---
 
@@ -125,13 +121,13 @@ function iconFor(name: string, isPdf: boolean): string {
     />
     <title>Documents — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-slate-50">
+  <body class="min-h-screen bg-[color:var(--color-background)]">
     <SkipToMain />
     <PortalHeader clientName={clientName}>
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
         >
           Sign out
         </button>
@@ -144,64 +140,32 @@ function iconFor(name: string, isPdf: boolean): string {
       <a
         href="/portal"
         aria-label="Home"
-        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-caption font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
       >
         <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
         Home
       </a>
 
-      <h1 class="text-xl font-semibold text-slate-900 mb-6">Documents</h1>
+      <h1 class="text-title text-[color:var(--color-text-primary)] mb-section">Documents</h1>
 
       {
         documents.length === 0 ? (
-          <div class="bg-white rounded-lg border border-slate-200 p-card">
-            <p class="text-slate-600">Documents will appear here as your engagement progresses.</p>
+          <div class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
+            <p class="text-body text-[color:var(--color-text-secondary)]">
+              Documents will appear here as your engagement progresses.
+            </p>
           </div>
         ) : (
           <div class="space-y-row">
             {documents.map((doc) => (
-              <a
+              <PortalListItem
+                variant="document"
                 href={`/api/portal/documents/${doc.key}`}
-                class="block bg-white rounded-lg border border-slate-200 p-stack hover:border-slate-300 hover:shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-              >
-                <div class="flex items-center justify-between gap-row">
-                  <div class="flex items-center gap-row min-w-0 flex-1">
-                    <div
-                      class="flex-shrink-0 w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center text-[color:var(--color-meta)]"
-                      aria-hidden="true"
-                    >
-                      <span class="material-symbols-outlined text-[20px]">
-                        {iconFor(doc.name, doc.isPdf)}
-                      </span>
-                    </div>
-                    <div class="min-w-0">
-                      <p class="text-sm font-semibold text-slate-900 truncate">{doc.name}</p>
-                      <p class="text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--color-meta)] mt-0.5">
-                        {doc.category ? (
-                          <>
-                            {doc.category}
-                            <span class="mx-1" aria-hidden="true">
-                              •
-                            </span>
-                          </>
-                        ) : null}
-                        Shared {formatDate(doc.uploaded)}
-                      </p>
-                    </div>
-                  </div>
-                  <span
-                    class="flex-shrink-0 inline-flex items-center justify-center w-11 h-11 rounded-full text-[color:var(--color-meta)]"
-                    aria-hidden="true"
-                  >
-                    <span class="material-symbols-outlined text-[20px]">
-                      {doc.isPdf ? 'open_in_new' : 'download'}
-                    </span>
-                  </span>
-                  <span class="sr-only">
-                    {doc.isPdf ? 'View' : 'Download'} {doc.name}
-                  </span>
-                </div>
-              </a>
+                icon={iconFor(doc.name, doc.isPdf)}
+                title={doc.name}
+                eyebrow={resolveEyebrow(doc)}
+                trailingIcon={doc.isPdf ? 'open_in_new' : 'download'}
+              />
             ))}
           </div>
         )

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -10,6 +10,7 @@ import MoneyDisplay from '../../../components/portal/MoneyDisplay.astro'
 import ActionCard from '../../../components/portal/ActionCard.astro'
 import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
 import { resolveInvoiceState } from '../../../lib/portal/states'
+import { formatShortDate } from '../../../lib/portal/formatters'
 
 /**
  * Invoice landing — deep-link surface per .stitch/portal-ux-brief.md.
@@ -109,6 +110,10 @@ const stripeUrl =
 const isPayable = stripeUrl !== null
 
 // Formatting
+// Long-form "Monday, April 20" — local because it's wrapped in "Due {X}" /
+// "Paid {X}" etc. below. The shared lib has a different composer
+// (`formatRelativeDueCaption`) that bakes the "Due/Overdue" into the string;
+// keeping the wrapping local here preserves the authored sentence shape.
 const formatDueCaption = (iso: string | null): string | null => {
   if (!iso) return null
   const d = new Date(iso)
@@ -118,13 +123,6 @@ const formatDueCaption = (iso: string | null): string | null => {
     month: 'long',
     day: 'numeric',
   })
-}
-
-const formatShortDate = (iso: string | null): string | null => {
-  if (!iso) return null
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return null
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 const daysUntil = (iso: string | null): number | null => {

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -2,11 +2,14 @@
 import '../../../styles/global.css'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
-import { listInvoicesForEntity, INVOICE_STATUSES } from '../../../lib/db/invoices'
+import { listInvoicesForEntity } from '../../../lib/db/invoices'
 import type { Invoice } from '../../../lib/db/invoices'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
+import PortalListItem from '../../../components/portal/PortalListItem.astro'
 import SkipToMain from '../../../components/SkipToMain.astro'
+import { formatShortDate } from '../../../lib/portal/formatters'
+import { resolveInvoiceTone, resolveInvoiceLabel } from '../../../lib/portal/status'
 
 /**
  * Client portal — invoices page.
@@ -20,7 +23,6 @@ import SkipToMain from '../../../components/SkipToMain.astro'
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
-// Resolve client entity from session
 const portalData = await getPortalClient(env.DB, session.userId, session.orgId)
 const entityId = portalData?.client.id ?? null
 const clientName = portalData?.client.name ?? ''
@@ -31,15 +33,7 @@ if (entityId) {
   invoices = await listInvoicesForEntity(env.DB, session.orgId, entityId)
 }
 
-// Status badge colors for portal-visible statuses
-const statusColorMap: Record<string, string> = {
-  sent: 'bg-blue-100 text-blue-800',
-  paid: 'bg-green-100 text-green-800',
-  overdue: 'bg-red-100 text-red-800',
-}
-
-// Type label map
-const typeLabels: Record<string, string> = {
+const typeLabel: Record<string, string> = {
   deposit: 'Deposit',
   completion: 'Completion',
   milestone: 'Milestone',
@@ -47,17 +41,14 @@ const typeLabels: Record<string, string> = {
   retainer: 'Retainer',
 }
 
-function formatCurrency(amount: number): string {
-  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+function resolveMetaCaption(inv: Invoice): string | null {
+  if (inv.paid_at) return `Paid ${formatShortDate(inv.paid_at)}`
+  if (inv.due_date) return `Due ${formatShortDate(inv.due_date)}`
+  return null
 }
 
-function formatDate(iso: string | null): string {
-  if (!iso) return '--'
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
+function resolveTrailingCaption(inv: Invoice): string | null {
+  return inv.status === 'overdue' ? 'Overdue' : null
 }
 ---
 
@@ -78,13 +69,13 @@ function formatDate(iso: string | null): string {
     />
     <title>Invoices — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-slate-50">
+  <body class="min-h-screen bg-[color:var(--color-background)]">
     <SkipToMain />
     <PortalHeader clientName={clientName}>
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
         >
           Sign out
         </button>
@@ -97,84 +88,35 @@ function formatDate(iso: string | null): string {
       <a
         href="/portal"
         aria-label="Home"
-        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-caption font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
       >
         <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
         Home
       </a>
 
-      <h1 class="text-xl font-semibold text-slate-900 mb-6">Invoices</h1>
+      <h1 class="text-title text-[color:var(--color-text-primary)] mb-section">Invoices</h1>
 
       {
         invoices.length === 0 ? (
-          <div class="bg-white rounded-lg border border-slate-200 p-card">
-            <p class="text-slate-600">
+          <div class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
+            <p class="text-body text-[color:var(--color-text-secondary)]">
               No invoices yet. When invoices are created for your engagement, they will appear here.
             </p>
           </div>
         ) : (
           <div class="space-y-row">
-            {invoices.map((inv: Invoice) => {
-              const isPayable =
-                inv.status !== 'paid' &&
-                inv.stripe_hosted_url &&
-                inv.stripe_hosted_url !== '#dev-mode'
-              const isPending = inv.status !== 'paid' && inv.stripe_hosted_url === '#dev-mode'
-              return (
-                <a
-                  href={`/portal/invoices/${inv.id}`}
-                  class="block bg-white rounded-lg border border-slate-200 p-stack hover:border-slate-300 hover:shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-                >
-                  <div class="flex flex-col sm:flex-row sm:items-center gap-row">
-                    <div class="flex-1 min-w-0">
-                      <div class="flex items-center gap-row mb-1">
-                        <span class="text-body font-semibold text-slate-900">
-                          {typeLabels[inv.type] ?? inv.type}
-                        </span>
-                        <span
-                          class={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusColorMap[inv.status] ?? 'bg-slate-100 text-slate-600'}`}
-                        >
-                          {INVOICE_STATUSES.find((s) => s.value === inv.status)?.label ??
-                            inv.status}
-                        </span>
-                      </div>
-                      <p class="text-body-lg font-semibold text-slate-900">
-                        {formatCurrency(inv.amount)}
-                      </p>
-                      <div class="mt-1 text-caption text-slate-500">
-                        {inv.paid_at ? (
-                          <span class="text-green-700">{formatDate(inv.paid_at)}</span>
-                        ) : inv.due_date ? (
-                          <span class={inv.status === 'overdue' ? 'text-red-600' : ''}>
-                            Due {formatDate(inv.due_date)}
-                          </span>
-                        ) : null}
-                      </div>
-                      {inv.description && (
-                        <p class="text-caption text-slate-500 mt-2">{inv.description}</p>
-                      )}
-                    </div>
-                    <div class="flex items-center sm:justify-end flex-shrink-0 sm:ml-stack">
-                      {isPayable && (
-                        <span class="inline-flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
-                          Pay
-                        </span>
-                      )}
-                      {isPending && (
-                        <span class="inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-500 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
-                          Payment link pending
-                        </span>
-                      )}
-                      {!isPayable && !isPending && (
-                        <span class="inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-600 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
-                          View details
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </a>
-              )
-            })}
+            {invoices.map((inv: Invoice) => (
+              <PortalListItem
+                variant="status"
+                href={`/portal/invoices/${inv.id}`}
+                tone={resolveInvoiceTone(inv.status)}
+                toneLabel={resolveInvoiceLabel(inv.status)}
+                title={typeLabel[inv.type] ?? inv.type}
+                amountCents={Math.round(inv.amount * 100)}
+                metaCaption={resolveMetaCaption(inv)}
+                trailingCaption={resolveTrailingCaption(inv)}
+              />
+            ))}
           </div>
         )
       }

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -11,6 +11,7 @@ import { getQuoteForEntity, parseSchedule, parseDeliverables } from '../../../li
 import type { ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
 import { resolveProposalState } from '../../../lib/portal/states'
+import { formatShortDate } from '../../../lib/portal/formatters'
 
 /**
  * Portal quote detail — C-hybrid proposal landing.
@@ -48,9 +49,6 @@ if (!quote) {
 const sowState = await getSOWStateForQuote(env.DB, session.orgId, quote.id)
 const activeSignatureRequest = sowState.openSignatureRequest
 const downloadableRevision = sowState.downloadableRevision
-
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 
 const depositPctDisplay = Math.round(quote.deposit_pct * 100)
 const balancePctDisplay = 100 - depositPctDisplay
@@ -237,7 +235,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
                     </span>
                     <div class="min-w-0">
                       <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
-                        Signed{quote.accepted_at ? ` ${formatDate(quote.accepted_at)}` : ''}.
+                        Signed{quote.accepted_at ? ` ${formatShortDate(quote.accepted_at)}` : ''}.
                       </p>
                       {surface.next && (
                         <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
@@ -454,7 +452,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
                       </span>
                       <div class="min-w-0">
                         <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
-                          Signed{quote.accepted_at ? ` ${formatDate(quote.accepted_at)}` : ''}.
+                          Signed{quote.accepted_at ? ` ${formatShortDate(quote.accepted_at)}` : ''}.
                         </p>
                         {surface.next && (
                           <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -6,19 +6,21 @@ import { listQuotesForEntity } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
+import PortalListItem from '../../../components/portal/PortalListItem.astro'
 import SkipToMain from '../../../components/SkipToMain.astro'
+import { formatShortDate } from '../../../lib/portal/formatters'
+import { resolveQuoteTone, resolveQuoteLabel } from '../../../lib/portal/status'
 
 /**
  * Portal quote list — shows all quotes visible to this client.
  *
- * Statuses shown: sent, accepted, declined, expired.
- * "Review & Sign" CTA for quotes with status = 'sent'.
+ * Statuses shown: sent, accepted, declined, expired (filtered by
+ * listQuotesForEntity).
  */
 
 const session = Astro.locals.session!
 const env = Astro.locals.runtime.env
 
-// Resolve client from session
 const portalData = await getPortalClient(env.DB, session.userId, session.orgId)
 if (!portalData) {
   return Astro.redirect('/auth/portal-login?error=no_account')
@@ -27,25 +29,16 @@ if (!portalData) {
 const { client } = portalData
 const quotes = await listQuotesForEntity(env.DB, session.orgId, client.id)
 
-// Helpers
-const formatCurrency = (amount: number) =>
-  `$${amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
-
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-
-const statusColorMap: Record<string, string> = {
-  sent: 'bg-blue-100 text-blue-800',
-  accepted: 'bg-green-100 text-green-800',
-  declined: 'bg-red-100 text-red-800',
-  expired: 'bg-amber-100 text-amber-800',
+function resolveMetaCaption(q: Quote): string {
+  return formatShortDate(q.sent_at ?? q.created_at)
 }
 
-const statusLabelMap: Record<string, string> = {
-  sent: 'Pending Review',
-  accepted: 'Accepted',
-  declined: 'Declined',
-  expired: 'Expired',
+function resolveTrailingCaption(q: Quote): string | null {
+  if (q.status !== 'sent' || !q.expires_at) return null
+  const diffMs = new Date(q.expires_at).getTime() - Date.now()
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays <= 0) return 'Expired'
+  return `Expires in ${diffDays} day${diffDays !== 1 ? 's' : ''}`
 }
 ---
 
@@ -66,13 +59,13 @@ const statusLabelMap: Record<string, string> = {
     />
     <title>Proposals — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-slate-50">
+  <body class="min-h-screen bg-[color:var(--color-background)]">
     <SkipToMain />
     <PortalHeader clientName={client.name}>
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
         >
           Sign out
         </button>
@@ -85,19 +78,19 @@ const statusLabelMap: Record<string, string> = {
       <a
         href="/portal"
         aria-label="Home"
-        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-[13px] font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+        class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-caption font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
       >
         <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
         Home
       </a>
 
-      <h1 class="text-xl font-semibold text-slate-900 mb-6">Proposals</h1>
+      <h1 class="text-title text-[color:var(--color-text-primary)] mb-section">Proposals</h1>
 
       {
         quotes.length === 0 ? (
-          <div class="bg-white rounded-lg border border-slate-200 p-section text-center">
+          <div class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section text-center">
             <svg
-              class="w-12 h-12 text-slate-300 mx-auto mb-3"
+              class="w-12 h-12 text-[color:var(--color-text-muted)] mx-auto mb-stack"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -109,71 +102,27 @@ const statusLabelMap: Record<string, string> = {
                 d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
               />
             </svg>
-            <p class="text-slate-600 font-medium">No proposals yet</p>
-            <p class="text-sm text-slate-400 mt-1">
+            <p class="text-body font-medium text-[color:var(--color-text-primary)]">
+              No proposals yet
+            </p>
+            <p class="text-caption text-[color:var(--color-text-muted)] mt-1">
               Proposals will appear here once they are ready for review.
             </p>
           </div>
         ) : (
           <div class="space-y-row">
-            {quotes.map((quote: Quote) => {
-              const dateLabel = quote.sent_at
-                ? formatDate(quote.sent_at)
-                : formatDate(quote.created_at)
-              const expiresLabel =
-                quote.status === 'sent' && quote.expires_at
-                  ? (() => {
-                      const diffMs = new Date(quote.expires_at).getTime() - Date.now()
-                      const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
-                      return diffDays > 0
-                        ? `Expires in ${diffDays} day${diffDays !== 1 ? 's' : ''}`
-                        : 'Expired'
-                    })()
-                  : null
-              return (
-                <a
-                  href={`/portal/quotes/${quote.id}`}
-                  class="block bg-white rounded-lg border border-slate-200 p-stack hover:border-slate-300 hover:shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-                >
-                  <div class="flex items-center justify-between gap-stack">
-                    <div class="flex-1 min-w-0">
-                      <div class="flex flex-wrap items-center gap-2 mb-1">
-                        <span
-                          class={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${statusColorMap[quote.status] ?? 'bg-slate-100 text-slate-600'}`}
-                        >
-                          {statusLabelMap[quote.status] ?? quote.status}
-                        </span>
-                        <h2 class="text-sm font-semibold text-slate-900 leading-tight truncate">
-                          Proposal #{quote.id.slice(0, 8)}
-                        </h2>
-                      </div>
-                      <div class="flex items-baseline gap-2 flex-wrap">
-                        <span class="text-lg font-bold text-[color:var(--color-primary)]">
-                          {formatCurrency(quote.total_price)}
-                        </span>
-                        <span class="text-xs text-slate-400">{dateLabel}</span>
-                        {expiresLabel && <span class="text-xs text-amber-600">{expiresLabel}</span>}
-                      </div>
-                    </div>
-
-                    <div class="flex items-center gap-stack flex-shrink-0">
-                      {quote.status === 'sent' ? (
-                        <span class="hidden sm:inline-flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
-                          Review &amp; Sign
-                        </span>
-                      ) : (
-                        <span class="hidden sm:inline-flex items-center justify-center px-4 py-2.5 bg-slate-100 text-slate-600 text-sm font-medium rounded-lg min-h-[44px] whitespace-nowrap">
-                          View Details
-                        </span>
-                      )}
-                      <span class="material-symbols-outlined text-slate-400" aria-hidden="true">
-                        chevron_right
-                      </span>
-                    </div>
-                  </div>
-                </a>
-              )
-            })}
+            {quotes.map((quote: Quote) => (
+              <PortalListItem
+                variant="status"
+                href={`/portal/quotes/${quote.id}`}
+                tone={resolveQuoteTone(quote.status)}
+                toneLabel={resolveQuoteLabel(quote.status)}
+                title={`Proposal #${quote.id.slice(0, 8)}`}
+                amountCents={Math.round(quote.total_price * 100)}
+                metaCaption={resolveMetaCaption(quote)}
+                trailingCaption={resolveTrailingCaption(quote)}
+              />
+            ))}
           </div>
         )
       }

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -119,3 +119,134 @@ describe('forbidden-strings: Pattern A/B violations must not appear in shipped s
     })
   }
 })
+
+// ============================================================================
+// Portal list-row registry — UI-PATTERNS R7 enforcement.
+//
+// List-row markup drifted across portal surfaces (proposals, invoices,
+// documents) when Stitch generated each screen in isolation. The registry
+// collapses the pattern to one component (`PortalListItem.astro`) + two
+// helper modules (`src/lib/portal/{formatters,status}.ts`). These tests
+// enforce the registry at CI time so drift fails the build, not review.
+//
+// Scope: every `src/pages/portal/*/index.astro` EXCEPT the home dashboard
+// (which iterates its timeline, not list rows). New portal list surfaces
+// auto-enroll — explicit exceptions go in LIST_INDEX_ALLOWLIST with a
+// comment explaining why.
+// ============================================================================
+
+const PORTAL_INDEX_ROOT = resolve('src/pages/portal')
+const PORTAL_HOME = resolve('src/pages/portal/index.astro')
+
+/**
+ * Allowlist for portal list-index files that legitimately cannot use
+ * `PortalListItem` (e.g., because they iterate something that isn't a
+ * list-row card — timeline, form fields, milestone rail). Each entry needs
+ * a comment explaining why.
+ */
+const LIST_INDEX_ALLOWLIST: string[] = [
+  // `engagement/index.astro` is the engagement DETAIL surface (one
+  // engagement per client), not a list of engagements. Its milestone
+  // rendering is a vertical-timeline with marker-ring state semantics, not
+  // a repeating card — a different primitive than `PortalListItem`. Track
+  // as a follow-up if milestone rail drifts or gains a second use.
+  resolve('src/pages/portal/engagement/index.astro'),
+]
+
+/** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */
+function collectPortalListIndexFiles(): string[] {
+  const files: string[] = []
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir)) {
+      const fullPath = join(dir, entry)
+      const stat = statSync(fullPath)
+      if (stat.isDirectory()) {
+        walk(fullPath)
+      } else if (entry === 'index.astro' && fullPath !== PORTAL_HOME) {
+        files.push(fullPath)
+      }
+    }
+  }
+  walk(PORTAL_INDEX_ROOT)
+  return files.filter((f) => !LIST_INDEX_ALLOWLIST.includes(f))
+}
+
+const portalListIndexFiles = collectPortalListIndexFiles()
+
+describe('portal list-row registry: UI-PATTERNS R7 enforcement', () => {
+  it('finds at least one portal list-index file to check (sanity)', () => {
+    // If this fails, the file collection logic broke — not the registry.
+    expect(portalListIndexFiles.length).toBeGreaterThan(0)
+  })
+
+  // ----------------------------------------------------------------
+  // Presence assertion.
+  //
+  // If the file iterates (`.map(`), it must render through
+  // `<PortalListItem`. Class-reorder evasion (the Devil's Advocate's
+  // objection to "no forbidden markup string" assertions) is defeated
+  // because this asserts PRESENCE of the primitive, not absence of
+  // specific class strings.
+  // ----------------------------------------------------------------
+  for (const file of portalListIndexFiles) {
+    const rel = file.replace(resolve('.') + '/', '')
+    it(`${rel} — must render list rows through <PortalListItem>`, () => {
+      const content = readFileSync(file, 'utf-8')
+      const iteratesList = /\.map\(/.test(content)
+      if (!iteratesList) return // not a list surface, no assertion
+      const usesPrimitive = content.includes('<PortalListItem')
+      expect(
+        usesPrimitive,
+        `${rel} iterates with .map( but does not render through <PortalListItem>. ` +
+          `Portal list-row markup must go through src/components/portal/PortalListItem.astro.`
+      ).toBe(true)
+    })
+  }
+
+  // ----------------------------------------------------------------
+  // No local helper redefinition.
+  //
+  // Drift starts when a page defines its own formatDate / statusColorMap
+  // instead of importing from src/lib/portal/{formatters,status}.ts.
+  // Catch it at the declaration site.
+  // ----------------------------------------------------------------
+  const FORBIDDEN_LOCAL_DECLARATIONS: Array<{ name: string; pattern: RegExp }> = [
+    {
+      name: 'formatDate',
+      pattern: /^\s*(?:const|function)\s+formatDate\b/m,
+    },
+    {
+      name: 'formatCurrency',
+      pattern: /^\s*(?:const|function)\s+formatCurrency\b/m,
+    },
+    {
+      name: 'statusColorMap',
+      pattern: /^\s*const\s+statusColorMap\b/m,
+    },
+    {
+      name: 'statusLabelMap',
+      pattern: /^\s*const\s+statusLabelMap\b/m,
+    },
+    {
+      name: 'typeLabels',
+      // Matches `typeLabels` as a standalone const; does NOT match
+      // `typeLabel` or `typeLabelMap` (detail pages use those for
+      // one-off single-title mapping and are out of scope).
+      pattern: /^\s*const\s+typeLabels\s*(?::|=)/m,
+    },
+  ]
+
+  for (const file of portalListIndexFiles) {
+    const rel = file.replace(resolve('.') + '/', '')
+    for (const { name, pattern } of FORBIDDEN_LOCAL_DECLARATIONS) {
+      it(`${rel} — must not redefine local helper \`${name}\``, () => {
+        const content = readFileSync(file, 'utf-8')
+        expect(
+          pattern.test(content),
+          `${rel} declares a local \`${name}\`. Import from ` +
+            `src/lib/portal/formatters.ts or src/lib/portal/status.ts instead.`
+        ).toBe(false)
+      })
+    }
+  }
+})

--- a/tests/invoices.test.ts
+++ b/tests/invoices.test.ts
@@ -468,12 +468,17 @@ describe('invoices: portal view', () => {
     expect(code).toContain('session.userId')
   })
 
-  it('displays invoice amount', () => {
-    expect(source()).toContain('formatCurrency')
+  it('passes amount to PortalListItem as cents', () => {
+    // After R7 registry: the page defers rendering to PortalListItem +
+    // MoneyDisplay. `inv.amount` is dollars; the page converts to cents.
+    const code = source()
+    expect(code).toContain('amountCents={Math.round(inv.amount * 100)}')
   })
 
-  it('displays invoice status badges', () => {
-    expect(source()).toContain('statusColorMap')
+  it('resolves status tone + label via shared helpers (R7 registry)', () => {
+    const code = source()
+    expect(code).toContain('resolveInvoiceTone')
+    expect(code).toContain('resolveInvoiceLabel')
   })
 
   it('links each row to the invoice detail page', () => {
@@ -481,21 +486,21 @@ describe('invoices: portal view', () => {
     expect(code).toContain('/portal/invoices/${inv.id}')
   })
 
-  it('shows a Pay affordance for unpaid invoices with a usable Stripe URL', () => {
+  it('signals unpaid/overdue state via tone, not a separate Pay button', () => {
     const code = source()
-    // The Stripe URL is still considered when choosing what affordance to render.
-    expect(code).toContain('stripe_hosted_url')
-    expect(code).toMatch(/Pay\b/)
+    // UI-PATTERNS R2 (redundancy): the card is the link; no standalone
+    // Pay affordance that would duplicate the card-level navigation.
+    // The tone (`info` for sent, `danger` for overdue) surfaces action-
+    // required state; detail page owns the actual pay CTA.
+    expect(code).toContain('resolveInvoiceTone')
+    expect(code).not.toMatch(/\bPay\b/)
+    expect(code).not.toContain('Payment link pending')
   })
 
-  it('shows a pending-link indicator when Stripe is not yet configured', () => {
-    expect(source()).toContain('Payment link pending')
-  })
-
-  it('shows paid date for paid invoices', () => {
+  it('surfaces paid / due dates via shared formatter', () => {
     const code = source()
-    expect(code).toContain('paid_at')
-    expect(code).toMatch(/formatDate\(inv\.paid_at\)/)
+    expect(code).toContain('formatShortDate')
+    expect(code).toMatch(/resolveMetaCaption/)
   })
 
   it('handles empty state when no invoices exist', () => {

--- a/tests/portal-list-consistency.test.ts
+++ b/tests/portal-list-consistency.test.ts
@@ -3,22 +3,21 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 /**
- * Regression guard for the unified portal list scaffolding established by
- * PRs #413–#415. The three list pages — Proposals, Invoices, Documents —
- * must share the same h1 class, list container spacing, and row-card
- * treatment so they stay visually consistent as copy/content changes.
+ * Regression guard for unified portal list scaffolding. Originally from
+ * PRs #413-415 when the three list pages shared canonical inline markup.
  *
- * If this test fails, the fix is either to update the other pages to match
- * or to update this test plus the scaffolding intentionally.
+ * After UI-PATTERNS R7 (portal list-row registry), the canonical markup
+ * lives in `src/components/portal/PortalListItem.astro`. The scaffolding
+ * contract is now: each list page imports the primitive, uses the shared
+ * spacing-rhythm container, and uses the token-based h1 class that
+ * replaced the literal slate-900 classes.
+ *
+ * The per-row rendering assertions from the pre-registry version moved
+ * to `tests/forbidden-strings.test.ts` (R7 presence assertion).
  */
 
-const CANONICAL_H1_CLASS = 'text-xl font-semibold text-slate-900 mb-6'
-// space-y-row (spacing-row token = 12px, generated from --spacing-row) —
-// replaces the former literal space-y-3 after UI-PATTERNS Rule 6 landed.
+const CANONICAL_H1_CLASS = 'text-title text-[color:var(--color-text-primary)] mb-section'
 const CANONICAL_LIST_CONTAINER = 'space-y-row'
-// p-stack (spacing-stack = 16px) replaces literal p-4 per Rule 6.
-const CANONICAL_ROW_CARD =
-  'block bg-white rounded-lg border border-slate-200 p-stack hover:border-slate-300 hover:shadow-sm transition-all'
 
 const PAGES = [
   { name: 'Proposals', path: 'src/pages/portal/quotes/index.astro' },
@@ -26,26 +25,32 @@ const PAGES = [
   { name: 'Documents', path: 'src/pages/portal/documents/index.astro' },
 ] as const
 
-describe('portal list pages: unified scaffolding', () => {
+describe('portal list pages: unified scaffolding (R7 registry)', () => {
   for (const page of PAGES) {
     const source = () => readFileSync(resolve(page.path), 'utf-8')
 
     describe(page.name, () => {
-      it('uses the canonical h1 class', () => {
+      it('uses the canonical token-based h1 class', () => {
         expect(source()).toContain(CANONICAL_H1_CLASS)
       })
 
-      it('uses space-y-3 for the list container', () => {
+      it('uses space-y-row for the list container', () => {
         expect(source()).toContain(CANONICAL_LIST_CONTAINER)
       })
 
-      it('uses the canonical row-card anchor class', () => {
-        expect(source()).toContain(CANONICAL_ROW_CARD)
+      it('imports PortalListItem primitive', () => {
+        const code = source()
+        expect(code).toContain(
+          "import PortalListItem from '../../../components/portal/PortalListItem.astro'"
+        )
+      })
+
+      it('renders rows through <PortalListItem>', () => {
+        expect(source()).toContain('<PortalListItem')
       })
 
       it('does not use a "Your X" heading', () => {
         const code = source()
-        // Only h1 tags are in scope — body copy may still address the user.
         expect(code).not.toMatch(/<h1[^>]*>\s*Your\s/i)
       })
     })

--- a/tests/portal-quotes.test.ts
+++ b/tests/portal-quotes.test.ts
@@ -176,28 +176,35 @@ describe('portal quotes: quote list page', () => {
     expect(source()).toContain('getPortalClient')
   })
 
-  it('displays status badges', () => {
+  it('resolves status via portal status helpers (R7 registry)', () => {
     const code = source()
-    expect(code).toContain('statusColorMap')
-    expect(code).toContain('bg-blue-100')
-    expect(code).toContain('bg-green-100')
-    expect(code).toContain('bg-red-100')
-    expect(code).toContain('bg-amber-100')
+    // After UI-PATTERNS R7: the list page delegates status rendering to
+    // PortalListItem + StatusPill via tone/label resolvers. It no longer
+    // carries its own statusColorMap / raw bg-*-100 classes.
+    expect(code).toContain('resolveQuoteTone')
+    expect(code).toContain('resolveQuoteLabel')
   })
 
   it('displays total price for each quote', () => {
+    // Amount is passed to PortalListItem as cents (total_price * 100).
     expect(source()).toContain('quote.total_price')
   })
 
-  it('displays date sent', () => {
-    expect(source()).toContain('quote.sent_at')
+  it('displays a date on every row', () => {
+    // sent_at (or created_at fallback for not-yet-sent) rendered via the
+    // shared formatShortDate through PortalListItem metaCaption.
+    const code = source()
+    expect(code).toContain('formatShortDate')
+    expect(code).toContain('metaCaption')
   })
 
-  it('shows Review & Sign CTA for sent quotes', () => {
+  it('signals the sent state via tone, not an inline CTA button', () => {
     const code = source()
-    expect(code).toContain('Review')
-    expect(code).toContain('Sign')
-    expect(code).toContain("quote.status === 'sent'")
+    // UI-PATTERNS R2 (redundancy): the card is the link. No standalone
+    // "Review & Sign" button alongside the card-is-link affordance. The
+    // pill's `info` tone on sent quotes does the work.
+    expect(code).toContain('resolveQuoteTone')
+    expect(code).not.toMatch(/"Review\s*&\s*Sign"/)
   })
 
   it('links to detail page', () => {


### PR DESCRIPTION
## Summary

Collapses hand-rolled list-row markup on the three portal list surfaces (proposals, invoices, documents) into a single shared primitive. Closes the drift that made the three screens visually incoherent after the #429 Stitch rewrite.

**Root cause:** Stitch generates each screen in isolation. Design tokens unified colors and spacing, but nothing unified element shape. Every regeneration produced different markup for the same conceptual list row. Prose rules in `UI-PATTERNS.md` couldn't survive this; only a code contract can.

## What shipped

- **`PortalListItem.astro`** — one component, two variants (`status` / `document`). Whole card is a link; chevron is the only affordance. No redundant "View details" / "Pay" / "Review & Sign" buttons (UI-PATTERNS R2).
- **`StatusPill.astro`** — tone-based pill, token-driven. Reusable on detail pages.
- **`src/lib/portal/formatters.ts`** — `formatShortDate`, `formatRelativeDueCaption`, `formatCentsToCurrency`.
- **`src/lib/portal/status.ts`** — per-entity resolvers with the full `status → tone → label` table documented in the header comment. Semantic `var(--color-*)` tokens. Admin's `status-badge.ts` stays un-migrated (raw Tailwind, different contract).
- **5 pages migrated** — `quotes/index`, `invoices/index`, `documents/index` (list surfaces) + `quotes/[id]`, `invoices/[id]` (detail pages, swap local formatters for shared).
- **New UI-PATTERNS R7** "Shared primitives for repeated patterns" with anti-pattern, correct pattern, registered primitives, portal/admin contract, detection citation, escape-hatch rules.

## Enforcement

Two new assertion families in `tests/forbidden-strings.test.ts`:

1. **Presence.** Every `src/pages/portal/*/index.astro` that iterates via `.map(` MUST render through `<PortalListItem>`. Inverts the usual "no forbidden markup" pattern — defeats class-reorder evasion because we assert presence of the primitive, not absence of a specific string.
2. **No local helper redefinition.** No `formatDate` / `formatCurrency` / `statusColorMap` / `statusLabelMap` / `typeLabels` declared locally in portal list-index files.

New portal list surfaces auto-enroll. The `LIST_INDEX_ALLOWLIST` currently holds only `engagement/index.astro` (milestone rail is a detail surface, not a list row).

Both drift tests verified interactively (see commit message).

## Explicitly NOT in this PR

- Separate `ui-patterns.yml` workflow (existing CI runs the test — merge gate is "tests pass").
- Dedicated `portal-components` skill file (one-line callout in `stitch-design` is enough until drift recurs).
- Admin `status-badge.ts` consolidation (admin is not the drift surface).
- Milestone rail primitive (trigger-based follow-up).
- `.tsx` registry conversion (Astro stays).

## Test plan

- [x] `npm run verify` — 1,272 tests pass, 2 skipped, 0 errors.
- [x] Intentional drift test 1 (helper redef) — assertion fails; reverted.
- [x] Intentional drift test 2 (class reorder) — assertion fails; reverted.
- [x] Dry-run grep for remaining raw slate/blue classes — only remaining hits are in `engagement/index.astro` milestone rail (explicit scope).
- [ ] **Manual visual sanity check post-merge:** open `/portal/quotes`, `/portal/invoices`, `/portal/documents` against seeded data; confirm pills, dates, typography match across the three surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)