### PR TITLE
fix(pages): sync secrets from Infisical after every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,31 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=ss-web
 
+      # `wrangler pages deploy` silently wipes Pages secrets that aren't
+      # declared in wrangler.toml. Re-bind them from Infisical immediately
+      # after deploy. Skipped (with warning) if INFISICAL_TOKEN isn't set —
+      # the next operator will have to re-run `scripts/sync-pages-secrets.sh`
+      # manually until the token is added as a repo secret.
+      - name: Install Infisical CLI
+        if: ${{ vars.INFISICAL_SYNC_ENABLED == 'true' }}
+        run: curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash && sudo apt-get update && sudo apt-get install -y infisical
+
+      - name: Sync Pages secrets from Infisical
+        if: ${{ vars.INFISICAL_SYNC_ENABLED == 'true' }}
+        env:
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bash scripts/sync-pages-secrets.sh
+
+      - name: Warn if Infisical sync skipped
+        if: ${{ vars.INFISICAL_SYNC_ENABLED != 'true' }}
+        run: |
+          echo "::warning::INFISICAL_SYNC_ENABLED is not 'true' — Pages secrets were NOT re-synced after deploy."
+          echo "::warning::Every dashboard-set/wrangler-pages-put secret just got wiped to empty string."
+          echo "::warning::Run: bash scripts/sync-pages-secrets.sh  (with a live Infisical session)"
+          echo "::warning::Or set repo var INFISICAL_SYNC_ENABLED=true + repo secret INFISICAL_TOKEN (machine identity)."
+
       - name: Run D1 migrations
         if: ${{ vars.D1_MIGRATIONS_ENABLED == 'true' }}
         uses: cloudflare/wrangler-action@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,34 @@ npm run lint            # Run linter
 npm run typecheck       # TypeScript validation
 npm run verify          # Full verification
 npm run format          # Format with Prettier
+npm run sync:pages-secrets  # Push Infisical /ss secrets to Cloudflare Pages
 ```
+
+## Pages secrets are not persistent by default
+
+**Read before debugging "this secret is empty at runtime".**
+
+Cloudflare Pages treats `wrangler.toml`'s `[vars]` block as the authoritative source of deployment bindings. Every `wrangler pages deploy` run (including every CI deploy from this repo's `.github/workflows/deploy.yml`) silently overrides the deployment's bindings so any secret set via `wrangler pages secret put` or the dashboard reaches the runtime as an **empty string**.
+
+The effect is invisible:
+
+- `RESEND_API_KEY` empty → `src/lib/email/resend.ts` falls back to `console.log`, so magic links and portal invitations stop arriving but the app logs success
+- `ANTHROPIC_API_KEY` empty → Claude calls 401 and look like upstream flakes
+- `LEAD_INGEST_API_KEY` empty → admin "Run now" on `/admin/generators/*` silently disables
+- `BOOKING_ENCRYPTION_KEY` empty → Google Calendar OAuth callback errors out at encryption time
+- `STRIPE_*`, `SIGNWELL_*`, `TURNSTILE_SECRET_KEY`, `GOOGLE_CLIENT_*` all suffer the same fate
+
+**Source of truth is Infisical `/ss` at `env=prod`.** After any Pages deploy, run:
+
+```
+npm run sync:pages-secrets
+```
+
+The script reads every secret at that path and re-binds each to the Pages production deployment via `wrangler pages secret put`. CI does this automatically **only when** the repo var `INFISICAL_SYNC_ENABLED=true` AND the repo secret `INFISICAL_TOKEN` (Infisical machine identity) are set — otherwise the deploy job emits a `::warning::` and the next operator has to run the sync manually.
+
+If you add a new env-backed secret to `src/env.d.ts`, add it to Infisical `/ss` at the same time — otherwise the sync step won't know about it.
+
+Enterprise note: this same gotcha is latent in every Pages project across ventures. See `docs/infra/secrets-management.md` in `crane-console` for the enterprise-level write-up.
 
 ## Instruction Modules
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck:workers": "for dir in workers/*/; do echo \"Typechecking $dir\" && npm run typecheck --prefix \"$dir\" || exit 1; done",
     "verify": "npm run typecheck && npm run typecheck:workers && npm run format:check && npm run lint && npm run build && npm run test",
     "db:migrate:local": "wrangler d1 migrations apply ss-console-db --local",
