### PR TITLE
feat(preview): fixture data for product-design gate 0

### DIFF
--- a/src/pages/_design-preview/portal-home.fixture.json
+++ b/src/pages/_design-preview/portal-home.fixture.json
@@ -1,0 +1,56 @@
+{
+  "client": {
+    "name": "Acme Manufacturing"
+  },
+  "consultant": {
+    "name": "Jamie Chen",
+    "firstName": "Jamie",
+    "photoUrl": null,
+    "role": "Principal consultant",
+    "phone": "+16025551234",
+    "nextTouchpointAt": "2026-04-24T17:00:00Z",
+    "nextTouchpointLabel": "Thursday, April 24 at 10:00 AM"
+  },
+  "pendingInvoice": {
+    "id": "inv_abc123",
+    "amountCents": 485000,
+    "pillLabel": "Invoice due",
+    "caption": "Invoice #abc123 • Due Apr 22"
+  },
+  "touchpointText": "Thursday, April 24 at 10:00 AM",
+  "timelineEntries": [
+    {
+      "date": "Apr 15",
+      "body": "Invoice paid.",
+      "artifactLabel": "Invoice #def456",
+      "artifactHref": "/portal/invoices/inv_def456",
+      "artifactIcon": "receipt_long"
+    },
+    {
+      "date": "Apr 12",
+      "body": "Milestone completed: Discovery phase."
+    },
+    {
+      "date": "Apr 8",
+      "body": "Proposal signed. Deposit due.",
+      "artifactLabel": "Proposal",
+      "artifactHref": "/portal/quotes/q_xyz789",
+      "artifactIcon": "description"
+    },
+    {
+      "date": "Apr 3",
+      "body": "Invoice sent.",
+      "artifactLabel": "Invoice #abc123",
+      "artifactHref": "/portal/invoices/inv_abc123",
+      "artifactIcon": "receipt_long"
+    },
+    {
+      "date": "Mar 28",
+      "body": "Proposal sent for review.",
+      "artifactLabel": "Proposal",
+      "artifactHref": "/portal/quotes/q_xyz789",
+      "artifactIcon": "description"
+    }
+  ],
+  "dashboardError": false
+}

--- a/src/pages/_design-preview/portal-quotes-detail.fixture.json
+++ b/src/pages/_design-preview/portal-quotes-detail.fixture.json
@@ -1,0 +1,61 @@
+{
+  "quote": {
+    "id": "q_002",
+    "status": "accepted",
+    "totalCents": 4850000,
+    "depositPct": 25,
+    "balancePct": 75,
+    "isThreeMilestone": true,
+    "paymentSplitText": "25% at signing, balance across milestones.",
+    "engagementTitle": "Production Line Optimization",
+    "engagementSubtitle": "A focused scope across 3 work areas tailored to your operation.",
+    "deliverables": [
+      {
+        "title": "Production Line Optimization",
+        "body": "Process mapping, bottleneck analysis, and a 90-day remediation plan with measurable throughput targets."
+      },
+      {
+        "title": "Quality Control Framework",
+        "body": "A documented QC protocol covering inspection cadence, defect classification, and escalation rules — handed off to your floor lead."
+      },
+      {
+        "title": "Operator Training",
+        "body": "Two on-site sessions covering the new protocol plus a reference guide each operator keeps at their station."
+      }
+    ],
+    "schedule": [
+      {
+        "label": "Week 1–2",
+        "body": "Discovery and current-state mapping. Two days on site."
+      },
+      {
+        "label": "Week 3–8",
+        "body": "Remediation playbook authored and reviewed with leadership."
+      },
+      {
+        "label": "Week 9–12",
+        "body": "Training delivery, handoff, and a 30-day check-in."
+      }
+    ]
+  },
+  "client": {
+    "name": "Acme Manufacturing"
+  },
+  "consultant": {
+    "name": "Jamie Chen",
+    "firstName": "Jamie",
+    "photoUrl": null,
+    "role": "Principal consultant",
+    "phone": "+16025551234"
+  },
+  "state": {
+    "isSigned": true,
+    "isDeclined": false,
+    "isExpired": false,
+    "isSuperseded": false,
+    "isSent": false
+  },
+  "pdfHref": "/api/portal/quotes/q_002/sow",
+  "supersedingQuoteId": null,
+  "nextStepText": "Kickoff scheduled for Monday, April 28 at 9:00 AM."
+}

