### PR TITLE
feat(design): admin identity sweep — Architect's Studio across all 11 surfaces

### DIFF
--- a/.design/admin-ux-brief.md
+++ b/.design/admin-ux-brief.md
@@ -1,0 +1,144 @@
+# Admin Console — UX Brief (Architect's Studio)
+
+_First-pass brief, authored 2026-04-19 alongside the identity sweep. Scope: the `admin.smd.services` subdomain under `role=admin`. Internal-only (Scott + future operations team). Inherits every identity commitment from `.design/DESIGN.md` and the portal brief (`.design/portal-ux-brief.md`); the per-surface rules here call out where admin diverges from portal in shape, density, or chrome._
+
+## Context
+
+The admin console is the operational interior of SMD Services. Leads, assessments, quotes, engagements, invoices, follow-ups, analytics, generators. High information density. Every surface is an operator's tool, not a customer surface.
+
+Only the operator (Scott today, a small operations team later) sees admin. Identity coherence with the client portal still matters: admin and portal are one product, built by one firm, and drift between them signals carelessness. Same palette, same type stack, same chrome conventions. Density and component choice differ where operator workflows demand it.
+
+## Scope — current surfaces
+
+Eleven pages today. Each is a full-page composition under `AdminLayout.astro`; no shared admin primitives directory exists yet. This brief treats the existing pages as the spec and updates them in place.
+
+| #   | Path                                | Archetype | Purpose                                                                                       |
+| --- | ----------------------------------- | --------- | --------------------------------------------------------------------------------------------- |
+| 1   | `/admin`                            | dashboard | Operator home. Counts, alerts, queue of work needing attention.                               |
+| 2   | `/admin/entities`                   | list      | Every entity (business) in the system. Filter by stage.                                       |
+| 3   | `/admin/entities/[id]`              | detail    | Single entity: stage, context timeline, contacts, assessments, engagements, quotes, invoices. |
+| 4   | `/admin/entities/[id]/quotes/[qid]` | detail    | Quote builder: line items, pricing preview, SOW PDF gen, SignWell send, status transitions.   |
+| 5   | `/admin/assessments/[id]`           | detail    | Live assessment workspace: entity context, schedule, live-notes textarea, completion form.    |
+| 6   | `/admin/engagements/[id]`           | detail    | Engagement lifecycle: milestones, invoices, documents, context log, status transitions.       |
+| 7   | `/admin/follow-ups/index`           | list      | Work queue: overdue / upcoming check-ins across engagements.                                  |
+| 8   | `/admin/generators/index`           | list      | Catalog of content generators (outreach drafts, proposals, follow-ups).                       |
+| 9   | `/admin/generators/[type]`          | detail    | Single generator: inputs + preview + run history.                                             |
+| 10  | `/admin/analytics/index`            | dashboard | Venture analytics: pipeline conversion, delivery, financial overview.                         |
+| 11  | `/admin/settings/google-connect`    | settings  | OAuth connect flow for Google Calendar / Drive integrations.                                  |
+
+## Visit modes
+
+- **Do the next thing** — operator logs in, scans the dashboard or follow-up queue, and acts on what's at the top.
+- **Find a thing** — entities list, search by name, drill into detail.
+- **Process a lead** — follow a specific entity through stage transitions (prospect → assessing → proposing → engaged → delivered).
+- **Author a document** — build a quote, generate outreach, draft a proposal.
+- **Log context** — append a note, transcript, or signal to an entity's timeline.
+
+Admin does not need mobile-first design. Operators use laptops. Layouts may assume ≥1024px and degrade gracefully, not the other way around.
+
+## Identity inheritance (from `.design/DESIGN.md`)
+
+Everything in `.design/DESIGN.md` applies to admin. Summary of what admin gets for free from the token cutover:
+
+- Cabinet Grotesk display + Satoshi body + JetBrains Mono data
+- Warm near-white `#FAFAF9` background, `#0A0A0A` graphite ink
+- Ochre `#B45309` primary / attention / focus-ring accent
+- 2px radii across cards, buttons, and status tags
+- Flat — no shadows, no gradient washes, no elevation
+- Motion minimal (120ms color transitions only)
+
+## Identity chrome conventions (admin interpretations)
+
+Where portal and admin share a convention, the rule is stated once in the portal brief. The list below is the admin-specific interpretation or difference.
+
+- **Masthead.** Admin uses the existing `AdminLayout.astro` sticky header: firm name + "Admin" tag on the left, nav tabs + session email + sign-out on the right. Client name does not appear there (multi-entity interior); entity context lives in the page breadcrumbs or hero.
+- **Breadcrumbs.** Used on deep pages (`entities/[id]`, quote builder, assessment detail, engagement detail). Format: `Dashboard / Entities / {Entity Name} / {Leaf}`. Chevron separators, caption-sized sans. Last crumb is `text-primary` and not linked.
+- **Section labels.** Mono-caps, hairline-underlined, consistent with portal. Used above grouped collapsibles (engagements, invoices, quotes, activity timeline) and between major page sections.
+- **Reference lines.** Not required on every card in admin (lower-stakes than client-facing portal). Use when an object has a meaningful external ID — quotes (`REF QUOTE-2026-042`), invoices (`REF INV-1023`), engagements (`REF ENG-2026-017`), assessments (`REF ASSESS-2026-009`). Mono caps, top of card, hairline underline.
+- **Status tags.** Single shared renderer: `statusBadgeClass(status)` in `src/lib/ui/status-badge.ts`. Returns a full class string — filled rectangular 2px tag with white text on tone-color background, mono caps with tracked letter-spacing. Admin maps ~20 status values across engagements, quotes, invoices, and leads to the five shared tones (info/success/danger/warning/neutral). Never wrap with extra padding or radius; the function covers it.
+- **Tables.** Permitted in admin (not in portal). Used for line items, invoice lists, milestone rosters, entity rolls. Header row is `text-label` mono-caps, hairline-separated from body. Row dividers are `--color-border-subtle`. Column alignment: prose left-aligned, numbers right-aligned with `tabular-nums`.
+- **Buttons.** Primary action ochre filled, secondary ghost with `--color-border` outline, destructive `--color-error` filled. **Stage-transition buttons are not rainbow-coded.** Difference communicated by label, not color: Promote / Book Assessment / Send Proposal / Mark Engaged / etc. all render as primary ochre. Lost / Dismiss / Cancel render neutral or destructive.
+- **Stage / tier / context-type badges.** Local helpers in individual admin pages currently return soft Tailwind family tints (`bg-amber-100 text-amber-700`, etc.) for fine-grained admin metadata. Tinted, pill-shaped, caption-sized. **Not identity-correct** but deferred — the signal density (8 stages × 4 tiers × 13 context types) doesn't collapse cleanly into five tones, and these tags are contextual operator metadata rather than primary status. Flagged as follow-up; see §Open follow-ups.
+- **Money.** Always JetBrains Mono with `tabular-nums`, same as portal. Already rendered through `formatCurrency(...)` helpers per page.
+- **Dates.** Two registers, same as portal: natural-language in prose (`April 14, 2026`), ISO in data rows (`2026-04-14`). Timestamps in activity logs use ISO with optional time suffix.
+
+## Data density
+
+Admin pages are denser than portal pages by intent. Operator workflows need to see many things at once: an entity's stage + context timeline + contacts + assessments + engagements + quotes + invoices + documents on one page. Pages tolerate:
+
+- 5+ distinct collapsible panels (engagements, quotes, invoices, documents, context)
+- Wide tables up to full content width
+- Sidebars for stage transitions and quick-action buttons
+- Inline forms for adding notes, updating stage, changing status
+
+What admin does NOT tolerate (same as portal identity):
+
+- Stock imagery, testimonials, marketing chrome
+- Progress bars (milestone status is a tag, not a bar)
+- Gradient backgrounds, elevation, shadow-lg
+- Rounded pill badges
+- Mixed typography registers within one information block
+
+## Anti-patterns (admin-specific, additional to the identity list in `.design/DESIGN.md`)
+
+- Color-coded stage-transition buttons. Label-first, ochre-uniform.
+- Pastel tinted cards as the main container (tinted cards are fine for inline error / success banners only).
+- Deep modal stacks. Admin prefers full-page navigation with breadcrumbs over nested modals.
+- Mobile-first layouts. Desktop is the primary target.
+- Hidden-until-click affordances for common actions. If an operator does it twice a day, it's above the fold.
+- Decorative emoji or icon-only buttons. Text labels over icon-only for every primary action.
+
+## Copy tone
+
+Same voice as portal: human, direct, evidence-over-reassurance, no em dashes, no AI filler. Admin copy is slightly more terse (operator is the reader, not the client). Concrete examples:
+
+- Empty state on entities list: "No entities in this stage."
+- Error on failed save: "Save failed. {reason}."
+- Confirmation on stage change: "Moved to Proposing."
+- Destructive confirm: "Cancel this engagement? Milestones and invoices remain on file."
+
+Never:
+
+- "Congrats! You did a thing!"
+- "Looks like…"
+- "Please try again later" (state the actual reason)
+- "All good!" (what's good? say what happened)
+
+## Error states
+
+Every failing admin action must surface a concrete reason and an immediate next step. Inline errors in page top-strips preferred over toasts for operator actions (toasts are ephemeral; operators need the error to stick until the issue is resolved).
+
+## Success criteria
+
+- Every admin page renders in Cabinet Grotesk + Satoshi + JetBrains Mono with no Inter / Plus Jakarta fallback.
+- Every status tag renders rectangular 2px (no pills anywhere).
+- Every monetary value renders mono tabular.
+- Palette reads warm: no cool slate or indigo anywhere in chrome or page body.
+- All buttons are ochre primary, neutral ghost, or error red. No rainbow.
+- Admin operator moves through a full lead-to-engagement lifecycle (prospect → assessing → proposing → engaged) and the visual continuity is uninterrupted.
+
+## Open follow-ups
+
+- **Local tag helpers** (stage, tier, context-type) still return soft Tailwind tints. Collapse to the shared tone scale OR accept tinted admin-specific tags as a tolerated exception. Decision deferred.
+- **Admin primitives directory.** `src/components/admin/` does not exist. Consider extracting shared pieces (breadcrumb header, collapsible detail panel, stage-transition button bar, activity-log entry, money column) after the next iteration of admin work. Premature now — scope not yet stable.
+- **Dashboard `/admin` index.** Currently a basic landing; should eventually show a real operator-facing home with "next thing to do" prominent, overdue follow-ups, pending signatures, revenue run-rate. Out of scope for this identity sweep; captured for next iteration.
+- **Analytics surface.** Same story — charts currently render with default palette. Chart colorways need a pass once a charting library is chosen; no charts ship in this sweep.
+
+## Approver
+
+Scott Durgan. Admin pages reviewed visually by running `npm run dev` and navigating `/admin/*` while logged in as admin.
+
+---
+
+## Appendix: Admin token map
+
+Admin inherits every token from `.design/DESIGN.md`. No admin-specific tokens. Any color / type / spacing / radius value in admin must map to a token in `src/styles/global.css` `@theme` — hardcoded Tailwind family colors outside of the inherited tinted-badge helpers are not permitted.
+
+## Appendix: Helper functions
+
+| Helper                             | Location                        | Output                                              |
+| ---------------------------------- | ------------------------------- | --------------------------------------------------- |
+| `statusBadgeClass(status)`         | `src/lib/ui/status-badge.ts`    | Full rectangular tag class list (identity-correct). |
+| `formatCurrency(n)` / `formatDate` | Per-page (currently duplicated) | ISO dates and USD amounts.                          |
+
+The per-page duplication of `formatCurrency` and `formatDate` is a follow-up opportunity — extract to `src/lib/format.ts` when the next admin sweep happens.

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -63,7 +63,9 @@ const navItems = [
     />
     <title>{title}</title>
   </head>
-  <body class="min-h-screen bg-slate-50 text-slate-900">
+  <body
+    class="min-h-screen bg-[color:var(--color-background)] text-[color:var(--color-text-primary)]"
+  >
     <SkipToMain />
     <header
       role="banner"
@@ -76,7 +78,10 @@ const navItems = [
             class="text-lg font-bold text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
             >SMD Services</a
           >
-          <span class="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">Admin</span>
+          <span
+            class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-2 py-0.5 rounded"
+            >Admin</span
+          >
         </div>
 
         <!-- Desktop: inline nav tabs + email + sign out -->
@@ -93,7 +98,7 @@ const navItems = [
                       'inline-flex items-center min-h-11 px-2 -mx-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded',
                       active
                         ? 'text-[color:var(--color-primary)] font-medium'
-                        : 'text-slate-600 hover:text-slate-900 active:text-slate-900',
+                        : 'text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)]',
                     ]}
                   >
                     {item.label}
@@ -102,12 +107,12 @@ const navItems = [
               })
             }
           </nav>
-          <span class="text-sm text-slate-300" aria-hidden="true">|</span>
-          <span class="text-sm text-slate-600">{session.email}</span>
+          <span class="text-sm text-[color:var(--color-text-muted)]" aria-hidden="true">|</span>
+          <span class="text-sm text-[color:var(--color-text-secondary)]">{session.email}</span>
           <form method="POST" action="/api/auth/logout">
             <button
               type="submit"
-              class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-slate-500 hover:text-slate-700 active:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+              class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
             >
               Sign out
             </button>