+    "sync:pages-secrets": "bash scripts/sync-pages-secrets.sh",
     "prepare": "node -e \"if(process.env.CI)process.exit(0)\" && husky"
   },
   "dependencies": {

--- a/scripts/sync-pages-secrets.sh
+++ b/scripts/sync-pages-secrets.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Sync Cloudflare Pages secrets from Infisical.
+#
+# ## Why this exists
+#
+# Cloudflare Pages projects with a `wrangler.toml` `[vars]` block treat that
+# file as the authoritative source of deployment bindings. Every
+# `wrangler pages deploy` run silently overrides the deployment's secret
+# bindings so they reach the runtime as empty strings — including secrets
+# set via `wrangler pages secret put` or the Cloudflare dashboard.
+#
+# The effect is invisible: Resend email silently falls back to console logs,
+# Claude calls 401, Stripe/SignWell webhooks stop working, etc. No deploy
+# failure, no error — just empty values at runtime.
+#
+# This script is the durable fix. It reads all secrets from Infisical at
+# the configured venture path and re-binds them to the Pages production
+# deployment after every deploy.
+#
+# ## Usage
+#
+# Local (authenticated Infisical session):
+#   bash scripts/sync-pages-secrets.sh                      # default path /ss, project ss-web
+#   bash scripts/sync-pages-secrets.sh --dry-run            # list what would be set
+#   bash scripts/sync-pages-secrets.sh --path /ss --env prod --project ss-web
+#
+# CI (requires INFISICAL_TOKEN machine-identity token):
+#   env INFISICAL_TOKEN=... bash scripts/sync-pages-secrets.sh
+#
+# ## Exit codes
+#   0 - Success (or dry-run completed)
+#   1 - Infisical not authenticated / no secrets found
+#   2 - Configuration or argument error
+
+set -euo pipefail
+
+# ---------- Defaults ----------
+INFISICAL_ENV="prod"
+INFISICAL_PATH="/ss"
+PAGES_PROJECT="ss-web"
+DRY_RUN=0
+
+# ---------- Args ----------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) INFISICAL_ENV="$2"; shift 2 ;;
+    --path) INFISICAL_PATH="$2"; shift 2 ;;
+    --project) PAGES_PROJECT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --help|-h)
+      sed -n '2,35p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "error: unknown arg '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ---------- Preflight ----------
+command -v infisical >/dev/null 2>&1 || { echo "error: infisical CLI not found"; exit 2; }
+command -v npx >/dev/null 2>&1 || { echo "error: npx not found"; exit 2; }
+
+# Infisical auth:
+#   - If INFISICAL_TOKEN is set (CI / machine identity), use it via --token flag
+#   - Otherwise assume the CLI has an interactive session (local dev)
+AUTH_FLAG=""
+if [[ -n "${INFISICAL_TOKEN:-}" ]]; then
+  AUTH_FLAG="--token=$INFISICAL_TOKEN"
+fi
+
+# ---------- Enumerate secrets in Infisical ----------
+echo "Listing Infisical secrets at path=$INFISICAL_PATH env=$INFISICAL_ENV"
+SECRET_NAMES=$(
+  infisical secrets $AUTH_FLAG \
+    --env="$INFISICAL_ENV" \
+    --path="$INFISICAL_PATH" \
+    --silent 2>/dev/null \
+    | grep -oE "^│ [A-Z_][A-Z0-9_]+\s" \
+    | tr -d '│ ' \
+    | sort -u \
+    | grep -v '^SECRET$' \
+    || true
+)
+
+if [[ -z "$SECRET_NAMES" ]]; then
+  echo "error: no secrets found at $INFISICAL_PATH (auth?)" >&2
+  exit 1
+fi
+
+COUNT=$(echo "$SECRET_NAMES" | wc -l | tr -d ' ')
+echo "Found $COUNT secrets."
+
+# ---------- Sync each ----------
+FAILED=0
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "[dry-run] would sync $name"
+    continue
+  fi
+
+  # Read value from Infisical (stdout only) and pipe directly into wrangler.
+  # Value never lands in a shell variable — minimises accidental exposure.
+  if infisical secrets get "$name" $AUTH_FLAG \
+       --env="$INFISICAL_ENV" \
+       --path="$INFISICAL_PATH" \
+       --plain 2>/dev/null \
+     | tr -d '\n' \
+     | npx --yes wrangler pages secret put "$name" --project-name "$PAGES_PROJECT" 2>&1 \
+     | grep -qE "Success|Uploaded"
+  then
+    echo "  ✓ $name"
+  else
+    echo "  ✗ $name (failed)"
+    FAILED=$((FAILED+1))
+  fi
+done <<< "$SECRET_NAMES"
+
+if [[ $FAILED -gt 0 ]]; then
+  echo "$FAILED secret(s) failed to sync" >&2
+  exit 1
+fi
+
+echo "Sync complete."


### PR DESCRIPTION
## Root cause

Cloudflare Pages treats `wrangler.toml`'s `[vars]` block as the authoritative source of deployment bindings. Every `wrangler pages deploy` silently detaches secrets set via `wrangler pages secret put` or the dashboard — they reach the runtime as empty strings. Latent since #178.

On-page diagnostic (#440) confirmed ALL secrets were empty at runtime. Effect invisible because of silent fallbacks (Resend → console.log, admin Run-now silently greyed, OAuth callback errors at encryption step).

## Fix

`scripts/sync-pages-secrets.sh` reads every secret at Infisical `/ss` prod and re-binds each to Pages via `wrangler pages secret put`. Values never land in a shell variable or stdout — piped directly from `infisical secrets get --plain` into wrangler.

Wired into `.github/workflows/deploy.yml` as a post-deploy step, gated on `vars.INFISICAL_SYNC_ENABLED=true` + `secrets.INFISICAL_TOKEN`. Until those are set, CI emits `::warning::` and the next operator runs `npm run sync:pages-secrets` manually.

## Already done locally

All 18 secrets at Infisical `/ss` are bound to the production deployment right now. Also:
- `TURNSTILE_SECRET_KEY` pulled from the CF Turnstile API and seeded.
- `BOOKING_ENCRYPTION_KEY` rotated (no recoverable original). Existing integration row for scott@… is now undecryptable — re-auth needed.
- `SIGNWELL_*` mirrored from Infisical root into `/ss`.

## Still missing

`GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — not in Infisical. Must come from Google Cloud Console, then seed to `/ss` and sync.

## Enterprise

Paired update to `crane-console/docs/infra/secrets-management.md` ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)