--- a/src/pages/_design-preview/portal-quotes-list.fixture.json
+++ b/src/pages/_design-preview/portal-quotes-list.fixture.json
@@ -1,0 +1,39 @@
+{
+  "client": {
+    "name": "Acme Manufacturing"
+  },
+  "quotes": [
+    {
+      "id": "q_001",
+      "status": "sent",
+      "title": "Q2 Operations Audit",
+      "metaCaption": "Apr 10",
+      "trailingCaption": "Expires in 5 days",
+      "href": "/portal/quotes/q_001"
+    },
+    {
+      "id": "q_002",
+      "status": "accepted",
+      "title": "Production Line Optimization",
+      "metaCaption": "Apr 1",
+      "trailingCaption": null,
+      "href": "/portal/quotes/q_002"
+    },
+    {
+      "id": "q_003",
+      "status": "declined",
+      "title": "Software Upgrade Advisory",
+      "metaCaption": "Mar 20",
+      "trailingCaption": null,
+      "href": "/portal/quotes/q_003"
+    },
+    {
+      "id": "q_004",
+      "status": "expired",
+      "title": "Annual Compliance Review (an older proposal with a longer title to test row wrapping behavior on narrow viewports)",
+      "metaCaption": "Feb 15",
+      "trailingCaption": "Expired",
+      "href": "/portal/quotes/q_004"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds three fixture JSON files under `src/pages/_design-preview/` for the product-design skill gate 0
- No runtime impact: data-only, imported by nothing; `_design-preview` underscore-prefix auto-excludes from Astro's routing scan
- `npm run typecheck` passes with 0 errors

## What these fixtures are

Hand-authored shapes that describe what each client-portal surface's component should render, derived from the computed values in the shipped pages (`src/pages/portal/index.astro`, `src/pages/portal/quotes/index.astro`, `src/pages/portal/quotes/[id].astro`).

When the product-design skill runs (gate 0), it will read these fixtures as the data contract and generate matching components:
- `portal-home.fixture.json` → PortalHomeDashboard component (dashboard archetype)
- `portal-quotes-list.fixture.json` → QuoteList component (list archetype)
- `portal-quotes-detail.fixture.json` → QuoteDetail component (detail archetype)

## Fixture coverage

Deliberately realistic with edge-case variation:

**portal-home** — active engagement + consultant + pending invoice + 5-entry timeline mixing proposal / invoice / milestone artifacts

**portal-quotes-list** — four quotes across sent / accepted / declined / expired statuses, with one deliberately long title to exercise row-wrap behavior

**portal-quotes-detail** — accepted proposal, 3-milestone split (`total_hours >= 40` path), full `deliverables` + `schedule`, signed-state `nextStepText`

## Why hand-authored

Auto-generated fixtures tend toward happy-path only. Hand-authoring forces explicit consideration of empty states, long text, status variations, and boundary values — which is what we need to evaluate whether the product-design skill produces production-quality components.

## What comes after this PR

Full plan: `crane-console/.claude/plans/cached-sparking-cook.md`

Gate 0 execution: run `/product-design --set portal` from crane-console, targeting ss-console. Skill consumes these fixtures + the existing NAVIGATION.md v3.1 + portal-ux-brief.md + existing component source, produces components under `src/components/portal/` and preview routes alongside these fixtures.

## Test plan

- [x] `npm run typecheck` passes (0 errors)
- [ ] `_design-preview` routes return 404 in production builds (verify after skill generation adds preview routes)
- [ ] Fixture shapes match what skill-generated components accept as props (verified when gate 0 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)