@@ -118,12 +123,12 @@ const navItems = [
         <details class="relative md:hidden">
           <summary
             aria-label="Open menu"
-            class="list-none w-11 h-11 flex items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 active:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 cursor-pointer"
+            class="list-none w-11 h-11 flex items-center justify-center rounded-[var(--radius-card)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border-subtle)] active:bg-[color:var(--color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 cursor-pointer"
           >
             <span class="material-symbols-outlined" aria-hidden="true">menu</span>
           </summary>
           <div
-            class="absolute right-0 top-12 w-64 bg-white border border-[color:var(--color-border)] rounded-lg shadow-lg p-2 z-50"
+            class="absolute right-0 top-12 w-64 bg-white border border-[color:var(--color-border)] rounded-[var(--radius-card)] p-2 z-50"
           >
             <nav aria-label="Primary" class="flex flex-col">
               {
@@ -134,8 +139,10 @@ const navItems = [
                       href={item.href}
                       aria-current={active ? 'page' : undefined}
                       class:list={[
-                        'block px-3 py-2.5 text-sm rounded hover:bg-slate-100 active:bg-slate-100',
-                        active ? 'text-[color:var(--color-primary)] font-medium' : 'text-slate-700',
+                        'block px-3 py-2.5 text-sm rounded hover:bg-[color:var(--color-border-subtle)] active:bg-[color:var(--color-border-subtle)]',
+                        active
+                          ? 'text-[color:var(--color-primary)] font-medium'
+                          : 'text-[color:var(--color-text-primary)]',
                       ]}
                     >
                       {item.label}
@@ -145,11 +152,13 @@ const navItems = [
               }
             </nav>
             <hr class="my-2 border-[color:var(--color-border)]" />
-            <p class="px-3 py-1.5 text-xs text-slate-500 break-all">{session.email}</p>
+            <p class="px-3 py-1.5 text-xs text-[color:var(--color-text-secondary)] break-all">
+              {session.email}
+            </p>
             <form method="POST" action="/api/auth/logout">
               <button
                 type="submit"
-                class="w-full text-left px-3 py-2.5 text-sm text-slate-700 rounded hover:bg-slate-100 active:bg-slate-100"
+                class="w-full text-left px-3 py-2.5 text-sm text-[color:var(--color-text-primary)] rounded hover:bg-[color:var(--color-border-subtle)] active:bg-[color:var(--color-border-subtle)]"
               >
                 Sign out
               </button>
@@ -163,12 +172,12 @@ const navItems = [
       {
         breadcrumbs.length > 0 && (
           <nav aria-label="Breadcrumb" class="mb-4">
-            <ol class="flex flex-wrap items-center gap-1 text-sm text-slate-500">
+            <ol class="flex flex-wrap items-center gap-1 text-sm text-[color:var(--color-text-secondary)]">
               {breadcrumbs.map((crumb, i) => (
                 <>
                   {i > 0 && (
                     <li aria-hidden="true" class="flex items-center">
-                      <span class="material-symbols-outlined text-base text-slate-300">
+                      <span class="material-symbols-outlined text-base text-[color:var(--color-text-muted)]">
                         chevron_right
                       </span>
                     </li>
@@ -182,7 +191,10 @@ const navItems = [
                         {crumb.label}
                       </a>
                     ) : (
-                      <span aria-current="page" class="text-slate-900 font-medium">
+                      <span
+                        aria-current="page"
+                        class="text-[color:var(--color-text-primary)] font-medium"
+                      >
                         {crumb.label}
                       </span>
                     )}

--- a/src/lib/ui/status-badge.ts
+++ b/src/lib/ui/status-badge.ts
@@ -1,26 +1,50 @@
 /**
- * Returns Tailwind badge classes for a given status string.
- * Canonical source of truth for all status badge colors across admin UI.
+ * Returns the full Tailwind class list for an admin status tag.
+ *
+ * Architect's Studio identity: rectangular filled tag with white text,
+ * mono caps, tracked letter-spacing, 2px radius. Matches the portal
+ * StatusPill shape (src/components/portal/StatusPill.astro + TONE_CLASS
+ * in src/lib/portal/status.ts) so admin and portal read as one product.
+ *
+ * Callers use the output directly — do not add padding, radius, or font
+ * classes on top:
+ *
+ *   <span class={statusBadgeClass(status)}>{label}</span>
  */
+
+const STRUCTURE =
+  'inline-flex items-center px-2 py-1 rounded-[var(--radius-badge)] ' +
+  'font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold whitespace-nowrap'
+
+const TONE: Record<string, string> = {
+  // Engagement lifecycle
+  scheduled: 'bg-[color:var(--color-primary)] text-white',
+  active: 'bg-[color:var(--color-complete)] text-white',
+  completed: 'bg-[color:var(--color-complete)] text-white',
+  handoff: 'bg-[color:var(--color-primary)] text-white',
+  safety_net: 'bg-[color:var(--color-attention)] text-white',
+  cancelled: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+
+  // Lead lifecycle
+  disqualified: 'bg-[color:var(--color-error)] text-white',
+  converted: 'bg-[color:var(--color-complete)] text-white',
+
+  // Quote lifecycle
+  draft: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+  sent: 'bg-[color:var(--color-primary)] text-white',
+  accepted: 'bg-[color:var(--color-complete)] text-white',
+  declined: 'bg-[color:var(--color-error)] text-white',
+  expired: 'bg-[color:var(--color-attention)] text-white',
+  superseded: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+
+  // Invoice lifecycle
+  paid: 'bg-[color:var(--color-complete)] text-white',
+  overdue: 'bg-[color:var(--color-error)] text-white',
+  void: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+}
+
+const FALLBACK = 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
+
 export function statusBadgeClass(status: string): string {
-  const map: Record<string, string> = {
-    scheduled: 'bg-blue-100 text-blue-700',
-    active: 'bg-green-100 text-green-700',
-    completed: 'bg-emerald-100 text-emerald-700',
-    handoff: 'bg-teal-100 text-teal-700',
-    safety_net: 'bg-amber-100 text-amber-700',
-    cancelled: 'bg-slate-100 text-slate-500',
-    disqualified: 'bg-red-100 text-red-600',
-    converted: 'bg-green-100 text-green-700',
-    draft: 'bg-slate-100 text-slate-600',
-    sent: 'bg-blue-100 text-blue-700',
-    accepted: 'bg-green-100 text-green-700',
-    declined: 'bg-red-100 text-red-700',
-    expired: 'bg-slate-100 text-slate-500',
-    paid: 'bg-green-100 text-green-700',
-    overdue: 'bg-red-100 text-red-700',
-    void: 'bg-slate-100 text-slate-400',
-    superseded: 'bg-slate-100 text-slate-400',
-  }
-  return map[status] ?? 'bg-slate-100 text-slate-600'
+  return `${STRUCTURE} ${TONE[status] ?? FALLBACK}`
 }

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -101,21 +101,27 @@ function complianceBarWidth(pct: number): string {
   title="Analytics — SMD Services"
   breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Analytics' }]}
 >
-  <h2 class="text-xl font-semibold text-slate-900 mb-6">Analytics</h2>
+  <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)] mb-6">Analytics</h2>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-card">
     {/* ── Pipeline Funnel ──────────────────────────────── */}
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
-      <h3 class="text-base font-semibold text-slate-900 mb-4">Pipeline Funnel</h3>
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Pipeline Funnel
+      </h3>
       {
         totalClients === 0 ? (
-          <p class="text-sm text-slate-500">No clients yet.</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No clients yet.</p>
         ) : (
           <div class="space-y-row">
             {pipelineStages.map((stage) => (
               <div class="flex items-center gap-row">
-                <span class="text-sm text-slate-600 w-24 shrink-0">{stage.label}</span>
-                <div class="flex-1 bg-slate-100 rounded-full h-6 overflow-hidden">
+                <span class="text-sm text-[color:var(--color-text-secondary)] w-24 shrink-0">
+                  {stage.label}
+                </span>
+                <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-6 overflow-hidden">
                   <div
                     class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
                     style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
@@ -128,11 +134,11 @@ function complianceBarWidth(pct: number): string {
                   </div>
                 </div>
                 {pipeline[stage.key] === 0 && (
-                  <span class="text-xs text-slate-400 w-6 text-right">0</span>
+                  <span class="text-xs text-[color:var(--color-text-muted)] w-6 text-right">0</span>
                 )}
               </div>
             ))}
-            <p class="text-xs text-slate-400 mt-2 pt-2 border-t border-slate-100">
+            <p class="text-xs text-[color:var(--color-text-muted)] mt-2 pt-2 border-t border-[color:var(--color-border-subtle)]">
               Total clients: {totalClients.toLocaleString()}
             </p>
           </div>
@@ -141,43 +147,57 @@ function complianceBarWidth(pct: number): string {
     </div>
 
     {/* ── Engagement Health ────────────────────────────── */}
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
-      <h3 class="text-base font-semibold text-slate-900 mb-4">Engagement Health</h3>
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Engagement Health
+      </h3>
       {
         health.total_engagements === 0 ? (
-          <p class="text-sm text-slate-500">No completed engagements yet.</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">
+            No completed engagements yet.
+          </p>
         ) : (
           <div class="space-y-stack">
             <div class="grid grid-cols-2 gap-stack">
               <div>
-                <p class="text-2xl font-bold text-slate-900">
+                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
                   {health.avg_days_to_completion.toLocaleString()}
                 </p>
-                <p class="text-xs text-slate-500">Avg days to completion</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">
+                  Avg days to completion
+                </p>
               </div>
               <div>
-                <p class="text-2xl font-bold text-slate-900">
+                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
                   {health.total_engagements.toLocaleString()}
                 </p>
-                <p class="text-xs text-slate-500">Completed engagements</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">
+                  Completed engagements
+                </p>
               </div>
               <div>
-                <p class="text-2xl font-bold text-slate-900">
+                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
                   {health.avg_parking_lot_items.toLocaleString()}
                 </p>
-                <p class="text-xs text-slate-500">Avg parking lot items</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">
+                  Avg parking lot items
+                </p>
               </div>
               <div>
-                <p class="text-2xl font-bold text-slate-900">{health.on_time_pct}%</p>
-                <p class="text-xs text-slate-500">On-time completion</p>
+                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+                  {health.on_time_pct}%
+                </p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">On-time completion</p>
               </div>
             </div>
             <div>
-              <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+              <div class="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)] mb-1">
                 <span>On-time rate</span>
                 <span>{health.on_time_pct}%</span>
               </div>
-              <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
+              <div class="bg-[color:var(--color-border-subtle)] rounded-full h-3 overflow-hidden">
                 <div
                   class="h-full rounded-full bg-emerald-500"
                   style={`width: ${complianceBarWidth(health.on_time_pct)}`}
@@ -190,40 +210,46 @@ function complianceBarWidth(pct: number): string {
     </div>
 
     {/* ── Revenue Summary ─────────────────────────────── */}
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
-      <h3 class="text-base font-semibold text-slate-900 mb-4">Revenue Summary</h3>
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Revenue Summary
+      </h3>
       {
         revenue.total_revenue === 0 ? (
-          <p class="text-sm text-slate-500">No invoices yet.</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No invoices yet.</p>
         ) : (
           <div class="space-y-stack">
             <div class="grid grid-cols-3 gap-stack">
               <div>
-                <p class="text-lg font-bold text-slate-900">
+                <p class="text-lg font-bold text-[color:var(--color-text-primary)]">
                   {formatCurrency(revenue.total_invoiced)}
                 </p>
-                <p class="text-xs text-slate-500">Total invoiced</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">Total invoiced</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-green-700">{formatCurrency(revenue.total_paid)}</p>
-                <p class="text-xs text-slate-500">Total paid</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">Total paid</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-amber-700">{formatCurrency(outstanding)}</p>
-                <p class="text-xs text-slate-500">Outstanding</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">Outstanding</p>
               </div>
             </div>
 
             {revenue.by_month.length > 0 && (
               <div>
-                <h4 class="text-sm font-medium text-slate-700 mb-2">Monthly Revenue</h4>
+                <h4 class="text-sm font-medium text-[color:var(--color-text-primary)] mb-2">
+                  Monthly Revenue
+                </h4>
                 <div class="space-y-2">
                   {revenue.by_month.map((m) => (
                     <div class="flex items-center gap-row">
-                      <span class="text-xs text-slate-600 w-20 shrink-0">
+                      <span class="text-xs text-[color:var(--color-text-secondary)] w-20 shrink-0">
                         {formatMonthLabel(m.month)}
                       </span>
-                      <div class="flex-1 bg-slate-100 rounded-full h-5 overflow-hidden">
+                      <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-5 overflow-hidden">
                         <div
                           class="h-full rounded-full bg-green-500 flex items-center justify-end pr-2"
                           style={`width: ${revenueBarWidth(m.amount)}`}
@@ -243,12 +269,18 @@ function complianceBarWidth(pct: number): string {
 
             {revenue.by_vertical.length > 0 && (
               <div>
-                <h4 class="text-sm font-medium text-slate-700 mb-2">Revenue by Vertical</h4>
+                <h4 class="text-sm font-medium text-[color:var(--color-text-primary)] mb-2">
+                  Revenue by Vertical
+                </h4>
                 <div class="space-y-1">
                   {revenue.by_vertical.map((v) => (
                     <div class="flex items-center justify-between text-sm">
-                      <span class="text-slate-600">{getVerticalLabel(v.vertical)}</span>
-                      <span class="font-medium text-slate-900">{formatCurrency(v.amount)}</span>
+                      <span class="text-[color:var(--color-text-secondary)]">
+                        {getVerticalLabel(v.vertical)}
+                      </span>
+                      <span class="font-medium text-[color:var(--color-text-primary)]">
+                        {formatCurrency(v.amount)}
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -260,48 +292,54 @@ function complianceBarWidth(pct: number): string {
     </div>
 
     {/* ── Follow-up Compliance ────────────────────────── */}
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
-      <h3 class="text-base font-semibold text-slate-900 mb-4">Follow-up Compliance</h3>
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Follow-up Compliance
+      </h3>
       {
         compliance.total === 0 ? (
-          <p class="text-sm text-slate-500">No follow-ups yet.</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No follow-ups yet.</p>
         ) : (
           <div class="space-y-stack">
             <div class="text-center">
-              <p class="text-4xl font-bold text-slate-900">{compliance.compliance_pct}%</p>
-              <p class="text-sm text-slate-500">Compliance rate</p>
+              <p class="text-4xl font-bold text-[color:var(--color-text-primary)]">
+                {compliance.compliance_pct}%
+              </p>
+              <p class="text-sm text-[color:var(--color-text-secondary)]">Compliance rate</p>
             </div>
             <div class="grid grid-cols-3 gap-stack text-center">
               <div>
                 <p class="text-lg font-bold text-green-700">
                   {compliance.completed_on_time.toLocaleString()}
                 </p>
-                <p class="text-xs text-slate-500">On time</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">On time</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-amber-700">
                   {compliance.completed_late.toLocaleString()}
                 </p>
-                <p class="text-xs text-slate-500">Late</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">Late</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-red-700">{compliance.missed.toLocaleString()}</p>
-                <p class="text-xs text-slate-500">Missed</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)]">Missed</p>
               </div>
             </div>
             <div>
-              <div class="flex items-center justify-between text-xs text-slate-500 mb-1">
+              <div class="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)] mb-1">
                 <span>Compliance</span>
                 <span>{compliance.compliance_pct}%</span>
               </div>
-              <div class="bg-slate-100 rounded-full h-3 overflow-hidden">
+              <div class="bg-[color:var(--color-border-subtle)] rounded-full h-3 overflow-hidden">
                 <div
                   class="h-full rounded-full bg-green-500"
                   style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
                 />
               </div>
             </div>
-            <p class="text-xs text-slate-400 pt-2 border-t border-slate-100">
+            <p class="text-xs text-[color:var(--color-text-muted)] pt-2 border-t border-[color:var(--color-border-subtle)]">
               Total follow-ups: {compliance.total.toLocaleString()}
             </p>
           </div>
@@ -310,16 +348,22 @@ function complianceBarWidth(pct: number): string {
     </div>
 
     {/* ── Quote Accuracy ──────────────────────────────── */}
-    <div class="bg-white rounded-lg border border-slate-200 p-card md:col-span-2">
-      <h3 class="text-base font-semibold text-slate-900 mb-4">Quote Accuracy</h3>
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card md:col-span-2"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Quote Accuracy
+      </h3>
       {
         quoteAccuracy.length === 0 ? (
-          <p class="text-sm text-slate-500">No completed engagements yet.</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">
+            No completed engagements yet.
+          </p>
         ) : (
           <div class="overflow-x-auto">
             <table class="w-full text-sm">
               <thead>
-                <tr class="text-left text-xs text-slate-500 border-b border-slate-200">
+                <tr class="text-left text-xs text-[color:var(--color-text-secondary)] border-b border-[color:var(--color-border)]">
                   <th class="pb-2 font-medium">Client</th>
                   <th class="pb-2 font-medium text-right">Estimated</th>
                   <th class="pb-2 font-medium text-right">Actual</th>
@@ -327,7 +371,7 @@ function complianceBarWidth(pct: number): string {
                   <th class="pb-2 font-medium text-right">Accuracy</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-slate-100">
+              <tbody class="divide-y divide-[color:var(--color-border-subtle)]">
                 {quoteAccuracy.map((row) => {
                   const variance = row.actual_hours - row.estimated_hours
                   const varianceStr =
@@ -336,14 +380,16 @@ function complianceBarWidth(pct: number): string {
                       : `${variance.toLocaleString()}h`
                   return (
                     <tr>
-                      <td class="py-2 text-slate-900">{row.client_name}</td>
-                      <td class="py-2 text-right text-slate-600">
+                      <td class="py-2 text-[color:var(--color-text-primary)]">{row.client_name}</td>
+                      <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
                         {row.estimated_hours.toLocaleString()}h
                       </td>
-                      <td class="py-2 text-right text-slate-600">
+                      <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
                         {row.actual_hours.toLocaleString()}h
                       </td>
-                      <td class="py-2 text-right text-slate-600">{varianceStr}</td>
+                      <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
+                        {varianceStr}
+                      </td>
                       <td class="py-2 text-right">
                         <span
                           class={`inline-block px-2 py-0.5 rounded text-xs font-medium ${accuracyColor(row.accuracy_pct)}`}
@@ -356,16 +402,16 @@ function complianceBarWidth(pct: number): string {
                 })}
               </tbody>
               <tfoot>
-                <tr class="border-t border-slate-200 font-medium">
-                  <td class="py-2 text-slate-900">Average</td>
-                  <td class="py-2 text-right text-slate-600">
+                <tr class="border-t border-[color:var(--color-border)] font-medium">
+                  <td class="py-2 text-[color:var(--color-text-primary)]">Average</td>
+                  <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
                     {Math.round(
                       quoteAccuracy.reduce((s, r) => s + r.estimated_hours, 0) /
                         quoteAccuracy.length
                     ).toLocaleString()}
                     h
                   </td>
-                  <td class="py-2 text-right text-slate-600">
+                  <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
                     {Math.round(
                       quoteAccuracy.reduce((s, r) => s + r.actual_hours, 0) / quoteAccuracy.length
                     ).toLocaleString()}

--- a/src/pages/admin/assessments/[id].astro
+++ b/src/pages/admin/assessments/[id].astro
@@ -84,9 +84,11 @@ function stageBadgeClass(stage: string): string {
     engaged: 'bg-green-100 text-green-700',
     delivered: 'bg-emerald-100 text-emerald-700',
     ongoing: 'bg-teal-100 text-teal-700',
-    lost: 'bg-slate-100 text-slate-500',
+    lost: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
   }
-  return map[stage] ?? 'bg-slate-100 text-slate-500'
+  return (
+    map[stage] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  )
 }
 
 function tierBadgeClass(tier: string): string {
@@ -94,16 +96,18 @@ function tierBadgeClass(tier: string): string {
     hot: 'bg-red-100 text-red-700',
     warm: 'bg-amber-100 text-amber-700',
     cool: 'bg-blue-100 text-blue-700',
-    cold: 'bg-slate-100 text-slate-500',
+    cold: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
   }
-  return map[tier] ?? 'bg-slate-100 text-slate-500'
+  return (
+    map[tier] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  )
 }
 
 function contextTypeBadge(type: string): string {
   const map: Record<string, string> = {
     signal: 'bg-amber-100 text-amber-700',
     enrichment: 'bg-cyan-100 text-cyan-700',
-    note: 'bg-slate-100 text-slate-600',
+    note: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
     transcript: 'bg-purple-100 text-purple-700',
     extraction: 'bg-indigo-100 text-indigo-700',
     outreach_draft: 'bg-blue-100 text-blue-700',
@@ -111,11 +115,13 @@ function contextTypeBadge(type: string): string {
     follow_up_result: 'bg-teal-100 text-teal-700',
     feedback: 'bg-emerald-100 text-emerald-700',
     parking_lot: 'bg-orange-100 text-orange-700',
-    stage_change: 'bg-slate-50 text-slate-500',
+    stage_change: 'bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)]',
     intake: 'bg-pink-100 text-pink-700',
     scorecard: 'bg-violet-100 text-violet-700',
   }
-  return map[type] ?? 'bg-slate-100 text-slate-600'
+  return (
+    map[type] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  )
 }
 ---
 
@@ -129,25 +135,29 @@ function contextTypeBadge(type: string): string {
 >
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         {decodeURIComponent(error)}
       </div>
     )
   }
   {
     saved && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Changes saved.
       </div>
     )
   }
 
   {/* Entity + Assessment Info */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
     <div class="flex items-start justify-between gap-stack mb-4">
       <div>
         <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+          <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+            {entity.name}
+          </h2>
           <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
             {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
           </span>
@@ -160,11 +170,16 @@ function contextTypeBadge(type: string): string {
           }
         </div>
 
-        <div class="flex items-center gap-stack text-sm text-slate-500 flex-wrap">
+        <div
+          class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)] flex-wrap"
+        >
           {
             entity.pain_score != null && (
               <span>
-                Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
+                Pain:{' '}
+                <strong class="text-[color:var(--color-text-primary)]">
+                  {entity.pain_score}/10
+                </strong>
               </span>
             )
           }
@@ -172,7 +187,7 @@ function contextTypeBadge(type: string): string {
           {entity.area && <span>{entity.area}</span>}
         </div>
       </div>
-      <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(assessment.status)}`}>
+      <span class={statusBadgeClass(assessment.status)}>
         {assessment.status}
       </span>
     </div>
@@ -182,15 +197,15 @@ function contextTypeBadge(type: string): string {
       schedule && (
         <div class="grid grid-cols-1 md:grid-cols-2 gap-stack text-sm">
           <div>
-            <span class="text-slate-500">Scheduled:</span>
-            <span class="ml-1 text-slate-900 font-medium">
+            <span class="text-[color:var(--color-text-secondary)]">Scheduled:</span>
+            <span class="ml-1 text-[color:var(--color-text-primary)] font-medium">
               {formatDateTime(schedule.slot_start_utc)}
             </span>
-            <span class="text-slate-400 ml-1">({schedule.timezone})</span>
+            <span class="text-[color:var(--color-text-muted)] ml-1">({schedule.timezone})</span>
           </div>
           <div>
-            <span class="text-slate-500">Contact:</span>
-            <span class="ml-1 text-slate-900">{schedule.guest_name}</span>
+            <span class="text-[color:var(--color-text-secondary)]">Contact:</span>
+            <span class="ml-1 text-[color:var(--color-text-primary)]">{schedule.guest_name}</span>
             <a href={`mailto:${schedule.guest_email}`} class="ml-1 text-blue-600 hover:underline">
               {schedule.guest_email}
             </a>
@@ -201,7 +216,7 @@ function contextTypeBadge(type: string): string {
                 href={schedule.google_meet_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-md hover:bg-blue-700 transition-colors"
+                class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-blue-700 transition-colors"
               >
                 Join Video Call
               </a>
@@ -224,7 +239,7 @@ function contextTypeBadge(type: string): string {
     }
     {
       !schedule && assessment.scheduled_at && (
-        <div class="text-sm text-slate-500">
+        <div class="text-sm text-[color:var(--color-text-secondary)]">
           Scheduled: {formatDateTime(assessment.scheduled_at)}
         </div>
       )
@@ -232,30 +247,34 @@ function contextTypeBadge(type: string): string {
   </div>
 
   {/* Live Notes */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
     <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold text-slate-900">Live Notes</h3>
-      <span id="save-status" class="text-xs text-slate-400">Saved</span>
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">Live Notes</h3>
+      <span id="save-status" class="text-xs text-[color:var(--color-text-muted)]">Saved</span>
     </div>
     <textarea
       id="live-notes"
       rows="10"
-      class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
+      class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
       placeholder="Take notes during the call...">{liveNotesValue}</textarea
     >
   </div>
 
   {/* Complete Assessment Form (collapsible) */}
-  <div class="bg-white rounded-lg border border-slate-200 mb-6">
+  <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-6">
     <button
       type="button"
       id="toggle-complete"
-      class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-slate-50 transition-colors"
+      class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-[color:var(--color-background)] transition-colors"
     >
-      <h3 class="text-base font-semibold text-slate-900">Complete Assessment</h3>
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+        Complete Assessment
+      </h3>
       <svg
         id="toggle-icon"
-        class="w-5 h-5 text-slate-400 transition-transform"
+        class="w-5 h-5 text-[color:var(--color-text-muted)] transition-transform"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -265,7 +284,10 @@ function contextTypeBadge(type: string): string {
       </svg>
     </button>
 
-    <div id="complete-form" class="hidden px-6 pb-6 border-t border-slate-100">
+    <div
+      id="complete-form"
+      class="hidden px-6 pb-6 border-t border-[color:var(--color-border-subtle)]"
+    >
       <form
         method="POST"
         action={`/api/admin/assessments/${assessmentId}/complete`}
@@ -274,26 +296,48 @@ function contextTypeBadge(type: string): string {
       >
         {/* Problems identified */}
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-2">Problems Identified</label>
+          <label class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-2"
+            >Problems Identified</label
+          >
           <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
-            <label class="flex items-center gap-2 text-sm text-slate-700">
-              <input type="checkbox" name="process_design" class="rounded border-slate-300" />
+            <label class="flex items-center gap-2 text-sm text-[color:var(--color-text-primary)]">
+              <input
+                type="checkbox"
+                name="process_design"
+                class="rounded border-[color:var(--color-border)]"
+              />
               Process design
             </label>
-            <label class="flex items-center gap-2 text-sm text-slate-700">
-              <input type="checkbox" name="tool_systems" class="rounded border-slate-300" />
+            <label class="flex items-center gap-2 text-sm text-[color:var(--color-text-primary)]">
+              <input
+                type="checkbox"
+                name="tool_systems"
+                class="rounded border-[color:var(--color-border)]"
+              />
               Tools & systems
             </label>
-            <label class="flex items-center gap-2 text-sm text-slate-700">
-              <input type="checkbox" name="data_visibility" class="rounded border-slate-300" />
+            <label class="flex items-center gap-2 text-sm text-[color:var(--color-text-primary)]">
+              <input
+                type="checkbox"
+                name="data_visibility"
+                class="rounded border-[color:var(--color-border)]"
+              />
               Data & visibility
             </label>
-            <label class="flex items-center gap-2 text-sm text-slate-700">
-              <input type="checkbox" name="customer_pipeline" class="rounded border-slate-300" />
+            <label class="flex items-center gap-2 text-sm text-[color:var(--color-text-primary)]">
+              <input
+                type="checkbox"
+                name="customer_pipeline"
+                class="rounded border-[color:var(--color-border)]"
+              />
               Customer pipeline
             </label>
-            <label class="flex items-center gap-2 text-sm text-slate-700">
-              <input type="checkbox" name="team_operations" class="rounded border-slate-300" />
+            <label class="flex items-center gap-2 text-sm text-[color:var(--color-text-primary)]">
+              <input
+                type="checkbox"
+                name="team_operations"
+                class="rounded border-[color:var(--color-border)]"
+              />
               Team operations
             </label>
           </div>
@@ -302,19 +346,21 @@ function contextTypeBadge(type: string): string {
               type="text"
               name="other_problem"
               placeholder="Other (describe)"
-              class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
             />
           </div>
         </div>
 
         {/* Disqualifiers */}
-        <div class="border border-slate-200 rounded-lg p-stack">
-          <label class="flex items-center gap-2 text-sm text-slate-700 mb-2">
+        <div class="border border-[color:var(--color-border)] rounded-[var(--radius-card)] p-stack">
+          <label
+            class="flex items-center gap-2 text-sm text-[color:var(--color-text-primary)] mb-2"
+          >
             <input
               type="checkbox"
               name="disqualified"
               id="disqualified-check"
-              class="rounded border-slate-300"
+              class="rounded border-[color:var(--color-border)]"
             />
             <span class="font-medium">Disqualified</span>
           </label>
@@ -323,14 +369,16 @@ function contextTypeBadge(type: string): string {
             name="disqualify_reason"
             id="disqualify-reason"
             placeholder="Reason for disqualification"
-            class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:opacity-50 disabled:bg-slate-50"
+            class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:opacity-50 disabled:bg-[color:var(--color-background)]"
             disabled
           />
         </div>
 
         {/* Duration */}
         <div>
-          <label for="duration_minutes" class="block text-sm font-medium text-slate-700 mb-1"
+          <label
+            for="duration_minutes"
+            class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
             >Duration (minutes)</label
           >
           <input
@@ -340,26 +388,30 @@ function contextTypeBadge(type: string): string {
             min="1"
             max="300"
             placeholder="30"
-            class="w-32 text-sm border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            class="w-32 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
           />
         </div>
 
         {/* Notes */}
         <div>
-          <label for="complete-notes" class="block text-sm font-medium text-slate-700 mb-1"
+          <label
+            for="complete-notes"
+            class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
             >Notes</label
           >
           <textarea
             name="notes"
             id="complete-notes"
             rows="4"
-            class="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
             placeholder="Assessment notes..."></textarea>
         </div>
 
         {/* Transcript upload */}
         <div>
-          <label for="transcript" class="block text-sm font-medium text-slate-700 mb-1"
+          <label
+            for="transcript"
+            class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
             >Transcript (optional)</label
           >
           <input
@@ -367,7 +419,7 @@ function contextTypeBadge(type: string): string {
             name="transcript"
             id="transcript"
             accept=".txt,.md,.pdf,.doc,.docx"
-            class="text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200"
+            class="text-sm text-[color:var(--color-text-secondary)] file:mr-4 file:py-2 file:px-4 file:rounded-[var(--radius-card)] file:border-0 file:text-sm file:font-medium file:bg-[color:var(--color-border-subtle)] file:text-[color:var(--color-text-primary)] hover:file:bg-[color:var(--color-border)]"
           />
         </div>
 
@@ -375,11 +427,11 @@ function contextTypeBadge(type: string): string {
         <div class="flex items-center gap-row pt-2">
           <button
             type="submit"
-            class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-lg hover:bg-green-700 transition-colors font-medium"
+            class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-[var(--radius-card)] hover:bg-green-700 transition-colors font-medium"
           >
             Complete & Draft Proposal
           </button>
-          <span class="text-xs text-slate-400"
+          <span class="text-xs text-[color:var(--color-text-muted)]"
             >Creates a draft quote and transitions to proposing stage</span
           >
         </div>
@@ -388,26 +440,36 @@ function contextTypeBadge(type: string): string {
   </div>
 
   {/* Entity Context Timeline */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card">
-    <h3 class="text-base font-semibold text-slate-900 mb-4">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+  >
+    <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
       Entity Context Timeline
-      <span class="text-sm font-normal text-slate-400 ml-1">({contextEntries.length} entries)</span>
+      <span class="text-sm font-normal text-[color:var(--color-text-muted)] ml-1"
+        >({contextEntries.length} entries)</span
+      >
     </h3>
 
-    {timelineEntries.length === 0 && <p class="text-sm text-slate-400">No context entries yet.</p>}
+    {
+      timelineEntries.length === 0 && (
+        <p class="text-sm text-[color:var(--color-text-muted)]">No context entries yet.</p>
+      )
+    }
 
     <div class="space-y-row">
       {
         timelineEntries.map((entry) => (
-          <div class="border border-slate-100 rounded-lg p-row">
+          <div class="border border-[color:var(--color-border-subtle)] rounded-[var(--radius-card)] p-row">
             <div class="flex items-center gap-2 mb-1">
               <span class={`text-xs px-1.5 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
                 {entry.type.replace(/_/g, ' ')}
               </span>
-              <span class="text-xs text-slate-400">{entry.source}</span>
-              <span class="text-xs text-slate-300 ml-auto">{formatDate(entry.created_at)}</span>
+              <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
+              <span class="text-xs text-[color:var(--color-text-muted)] ml-auto">
+                {formatDate(entry.created_at)}
+              </span>
             </div>
-            <div class="text-sm text-slate-700 whitespace-pre-wrap break-words">
+            <div class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap break-words">
               {entry.content.length > 500 ? entry.content.slice(0, 500) + '...' : entry.content}
             </div>
           </div>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -54,7 +54,7 @@ function formatDate(d: string | null): string {
 function msBadgeClass(s: string): string {
   switch (s) {
     case 'pending':
-      return 'bg-slate-100 text-slate-600'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
     case 'in_progress':
       return 'bg-blue-100 text-blue-700'
     case 'completed':
@@ -62,14 +62,14 @@ function msBadgeClass(s: string): string {
     case 'skipped':
       return 'bg-red-100 text-red-600'
     default:
-      return 'bg-slate-100 text-slate-600'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
   }
 }
 
 function invoiceBadgeClass(s: string): string {
   switch (s) {
     case 'draft':
-      return 'bg-slate-100 text-slate-600'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
     case 'sent':
       return 'bg-blue-100 text-blue-700'
     case 'paid':
@@ -77,9 +77,9 @@ function invoiceBadgeClass(s: string): string {
     case 'overdue':
       return 'bg-red-100 text-red-600'
     case 'void':
-      return 'bg-slate-200 text-slate-500'
+      return 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
     default:
-      return 'bg-slate-100 text-slate-600'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
   }
 }
 
@@ -94,7 +94,7 @@ function contextTypeBadgeClass(t: string): string {
     case 'feedback':
       return 'bg-purple-100 text-purple-700'
     default:
-      return 'bg-slate-100 text-slate-600'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
   }
 }
 
@@ -150,20 +150,22 @@ function fileSize(bytes: number): string {
     }
 
     <!-- Header -->
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
       <div class="flex items-start justify-between">
         <div>
           <div class="flex items-center gap-row mb-2">
-            <h1 class="text-2xl font-semibold text-slate-900">
+            <h1 class="text-2xl font-semibold text-[color:var(--color-text-primary)]">
               {entity?.name ?? 'Unknown Entity'}
             </h1>
-            <span
-              class={`text-xs px-2.5 py-1 rounded font-medium ${statusBadgeClass(engagement.status)}`}
-            >
+            <span class={statusBadgeClass(engagement.status)}>
               {engagement.status}
             </span>
           </div>
-          <div class="flex flex-wrap gap-x-card gap-y-1 text-sm text-slate-500">
+          <div
+            class="flex flex-wrap gap-x-card gap-y-1 text-sm text-[color:var(--color-text-secondary)]"
+          >
             <span>Start: {formatDate(engagement.start_date)}</span>
             <span>Est. End: {formatDate(engagement.estimated_end)}</span>
             {engagement.handoff_date && <span>Handoff: {formatDate(engagement.handoff_date)}</span>}
@@ -182,7 +184,7 @@ function fileSize(bytes: number): string {
                     class={`text-xs px-3 py-1.5 rounded font-medium border transition-colors ${
                       ns === 'cancelled'
                         ? 'border-red-300 text-red-700 hover:bg-red-50'
-                        : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                        : 'border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]'
                     }`}
                   >
                     {ns === 'active'
@@ -207,24 +209,27 @@ function fileSize(bytes: number): string {
       {/* Quote summary */}
       {
         quote && (
-          <div class="mt-4 pt-4 border-t border-slate-100">
+          <div class="mt-4 pt-4 border-t border-[color:var(--color-border-subtle)]">
             <div class="flex flex-wrap gap-x-card gap-y-1 text-sm">
-              <span class="text-slate-500">
+              <span class="text-[color:var(--color-text-secondary)]">
                 Quote:{' '}
-                <span class="font-medium text-slate-700">
+                <span class="font-medium text-[color:var(--color-text-primary)]">
                   ${quote.total_price.toLocaleString()}
                 </span>
               </span>
-              <span class="text-slate-500">
-                Hours: <span class="font-medium text-slate-700">{quote.total_hours}h est</span>
+              <span class="text-[color:var(--color-text-secondary)]">
+                Hours:{' '}
+                <span class="font-medium text-[color:var(--color-text-primary)]">
+                  {quote.total_hours}h est
+                </span>
                 {engagement.actual_hours > 0 && (
                   <span class="ml-1">/ {engagement.actual_hours}h actual</span>
                 )}
               </span>
               {quote.deposit_pct != null && (
-                <span class="text-slate-500">
+                <span class="text-[color:var(--color-text-secondary)]">
                   Deposit:{' '}
-                  <span class="font-medium text-slate-700">
+                  <span class="font-medium text-[color:var(--color-text-primary)]">
                     {(quote.deposit_pct * 100).toFixed(0)}%
                   </span>
                 </span>
@@ -232,13 +237,15 @@ function fileSize(bytes: number): string {
             </div>
             {depositInvoice && (
               <div class="mt-2 text-sm">
-                <span class="text-slate-500">Deposit Invoice:</span>{' '}
+                <span class="text-[color:var(--color-text-secondary)]">Deposit Invoice:</span>{' '}
                 <span
                   class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(depositInvoice.status)}`}
                 >
                   {depositInvoice.status}
                 </span>
-                <span class="ml-2 text-slate-500">${depositInvoice.amount.toLocaleString()}</span>
+                <span class="ml-2 text-[color:var(--color-text-secondary)]">
+                  ${depositInvoice.amount.toLocaleString()}
+                </span>
               </div>
             )}
           </div>
@@ -247,33 +254,45 @@ function fileSize(bytes: number): string {
 
       {
         engagement.scope_summary && (
-          <div class="mt-4 pt-4 border-t border-slate-100">
-            <p class="text-sm text-slate-600 whitespace-pre-wrap">{engagement.scope_summary}</p>
+          <div class="mt-4 pt-4 border-t border-[color:var(--color-border-subtle)]">
+            <p class="text-sm text-[color:var(--color-text-secondary)] whitespace-pre-wrap">
+              {engagement.scope_summary}
+            </p>
           </div>
         )
       }
     </div>
 
     <!-- Edit Details -->
-    <details class="bg-white rounded-lg border border-slate-200">
-      <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900"> Edit Details </summary>
+    <details
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]"
+    >
+      <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+        Edit Details
+      </summary>
       <div class="px-6 pb-6">
         <form method="POST" action={`/api/admin/engagements/${engagementId}`} class="space-y-stack">
           <div>
-            <label for="scope_summary" class="block text-sm font-medium text-slate-700 mb-1">
+            <label
+              for="scope_summary"
+              class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+            >
               Scope Summary
             </label>
             <textarea
               id="scope_summary"
               name="scope_summary"
               rows="3"
-              class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
               >{engagement.scope_summary ?? ''}</textarea
             >
           </div>
           <div class="grid grid-cols-2 gap-stack">
             <div>
-              <label for="start_date" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="start_date"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Start Date
               </label>
               <input
@@ -281,11 +300,14 @@ function fileSize(bytes: number): string {
                 id="start_date"
                 name="start_date"
                 value={engagement.start_date?.split('T')[0] ?? ''}
-                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
             <div>
-              <label for="estimated_end" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="estimated_end"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Estimated End
               </label>
               <input
@@ -293,13 +315,16 @@ function fileSize(bytes: number): string {
                 id="estimated_end"
                 name="estimated_end"
                 value={engagement.estimated_end?.split('T')[0] ?? ''}
-                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
           </div>
           <div class="grid grid-cols-2 gap-stack">
             <div>
-              <label for="estimated_hours" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="estimated_hours"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Estimated Hours
               </label>
               <input
@@ -308,11 +333,14 @@ function fileSize(bytes: number): string {
                 name="estimated_hours"
                 step="0.5"
                 value={engagement.estimated_hours ?? ''}
-                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
             <div>
-              <label for="actual_hours" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="actual_hours"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Actual Hours
               </label>
               <input
@@ -321,7 +349,7 @@ function fileSize(bytes: number): string {
                 name="actual_hours"
                 step="0.5"
                 value={engagement.actual_hours ?? ''}
-                class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
           </div>
@@ -338,14 +366,16 @@ function fileSize(bytes: number): string {
     </details>
 
     <!-- Milestones -->
-    <div class="bg-white rounded-lg border border-slate-200">
-      <div class="px-6 py-4 border-b border-slate-100">
-        <h2 class="font-medium text-slate-900">Milestones</h2>
+    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
+      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--color-text-primary)]">Milestones</h2>
       </div>
-      <div class="divide-y divide-slate-100">
+      <div class="divide-y divide-[color:var(--color-border-subtle)]">
         {
           milestones.length === 0 && (
-            <div class="px-6 py-8 text-center text-sm text-slate-400">No milestones yet.</div>
+            <div class="px-6 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
+              No milestones yet.
+            </div>
           )
         }
         {
@@ -359,7 +389,9 @@ function fileSize(bytes: number): string {
                     <span class={`text-xs px-2 py-0.5 rounded ${msBadgeClass(ms.status)}`}>
                       {ms.status}
                     </span>
-                    <span class="text-sm font-medium text-slate-900 truncate">{ms.name}</span>
+                    <span class="text-sm font-medium text-[color:var(--color-text-primary)] truncate">
+                      {ms.name}
+                    </span>
                     {ms.payment_trigger ? (
                       <span class="text-xs px-1.5 py-0.5 rounded bg-amber-100 text-amber-700">
                         $
@@ -367,10 +399,12 @@ function fileSize(bytes: number): string {
                     ) : null}
                   </div>
                   {ms.description && (
-                    <p class="text-xs text-slate-500 mt-1 truncate">{ms.description}</p>
+                    <p class="text-xs text-[color:var(--color-text-secondary)] mt-1 truncate">
+                      {ms.description}
+                    </p>
                   )}
                   {ms.due_date && (
-                    <span class="text-xs text-slate-400 mt-1 block">
+                    <span class="text-xs text-[color:var(--color-text-muted)] mt-1 block">
                       Due: {formatDate(ms.due_date)}
                     </span>
                   )}
@@ -388,7 +422,7 @@ function fileSize(bytes: number): string {
                       class={`text-xs px-2 py-1 rounded border transition-colors ${
                         ms.payment_trigger
                           ? 'border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100'
-                          : 'border-slate-200 text-slate-400 hover:text-slate-600 hover:border-slate-300'
+                          : 'border-[color:var(--color-border)] text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border)]'
                       }`}
                     >
                       $
@@ -410,7 +444,7 @@ function fileSize(bytes: number): string {
                             ? 'border-green-300 text-green-700 hover:bg-green-50'
                             : ns === 'in_progress'
                               ? 'border-blue-300 text-blue-700 hover:bg-blue-50'
-                              : 'border-slate-300 text-slate-600 hover:bg-slate-50'
+                              : 'border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)]'
                         }`}
                       >
                         {ns === 'in_progress'
@@ -448,8 +482,10 @@ function fileSize(bytes: number): string {
       </div>
 
       {/* Add milestone form */}
-      <details class="border-t border-slate-100">
-        <summary class="px-6 py-3 cursor-pointer text-sm text-slate-500 hover:text-slate-700">
+      <details class="border-t border-[color:var(--color-border-subtle)]">
+        <summary
+          class="px-6 py-3 cursor-pointer text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+        >
           + Add Milestone
         </summary>
         <div class="px-6 pb-4">
@@ -460,7 +496,10 @@ function fileSize(bytes: number): string {
           >
             <div class="grid grid-cols-2 gap-row">
               <div>
-                <label for="ms_name" class="block text-xs font-medium text-slate-600 mb-1">
+                <label
+                  for="ms_name"
+                  class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+                >
                   Name *
                 </label>
                 <input
@@ -468,34 +507,42 @@ function fileSize(bytes: number): string {
                   id="ms_name"
                   name="name"
                   required
-                  class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
+                  class="w-full border border-[color:var(--color-border)] rounded px-3 py-1.5 text-sm"
                 />
               </div>
               <div>
-                <label for="ms_due" class="block text-xs font-medium text-slate-600 mb-1">
+                <label
+                  for="ms_due"
+                  class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+                >
                   Due Date
                 </label>
                 <input
                   type="date"
                   id="ms_due"
                   name="due_date"
-                  class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
+                  class="w-full border border-[color:var(--color-border)] rounded px-3 py-1.5 text-sm"
                 />
               </div>
             </div>
             <div>
-              <label for="ms_desc" class="block text-xs font-medium text-slate-600 mb-1">
+              <label
+                for="ms_desc"
+                class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+              >
                 Description
               </label>
               <input
                 type="text"
                 id="ms_desc"
                 name="description"
-                class="w-full border border-slate-300 rounded px-3 py-1.5 text-sm"
+                class="w-full border border-[color:var(--color-border)] rounded px-3 py-1.5 text-sm"
               />
             </div>
             <div class="flex items-center gap-stack">
-              <label class="flex items-center gap-2 text-sm text-slate-600">
+              <label
+                class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]"
+              >
                 <input type="checkbox" name="payment_trigger" value="1" />
                 Payment trigger
               </label>
@@ -513,10 +560,10 @@ function fileSize(bytes: number): string {
     </div>
 
     <!-- Consultant photo -->
-    <div class="bg-white rounded-lg border border-slate-200">
-      <div class="px-6 py-4 border-b border-slate-100">
-        <h2 class="font-medium text-slate-900">Consultant Photo</h2>
-        <p class="text-xs text-slate-500 mt-1">
+    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
+      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--color-text-primary)]">Consultant Photo</h2>
+        <p class="text-xs text-[color:var(--color-text-secondary)] mt-1">
           Shown on every portal surface for this engagement. Square, 400×400 recommended. We'll crop
           to a circle and encode as WebP in your browser before upload. JPEG/PNG/WebP up to 5 MB.
         </p>
@@ -524,7 +571,7 @@ function fileSize(bytes: number): string {
       <div class="px-6 py-5">
         <div class="flex items-start gap-5">
           <div
-            class="w-20 h-20 shrink-0 rounded-full bg-slate-50 border border-slate-200 overflow-hidden"
+            class="w-20 h-20 shrink-0 rounded-full bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden"
           >
             {
               engagement.consultant_photo_url ? (
@@ -538,7 +585,7 @@ function fileSize(bytes: number): string {
                 <svg
                   id="consultant-photo-placeholder"
                   viewBox="0 0 80 80"
-                  class="w-full h-full text-slate-400"
+                  class="w-full h-full text-[color:var(--color-text-muted)]"
                   aria-hidden="true"
                 >
                   <rect width="80" height="80" fill="currentColor" fill-opacity="0.12" />
@@ -557,7 +604,7 @@ function fileSize(bytes: number): string {
               id="photo-preview"
               width="160"
               height="160"
-              class="hidden rounded-full border border-slate-200 mb-3"></canvas>
+              class="hidden rounded-full border border-[color:var(--color-border)] mb-3"></canvas>
             <div id="photo-controls" class="flex flex-wrap items-center gap-2">
               <input
                 type="file"
@@ -568,7 +615,7 @@ function fileSize(bytes: number): string {
               <button
                 type="button"
                 id="photo-choose"
-                class="text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-700 hover:bg-slate-50 transition-colors"
+                class="text-xs px-3 py-1.5 rounded border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)] transition-colors"
               >
                 Choose Photo
               </button>
@@ -582,7 +629,7 @@ function fileSize(bytes: number): string {
               <button
                 type="button"
                 id="photo-cancel"
-                class="hidden text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-600 hover:bg-slate-50 transition-colors"
+                class="hidden text-xs px-3 py-1.5 rounded border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)] transition-colors"
               >
                 Cancel
               </button>
@@ -598,21 +645,21 @@ function fileSize(bytes: number): string {
                 )
               }
             </div>
-            <p id="photo-status" class="mt-2 text-xs text-slate-500"></p>
+            <p id="photo-status" class="mt-2 text-xs text-[color:var(--color-text-secondary)]"></p>
           </div>
         </div>
       </div>
     </div>
 
     <!-- Deliverables -->
-    <div class="bg-white rounded-lg border border-slate-200">
-      <div class="px-6 py-4 border-b border-slate-100">
-        <h2 class="font-medium text-slate-900">Deliverables</h2>
+    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
+      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--color-text-primary)]">Deliverables</h2>
       </div>
       <div class="px-6 py-4">
         {
           documents.length === 0 && (
-            <p class="text-sm text-slate-400 mb-4">No files uploaded yet.</p>
+            <p class="text-sm text-[color:var(--color-text-muted)] mb-4">No files uploaded yet.</p>
           )
         }
         {
@@ -628,7 +675,7 @@ function fileSize(bytes: number): string {
                     >
                       {name}
                     </a>
-                    <span class="text-xs text-slate-400 flex-shrink-0 ml-4">
+                    <span class="text-xs text-[color:var(--color-text-muted)] flex-shrink-0 ml-4">
                       {fileSize(doc.size)} &middot; {formatDate(doc.uploaded.toISOString())}
                     </span>
                   </li>
@@ -639,18 +686,21 @@ function fileSize(bytes: number): string {
         }
         <div
           id="upload-area"
-          class="border-2 border-dashed border-slate-200 rounded-lg p-card text-center"
+          class="border-2 border-dashed border-[color:var(--color-border)] rounded-[var(--radius-card)] p-card text-center"
         >
-          <p class="text-sm text-slate-500 mb-2">Drag files here or click to upload</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)] mb-2">
+            Drag files here or click to upload
+          </p>
           <input type="file" id="file-input" class="hidden" multiple />
           <button
             type="button"
             id="upload-btn"
-            class="text-xs px-3 py-1.5 rounded border border-slate-300 text-slate-600 hover:bg-slate-50 transition-colors"
+            class="text-xs px-3 py-1.5 rounded border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)] transition-colors"
           >
             Choose Files
           </button>
-          <div id="upload-status" class="text-xs text-slate-400 mt-2 hidden"></div>
+          <div id="upload-status" class="text-xs text-[color:var(--color-text-muted)] mt-2 hidden">
+          </div>
         </div>
       </div>
     </div>
@@ -658,21 +708,23 @@ function fileSize(bytes: number): string {
     <!-- Invoices -->
     {
       invoices.length > 0 && (
-        <div class="bg-white rounded-lg border border-slate-200">
-          <div class="px-6 py-4 border-b border-slate-100">
-            <h2 class="font-medium text-slate-900">Invoices</h2>
+        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
+          <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
+            <h2 class="font-medium text-[color:var(--color-text-primary)]">Invoices</h2>
           </div>
-          <div class="divide-y divide-slate-100">
+          <div class="divide-y divide-[color:var(--color-border-subtle)]">
             {invoices.map((inv) => (
               <div class="px-6 py-3 flex items-center justify-between text-sm">
                 <div class="flex items-center gap-row">
                   <span class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(inv.status)}`}>
                     {inv.status}
                   </span>
-                  <span class="text-slate-700 capitalize">{inv.type}</span>
+                  <span class="text-[color:var(--color-text-primary)] capitalize">{inv.type}</span>
                 </div>
-                <div class="flex items-center gap-stack text-slate-500">
-                  <span class="font-medium text-slate-700">${inv.amount.toLocaleString()}</span>
+                <div class="flex items-center gap-stack text-[color:var(--color-text-secondary)]">
+                  <span class="font-medium text-[color:var(--color-text-primary)]">
+                    ${inv.amount.toLocaleString()}
+                  </span>
                   {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
                   {inv.paid_at && <span>Paid: {formatDate(inv.paid_at)}</span>}
                 </div>
@@ -684,30 +736,36 @@ function fileSize(bytes: number): string {
     }
 
     <!-- Context Timeline -->
-    <div class="bg-white rounded-lg border border-slate-200">
-      <div class="px-6 py-4 border-b border-slate-100">
-        <h2 class="font-medium text-slate-900">Timeline</h2>
+    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
+      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--color-text-primary)]">Timeline</h2>
       </div>
       {
         contextEntries.length === 0 && (
-          <div class="px-6 py-8 text-center text-sm text-slate-400">
+          <div class="px-6 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
             No context entries for this engagement.
           </div>
         )
       }
       {
         contextEntries.length > 0 && (
-          <div class="divide-y divide-slate-100">
+          <div class="divide-y divide-[color:var(--color-border-subtle)]">
             {contextEntries.map((entry) => (
               <div class="px-6 py-3">
                 <div class="flex items-center gap-2 mb-1">
                   <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadgeClass(entry.type)}`}>
                     {entry.type.replace(/_/g, ' ')}
                   </span>
-                  <span class="text-xs text-slate-400">{formatDate(entry.created_at)}</span>
-                  <span class="text-xs text-slate-400">via {entry.source}</span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                    {formatDate(entry.created_at)}
+                  </span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                    via {entry.source}
+                  </span>
                 </div>
-                <p class="text-sm text-slate-700 whitespace-pre-wrap">{entry.content}</p>
+                <p class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap">
+                  {entry.content}
+                </p>
               </div>
             ))}
           </div>
@@ -785,7 +843,9 @@ function fileSize(bytes: number): string {
     function setStatus(msg, isError) {
       if (!photoStatus) return
       photoStatus.textContent = msg
-      photoStatus.className = isError ? 'mt-2 text-xs text-red-600' : 'mt-2 text-xs text-slate-500'
+      photoStatus.className = isError
+        ? 'mt-2 text-xs text-red-600'
+        : 'mt-2 text-xs text-[color:var(--color-text-secondary)]'
     }
 
     async function cropToSquareWebp(file) {

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -75,59 +75,101 @@ const TRANSITIONS: Record<
     {
       label: 'Promote',
       stage: 'prospect',
-      style: 'bg-primary text-white hover:bg-primary/90',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
       action: `/api/admin/entities/${entity.id}/promote`,
     },
-    { label: 'Dismiss', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+    {
+      label: 'Dismiss',
+      stage: 'lost',
+      style:
+        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
+    },
   ],
   prospect: [
     {
       label: 'Book Assessment',
       stage: 'assessing',
-      style: 'bg-purple-600 text-white hover:bg-purple-700',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
     },
-    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+    {
+      label: 'Lost',
+      stage: 'lost',
+      style:
+        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
+    },
   ],
   assessing: [
     {
       label: 'Send Proposal',
       stage: 'proposing',
-      style: 'bg-indigo-600 text-white hover:bg-indigo-700',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
     },
-    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+    {
+      label: 'Lost',
+      stage: 'lost',
+      style:
+        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
+    },
   ],
   proposing: [
-    { label: 'Engaged', stage: 'engaged', style: 'bg-green-600 text-white hover:bg-green-700' },
-    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+    {
+      label: 'Engaged',
+      stage: 'engaged',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
+    },
+    {
+      label: 'Lost',
+      stage: 'lost',
+      style:
+        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
+    },
   ],
   engaged: [
     {
       label: 'Delivered',
       stage: 'delivered',
-      style: 'bg-emerald-600 text-white hover:bg-emerald-700',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
     },
   ],
   delivered: [
-    { label: 'Ongoing', stage: 'ongoing', style: 'bg-teal-600 text-white hover:bg-teal-700' },
+    {
+      label: 'Ongoing',
+      stage: 'ongoing',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
+    },
     {
       label: 'Re-engage',
       stage: 'prospect',
-      style: 'bg-blue-600 text-white hover:bg-blue-700',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
     },
   ],
   ongoing: [
     {
       label: 'Re-engage',
       stage: 'prospect',
-      style: 'bg-blue-600 text-white hover:bg-blue-700',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
     },
-    { label: 'Lost', stage: 'lost', style: 'bg-slate-100 text-slate-600 hover:bg-slate-200' },
+    {
+      label: 'Lost',
+      stage: 'lost',
+      style:
+        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
+    },
   ],
   lost: [
     {
       label: 'Re-engage',
       stage: 'prospect',
-      style: 'bg-blue-600 text-white hover:bg-blue-700',
+      style:
+        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
     },
   ],
 }
@@ -136,7 +178,7 @@ function contextTypeBadge(type: string): string {
   const map: Record<string, string> = {
     signal: 'bg-amber-100 text-amber-700',
     enrichment: 'bg-cyan-100 text-cyan-700',
-    note: 'bg-slate-100 text-slate-600',
+    note: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
     transcript: 'bg-purple-100 text-purple-700',
     extraction: 'bg-indigo-100 text-indigo-700',
     outreach_draft: 'bg-blue-100 text-blue-700',
@@ -144,10 +186,12 @@ function contextTypeBadge(type: string): string {
     follow_up_result: 'bg-teal-100 text-teal-700',
     feedback: 'bg-emerald-100 text-emerald-700',
     parking_lot: 'bg-orange-100 text-orange-700',
-    stage_change: 'bg-slate-50 text-slate-500',
+    stage_change: 'bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)]',
     intake: 'bg-pink-100 text-pink-700',
   }
-  return map[type] ?? 'bg-slate-100 text-slate-600'
+  return (
+    map[type] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  )
 }
 
 function stageBadgeClass(stage: string): string {
@@ -159,9 +203,11 @@ function stageBadgeClass(stage: string): string {
     engaged: 'bg-green-100 text-green-700',
     delivered: 'bg-emerald-100 text-emerald-700',
     ongoing: 'bg-teal-100 text-teal-700',
-    lost: 'bg-slate-100 text-slate-500',
+    lost: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
   }
-  return map[stage] ?? 'bg-slate-100 text-slate-500'
+  return (
+    map[stage] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  )
 }
 
 function formatDate(iso: string): string {
@@ -231,19 +277,21 @@ function renderSimpleMarkdown(md: string): string {
   // Headings: ## -> h4 (sized for card context)
   html = html.replace(
     /^## (.+)$/gm,
-    (_m, t) => `<h4 class="font-semibold text-sm text-slate-900 mt-4 mb-1">${t}</h4>`
+    (_m, t) =>
+      `<h4 class="font-semibold text-sm text-[color:var(--color-text-primary)] mt-4 mb-1">${t}</h4>`
   )
   // Bold
   html = html.replace(/\*\*(.+?)\*\*/g, (_m, t) => `<strong>${t}</strong>`)
   // Unordered list items
   html = html.replace(
     /^- (.+)$/gm,
-    (_m, t) => `<li class="ml-4 list-disc text-sm text-slate-700">${t}</li>`
+    (_m, t) => `<li class="ml-4 list-disc text-sm text-[color:var(--color-text-primary)]">${t}</li>`
   )
   // Numbered list items
   html = html.replace(
     /^\d+\. (.+)$/gm,
-    (_m, t) => `<li class="ml-4 list-decimal text-sm text-slate-700">${t}</li>`
+    (_m, t) =>
+      `<li class="ml-4 list-decimal text-sm text-[color:var(--color-text-primary)]">${t}</li>`
   )
   // Wrap consecutive <li> in <ul>/<ol>
   html = html.replace(
@@ -257,10 +305,13 @@ function renderSimpleMarkdown(md: string): string {
   // Paragraphs: non-empty lines that aren't already wrapped
   html = html.replace(
     /^(?!<[hulo])(.+)$/gm,
-    (_m, t) => `<p class="text-sm text-slate-700 mb-2">${t}</p>`
+    (_m, t) => `<p class="text-sm text-[color:var(--color-text-primary)] mb-2">${t}</p>`
   )
   // Clean up empty paragraphs
-  html = html.replace(/<p class="text-sm text-slate-700 mb-2"><\/p>/g, '')
+  html = html.replace(
+    /<p class="text-sm text-\[color:var\(--color-text-primary\)\] mb-2"><\/p>/g,
+    ''
+  )
 
   return html
 }
@@ -268,13 +319,13 @@ function renderSimpleMarkdown(md: string): string {
 function sentimentColor(trend: string): string {
   if (trend === 'improving') return 'text-green-700 bg-green-50'
   if (trend === 'declining') return 'text-red-700 bg-red-50'
-  return 'text-slate-600 bg-slate-50'
+  return 'text-[color:var(--color-text-secondary)] bg-[color:var(--color-background)]'
 }
 
 function confidenceColor(confidence: string): string {
   if (confidence === 'high') return 'bg-rose-100 text-rose-700'
   if (confidence === 'medium') return 'bg-amber-100 text-amber-700'
-  return 'bg-slate-100 text-slate-600'
+  return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
 }
 ---
 
@@ -288,46 +339,50 @@ function confidenceColor(confidence: string): string {
 >
   {
     promoted && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Entity promoted to prospect.
       </div>
     )
   }
   {
     noteAdded && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Note added.
       </div>
     )
   }
   {
     stageUpdated && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Stage updated.
       </div>
     )
   }
   {
     dossierGenerated && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Intelligence dossier generated. See enrichment entries in the timeline below.
       </div>
     )
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         {decodeURIComponent(error)}
       </div>
     )
   }
 
   {/* Entity Summary */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
     <div class="flex items-start justify-between gap-stack">
       <div>
         <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
+          <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+            {entity.name}
+          </h2>
           <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
             {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
           </span>
@@ -341,7 +396,7 @@ function confidenceColor(confidence: string): string {
                       ? 'bg-amber-100 text-amber-700'
                       : entity.tier === 'cool'
                         ? 'bg-blue-100 text-blue-700'
-                        : 'bg-slate-100 text-slate-500'
+                        : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
                 }`}
               >
                 {entity.tier}
@@ -350,11 +405,16 @@ function confidenceColor(confidence: string): string {
           }
         </div>
 
-        <div class="flex items-center gap-stack text-sm text-slate-500 mb-2 flex-wrap">
+        <div
+          class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)] mb-2 flex-wrap"
+        >
           {
             entity.pain_score && (
               <span>
-                Pain: <strong class="text-slate-700">{entity.pain_score}/10</strong>
+                Pain:{' '}
+                <strong class="text-[color:var(--color-text-primary)]">
+                  {entity.pain_score}/10
+                </strong>
               </span>
             )
           }
@@ -363,7 +423,7 @@ function confidenceColor(confidence: string): string {
           {entity.employee_count && <span>~{entity.employee_count} employees</span>}
         </div>
 
-        <div class="flex items-center gap-row text-xs text-slate-400">
+        <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)]">
           {
             entity.source_pipeline && (
               <span>Source: {entity.source_pipeline.replace(/_/g, ' ')}</span>
@@ -408,7 +468,7 @@ function confidenceColor(confidence: string): string {
               <input type="hidden" name="reason" value={`${t.label} by admin.`} />
               <button
                 type="submit"
-                class={`text-xs px-3 py-1.5 rounded-md transition-colors ${t.style}`}
+                class={`text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors ${t.style}`}
               >
                 {t.label}
               </button>
@@ -425,7 +485,7 @@ function confidenceColor(confidence: string): string {
               <button
                 type="submit"
                 id="dossier-btn"
-                class="text-xs px-3 py-1.5 rounded-md transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Generate Dossier
               </button>
@@ -437,18 +497,20 @@ function confidenceColor(confidence: string): string {
   </div>
 
   {/* Add Note */}
-  <div class="bg-white rounded-lg border border-slate-200 p-stack mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack mb-6"
+  >
     <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-row">
       <input type="hidden" name="type" value="note" />
       <textarea
         name="content"
         placeholder="Add a note..."
         rows="2"
-        class="flex-1 text-sm border border-slate-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        class="flex-1 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
       ></textarea>
       <button
         type="submit"
-        class="self-end text-sm bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90 transition-colors"
+        class="self-end text-sm bg-primary text-white px-4 py-2 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
       >
         Add Note
       </button>
@@ -458,52 +520,56 @@ function confidenceColor(confidence: string): string {
   {/* Dossier Summary */}
   {
     hasDossier && (
-      <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
-        <h3 class="text-base font-semibold text-slate-900 mb-4">Dossier Summary</h3>
+      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6">
+        <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+          Dossier Summary
+        </h3>
 
         {/* Zone 1: Quick Stats */}
         <div class="grid grid-cols-2 md:grid-cols-4 gap-stack mb-5">
           {reviewMeta?.unified_rating != null && (
-            <div class="bg-slate-50 rounded-lg p-row">
-              <div class="text-2xl font-bold text-slate-900">
+            <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
+              <div class="text-2xl font-bold text-[color:var(--color-text-primary)]">
                 {reviewMeta.unified_rating.toFixed(1)}
-                <span class="text-sm font-normal text-slate-400"> / 5</span>
+                <span class="text-sm font-normal text-[color:var(--color-text-muted)]"> / 5</span>
               </div>
-              <div class="text-xs text-slate-500">
+              <div class="text-xs text-[color:var(--color-text-secondary)]">
                 {reviewMeta.total_reviews_across_platforms ?? 0} reviews
               </div>
             </div>
           )}
           {reviewMeta?.sentiment_trend && reviewMeta.sentiment_trend !== 'insufficient_data' && (
-            <div class="bg-slate-50 rounded-lg p-row">
+            <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
               <div
                 class={`text-sm font-semibold px-2 py-0.5 rounded inline-block ${sentimentColor(reviewMeta.sentiment_trend)}`}
               >
                 {reviewMeta.sentiment_trend}
               </div>
-              <div class="text-xs text-slate-500 mt-1">Sentiment trend</div>
+              <div class="text-xs text-[color:var(--color-text-secondary)] mt-1">
+                Sentiment trend
+              </div>
             </div>
           )}
           {websiteMeta?.digital_maturity?.score != null && (
-            <div class="bg-slate-50 rounded-lg p-row">
-              <div class="text-2xl font-bold text-slate-900">
+            <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
+              <div class="text-2xl font-bold text-[color:var(--color-text-primary)]">
                 {websiteMeta.digital_maturity.score}
-                <span class="text-sm font-normal text-slate-400"> / 10</span>
+                <span class="text-sm font-normal text-[color:var(--color-text-muted)]"> / 10</span>
               </div>
-              <div class="text-xs text-slate-500">Digital maturity</div>
+              <div class="text-xs text-[color:var(--color-text-secondary)]">Digital maturity</div>
             </div>
           )}
           {competitorMeta?.entity_rank_by_rating != null &&
             competitorMeta?.total_competitors != null && (
-              <div class="bg-slate-50 rounded-lg p-row">
-                <div class="text-2xl font-bold text-slate-900">
+              <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
+                <div class="text-2xl font-bold text-[color:var(--color-text-primary)]">
                   #{competitorMeta.entity_rank_by_rating}
-                  <span class="text-sm font-normal text-slate-400">
+                  <span class="text-sm font-normal text-[color:var(--color-text-muted)]">
                     {' '}
                     of {competitorMeta.total_competitors}
                   </span>
                 </div>
-                <div class="text-xs text-slate-500">Local ranking</div>
+                <div class="text-xs text-[color:var(--color-text-secondary)]">Local ranking</div>
               </div>
             )}
         </div>
@@ -511,7 +577,7 @@ function confidenceColor(confidence: string): string {
         {/* Zone 2: Identified Problems */}
         {reviewMeta?.operational_problems && reviewMeta.operational_problems.length > 0 && (
           <div class="mb-5">
-            <div class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">
+            <div class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide mb-2">
               Identified Problems
             </div>
             <div class="flex flex-wrap gap-2">
@@ -529,9 +595,9 @@ function confidenceColor(confidence: string): string {
         )}
 
         {/* Zone 3: Intelligence Brief */}
-        <div class="border-t border-slate-100 pt-4 mb-4">
+        <div class="border-t border-[color:var(--color-border-subtle)] pt-4 mb-4">
           <details>
-            <summary class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-3 cursor-pointer">
+            <summary class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide mb-3 cursor-pointer">
               Intelligence Brief
             </summary>
             <div
@@ -543,24 +609,26 @@ function confidenceColor(confidence: string): string {
 
         {/* Zone 4: Outreach Draft */}
         {outreachEntry && (
-          <div class="border-t border-slate-100 pt-4">
+          <div class="border-t border-[color:var(--color-border-subtle)] pt-4">
             <div class="flex items-center justify-between mb-2">
-              <div class="text-xs font-medium text-slate-500 uppercase tracking-wide">
+              <div class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide">
                 Outreach Draft
                 {!outreachFromDossier && (
-                  <span class="normal-case font-normal text-slate-400 ml-2">Pre-dossier draft</span>
+                  <span class="normal-case font-normal text-[color:var(--color-text-muted)] ml-2">
+                    Pre-dossier draft
+                  </span>
                 )}
               </div>
               <button
                 id="copy-outreach-btn"
-                class="text-xs px-2 py-1 rounded bg-slate-100 text-slate-600 hover:bg-slate-200 transition-colors"
+                class="text-xs px-2 py-1 rounded bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)] transition-colors"
               >
                 Copy
               </button>
             </div>
             <pre
               id="outreach-content"
-              class="text-sm text-slate-700 whitespace-pre-wrap bg-slate-50 rounded-lg p-stack border border-slate-100"
+              class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-stack border border-[color:var(--color-border-subtle)]"
             >
               {outreachEntry.content}
             </pre>
@@ -573,9 +641,11 @@ function confidenceColor(confidence: string): string {
   {/* Context Timeline */}
   <div class="mb-6">
     <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold text-slate-900">
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
         Context Timeline
-        <span class="text-sm font-normal text-slate-400">({contextEntries.length})</span>
+        <span class="text-sm font-normal text-[color:var(--color-text-muted)]"
+          >({contextEntries.length})</span
+        >
       </h3>
     </div>
 
@@ -583,7 +653,7 @@ function confidenceColor(confidence: string): string {
     <div class="flex gap-1 mb-4 flex-wrap">
       <a
         href={`/admin/entities/${entity.id}`}
-        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'}`}
+        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]'}`}
       >
         All ({contextEntries.length})
       </a>
@@ -602,8 +672,8 @@ function confidenceColor(confidence: string): string {
     {/* Timeline entries */}
     {
       filteredEntries.length === 0 ? (
-        <div class="bg-white rounded-lg border border-slate-200 p-stack">
-          <p class="text-slate-500 text-sm">No context entries yet.</p>
+        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack">
+          <p class="text-[color:var(--color-text-secondary)] text-sm">No context entries yet.</p>
         </div>
       ) : (
         <div class="space-y-row">
@@ -611,13 +681,15 @@ function confidenceColor(confidence: string): string {
             const meta = parseMetadata(entry.metadata)
             const problems = meta?.top_problems as string[] | undefined
             return (
-              <div class="bg-white rounded-lg border border-slate-200 px-4 py-3">
+              <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-3">
                 <div class="flex items-center gap-2 mb-1.5">
                   <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
                     {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
                   </span>
-                  <span class="text-xs text-slate-400">{entry.source}</span>
-                  <span class="text-xs text-slate-400">{formatDateTime(entry.created_at)}</span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                    {formatDateTime(entry.created_at)}
+                  </span>
                   {entry.type === 'signal' && meta?.pain_score && (
                     <span class="text-xs font-semibold text-red-600">
                       Pain: {String(meta.pain_score)}/10
@@ -628,7 +700,7 @@ function confidenceColor(confidence: string): string {
                 {problems && problems.length > 0 && (
                   <div class="flex gap-1 mb-1.5">
                     {problems.map((p: string) => (
-                      <span class="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded">
+                      <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded">
                         {p.replace(/_/g, ' ')}
                       </span>
                     ))}
@@ -636,7 +708,7 @@ function confidenceColor(confidence: string): string {
                 )}
 
                 <details class="group">
-                  <summary class="text-sm text-slate-700 cursor-pointer line-clamp-3 group-open:line-clamp-none whitespace-pre-wrap">
+                  <summary class="text-sm text-[color:var(--color-text-primary)] cursor-pointer line-clamp-3 group-open:line-clamp-none whitespace-pre-wrap">
                     {entry.content}
                   </summary>
                 </details>
@@ -651,22 +723,27 @@ function confidenceColor(confidence: string): string {
   {/* Related Data Panels */}
   {
     contacts.length > 0 && (
-      <details class="bg-white rounded-lg border border-slate-200 mb-4" open>
-        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+      <details
+        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4"
+        open
+      >
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
           Contacts ({contacts.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-slate-100">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
           {contacts.map((c) => (
             <div class="py-2 flex items-center justify-between">
               <div>
-                <span class="text-sm font-medium text-slate-900">{c.name}</span>
+                <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+                  {c.name}
+                </span>
                 {c.role && (
-                  <span class="text-xs bg-slate-100 text-slate-500 px-1.5 py-0.5 rounded ml-2">
+                  <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded ml-2">
                     {c.role}
                   </span>
                 )}
               </div>
-              <div class="text-xs text-slate-400 flex gap-row">
+              <div class="text-xs text-[color:var(--color-text-muted)] flex gap-row">
                 {c.email && <span>{c.email}</span>}
                 {c.phone && <span>{c.phone}</span>}
               </div>
@@ -679,21 +756,23 @@ function confidenceColor(confidence: string): string {
 
   {
     assessments.length > 0 && (
-      <details class="bg-white rounded-lg border border-slate-200 mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
           Assessments ({assessments.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-slate-100">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
           {assessments.map((a) => (
             <div class="py-2 flex items-center gap-2">
-              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(a.status)}`}>
-                {a.status}
-              </span>
+              <span class={statusBadgeClass(a.status)}>{a.status}</span>
               {a.scheduled_at && (
-                <span class="text-sm text-slate-700">{formatDate(a.scheduled_at)}</span>
+                <span class="text-sm text-[color:var(--color-text-primary)]">
+                  {formatDate(a.scheduled_at)}
+                </span>
               )}
               {a.duration_minutes && (
-                <span class="text-xs text-slate-400">{a.duration_minutes} min</span>
+                <span class="text-xs text-[color:var(--color-text-muted)]">
+                  {a.duration_minutes} min
+                </span>
               )}
             </div>
           ))}
@@ -704,24 +783,24 @@ function confidenceColor(confidence: string): string {
 
   {
     engagements.length > 0 && (
-      <details class="bg-white rounded-lg border border-slate-200 mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
           Engagements ({engagements.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-slate-100">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
           {engagements.map((e) => (
             <a
               href={`/admin/engagements/${e.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
+              class="py-2 flex items-center gap-2 hover:bg-[color:var(--color-background)] -mx-2 px-2 rounded transition-colors"
             >
-              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(e.status)}`}>
-                {e.status}
-              </span>
+              <span class={statusBadgeClass(e.status)}>{e.status}</span>
               {e.start_date && (
-                <span class="text-sm text-slate-700">{formatDate(e.start_date)}</span>
+                <span class="text-sm text-[color:var(--color-text-primary)]">
+                  {formatDate(e.start_date)}
+                </span>
               )}
               {e.estimated_hours && (
-                <span class="text-xs text-slate-400">
+                <span class="text-xs text-[color:var(--color-text-muted)]">
                   {e.actual_hours}/{e.estimated_hours} hrs
                 </span>
               )}
@@ -734,24 +813,22 @@ function confidenceColor(confidence: string): string {
 
   {
     quotes.length > 0 && (
-      <details class="bg-white rounded-lg border border-slate-200 mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
           Quotes ({quotes.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-slate-100">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
           {quotes.map((q) => (
             <a
               href={`/admin/entities/${entity.id}/quotes/${q.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-slate-50 -mx-2 px-2 rounded transition-colors"
+              class="py-2 flex items-center gap-2 hover:bg-[color:var(--color-background)] -mx-2 px-2 rounded transition-colors"
             >
-              <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(q.status)}`}>
-                {q.status}
-              </span>
-              <span class="text-sm font-medium text-slate-700">
+              <span class={statusBadgeClass(q.status)}>{q.status}</span>
+              <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
                 ${q.total_price.toLocaleString()}
               </span>
-              <span class="text-xs text-slate-400">{q.total_hours} hrs</span>
-              <span class="text-xs text-slate-400">v{q.version}</span>
+              <span class="text-xs text-[color:var(--color-text-muted)]">{q.total_hours} hrs</span>
+              <span class="text-xs text-[color:var(--color-text-muted)]">v{q.version}</span>
             </a>
           ))}
         </div>
@@ -761,23 +838,23 @@ function confidenceColor(confidence: string): string {
 
   {
     invoices.length > 0 && (
-      <details class="bg-white rounded-lg border border-slate-200 mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-slate-900">
+      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
           Invoices ({invoices.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-slate-100">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
           {invoices.map((inv) => (
             <div class="py-2 flex items-center justify-between">
               <div class="flex items-center gap-2">
-                <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(inv.status)}`}>
-                  {inv.status}
-                </span>
-                <span class="text-sm font-medium text-slate-700">
+                <span class={statusBadgeClass(inv.status)}>{inv.status}</span>
+                <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
                   ${inv.amount.toLocaleString()}
                 </span>
-                <span class="text-xs text-slate-400">{inv.type}</span>
+                <span class="text-xs text-[color:var(--color-text-muted)]">{inv.type}</span>
                 {inv.due_date && (
-                  <span class="text-xs text-slate-400">Due {formatDate(inv.due_date)}</span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                    Due {formatDate(inv.due_date)}
+                  </span>
                 )}
               </div>
             </div>

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -105,14 +105,14 @@ function formatCurrency(amount: number): string {
 >
   {
     saved && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Quote saved.
       </div>
     )
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         {error === 'invalid_transition'
           ? 'Invalid status transition.'
           : error === 'no_sow'
@@ -131,7 +131,7 @@ function formatCurrency(amount: number): string {
   {/* Stale PDF warning (OQ-006) */}
   {
     isSowStale && (
-      <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         The quote has been modified since the last SOW PDF was generated. Re-generate the PDF before
         sending.
       </div>
@@ -139,16 +139,20 @@ function formatCurrency(amount: number): string {
   }
 
   {/* Header */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
     <div class="flex items-start justify-between gap-stack">
       <div>
         <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-slate-900">{entity.name}</h2>
-          <span class={`text-xs px-2 py-0.5 rounded ${statusBadgeClass(status)}`}>
+          <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+            {entity.name}
+          </h2>
+          <span class={statusBadgeClass(status)}>
             {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
           </span>
         </div>
-        <div class="flex items-center gap-stack text-sm text-slate-500">
+        <div class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)]">
           <span>Created {formatDate(quote.created_at)}</span>
           {
             expiresAt && (
@@ -165,9 +169,11 @@ function formatCurrency(amount: number): string {
   </div>
 
   {/* Line Item Editor */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
     <div class="flex items-center justify-between mb-4">
-      <h3 class="text-lg font-semibold text-slate-900">Line Items</h3>
+      <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)]">Line Items</h3>
       <div id="line-item-warning" class="hidden text-sm text-amber-600 font-medium">
         Consider keeping scope focused — 3+ line items may indicate too broad an engagement (OQ-005)
       </div>
@@ -176,61 +182,78 @@ function formatCurrency(amount: number): string {
     <div id="line-items-container">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b border-slate-200">
-            <th class="text-left py-2 px-2 text-slate-500 font-medium w-8">#</th>
-            <th class="text-left py-2 px-2 text-slate-500 font-medium w-48">Problem</th>
-            <th class="text-left py-2 px-2 text-slate-500 font-medium">Description</th>
-            <th class="text-right py-2 px-2 text-slate-500 font-medium w-24">Est. Hours</th>
+          <tr class="border-b border-[color:var(--color-border)]">
+            <th class="text-left py-2 px-2 text-[color:var(--color-text-secondary)] font-medium w-8"
+              >#</th
+            >
+            <th
+              class="text-left py-2 px-2 text-[color:var(--color-text-secondary)] font-medium w-48"
+              >Problem</th
+            >
+            <th class="text-left py-2 px-2 text-[color:var(--color-text-secondary)] font-medium"
+              >Description</th
+            >
+            <th
+              class="text-right py-2 px-2 text-[color:var(--color-text-secondary)] font-medium w-24"
+              >Est. Hours</th
+            >
             {isDraft && <th class="py-2 px-2 w-10" />}
           </tr>
         </thead>
         <tbody id="line-items-body">
           {
             lineItems.map((item, index) => (
-              <tr class="border-b border-slate-100 line-item-row" data-index={index}>
-                <td class="py-2 px-2 text-slate-400 row-number">{index + 1}</td>
+              <tr
+                class="border-b border-[color:var(--color-border-subtle)] line-item-row"
+                data-index={index}
+              >
+                <td class="py-2 px-2 text-[color:var(--color-text-muted)] row-number">
+                  {index + 1}
+                </td>
                 <td class="py-2 px-2">
                   {isDraft ? (
                     <input
                       type="text"
-                      class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem"
+                      class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-problem"
                       value={item.problem}
                       placeholder="e.g., Scheduling chaos"
                     />
                   ) : (
-                    <span class="text-slate-700">{item.problem}</span>
+                    <span class="text-[color:var(--color-text-primary)]">{item.problem}</span>
                   )}
                 </td>
                 <td class="py-2 px-2">
                   {isDraft ? (
                     <input
                       type="text"
-                      class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-description"
+                      class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-description"
                       value={item.description}
                       placeholder="What we'll deliver"
                     />
                   ) : (
-                    <span class="text-slate-700">{item.description}</span>
+                    <span class="text-[color:var(--color-text-primary)]">{item.description}</span>
                   )}
                 </td>
                 <td class="py-2 px-2 text-right">
                   {isDraft ? (
                     <input
                       type="number"
-                      class="w-20 border border-slate-200 rounded px-2 py-1 text-sm text-right item-hours"
+                      class="w-20 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm text-right item-hours"
                       value={item.estimated_hours}
                       min="0.5"
                       step="0.5"
                     />
                   ) : (
-                    <span class="text-slate-700">{item.estimated_hours}</span>
+                    <span class="text-[color:var(--color-text-primary)]">
+                      {item.estimated_hours}
+                    </span>
                   )}
                 </td>
                 {isDraft && (
                   <td class="py-2 px-2 text-center">
                     <button
                       type="button"
-                      class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn"
+                      class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-item-btn"
                       title="Remove"
                     >
                       &times;
@@ -257,14 +280,15 @@ function formatCurrency(amount: number): string {
     </div>
 
     {/* Totals */}
-    <div class="mt-4 pt-4 border-t border-slate-200 flex justify-end">
+    <div class="mt-4 pt-4 border-t border-[color:var(--color-border)] flex justify-end">
       <div class="text-right space-y-1">
-        <div class="text-sm text-slate-500">
-          Total hours: <span id="total-hours" class="font-medium text-slate-900"
-            >{quote.total_hours}</span
+        <div class="text-sm text-[color:var(--color-text-secondary)]">
+          Total hours: <span
+            id="total-hours"
+            class="font-medium text-[color:var(--color-text-primary)]">{quote.total_hours}</span
           >
         </div>
-        <div class="text-lg font-semibold text-slate-900">
+        <div class="text-lg font-semibold text-[color:var(--color-text-primary)]">
           Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
         </div>
       </div>
@@ -272,17 +296,23 @@ function formatCurrency(amount: number): string {
   </div>
 
   {/* Payment Structure */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
-    <h3 class="text-lg font-semibold text-slate-900 mb-4">Payment Structure</h3>
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
+    <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-4">
+      Payment Structure
+    </h3>
 
     <div class="space-y-row">
       <div class="flex items-center gap-stack">
-        <label class="text-sm text-slate-600 w-36">Deposit percentage:</label>
+        <label class="text-sm text-[color:var(--color-text-secondary)] w-36"
+          >Deposit percentage:</label
+        >
         {
           isDraft ? (
             <select
               id="deposit-pct-select"
-              class="border border-slate-200 rounded px-2 py-1 text-sm"
+              class="border border-[color:var(--color-border)] rounded px-2 py-1 text-sm"
             >
               <option value="0.5" selected={depositPct === 0.5}>
                 50%
@@ -292,7 +322,9 @@ function formatCurrency(amount: number): string {
               </option>
             </select>
           ) : (
-            <span class="text-sm text-slate-900">{Math.round(depositPct * 100)}%</span>
+            <span class="text-sm text-[color:var(--color-text-primary)]">
+              {Math.round(depositPct * 100)}%
+            </span>
           )
         }
       </div>
@@ -306,10 +338,10 @@ function formatCurrency(amount: number): string {
         )
       }
 
-      <div class="text-sm text-slate-600 space-y-1">
+      <div class="text-sm text-[color:var(--color-text-secondary)] space-y-1">
         <div class="flex justify-between max-w-xs">
           <span>Deposit:</span>
-          <span id="deposit-amount" class="font-medium text-slate-900">
+          <span id="deposit-amount" class="font-medium text-[color:var(--color-text-primary)]">
             {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
           </span>
         </div>
@@ -318,13 +350,13 @@ function formatCurrency(amount: number): string {
             <>
               <div class="flex justify-between max-w-xs">
                 <span>Mid-engagement milestone:</span>
-                <span class="font-medium text-slate-900">
+                <span class="font-medium text-[color:var(--color-text-primary)]">
                   {formatCurrency(quote.total_price * 0.3)}
                 </span>
               </div>
               <div class="flex justify-between max-w-xs">
                 <span>Completion:</span>
-                <span class="font-medium text-slate-900">
+                <span class="font-medium text-[color:var(--color-text-primary)]">
                   {formatCurrency(quote.total_price * 0.3)}
                 </span>
               </div>
@@ -332,7 +364,10 @@ function formatCurrency(amount: number): string {
           ) : (
             <div class="flex justify-between max-w-xs">
               <span>Completion:</span>
-              <span id="completion-amount" class="font-medium text-slate-900">
+              <span
+                id="completion-amount"
+                class="font-medium text-[color:var(--color-text-primary)]"
+              >
                 {formatCurrency(quote.total_price * (1 - depositPct))}
               </span>
             </div>
@@ -343,9 +378,13 @@ function formatCurrency(amount: number): string {
   </div>
 
   {/* Authored client-facing content (#377) */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+  >
     <div class="flex items-start justify-between mb-1">
-      <h3 class="text-lg font-semibold text-slate-900">Client-facing content</h3>
+      <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)]">
+        Client-facing content
+      </h3>
       {
         missingAuthored.length > 0 ? (
           <span class="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-800 font-medium">
@@ -358,7 +397,7 @@ function formatCurrency(amount: number): string {
         )
       }
     </div>
-    <p class="text-sm text-slate-500 mb-5">
+    <p class="text-sm text-[color:var(--color-text-secondary)] mb-5">
       Authored per engagement. Renders on the client proposal page and SOW PDF. Quotes cannot be
       sent until the schedule and deliverables are populated.
     </p>
@@ -366,7 +405,9 @@ function formatCurrency(amount: number): string {
     {/* Schedule */}
     <div class="mb-6">
       <div class="flex items-center justify-between mb-2">
-        <label class="text-sm font-semibold text-slate-700"> How we'll work (schedule) </label>
+        <label class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+          How we'll work (schedule)
+        </label>
         {
           isDraft && (
             <button
@@ -379,13 +420,13 @@ function formatCurrency(amount: number): string {
           )
         }
       </div>
-      <p class="text-xs text-slate-500 mb-2">
+      <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
         One row per phase. The label sits in the left gutter (e.g. "Discovery", "Build").
       </p>
       <div id="schedule-rows" data-empty-text="No schedule rows authored yet.">
         {
           schedule.length === 0 ? (
-            <div class="text-sm text-slate-500 italic py-2 schedule-empty-state">
+            <div class="text-sm text-[color:var(--color-text-secondary)] italic py-2 schedule-empty-state">
               No schedule rows authored yet.
             </div>
           ) : (
@@ -395,19 +436,19 @@ function formatCurrency(amount: number): string {
                   <>
                     <input
                       type="text"
-                      class="w-32 border border-slate-200 rounded px-2 py-1 text-sm schedule-label"
+                      class="w-32 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-label"
                       value={row.label}
                       placeholder="Label"
                     />
                     <input
                       type="text"
-                      class="flex-1 border border-slate-200 rounded px-2 py-1 text-sm schedule-body"
+                      class="flex-1 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-body"
                       value={row.body}
                       placeholder="What happens in this phase"
                     />
                     <button
                       type="button"
-                      class="text-slate-400 hover:text-red-500 transition-colors remove-schedule-row-btn px-2"
+                      class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2"
                       title="Remove"
                     >
                       &times;
@@ -415,8 +456,12 @@ function formatCurrency(amount: number): string {
                   </>
                 ) : (
                   <>
-                    <span class="w-32 text-sm font-medium text-slate-600">{row.label}</span>
-                    <span class="flex-1 text-sm text-slate-700">{row.body}</span>
+                    <span class="w-32 text-sm font-medium text-[color:var(--color-text-secondary)]">
+                      {row.label}
+                    </span>
+                    <span class="flex-1 text-sm text-[color:var(--color-text-primary)]">
+                      {row.body}
+                    </span>
                   </>
                 )}
               </div>
@@ -429,7 +474,9 @@ function formatCurrency(amount: number): string {
     {/* Deliverables */}
     <div class="mb-6">
       <div class="flex items-center justify-between mb-2">
-        <label class="text-sm font-semibold text-slate-700"> What you'll get (deliverables) </label>
+        <label class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+          What you'll get (deliverables)
+        </label>
         {
           isDraft && (
             <button
@@ -442,13 +489,13 @@ function formatCurrency(amount: number): string {
           )
         }
       </div>
-      <p class="text-xs text-slate-500 mb-2">
+      <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
         Authored deliverables replace the line-item-derived list on the proposal page.
       </p>
       <div id="deliverable-rows" data-empty-text="No deliverables authored yet.">
         {
           deliverables.length === 0 ? (
-            <div class="text-sm text-slate-500 italic py-2 deliverable-empty-state">
+            <div class="text-sm text-[color:var(--color-text-secondary)] italic py-2 deliverable-empty-state">
               No deliverables authored yet.
             </div>
           ) : (
@@ -459,12 +506,12 @@ function formatCurrency(amount: number): string {
                     <div class="flex-1 space-y-1">
                       <input
                         type="text"
-                        class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-title"
+                        class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-title"
                         value={row.title}
                         placeholder="Title"
                       />
                       <textarea
-                        class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-body"
+                        class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-body"
                         rows="2"
                         placeholder="Description"
                       >
@@ -473,7 +520,7 @@ function formatCurrency(amount: number): string {
                     </div>
                     <button
                       type="button"
-                      class="text-slate-400 hover:text-red-500 transition-colors remove-deliverable-row-btn px-2"
+                      class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2"
                       title="Remove"
                     >
                       &times;
@@ -481,8 +528,10 @@ function formatCurrency(amount: number): string {
                   </div>
                 ) : (
                   <div>
-                    <p class="text-sm font-semibold text-slate-700">{row.title}</p>
-                    <p class="text-sm text-slate-600">{row.body}</p>
+                    <p class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                      {row.title}
+                    </p>
+                    <p class="text-sm text-[color:var(--color-text-secondary)]">{row.body}</p>
                   </div>
                 )}
               </div>
@@ -495,27 +544,29 @@ function formatCurrency(amount: number): string {
     {/* Engagement overview (SOW PDF) */}
     <div class="mb-6">
       <label
-        class="block text-sm font-semibold text-slate-700 mb-1"
+        class="block text-sm font-semibold text-[color:var(--color-text-primary)] mb-1"
         for="engagement-overview-input"
       >
         Engagement overview (SOW PDF)
       </label>
-      <p class="text-xs text-slate-500 mb-2">
+      <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
         Renders on the SOW PDF "Engagement overview" page. Required before generating the SOW PDF.
       </p>
       {
         isDraft ? (
           <textarea
             id="engagement-overview-input"
-            class="w-full border border-slate-200 rounded px-3 py-2 text-sm"
+            class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
             rows="3"
             placeholder="What this engagement is about, in one or two sentences."
           >
             {engagementOverview}
           </textarea>
         ) : (
-          <p class="text-sm text-slate-700 whitespace-pre-wrap">
-            {engagementOverview || <span class="italic text-slate-400">Not authored.</span>}
+          <p class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap">
+            {engagementOverview || (
+              <span class="italic text-[color:var(--color-text-muted)]">Not authored.</span>
+            )}
           </p>
         )
       }
@@ -526,12 +577,12 @@ function formatCurrency(amount: number): string {
       isThreeMilestone && (
         <div class="mb-2">
           <label
-            class="block text-sm font-semibold text-slate-700 mb-1"
+            class="block text-sm font-semibold text-[color:var(--color-text-primary)] mb-1"
             for="milestone-label-input"
           >
             Mid-engagement milestone label
           </label>
-          <p class="text-xs text-slate-500 mb-2">
+          <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
             Per-engagement label for the 30% mid-engagement milestone (e.g. "First-pass review",
             "Pilot rollout"). Optional; the SOW renders neutral wording when empty.
           </p>
@@ -539,13 +590,15 @@ function formatCurrency(amount: number): string {
             <input
               id="milestone-label-input"
               type="text"
-              class="w-full border border-slate-200 rounded px-3 py-2 text-sm"
+              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
               value={milestoneLabel}
               placeholder="Optional label for the mid-engagement milestone"
             />
           ) : (
-            <p class="text-sm text-slate-700">
-              {milestoneLabel || <span class="italic text-slate-400">Not authored.</span>}
+            <p class="text-sm text-[color:var(--color-text-primary)]">
+              {milestoneLabel || (
+                <span class="italic text-[color:var(--color-text-muted)]">Not authored.</span>
+              )}
             </p>
           )}
         </div>
@@ -556,9 +609,9 @@ function formatCurrency(amount: number): string {
   {/* SOW PDF Status */}
   {
     hasSow && (
-      <div class="bg-white rounded-lg border border-slate-200 p-card mb-6">
-        <h3 class="text-lg font-semibold text-slate-900 mb-2">SOW PDF</h3>
-        <div class="text-sm text-slate-600 space-y-1">
+      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6">
+        <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-2">SOW PDF</h3>
+        <div class="text-sm text-[color:var(--color-text-secondary)] space-y-1">
           <div>
             Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
           </div>
@@ -571,8 +624,10 @@ function formatCurrency(amount: number): string {
   }
 
   {/* Actions */}
-  <div class="bg-white rounded-lg border border-slate-200 p-card">
-    <h3 class="text-lg font-semibold text-slate-900 mb-4">Actions</h3>
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+  >
+    <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-4">Actions</h3>
     <div class="flex flex-wrap gap-row">
       {/* Save Draft */}
       {
@@ -647,7 +702,7 @@ function formatCurrency(amount: number): string {
           <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
             <select
               name="signer_contact_id"
-              class="px-3 py-2 border border-slate-300 rounded text-sm bg-white"
+              class="px-3 py-2 border border-[color:var(--color-border)] rounded text-sm bg-white"
               required
             >
               {contacts
@@ -675,7 +730,7 @@ function formatCurrency(amount: number): string {
             <input type="hidden" name="action" value="decline" />
             <button
               type="submit"
-              class="px-4 py-2 bg-slate-100 text-slate-600 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
+              class="px-4 py-2 bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] rounded hover:bg-[color:var(--color-border)] transition-colors text-sm font-medium"
             >
               Decline
             </button>
@@ -690,7 +745,7 @@ function formatCurrency(amount: number): string {
             <input type="hidden" name="action" value="expire" />
             <button
               type="submit"
-              class="px-4 py-2 bg-slate-100 text-slate-500 rounded hover:bg-slate-200 transition-colors text-sm font-medium"
+              class="px-4 py-2 bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] rounded hover:bg-[color:var(--color-border)] transition-colors text-sm font-medium"
             >
               Mark Expired
             </button>
@@ -701,7 +756,7 @@ function formatCurrency(amount: number): string {
 
     {
       isTerminal && (
-        <p class="mt-3 text-sm text-slate-500">
+        <p class="mt-3 text-sm text-[color:var(--color-text-secondary)]">
           This quote is in a terminal state ({status}) and cannot be modified.
         </p>
       )
@@ -815,7 +870,7 @@ function formatCurrency(amount: number): string {
         if (rows.length === 0) {
           const div = document.createElement('div')
           div.className =
-            'text-sm text-slate-500 italic py-2 ' +
+            'text-sm text-[color:var(--color-text-secondary)] italic py-2 ' +
             (isDeliverable ? 'deliverable-empty-state' : 'schedule-empty-state')
           div.textContent = container.getAttribute('data-empty-text') ?? ''
           container.appendChild(div)
@@ -869,9 +924,9 @@ function formatCurrency(amount: number): string {
         const div = document.createElement('div')
         div.className = 'flex gap-2 mb-2 schedule-row'
         div.innerHTML = `
-          <input type="text" class="w-32 border border-slate-200 rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
-          <input type="text" class="flex-1 border border-slate-200 rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
-          <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
+          <input type="text" class="w-32 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
+          <input type="text" class="flex-1 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
+          <button type="button" class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
         `
         scheduleRowsContainer.appendChild(div)
       }
@@ -884,10 +939,10 @@ function formatCurrency(amount: number): string {
         div.innerHTML = `
           <div class="flex gap-2">
             <div class="flex-1 space-y-1">
-              <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
-              <textarea class="w-full border border-slate-200 rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
+              <input type="text" class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
+              <textarea class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
             </div>
-            <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
+            <button type="button" class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
           </div>
         `
         deliverableRowsContainer.appendChild(div)
@@ -932,21 +987,21 @@ function formatCurrency(amount: number): string {
       function addRow() {
         const index = body.querySelectorAll('.line-item-row').length
         const tr = document.createElement('tr')
-        tr.className = 'border-b border-slate-100 line-item-row'
+        tr.className = 'border-b border-[color:var(--color-border-subtle)] line-item-row'
         tr.setAttribute('data-index', String(index))
         tr.innerHTML = `
-            <td class="py-2 px-2 text-slate-400 row-number">${index + 1}</td>
+            <td class="py-2 px-2 text-[color:var(--color-text-muted)] row-number">${index + 1}</td>
             <td class="py-2 px-2">
-              <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
+              <input type="text" class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
             </td>
             <td class="py-2 px-2">
-              <input type="text" class="w-full border border-slate-200 rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
+              <input type="text" class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
             </td>
             <td class="py-2 px-2 text-right">
-              <input type="number" class="w-20 border border-slate-200 rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
+              <input type="number" class="w-20 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
             </td>
             <td class="py-2 px-2 text-center">
-              <button type="button" class="text-slate-400 hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
+              <button type="button" class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
             </td>
           `
         body.appendChild(tr)

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -52,7 +52,7 @@ function pipelineBadgeClass(pipeline: string): string {
     case 'website_intake':
       return 'bg-teal-100 text-teal-700'
     default:
-      return 'bg-slate-100 text-slate-600'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
   }
 }
 
@@ -65,17 +65,17 @@ function tierBadgeClass(tier: string | null): string {
     case 'cool':
       return 'bg-blue-100 text-blue-700'
     case 'cold':
-      return 'bg-slate-100 text-slate-500'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
     default:
       return ''
   }
 }
 
 function painScoreClass(score: number | null): string {
-  if (!score) return 'text-slate-400'
+  if (!score) return 'text-[color:var(--color-text-muted)]'
   if (score >= 8) return 'text-red-600 font-bold'
   if (score >= 6) return 'text-amber-600 font-semibold'
-  return 'text-slate-500'
+  return 'text-[color:var(--color-text-secondary)]'
 }
 
 function stageBadgeClass(stage: string): string {
@@ -95,9 +95,9 @@ function stageBadgeClass(stage: string): string {
     case 'ongoing':
       return 'border-teal-500 text-teal-600'
     case 'lost':
-      return 'border-slate-400 text-slate-500'
+      return 'border-slate-400 text-[color:var(--color-text-secondary)]'
     default:
-      return 'border-slate-300 text-slate-500'
+      return 'border-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
   }
 }
 
@@ -116,33 +116,33 @@ function formatDate(iso: string): string {
 >
   {
     promoted && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Entity promoted to prospect.
       </div>
     )
   }
   {
     dismissed && (
-      <div class="bg-slate-50 border border-slate-200 text-slate-600 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-[color:var(--color-background)] border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Entity dismissed.
       </div>
     )
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         {error}
       </div>
     )
   }
 
   <div class="flex items-center justify-between mb-6">
-    <h2 class="text-xl font-semibold text-slate-900">Entities</h2>
+    <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Entities</h2>
     <form method="GET" class="flex items-center gap-2">
       <input type="hidden" name="stage" value={filterStage} />
       <select
         name="pipeline"
-        class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+        class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
         onchange="this.form.submit()"
       >
         <option value="">All pipelines</option>
@@ -158,7 +158,7 @@ function formatDate(iso: string): string {
   </div>
 
   {/* Stage tabs */}
-  <div class="flex gap-1 mb-6 border-b border-slate-200 overflow-x-auto">
+  <div class="flex gap-1 mb-6 border-b border-[color:var(--color-border)] overflow-x-auto">
     {
       ENTITY_STAGES.map((s) => (
         <a
@@ -166,7 +166,7 @@ function formatDate(iso: string): string {
           class={`px-3 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
             filterStage === s.value
               ? stageBadgeClass(s.value) + ' border-current'
-              : 'border-transparent text-slate-500 hover:text-slate-700'
+              : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
           }`}
         >
           {s.label}
@@ -183,13 +183,13 @@ function formatDate(iso: string): string {
   {/* Entity list */}
   {
     entities.length === 0 ? (
-      <div class="bg-white rounded-lg border border-slate-200 p-card">
-        <p class="text-slate-500 text-sm">
+      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
+        <p class="text-[color:var(--color-text-secondary)] text-sm">
           No entities at the <strong>{filterStage}</strong> stage.
         </p>
       </div>
     ) : (
-      <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
         {entities.map((e: Entity) => (
           <div class="px-6 py-4">
             <div class="flex items-start justify-between gap-stack">
@@ -197,7 +197,7 @@ function formatDate(iso: string): string {
                 <div class="flex items-center gap-2 mb-1 flex-wrap">
                   <a
                     href={`/admin/entities/${e.id}`}
-                    class="text-sm font-medium text-slate-900 hover:text-primary transition-colors"
+                    class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary transition-colors"
                   >
                     {e.name}
                   </a>
@@ -220,7 +220,11 @@ function formatDate(iso: string): string {
                   )}
                 </div>
 
-                {e.summary && <p class="text-xs text-slate-600 mb-1 line-clamp-2">{e.summary}</p>}
+                {e.summary && (
+                  <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2">
+                    {e.summary}
+                  </p>
+                )}
 
                 {e.next_action && (
                   <p class="text-xs text-amber-600 mb-1">
@@ -229,7 +233,7 @@ function formatDate(iso: string): string {
                   </p>
                 )}
 
-                <div class="flex items-center gap-row text-xs text-slate-400 mt-1">
+                <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1">
                   <span>{formatDate(e.created_at)}</span>
                   {e.area && <span>{e.area}</span>}
                   {e.vertical && <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>}
@@ -243,7 +247,7 @@ function formatDate(iso: string): string {
                     <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
                       <button
                         type="submit"
-                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
                       >
                         Promote
                       </button>
@@ -251,7 +255,7 @@ function formatDate(iso: string): string {
                     <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
                       <button
                         type="submit"
-                        class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                        class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
                       >
                         Dismiss
                       </button>
@@ -260,7 +264,7 @@ function formatDate(iso: string): string {
                 ) : (
                   <a
                     href={`/admin/entities/${e.id}`}
-                    class="text-xs bg-slate-50 text-slate-700 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                    class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
                   >
                     View
                   </a>

--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -93,21 +93,21 @@ const success = Astro.url.searchParams.get('saved')
 >
   {
     success && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-lg mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Follow-up updated successfully.
       </div>
     )
   }
 
   <div class="flex items-center justify-between mb-6">
-    <h2 class="text-xl font-semibold text-slate-900">Follow-ups</h2>
+    <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Follow-ups</h2>
 
     {/* Type filter */}
     <form method="GET" class="flex items-center gap-2">
       <input type="hidden" name="tab" value={activeTab} />
       <select
         name="type"
-        class="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700"
+        class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
         onchange="this.form.submit()"
       >
         <option value="">All types</option>
@@ -123,13 +123,13 @@ const success = Astro.url.searchParams.get('saved')
   </div>
 
   {/* Tabs */}
-  <div class="flex gap-1 mb-6 border-b border-slate-200">
+  <div class="flex gap-1 mb-6 border-b border-[color:var(--color-border)]">
     <a
       href={`/admin/follow-ups?tab=upcoming${filterType ? `&type=${filterType}` : ''}`}
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'upcoming'
           ? 'border-primary text-primary'
-          : 'border-transparent text-slate-500 hover:text-slate-700'
+          : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
       }`}
     >
       Upcoming ({upcoming.length})
@@ -139,7 +139,7 @@ const success = Astro.url.searchParams.get('saved')
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'overdue'
           ? 'border-red-500 text-red-600'
-          : 'border-transparent text-slate-500 hover:text-slate-700'
+          : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
       }`}
     >
       Overdue ({overdue.length})
@@ -149,7 +149,7 @@ const success = Astro.url.searchParams.get('saved')
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'completed'
           ? 'border-green-500 text-green-600'
-          : 'border-transparent text-slate-500 hover:text-slate-700'
+          : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
       }`}
     >
       Completed ({completed.length})
@@ -163,8 +163,8 @@ const success = Astro.url.searchParams.get('saved')
         activeTab === 'overdue' ? overdue : activeTab === 'completed' ? completed : upcoming
       if (items.length === 0) {
         return (
-          <div class="bg-white rounded-lg border border-slate-200 p-card">
-            <p class="text-slate-500 text-sm">
+          <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
+            <p class="text-[color:var(--color-text-secondary)] text-sm">
               {activeTab === 'upcoming' && 'No upcoming follow-ups.'}
               {activeTab === 'overdue' && 'No overdue follow-ups.'}
               {activeTab === 'completed' && 'No completed follow-ups.'}
@@ -173,29 +173,29 @@ const success = Astro.url.searchParams.get('saved')
         )
       }
       return (
-        <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
           {items.map((f: FollowUp) => (
             <div class="px-6 py-4">
               <div class="flex items-start justify-between gap-stack">
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2 mb-1">
                     <span
-                      class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-slate-900' : 'italic text-slate-400'}`}
+                      class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-[color:var(--color-text-primary)]' : 'italic text-[color:var(--color-text-muted)]'}`}
                     >
                       {f.entity_id ? (clientMap[f.entity_id] ?? 'Missing entity') : 'Unlinked'}
                     </span>
-                    <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded">
+                    <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-2 py-0.5 rounded">
                       {getTypeLabel(f.type)}
                     </span>
                   </div>
-                  <div class="flex items-center gap-row text-xs text-slate-400">
+                  <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)]">
                     <span>{formatDate(f.scheduled_for)}</span>
                     {f.status === 'scheduled' && (
                       <span
                         class={
                           daysUntil(f.scheduled_for) < 0
                             ? 'text-red-500 font-medium'
-                            : 'text-slate-500'
+                            : 'text-[color:var(--color-text-secondary)]'
                         }
                       >
                         {daysLabel(f.scheduled_for)}
@@ -211,7 +211,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="send_email" />
                       <button
                         type="submit"
-                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-md hover:bg-primary/90 transition-colors"
+                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
                       >
                         Send Email
                       </button>
@@ -220,7 +220,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="complete" />
                       <button
                         type="submit"
-                        class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-md hover:bg-green-100 transition-colors"
+                        class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-green-100 transition-colors"
                       >
                         Mark Complete
                       </button>
@@ -229,7 +229,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="skip" />
                       <button
                         type="submit"
-                        class="text-xs bg-slate-50 text-slate-600 px-3 py-1.5 rounded-md hover:bg-slate-100 transition-colors"
+                        class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
                       >
                         Skip
                       </button>

--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -256,9 +256,9 @@ function tierClass(tier: string | null): string {
     case 'cool':
       return 'bg-blue-100 text-blue-700'
     case 'cold':
-      return 'bg-slate-100 text-slate-500'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
     default:
-      return 'bg-slate-100 text-slate-500'
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
   }
 }
 
@@ -292,20 +292,24 @@ const runDisabledReason = !runWorkerUrl
   ]}
 >
   <div class="mb-6">
-    <h2 class="text-xl font-semibold text-slate-900">{PIPELINE_LABELS[type]}</h2>
-    <p class="text-sm text-slate-600 mt-1">{PIPELINE_DESCRIPTIONS[type]}</p>
+    <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+      {PIPELINE_LABELS[type]}
+    </h2>
+    <p class="text-sm text-[color:var(--color-text-secondary)] mt-1">
+      {PIPELINE_DESCRIPTIONS[type]}
+    </p>
   </div>
 
   {
     saved && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-lg">
+      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-green-800">Configuration saved.</p>
       </div>
     )
   }
   {
     ran && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-lg">
+      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-green-800">
           Run complete. {ranSignals} signal{ranSignals === '1' ? '' : 's'} written.
         </p>
@@ -314,7 +318,7 @@ const runDisabledReason = !runWorkerUrl
   }
   {
     errorParam && (
-      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-lg">
+      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-red-800">
           {errorParam === 'run_not_configured'
             ? `Run-now is not configured. Set ${type.toUpperCase()}_WORKER_URL and LEAD_INGEST_API_KEY on this Pages project.`
@@ -325,7 +329,7 @@ const runDisabledReason = !runWorkerUrl
   }
   {
     configRow.parseError.length > 0 && (
-      <div class="mb-6 p-stack bg-yellow-50 border border-yellow-200 rounded-lg">
+      <div class="mb-6 p-stack bg-yellow-50 border border-yellow-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-yellow-800 font-medium mb-1">
           Stored configuration failed validation. Showing defaults.
         </p>
@@ -339,25 +343,27 @@ const runDisabledReason = !runWorkerUrl
   }
 
   <section aria-labelledby="liveness" class="mb-8">
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
       <div class="flex items-center justify-between gap-4 flex-wrap">
         <div class="flex items-center gap-row">
           <div
             class={`w-3 h-3 rounded-full ${configRow.enabled ? 'bg-green-500' : 'bg-slate-300'}`}
           >
           </div>
-          <span class="text-sm font-medium text-slate-900">
+          <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
             {configRow.enabled ? 'Enabled' : 'Disabled'}
           </span>
-          <span class="text-xs text-slate-400">·</span>
-          <span class="text-sm text-slate-600">
+          <span class="text-xs text-[color:var(--color-text-muted)]">·</span>
+          <span class="text-sm text-[color:var(--color-text-secondary)]">
             Last run: {formatRelative(configRow.last_run_at)}
           </span>
           {
             configRow.last_run_signals_count !== null && (
               <>
-                <span class="text-xs text-slate-400">·</span>
-                <span class="text-sm text-slate-600">
+                <span class="text-xs text-[color:var(--color-text-muted)]">·</span>
+                <span class="text-sm text-[color:var(--color-text-secondary)]">
                   {configRow.last_run_signals_count} signal
                   {configRow.last_run_signals_count === 1 ? '' : 's'}
                 </span>
@@ -367,7 +373,7 @@ const runDisabledReason = !runWorkerUrl
           {
             configRow.last_run_error && (
               <>
-                <span class="text-xs text-slate-400">·</span>
+                <span class="text-xs text-[color:var(--color-text-muted)]">·</span>
                 <span class="text-sm text-red-600">Error: {configRow.last_run_error}</span>
               </>
             )
@@ -378,7 +384,7 @@ const runDisabledReason = !runWorkerUrl
           <button
             type="submit"
             disabled={!runConfigured}
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 disabled:bg-slate-300 disabled:cursor-not-allowed transition-colors"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-[var(--radius-card)] hover:bg-primary/90 disabled:bg-slate-300 disabled:cursor-not-allowed transition-colors"
             title={runConfigured ? 'Invoke worker now' : runDisabledReason}
           >
             <span class="material-symbols-outlined text-base">play_arrow</span>
@@ -388,7 +394,7 @@ const runDisabledReason = !runWorkerUrl
       </div>
       {
         !runConfigured && (
-          <p class="mt-2 text-xs text-slate-500">
+          <p class="mt-2 text-xs text-[color:var(--color-text-secondary)]">
             Run-now disabled: <code class="font-mono">{runDisabledReason}</code>
           </p>
         )
@@ -397,8 +403,16 @@ const runDisabledReason = !runWorkerUrl
   </section>
 
   <section aria-labelledby="config-form" class="mb-8">
-    <h3 id="config-form" class="text-base font-semibold text-slate-900 mb-3">Configuration</h3>
-    <form method="POST" class="bg-white rounded-lg border border-slate-200 p-card space-y-stack">
+    <h3
+      id="config-form"
+      class="text-base font-semibold text-[color:var(--color-text-primary)] mb-3"
+    >
+      Configuration
+    </h3>
+    <form
+      method="POST"
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card space-y-stack"
+    >
       <input type="hidden" name="action" value="save_config" />
 
       <div class="flex items-center gap-row">
@@ -407,32 +421,40 @@ const runDisabledReason = !runWorkerUrl
           id="enabled"
           name="enabled"
           checked={configRow.enabled}
-          class="w-4 h-4 rounded border-slate-300"
+          class="w-4 h-4 rounded border-[color:var(--color-border)]"
         />
-        <label for="enabled" class="text-sm font-medium text-slate-900">
+        <label for="enabled" class="text-sm font-medium text-[color:var(--color-text-primary)]">
           Enabled — when unchecked, worker returns early and writes no signals
         </label>
       </div>
 
       <div>
-        <label for="target_verticals" class="text-sm font-medium text-slate-900 block mb-1">
-          Target verticals <span class="text-xs text-slate-500">(one per line)</span>
+        <label
+          for="target_verticals"
+          class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+        >
+          Target verticals <span class="text-xs text-[color:var(--color-text-secondary)]"
+            >(one per line)</span
+          >
         </label>
         <textarea
           id="target_verticals"
           name="target_verticals"
           rows="6"
-          class="w-full border border-slate-300 rounded px-3 py-2 text-sm font-mono"
+          class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
           set:html={(configRow.config as NewBusinessConfig).target_verticals.join('\n')}
         />
-        <p class="text-xs text-slate-500 mt-1">
+        <p class="text-xs text-[color:var(--color-text-secondary)] mt-1">
           Free-text. Suggestions: {VERTICALS.map((v) => v.replace(/_/g, ' ')).join(', ')}.
         </p>
       </div>
 
       <div class="grid grid-cols-2 gap-4">
         <div>
-          <label for="revenue_min_usd" class="text-sm font-medium text-slate-900 block mb-1">
+          <label
+            for="revenue_min_usd"
+            class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+          >
             Revenue min (USD)
           </label>
           <input
@@ -442,11 +464,14 @@ const runDisabledReason = !runWorkerUrl
             value={(configRow.config as NewBusinessConfig).revenue_range.min_usd}
             min="0"
             step="50000"
-            class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+            class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
           />
         </div>
         <div>
-          <label for="revenue_max_usd" class="text-sm font-medium text-slate-900 block mb-1">
+          <label
+            for="revenue_max_usd"
+            class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+          >
             Revenue max (USD)
           </label>
           <input
@@ -456,20 +481,25 @@ const runDisabledReason = !runWorkerUrl
             value={(configRow.config as NewBusinessConfig).revenue_range.max_usd}
             min="0"
             step="50000"
-            class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+            class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
           />
         </div>
       </div>
 
       <div>
-        <label for="geos" class="text-sm font-medium text-slate-900 block mb-1">
-          Geographies <span class="text-xs text-slate-500">(one per line)</span>
+        <label
+          for="geos"
+          class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+        >
+          Geographies <span class="text-xs text-[color:var(--color-text-secondary)]"
+            >(one per line)</span
+          >
         </label>
         <textarea
           id="geos"
           name="geos"
           rows="2"
-          class="w-full border border-slate-300 rounded px-3 py-2 text-sm font-mono"
+          class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
           set:html={(configRow.config as NewBusinessConfig).geos.join('\n')}
         />
       </div>
@@ -477,7 +507,9 @@ const runDisabledReason = !runWorkerUrl
       {
         type === 'new_business' && (
           <div>
-            <label class="text-sm font-medium text-slate-900 block mb-2">Data sources</label>
+            <label class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-2">
+              Data sources
+            </label>
             <div class="space-y-1">
               {nb.soda_sources.map((s) => (
                 <label class="flex items-center gap-2 text-sm">
@@ -485,13 +517,13 @@ const runDisabledReason = !runWorkerUrl
                     type="checkbox"
                     name={`soda_${s.city}`}
                     checked={s.enabled}
-                    class="w-4 h-4 rounded border-slate-300"
+                    class="w-4 h-4 rounded border-[color:var(--color-border)]"
                   />
                   <span class="font-mono text-xs">{s.city.replace(/_/g, ' ')}</span>
                 </label>
               ))}
             </div>
-            <p class="text-xs text-slate-500 mt-1">
+            <p class="text-xs text-[color:var(--color-text-secondary)] mt-1">
               Per-city toggles. Unchecking skips that feed entirely on the next run.
             </p>
           </div>
@@ -501,14 +533,18 @@ const runDisabledReason = !runWorkerUrl
       {
         type === 'job_monitor' && (
           <div>
-            <label for="search_queries" class="text-sm font-medium text-slate-900 block mb-1">
-              Search queries <span class="text-xs text-slate-500">(one per line)</span>
+            <label
+              for="search_queries"
+              class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+            >
+              Search queries{' '}
+              <span class="text-xs text-[color:var(--color-text-secondary)]">(one per line)</span>
             </label>
             <textarea
               id="search_queries"
               name="search_queries"
               rows="8"
-              class="w-full border border-slate-300 rounded px-3 py-2 text-sm font-mono"
+              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
               set:html={jm.search_queries.join('\n')}
             />
           </div>
@@ -519,27 +555,36 @@ const runDisabledReason = !runWorkerUrl
         type === 'review_mining' && (
           <>
             <div>
-              <label for="discovery_queries" class="text-sm font-medium text-slate-900 block mb-1">
-                Discovery queries <span class="text-xs text-slate-500">(one per line)</span>
+              <label
+                for="discovery_queries"
+                class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+              >
+                Discovery queries{' '}
+                <span class="text-xs text-[color:var(--color-text-secondary)]">(one per line)</span>
               </label>
               <textarea
                 id="discovery_queries"
                 name="discovery_queries"
                 rows="10"
-                class="w-full border border-slate-300 rounded px-3 py-2 text-sm font-mono"
+                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
                 set:html={rm.discovery_queries.join('\n')}
               />
             </div>
             <div>
-              <label class="text-sm font-medium text-slate-900 block mb-1">Search area</label>
-              <p class="text-xs text-slate-500 mb-2">
+              <label class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1">
+                Search area
+              </label>
+              <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
                 Google Places biases results near this point. Defaults are Phoenix downtown
                 (33.4484, -112.074) with a 50km radius — covers Scottsdale, Tempe, Mesa, Chandler,
                 Glendale.
               </p>
               <div class="grid grid-cols-3 gap-4">
                 <div>
-                  <label for="geo_lat" class="text-xs text-slate-600 block mb-1">
+                  <label
+                    for="geo_lat"
+                    class="text-xs text-[color:var(--color-text-secondary)] block mb-1"
+                  >
                     Latitude
                   </label>
                   <input
@@ -548,11 +593,14 @@ const runDisabledReason = !runWorkerUrl
                     name="geo_lat"
                     value={rm.geo_center.lat}
                     step="0.0001"
-                    class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                    class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
                   />
                 </div>
                 <div>
-                  <label for="geo_lon" class="text-xs text-slate-600 block mb-1">
+                  <label
+                    for="geo_lon"
+                    class="text-xs text-[color:var(--color-text-secondary)] block mb-1"
+                  >
                     Longitude
                   </label>
                   <input
@@ -561,11 +609,14 @@ const runDisabledReason = !runWorkerUrl
                     name="geo_lon"
                     value={rm.geo_center.lon}
                     step="0.0001"
-                    class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                    class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
                   />
                 </div>
                 <div>
-                  <label for="geo_radius_km" class="text-xs text-slate-600 block mb-1">
+                  <label
+                    for="geo_radius_km"
+                    class="text-xs text-[color:var(--color-text-secondary)] block mb-1"
+                  >
                     Radius (km, 1–500)
                   </label>
                   <input
@@ -575,7 +626,7 @@ const runDisabledReason = !runWorkerUrl
                     value={rm.geo_radius_km}
                     min="1"
                     max="500"
-                    class="w-full border border-slate-300 rounded px-3 py-2 text-sm"
+                    class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
                   />
                 </div>
               </div>
@@ -594,14 +645,18 @@ const runDisabledReason = !runWorkerUrl
       {
         type === 'social_listening' && (
           <div>
-            <label for="search_queries" class="text-sm font-medium text-slate-900 block mb-1">
-              Search queries <span class="text-xs text-slate-500">(one per line)</span>
+            <label
+              for="search_queries"
+              class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+            >
+              Search queries{' '}
+              <span class="text-xs text-[color:var(--color-text-secondary)]">(one per line)</span>
             </label>
             <textarea
               id="search_queries"
               name="search_queries"
               rows="5"
-              class="w-full border border-slate-300 rounded px-3 py-2 text-sm font-mono"
+              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
               set:html={sl.search_queries.join('\n')}
             />
           </div>
@@ -611,7 +666,7 @@ const runDisabledReason = !runWorkerUrl
       <div>
         <button
           type="submit"
-          class="px-4 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+          class="px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
         >
           Save configuration
         </button>
@@ -620,21 +675,31 @@ const runDisabledReason = !runWorkerUrl
   </section>
 
   <section aria-labelledby="volume" class="mb-8">
-    <h3 id="volume" class="text-base font-semibold text-slate-900 mb-3">Signal volume (30 days)</h3>
-    <div class="bg-white rounded-lg border border-slate-200 p-card">
+    <h3 id="volume" class="text-base font-semibold text-[color:var(--color-text-primary)] mb-3">
+      Signal volume (30 days)
+    </h3>
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
       {
         daysWithData.length === 0 ? (
-          <p class="text-sm text-slate-500">No signals in the last 30 days.</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">
+            No signals in the last 30 days.
+          </p>
         ) : (
           <ul class="space-y-1">
             {daysWithData.map((d) => (
               <li class="flex items-center gap-3 text-sm">
-                <span class="text-xs text-slate-500 font-mono w-20">{d.day}</span>
+                <span class="text-xs text-[color:var(--color-text-secondary)] font-mono w-20">
+                  {d.day}
+                </span>
                 <span
                   class="h-3 bg-primary/20 rounded-sm"
                   style={`width: ${(d.count / maxDayCount) * 100}%; min-width: 2px;`}
                 />
-                <span class="text-xs text-slate-700 font-medium">{d.count}</span>
+                <span class="text-xs text-[color:var(--color-text-primary)] font-medium">
+                  {d.count}
+                </span>
               </li>
             ))}
           </ul>
@@ -644,29 +709,33 @@ const runDisabledReason = !runWorkerUrl
   </section>
 
   <section aria-labelledby="signals">
-    <h3 id="signals" class="text-base font-semibold text-slate-900 mb-3">
+    <h3 id="signals" class="text-base font-semibold text-[color:var(--color-text-primary)] mb-3">
       Last {signalRows.length} signals
     </h3>
     {
       signalRows.length === 0 ? (
-        <div class="bg-white rounded-lg border border-slate-200 p-card">
-          <p class="text-sm text-slate-500">No signals yet for this pipeline.</p>
+        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
+          <p class="text-sm text-[color:var(--color-text-secondary)]">
+            No signals yet for this pipeline.
+          </p>
         </div>
       ) : (
-        <div class="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
           {signalRows.map((s) => (
             <details class="group">
-              <summary class="px-6 py-3 flex items-start justify-between gap-3 cursor-pointer hover:bg-slate-50 list-none">
+              <summary class="px-6 py-3 flex items-start justify-between gap-3 cursor-pointer hover:bg-[color:var(--color-background)] list-none">
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2 flex-wrap">
                     <a
                       href={`/admin/entities/${s.id}`}
-                      class="text-sm font-medium text-slate-900 hover:text-primary truncate"
+                      class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary truncate"
                     >
                       {s.name}
                     </a>
                     {s.pain_score !== null && (
-                      <span class="text-xs text-slate-500">Pain: {s.pain_score}/10</span>
+                      <span class="text-xs text-[color:var(--color-text-secondary)]">
+                        Pain: {s.pain_score}/10
+                      </span>
                     )}
                     {s.tier && (
                       <span class={`text-xs px-1.5 py-0.5 rounded ${tierClass(s.tier)}`}>
@@ -674,26 +743,30 @@ const runDisabledReason = !runWorkerUrl
                       </span>
                     )}
                     {s.vertical && s.vertical !== 'unknown' && (
-                      <span class="text-xs text-slate-500 capitalize">
+                      <span class="text-xs text-[color:var(--color-text-secondary)] capitalize">
                         {s.vertical.replace(/_/g, ' ')}
                       </span>
                     )}
-                    {s.area && <span class="text-xs text-slate-400">{s.area}</span>}
+                    {s.area && (
+                      <span class="text-xs text-[color:var(--color-text-muted)]">{s.area}</span>
+                    )}
                   </div>
                   {s.context_content && (
-                    <p class="text-xs text-slate-600 mt-1 line-clamp-2">{s.context_content}</p>
+                    <p class="text-xs text-[color:var(--color-text-secondary)] mt-1 line-clamp-2">
+                      {s.context_content}
+                    </p>
                   )}
                 </div>
-                <div class="flex items-center gap-2 shrink-0 text-xs text-slate-400">
+                <div class="flex items-center gap-2 shrink-0 text-xs text-[color:var(--color-text-muted)]">
                   <span>{formatDate(s.created_at)}</span>
                   <span class="material-symbols-outlined text-sm group-open:rotate-90 transition-transform">
                     chevron_right
                   </span>
                 </div>
               </summary>
-              <div class="px-6 pb-4 pt-1 bg-slate-50/50">
+              <div class="px-6 pb-4 pt-1 bg-[color:var(--color-background)]/50">
                 {s.context_source_ref && (
-                  <p class="text-xs text-slate-500 mb-2">
+                  <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
                     Source ref: <code class="font-mono">{s.context_source_ref}</code>
                   </p>
                 )}
@@ -702,7 +775,9 @@ const runDisabledReason = !runWorkerUrl
                     {prettyJson(s.context_metadata)}
                   </pre>
                 ) : (
-                  <p class="text-xs text-slate-500 italic">No metadata recorded.</p>
+                  <p class="text-xs text-[color:var(--color-text-secondary)] italic">
+                    No metadata recorded.
+                  </p>
                 )}
               </div>
             </details>

--- a/src/pages/admin/generators/index.astro
+++ b/src/pages/admin/generators/index.astro
@@ -159,10 +159,10 @@ function vlabel(v: string): string {
 >
   <div class="flex items-start justify-between mb-6 gap-4 flex-wrap">
     <div>
-      <h2 class="text-xl font-semibold text-slate-900">Generators</h2>
-      <p class="text-sm text-slate-600 mt-1">
+      <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Generators</h2>
+      <p class="text-sm text-[color:var(--color-text-secondary)] mt-1">
         Lead generation pipelines. Each pipeline writes entities at stage <code
-          class="text-xs bg-slate-100 px-1 rounded">signal</code
+          class="text-xs bg-[color:var(--color-border-subtle)] px-1 rounded">signal</code
         >.
       </p>
     </div>
@@ -181,7 +181,7 @@ function vlabel(v: string): string {
         return (
           <a
             href={`/admin/generators/${pipeline.id}`}
-            class="block bg-white rounded-lg border border-slate-200 p-card hover:border-slate-300 hover:shadow-sm transition-all"
+            class="block bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card hover:border-[color:var(--color-border)] hover:shadow-sm transition-all"
           >
             <div class="flex items-start justify-between mb-3 gap-2">
               <div class="min-w-0">
@@ -190,64 +190,86 @@ function vlabel(v: string): string {
                     class={`w-2 h-2 rounded-full shrink-0 ${enabled ? 'bg-green-500' : 'bg-slate-300'}`}
                     title={enabled ? 'Enabled' : 'Disabled'}
                   />
-                  <h3 class="text-base font-semibold text-slate-900 truncate">
+                  <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] truncate">
                     {PIPELINE_LABELS[pipeline.id]}
                   </h3>
                 </div>
-                <p class="text-xs text-slate-500 mt-0.5">{pipeline.description}</p>
+                <p class="text-xs text-[color:var(--color-text-secondary)] mt-0.5">
+                  {pipeline.description}
+                </p>
               </div>
-              <span class="text-xs text-slate-400 whitespace-nowrap">{lastRun(pipeline.id)}</span>
+              <span class="text-xs text-[color:var(--color-text-muted)] whitespace-nowrap">
+                {lastRun(pipeline.id)}
+              </span>
             </div>
 
             <dl class="grid grid-cols-2 gap-row text-sm">
               <div>
-                <dt class="text-xs text-slate-500">Total signals</dt>
-                <dd class="text-slate-900 font-medium">{m.total_signals}</dd>
+                <dt class="text-xs text-[color:var(--color-text-secondary)]">Total signals</dt>
+                <dd class="text-[color:var(--color-text-primary)] font-medium">
+                  {m.total_signals}
+                </dd>
               </div>
               <div>
-                <dt class="text-xs text-slate-500">Last 7 days</dt>
-                <dd class="text-slate-900 font-medium">{m.last_7d}</dd>
+                <dt class="text-xs text-[color:var(--color-text-secondary)]">Last 7 days</dt>
+                <dd class="text-[color:var(--color-text-primary)] font-medium">{m.last_7d}</dd>
               </div>
 
               {painPct >= 50 && avgPain !== null && (
                 <div>
-                  <dt class="text-xs text-slate-500">
-                    Avg pain <span class="text-slate-400">({painPct}% coverage)</span>
+                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                    Avg pain{' '}
+                    <span class="text-[color:var(--color-text-muted)]">({painPct}% coverage)</span>
                   </dt>
-                  <dd class="text-slate-900 font-medium">{avgPain.toFixed(1)}/10</dd>
+                  <dd class="text-[color:var(--color-text-primary)] font-medium">
+                    {avgPain.toFixed(1)}/10
+                  </dd>
                 </div>
               )}
 
               {verticalPct >= 50 && m.top_vertical && (
                 <div>
-                  <dt class="text-xs text-slate-500">
-                    Top vertical <span class="text-slate-400">({verticalPct}% coverage)</span>
+                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                    Top vertical{' '}
+                    <span class="text-[color:var(--color-text-muted)]">
+                      ({verticalPct}% coverage)
+                    </span>
                   </dt>
-                  <dd class="text-slate-900 font-medium capitalize">{vlabel(m.top_vertical)}</dd>
+                  <dd class="text-[color:var(--color-text-primary)] font-medium capitalize">
+                    {vlabel(m.top_vertical)}
+                  </dd>
                 </div>
               )}
 
               {empPct >= 50 && (
                 <div>
-                  <dt class="text-xs text-slate-500">
-                    Employee count <span class="text-slate-400">({empPct}% coverage)</span>
+                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                    Employee count{' '}
+                    <span class="text-[color:var(--color-text-muted)]">({empPct}% coverage)</span>
                   </dt>
-                  <dd class="text-slate-900 font-medium">{m.has_employee_count} enriched</dd>
+                  <dd class="text-[color:var(--color-text-primary)] font-medium">
+                    {m.has_employee_count} enriched
+                  </dd>
                 </div>
               )}
 
               {areaPct >= 50 && (
                 <div>
-                  <dt class="text-xs text-slate-500">
-                    Area <span class="text-slate-400">({areaPct}% coverage)</span>
+                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                    Area{' '}
+                    <span class="text-[color:var(--color-text-muted)]">({areaPct}% coverage)</span>
                   </dt>
-                  <dd class="text-slate-900 font-medium">{m.has_area} tagged</dd>
+                  <dd class="text-[color:var(--color-text-primary)] font-medium">
+                    {m.has_area} tagged
+                  </dd>
                 </div>
               )}
             </dl>
 
             {m.total_signals === 0 && (
-              <p class="text-xs text-slate-500 mt-3 italic">No signals yet.</p>
+              <p class="text-xs text-[color:var(--color-text-secondary)] mt-3 italic">
+                No signals yet.
+              </p>
             )}
           </a>
         )

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -144,41 +144,51 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 <AdminLayout title="Dashboard — SMD Services" maxWidth="max-w-6xl">
   <div class="space-y-card">
     <!-- Card 1: Today's Work -->
-    <section class="bg-white rounded-lg border border-slate-200 p-card">
-      <h2 class="text-base font-semibold text-slate-900 mb-4">Today's Work</h2>
+    <section
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h2 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Today's Work
+      </h2>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-stack">
         <a
           href="/admin/entities?stage=signal"
-          class="flex items-center gap-row p-row rounded-lg hover:bg-slate-50 transition-colors"
+          class="flex items-center gap-row p-row rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
         >
           <div
             class:list={[
               'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
-              signalCount > 0 ? 'bg-amber-100 text-amber-700' : 'bg-slate-100 text-slate-400',
+              signalCount > 0
+                ? 'bg-amber-100 text-amber-700'
+                : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-muted)]',
             ]}
           >
             {signalCount}
           </div>
           <div>
-            <div class="text-sm font-medium text-slate-900">Signals to triage</div>
-            <div class="text-xs text-slate-500">Promote or dismiss</div>
+            <div class="text-sm font-medium text-[color:var(--color-text-primary)]">
+              Signals to triage
+            </div>
+            <div class="text-xs text-[color:var(--color-text-secondary)]">Promote or dismiss</div>
           </div>
         </a>
 
-        <div class="flex items-center gap-row p-row rounded-lg">
+        <div class="flex items-center gap-row p-row rounded-[var(--radius-card)]">
           <div
             class:list={[
               'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
               todayAssessments.length > 0
                 ? 'bg-indigo-100 text-indigo-700'
-                : 'bg-slate-100 text-slate-400',
+                : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-muted)]',
             ]}
           >
             {todayAssessments.length}
           </div>
           <div>
-            <div class="text-sm font-medium text-slate-900">Assessments today</div>
-            <div class="text-xs text-slate-500">
+            <div class="text-sm font-medium text-[color:var(--color-text-primary)]">
+              Assessments today
+            </div>
+            <div class="text-xs text-[color:var(--color-text-secondary)]">
               {
                 todayAssessments.length > 0
                   ? todayAssessments
@@ -200,19 +210,23 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
         <a
           href="/admin/follow-ups?filter=overdue"
-          class="flex items-center gap-row p-row rounded-lg hover:bg-slate-50 transition-colors"
+          class="flex items-center gap-row p-row rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
         >
           <div
             class:list={[
               'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
-              overdueCount > 0 ? 'bg-red-100 text-red-700' : 'bg-slate-100 text-slate-400',
+              overdueCount > 0
+                ? 'bg-red-100 text-red-700'
+                : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-muted)]',
             ]}
           >
             {overdueCount}
           </div>
           <div>
-            <div class="text-sm font-medium text-slate-900">Overdue follow-ups</div>
-            <div class="text-xs text-slate-500">
+            <div class="text-sm font-medium text-[color:var(--color-text-primary)]">
+              Overdue follow-ups
+            </div>
+            <div class="text-xs text-[color:var(--color-text-secondary)]">
               {overdueCount > 0 ? 'Needs attention' : 'All clear'}
             </div>
           </div>
@@ -221,10 +235,14 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
     </section>
 
     <!-- Card 2: Pipeline State -->
-    <section class="bg-white rounded-lg border border-slate-200 p-card">
+    <section
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-base font-semibold text-slate-900">Pipeline</h2>
-        <a href="/admin/entities" class="text-xs text-slate-500 hover:text-slate-700"
+        <h2 class="text-base font-semibold text-[color:var(--color-text-primary)]">Pipeline</h2>
+        <a
+          href="/admin/entities"
+          class="text-xs text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
           >{totalPipeline} total</a
         >
       </div>
@@ -232,7 +250,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
       <!-- Funnel bar -->
       {
         totalPipeline > 0 && (
-          <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-slate-100">
+          <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-[color:var(--color-border-subtle)]">
             {pipelineStages.map((s) =>
               s.count > 0 ? (
                 <div
@@ -258,17 +276,19 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           pipelineStages.map((s) => (
             <a
               href={`/admin/entities?stage=${s.stage}`}
-              class="text-center p-2 rounded-lg hover:bg-slate-50 transition-colors"
+              class="text-center p-2 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
             >
               <div
                 class:list={[
                   'text-2xl font-bold',
-                  s.count > 0 ? 'text-slate-900' : 'text-slate-300',
+                  s.count > 0
+                    ? 'text-[color:var(--color-text-primary)]'
+                    : 'text-[color:var(--color-text-muted)]',
                 ]}
               >
                 {s.count}
               </div>
-              <div class="text-xs text-slate-500">{s.label}</div>
+              <div class="text-xs text-[color:var(--color-text-secondary)]">{s.label}</div>
             </a>
           ))
         }
@@ -276,10 +296,10 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
       {
         pipeline.lost > 0 && (
-          <div class="mt-3 pt-3 border-t border-slate-100 text-center">
+          <div class="mt-3 pt-3 border-t border-[color:var(--color-border-subtle)] text-center">
             <a
               href="/admin/entities?stage=lost"
-              class="text-xs text-slate-400 hover:text-slate-600"
+              class="text-xs text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-secondary)]"
             >
               {pipeline.lost} lost
             </a>
@@ -290,43 +310,51 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-card">
       <!-- Card 3: Revenue -->
-      <section class="bg-white rounded-lg border border-slate-200 p-card">
-        <h2 class="text-base font-semibold text-slate-900 mb-4">Revenue</h2>
+      <section
+        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      >
+        <h2 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">Revenue</h2>
         <div class="space-y-row">
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">Invoiced</span>
-            <span class="text-lg font-semibold text-slate-900">
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Invoiced</span>
+            <span class="text-lg font-semibold text-[color:var(--color-text-primary)]">
               ${revenue.total_invoiced.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">Paid</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Paid</span>
             <span class="text-lg font-semibold text-green-600">
               ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">Outstanding</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Outstanding</span>
             <span
               class:list={[
                 'text-lg font-semibold',
-                outstandingTotal > 0 ? 'text-amber-600' : 'text-slate-400',
+                outstandingTotal > 0 ? 'text-amber-600' : 'text-[color:var(--color-text-muted)]',
               ]}
             >
               ${outstandingTotal.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
 
-          <div class="pt-3 border-t border-slate-100">
+          <div class="pt-3 border-t border-[color:var(--color-border-subtle)]">
             <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Active engagements</span>
-              <span class="text-sm font-medium text-slate-900">{activeEngagements.length}</span>
+              <span class="text-sm text-[color:var(--color-text-secondary)]"
+                >Active engagements</span
+              >
+              <span class="text-sm font-medium text-[color:var(--color-text-primary)]"
+                >{activeEngagements.length}</span
+              >
             </div>
             {
               health.avg_days_to_completion > 0 && (
                 <div class="flex justify-between items-baseline mt-1">
-                  <span class="text-sm text-slate-500">Avg completion</span>
-                  <span class="text-sm font-medium text-slate-900">
+                  <span class="text-sm text-[color:var(--color-text-secondary)]">
+                    Avg completion
+                  </span>
+                  <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
                     {health.avg_days_to_completion} days
                   </span>
                 </div>
@@ -337,16 +365,22 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
       </section>
 
       <!-- Card 4: Follow-up Health -->
-      <section class="bg-white rounded-lg border border-slate-200 p-card">
+      <section
+        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      >
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-base font-semibold text-slate-900">Follow-up Health</h2>
-          <a href="/admin/follow-ups" class="text-xs text-slate-500 hover:text-slate-700"
+          <h2 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+            Follow-up Health
+          </h2>
+          <a
+            href="/admin/follow-ups"
+            class="text-xs text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
             >View all</a
           >
         </div>
         <div class="space-y-row">
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">On-time rate</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">On-time rate</span>
             <span
               class:list={[
                 'text-lg font-semibold',
@@ -361,36 +395,40 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">Sent on time</span>
-            <span class="text-sm font-medium text-slate-900">{compliance.completed_on_time}</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Sent on time</span>
+            <span class="text-sm font-medium text-[color:var(--color-text-primary)]"
+              >{compliance.completed_on_time}</span
+            >
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">Sent late</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Sent late</span>
             <span
               class:list={[
                 'text-sm font-medium',
-                compliance.completed_late > 0 ? 'text-amber-600' : 'text-slate-900',
+                compliance.completed_late > 0
+                  ? 'text-amber-600'
+                  : 'text-[color:var(--color-text-primary)]',
               ]}
             >
               {compliance.completed_late}
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-slate-500">Missed</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Missed</span>
             <span
               class:list={[
                 'text-sm font-medium',
-                compliance.missed > 0 ? 'text-red-600' : 'text-slate-900',
+                compliance.missed > 0 ? 'text-red-600' : 'text-[color:var(--color-text-primary)]',
               ]}
             >
               {compliance.missed}
             </span>
           </div>
 
-          <div class="pt-3 border-t border-slate-100">
+          <div class="pt-3 border-t border-[color:var(--color-border-subtle)]">
             <div class="flex justify-between items-baseline">
-              <span class="text-sm text-slate-500">Upcoming</span>
-              <span class="text-sm font-medium text-slate-900"
+              <span class="text-sm text-[color:var(--color-text-secondary)]">Upcoming</span>
+              <span class="text-sm font-medium text-[color:var(--color-text-primary)]"
                 >{upcomingFollowUps.length} scheduled</span
               >
             </div>
@@ -400,9 +438,13 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
     </div>
 
     <!-- Card 5: Automations -->
-    <section class="bg-white rounded-lg border border-slate-200 p-card">
-      <h2 class="text-base font-semibold text-slate-900 mb-4">Automations</h2>
-      <div class="divide-y divide-slate-100">
+    <section
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h2 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+        Automations
+      </h2>
+      <div class="divide-y divide-[color:var(--color-border-subtle)]">
         <!-- Google Calendar -->
         <div class="flex items-center justify-between py-2">
           <div class="flex items-center gap-2">
@@ -417,12 +459,14 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               ]}
             >
             </div>
-            <span class="text-sm text-slate-600">Google Calendar</span>
+            <span class="text-sm text-[color:var(--color-text-secondary)]">Google Calendar</span>
           </div>
           <span
             class:list={[
               'text-xs',
-              calStatus === 'error' || calStatus === 'revoked' ? 'text-red-600' : 'text-slate-400',
+              calStatus === 'error' || calStatus === 'revoked'
+                ? 'text-red-600'
+                : 'text-[color:var(--color-text-muted)]',
             ]}
           >
             {
@@ -462,13 +506,15 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               <div class="flex items-center justify-between py-2">
                 <div class="flex items-center gap-2">
                   <div class:list={['w-2 h-2 rounded-full', p.color]} />
-                  <span class="text-sm text-slate-600">{p.label}</span>
+                  <span class="text-sm text-[color:var(--color-text-secondary)]">{p.label}</span>
                 </div>
-                <span class="text-xs text-slate-400">{p.ago}</span>
+                <span class="text-xs text-[color:var(--color-text-muted)]">{p.ago}</span>
               </div>
             ))
           ) : (
-            <div class="py-2 text-xs text-slate-400">No pipeline data yet</div>
+            <div class="py-2 text-xs text-[color:var(--color-text-muted)]">
+              No pipeline data yet
+            </div>
           )
         }
       </div>

--- a/src/pages/admin/settings/google-connect.astro
+++ b/src/pages/admin/settings/google-connect.astro
@@ -51,11 +51,13 @@ const errorMessages: Record<string, string> = {
     { label: 'Google Calendar' },
   ]}
 >
-  <h2 class="text-xl font-semibold text-slate-900 mb-6">Google Calendar Integration</h2>
+  <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)] mb-6">
+    Google Calendar Integration
+  </h2>
 
   {
     successParam === 'connected' && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-lg">
+      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-green-800">Google Calendar connected successfully.</p>
       </div>
     )
@@ -63,7 +65,7 @@ const errorMessages: Record<string, string> = {
 
   {
     successParam === 'disconnected' && (
-      <div class="mb-6 p-stack bg-blue-50 border border-blue-200 rounded-lg">
+      <div class="mb-6 p-stack bg-blue-50 border border-blue-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-blue-800">Google Calendar disconnected.</p>
       </div>
     )
@@ -71,7 +73,7 @@ const errorMessages: Record<string, string> = {
 
   {
     errorParam && (
-      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-lg">
+      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--radius-card)]">
         <p class="text-sm text-red-800">
           {errorMessages[errorParam] ?? `Something went wrong (${errorParam}). Please try again.`}
         </p>
@@ -79,36 +81,42 @@ const errorMessages: Record<string, string> = {
     )
   }
 
-  <div class="bg-white rounded-lg border border-slate-200 p-card">
+  <div
+    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+  >
     {
       isConnected ? (
         <div>
           <div class="flex items-center gap-row mb-4">
             <div class="w-3 h-3 rounded-full bg-green-500" />
-            <span class="text-sm font-medium text-slate-900">Connected</span>
+            <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+              Connected
+            </span>
           </div>
           <dl class="grid grid-cols-1 gap-row text-sm mb-6">
             <div>
-              <dt class="text-slate-500">Account</dt>
-              <dd class="text-slate-900 font-medium">{integration.account_email}</dd>
+              <dt class="text-[color:var(--color-text-secondary)]">Account</dt>
+              <dd class="text-[color:var(--color-text-primary)] font-medium">
+                {integration.account_email}
+              </dd>
             </div>
             <div>
-              <dt class="text-slate-500">Calendar</dt>
-              <dd class="text-slate-900">{integration.calendar_id}</dd>
+              <dt class="text-[color:var(--color-text-secondary)]">Calendar</dt>
+              <dd class="text-[color:var(--color-text-primary)]">{integration.calendar_id}</dd>
             </div>
             <div>
-              <dt class="text-slate-500">Status</dt>
-              <dd class="text-slate-900">{integration.status}</dd>
+              <dt class="text-[color:var(--color-text-secondary)]">Status</dt>
+              <dd class="text-[color:var(--color-text-primary)]">{integration.status}</dd>
             </div>
             <div>
-              <dt class="text-slate-500">Connected</dt>
-              <dd class="text-slate-900">
+              <dt class="text-[color:var(--color-text-secondary)]">Connected</dt>
+              <dd class="text-[color:var(--color-text-primary)]">
                 {new Date(integration.created_at).toLocaleDateString()}
               </dd>
             </div>
             {integration.last_error && (
               <div>
-                <dt class="text-slate-500">Last error</dt>
+                <dt class="text-[color:var(--color-text-secondary)]">Last error</dt>
                 <dd class="text-red-600">{integration.last_error}</dd>
               </div>
             )}
@@ -117,7 +125,7 @@ const errorMessages: Record<string, string> = {
             <input type="hidden" name="action" value="disconnect" />
             <button
               type="submit"
-              class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100 transition-colors"
+              class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-[var(--radius-card)] hover:bg-red-100 transition-colors"
               onclick="return confirm('Disconnect Google Calendar? Existing booked events will not be affected.')"
             >
               Disconnect
@@ -128,15 +136,17 @@ const errorMessages: Record<string, string> = {
         <div>
           <div class="flex items-center gap-row mb-4">
             <div class="w-3 h-3 rounded-full bg-slate-300" />
-            <span class="text-sm font-medium text-slate-900">Not connected</span>
+            <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+              Not connected
+            </span>
           </div>
-          <p class="text-sm text-slate-600 mb-6">
+          <p class="text-sm text-[color:var(--color-text-secondary)] mb-6">
             Connect your Google Calendar to automatically create events when assessments are booked
             and check availability in real time.
           </p>
           <a
             href="/api/auth/google/connect"
-            class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors"
+            class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
           >
             Connect Google Calendar
           </a>


### PR DESCRIPTION
## Summary

Cuts the admin console (`admin.smd.services`) over to the Architect's Studio identity committed with the portal in #455. One commit, all eleven admin surfaces.

## What landed

- **`.design/admin-ux-brief.md`** — Step 4 deliverable. Scope (11 surfaces, archetype + purpose per), visit modes, identity inheritance, admin-specific chrome conventions (masthead, breadcrumbs, section labels, reference lines, tables, buttons, stage/tier/context tags, money, dates), anti-patterns, data density rules, open follow-ups.

- **`AdminLayout.astro`** — raw slate colors → semantic tokens, `shadow-lg` on mobile menu removed (identity is flat), `rounded-lg` → `rounded-[var(--radius-card)]`.

- **`src/lib/ui/status-badge.ts`** — rewritten to return a full rectangular-tag class list (structure + tone). Filled backgrounds with white text, mono caps, 2px radius, matches portal `StatusPill` / `TONE_CLASS` shape. Callers simplified to `<span class={statusBadgeClass(status)}>`.

- **All 11 admin pages** — 769 bulk replacements across slate color families, radii, and shadows. Plus one regex-literal escape fix in `entities/[id].astro` and a button-rainbow collapse (six distinct color families for stage-transition buttons → uniform ochre primary; label-first).

## Identity shift

| Token | Before | After |
|---|---|---|
| Palette | Cool slate (`bg-slate-50..200`, `text-slate-300..900`) | Warm semantic tokens (`--color-background`, `--color-border(-subtle)`, `--color-text-{primary,secondary,muted}`) |
| Radii | `rounded-md/lg/xl/2xl` | `rounded-[var(--radius-card)]` (2px) |
| Shadows | `shadow-lg` on mobile menu | None — identity is flat |
| Status tags | Tinted `bg-{color}-100 text-{color}-700` pills | Filled ochre/green/red/neutral rectangles with white text, mono caps, 2px |
| Stage-transition buttons | 6-color rainbow (purple / indigo / green / emerald / teal / blue) | Uniform ochre primary, label-differentiated |

## Out of admin scope (flagged, not resolved)

- **Local tag helpers** in `entities/[id].astro`, `assessments/[id].astro`, `engagements/[id].astro` still return soft Tailwind family tints for stage (8), tier (4), context-type (13). Documented as a follow-up in the admin brief — signal density doesn't collapse cleanly into five tones and these are operator-only contextual metadata.
- **`src/components/admin/` primitives directory** doesn't exist yet. Premature to extract — scope not yet stable.
- **Dashboard index and analytics** still have basic page-level styling. Functional but not visually reimagined; next admin pass.

## Test plan

Local `npm run verify` is green:
- [x] `typecheck`: 0 errors
- [x] `typecheck:workers`: clean
- [x] `format:check`: all files use Prettier code style
- [x] `lint`: 0 errors (11 pre-existing worker warnings unchanged)
- [x] `build`: complete
- [x] `test`: 1272 / 1272 pass (2 skipped, pre-existing)

## Captain visual review

Dev server, log in as admin, walk through:
- [ ] `/admin` — dashboard chrome reads warm, not cool
- [ ] `/admin/entities` — list items use semantic tokens; filters ochre when active
- [ ] `/admin/entities/[id]` — stage-transition buttons all ochre (not rainbow); status tags rectangular filled
- [ ] `/admin/entities/[id]/quotes/[qid]` — quote builder chrome, tables, status tag on header
- [ ] `/admin/assessments/[id]` — live-notes textarea and completion form chrome
- [ ] `/admin/engagements/[id]` — milestones, invoices, documents panels; status tag
- [ ] `/admin/follow-ups`, `/admin/generators`, `/admin/analytics`, `/admin/settings/google-connect` — chrome alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
