### PR TITLE
feat(design): portal identity reset — Architect's Studio across all 7 surfaces

### DIFF
--- a/.design/DESIGN.md
+++ b/.design/DESIGN.md
@@ -1,0 +1,187 @@
+# SMD Services — Design Identity
+
+**Identity direction:** Architect's Studio — the portal reads like the project file from a small design studio. Monospace for data, geometric sans for prose, hairline structure, a reference number on everything. Authority through precision, not decoration.
+
+**Source:** Extracted from `frontend-design` plugin output on 2026-04-19. Regenerate when identity is revised.
+
+- `portal-home.html` (dashboard, invoice-pending state)
+- `portal-invoices-detail.html` (invoice detail, unpaid state)
+
+Both live in `.design/frontend-design-output/` and are the canonical pixel source for every token below.
+
+---
+
+## Color
+
+Semantic roles. Downstream components reference tokens by role, not by hex.
+
+| Role             | Hex       | Usage                                                                                        |
+| ---------------- | --------- | -------------------------------------------------------------------------------------------- |
+| `background`     | `#FAFAF9` | Warm near-white page background ("paper")                                                    |
+| `surface`        | `#FFFFFF` | Card and panel backgrounds (subtly lifts off background)                                     |
+| `border`         | `#E5E5E4` | Hairline card edges                                                                          |
+| `border-subtle`  | `#F0EFED` | Interior rules inside cards, row dividers                                                    |
+| `text-primary`   | `#0A0A0A` | Body copy, headlines, authoritative text                                                     |
+| `text-secondary` | `#52525B` | Captions, meta values, reference-line text                                                   |
+| `text-muted`     | `#A1A1AA` | Meta labels, placeholders, timestamps                                                        |
+| `meta`           | `#52525B` | Eyebrow labels, non-primary accent text (same as text-secondary, named for semantic clarity) |
+| `primary`        | `#B45309` | Primary buttons, focus rings, attention accent (Amber 700)                                   |
+| `primary-hover`  | `#92400E` | Primary button hover state (Amber 800)                                                       |
+| `action`         | `#B45309` | Focus ring outline color                                                                     |
+| `attention`      | `#B45309` | Status indicators needing action — same as primary by design                                 |
+| `complete`       | `#15803D` | Completed / paid status                                                                      |
+| `error`          | `#991B1B` | Destructive states, validation failures                                                      |
+
+**Contrast ratios (WCAG 2.2 AA, 4.5:1 floor for body text):**
+
+| Foreground        | Background          | Ratio    | Pass       |
+| ----------------- | ------------------- | -------- | ---------- |
+| `text-primary`    | `background`        | 19.4 : 1 | AAA        |
+| `text-primary`    | `surface`           | 20.6 : 1 | AAA        |
+| `text-secondary`  | `background`        | 8.1 : 1  | AAA        |
+| `text-secondary`  | `surface`           | 8.6 : 1  | AAA        |
+| `text-muted`      | `background`        | 3.1 : 1  | large only |
+| `text-muted`      | `surface`           | 3.3 : 1  | large only |
+| `primary` (white) | `primary` on button | 5.6 : 1  | AA         |
+| `primary`         | `background`        | 5.3 : 1  | AA         |
+
+`text-muted` passes only at large sizes (≥18px or ≥14px bold) and is reserved for metadata labels and timestamps. Never use it for body prose.
+
+---
+
+## Typography
+
+| Role      | Family          | Weight | Size / Line-height   | Letter-spacing | Notes                                      |
+| --------- | --------------- | ------ | -------------------- | -------------- | ------------------------------------------ |
+| `display` | Cabinet Grotesk | 700    | 2.5rem / 2.75rem     | -0.02em        | Hero headlines, dominant statements        |
+| `title`   | Cabinet Grotesk | 600    | 1.5rem / 2rem        | -0.01em        | Section titles                             |
+| `heading` | Cabinet Grotesk | 600    | 1.125rem / 1.5rem    | —              | Subsection, card titles                    |
+| `body-lg` | Satoshi         | 400    | 1.125rem / 1.75rem   | —              | Long-form prose                            |
+| `body`    | Satoshi         | 400    | 1rem / 1.5rem        | —              | Default body                               |
+| `caption` | Satoshi         | 500    | 0.8125rem / 1.125rem | 0.01em         | Metadata values                            |
+| `label`   | JetBrains Mono  | 600    | 0.75rem / 1rem       | 0.08em         | Uppercase eyebrow labels, reference strips |
+| `money`   | JetBrains Mono  | 500    | 2rem / 2.5rem        | —              | Dollar figures, `tabular-nums`             |
+
+**Font rationale.** Cabinet Grotesk is a wide, confident geometric sans that gives headlines weight without feeling modern-SaaS. Satoshi is a neutral body sans that stays out of the way. JetBrains Mono anchors every piece of data (dates, amounts, reference codes) with a typewriter-precision feel — the key signal of the "project file" aesthetic.
+
+**Font loading:**
+
+```html
+<link
+  href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+  rel="stylesheet"
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+  rel="stylesheet"
+/>
+```
+
+- **Cabinet Grotesk** and **Satoshi** — Fontshare (free for personal and commercial use)
+- **JetBrains Mono** — Google Fonts (SIL Open Font License 1.1)
+
+All three are free to ship. No license purchase required.
+
+**Figure conventions:** All money amounts, dates in ISO format, and numerical data use `font-variant-numeric: tabular-nums` for column alignment. Prose dates may use lining figures without `tnum`.
+
+---
+
+## Spacing
+
+Generous rhythm, hairline-separated sections. No dense SaaS-style compression.
+
+| Token     | Value            | Usage                                    |
+| --------- | ---------------- | ---------------------------------------- |
+| `section` | `2.5rem` (40px)  | Gap between major page sections          |
+| `card`    | `1.75rem` (28px) | Card and panel internal padding          |
+| `stack`   | `1rem` (16px)    | Default vertical rhythm between siblings |
+| `row`     | `0.75rem` (12px) | Gap between list rows                    |
+
+Tailwind v4 generates `p-section`, `gap-section`, `space-y-stack`, etc. from these.
+
+---
+
+## Shape
+
+Sharp by intent. The portal is a document, not an app.
+
+| Token           | Value | Usage                                |
+| --------------- | ----- | ------------------------------------ |
+| `radius-card`   | `2px` | Card corners                         |
+| `radius-button` | `2px` | Button corners                       |
+| `radius-badge`  | `2px` | Status tags (rectangular, not pills) |
+
+`2px` over `0` is deliberate — pure sharp corners render too brutalist on screen. A barely-there chamfer reads as "technical but not hostile."
+
+**Notable: no pills.** Status indicators are rectangular mono-cap tags, not filled pills. This is an intentional break from generic SaaS UI.
+
+---
+
+## Motion
+
+Minimal and purposeful.
+
+| Token            | Value        | Usage                                          |
+| ---------------- | ------------ | ---------------------------------------------- |
+| `motion-default` | `120ms ease` | Hover color transitions, focus-ring appearance |
+
+- **No page transitions.** Links and routing are instant.
+- **No scroll-triggered animations.** No parallax, no scroll-bound reveals, no fade-in-on-view.
+- **No loading skeletons that pulse.** Empty states render static type ("No invoices on file yet.").
+- **Reduced motion:** respected by default. Any future animation must honor `prefers-reduced-motion: reduce`.
+
+**Rejection clause:** The identity is print-inspired. Motion is for feedback, never for decoration.
+
+---
+
+## Shadows / depth
+
+**None.** The identity is flat. Hairline borders and typographic hierarchy do all the structural work. If a future surface needs depth, consider revising the identity direction rather than adding shadows piecemeal.
+
+---
+
+## Anti-patterns (identity-level)
+
+Design moves that are incompatible with Architect's Studio and must be rejected if proposed:
+
+- Purple-gradient SaaS chrome
+- Pill-shaped status badges
+- Card-with-shadow-and-rounded-corners
+- Illustrated empty states or marketing mascots
+- KPI cards with icon + number + trend arrow
+- Tabbed dashboards, sidebar navigation
+- Stock imagery of business owners, laptops, handshakes
+- "Welcome back, [Name]!" greetings
+- Progress bars (stepped, segmented, percentage, radial — all of them)
+- Trust badges, testimonial carousels, marketing social proof
+- Initials-in-a-circle avatars (use named photo placeholder instead)
+- Softening microcopy: "Don't worry," "We've got you covered," "Oops!"
+- Jira-speak milestone names ("Process documented for new client intake")
+
+---
+
+## Voice notes
+
+The visual identity is terse, honest, dated. Copy must match:
+
+- **Evidence over reassurance.** "Scott sat with your dispatcher Tuesday" beats "Things are going well."
+- **Past-tense events.** Timeline entries are things that happened, not things that are "in progress."
+- **Concrete and specific.** Names, numbers, dates. Never vague status words.
+- **No em dashes.** Use commas, periods, colons.
+- **No AI-style parallel structures.** Vary sentence shape.
+
+Reference register: a studio principal reporting back to a client between visits. Calm, direct, numerate.
+
+---
+
+## Mapping to Tailwind v4 `@theme`
+
+The tokens above are emitted in paste-ready form at `.design/theme.css`. Consumers reference them via Tailwind v4 utilities:
+
+- Colors: `bg-primary`, `text-text-primary`, `border-border`
+- Typography: `text-display`, `text-title`, `text-heading`, `text-body`, `text-caption`, `text-label`, `text-money`
+- Spacing: `p-card`, `gap-section`, `space-y-stack`
+- Shape: `rounded-card`, `rounded-button`, `rounded-badge`
+- Font family: `font-display`, `font-body`, `font-mono`
+
+Shipped components already reference tokens semantically (`bg-[color:var(--color-primary)]`, `text-heading`, `p-card`). Cutting `theme.css` into `src/styles/global.css` propagates the new identity to all four shipped portal surfaces without requiring regeneration.

--- a/.design/frontend-design-output/README.md
+++ b/.design/frontend-design-output/README.md
@@ -1,0 +1,61 @@
+# frontend-design output — SMD Services portal
+
+Aesthetic direction chosen by Captain on 2026-04-19: **Architect's Studio**.
+
+Thesis: the portal reads like the project file from a small design studio.
+Monospace for data, geometric sans for prose, hairline structure, a reference
+number on everything. Authority through precision, not decoration.
+
+## Files
+
+- `portal-home.html` — hero surface 1. Dashboard in invoice-pending state.
+  Shows: masthead, dominant action card, consultant block with photo placeholder,
+  activity log, engagement summary, ledger. Responsive 390px / 1280px.
+- `portal-invoices-detail.html` — hero surface 2. Invoice deep-link, unpaid.
+  Shows: breadcrumb, status badge, invoice body with line items, pay CTA,
+  consultant block, download affordance. Responsive 390px / 1280px.
+
+Both files are self-contained HTML with `<style>` blocks declaring CSS custom
+properties. `/design-brief --extract-identity` reads them directly.
+
+## Token stack (summary; authoritative values live in each file's `:root`)
+
+### Color
+
+- Background `#FAFAF9` (warm near-white)
+- Surface `#FFFFFF`
+- Border hairline `#E5E5E4`
+- Border subtle `#F0EFED`
+- Text primary `#0A0A0A` (graphite)
+- Text secondary `#52525B`
+- Text muted `#A1A1AA`
+- Primary / attention `#B45309` (deep ochre, amber 700)
+- Primary hover `#92400E`
+- Complete `#15803D`
+- Error `#991B1B`
+
+### Typography
+
+- Display — **Cabinet Grotesk** (Fontshare, free) 700, tracking -0.02em
+- Body — **Satoshi** (Fontshare, free) 400/500
+- Data / labels — **JetBrains Mono** (Google, OFL) 500, tabular-nums
+- No Inter anywhere. No PJS anywhere.
+
+### Spacing rhythm
+
+- section 40px, card 28px, stack 16px, row 12px
+
+### Shape
+
+- Card radius 2px, button radius 2px, badge radius 2px. Sharp by intent.
+
+### Motion
+
+- Hover color transitions: 120ms ease
+- No scroll-driven animations, no page-transition flourishes. Print logic.
+
+## Next
+
+Step 2 of the pipeline: `/design-brief --extract-identity /Users/scottdurgan/dev/ss-console/.design/frontend-design-output/`
+
+That emits `.design/DESIGN.md` + `.design/theme.css` from these files.

