### PR TITLE
fix(booking): reword SlotPicker JSDoc to unblock npm run dev

### DIFF
--- a/src/components/booking/SlotPicker.astro
+++ b/src/components/booking/SlotPicker.astro
@@ -5,7 +5,7 @@
  * Left column: monthly calendar grid with month-by-month navigation.
  * Right column: time slots for the selected date (30-min in guest tz).
  *
- * All interactivity is handled in the <script> tag below. On mount it
+ * All interactivity is handled in the client script block below. On mount it
  * detects the guest's timezone, fetches /api/booking/slots, and renders
  * the first date with availability pre-selected.
  *


### PR DESCRIPTION
## Summary

One-line comment change. The JSDoc in \`SlotPicker.astro\` contained a literal \`<script>\` reference. Vite's esbuild dep-scanner extracts that as a script entry, then fails to parse the remaining comment text, blocking \`npm run dev\` entirely.

Production build was unaffected — issue is dev-server-only.

## Test plan

- [x] \`npm run verify\` — 1,272 tests pass.
- [x] \`npm run dev\` — starts cleanly at http://localhost:4321/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)