### PR TITLE
feat(portal): QuoteList — product-design gate 0 surface 3

### DIFF
--- a/src/components/portal/PortalHomeDashboard.astro
+++ b/src/components/portal/PortalHomeDashboard.astro
@@ -1,0 +1,216 @@
+---
+/**
+ * PortalHomeDashboard — body component for /portal/ home surface.
+ *
+ * Classification:
+ *   surface:   session-auth-client
+ *   archetype: dashboard
+ *   viewport:  mobile (mobile-first; desktop upgrades to two-column)
+ *   task:      see-whats-happening
+ *   pattern:   persistent-tabs
+ *
+ * All data arrives as props. No data fetching, no Astro.locals, no D1.
+ * Layout and state-rendering logic mirrors src/pages/portal/index.astro.
+ */
+
+import SkipToMain from '../SkipToMain.astro'
+import PortalHeader from './PortalHeader.astro'
+import PortalTabs from './PortalTabs.astro'
+import ActionCard from './ActionCard.astro'
+import ConsultantBlock from './ConsultantBlock.astro'
+import TimelineEntry from './TimelineEntry.astro'
+
+export interface Props {
+  client: { name: string }
+  consultant: {
+    name: string
+    firstName: string
+    photoUrl: string | null
+    role: string | null
+    phone: string | null
+    nextTouchpointAt: string | null
+    nextTouchpointLabel: string | null
+  } | null
+  pendingInvoice: {
+    id: string
+    amountCents: number
+    pillLabel: string
+    caption: string
+  } | null
+  touchpointText: string | null
+  timelineEntries: Array<{
+    date: string
+    body: string
+    artifactLabel?: string
+    artifactHref?: string
+    artifactIcon?: string
+  }>
+  dashboardError: boolean
+}
+
+const { client, consultant, pendingInvoice, touchpointText, timelineEntries, dashboardError } =
+  Astro.props
+
+const consultantFirst = consultant?.firstName ?? null
+
+// H1 greeting: consultant presence signals an active engagement.
+const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
+---
+
+<SkipToMain />
+<PortalHeader
+  clientName={client.name}
+  consultantPhone={consultant?.phone ?? null}
+  consultantFirstName={consultantFirst}
+/>
+<PortalTabs pathname="/portal/" />
+
+<main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
+  {
+    dashboardError ? (
+      /* ------------------------------------------------------------------ */
+      /* Error state: single error card + consultant block (if available).   */
+      /* ------------------------------------------------------------------ */
+      <div class="flex flex-col gap-card">
+        <section
+          class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 p-card sm:p-section"
+          aria-live="polite"
+        >
+          <div class="flex items-start gap-row">
+            <span
+              class="material-symbols-outlined text-[24px] text-[color:var(--color-attention)] mt-0.5"
+              aria-hidden="true"
+            >
+              error
+            </span>
+            <div class="min-w-0">
+              <h1 class="text-title text-[color:var(--color-text-primary)]">
+                Something went wrong loading your portal.
+              </h1>
+              <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
+                {consultantFirst
+                  ? `Give it a moment and try again. If it keeps happening, ${consultantFirst} can help.`
+                  : 'Give it a moment and try again.'}
+              </p>
+              <div class="mt-5 flex flex-wrap gap-row">
+                <a
+                  href="/portal"
+                  class="inline-flex items-center justify-center min-h-[44px] px-5 py-2.5 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                >
+                  Retry
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+        {consultant && (
+          <ConsultantBlock
+            name={consultant.name}
+            photoUrl={consultant.photoUrl}
+            role={consultant.role}
+            nextTouchpointAt={consultant.nextTouchpointAt}
+            nextTouchpointLabel={consultant.nextTouchpointLabel}
+            phone={consultant.phone}
+          />
+        )}
+      </div>
+    ) : (
+      /* ------------------------------------------------------------------ */
+      /* Happy path                                                           */
+      /* ------------------------------------------------------------------ */
+      <>
+        {/* Visually hidden H1 gives screen readers a page landmark.
+            Sighted users see "Engagement in flight." / "Welcome." as the
+            page-level context before the action content. */}
+        <h1 class="text-title text-[color:var(--color-text-primary)] mb-section">
+          {contextHeadline}
+        </h1>
+
+        {/* Desktop: two-column split (timeline main + sticky 340px right rail).
+            Mobile: single column, action-first above the fold, divider,
+            timeline below. */}
+        <div class="flex flex-col md:flex-row md:items-start md:gap-section">
+          {/* Right rail (mobile: renders first; desktop: order-2 right column). */}
+          <aside
+            class="w-full md:order-2 md:w-[340px] md:shrink-0 space-y-card md:sticky md:top-10"
+            aria-label="Action and consultant"
+          >
+            {pendingInvoice ? (
+              <ActionCard
+                pillLabel={pendingInvoice.pillLabel}
+                amountCents={pendingInvoice.amountCents}
+                amountLabel={pendingInvoice.caption}
+                ctaLabel="Pay invoice"
+                ctaHref={`/portal/invoices/${pendingInvoice.id}`}
+                ctaSubtext="Secure payment via Stripe."
+              />
+            ) : touchpointText ? (
+              <section
+                class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card sm:p-section"
+                aria-label="Next check-in"
+              >
+                <p class="text-label uppercase text-[color:var(--color-primary)]">Next check-in</p>
+                <p class="mt-3 text-display text-[color:var(--color-text-primary)]">
+                  {touchpointText}
+                </p>
+                {consultantFirst && (
+                  <p class="mt-2 text-caption text-[color:var(--color-text-muted)]">
+                    with {consultantFirst}
+                  </p>
+                )}
+              </section>
+            ) : (
+              <section
+                class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card sm:p-section"
+                aria-label="Engagement status"
+              >
+                <p class="text-label uppercase text-[color:var(--color-primary)]">In flight</p>
+                <p class="mt-3 text-body text-[color:var(--color-text-secondary)]">
+                  Nothing needs your attention right now.
+                </p>
+              </section>
+            )}
+
+            {consultant && (
+              <ConsultantBlock
+                name={consultant.name}
+                photoUrl={consultant.photoUrl}
+                role={consultant.role}
+                nextTouchpointAt={consultant.nextTouchpointAt}
+                nextTouchpointLabel={consultant.nextTouchpointLabel}
+                phone={consultant.phone}
+              />
+            )}
+          </aside>
+
+          {/* Main column: Recent activity timeline. */}
+          <section
+            class="flex-1 min-w-0 md:order-1 mt-section md:mt-0 pt-section md:pt-0 border-t md:border-t-0 border-[color:var(--color-border)]"
+            aria-labelledby="timeline-heading"
+          >
+            <h2 id="timeline-heading" class="text-title text-[color:var(--color-text-primary)]">
+              Recent activity
+            </h2>
+            {timelineEntries.length > 0 ? (
+              <div class="mt-stack flex flex-col gap-card">
+                {timelineEntries.map((entry) => (
+                  <TimelineEntry
+                    date={entry.date}
+                    body={entry.body}
+                    artifactLabel={entry.artifactLabel}
+                    artifactHref={entry.artifactHref}
+                    artifactIcon={entry.artifactIcon}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p class="mt-stack text-body text-[color:var(--color-text-secondary)]">
+                Nothing here yet. First entry lands after your next touchpoint.
+              </p>
+            )}
+          </section>
+        </div>
+      </>
+    )
+  }
+</main>

--- a/src/components/portal/QuoteList.astro
+++ b/src/components/portal/QuoteList.astro
@@ -1,0 +1,64 @@
+---
+/**
+ * Portal quote list body — all proposals for a client.
+ *
+ * surface: session-auth-client / archetype: list / viewport: mobile-first
+ * task: review-sign-proposal / pattern: persistent-tabs
+ *
+ * No data fetching. All values via props. Rows render through
+ * PortalListItem (status variant) — the ONLY place list-row markup should
+ * exist on portal surfaces, per PortalListItem.astro's invariant.
+ */
+
+import SkipToMain from '../SkipToMain.astro'
+import PortalHeader from './PortalHeader.astro'
+import PortalTabs from './PortalTabs.astro'
+import PortalListItem from './PortalListItem.astro'
+import { resolveQuoteTone, resolveQuoteLabel } from '../../lib/portal/status'
+
+export interface Props {
+  client: { name: string }
+  quotes: Array<{
+    id: string
+    status: string
+    title: string
+    totalCents: number
+    metaCaption: string
+    trailingCaption: string | null
+    href: string
+  }>
+}
+
+const { client, quotes } = Astro.props
+---
+
+<SkipToMain />
+<PortalHeader clientName={client.name} />
+<PortalTabs pathname="/portal/quotes" />
+
+<main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
+  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Proposals</h1>
+
+  {
+    quotes.length === 0 ? (
+      <p class="text-caption text-[color:var(--color-text-muted)]">No proposals yet.</p>
+    ) : (
+      <ul class="space-y-row" role="list">
+        {quotes.map((quote) => (
+          <li>
+            <PortalListItem
+              variant="status"
+              href={quote.href}
+              tone={resolveQuoteTone(quote.status)}
+              toneLabel={resolveQuoteLabel(quote.status)}
+              title={quote.title}
+              amountCents={quote.totalCents}
+              metaCaption={quote.metaCaption}
+              trailingCaption={quote.trailingCaption}
+            />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+</main>

--- a/src/pages/design-preview/portal-home.astro
+++ b/src/pages/design-preview/portal-home.astro
@@ -1,0 +1,34 @@
+---
+// src/pages/design-preview/portal-home.astro
+// Dev-only preview. Production exclusion via import.meta.env.DEV guard.
+
+import '../../styles/global.css'
+import fixtureData from './portal-home.fixture.json'
+import PortalHomeDashboard from '../../components/portal/PortalHomeDashboard.astro'
+
+if (!import.meta.env.DEV) {
+  return Astro.redirect('/404')
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>[preview] PortalHomeDashboard</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <PortalHomeDashboard {...fixtureData} />
+  </body>
+</html>

--- a/src/pages/design-preview/portal-quotes-list.astro
+++ b/src/pages/design-preview/portal-quotes-list.astro
@@ -1,0 +1,33 @@
+---
+// src/pages/design-preview/portal-quotes-list.astro
+
+import '../../styles/global.css'
+import fixtureData from './portal-quotes-list.fixture.json'
+import QuoteList from '../../components/portal/QuoteList.astro'
+
+if (!import.meta.env.DEV) {
+  return Astro.redirect('/404')
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>[preview] QuoteList</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <QuoteList {...fixtureData} />
+  </body>
+</html>

--- a/src/pages/design-preview/portal-quotes-list.fixture.json
+++ b/src/pages/design-preview/portal-quotes-list.fixture.json
@@ -7,6 +7,7 @@
       "id": "q_001",
       "status": "sent",
       "title": "Q2 Operations Audit",
+      "totalCents": 680000,
       "metaCaption": "Apr 10",
       "trailingCaption": "Expires in 5 days",
       "href": "/portal/quotes/q_001"
@@ -15,6 +16,7 @@
       "id": "q_002",
       "status": "accepted",
       "title": "Production Line Optimization",
+      "totalCents": 4850000,
       "metaCaption": "Apr 1",
       "trailingCaption": null,
       "href": "/portal/quotes/q_002"
@@ -23,6 +25,7 @@
       "id": "q_003",
       "status": "declined",
       "title": "Software Upgrade Advisory",
+      "totalCents": 220000,
       "metaCaption": "Mar 20",
       "trailingCaption": null,
       "href": "/portal/quotes/q_003"
@@ -31,6 +34,7 @@
       "id": "q_004",
       "status": "expired",
       "title": "Annual Compliance Review (an older proposal with a longer title to test row wrapping behavior on narrow viewports)",
+      "totalCents": 1800000,
       "metaCaption": "Feb 15",
       "trailingCaption": "Expired",
       "href": "/portal/quotes/q_004"


### PR DESCRIPTION
## Summary

- Third component generated by the `product-design` skill — list archetype (`/portal/quotes/`)
- Uses `PortalListItem` (status variant) for rows, matching shipped page's idiom and the component's stated invariant ("ONLY place list-row markup should exist on portal surfaces")
- Fixture updated to include `totalCents` per quote — money displays per brief §Money rule

## How to review

```bash
git fetch
git checkout feat/product-design-list
npm run dev
# http://localhost:4321/design-preview/portal-quotes-list
```

Fixture renders four proposals across all four statuses (Pending Review / Accepted / Declined / Expired) with one deliberately-long title to exercise truncation.

## Process correction worth noting

First sub-agent pass avoided `PortalListItem` because I prompted it that "no per-item pricing on list surfaces" — which I invented. The brief's actual money rule says the opposite: "all monetary values render as dollar figures." Sub-agent flagged the contradiction rather than silently rendering `$0` on every row, and rendered inline card shells instead.

When I checked the shipped `/portal/quotes/` page, it does show money. Corrected by adding `totalCents` to the fixture and switching to `PortalListItem` — now matches shipped behavior.

Good signal that the reuse-flagging behavior catches contradictions rather than quietly reinventing. The skill's "refuse or ask" discipline worked here.

## Gate 0 scorecard

- ✓ Surface 1 (detail): merged in #449
- ○ Surface 2 (dashboard): #450 awaiting merge
- **This PR** → Surface 3 (list)
- Negative case: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)