--- a/.design/frontend-design-output/portal-home.html
+++ b/.design/frontend-design-output/portal-home.html
@@ -1,0 +1,782 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portal / Home — SMD Services</title>
+    <link
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ===================================================================
+       * SMD Services — Architect's Studio identity
+       * Hero surface 1: portal-home / invoice-pending state
+       * =================================================================== */
+
+      :root {
+        /* ---------- Color ---------- */
+        --color-bg: #fafaf9;
+        --color-surface: #ffffff;
+        --color-border: #e5e5e4;
+        --color-border-subtle: #f0efed;
+        --color-text-primary: #0a0a0a;
+        --color-text-secondary: #52525b;
+        --color-text-muted: #a1a1aa;
+        --color-primary: #b45309;
+        --color-primary-hover: #92400e;
+        --color-action: #b45309;
+        --color-complete: #15803d;
+        --color-attention: #b45309;
+        --color-error: #991b1b;
+        --color-meta: #52525b;
+
+        /* ---------- Typography ---------- */
+        --font-display: 'Cabinet Grotesk', system-ui, sans-serif;
+        --font-body: 'Satoshi', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+
+        --text-display-size: 2.5rem; /* 40px */
+        --text-display-lh: 2.75rem; /* 44px */
+        --text-display-weight: 700;
+        --text-display-tracking: -0.02em;
+
+        --text-title-size: 1.5rem; /* 24px */
+        --text-title-lh: 2rem; /* 32px */
+        --text-title-weight: 600;
+        --text-title-tracking: -0.01em;
+
+        --text-heading-size: 1.125rem; /* 18px */
+        --text-heading-lh: 1.5rem; /* 24px */
+        --text-heading-weight: 600;
+
+        --text-body-lg-size: 1.125rem; /* 18px */
+        --text-body-lg-lh: 1.75rem; /* 28px */
+
+        --text-body-size: 1rem; /* 16px */
+        --text-body-lh: 1.5rem; /* 24px */
+        --text-body-weight: 400;
+
+        --text-caption-size: 0.8125rem; /* 13px */
+        --text-caption-lh: 1.125rem; /* 18px */
+        --text-caption-weight: 500;
+        --text-caption-tracking: 0.01em;
+
+        --text-label-size: 0.75rem; /* 12px */
+        --text-label-lh: 1rem; /* 16px */
+        --text-label-weight: 600;
+        --text-label-tracking: 0.08em;
+
+        --text-money-size: 2rem; /* 32px */
+        --text-money-lh: 2.5rem; /* 40px */
+        --text-money-weight: 500;
+
+        /* ---------- Spacing rhythm ---------- */
+        --space-section: 2.5rem; /* 40px gap between major sections */
+        --space-card: 1.75rem; /* 28px card internal padding */
+        --space-stack: 1rem; /* 16px default vertical rhythm */
+        --space-row: 0.75rem; /* 12px list-row gap */
+
+        /* ---------- Shape ---------- */
+        --radius-card: 2px;
+        --radius-button: 2px;
+        --radius-badge: 2px;
+
+        /* ---------- Motion ---------- */
+        --motion-default: 120ms ease;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        background: var(--color-bg);
+      }
+
+      body {
+        color: var(--color-text-primary);
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ---------- Shell ---------- */
+
+      .shell {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 4rem;
+      }
+
+      @media (min-width: 768px) {
+        .shell {
+          padding: 3.5rem 2.5rem 6rem;
+        }
+      }
+
+      /* ---------- Masthead ---------- */
+
+      .masthead {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .masthead__brand {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-primary);
+      }
+
+      .masthead__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* ---------- Hero block ---------- */
+
+      .hero {
+        margin-top: var(--space-section);
+      }
+
+      .hero__client-label {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        font-weight: var(--text-label-weight);
+      }
+
+      .hero__headline {
+        margin-top: 0.75rem;
+        font-family: var(--font-display);
+        font-size: var(--text-display-size);
+        line-height: var(--text-display-lh);
+        font-weight: var(--text-display-weight);
+        letter-spacing: var(--text-display-tracking);
+        color: var(--color-text-primary);
+        max-width: 36ch;
+      }
+
+      @media (max-width: 640px) {
+        .hero__headline {
+          font-size: 1.875rem; /* 30px on mobile */
+          line-height: 2.125rem;
+        }
+      }
+
+      /* ---------- Invoice card (dominant action) ---------- */
+
+      .invoice-card {
+        margin-top: var(--space-section);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+        padding: var(--space-card);
+      }
+
+      .invoice-card__ref {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--color-border-subtle);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .invoice-card__status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        color: var(--color-attention);
+      }
+
+      .invoice-card__status::before {
+        content: '';
+        display: inline-block;
+        width: 0.375rem;
+        height: 0.375rem;
+        background: var(--color-attention);
+        border-radius: var(--radius-badge);
+      }
+
+      .invoice-card__body {
+        padding-top: 1.5rem;
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+      }
+
+      @media (min-width: 768px) {
+        .invoice-card__body {
+          grid-template-columns: 1.2fr 1fr;
+          align-items: end;
+          gap: 2.5rem;
+        }
+      }
+
+      .invoice-card__amount {
+        font-family: var(--font-mono);
+        font-size: var(--text-money-size);
+        line-height: var(--text-money-lh);
+        font-weight: var(--text-money-weight);
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-primary);
+        letter-spacing: -0.01em;
+      }
+
+      @media (min-width: 768px) {
+        .invoice-card__amount {
+          font-size: 3rem; /* 48px desktop */
+          line-height: 3.25rem;
+        }
+      }
+
+      .invoice-card__meta-rows {
+        margin-top: 0.75rem;
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .invoice-card__meta-row {
+        display: grid;
+        grid-template-columns: 7rem 1fr;
+        align-items: baseline;
+        font-family: var(--font-mono);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-secondary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .invoice-card__meta-label {
+        text-transform: uppercase;
+        letter-spacing: var(--text-label-tracking);
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        font-size: var(--text-label-size);
+      }
+
+      .invoice-card__meta-value {
+        color: var(--color-text-secondary);
+      }
+
+      /* ---------- Button ---------- */
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 1.25rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        font-weight: 600;
+        line-height: 1;
+        letter-spacing: 0.005em;
+        border: 1px solid transparent;
+        border-radius: var(--radius-button);
+        background: var(--color-primary);
+        color: #ffffff;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-default),
+          border-color var(--motion-default);
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      .btn:hover {
+        background: var(--color-primary-hover);
+      }
+
+      .btn:focus-visible {
+        outline: 2px solid var(--color-action);
+        outline-offset: 2px;
+      }
+
+      .btn--ghost {
+        background: transparent;
+        color: var(--color-text-primary);
+        border-color: var(--color-border);
+      }
+
+      .btn--ghost:hover {
+        background: var(--color-surface);
+        border-color: var(--color-text-primary);
+      }
+
+      .btn-row {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        align-items: stretch;
+      }
+
+      @media (min-width: 640px) {
+        .btn-row {
+          flex-direction: row;
+          align-items: center;
+        }
+      }
+
+      /* ---------- Consultant block ---------- */
+
+      .consultant {
+        margin-top: var(--space-section);
+        padding: var(--space-card);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+        display: grid;
+        grid-template-columns: 80px 1fr;
+        gap: 1.25rem;
+        align-items: start;
+      }
+
+      @media (min-width: 768px) {
+        .consultant {
+          grid-template-columns: 112px 1fr auto;
+          gap: 2rem;
+          align-items: center;
+        }
+      }
+
+      .consultant__photo {
+        width: 80px;
+        height: 80px;
+        background: #ece9e4;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 0.5rem;
+        font-family: var(--font-mono);
+        font-size: 9px;
+        line-height: 1.2;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+      }
+
+      @media (min-width: 768px) {
+        .consultant__photo {
+          width: 112px;
+          height: 112px;
+        }
+      }
+
+      .consultant__name {
+        font-family: var(--font-display);
+        font-size: var(--text-heading-size);
+        line-height: var(--text-heading-lh);
+        font-weight: var(--text-heading-weight);
+        color: var(--color-text-primary);
+      }
+
+      .consultant__role {
+        margin-top: 0.125rem;
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+      }
+
+      .consultant__next {
+        margin-top: 0.75rem;
+        font-family: var(--font-mono);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .consultant__channel {
+        margin-top: 0.25rem;
+        font-family: var(--font-body);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-secondary);
+      }
+
+      .consultant__channel a {
+        color: var(--color-text-primary);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ---------- Section label pattern ---------- */
+
+      .section {
+        margin-top: var(--space-section);
+      }
+
+      .section__label {
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-primary);
+      }
+
+      /* ---------- Activity log ---------- */
+
+      .log {
+        list-style: none;
+      }
+
+      .log__entry {
+        padding: 1.25rem 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 0.375rem;
+      }
+
+      @media (min-width: 768px) {
+        .log__entry {
+          grid-template-columns: 12rem 1fr;
+          gap: 1.5rem;
+          align-items: baseline;
+        }
+      }
+
+      .log__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-secondary);
+        font-variant-numeric: tabular-nums;
+        display: flex;
+        gap: 1rem;
+        align-items: baseline;
+      }
+
+      .log__date {
+        color: var(--color-text-secondary);
+      }
+
+      .log__actor {
+        text-transform: uppercase;
+        letter-spacing: var(--text-label-tracking);
+        font-size: var(--text-label-size);
+        color: var(--color-text-primary);
+        font-weight: var(--text-label-weight);
+      }
+
+      .log__body {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+      }
+
+      .log__artifact {
+        margin-top: 0.375rem;
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ---------- Facts grid (engagement summary) ---------- */
+
+      .facts {
+        margin-top: 1.25rem;
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1rem;
+      }
+
+      @media (min-width: 768px) {
+        .facts {
+          grid-template-columns: repeat(3, 1fr);
+          gap: 2.5rem;
+        }
+      }
+
+      .fact__label {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        font-weight: var(--text-label-weight);
+      }
+
+      .fact__value {
+        margin-top: 0.375rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+      }
+
+      .fact__value--mono {
+        font-family: var(--font-mono);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* ---------- Ledger rows ---------- */
+
+      .ledger {
+        margin-top: 1.25rem;
+      }
+
+      .ledger__row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: baseline;
+        padding: 0.875rem 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .ledger__row:last-child {
+        border-bottom: none;
+      }
+
+      .ledger__label {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+      }
+
+      .ledger__value {
+        font-family: var(--font-mono);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+        font-weight: 500;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .ledger__value--attention {
+        color: var(--color-attention);
+      }
+
+      .ledger__context {
+        display: block;
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        margin-top: 0.125rem;
+      }
+
+      /* ---------- Footer ---------- */
+
+      .footer {
+        margin-top: 5rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <!-- Masthead -->
+      <header class="masthead">
+        <div class="masthead__brand">SMD Services</div>
+        <div class="masthead__meta">2026.04.19</div>
+      </header>
+
+      <!-- Hero -->
+      <section class="hero" aria-labelledby="hero-headline">
+        <div class="hero__client-label">Client · Delgado Plumbing</div>
+        <h1 id="hero-headline" class="hero__headline">Your April invoice is due Friday.</h1>
+      </section>
+
+      <!-- Dominant action card: invoice -->
+      <section class="invoice-card" aria-labelledby="invoice-heading">
+        <div class="invoice-card__ref">
+          <span>REF INV-1023 / ISSUED 2026-04-15</span>
+          <span class="invoice-card__status">STATUS · DUE</span>
+        </div>
+        <div class="invoice-card__body">
+          <div>
+            <h2
+              id="invoice-heading"
+              class="invoice-card__amount"
+              aria-label="Amount due: four thousand two hundred fifty dollars"
+            >
+              $4,250.00
+            </h2>
+            <div class="invoice-card__meta-rows">
+              <div class="invoice-card__meta-row">
+                <span class="invoice-card__meta-label">Issued</span>
+                <span class="invoice-card__meta-value">2026-04-15</span>
+              </div>
+              <div class="invoice-card__meta-row">
+                <span class="invoice-card__meta-label">Due</span>
+                <span class="invoice-card__meta-value">2026-04-24 · Friday</span>
+              </div>
+              <div class="invoice-card__meta-row">
+                <span class="invoice-card__meta-label">Method</span>
+                <span class="invoice-card__meta-value">Stripe</span>
+              </div>
+            </div>
+          </div>
+          <div class="btn-row">
+            <a class="btn" href="#pay">Pay invoice</a>
+            <a class="btn btn--ghost" href="#download">Download PDF</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Consultant block -->
+      <aside class="consultant" aria-label="Your consultant">
+        <div class="consultant__photo" aria-hidden="true">Consultant<br />photo</div>
+        <div>
+          <div class="consultant__name">Scott Durgan</div>
+          <div class="consultant__role">Consultant</div>
+          <div class="consultant__next">Next check-in · Wed 2026-04-22 · 10:00 MST</div>
+          <div class="consultant__channel">
+            Reach by SMS: <a href="sms:+16025550100">(602) 555-0100</a>. Replies within 1 business
+            day.
+          </div>
+        </div>
+      </aside>
+
+      <!-- Activity log -->
+      <section class="section" aria-labelledby="log-heading">
+        <h2 id="log-heading" class="section__label">Activity log</h2>
+        <ul class="log">
+          <li class="log__entry">
+            <div class="log__meta">
+              <span class="log__date">2026-04-14</span>
+              <span class="log__actor">Scott</span>
+            </div>
+            <div class="log__body">
+              Sat with your dispatcher. Two issues surfaced: warranty questions aren't being asked
+              on intake, and after-hours calls route to voicemail for 12 minutes before forwarding.
+              <a class="log__artifact" href="#notes-0414">View notes · 2026-04-14</a>
+            </div>
+          </li>
+          <li class="log__entry">
+            <div class="log__meta">
+              <span class="log__date">2026-04-09</span>
+              <span class="log__actor">Scott</span>
+            </div>
+            <div class="log__body">
+              Delivered new call script. Maria now prompts for warranty status before dispatching.
+              <a class="log__artifact" href="#doc-call-script">Open call script</a>
+            </div>
+          </li>
+          <li class="log__entry">
+            <div class="log__meta">
+              <span class="log__date">2026-04-02</span>
+              <span class="log__actor">Scott</span>
+            </div>
+            <div class="log__body">
+              Initial on-site assessment. Toured intake, dispatch, and invoicing. Identified 14
+              candidate improvements; priced and prioritized top three.
+              <a class="log__artifact" href="#doc-assessment">Open assessment summary</a>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Engagement summary -->
+      <section class="section" aria-labelledby="engagement-heading">
+        <h2 id="engagement-heading" class="section__label">Engagement</h2>
+        <div class="facts">
+          <div>
+            <div class="fact__label">Scope</div>
+            <div class="fact__value">Operations assessment: intake, dispatch, follow-up</div>
+          </div>
+          <div>
+            <div class="fact__label">Started</div>
+            <div class="fact__value fact__value--mono">2026-03-22</div>
+          </div>
+          <div>
+            <div class="fact__label">Estimated completion</div>
+            <div class="fact__value fact__value--mono">2026-05-15</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Ledger -->
+      <section class="section" aria-labelledby="ledger-heading">
+        <h2 id="ledger-heading" class="section__label">Ledger</h2>
+        <div class="ledger">
+          <div class="ledger__row">
+            <span class="ledger__label">Paid to date</span>
+            <span class="ledger__value">$2,000.00</span>
+          </div>
+          <div class="ledger__row">
+            <span class="ledger__label">Remaining</span>
+            <span class="ledger__value">$6,250.00</span>
+          </div>
+          <div class="ledger__row">
+            <span class="ledger__label">
+              Next charge
+              <span class="ledger__context">due 2026-04-24</span>
+            </span>
+            <span class="ledger__value ledger__value--attention">$4,250.00</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <span>SMD Services · Client portal</span>
+        <span>v1 · 2026.04.19</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/.design/frontend-design-output/portal-invoices-detail.html
+++ b/.design/frontend-design-output/portal-invoices-detail.html
@@ -1,0 +1,815 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portal / Invoice 1023 — SMD Services</title>
+    <link
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ===================================================================
+       * SMD Services — Architect's Studio identity
+       * Hero surface 2: portal-invoices-detail / unpaid state
+       * Tokens match portal-home.html. Any divergence is intentional.
+       * =================================================================== */
+
+      :root {
+        /* Color */
+        --color-bg: #fafaf9;
+        --color-surface: #ffffff;
+        --color-border: #e5e5e4;
+        --color-border-subtle: #f0efed;
+        --color-text-primary: #0a0a0a;
+        --color-text-secondary: #52525b;
+        --color-text-muted: #a1a1aa;
+        --color-primary: #b45309;
+        --color-primary-hover: #92400e;
+        --color-action: #b45309;
+        --color-complete: #15803d;
+        --color-attention: #b45309;
+        --color-error: #991b1b;
+        --color-meta: #52525b;
+
+        /* Typography */
+        --font-display: 'Cabinet Grotesk', system-ui, sans-serif;
+        --font-body: 'Satoshi', system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+
+        --text-display-size: 2.5rem;
+        --text-display-lh: 2.75rem;
+        --text-display-weight: 700;
+        --text-display-tracking: -0.02em;
+
+        --text-title-size: 1.5rem;
+        --text-title-lh: 2rem;
+        --text-title-weight: 600;
+        --text-title-tracking: -0.01em;
+
+        --text-heading-size: 1.125rem;
+        --text-heading-lh: 1.5rem;
+        --text-heading-weight: 600;
+
+        --text-body-lg-size: 1.125rem;
+        --text-body-lg-lh: 1.75rem;
+
+        --text-body-size: 1rem;
+        --text-body-lh: 1.5rem;
+        --text-body-weight: 400;
+
+        --text-caption-size: 0.8125rem;
+        --text-caption-lh: 1.125rem;
+        --text-caption-weight: 500;
+        --text-caption-tracking: 0.01em;
+
+        --text-label-size: 0.75rem;
+        --text-label-lh: 1rem;
+        --text-label-weight: 600;
+        --text-label-tracking: 0.08em;
+
+        --text-money-size: 2rem;
+        --text-money-lh: 2.5rem;
+        --text-money-weight: 500;
+
+        /* Spacing rhythm */
+        --space-section: 2.5rem;
+        --space-card: 1.75rem;
+        --space-stack: 1rem;
+        --space-row: 0.75rem;
+
+        /* Shape */
+        --radius-card: 2px;
+        --radius-button: 2px;
+        --radius-badge: 2px;
+
+        /* Motion */
+        --motion-default: 120ms ease;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        background: var(--color-bg);
+      }
+
+      body {
+        color: var(--color-text-primary);
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ---------- Shell ---------- */
+
+      .shell {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 4rem;
+      }
+
+      @media (min-width: 768px) {
+        .shell {
+          padding: 3.5rem 2.5rem 6rem;
+        }
+      }
+
+      /* ---------- Masthead ---------- */
+
+      .masthead {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .masthead__brand {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-primary);
+      }
+
+      .masthead__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* ---------- Breadcrumb ---------- */
+
+      .breadcrumb {
+        margin-top: 2rem;
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        font-weight: var(--text-label-weight);
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        transition: color var(--motion-default);
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-text-primary);
+      }
+
+      .breadcrumb__sep {
+        display: inline-block;
+        margin: 0 0.5rem;
+        color: var(--color-text-muted);
+      }
+
+      /* ---------- Hero ---------- */
+
+      .hero {
+        margin-top: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding-bottom: var(--space-section);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      @media (min-width: 768px) {
+        .hero {
+          display: grid;
+          grid-template-columns: 1fr auto;
+          gap: 2rem;
+          align-items: end;
+        }
+      }
+
+      .hero__title {
+        font-family: var(--font-display);
+        font-size: var(--text-display-size);
+        line-height: var(--text-display-lh);
+        font-weight: var(--text-display-weight);
+        letter-spacing: var(--text-display-tracking);
+        color: var(--color-text-primary);
+        max-width: 28ch;
+      }
+
+      @media (max-width: 640px) {
+        .hero__title {
+          font-size: 1.875rem;
+          line-height: 2.125rem;
+        }
+      }
+
+      .hero__subtitle {
+        margin-top: 0.25rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-lg-size);
+        line-height: var(--text-body-lg-lh);
+        color: var(--color-text-secondary);
+      }
+
+      .status-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.875rem;
+        border-radius: var(--radius-badge);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        background: var(--color-attention);
+        color: #ffffff;
+        align-self: flex-start;
+      }
+
+      .status-tag--complete {
+        background: var(--color-complete);
+        color: #ffffff;
+      }
+
+      .status-tag--error {
+        background: var(--color-error);
+        color: #ffffff;
+      }
+
+      /* ---------- Layout grid ---------- */
+
+      .content {
+        margin-top: var(--space-section);
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--space-section);
+      }
+
+      @media (min-width: 960px) {
+        .content {
+          grid-template-columns: minmax(0, 1fr) 320px;
+          gap: 3rem;
+          align-items: start;
+        }
+      }
+
+      /* ---------- Panel ---------- */
+
+      .panel {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+        padding: var(--space-card);
+      }
+
+      .panel + .panel {
+        margin-top: var(--space-stack);
+      }
+
+      .panel__ref {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--color-border-subtle);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .panel__body {
+        padding-top: 1.5rem;
+      }
+
+      .panel__section-label {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      /* ---------- Amount block ---------- */
+
+      .amount {
+        display: flex;
+        align-items: baseline;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .amount__value {
+        font-family: var(--font-mono);
+        font-size: 3rem;
+        line-height: 3.25rem;
+        font-weight: var(--text-money-weight);
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-primary);
+        letter-spacing: -0.01em;
+      }
+
+      @media (max-width: 640px) {
+        .amount__value {
+          font-size: var(--text-money-size);
+          line-height: var(--text-money-lh);
+        }
+      }
+
+      .amount__currency {
+        font-family: var(--font-mono);
+        font-size: var(--text-caption-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+      }
+
+      /* ---------- Meta rows ---------- */
+
+      .meta-rows {
+        margin-top: 1.5rem;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .meta-row {
+        display: grid;
+        grid-template-columns: 8rem 1fr;
+        align-items: baseline;
+        font-family: var(--font-mono);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .meta-row__label {
+        text-transform: uppercase;
+        letter-spacing: var(--text-label-tracking);
+        font-size: var(--text-label-size);
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .meta-row__value--attention {
+        color: var(--color-attention);
+      }
+
+      /* ---------- Button ---------- */
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 1.25rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        font-weight: 600;
+        line-height: 1;
+        letter-spacing: 0.005em;
+        border: 1px solid transparent;
+        border-radius: var(--radius-button);
+        background: var(--color-primary);
+        color: #ffffff;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-default),
+          border-color var(--motion-default);
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      .btn:hover {
+        background: var(--color-primary-hover);
+      }
+
+      .btn:focus-visible {
+        outline: 2px solid var(--color-action);
+        outline-offset: 2px;
+      }
+
+      .btn--ghost {
+        background: transparent;
+        color: var(--color-text-primary);
+        border-color: var(--color-border);
+      }
+
+      .btn--ghost:hover {
+        background: var(--color-bg);
+        border-color: var(--color-text-primary);
+      }
+
+      .btn-row {
+        margin-top: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      @media (min-width: 640px) {
+        .btn-row {
+          flex-direction: row;
+          align-items: center;
+        }
+      }
+
+      /* ---------- Line items ---------- */
+
+      .line-items {
+        margin-top: 1.5rem;
+      }
+
+      .line-items__head {
+        display: grid;
+        grid-template-columns: 1fr 4rem 6rem;
+        gap: 1rem;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .line-items__head-hours,
+      .line-items__head-amount {
+        text-align: right;
+      }
+
+      .line-items__row {
+        display: grid;
+        grid-template-columns: 1fr 4rem 6rem;
+        gap: 1rem;
+        padding: 1rem 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+        align-items: baseline;
+      }
+
+      .line-items__description {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+      }
+
+      .line-items__hours,
+      .line-items__amount {
+        font-family: var(--font-mono);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+      }
+
+      .line-items__total {
+        display: grid;
+        grid-template-columns: 1fr 4rem 6rem;
+        gap: 1rem;
+        padding-top: 1rem;
+        margin-top: 0.5rem;
+        border-top: 2px solid var(--color-text-primary);
+        align-items: baseline;
+      }
+
+      .line-items__total-label {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-primary);
+      }
+
+      .line-items__total-amount {
+        grid-column: 3;
+        font-family: var(--font-mono);
+        font-size: var(--text-heading-size);
+        line-height: var(--text-heading-lh);
+        font-weight: 600;
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+      }
+
+      /* ---------- Side rail ---------- */
+
+      .rail {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-stack);
+      }
+
+      /* ---------- Consultant (side-rail variant) ---------- */
+
+      .consultant-rail {
+        padding: var(--space-card);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+      }
+
+      .consultant-rail__photo {
+        width: 88px;
+        height: 88px;
+        background: #ece9e4;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 0.5rem;
+        font-family: var(--font-mono);
+        font-size: 9px;
+        line-height: 1.2;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+      }
+
+      .consultant-rail__name {
+        margin-top: 1rem;
+        font-family: var(--font-display);
+        font-size: var(--text-heading-size);
+        line-height: var(--text-heading-lh);
+        font-weight: var(--text-heading-weight);
+        color: var(--color-text-primary);
+      }
+
+      .consultant-rail__role {
+        margin-top: 0.125rem;
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+      }
+
+      .consultant-rail__next {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--color-border-subtle);
+        font-family: var(--font-mono);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .consultant-rail__channel {
+        margin-top: 0.5rem;
+        font-family: var(--font-body);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-secondary);
+      }
+
+      .consultant-rail__channel a {
+        color: var(--color-text-primary);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ---------- Payment note card ---------- */
+
+      .payment-note {
+        padding: var(--space-card);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-card);
+      }
+
+      .payment-note__label {
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .payment-note__body {
+        margin-top: 0.5rem;
+        font-family: var(--font-body);
+        font-size: var(--text-caption-size);
+        line-height: var(--text-caption-lh);
+        color: var(--color-text-secondary);
+      }
+
+      /* ---------- Footer ---------- */
+
+      .footer {
+        margin-top: 5rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--color-border);
+        font-family: var(--font-mono);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <!-- Masthead -->
+      <header class="masthead">
+        <div class="masthead__brand">SMD Services</div>
+        <div class="masthead__meta">2026.04.19</div>
+      </header>
+
+      <!-- Breadcrumb -->
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="#home">Portal</a>
+        <span class="breadcrumb__sep">/</span>
+        <a href="#invoices">Invoices</a>
+        <span class="breadcrumb__sep">/</span>
+        <span>1023</span>
+      </nav>
+
+      <!-- Hero -->
+      <section class="hero" aria-labelledby="invoice-title">
+        <div>
+          <h1 id="invoice-title" class="hero__title">Invoice 1023</h1>
+          <p class="hero__subtitle">April 2026 · operations assessment</p>
+        </div>
+        <div class="status-tag" role="status">Status · Due</div>
+      </section>
+
+      <!-- Content grid: main + rail -->
+      <div class="content">
+        <!-- Main column -->
+        <article>
+          <!-- Invoice panel -->
+          <section class="panel" aria-labelledby="invoice-panel-heading">
+            <div class="panel__ref">
+              <span>REF INV-1023 / ISSUED 2026-04-15</span>
+              <span>CLIENT · DELGADO PLUMBING</span>
+            </div>
+            <div class="panel__body">
+              <div class="panel__section-label">Amount due</div>
+              <div class="amount" aria-labelledby="invoice-panel-heading">
+                <span id="invoice-panel-heading" class="amount__value">$4,250.00</span>
+                <span class="amount__currency">USD</span>
+              </div>
+              <div class="meta-rows">
+                <div class="meta-row">
+                  <span class="meta-row__label">Issued</span>
+                  <span>2026-04-15</span>
+                </div>
+                <div class="meta-row">
+                  <span class="meta-row__label">Due date</span>
+                  <span class="meta-row__value--attention">2026-04-24 · Friday</span>
+                </div>
+                <div class="meta-row">
+                  <span class="meta-row__label">Method</span>
+                  <span>Stripe (card or ACH)</span>
+                </div>
+                <div class="meta-row">
+                  <span class="meta-row__label">Terms</span>
+                  <span>Net 9</span>
+                </div>
+              </div>
+              <div class="btn-row">
+                <a class="btn" href="#pay">Pay invoice</a>
+                <a class="btn btn--ghost" href="#download">Download PDF</a>
+              </div>
+            </div>
+          </section>
+
+          <!-- Line items panel -->
+          <section class="panel" aria-labelledby="line-items-heading">
+            <div class="panel__ref">
+              <span id="line-items-heading">Line items</span>
+              <span>4 ENTRIES</span>
+            </div>
+            <div class="panel__body">
+              <div class="line-items">
+                <div class="line-items__head" role="row">
+                  <span>Item</span>
+                  <span class="line-items__head-hours">Hours</span>
+                  <span class="line-items__head-amount">Amount</span>
+                </div>
+                <div class="line-items__row" role="row">
+                  <span class="line-items__description"
+                    >On-site assessment: intake, dispatch, invoicing tour</span
+                  >
+                  <span class="line-items__hours">8.0</span>
+                  <span class="line-items__amount">$1,400.00</span>
+                </div>
+                <div class="line-items__row" role="row">
+                  <span class="line-items__description"
+                    >Call-intake script rewrite and dispatcher training</span
+                  >
+                  <span class="line-items__hours">6.5</span>
+                  <span class="line-items__amount">$1,137.50</span>
+                </div>
+                <div class="line-items__row" role="row">
+                  <span class="line-items__description"
+                    >After-hours routing audit and forwarding fix</span
+                  >
+                  <span class="line-items__hours">4.0</span>
+                  <span class="line-items__amount">$700.00</span>
+                </div>
+                <div class="line-items__row" role="row">
+                  <span class="line-items__description"
+                    >Warranty-question intake checklist, documented for Maria</span
+                  >
+                  <span class="line-items__hours">5.75</span>
+                  <span class="line-items__amount">$1,012.50</span>
+                </div>
+                <div class="line-items__total" role="row">
+                  <span class="line-items__total-label">Total due</span>
+                  <span class="line-items__total-amount">$4,250.00</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- Previous payments panel -->
+          <section class="panel" aria-labelledby="prior-heading">
+            <div class="panel__ref">
+              <span id="prior-heading">Prior payments</span>
+              <span>ENGAGEMENT TOTAL · $8,250.00</span>
+            </div>
+            <div class="panel__body">
+              <div class="meta-rows">
+                <div class="meta-row">
+                  <span class="meta-row__label">2026-03-22</span>
+                  <span>Deposit · $2,000.00 · Paid</span>
+                </div>
+                <div class="meta-row">
+                  <span class="meta-row__label">After this</span>
+                  <span>Remaining $2,000.00 at final handoff</span>
+                </div>
+              </div>
+            </div>
+          </section>
+        </article>
+
+        <!-- Side rail -->
+        <aside class="rail" aria-label="Consultant and payment">
+          <div class="consultant-rail">
+            <div class="consultant-rail__photo" aria-hidden="true">Consultant<br />photo</div>
+            <div class="consultant-rail__name">Scott Durgan</div>
+            <div class="consultant-rail__role">Consultant</div>
+            <div class="consultant-rail__next">Next check-in · Wed 2026-04-22 · 10:00 MST</div>
+            <div class="consultant-rail__channel">
+              Questions about this invoice? SMS
+              <a href="sms:+16025550100">(602) 555-0100</a>. Replies within 1 business day.
+            </div>
+          </div>
+
+          <div class="payment-note">
+            <div class="payment-note__label">Payment</div>
+            <p class="payment-note__body">
+              Card and ACH accepted through Stripe. Receipt emailed to the address on file within 2
+              minutes of payment.
+            </p>
+          </div>
+        </aside>
+      </div>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <span>SMD Services · Client portal</span>
+        <span>v1 · 2026.04.19</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/.design/frontend-design-output/variants/legal-dossier/README.md
+++ b/.design/frontend-design-output/variants/legal-dossier/README.md
@@ -1,0 +1,45 @@
+# Legal Dossier — comparison variant
+
+Same two hero surfaces as the parent directory, rendered in the **Legal Dossier**
+direction rather than **Architect's Studio**. Produced for side-by-side visual
+comparison before committing.
+
+## What's different from the Architect's Studio version
+
+| Axis              | Architect's Studio (parent)               | Legal Dossier (this variant)                           |
+| ----------------- | ----------------------------------------- | ------------------------------------------------------ |
+| Display font      | Cabinet Grotesk (Fontshare)               | **EB Garamond** (Google, serif with real small caps)   |
+| Body font         | Satoshi (Fontshare)                       | **EB Garamond** — prose in serif for a reading feel    |
+| Meta font         | JetBrains Mono (mono)                     | **Public Sans** (civic sans, tracked caps)             |
+| Background        | `#FAFAF9` (warm near-white)               | `#F8F5EF` (document cream)                             |
+| Ink               | `#0A0A0A` (graphite)                      | `#111827` (near-black, slightly cooler)                |
+| Accent            | `#B45309` (deep ochre)                    | `#7C1D1D` (claret — "wax seal")                        |
+| Card radius       | 2px                                       | 0 — sharp rectangles                                   |
+| Max content width | 1040px                                    | 780px — classical brief column                         |
+| Layout            | Two-column on desktop (main + rail)       | Single column — no side rail                           |
+| Chrome            | Reference strips on every card, mono data | Section numbering (I–IV), numbered entries, letterhead |
+| Date format       | `2026-04-14` (ISO)                        | `April 14, 2026` (natural American)                    |
+| Money             | Mono tabular                              | Serif with lining tabular figures                      |
+| Status indicator  | Filled rectangular badge                  | Small-caps inline marker with left rule                |
+| Figure style      | Lining throughout                         | Old-style in prose, lining in tables                   |
+
+## What stays the same
+
+- Same 7 surfaces eventually (this variant only renders 2 hero examples)
+- Same data, same fixture copy, same "named human" requirement, same money rule
+- Same anti-patterns respected (no tiles, no progress bars, no KPI cards, etc.)
+
+## How to preview
+
+```bash
+open /Users/scottdurgan/dev/ss-console/.design/frontend-design-output/variants/legal-dossier/portal-home.html
+open /Users/scottdurgan/dev/ss-console/.design/frontend-design-output/variants/legal-dossier/portal-invoices-detail.html
+```
+
+Compare side-by-side with the Architect's Studio files one level up.
+
+## If this is the chosen direction
+
+Move these two files up one level, overwriting the Studio versions, and update
+the parent `README.md` token summary. The `/design-brief --extract-identity`
+step reads whatever is in the parent directory.

--- a/.design/frontend-design-output/variants/legal-dossier/portal-home.html
+++ b/.design/frontend-design-output/variants/legal-dossier/portal-home.html
@@ -1,0 +1,851 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portal / Home — SMD Services (Legal Dossier)</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Public+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ===================================================================
+       * SMD Services — Legal Dossier identity (variant for comparison)
+       * Hero surface 1: portal-home / invoice-pending state
+       * =================================================================== */
+
+      :root {
+        /* ---------- Color ---------- */
+        --color-bg: #f8f5ef; /* document cream */
+        --color-surface: #ffffff; /* paper sheets on the desk */
+        --color-border: #d6cdb9; /* warm aged hairline */
+        --color-border-subtle: #e8e0cc; /* interior rules */
+        --color-text-primary: #111827; /* near-black ink */
+        --color-text-secondary: #4b4b4b;
+        --color-text-muted: #5e5648; /* warm muted */
+        --color-primary: #7c1d1d; /* claret — wax seal */
+        --color-primary-hover: #5d1515;
+        --color-action: #7c1d1d;
+        --color-complete: #1f5132;
+        --color-attention: #7c1d1d;
+        --color-error: #991b1b;
+        --color-meta: #5e5648;
+
+        /* ---------- Typography ---------- */
+        --font-display: 'EB Garamond', 'Garamond', 'Times New Roman', serif;
+        --font-body: 'EB Garamond', 'Garamond', 'Times New Roman', serif;
+        --font-meta: 'Public Sans', system-ui, -apple-system, sans-serif;
+
+        --text-display-size: 2.75rem; /* 44px */
+        --text-display-lh: 3.125rem; /* 50px */
+        --text-display-weight: 600;
+        --text-display-tracking: -0.01em;
+
+        --text-title-size: 1.875rem; /* 30px */
+        --text-title-lh: 2.375rem; /* 38px */
+        --text-title-weight: 600;
+        --text-title-tracking: -0.005em;
+
+        --text-heading-size: 1.375rem; /* 22px */
+        --text-heading-lh: 1.875rem; /* 30px */
+        --text-heading-weight: 600;
+
+        --text-body-lg-size: 1.25rem; /* 20px */
+        --text-body-lg-lh: 2rem; /* 32px */
+
+        --text-body-size: 1.125rem; /* 18px — serif needs more air */
+        --text-body-lh: 1.875rem; /* 30px */
+        --text-body-weight: 400;
+
+        --text-caption-size: 0.8125rem; /* 13px */
+        --text-caption-lh: 1.125rem; /* 18px */
+        --text-caption-weight: 500;
+
+        --text-label-size: 0.6875rem; /* 11px */
+        --text-label-lh: 1rem;
+        --text-label-weight: 600;
+        --text-label-tracking: 0.12em;
+
+        --text-money-size: 2.25rem; /* 36px */
+        --text-money-lh: 2.625rem;
+        --text-money-weight: 500;
+
+        /* ---------- Spacing rhythm — more generous than Studio ---------- */
+        --space-section: 3rem; /* 48px between major sections */
+        --space-card: 2rem; /* 32px card internal padding */
+        --space-stack: 1.125rem; /* 18px default vertical rhythm */
+        --space-row: 0.875rem; /* 14px row gap */
+
+        /* ---------- Shape — sharp, no rounding ---------- */
+        --radius-card: 0;
+        --radius-button: 0;
+        --radius-badge: 0;
+
+        /* ---------- Motion ---------- */
+        --motion-default: 120ms ease;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        background: var(--color-bg);
+      }
+
+      body {
+        color: var(--color-text-primary);
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        font-weight: 400;
+        font-feature-settings:
+          'onum' 1,
+          'kern' 1,
+          'liga' 1;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* Lining tabular figures for any money / columnar data */
+      .fig-tab {
+        font-variant-numeric: tabular-nums lining-nums;
+        font-feature-settings:
+          'lnum' 1,
+          'tnum' 1;
+      }
+
+      /* Real small caps via EB Garamond feature */
+      .sc {
+        font-feature-settings:
+          'smcp' 1,
+          'onum' 1;
+        letter-spacing: 0.08em;
+      }
+
+      /* Meta label (sans tracked caps) */
+      .meta-label {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        font-feature-settings:
+          'tnum' 1,
+          'lnum' 1;
+      }
+
+      /* ---------- Shell (narrower than Studio) ---------- */
+
+      .shell {
+        max-width: 780px;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem 4rem;
+      }
+
+      @media (min-width: 768px) {
+        .shell {
+          padding: 4rem 3rem 6rem;
+        }
+      }
+
+      /* ---------- Letterhead ---------- */
+
+      .letterhead {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: end;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 2px solid var(--color-text-primary);
+      }
+
+      .letterhead__firm {
+        font-family: var(--font-display);
+        font-size: 1.625rem;
+        line-height: 1.75rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        font-feature-settings:
+          'smcp' 1,
+          'onum' 1;
+        letter-spacing: 0.06em;
+        text-transform: lowercase;
+      }
+
+      .letterhead__tagline {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        margin-top: 0.25rem;
+      }
+
+      .letterhead__meta {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        line-height: 1.5;
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        text-align: right;
+      }
+
+      .letterhead__meta div + div {
+        margin-top: 0.125rem;
+      }
+
+      /* ---------- Section pattern ---------- */
+
+      .section {
+        margin-top: var(--space-section);
+      }
+
+      .section__label {
+        font-family: var(--font-body);
+        font-size: 1rem;
+        line-height: 1.375rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        font-feature-settings:
+          'smcp' 1,
+          'onum' 1;
+        letter-spacing: 0.12em;
+        text-transform: lowercase;
+        padding-bottom: 0.625rem;
+        border-bottom: 1px solid var(--color-border);
+        margin-bottom: 1.5rem;
+      }
+
+      /* ---------- Hero ---------- */
+
+      .hero__headline {
+        font-family: var(--font-display);
+        font-size: var(--text-display-size);
+        line-height: var(--text-display-lh);
+        font-weight: var(--text-display-weight);
+        letter-spacing: var(--text-display-tracking);
+        color: var(--color-text-primary);
+        max-width: 22ch;
+      }
+
+      @media (max-width: 640px) {
+        .hero__headline {
+          font-size: 2rem;
+          line-height: 2.375rem;
+        }
+      }
+
+      /* ---------- Statement (invoice card) ---------- */
+
+      .statement {
+        margin-top: var(--space-section);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        padding: var(--space-card);
+      }
+
+      .statement__header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .statement__ref,
+      .statement__status {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+      }
+
+      .statement__ref {
+        color: var(--color-text-muted);
+        font-feature-settings:
+          'tnum' 1,
+          'lnum' 1;
+      }
+
+      .statement__status {
+        color: var(--color-attention);
+      }
+
+      .statement__body {
+        padding-top: 1.5rem;
+      }
+
+      .statement__amount {
+        font-family: var(--font-display);
+        font-size: 3rem;
+        line-height: 3.25rem;
+        font-weight: var(--text-money-weight);
+        color: var(--color-text-primary);
+        letter-spacing: -0.01em;
+        font-variant-numeric: tabular-nums lining-nums;
+      }
+
+      @media (max-width: 640px) {
+        .statement__amount {
+          font-size: var(--text-money-size);
+          line-height: var(--text-money-lh);
+        }
+      }
+
+      .statement__amount-caption {
+        display: inline-block;
+        margin-left: 0.625rem;
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        font-weight: var(--text-label-weight);
+        vertical-align: 0.9rem;
+      }
+
+      .statement__meta {
+        margin-top: 1.75rem;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .meta-row {
+        display: grid;
+        grid-template-columns: 9rem 1fr;
+        align-items: baseline;
+        gap: 1rem;
+      }
+
+      .meta-row dt {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .meta-row dd {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: 1.75rem;
+        color: var(--color-text-primary);
+      }
+
+      .meta-row dd.fig-tab {
+        font-feature-settings:
+          'lnum' 1,
+          'tnum' 1;
+      }
+
+      .meta-row dd.attention {
+        color: var(--color-attention);
+      }
+
+      /* ---------- Buttons ---------- */
+
+      .btn-row {
+        margin-top: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      @media (min-width: 640px) {
+        .btn-row {
+          flex-direction: row;
+          align-items: center;
+        }
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 48px;
+        padding: 0 1.5rem;
+        font-family: var(--font-body);
+        font-size: 1.0625rem;
+        line-height: 1;
+        font-weight: 500;
+        letter-spacing: 0.005em;
+        border: 1px solid transparent;
+        border-radius: var(--radius-button);
+        background: var(--color-primary);
+        color: #ffffff;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-default),
+          border-color var(--motion-default);
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      .btn:hover {
+        background: var(--color-primary-hover);
+      }
+
+      .btn:focus-visible {
+        outline: 2px solid var(--color-action);
+        outline-offset: 2px;
+      }
+
+      .btn--ghost {
+        background: transparent;
+        color: var(--color-text-primary);
+        border-color: var(--color-text-primary);
+      }
+
+      .btn--ghost:hover {
+        background: var(--color-text-primary);
+        color: var(--color-surface);
+      }
+
+      /* ---------- Consultant block ---------- */
+
+      .consultant {
+        margin-top: var(--space-section);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        padding: var(--space-card);
+        display: grid;
+        grid-template-columns: 96px 1fr;
+        gap: 1.5rem;
+        align-items: start;
+      }
+
+      @media (min-width: 768px) {
+        .consultant {
+          grid-template-columns: 128px 1fr;
+          gap: 2rem;
+        }
+      }
+
+      .consultant__photo {
+        width: 96px;
+        height: 120px;
+        background: #efe9db;
+        border: 1px solid var(--color-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 0.5rem;
+        font-family: var(--font-meta);
+        font-size: 9px;
+        line-height: 1.3;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        font-weight: 500;
+      }
+
+      @media (min-width: 768px) {
+        .consultant__photo {
+          width: 128px;
+          height: 160px;
+        }
+      }
+
+      .consultant__name {
+        font-family: var(--font-display);
+        font-size: var(--text-heading-size);
+        line-height: var(--text-heading-lh);
+        font-weight: var(--text-heading-weight);
+        color: var(--color-text-primary);
+      }
+
+      .consultant__name-role {
+        font-style: italic;
+        font-weight: 400;
+        color: var(--color-text-secondary);
+      }
+
+      .consultant__next {
+        margin-top: 0.75rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: 1.75rem;
+        color: var(--color-text-primary);
+      }
+
+      .consultant__channel {
+        margin-top: 0.625rem;
+        font-family: var(--font-body);
+        font-size: 1rem;
+        line-height: 1.625rem;
+        color: var(--color-text-secondary);
+      }
+
+      .consultant__channel a {
+        color: var(--color-primary);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ---------- Engagement record (entries) ---------- */
+
+      .entries {
+        list-style: none;
+        counter-reset: none;
+      }
+
+      .entry {
+        padding: 1.5rem 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .entry:first-child {
+        padding-top: 0;
+      }
+
+      .entry:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
+
+      .entry__header {
+        display: flex;
+        align-items: baseline;
+        gap: 1.25rem;
+        flex-wrap: wrap;
+        margin-bottom: 0.625rem;
+      }
+
+      .entry__number,
+      .entry__date,
+      .entry__actor {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+      }
+
+      .entry__number {
+        color: var(--color-text-primary);
+      }
+
+      .entry__date {
+        color: var(--color-text-muted);
+        font-feature-settings:
+          'tnum' 1,
+          'lnum' 1;
+      }
+
+      .entry__actor {
+        color: var(--color-text-muted);
+      }
+
+      .entry__body {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+        max-width: 60ch;
+      }
+
+      .entry__artifact {
+        display: inline-block;
+        margin-top: 0.625rem;
+        font-family: var(--font-body);
+        font-style: italic;
+        font-size: 1rem;
+        color: var(--color-primary);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ---------- Summary ---------- */
+
+      .summary {
+        display: grid;
+        gap: 0.875rem;
+      }
+
+      .summary-row {
+        display: grid;
+        grid-template-columns: 11rem 1fr;
+        align-items: baseline;
+        gap: 1rem;
+        padding-bottom: 0.875rem;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .summary-row:last-child {
+        border-bottom: none;
+      }
+
+      .summary-row dt {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .summary-row dd {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        color: var(--color-text-primary);
+      }
+
+      .summary-row dd.fig-tab {
+        font-feature-settings:
+          'lnum' 1,
+          'tnum' 1;
+      }
+
+      /* ---------- Ledger ---------- */
+
+      .ledger {
+        display: grid;
+      }
+
+      .ledger-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: baseline;
+        gap: 1rem;
+        padding: 0.875rem 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .ledger-row:last-child {
+        border-bottom: none;
+        padding-top: 1.25rem;
+        border-top: 2px solid var(--color-text-primary);
+      }
+
+      .ledger-row dt {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .ledger-row__context {
+        display: block;
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        color: var(--color-text-muted);
+        margin-top: 0.125rem;
+      }
+
+      .ledger-row dd {
+        font-family: var(--font-display);
+        font-size: 1.25rem;
+        line-height: 1.75rem;
+        font-weight: 500;
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums lining-nums;
+      }
+
+      .ledger-row--attention dd {
+        color: var(--color-attention);
+        font-size: 1.5rem;
+      }
+
+      /* ---------- Colophon ---------- */
+
+      .colophon {
+        margin-top: 5rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--color-border);
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <!-- Letterhead -->
+      <header class="letterhead">
+        <div>
+          <div class="letterhead__firm">SMD Services</div>
+          <div class="letterhead__tagline">Consultants · Phoenix, Arizona</div>
+        </div>
+        <div class="letterhead__meta">
+          <div>File DEL-2026-001</div>
+          <div>April 19, 2026</div>
+        </div>
+      </header>
+
+      <!-- Section I -->
+      <section class="section" aria-labelledby="section-1-label">
+        <div id="section-1-label" class="section__label">Section I · Current status</div>
+        <h1 class="hero__headline">Your April invoice is due Friday.</h1>
+      </section>
+
+      <!-- Statement -->
+      <section class="statement" aria-labelledby="statement-heading">
+        <header class="statement__header">
+          <span class="statement__ref">Entry · Invoice 1023</span>
+          <span class="statement__status">Status · Due</span>
+        </header>
+        <div class="statement__body">
+          <p id="statement-heading" class="statement__amount">
+            $4,250.00<span class="statement__amount-caption">USD</span>
+          </p>
+          <dl class="statement__meta">
+            <div class="meta-row">
+              <dt>Issued</dt>
+              <dd class="fig-tab">April 15, 2026</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Due</dt>
+              <dd class="fig-tab attention">Friday, April 24, 2026</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Method</dt>
+              <dd>Stripe — card or ACH</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Terms</dt>
+              <dd>Net 9</dd>
+            </div>
+          </dl>
+          <div class="btn-row">
+            <a class="btn" href="#pay">Review and pay</a>
+            <a class="btn btn--ghost" href="#download">Download PDF</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Consultant -->
+      <aside class="consultant" aria-label="Your consultant">
+        <div class="consultant__photo" aria-hidden="true">Consultant<br />photo on file</div>
+        <div>
+          <div class="consultant__name">
+            Scott Durgan<span class="consultant__name-role">, Consultant</span>
+          </div>
+          <p class="consultant__next">Next check-in Wednesday, April 22, at 10:00 a.m. MST.</p>
+          <p class="consultant__channel">
+            Questions may be directed by short message to
+            <a href="sms:+16025550100">(602) 555-0100</a>. Replies within one business day.
+          </p>
+        </div>
+      </aside>
+
+      <!-- Section II — Engagement record -->
+      <section class="section" aria-labelledby="section-2-label">
+        <div id="section-2-label" class="section__label">Section II · Engagement record</div>
+        <ol class="entries">
+          <li class="entry">
+            <header class="entry__header">
+              <span class="entry__number">Entry 03</span>
+              <span class="entry__date">April 14, 2026</span>
+              <span class="entry__actor">Scott</span>
+            </header>
+            <p class="entry__body">
+              Sat with the dispatcher. Two issues surfaced: warranty questions are not being asked
+              on intake, and after-hours calls route to voicemail for twelve minutes before
+              forwarding.
+            </p>
+            <a class="entry__artifact" href="#notes-0414">Notes filed April 14.</a>
+          </li>
+          <li class="entry">
+            <header class="entry__header">
+              <span class="entry__number">Entry 02</span>
+              <span class="entry__date">April 9, 2026</span>
+              <span class="entry__actor">Scott</span>
+            </header>
+            <p class="entry__body">
+              Delivered the revised call script. Maria now prompts for warranty status before
+              dispatching.
+            </p>
+            <a class="entry__artifact" href="#doc-call-script">Call script on file.</a>
+          </li>
+          <li class="entry">
+            <header class="entry__header">
+              <span class="entry__number">Entry 01</span>
+              <span class="entry__date">April 2, 2026</span>
+              <span class="entry__actor">Scott</span>
+            </header>
+            <p class="entry__body">
+              Initial on-site assessment. Toured intake, dispatch, and invoicing. Identified
+              fourteen candidate improvements; priced and prioritized the top three.
+            </p>
+            <a class="entry__artifact" href="#doc-assessment">Assessment summary on file.</a>
+          </li>
+        </ol>
+      </section>
+
+      <!-- Section III — Engagement summary -->
+      <section class="section" aria-labelledby="section-3-label">
+        <div id="section-3-label" class="section__label">Section III · Engagement summary</div>
+        <dl class="summary">
+          <div class="summary-row">
+            <dt>Scope</dt>
+            <dd>Operations assessment: intake, dispatch, and follow-up</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Opened</dt>
+            <dd class="fig-tab">March 22, 2026</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Estimated completion</dt>
+            <dd class="fig-tab">May 15, 2026</dd>
+          </div>
+        </dl>
+      </section>
+
+      <!-- Section IV — Ledger -->
+      <section class="section" aria-labelledby="section-4-label">
+        <div id="section-4-label" class="section__label">Section IV · Ledger</div>
+        <dl class="ledger">
+          <div class="ledger-row">
+            <dt>Paid to date</dt>
+            <dd>$2,000.00</dd>
+          </div>
+          <div class="ledger-row">
+            <dt>Remaining</dt>
+            <dd>$6,250.00</dd>
+          </div>
+          <div class="ledger-row ledger-row--attention">
+            <dt>
+              Next charge
+              <span class="ledger-row__context">Due April 24, 2026</span>
+            </dt>
+            <dd>$4,250.00</dd>
+          </div>
+        </dl>
+      </section>
+
+      <footer class="colophon">
+        <span>SMD Services · Client portal</span>
+        <span>v.1 · April 19, 2026</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/.design/frontend-design-output/variants/legal-dossier/portal-invoices-detail.html
+++ b/.design/frontend-design-output/variants/legal-dossier/portal-invoices-detail.html
@@ -1,0 +1,832 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portal / Invoice 1023 — SMD Services (Legal Dossier)</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Public+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ===================================================================
+       * SMD Services — Legal Dossier identity (variant for comparison)
+       * Hero surface 2: portal-invoices-detail / unpaid state
+       * =================================================================== */
+
+      :root {
+        /* Color */
+        --color-bg: #f8f5ef;
+        --color-surface: #ffffff;
+        --color-border: #d6cdb9;
+        --color-border-subtle: #e8e0cc;
+        --color-text-primary: #111827;
+        --color-text-secondary: #4b4b4b;
+        --color-text-muted: #5e5648;
+        --color-primary: #7c1d1d;
+        --color-primary-hover: #5d1515;
+        --color-action: #7c1d1d;
+        --color-complete: #1f5132;
+        --color-attention: #7c1d1d;
+        --color-error: #991b1b;
+        --color-meta: #5e5648;
+
+        /* Typography */
+        --font-display: 'EB Garamond', 'Garamond', 'Times New Roman', serif;
+        --font-body: 'EB Garamond', 'Garamond', 'Times New Roman', serif;
+        --font-meta: 'Public Sans', system-ui, -apple-system, sans-serif;
+
+        --text-display-size: 2.75rem;
+        --text-display-lh: 3.125rem;
+        --text-display-weight: 600;
+        --text-display-tracking: -0.01em;
+
+        --text-title-size: 1.875rem;
+        --text-title-lh: 2.375rem;
+        --text-title-weight: 600;
+        --text-title-tracking: -0.005em;
+
+        --text-heading-size: 1.375rem;
+        --text-heading-lh: 1.875rem;
+        --text-heading-weight: 600;
+
+        --text-body-lg-size: 1.25rem;
+        --text-body-lg-lh: 2rem;
+
+        --text-body-size: 1.125rem;
+        --text-body-lh: 1.875rem;
+        --text-body-weight: 400;
+
+        --text-caption-size: 0.8125rem;
+        --text-caption-lh: 1.125rem;
+        --text-caption-weight: 500;
+
+        --text-label-size: 0.6875rem;
+        --text-label-lh: 1rem;
+        --text-label-weight: 600;
+        --text-label-tracking: 0.12em;
+
+        --text-money-size: 2.25rem;
+        --text-money-lh: 2.625rem;
+        --text-money-weight: 500;
+
+        /* Spacing rhythm */
+        --space-section: 3rem;
+        --space-card: 2rem;
+        --space-stack: 1.125rem;
+        --space-row: 0.875rem;
+
+        /* Shape */
+        --radius-card: 0;
+        --radius-button: 0;
+        --radius-badge: 0;
+
+        /* Motion */
+        --motion-default: 120ms ease;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        background: var(--color-bg);
+      }
+
+      body {
+        color: var(--color-text-primary);
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: var(--text-body-lh);
+        font-weight: 400;
+        font-feature-settings:
+          'onum' 1,
+          'kern' 1,
+          'liga' 1;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ---------- Shell (narrow single-column like a brief) ---------- */
+
+      .shell {
+        max-width: 780px;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem 4rem;
+      }
+
+      @media (min-width: 768px) {
+        .shell {
+          padding: 4rem 3rem 6rem;
+        }
+      }
+
+      /* ---------- Letterhead ---------- */
+
+      .letterhead {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: end;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 2px solid var(--color-text-primary);
+      }
+
+      .letterhead__firm {
+        font-family: var(--font-display);
+        font-size: 1.625rem;
+        line-height: 1.75rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        font-feature-settings:
+          'smcp' 1,
+          'onum' 1;
+        letter-spacing: 0.06em;
+        text-transform: lowercase;
+      }
+
+      .letterhead__tagline {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        line-height: var(--text-label-lh);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        margin-top: 0.25rem;
+      }
+
+      .letterhead__meta {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        line-height: 1.5;
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        text-align: right;
+      }
+
+      .letterhead__meta div + div {
+        margin-top: 0.125rem;
+      }
+
+      /* ---------- Breadcrumb ---------- */
+
+      .breadcrumb {
+        margin-top: 1.75rem;
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .breadcrumb a {
+        color: var(--color-text-muted);
+        text-decoration: none;
+        transition: color var(--motion-default);
+      }
+
+      .breadcrumb a:hover {
+        color: var(--color-primary);
+      }
+
+      .breadcrumb__sep {
+        display: inline-block;
+        margin: 0 0.5rem;
+        color: var(--color-border);
+      }
+
+      /* ---------- Hero ---------- */
+
+      .hero {
+        margin-top: 1.25rem;
+        padding-bottom: 1.75rem;
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .hero__eyebrow {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .hero__title {
+        margin-top: 0.5rem;
+        font-family: var(--font-display);
+        font-size: var(--text-display-size);
+        line-height: var(--text-display-lh);
+        font-weight: var(--text-display-weight);
+        letter-spacing: var(--text-display-tracking);
+        color: var(--color-text-primary);
+      }
+
+      @media (max-width: 640px) {
+        .hero__title {
+          font-size: 2.125rem;
+          line-height: 2.5rem;
+        }
+      }
+
+      .hero__subtitle {
+        margin-top: 0.5rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-lg-size);
+        line-height: var(--text-body-lg-lh);
+        color: var(--color-text-secondary);
+        font-style: italic;
+      }
+
+      .hero__status {
+        display: inline-block;
+        margin-top: 1rem;
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-primary);
+        padding-left: 1rem;
+        border-left: 3px solid var(--color-primary);
+      }
+
+      /* ---------- Panel ---------- */
+
+      .panel {
+        margin-top: var(--space-section);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        padding: var(--space-card);
+      }
+
+      .panel__header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .panel__title,
+      .panel__context {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+      }
+
+      .panel__title {
+        color: var(--color-text-primary);
+      }
+
+      .panel__context {
+        color: var(--color-text-muted);
+      }
+
+      .panel__body {
+        padding-top: 1.5rem;
+      }
+
+      /* ---------- Amount block ---------- */
+
+      .amount-block__label {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .amount-block__value {
+        margin-top: 0.375rem;
+        font-family: var(--font-display);
+        font-size: 3.25rem;
+        line-height: 3.5rem;
+        font-weight: var(--text-money-weight);
+        color: var(--color-text-primary);
+        letter-spacing: -0.01em;
+        font-variant-numeric: tabular-nums lining-nums;
+      }
+
+      @media (max-width: 640px) {
+        .amount-block__value {
+          font-size: 2.5rem;
+          line-height: 2.875rem;
+        }
+      }
+
+      .amount-block__currency {
+        display: inline-block;
+        margin-left: 0.625rem;
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        font-weight: var(--text-label-weight);
+        vertical-align: 1rem;
+      }
+
+      .meta-rows {
+        margin-top: 1.75rem;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .meta-row {
+        display: grid;
+        grid-template-columns: 9rem 1fr;
+        align-items: baseline;
+        gap: 1rem;
+      }
+
+      .meta-row dt {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .meta-row dd {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: 1.75rem;
+        color: var(--color-text-primary);
+      }
+
+      .meta-row dd.fig-tab {
+        font-feature-settings:
+          'lnum' 1,
+          'tnum' 1;
+      }
+
+      .meta-row dd.attention {
+        color: var(--color-attention);
+      }
+
+      /* ---------- Buttons ---------- */
+
+      .btn-row {
+        margin-top: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      @media (min-width: 640px) {
+        .btn-row {
+          flex-direction: row;
+          align-items: center;
+        }
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 48px;
+        padding: 0 1.5rem;
+        font-family: var(--font-body);
+        font-size: 1.0625rem;
+        line-height: 1;
+        font-weight: 500;
+        letter-spacing: 0.005em;
+        border: 1px solid transparent;
+        border-radius: var(--radius-button);
+        background: var(--color-primary);
+        color: #ffffff;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-default),
+          border-color var(--motion-default);
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      .btn:hover {
+        background: var(--color-primary-hover);
+      }
+
+      .btn:focus-visible {
+        outline: 2px solid var(--color-action);
+        outline-offset: 2px;
+      }
+
+      .btn--ghost {
+        background: transparent;
+        color: var(--color-text-primary);
+        border-color: var(--color-text-primary);
+      }
+
+      .btn--ghost:hover {
+        background: var(--color-text-primary);
+        color: var(--color-surface);
+      }
+
+      /* ---------- Schedule (line items) ---------- */
+
+      .schedule-head {
+        display: grid;
+        grid-template-columns: 1fr 4rem 7rem;
+        gap: 1rem;
+        padding: 0.875rem 0;
+        border-bottom: 2px solid var(--color-text-primary);
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-primary);
+      }
+
+      .schedule-head-right {
+        text-align: right;
+      }
+
+      .schedule-row {
+        display: grid;
+        grid-template-columns: 1fr 4rem 7rem;
+        gap: 1rem;
+        padding: 1rem 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+        align-items: baseline;
+      }
+
+      .schedule-row:last-of-type {
+        border-bottom: 1px solid var(--color-text-primary);
+      }
+
+      .schedule-row__description {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: 1.75rem;
+        color: var(--color-text-primary);
+      }
+
+      .schedule-row__number {
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: 1.75rem;
+        color: var(--color-text-primary);
+        text-align: right;
+        font-variant-numeric: tabular-nums lining-nums;
+      }
+
+      .schedule-total {
+        display: grid;
+        grid-template-columns: 1fr 4rem 7rem;
+        gap: 1rem;
+        padding-top: 1rem;
+        align-items: baseline;
+      }
+
+      .schedule-total__label {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-primary);
+      }
+
+      .schedule-total__amount {
+        grid-column: 3;
+        font-family: var(--font-display);
+        font-size: 1.625rem;
+        line-height: 2rem;
+        font-weight: 600;
+        color: var(--color-text-primary);
+        font-variant-numeric: tabular-nums lining-nums;
+        text-align: right;
+      }
+
+      /* ---------- Prior payments ---------- */
+
+      .payments-list {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .payments-list .meta-row dd {
+        font-style: italic;
+      }
+
+      .payments-list .meta-row dd .fig-tab-inline {
+        font-style: normal;
+        font-feature-settings:
+          'lnum' 1,
+          'tnum' 1;
+      }
+
+      /* ---------- Consultant block ---------- */
+
+      .consultant {
+        margin-top: var(--space-section);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        padding: var(--space-card);
+        display: grid;
+        grid-template-columns: 96px 1fr;
+        gap: 1.5rem;
+        align-items: start;
+      }
+
+      @media (min-width: 768px) {
+        .consultant {
+          grid-template-columns: 128px 1fr;
+          gap: 2rem;
+        }
+      }
+
+      .consultant__photo {
+        width: 96px;
+        height: 120px;
+        background: #efe9db;
+        border: 1px solid var(--color-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 0.5rem;
+        font-family: var(--font-meta);
+        font-size: 9px;
+        line-height: 1.3;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-text-muted);
+        font-weight: 500;
+      }
+
+      @media (min-width: 768px) {
+        .consultant__photo {
+          width: 128px;
+          height: 160px;
+        }
+      }
+
+      .consultant__name {
+        font-family: var(--font-display);
+        font-size: var(--text-heading-size);
+        line-height: var(--text-heading-lh);
+        font-weight: var(--text-heading-weight);
+        color: var(--color-text-primary);
+      }
+
+      .consultant__name-role {
+        font-style: italic;
+        font-weight: 400;
+        color: var(--color-text-secondary);
+      }
+
+      .consultant__next {
+        margin-top: 0.75rem;
+        font-family: var(--font-body);
+        font-size: var(--text-body-size);
+        line-height: 1.75rem;
+        color: var(--color-text-primary);
+      }
+
+      .consultant__channel {
+        margin-top: 0.625rem;
+        font-family: var(--font-body);
+        font-size: 1rem;
+        line-height: 1.625rem;
+        color: var(--color-text-secondary);
+      }
+
+      .consultant__channel a {
+        color: var(--color-primary);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ---------- Payment notice ---------- */
+
+      .notice {
+        margin-top: var(--space-stack);
+        padding: 1.5rem 2rem;
+        border-left: 3px solid var(--color-primary);
+        background: transparent;
+      }
+
+      .notice__label {
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+      }
+
+      .notice__body {
+        margin-top: 0.5rem;
+        font-family: var(--font-body);
+        font-size: 1rem;
+        line-height: 1.625rem;
+        color: var(--color-text-secondary);
+        font-style: italic;
+      }
+
+      /* ---------- Colophon ---------- */
+
+      .colophon {
+        margin-top: 5rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--color-border);
+        font-family: var(--font-meta);
+        font-size: var(--text-label-size);
+        letter-spacing: var(--text-label-tracking);
+        text-transform: uppercase;
+        font-weight: var(--text-label-weight);
+        color: var(--color-text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <!-- Letterhead -->
+      <header class="letterhead">
+        <div>
+          <div class="letterhead__firm">SMD Services</div>
+          <div class="letterhead__tagline">Consultants · Phoenix, Arizona</div>
+        </div>
+        <div class="letterhead__meta">
+          <div>File DEL-2026-001</div>
+          <div>April 19, 2026</div>
+        </div>
+      </header>
+
+      <!-- Breadcrumb -->
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="#home">Portal</a>
+        <span class="breadcrumb__sep">/</span>
+        <a href="#invoices">Invoices</a>
+        <span class="breadcrumb__sep">/</span>
+        <span>1023</span>
+      </nav>
+
+      <!-- Hero -->
+      <section class="hero" aria-labelledby="invoice-title">
+        <div class="hero__eyebrow">Invoice No. 1023</div>
+        <h1 id="invoice-title" class="hero__title">April 2026 engagement</h1>
+        <p class="hero__subtitle">Operations assessment for Delgado Plumbing.</p>
+        <div class="hero__status" role="status">Status · Due</div>
+      </section>
+
+      <!-- Statement -->
+      <section class="panel" aria-labelledby="statement-heading">
+        <header class="panel__header">
+          <span id="statement-heading" class="panel__title">Statement</span>
+          <span class="panel__context">Issued April 15, 2026</span>
+        </header>
+        <div class="panel__body">
+          <div class="amount-block">
+            <div class="amount-block__label">Amount due</div>
+            <div class="amount-block__value">
+              $4,250.00<span class="amount-block__currency">USD</span>
+            </div>
+          </div>
+          <dl class="meta-rows">
+            <div class="meta-row">
+              <dt>Issued</dt>
+              <dd class="fig-tab">April 15, 2026</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Due date</dt>
+              <dd class="fig-tab attention">Friday, April 24, 2026</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Method</dt>
+              <dd>Stripe — card or ACH</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Terms</dt>
+              <dd>Net 9</dd>
+            </div>
+          </dl>
+          <div class="btn-row">
+            <a class="btn" href="#pay">Review and pay</a>
+            <a class="btn btn--ghost" href="#download">Download PDF</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Schedule A — line items -->
+      <section class="panel" aria-labelledby="schedule-a-heading">
+        <header class="panel__header">
+          <span id="schedule-a-heading" class="panel__title">Schedule A · Line items</span>
+          <span class="panel__context">Four entries</span>
+        </header>
+        <div class="panel__body">
+          <div class="schedule-head" role="row">
+            <span>Item</span>
+            <span class="schedule-head-right">Hours</span>
+            <span class="schedule-head-right">Amount</span>
+          </div>
+          <div class="schedule-row" role="row">
+            <span class="schedule-row__description">
+              On-site assessment: intake, dispatch, and invoicing tour
+            </span>
+            <span class="schedule-row__number">8.0</span>
+            <span class="schedule-row__number">$1,400.00</span>
+          </div>
+          <div class="schedule-row" role="row">
+            <span class="schedule-row__description">
+              Call-intake script rewrite and dispatcher training
+            </span>
+            <span class="schedule-row__number">6.5</span>
+            <span class="schedule-row__number">$1,137.50</span>
+          </div>
+          <div class="schedule-row" role="row">
+            <span class="schedule-row__description">
+              After-hours routing audit and forwarding fix
+            </span>
+            <span class="schedule-row__number">4.0</span>
+            <span class="schedule-row__number">$700.00</span>
+          </div>
+          <div class="schedule-row" role="row">
+            <span class="schedule-row__description">
+              Warranty-question intake checklist, documented for Maria
+            </span>
+            <span class="schedule-row__number">5.75</span>
+            <span class="schedule-row__number">$1,012.50</span>
+          </div>
+          <div class="schedule-total" role="row">
+            <span class="schedule-total__label">Total due</span>
+            <span class="schedule-total__amount">$4,250.00</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Schedule B — prior payments -->
+      <section class="panel" aria-labelledby="schedule-b-heading">
+        <header class="panel__header">
+          <span id="schedule-b-heading" class="panel__title">Schedule B · Prior payments</span>
+          <span class="panel__context">Engagement total · $8,250.00</span>
+        </header>
+        <div class="panel__body">
+          <dl class="payments-list">
+            <div class="meta-row">
+              <dt>March 22, 2026</dt>
+              <dd>Deposit · <span class="fig-tab-inline">$2,000.00</span> · Paid</dd>
+            </div>
+            <div class="meta-row">
+              <dt>Upon completion</dt>
+              <dd>Remaining <span class="fig-tab-inline">$2,000.00</span> at final handoff</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <!-- Consultant -->
+      <aside class="consultant" aria-label="Your consultant">
+        <div class="consultant__photo" aria-hidden="true">Consultant<br />photo on file</div>
+        <div>
+          <div class="consultant__name">
+            Scott Durgan<span class="consultant__name-role">, Consultant</span>
+          </div>
+          <p class="consultant__next">Next check-in Wednesday, April 22, at 10:00 a.m. MST.</p>
+          <p class="consultant__channel">
+            Questions about this invoice may be directed by short message to
+            <a href="sms:+16025550100">(602) 555-0100</a>. Replies within one business day.
+          </p>
+        </div>
+      </aside>
+
+      <!-- Payment notice -->
+      <aside class="notice" aria-label="Payment notice">
+        <div class="notice__label">Payment</div>
+        <p class="notice__body">
+          Card and ACH payments accepted through Stripe. A receipt is emailed to the address on file
+          within two minutes of payment.
+        </p>
+      </aside>
+
+      <footer class="colophon">
+        <span>SMD Services · Client portal</span>
+        <span>v.1 · April 19, 2026</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/.design/portal-ux-brief.md
+++ b/.design/portal-ux-brief.md
@@ -1,10 +1,12 @@
-# Client Portal — UX Redesign Brief (final)
+# Client Portal — UX Redesign Brief (final, post-identity-reset)
+
+_Revised 2026-04-19 against the Architect's Studio identity (see `.design/DESIGN.md`). Earlier revision was written against the generic SaaS placeholder identity — palette, typography, chrome conventions, and anti-patterns all updated to match the new direction. Structural decisions (surfaces, visit modes, three concepts, accessibility floor) unchanged._
 
 ## Context
 
 SMD Services sells scope-based consulting engagements to businesses doing $750k-$5M in revenue. The portal is the documented side of a relationship between our visits — not software the client bought.
 
-The current portal is undifferentiated. Every element has equal weight; nothing adapts to why a client arrived or what state their engagement is in.
+The portal is the project file from a small design studio, printed to the client's screen. Authority through precision, not decoration.
 
 ## Scope
 
@@ -26,13 +28,13 @@ Principles, anti-patterns, money rule, photo rule, accessibility floor, copy ton
 
 Each surface has one primary visit-mode fit and a single above-the-fold question it must answer:
 
-- **`portal-home`** — action responder / status checker. "What needs my attention, and what's happening with my engagement?" Dashboard archetype. Dominant action card (pending invoice if any) or "next check-in" card; timeline of past work below. Detailed in the worked example above.
+- **`portal-home`** — action responder / status checker. "What needs my attention, and what's happening with my engagement?" Dashboard archetype. Dominant action card (pending invoice if any) or "next check-in" card; timeline of past work below. Detailed in the worked example below.
 
-- **`portal-quotes-list`** — document retriever / status checker. "Show me every proposal sent to me." List of proposal rows: title, status pill (Pending Review / Accepted / Declined / Expired), sent date, total amount (per the money rule — no per-item breakdown), expiry caption if applicable. Each row links to the detail view. Chrome: sticky header + persistent tabs.
+- **`portal-quotes-list`** — document retriever / status checker. "Show me every proposal sent to me." List of proposal rows: title, status tag (Pending Review / Accepted / Declined / Expired, rendered as rectangular mono-cap tag), sent date, total amount (per the money rule — no per-item breakdown), expiry caption if applicable. Each row links to the detail view. Chrome: sticky masthead + persistent tabs.
 
-- **`portal-quotes-detail`** — action responder. "Show me this proposal; let me sign it or download the PDF." Five states (isSigned / isDeclined / isExpired / isSuperseded / isSent) — see state-rendering rules. Above fold on mobile: engagement title + status pill + dominant action (Review and sign / Signed confirmation / Superseded banner). Consultant block required.
+- **`portal-quotes-detail`** — action responder. "Show me this proposal; let me sign it or download the PDF." Five states (isSigned / isDeclined / isExpired / isSuperseded / isSent) — see state-rendering rules. Above fold on mobile: engagement title + status tag + dominant action (Review and sign / Signed confirmation / Superseded banner). Consultant block required.
 
-- **`portal-invoices-list`** — document retriever. "Show me every invoice sent to me." Same structural pattern as quotes list: title ("Invoice #abc123"), status pill (Due / Paid / Overdue), issue date, amount in dollars, due date caption. Each row links to detail.
+- **`portal-invoices-list`** — document retriever. "Show me every invoice sent to me." Same structural pattern as quotes list: title ("Invoice #abc123"), status tag (Due / Paid / Overdue), issue date, amount in dollars, due date caption. Each row links to detail.
 
 - **`portal-invoices-detail`** — action responder. "Show me this invoice, let me pay it via Stripe, and let me download the PDF." States: isUnpaid (dominant [Pay invoice] CTA) / isPaid (receipt + amount paid + date) / isOverdue (same as unpaid but with attention-color status). Consultant block required. Stripe URL comes from props.
 
@@ -70,8 +72,22 @@ Deep links land on the thing, not on a dashboard that contains the thing.
 - **Evidence over reassurance.** "Scott met with your dispatcher Tuesday; two issues surfaced" beats "Things are going well."
 - **A named human, visible.** Real photo + next scheduled touchpoint on every surface. Nothing else substitutes.
 - **Evidence, not theater.** No badges, testimonials, marketing chrome.
-- **Printed dossier, not SaaS app.**
+- **Printed dossier, not SaaS app.** Sharp corners, hairline structure, mono-anchored data. The page is the project file, not a product surface.
+- **Precision over decoration.** Every reference number, every date, every dollar figure is typeset deliberately. Nothing is decorative.
 - If the client forwarded a screenshot to their spouse, one glance confirms real work is happening.
+
+## Identity chrome conventions (Architect's Studio)
+
+These are the recurring structural/visual moves that define the aesthetic. Components in Step 5 must honor them:
+
+- **Reference lines** cap every card at the top. Format: `REF {ID} / {ATTRIBUTE · VALUE} / {SECONDARY · VALUE}`. JetBrains Mono, 12px (label token), uppercase, tracking 0.08em, `text-text-muted`. Separated from card body by a `border-border-subtle` hairline.
+- **Section labels** introduce each major page section. Short, uppercase, mono-caps: `Activity log`, `Engagement`, `Ledger`, `Prior payments`. Rendered at the label token, underlined by a `border-border` hairline.
+- **Status tags** are rectangular (2px radius), not pills. JetBrains Mono caps, `text-label` size, background in the semantic color (`--color-attention` for Due, `--color-complete` for Paid, `--color-error` for failure), `text-white`. A small dot can precede the label for redundancy (`● STATUS · DUE`).
+- **Dates render two ways.** In headlines: natural language ("due Friday", "April 2026 engagement"). In data rows, timeline entries, and reference lines: ISO (`2026-04-14`). Never mix registers within one element.
+- **All money renders in JetBrains Mono with `tabular-nums`.** No exceptions. The dollar sign is part of the value, not decoration.
+- **Timeline entries read as log lines.** Format: `{ISO-date} · {ACTOR-CAPS}` as meta row (mono, label token), then narrative body in Satoshi below. Optional artifact link in mono caps.
+- **Hairlines, not shadows.** Cards separate from surface via 1px `--color-border`, interior rules via `--color-border-subtle`. The identity is flat.
+- **Masthead at top of every surface.** Firm name or client label left, ISO date right, both in mono caps. Separated from page body by a 1px `--color-border` rule.
 
 ## Three concepts requested (structurally distinct, not visual variations)
 
@@ -86,32 +102,37 @@ Deep links land on the thing, not on a dashboard that contains the thing.
 
 ## Worked example (fidelity reference)
 
-Concept A, invoice-pending state, 390px above the fold:
+Concept A, invoice-pending state, 390px above the fold (post-identity tokens):
 
-- "Delgado Plumbing" (caption size, Inter 500, 13/18)
-- Headline: "Your April invoice is due Friday." (PJS 700, 22/28)
+- Masthead: `SMD SERVICES` left + `2026.04.19` right (JetBrains Mono, 12/16, caps, tracking 0.08em)
+- Client label: "Client · Delgado Plumbing" (JetBrains Mono caps, label token 12/16)
+- Headline: "Your April invoice is due Friday." (Cabinet Grotesk 700, 40/44, tracking -0.02em; mobile drops to 30/34)
 - Invoice card:
-  - Amount in dollars (Inter 500, tabular-nums, 24/28)
-  - Due date (caption size)
-  - [Pay invoice] primary button (44px min height, thumb zone)
-- Consultant block: Scott Durgan with photo, "Next check-in Wednesday 10am" (Inter 400, 16/24)
-- Below fold: previous timeline entries as muted dated lines (Inter 400, 14/20, slate-600)
+  - Reference line: "REF INV-1023 / ISSUED 2026-04-15" left + "STATUS · DUE" right, with ochre attention dot (JetBrains Mono caps, 12/16)
+  - Amount: "$4,250.00" (JetBrains Mono 500, 32/40 mobile, 48/52 desktop, tabular-nums)
+  - Meta rows, 4 entries (JetBrains Mono 500, 13/18, tabular-nums): Issued, Due, Method, Terms
+  - [Pay invoice] primary button (44px min height, ochre `--color-primary`, 2px radius, thumb zone)
+  - Secondary: [Download PDF] ghost button with `--color-border` outline
+- Consultant block (separate card): photo placeholder 80px square, name "Scott Durgan" (Cabinet Grotesk 600, 18/24), role "Consultant" (JetBrains Mono caps, label), next check-in line (JetBrains Mono 500, 13/18)
+- Below fold: timeline entries with mono date + actor prefix (`2026-04-14 · SCOTT`), body prose in Satoshi (16/24, `text-text-primary`), optional artifact link (mono caps, underlined)
 
 ## Above-fold specs for B and C (matching A's format)
 
-**B, invoice-pending, 390px above fold:** Pending-action entry inverts to top — dated header ("Apr 14 — From Scott"), invoice card with amount + due date + [Pay invoice], consultant photo and next touchpoint underneath. Scroll reveals older dated entries below.
+**B, invoice-pending, 390px above fold:** Pending-action entry inverts to top — dated header (`2026-04-14 · FROM SCOTT`, JetBrains Mono caps), invoice card with amount + due date + [Pay invoice], consultant photo and next touchpoint underneath. Scroll reveals older dated entries below, each a log-line header + prose body.
 
-**C, invoice-pending, 390px above fold:** Full-bleed invoice treatment dominates viewport — amount in large display type (PJS 800, 32/36), due date caption, [Pay invoice] button in thumb zone, consultant block below the action, one-line recent-activity link at the bottom.
+**C, invoice-pending, 390px above fold:** Full-bleed invoice treatment dominates viewport — amount in large display type (JetBrains Mono 500, 48/52 desktop / 32/40 mobile, tabular-nums), due date caption (mono 13/18), [Pay invoice] button in thumb zone, consultant block below the action, one-line recent-activity link at the bottom (`Last update · 2026-04-14`).
 
 ## What must be preserved
 
-Typography, palette (hex in Appendix), 8px rounded surfaces + full-rounded pills, generous vertical rhythm on chrome, voice (guide persona, human and direct, no hype, no em dashes, no AI-flavored copy), minimal iconography (Material Symbols Outlined, the established set).
+Typography (Cabinet Grotesk display, Satoshi body, JetBrains Mono data — see Appendix), palette (hex in Appendix), 2px radii across surfaces and buttons (rectangular mono-cap tags, not pills), generous vertical rhythm on chrome (40px sections, 28px card padding), voice (guide persona, human and direct, no hype, no em dashes, no AI-flavored copy), minimal iconography (Material Symbols Outlined used sparingly — the data speaks louder than icons in this identity).
 
 ## What is open
 
-Layout, hierarchy, component choice, grouping, navigation patterns, animation, empty states, entire flow.
+Layout, hierarchy, component choice, grouping, navigation patterns, empty states, entire flow. Motion is locked (120ms color transitions only; no scroll-driven or page-transition effects per identity).
 
 ## Anti-patterns (do not produce)
+
+Existing (pre-identity) anti-patterns, still banned:
 
 - 3-up equal-weight tile grid
 - "Welcome back, [Name]!" greetings
@@ -127,6 +148,17 @@ Layout, hierarchy, component choice, grouping, navigation patterns, animation, e
 - Softening or patronizing copy ("Don't worry", "We've got you covered")
 - Jira-speak milestone names ("Process documented for new client intake")
 
+New (identity-level) anti-patterns introduced by the Architect's Studio direction:
+
+- **Pill-shaped status badges** (fully rounded). Status renders as a rectangular mono-cap tag.
+- **Elevation / shadows of any kind.** The identity is flat. Hairlines and typographic hierarchy do the work.
+- **Non-mono dates, money, or reference IDs.** These always render in JetBrains Mono with `tabular-nums`.
+- **Mixing ISO and natural-language dates in the same element.** Headlines are natural-language; data rows are ISO. One register per element.
+- **Gradient backgrounds, glow effects, color washes.** The canvas is warm near-white (`#FAFAF9`), flat.
+- **Heavy icon usage.** Icons as decoration, icons substituting for text labels, duotone icons, colorized icons. Material Symbols Outlined, monotone in `--color-text-muted`, used only when text alone is ambiguous.
+- **Rounded-corner cards (above 4px).** 2px is the hard ceiling.
+- **Caps-lock shouting in body copy.** Uppercase is reserved for labels, reference lines, and section eyebrows — never for body prose.
+
 ## Mobile spec (390x844)
 
 - Design mobile first; desktop is an expansion
@@ -140,6 +172,7 @@ Layout, hierarchy, component choice, grouping, navigation patterns, animation, e
 
 - Primary action in right-rail card at eye level, not bottom-anchored
 - Timeline or main content fills the primary column
+- Max content width 1040px, centered with generous side margins
 
 ## Contact affordance spec
 
@@ -151,12 +184,23 @@ Layout, hierarchy, component choice, grouping, navigation patterns, animation, e
 
 ## Copy samples (tone calibration)
 
+Prose samples (Satoshi body):
+
 - Invoice pending: "Your April invoice is due Friday."
 - Mid-engagement status: "We're in week 2. Scott sat with your dispatcher Tuesday."
 - Milestone (concrete, past tense): "New call script so Maria stops forgetting the warranty question."
 - Human presence: "Scott Durgan, your consultant. Next check-in: Wednesday at 10am."
 - Empty state: "Nothing needs your attention. Next touchpoint is Wednesday."
 - Paid invoice: "Paid April 12. Receipt attached."
+
+Chrome samples (JetBrains Mono caps):
+
+- Reference line: `REF INV-1023 / ISSUED 2026-04-15`
+- Status tag: `STATUS · DUE` (with leading dot in attention color)
+- Section label: `ACTIVITY LOG` · `ENGAGEMENT` · `LEDGER` · `LINE ITEMS`
+- Timeline meta: `2026-04-14 · SCOTT`
+- Masthead: `SMD SERVICES` (left) · `2026.04.19` (right)
+- Consultant role: `CONSULTANT` (under name)
 
 ## Error states (must design)
 
@@ -171,25 +215,36 @@ Every error surface includes the named human and a next step. No generic error p
 
 `Event = { date, actor, verb, object, optional artifact link }`. Past tense. No system-generated "status updated" entries.
 
-Date format: "Apr 9" short form. Year appears only when crossing a year boundary.
+**Rendering format:** meta row is mono caps `{ISO-date} · {ACTOR}`, followed by narrative body in Satoshi. Artifact link (when present) renders in mono caps, underlined.
 
-Example: _"Apr 9 — Scott sat with dispatcher. Two issues identified."_
+Example:
+
+```
+2026-04-14 · SCOTT
+Sat with your dispatcher. Two issues surfaced: warranty questions are
+not being asked on intake, and after-hours calls route to voicemail
+for twelve minutes before forwarding.
+NOTES FILED 2026-04-14
+```
+
+ISO date format (`YYYY-MM-DD`) in the meta row is required for the mono alignment. Natural-language date ("Apr 14") may appear in prose bodies where it reads better.
 
 ## Money rule
 
-All monetary values render as dollar figures (e.g., "$4,250"). Never as percentages, bars, or progress indicators.
+All monetary values render as dollar figures (e.g., "$4,250.00"). Never as percentages, bars, or progress indicators. Typeset in JetBrains Mono 500 with `font-variant-numeric: tabular-nums`. Two decimal places required on invoice detail surfaces for alignment; headline treatments may round (e.g., `$4,250`).
 
 ## Photo placeholder rule
 
-Where consultant photo is called for and the real photo is not yet available, use a neutral portrait placeholder with caption "consultant photo". Never initials-in-a-circle avatars.
+Where consultant photo is called for and the real photo is not yet available, use a neutral portrait placeholder — cream-brown rectangle with mono-caps caption "Consultant photo" centered. Never initials-in-a-circle avatars. Rectangle radius 2px matches card radius.
 
 ## Accessibility floor
 
-- WCAG 2.2 AA: 4.5:1 text contrast minimum
-- Visible focus rings on all interactive elements (2px ring, 2px offset, color #3B82F6)
+- WCAG 2.2 AA: 4.5:1 text contrast minimum (token pairings verified — see `.design/DESIGN.md` contrast table)
+- Visible focus rings on all interactive elements (2px ring, 2px offset, color `--color-action` / `#B45309` ochre)
 - Semantic landmarks (header, main, nav)
 - Screen-reader labels on icon-only buttons
 - Tap targets ≥44px (see mobile spec)
+- `prefers-reduced-motion: reduce` respected — not that we have much motion to disable (per identity)
 
 ## Success criteria
 
@@ -200,14 +255,17 @@ Where consultant photo is called for and the real photo is not yet available, us
 - A status-checker can name the next milestone and when they'll next hear from us within 10 seconds of landing, testable with 3 users
 - Each concept independently passes the 10-second next-milestone test
 - Three concepts are structurally distinct, not visual variations
+- Every reference line, timeline entry, and money value renders in JetBrains Mono (identity integrity check)
+- No pill-shaped status badges anywhere (identity integrity check)
 
 ## Follow-ups (scheduled, not gaps)
 
-These are real priorities scheduled after this Stitch pass:
+These are real priorities scheduled after this identity-reset sweep:
 
 - **Secondary contact access** (Elena use case) — target: next sprint
 - **SMS inbound/outbound channel** — target: next sprint
-- **Consultant real photo hosting** (Scott) — target: this week. Stitch uses neutral portrait placeholder until available.
+- **Consultant real photo hosting** (Scott) — target: this week. Portal uses neutral portrait placeholder until available.
+- **Email / PDF identity cut-over** — email templates, SOW PDF, scorecard PDF, and the `book/manage` apex page still reference Inter + Plus Jakarta Sans. Not in portal scope; separate decision whether the firm identity should propagate to those surfaces.
 
 ## Data available
 
@@ -226,55 +284,81 @@ If a proposed design needs data not listed, call it out as an open question.
 
 ## Constraints
 
-- Astro + Tailwind + Cloudflare Pages implementation
+- Astro + Tailwind v4 + Cloudflare Workers (Static Assets) implementation
 - Single client user per account (v1; Elena access follow-up scheduled)
 - No real-time updates; page-load freshness is acceptable
 - No authentication UI in scope
 
 ## Approver
 
-Scott Durgan. Stitch output reviewed before any iteration.
+Scott Durgan. Generated components reviewed visually at `/design-preview/portal-*` before any iteration.
 
 ---
 
-## Appendix: Hard design tokens
+## Appendix: Hard design tokens (Architect's Studio — authoritative)
+
+Full token spec and rationale: `.design/DESIGN.md`. Paste-ready `@theme` block: `.design/theme.css` (already merged into `src/styles/global.css` in PR #455).
 
 ### Color
 
 ```
-Primary:         #1E40AF   (deep indigo blue)
-Primary hover:   #1E3A8A
-Background:      #F8FAFC
-Surface:         #FFFFFF
-Border/divider:  #E2E8F0   (1px)
-Text primary:    #0F172A
-Text secondary:  #475569
-Text muted:      #94A3B8   (distinct use from divider)
-Focus ring:      #3B82F6   (2px ring, 2px offset)
-Action:          #3B82F6
-Complete:        #10B981
-Attention:       #F59E0B
-Error:           #EF4444
+Background:       #FAFAF9   (warm near-white)
+Surface:          #FFFFFF
+Border:           #E5E5E4   (hairline, 1px)
+Border subtle:    #F0EFED   (interior rules)
+Text primary:     #0A0A0A   (warm graphite)
+Text secondary:   #52525B
+Text muted:       #A1A1AA
+Primary:          #B45309   (deep ochre, amber 700)
+Primary hover:    #92400E
+Action:           #B45309   (focus ring, 2px ring + 2px offset)
+Attention:        #B45309   (same as primary by design)
+Complete:         #15803D
+Error:            #991B1B
+Meta:             #52525B   (same as text-secondary, semantic name)
 ```
 
 ### Typography
 
 ```
-Display:     Plus Jakarta Sans 800,  32/36, tracking -0.02em
-H2:          Plus Jakarta Sans 700,  22/28
-H3:          Plus Jakarta Sans 700,  18/24
-Body:        Inter 400,              16/24
-Body emph:   Inter 500,              16/24
-Caption:     Inter 500,              13/18, tracking 0.01em
-Money/data:  Inter 500,              16/24, tabular-nums
+Display:      Cabinet Grotesk 700,  40/44, tracking -0.02em
+Title:        Cabinet Grotesk 600,  24/32, tracking -0.01em
+Heading:      Cabinet Grotesk 600,  18/24
+Body-lg:      Satoshi 400,           18/28
+Body:         Satoshi 400,           16/24
+Body emph:    Satoshi 500,           16/24
+Caption:      Satoshi 500,           13/18, tracking 0.01em
+Label:        JetBrains Mono 600,    12/16, tracking 0.08em, uppercase
+Money:        JetBrains Mono 500,    32/40, tabular-nums
+Data meta:    JetBrains Mono 500,    13/18, tabular-nums (in-flow mono)
 ```
 
 ### Spacing and shape
 
 ```
-Rounded:          8px (surfaces), full (pills)
-Surface padding:  20-24px mobile, 24-32px desktop
-Stack rhythm:     16px default, 24px between sections
+Section:          40px (vertical gap between major page sections)
+Card:             28px (card internal padding)
+Stack:            16px (default vertical rhythm)
+Row:              12px (list-row gap)
 Tap target:       44px minimum
+Radius:           2px (cards, buttons, badges — no pills)
 Breakpoints:      390px (mobile) / 1280px (desktop)
+Max content:      1040px (centered, generous side margins)
 ```
+
+### Font loading
+
+Served via two CDNs. The Astro layouts (`Base.astro`, `AdminLayout.astro`) and the four portal design-preview pages include:
+
+```html
+<link
+  href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+  rel="stylesheet"
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+  rel="stylesheet"
+/>
+```
+
+Cabinet Grotesk + Satoshi: Fontshare (free for personal + commercial). JetBrains Mono: Google Fonts (SIL OFL 1.1). No licensing to purchase.

--- a/.design/theme.css
+++ b/.design/theme.css
@@ -1,13 +1,16 @@
-@import 'tailwindcss';
+/* ---------------------------------------------------------------------
+ * SMD Services — Architect's Studio identity
+ * Paste this @theme block into src/styles/global.css, replacing the
+ * existing @theme block. Font @import lines go in the Astro layout head.
+ *
+ * Source: Extracted from .design/frontend-design-output/*.html on 2026-04-19.
+ * Full token documentation: .design/DESIGN.md
+ * --------------------------------------------------------------------- */
 
 @theme {
   /* ------------------------------------------------------------------
-   * SMD Services — Architect's Studio identity
-   * Cut over from .design/theme.css on 2026-04-19.
-   * Full token documentation: .design/DESIGN.md
+   * Color roles (semantic, not per-screen)
    * ------------------------------------------------------------------ */
-
-  /* ---------- Color roles (semantic, not per-screen) ---------- */
   --color-background: #fafaf9;
   --color-surface: #ffffff;
   --color-border: #e5e5e4;
@@ -26,12 +29,16 @@
   --color-complete: #15803d;
   --color-error: #991b1b;
 
-  /* ---------- Typography families ---------- */
+  /* ------------------------------------------------------------------
+   * Typography families
+   * ------------------------------------------------------------------ */
   --font-display: 'Cabinet Grotesk', system-ui, sans-serif;
   --font-body: 'Satoshi', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
 
-  /* ---------- Typography scale — docs/style/UI-PATTERNS.md Rule 5 ---------- */
+  /* ------------------------------------------------------------------
+   * Typography scale
+   * ------------------------------------------------------------------ */
   --text-display: 2.5rem; /* 40px */
   --text-display--line-height: 2.75rem; /* 44px */
   --text-display--font-weight: 700;
@@ -68,48 +75,19 @@
   --text-money--line-height: 2.5rem; /* 40px */
   --text-money--font-weight: 500;
 
-  /* ---------- Spacing rhythm — docs/style/UI-PATTERNS.md Rule 6 ---------- */
-  --spacing-section: 2.5rem; /* 40px — gap between major page sections */
-  --spacing-card: 1.75rem; /* 28px — card internal padding */
-  --spacing-stack: 1rem; /* 16px — vertical stack of sibling content */
-  --spacing-row: 0.75rem; /* 12px — gap between list rows */
+  /* ------------------------------------------------------------------
+   * Spacing rhythm
+   * Generates utilities: p-card, gap-section, space-y-stack, etc.
+   * ------------------------------------------------------------------ */
+  --spacing-section: 2.5rem; /* 40px */
+  --spacing-card: 1.75rem; /* 28px */
+  --spacing-stack: 1rem; /* 16px */
+  --spacing-row: 0.75rem; /* 12px */
 
-  /* ---------- Shape — sharp by intent. No pills. ---------- */
+  /* ------------------------------------------------------------------
+   * Shape — sharp by intent. No pills.
+   * ------------------------------------------------------------------ */
   --radius-card: 2px;
   --radius-button: 2px;
   --radius-badge: 2px;
-}
-
-@layer base {
-  body {
-    background-color: var(--color-background);
-    color: var(--color-text-primary);
-    font-family: var(--font-body);
-    -webkit-font-smoothing: antialiased;
-  }
-  h1,
-  h2,
-  h3 {
-    font-family: var(--font-display);
-  }
-}
-
-.material-symbols-outlined {
-  font-family: 'Material Symbols Outlined';
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  font-variation-settings:
-    'FILL' 0,
-    'wght' 400,
-    'GRAD' 0,
-    'opsz' 24;
 }

--- a/src/components/portal/ActionCard.astro
+++ b/src/components/portal/ActionCard.astro
@@ -14,7 +14,7 @@ const { pillLabel, amountCents, amountLabel, ctaLabel, ctaHref, ctaSubtext } = A
 ---
 
 <section
-  class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-card sm:p-section"
+  class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card sm:p-section"
   aria-label={pillLabel}
 >
   <p class="text-label uppercase text-[color:var(--color-primary)]">
@@ -35,7 +35,7 @@ const { pillLabel, amountCents, amountLabel, ctaLabel, ctaHref, ctaSubtext } = A
   <div class="mt-6">
     <a
       href={ctaHref}
-      class="inline-flex w-full sm:w-auto items-center justify-center gap-2 min-h-[44px] px-6 py-3 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+      class="inline-flex w-full sm:w-auto items-center justify-center gap-2 min-h-[44px] px-6 py-3 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
     >
       {ctaLabel}
     </a>

--- a/src/components/portal/ArtifactChip.astro
+++ b/src/components/portal/ArtifactChip.astro
@@ -1,13 +1,16 @@
 ---
 /**
- * Small rounded chip pointing at a document, PDF, or external artifact.
- * 8px radius, 1px border in --color-border, white surface.
+ * Mono-caps artifact link pointing at a document, PDF, or external artifact.
+ * Rendered as a plain underlined link, not a bordered chip, matching the
+ * Architect's Studio identity (hairlines + typography carry the structure;
+ * no decorative containers for inline affordances).
  *
- * Icon is a Material Symbols Outlined name (e.g. "description", "receipt_long").
+ * Icon is an optional Material Symbols Outlined name (e.g. "description",
+ * "receipt_long") rendered at the label's baseline for redundancy.
  */
 
 interface Props {
-  icon: string
+  icon?: string
   label: string
   href: string
 }
@@ -17,8 +20,8 @@ const { icon, label, href } = Astro.props
 
 <a
   href={href}
-  class="inline-flex items-center gap-2 rounded-lg bg-[color:var(--color-surface)] border border-[color:var(--color-border)] px-3 py-1.5 text-[12px] font-medium text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-text-muted)] transition-colors"
+  class="inline-flex items-center gap-1.5 font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] underline decoration-[color:var(--color-border)] hover:decoration-[color:var(--color-text-primary)] underline-offset-4 decoration-1 transition-colors"
 >
-  <span class="material-symbols-outlined text-[16px]">{icon}</span>
+  {icon && <span class="material-symbols-outlined text-[14px]">{icon}</span>}
   <span>{label}</span>
 </a>

--- a/src/components/portal/ConsultantBlock.astro
+++ b/src/components/portal/ConsultantBlock.astro
@@ -64,12 +64,12 @@ const touchpointText = formatTouchpoint()
 ---
 
 <section
-  class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-5 sm:p-card"
+  class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-5 sm:p-card"
   aria-label="Your consultant"
 >
   <div class="flex items-start gap-stack">
     <div
-      class="w-14 h-14 shrink-0 rounded-full bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden"
+      class="w-16 h-20 shrink-0 rounded-[var(--radius-card)] bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden"
     >
       {
         photoUrl ? (
@@ -81,31 +81,33 @@ const touchpointText = formatTouchpoint()
           />
         ) : (
           <svg
-            viewBox="0 0 56 56"
+            viewBox="0 0 64 80"
             role="img"
             aria-label="consultant photo"
             class="w-full h-full text-[color:var(--color-text-muted)]"
           >
-            <rect width="56" height="56" fill="currentColor" fill-opacity="0.12" />
-            <circle cx="28" cy="22" r="9" fill="currentColor" fill-opacity="0.5" />
-            <path
-              d="M10 52c2.5-9 9.5-14 18-14s15.5 5 18 14"
-              fill="currentColor"
-              fill-opacity="0.5"
-            />
+            <rect width="64" height="80" fill="currentColor" fill-opacity="0.12" />
+            <circle cx="32" cy="30" r="12" fill="currentColor" fill-opacity="0.5" />
+            <path d="M8 78c3-14 12-20 24-20s21 6 24 20" fill="currentColor" fill-opacity="0.5" />
           </svg>
         )
       }
     </div>
     <div class="flex-1 min-w-0">
-      <p class="text-base font-semibold text-[color:var(--color-text-primary)]">
+      <p class="text-heading text-[color:var(--color-text-primary)]">
         {name}
       </p>
-      {role && <p class="text-caption text-[color:var(--color-text-muted)]">{role}</p>}
+      {
+        role && (
+          <p class="mt-0.5 font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]">
+            {role}
+          </p>
+        )
+      }
       {
         touchpointText && (
-          <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
-            Next check-in {touchpointText}
+          <p class="mt-row font-mono text-caption tabular-nums text-[color:var(--color-text-primary)]">
+            Next check-in · {touchpointText}
           </p>
         )
       }

--- a/src/components/portal/Documents.astro
+++ b/src/components/portal/Documents.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * Portal documents library — every document the engagement has produced,
+ * grouped by category.
+ *
+ * surface: session-auth-client / archetype: list / viewport: mobile-first
+ * task: find-document / pattern: persistent-tabs
+ *
+ * No data fetching. All values via props. Rows render through
+ * PortalListItem (document variant) — the ONLY place list-row markup
+ * should exist on portal surfaces.
+ *
+ * Categories render with a mono-caps section label per Architect's Studio
+ * identity chrome convention. Each group is hairline-separated from the
+ * next.
+ *
+ * No money fields on this surface per brief §Per-surface intent.
+ */
+
+import SkipToMain from '../SkipToMain.astro'
+import PortalHeader from './PortalHeader.astro'
+import PortalTabs from './PortalTabs.astro'
+import PortalListItem from './PortalListItem.astro'
+
+export interface DocumentItem {
+  id: string
+  title: string
+  /** Material Symbols Outlined name (e.g., "description", "receipt_long"). */
+  icon: string
+  /** Short eyebrow — e.g., "SIGNED APR 2, 2026" or "DELIVERED MAR 29". */
+  eyebrow: string | null
+  href: string
+  /** Either "open_in_new" or "download". Plain string in the interface for
+   *  JSON fixture compatibility; PortalListItem enforces the union. */
+  trailingIcon: string
+  /** If true, link opens in a new tab (typical for external-hosted PDFs). */
+  external?: boolean
+}
+
+export interface DocumentGroup {
+  /** Short uppercase label. Renders as mono-caps section label. */
+  label: string
+  items: DocumentItem[]
+}
+
+export interface Props {
+  client: { name: string }
+  groups: DocumentGroup[]
+}
+
+const { client, groups } = Astro.props
+
+const totalCount = groups.reduce((sum, g) => sum + g.items.length, 0)
+---
+
+<SkipToMain />
+<PortalHeader clientName={client.name} />
+<PortalTabs pathname="/portal/documents" />
+
+<main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
+  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Documents</h1>
+
+  {
+    totalCount === 0 ? (
+      <p class="text-caption text-[color:var(--color-text-muted)]">
+        Nothing on file yet. Documents will appear here as the engagement produces them.
+      </p>
+    ) : (
+      <div class="flex flex-col gap-section">
+        {groups.map((group) =>
+          group.items.length === 0 ? null : (
+            <section aria-labelledby={`group-${group.label.toLowerCase().replace(/\s+/g, '-')}`}>
+              <h2
+                id={`group-${group.label.toLowerCase().replace(/\s+/g, '-')}`}
+                class="mb-stack pb-row border-b border-[color:var(--color-border)] font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-primary)]"
+              >
+                {group.label}
+              </h2>
+              <ul class="space-y-row" role="list">
+                {group.items.map((doc) => (
+                  <li>
+                    <PortalListItem
+                      variant="document"
+                      href={doc.href}
+                      icon={doc.icon}
+                      title={doc.title}
+                      eyebrow={doc.eyebrow}
+                      trailingIcon={doc.trailingIcon === 'download' ? 'download' : 'open_in_new'}
+                      external={doc.external}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )
+        )}
+      </div>
+    )
+  }
+</main>

--- a/src/components/portal/EngagementProgress.astro
+++ b/src/components/portal/EngagementProgress.astro
@@ -1,0 +1,179 @@
+---
+/**
+ * Portal engagement progress surface.
+ *
+ * surface: session-auth-client / archetype: detail / viewport: mobile-first
+ * task: check-progress / pattern: persistent-tabs
+ *
+ * Status checker's view: "where are we in the work, what's been done,
+ * what's next." No progress bars, ever. Evidence over reassurance
+ * (brief §Design principles).
+ *
+ * Structure:
+ *   1. Heading "Engagement"
+ *   2. Engagement summary panel — reference line + scope + opened / due
+ *      dates + status tag
+ *   3. Activity log section — timeline entries (past tense, concrete)
+ *   4. Consultant block with next-touchpoint
+ *
+ * No data fetching. All values via props.
+ */
+
+import SkipToMain from '../SkipToMain.astro'
+import PortalHeader from './PortalHeader.astro'
+import PortalTabs from './PortalTabs.astro'
+import ConsultantBlock from './ConsultantBlock.astro'
+import StatusPill from './StatusPill.astro'
+import TimelineEntry from './TimelineEntry.astro'
+import type { Tone } from '../../lib/portal/status'
+
+const VALID_TONES: Tone[] = ['info', 'success', 'danger', 'warning', 'neutral']
+function coerceTone(value: string): Tone {
+  return (VALID_TONES as string[]).includes(value) ? (value as Tone) : 'neutral'
+}
+
+export interface Props {
+  client: { name: string }
+  engagement: {
+    /** Short reference id — e.g., "DEL-2026-001" */
+    reference: string
+    /** Short scope summary — one sentence. */
+    scope: string
+    /** ISO date (`YYYY-MM-DD`). Rendered as-is. */
+    openedOn: string
+    /** ISO date of estimated completion. */
+    estimatedCompletion: string
+    /** One of the Tone values (info/success/danger/warning/neutral). Plain
+     *  string in the interface for JSON fixture compatibility; coerced
+     *  before passing to StatusPill. */
+    statusTone: string
+    statusLabel: string
+  }
+  /**
+   * Chronological activity log. Most recent first. Each entry renders
+   * through <TimelineEntry /> in log-line format (mono-caps meta row
+   * above Satoshi prose body).
+   */
+  timeline: Array<{
+    id: string
+    date: string
+    actor: string
+    body: string
+    artifactLabel?: string | null
+    artifactHref?: string | null
+    artifactIcon?: string
+  }>
+  consultant: {
+    name: string
+    firstName: string
+    photoUrl: string | null
+    role: string | null
+    phone: string | null
+    email?: string | null
+    nextTouchpointAt: string | null
+    nextTouchpointLabel: string | null
+  }
+}
+
+const { client, engagement, timeline, consultant } = Astro.props
+---
+
+<SkipToMain />
+<PortalHeader
+  clientName={client.name}
+  consultantPhone={consultant.phone}
+  consultantEmail={consultant.email ?? null}
+  consultantFirstName={consultant.firstName}
+/>
+<PortalTabs pathname="/portal/engagement" />
+
+<main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
+  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Engagement</h1>
+
+  <!-- Summary panel -->
+  <section
+    class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-section"
+    aria-labelledby="summary-heading"
+  >
+    <div
+      class="flex items-center justify-between gap-stack pb-stack border-b border-[color:var(--color-border-subtle)] font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)] tabular-nums"
+    >
+      <span>REF {engagement.reference}</span>
+      <StatusPill tone={coerceTone(engagement.statusTone)} label={engagement.statusLabel} />
+    </div>
+    <h2 id="summary-heading" class="sr-only">Engagement summary</h2>
+    <div class="pt-card grid grid-cols-1 md:grid-cols-3 gap-stack md:gap-section">
+      <div>
+        <p
+          class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]"
+        >
+          Scope
+        </p>
+        <p class="mt-row text-body text-[color:var(--color-text-primary)]">{engagement.scope}</p>
+      </div>
+      <div>
+        <p
+          class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]"
+        >
+          Opened
+        </p>
+        <p class="mt-row font-mono text-body tabular-nums text-[color:var(--color-text-primary)]">
+          {engagement.openedOn}
+        </p>
+      </div>
+      <div>
+        <p
+          class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]"
+        >
+          Estimated completion
+        </p>
+        <p class="mt-row font-mono text-body tabular-nums text-[color:var(--color-text-primary)]">
+          {engagement.estimatedCompletion}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Activity log -->
+  <section class="mb-section" aria-labelledby="log-heading">
+    <h2
+      id="log-heading"
+      class="mb-stack pb-row border-b border-[color:var(--color-border)] font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-primary)]"
+    >
+      Activity log
+    </h2>
+    {
+      timeline.length === 0 ? (
+        <p class="text-caption text-[color:var(--color-text-muted)]">
+          The work begins at the first scheduled check-in.
+        </p>
+      ) : (
+        <ol class="flex flex-col gap-stack" role="list">
+          {timeline.map((entry) => (
+            <li class="pt-stack border-t border-[color:var(--color-border-subtle)] first:border-t-0 first:pt-0">
+              <TimelineEntry
+                date={entry.date}
+                actor={entry.actor}
+                body={entry.body}
+                artifactLabel={entry.artifactLabel ?? undefined}
+                artifactHref={entry.artifactHref ?? undefined}
+                artifactIcon={entry.artifactIcon}
+              />
+            </li>
+          ))}
+        </ol>
+      )
+    }
+  </section>
+
+  <!-- Consultant block -->
+  <ConsultantBlock
+    name={consultant.name}
+    photoUrl={consultant.photoUrl}
+    role={consultant.role}
+    nextTouchpointAt={consultant.nextTouchpointAt}
+    nextTouchpointLabel={consultant.nextTouchpointLabel}
+    phone={consultant.phone}
+    email={consultant.email ?? null}
+  />
+</main>

--- a/src/components/portal/InvoiceDetail.astro
+++ b/src/components/portal/InvoiceDetail.astro
@@ -117,7 +117,7 @@ const pathname = `/portal/invoices/${invoice.id}`
   <a
     href="/portal/invoices"
     aria-label="All invoices"
-    class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-label uppercase font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg"
+    class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-label uppercase font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-[var(--radius-card)]"
   >
     <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
     All invoices
@@ -138,7 +138,7 @@ const pathname = `/portal/invoices/${invoice.id}`
         </div>
 
         <h1
-          class="mt-3 font-['Plus_Jakarta_Sans'] font-extrabold text-display tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+          class="mt-3 font-display font-bold text-display tracking-[-0.02em] text-[color:var(--color-text-primary)]"
         >
           {invoice.title}
         </h1>
@@ -179,7 +179,7 @@ const pathname = `/portal/invoices/${invoice.id}`
         {
           isErrorState && (
             <div
-              class="mb-card rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
+              class="mb-card rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
               role="status"
             >
               <div class="flex items-start gap-row">
@@ -201,7 +201,7 @@ const pathname = `/portal/invoices/${invoice.id}`
         }
 
         <div
-          class="relative overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-card"
+          class="relative overflow-hidden rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-card"
         >
           <!-- Accent bar -->
           <div
@@ -278,7 +278,7 @@ const pathname = `/portal/invoices/${invoice.id}`
       {
         lineItems.length > 0 && (
           <div>
-            <h2 class="font-['Plus_Jakarta_Sans'] font-bold text-title text-[color:var(--color-text-primary)]">
+            <h2 class="font-display font-semibold text-title text-[color:var(--color-text-primary)]">
               What's included
             </h2>
             <ul class="mt-stack flex flex-col" aria-label="Invoice line items">
@@ -299,7 +299,7 @@ const pathname = `/portal/invoices/${invoice.id}`
               ))}
             </ul>
             <div class="mt-card pt-5 flex justify-between items-baseline">
-              <span class="font-['Plus_Jakarta_Sans'] font-bold text-title text-[color:var(--color-text-primary)]">
+              <span class="font-display font-semibold text-title text-[color:var(--color-text-primary)]">
                 Total
               </span>
               <MoneyDisplay amountCents={invoice.totalCents} size="h2" />
@@ -310,15 +310,13 @@ const pathname = `/portal/invoices/${invoice.id}`
 
       <!-- ── Payment details ── -->
       <div>
-        <h2
-          class="font-['Plus_Jakarta_Sans'] font-bold text-title text-[color:var(--color-text-primary)]"
-        >
+        <h2 class="font-display font-semibold text-title text-[color:var(--color-text-primary)]">
           Payment details
         </h2>
         <ul class="mt-stack grid grid-cols-1 sm:grid-cols-2 gap-card">
           {
             invoice.dueShortDate && !isPaid && (
-              <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card">
+              <li class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card">
                 <span
                   class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
                   style="font-variation-settings: 'FILL' 1;"
@@ -336,7 +334,7 @@ const pathname = `/portal/invoices/${invoice.id}`
           }
           {
             isPaid && invoice.paidShortDate && (
-              <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card">
+              <li class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card">
                 <span
                   class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)]"
                   style="font-variation-settings: 'FILL' 1;"
@@ -352,7 +350,9 @@ const pathname = `/portal/invoices/${invoice.id}`
               </li>
             )
           }
-          <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card">
+          <li
+            class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card"
+          >
             <span
               class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
               style="font-variation-settings: 'FILL' 1;"
@@ -369,7 +369,9 @@ const pathname = `/portal/invoices/${invoice.id}`
               </p>
             </div>
           </li>
-          <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card">
+          <li
+            class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card"
+          >
             <span
               class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
               style="font-variation-settings: 'FILL' 1;"
@@ -412,7 +414,7 @@ const pathname = `/portal/invoices/${invoice.id}`
       {
         isErrorState && (
           <div
-            class="rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
+            class="rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
             role="status"
           >
             <div class="flex items-start gap-row">
@@ -437,7 +439,7 @@ const pathname = `/portal/invoices/${invoice.id}`
       {
         isPaid ? (
           <section
-            class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
             aria-label="Invoice paid"
           >
             <p class="text-label uppercase text-[color:var(--color-complete)]">Paid</p>
@@ -452,7 +454,7 @@ const pathname = `/portal/invoices/${invoice.id}`
           </section>
         ) : isLinkExpired ? (
           <section
-            class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
             aria-label="Link expired"
           >
             <p class="text-label uppercase text-[color:var(--color-attention)]">Link expired</p>
@@ -479,7 +481,7 @@ const pathname = `/portal/invoices/${invoice.id}`
           </section>
         ) : invoice.isPayable && invoice.stripeUrl ? (
           <section
-            class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
             aria-label={ctaLabel}
           >
             <p class="text-label uppercase text-[color:var(--color-text-muted)]">
@@ -508,7 +510,7 @@ const pathname = `/portal/invoices/${invoice.id}`
           </section>
         ) : (
           <section
-            class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
             aria-label="Payment link pending"
           >
             <p class="text-label uppercase text-[color:var(--color-text-muted)]">

--- a/src/components/portal/InvoicesList.astro
+++ b/src/components/portal/InvoicesList.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * Portal invoices list body — all invoices for a client.
+ *
+ * surface: session-auth-client / archetype: list / viewport: mobile-first
+ * task: review-past-invoices / pattern: persistent-tabs
+ *
+ * No data fetching. All values via props. Rows render through
+ * PortalListItem (status variant) — the ONLY place list-row markup should
+ * exist on portal surfaces, per PortalListItem.astro's invariant.
+ */
+
+import SkipToMain from '../SkipToMain.astro'
+import PortalHeader from './PortalHeader.astro'
+import PortalTabs from './PortalTabs.astro'
+import PortalListItem from './PortalListItem.astro'
+import { resolveInvoiceTone, resolveInvoiceLabel } from '../../lib/portal/status'
+
+export interface Props {
+  client: { name: string }
+  invoices: Array<{
+    id: string
+    status: string
+    title: string
+    amountCents: number
+    /** Short meta caption — e.g., "Issued Apr 15" or "Paid Apr 12" */
+    metaCaption: string
+    /** Trailing caption — e.g., "Due Friday" (attention color) or null */
+    trailingCaption: string | null
+    href: string
+  }>
+}
+
+const { client, invoices } = Astro.props
+---
+
+<SkipToMain />
+<PortalHeader clientName={client.name} />
+<PortalTabs pathname="/portal/invoices" />
+
+<main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
+  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Invoices</h1>
+
+  {
+    invoices.length === 0 ? (
+      <p class="text-caption text-[color:var(--color-text-muted)]">No invoices yet.</p>
+    ) : (
+      <ul class="space-y-row" role="list">
+        {invoices.map((invoice) => (
+          <li>
+            <PortalListItem
+              variant="status"
+              href={invoice.href}
+              tone={resolveInvoiceTone(invoice.status)}
+              toneLabel={resolveInvoiceLabel(invoice.status)}
+              title={invoice.title}
+              amountCents={invoice.amountCents}
+              metaCaption={invoice.metaCaption}
+              trailingCaption={invoice.trailingCaption}
+            />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+</main>

--- a/src/components/portal/MoneyDisplay.astro
+++ b/src/components/portal/MoneyDisplay.astro
@@ -1,15 +1,18 @@
 ---
 /**
- * Dollar-figure renderer. Money rule (brief §Appendix): every monetary value
- * appears as dollar figures. NEVER percentages, bars, or progress indicators.
+ * Dollar-figure renderer. Money rule (brief §Appendix): every monetary
+ * value appears as dollar figures. NEVER percentages, bars, or progress
+ * indicators.
  *
- * Size presets match the typography scale in the brief.
- *   display → 32/36, PJS 800, tracking -0.02em
- *   h2      → 22/28, PJS 700
- *   body    → 16/24, Inter 500, tabular-nums
+ * Architect's Studio identity: all money in JetBrains Mono with
+ * tabular-nums. Size presets map to the typography scale:
  *
- * Input is cents (integer) to avoid float rounding. No decimal places for
- * whole-dollar amounts.
+ *   display → 32/40 (text-money token), JetBrains Mono 500, tabular-nums
+ *   h2      → 24/32 (text-title size), JetBrains Mono 500, tabular-nums
+ *   body    → 16/24 (text-body size), JetBrains Mono 500, tabular-nums
+ *
+ * Input is cents (integer) to avoid float rounding. No decimal places
+ * for whole-dollar amounts.
  */
 
 interface Props {
@@ -30,12 +33,12 @@ const formatted = new Intl.NumberFormat('en-US', {
 
 const sizeClass =
   size === 'display'
-    ? "font-['Plus_Jakarta_Sans'] font-extrabold text-display tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+    ? 'font-mono text-money font-medium text-[color:var(--color-text-primary)]'
     : size === 'h2'
-      ? "font-['Plus_Jakarta_Sans'] font-bold text-title text-[color:var(--color-text-primary)]"
+      ? 'font-mono text-title font-medium text-[color:var(--color-text-primary)]'
       : emphasize
-        ? 'text-base leading-6 font-semibold text-[color:var(--color-text-primary)]'
-        : 'text-base leading-6 font-medium text-[color:var(--color-text-primary)]'
+        ? 'font-mono text-body font-semibold text-[color:var(--color-text-primary)]'
+        : 'font-mono text-body font-medium text-[color:var(--color-text-primary)]'
 ---
 
 <span class={`tabular-nums ${sizeClass} ${klass}`}>{formatted}</span>

--- a/src/components/portal/PortalHeader.astro
+++ b/src/components/portal/PortalHeader.astro
@@ -37,7 +37,7 @@ const telHref = phoneDigits ? `tel:${phoneDigits}` : null
 const mailtoHref = consultantEmail ? `mailto:${consultantEmail}` : null
 
 const iconClasses =
-  'inline-flex items-center justify-center w-11 h-11 rounded-lg text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2'
+  'inline-flex items-center justify-center w-11 h-11 rounded-[var(--radius-button)] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2'
 ---
 
 <header

--- a/src/components/portal/PortalListItem.astro
+++ b/src/components/portal/PortalListItem.astro
@@ -100,7 +100,7 @@ const shellClass = [
     >
       <div class="flex items-center gap-stack min-h-[44px]">
         <span
-          class="flex-shrink-0 w-10 h-10 rounded-lg bg-[color:var(--color-primary)]/10 flex items-center justify-center text-[color:var(--color-primary)]"
+          class="flex-shrink-0 w-10 h-10 rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] flex items-center justify-center text-[color:var(--color-text-secondary)]"
           aria-hidden="true"
         >
           <span class="material-symbols-outlined">{props.icon}</span>

--- a/src/components/portal/QuoteDetail.astro
+++ b/src/components/portal/QuoteDetail.astro
@@ -100,7 +100,7 @@ const showSignButton = isSent
   <a
     href="/portal/quotes"
     aria-label="All proposals"
-    class="inline-flex items-center gap-2 min-h-11 -mx-2 px-2 mb-8 text-caption font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-lg transition-colors"
+    class="inline-flex items-center gap-2 min-h-11 -mx-2 px-2 mb-8 text-caption font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-[var(--radius-card)] transition-colors"
   >
     <span class="material-symbols-outlined text-[18px]" aria-hidden="true">arrow_back</span>
     All proposals
@@ -115,9 +115,7 @@ const showSignButton = isSent
           <p class="text-label uppercase text-[color:var(--color-meta)]">Proposal</p>
           <StatusPill tone={statusTone} label={statusLabel} size="base" />
         </div>
-        <h1
-          class="mt-3 text-display font-extrabold tracking-[-0.02em] text-[color:var(--color-text-primary)]"
-        >
+        <h1 class="mt-3 text-display text-[color:var(--color-text-primary)]">
           {quote.engagementTitle}
         </h1>
         <p class="mt-stack text-body-lg text-[color:var(--color-text-secondary)] max-w-xl">
@@ -128,7 +126,7 @@ const showSignButton = isSent
       <!-- Superseded banner (above action card on mobile, always visible) -->
       {
         isSuperseded && supersedingQuoteId && (
-          <div class="mb-section rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack">
+          <div class="mb-section rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack">
             <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
               A newer version is available.
             </p>
@@ -149,7 +147,7 @@ const showSignButton = isSent
       <!-- Mobile action card (hidden on desktop — right rail handles it) -->
       <div class="lg:hidden mb-section">
         <div
-          class="bg-[color:var(--color-surface)] rounded-xl border border-[color:var(--color-border)] p-card flex flex-col gap-stack"
+          class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card flex flex-col gap-stack"
         >
           {
             showPricingAction && (
@@ -167,7 +165,7 @@ const showSignButton = isSent
 
           {
             isSigned ? (
-              <div class="flex items-start gap-row rounded-lg border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/10 p-stack">
+              <div class="flex items-start gap-row rounded-[var(--radius-card)] border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/10 p-stack">
                 <span
                   class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)] mt-0.5"
                   style="font-variation-settings: 'FILL' 1"
@@ -204,7 +202,7 @@ const showSignButton = isSent
             ) : showSignButton ? (
               <a
                 href={signHref}
-                class="inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                class="inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--radius-card)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
               >
                 Review and sign
               </a>
@@ -286,7 +284,7 @@ const showSignButton = isSent
           isSent && (
             <section class="border-t border-[color:var(--color-border)] pt-section">
               <h2 class="text-title text-[color:var(--color-text-primary)] mb-card">Terms</h2>
-              <div class="bg-[color:var(--color-surface)] rounded-xl border border-[color:var(--color-border)] p-card space-y-row">
+              <div class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card space-y-row">
                 <p class="text-body text-[color:var(--color-text-primary)]">
                   <span class="font-semibold">Total:</span>{' '}
                   <MoneyDisplay amountCents={quote.totalCents} size="body" emphasize />
@@ -345,7 +343,7 @@ const showSignButton = isSent
       <div class="sticky top-8 space-y-card">
         <!-- Action / status card -->
         <div
-          class="bg-[color:var(--color-surface)] rounded-xl border border-[color:var(--color-border)] p-card"
+          class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
         >
           {
             showPricingAction ? (
@@ -361,7 +359,7 @@ const showSignButton = isSent
           {
             isSigned ? (
               <div class={showPricingAction ? 'mt-card' : ''}>
-                <div class="flex items-start gap-row rounded-lg border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/10 p-stack">
+                <div class="flex items-start gap-row rounded-[var(--radius-card)] border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/10 p-stack">
                   <span
                     class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)] mt-0.5"
                     style="font-variation-settings: 'FILL' 1"
@@ -381,7 +379,7 @@ const showSignButton = isSent
                 </div>
               </div>
             ) : isSuperseded ? (
-              <div class="rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack">
+              <div class="rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack">
                 <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
                   A revised version is available.
                 </p>
@@ -428,7 +426,7 @@ const showSignButton = isSent
             ) : showSignButton ? (
               <a
                 href={signHref}
-                class="mt-card inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                class="mt-card inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--radius-card)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
               >
                 Review and sign
               </a>

--- a/src/components/portal/StatusPill.astro
+++ b/src/components/portal/StatusPill.astro
@@ -1,12 +1,17 @@
 ---
 /**
- * Tone-based status pill. The only place pill markup should exist on portal
- * surfaces. Consumes TONE_CLASS from src/lib/portal/status.ts so a tone
- * change (e.g., 'warning' shifts color) propagates everywhere at once.
+ * Tone-based status tag. The only place status-tag markup should exist on
+ * portal surfaces. Consumes TONE_CLASS from src/lib/portal/status.ts so a
+ * tone change propagates everywhere at once.
  *
- * Accessibility: a pill is a visual affordance for a fact that is already
- * available in the DOM (the status field). It does not need aria-label
- * when its text content matches the fact.
+ * Architect's Studio identity: rectangular mono-caps tag with a filled
+ * tone background and white text. 2px radius via --radius-badge. The
+ * component name is retained as StatusPill for import stability, but the
+ * shape is a tag, not a pill.
+ *
+ * Accessibility: a status tag is a visual affordance for a fact that is
+ * already available in the DOM (the status field). It does not need
+ * aria-label when its text content matches the fact.
  */
 
 import { TONE_CLASS, type Tone } from '../../lib/portal/status'
@@ -15,8 +20,8 @@ interface Props {
   tone: Tone
   label: string
   /**
-   * `compact` is the default (table/list rows). `base` is the larger pill
-   * used on detail pages where the pill is the primary status signal.
+   * `compact` is the default (table/list rows). `base` is the larger tag
+   * used on detail pages where status is the primary signal.
    */
   size?: 'compact' | 'base'
   class?: string
@@ -24,13 +29,13 @@ interface Props {
 
 const { tone, label, size = 'compact', class: klass = '' } = Astro.props
 
-const sizeClass = size === 'base' ? 'px-3 py-1 text-caption' : 'px-2.5 py-0.5 text-[11px] leading-4'
+const sizeClass = size === 'base' ? 'px-3 py-1.5 text-label' : 'px-2 py-1 text-label'
 
 const toneClass = TONE_CLASS[tone]
 ---
 
 <span
-  class={`inline-flex items-center font-medium rounded-full whitespace-nowrap ${sizeClass} ${toneClass} ${klass}`}
+  class={`inline-flex items-center font-mono uppercase tracking-[var(--text-label--letter-spacing)] font-semibold rounded-[var(--radius-badge)] whitespace-nowrap ${sizeClass} ${toneClass} ${klass}`}
 >
   {label}
 </span>

--- a/src/components/portal/TimelineEntry.astro
+++ b/src/components/portal/TimelineEntry.astro
@@ -1,43 +1,58 @@
 ---
 /**
- * Dated narrative entry for the engagement timeline. Past tense, concrete;
- * no status-updated system entries.
+ * Dated narrative entry for the engagement timeline. Past tense, concrete.
+ * No status-updated system entries.
  *
- * Date format: short ("Apr 9"). Year only when crossing a year boundary —
- * handled by the host page; this component renders whatever string is passed.
+ * Architect's Studio identity: log-line format — mono-caps meta row
+ * above prose body. Date in ISO format for alignment, actor in uppercase
+ * caps. Optional mono-caps artifact link below the body.
  *
- * COLOR RULE (brief §Appendix): dates and timeline metadata use
- * --color-meta (muted indigo, #6366F1) to differentiate from text muted.
+ * Format:
+ *   2026-04-14 · SCOTT
+ *   Sat with your dispatcher. Two issues surfaced…
+ *   Notes filed 2026-04-14
  */
 
 import ArtifactChip from './ArtifactChip.astro'
 
 interface Props {
+  /** ISO date string recommended (e.g., `2026-04-14`). Host may format narrative date in body if desired. */
   date: string
+  /** Uppercase rendering recommended. Default `Scott`. */
+  actor?: string
   body: string
   artifactLabel?: string
   artifactHref?: string
   artifactIcon?: string
 }
 
-const { date, body, artifactLabel, artifactHref, artifactIcon = 'description' } = Astro.props
+const {
+  date,
+  actor = 'Scott',
+  body,
+  artifactLabel,
+  artifactHref,
+  artifactIcon = 'description',
+} = Astro.props
 ---
 
-<div class="flex gap-stack">
-  <div class="w-[48px] shrink-0">
+<div class="flex flex-col gap-row">
+  <div class="flex items-baseline gap-stack">
     <span
-      class="text-caption font-medium tracking-[0.01em] text-[color:var(--color-meta)] tabular-nums"
+      class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold tabular-nums text-[color:var(--color-text-secondary)]"
       >{date}</span
     >
+    <span
+      class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-primary)]"
+      >{actor}</span
+    >
   </div>
-  <div class="flex-1">
-    <p class="text-sm leading-[20px] text-[color:var(--color-text-secondary)]">{body}</p>
-    {
-      artifactLabel && artifactHref && (
-        <div class="mt-2">
-          <ArtifactChip icon={artifactIcon} label={artifactLabel} href={artifactHref} />
-        </div>
-      )
-    }
-  </div>
+  <p class="text-body text-[color:var(--color-text-primary)]">{body}</p>
+  {
+    artifactLabel && artifactHref && (
+      <div class="mt-row">
+        <ArtifactChip icon={artifactIcon} label={artifactLabel} href={artifactHref} />
+      </div>
+    )
+  }
 </div>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -50,7 +50,11 @@ const navItems = [
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,7 +25,11 @@ const ogImageUrl = new URL('/og-image.png', 'https://smd.services')
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/lib/portal/status.ts
+++ b/src/lib/portal/status.ts
@@ -98,15 +98,16 @@ export function resolveQuoteLabel(status: string): string {
  * Not exported as part of the public API — consumers pass a Tone; only
  * StatusPill renders the pill.
  *
- * The alpha-channel backgrounds (e.g., `bg-[color:var(--color-primary)]/10`)
- * give the pill a tinted surface without hard-coding a separate color
- * variable per tone. Text color uses the same semantic role at full
- * saturation for AA contrast against the tinted background.
+ * Architect's Studio identity: filled rectangular tag with white text, not
+ * a tinted pill. The high-contrast solid block reads as a status indicator
+ * in a technical document, not a marketing badge. `neutral` is the one
+ * subtle variant — it pairs border gray with secondary text for muted
+ * internal states (draft, superseded) that rarely surface to the client.
  */
 export const TONE_CLASS: Record<Tone, string> = {
-  info: 'bg-[color:var(--color-primary)]/10 text-[color:var(--color-primary)]',
-  success: 'bg-[color:var(--color-complete)]/10 text-[color:var(--color-complete)]',
-  danger: 'bg-[color:var(--color-error)]/10 text-[color:var(--color-error)]',
-  warning: 'bg-[color:var(--color-attention)]/10 text-[color:var(--color-attention)]',
-  neutral: 'bg-[color:var(--color-surface-muted,#f1f5f9)] text-[color:var(--color-text-secondary)]',
+  info: 'bg-[color:var(--color-primary)] text-white',
+  success: 'bg-[color:var(--color-complete)] text-white',
+  danger: 'bg-[color:var(--color-error)] text-white',
+  warning: 'bg-[color:var(--color-attention)] text-white',
+  neutral: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
 }

--- a/src/pages/design-preview/portal-documents.astro
+++ b/src/pages/design-preview/portal-documents.astro
@@ -1,0 +1,38 @@
+---
+// src/pages/design-preview/portal-documents.astro
+// Dev-only preview. Production exclusion via import.meta.env.DEV guard.
+
+import '../../styles/global.css'
+import fixtureData from './portal-documents.fixture.json'
+import Documents from '../../components/portal/Documents.astro'
+
+if (!import.meta.env.DEV) {
+  return Astro.redirect('/404')
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>[preview] Documents</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <Documents {...fixtureData} />
+  </body>
+</html>

--- a/src/pages/design-preview/portal-documents.fixture.json
+++ b/src/pages/design-preview/portal-documents.fixture.json
@@ -1,0 +1,70 @@
+{
+  "client": {
+    "name": "Delgado Plumbing"
+  },
+  "groups": [
+    {
+      "label": "Agreement",
+      "items": [
+        {
+          "id": "doc_sow_001",
+          "title": "Statement of Work — operations assessment",
+          "icon": "receipt_long",
+          "eyebrow": "SIGNED 22 MARCH 2026",
+          "href": "/portal/documents/sow_001/download",
+          "trailingIcon": "download"
+        }
+      ]
+    },
+    {
+      "label": "Deliverables",
+      "items": [
+        {
+          "id": "doc_intake_script",
+          "title": "Call-intake script — revised",
+          "icon": "description",
+          "eyebrow": "DELIVERED 9 APRIL 2026",
+          "href": "/portal/documents/intake_script/download",
+          "trailingIcon": "download"
+        },
+        {
+          "id": "doc_afterhours",
+          "title": "After-hours routing audit and fix plan",
+          "icon": "description",
+          "eyebrow": "DELIVERED 14 APRIL 2026",
+          "href": "/portal/documents/afterhours/download",
+          "trailingIcon": "download"
+        },
+        {
+          "id": "doc_warranty_checklist",
+          "title": "Warranty-question intake checklist",
+          "icon": "checklist",
+          "eyebrow": "DELIVERED 14 APRIL 2026",
+          "href": "/portal/documents/warranty_checklist/download",
+          "trailingIcon": "download"
+        }
+      ]
+    },
+    {
+      "label": "Notes on file",
+      "items": [
+        {
+          "id": "doc_notes_0414",
+          "title": "Dispatcher shadow — session notes",
+          "icon": "edit_note",
+          "eyebrow": "FILED 14 APRIL 2026",
+          "href": "/portal/documents/notes_0414/download",
+          "trailingIcon": "download"
+        },
+        {
+          "id": "doc_assessment",
+          "title": "Initial assessment summary",
+          "icon": "edit_note",
+          "eyebrow": "FILED 2 APRIL 2026",
+          "href": "/portal/documents/assessment/download",
+          "trailingIcon": "download"
+        }
+      ]
+    }
+  ]
+}

--- a/src/pages/design-preview/portal-engagement.astro
+++ b/src/pages/design-preview/portal-engagement.astro
@@ -1,0 +1,38 @@
+---
+// src/pages/design-preview/portal-engagement.astro
+// Dev-only preview. Production exclusion via import.meta.env.DEV guard.
+
+import '../../styles/global.css'
+import fixtureData from './portal-engagement.fixture.json'
+import EngagementProgress from '../../components/portal/EngagementProgress.astro'
+
+if (!import.meta.env.DEV) {
+  return Astro.redirect('/404')
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>[preview] EngagementProgress</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <EngagementProgress {...fixtureData} />
+  </body>
+</html>

--- a/src/pages/design-preview/portal-engagement.fixture.json
+++ b/src/pages/design-preview/portal-engagement.fixture.json
@@ -1,0 +1,52 @@
+{
+  "client": {
+    "name": "Delgado Plumbing"
+  },
+  "engagement": {
+    "reference": "DEL-2026-001",
+    "scope": "Operations assessment — intake, dispatch, and follow-up.",
+    "openedOn": "2026-03-22",
+    "estimatedCompletion": "2026-05-15",
+    "statusTone": "info",
+    "statusLabel": "Active"
+  },
+  "timeline": [
+    {
+      "id": "ev_2026_04_14",
+      "date": "2026-04-14",
+      "actor": "SCOTT",
+      "body": "Sat with the dispatcher. Two issues surfaced: warranty questions are not being asked on intake, and after-hours calls route to voicemail for twelve minutes before forwarding.",
+      "artifactLabel": "NOTES FILED 2026-04-14",
+      "artifactHref": "/portal/documents/notes_0414/download",
+      "artifactIcon": "description"
+    },
+    {
+      "id": "ev_2026_04_09",
+      "date": "2026-04-09",
+      "actor": "SCOTT",
+      "body": "Delivered the revised call script. Maria now prompts for warranty status before dispatching.",
+      "artifactLabel": "CALL SCRIPT ON FILE",
+      "artifactHref": "/portal/documents/intake_script/download",
+      "artifactIcon": "description"
+    },
+    {
+      "id": "ev_2026_04_02",
+      "date": "2026-04-02",
+      "actor": "SCOTT",
+      "body": "Initial on-site assessment. Toured intake, dispatch, and invoicing. Identified fourteen candidate improvements; priced and prioritized the top three.",
+      "artifactLabel": "ASSESSMENT SUMMARY ON FILE",
+      "artifactHref": "/portal/documents/assessment/download",
+      "artifactIcon": "edit_note"
+    }
+  ],
+  "consultant": {
+    "name": "Scott Durgan",
+    "firstName": "Scott",
+    "photoUrl": null,
+    "role": "Consultant",
+    "phone": "+16025550100",
+    "email": "scott@smd.services",
+    "nextTouchpointAt": "2026-04-22T17:00:00.000Z",
+    "nextTouchpointLabel": "Wed, Apr 22 at 10:00 AM"
+  }
+}

--- a/src/pages/design-preview/portal-home.astro
+++ b/src/pages/design-preview/portal-home.astro
@@ -19,7 +19,11 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-invoices-detail.astro
+++ b/src/pages/design-preview/portal-invoices-detail.astro
@@ -19,7 +19,11 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-invoices-list.astro
+++ b/src/pages/design-preview/portal-invoices-list.astro
@@ -1,0 +1,38 @@
+---
+// src/pages/design-preview/portal-invoices-list.astro
+// Dev-only preview. Production exclusion via import.meta.env.DEV guard.
+
+import '../../styles/global.css'
+import fixtureData from './portal-invoices-list.fixture.json'
+import InvoicesList from '../../components/portal/InvoicesList.astro'
+
+if (!import.meta.env.DEV) {
+  return Astro.redirect('/404')
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>[preview] InvoicesList</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <InvoicesList {...fixtureData} />
+  </body>
+</html>

--- a/src/pages/design-preview/portal-invoices-list.fixture.json
+++ b/src/pages/design-preview/portal-invoices-list.fixture.json
@@ -1,0 +1,43 @@
+{
+  "client": {
+    "name": "Delgado Plumbing"
+  },
+  "invoices": [
+    {
+      "id": "inv_1023",
+      "status": "sent",
+      "title": "Invoice 1023",
+      "amountCents": 425000,
+      "metaCaption": "Issued Apr 15",
+      "trailingCaption": "Due Friday",
+      "href": "/portal/invoices/inv_1023"
+    },
+    {
+      "id": "inv_1019",
+      "status": "overdue",
+      "title": "Invoice 1019",
+      "amountCents": 180000,
+      "metaCaption": "Issued Apr 2",
+      "trailingCaption": "5 days overdue",
+      "href": "/portal/invoices/inv_1019"
+    },
+    {
+      "id": "inv_1012",
+      "status": "paid",
+      "title": "Invoice 1012",
+      "amountCents": 200000,
+      "metaCaption": "Paid Apr 12",
+      "trailingCaption": null,
+      "href": "/portal/invoices/inv_1012"
+    },
+    {
+      "id": "inv_1004",
+      "status": "paid",
+      "title": "Invoice 1004",
+      "amountCents": 350000,
+      "metaCaption": "Paid Mar 28",
+      "trailingCaption": null,
+      "href": "/portal/invoices/inv_1004"
+    }
+  ]
+}

--- a/src/pages/design-preview/portal-quotes-detail.astro
+++ b/src/pages/design-preview/portal-quotes-detail.astro
@@ -18,7 +18,11 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-quotes-list.astro
+++ b/src/pages/design-preview/portal-quotes-list.astro
@@ -18,7 +18,11 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@700;800&family=Inter:wght@400;500;600&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,600,700,800&f[]=satoshi@400,500,600,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <link


### PR DESCRIPTION
## Summary

Full portal identity reset. Runs the pipeline end to end:

1. **Step 1** `/frontend-design` — explored directions, Captain chose **Architect's Studio**. Pixels at `.design/frontend-design-output/` (with `variants/legal-dossier/` preserved as comparison provenance).
2. **Step 2** `/design-brief --extract-identity` — produced `.design/DESIGN.md` (identity spec + contrast tables) and `.design/theme.css` (paste-ready Tailwind v4 `@theme` block).
3. **Step 3** global.css cut-over — merged the new `@theme` block, updated `@layer base` defaults to the new fonts, swapped font links across `Base.astro`, `AdminLayout.astro`, and the four portal design-preview pages.
4. **Step 4** `/ux-brief portal --revise` — updated `.design/portal-ux-brief.md` with new identity tokens, a new "Identity chrome conventions" section, new anti-patterns (pill badges, shadows, non-mono data, mixed date registers, gradients, heavy icons, >4px radii, caps-lock in body), and an expanded Appendix.
5. **Step 5** `/product-design --set portal` — revised portal primitives to the new chrome conventions and added the three fresh surfaces (`InvoicesList`, `Documents`, `EngagementProgress`).
6. **Step 6** this PR — Captain reviews visually via `npm run dev`, merges when satisfied.

## Identity shift at a glance

| Token | Before | After |
|---|---|---|
| `--color-primary` | `#1E40AF` indigo | `#B45309` deep ochre (amber 700) |
| Display font | Plus Jakarta Sans | Cabinet Grotesk (Fontshare) |
| Body font | Inter | Satoshi (Fontshare) |
| Data / labels | — | JetBrains Mono (Google OFL) |
| `--radius-card` | 0.75rem (12px) | 2px |
| `--radius-badge` | 9999px (pill) | 2px (rectangular tag) |
| Status indicator | Tinted pill | Filled rectangular mono-caps tag |
| Timeline entries | Dated-column row | Log-line format (mono meta + Satoshi prose) |
| Money | Plus Jakarta + Inter tabular | JetBrains Mono tabular, every size |
| Photo placeholder | Circle (`rounded-full`) | Rectangle (2px) |
| Consultant role | Caption muted | Mono caps |
| Section labels | — | Mono-caps eyebrow with hairline underline |
| Reference lines | — | On every card top |

## All seven portal surfaces

| # | Surface | Component | Preview |
|---|---|---|---|
| 1 | `portal-home` | `PortalHomeDashboard` (revised) | `/design-preview/portal-home` |
| 2 | `portal-quotes-list` | `QuoteList` (revised) | `/design-preview/portal-quotes-list` |
| 3 | `portal-quotes-detail` | `QuoteDetail` (revised) | `/design-preview/portal-quotes-detail` |
| 4 | `portal-invoices-list` | `InvoicesList` ✨ new | `/design-preview/portal-invoices-list` |
| 5 | `portal-invoices-detail` | `InvoiceDetail` (revised) | `/design-preview/portal-invoices-detail` |
| 6 | `portal-documents` | `Documents` ✨ new | `/design-preview/portal-documents` |
| 7 | `portal-engagement` | `EngagementProgress` ✨ new | `/design-preview/portal-engagement` |

## Commits

- `1ccdbe3` feat(design): portal identity reset — Architect's Studio tokens land _(step 3 — global.css + .design outputs)_
- `5fac800` docs(design): portal UX brief — revise against Architect's Studio identity _(step 4)_
- `dd5f84b` feat(design): portal primitives — Architect's Studio chrome conventions _(step 5a — StatusPill, TimelineEntry, ArtifactChip, ConsultantBlock, MoneyDisplay, ActionCard, PortalListItem, PortalHeader, QuoteDetail, InvoiceDetail)_
- `dcdc2dd` feat(portal): three fresh surfaces — invoices list, documents, engagement _(step 5b)_

## Out of portal scope

Email templates, SOW / scorecard PDF templates, and `book/manage` apex page still reference Inter + Plus Jakarta Sans via inline style attributes. Not in portal scope. Separate decision whether firm identity should propagate to those surfaces — `.design/portal-ux-brief.md` §Follow-ups flags this.

## Test plan

Local `npm run verify` green:
- [x] `typecheck`: 0 errors
- [x] `typecheck:workers`: clean
- [x] `format:check`: all files use Prettier code style
- [x] `lint`: 0 errors (11 pre-existing warnings in unchanged worker code)
- [x] `build`: complete
- [x] `test`: 1272 / 1272 pass (2 skipped, pre-existing)

CI status (latest commit `dcdc2dd`):
- [x] Typecheck, Lint, Format, Test — pass
- [x] Block undeferred TODO(#NNN) patterns — pass
- [x] npm audit (high+) — pass

Captain visual review via `npm run dev`:
- [ ] `portal-home` reads as "project file" — ochre + mono data + sharp corners
- [ ] `portal-quotes-list` / `portal-invoices-list` — rectangular status tags, not pills
- [ ] `portal-quotes-detail` / `portal-invoices-detail` — reference-lined panels, mono money and dates
- [ ] `portal-documents` — grouped by category with mono-caps section labels
- [ ] `portal-engagement` — reference-lined summary, log-line timeline, no progress bars anywhere
- [ ] Consultant photo placeholder renders as rectangle, not circle
- [ ] Focus rings visible in ochre on keyboard nav
- [ ] All surfaces render in Cabinet Grotesk + Satoshi + JetBrains Mono (no Inter, no Plus Jakarta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
