### PR TITLE
feat(design): marketing identity sweep — Architect's Studio across public surfaces

### DIFF
--- a/.design/marketing-ux-brief.md
+++ b/.design/marketing-ux-brief.md
@@ -1,0 +1,113 @@
+# Marketing — UX Brief (Architect's Studio)
+
+_First-pass brief, authored 2026-04-19 alongside the identity sweep. Scope: the `smd.services` apex (public) surfaces — homepage, booking flow, get-started, scorecard, contact, 404, and the sign-in pages. Every surface inherits the Architect's Studio identity committed in `.design/DESIGN.md`._
+
+## Context
+
+Marketing is the first thing a prospective client sees. They're reading it on a laptop between jobs or on a phone in a truck cab. They're deciding whether to book a call, not whether to read about a framework. Copy + clarity first; chrome second.
+
+SMD Services sells scope-based consulting engagements to businesses doing $750k–$5M in revenue. Positioning: collaborative guide, not diagnostic expert. Marketing must read like the firm it belongs to — calm, direct, substance over polish, evidence over reassurance.
+
+## Scope
+
+| #   | Path                   | Archetype      | Purpose                                                           |
+| --- | ---------------------- | -------------- | ----------------------------------------------------------------- |
+| 1   | `/`                    | marketing-home | Positioning, what-we-do, who-we-help, case snippets, primary CTA. |
+| 2   | `/book`                | booking-wizard | Multi-step booking flow for the paid assessment call.             |
+| 3   | `/book/manage/[token]` | booking-manage | Reschedule / cancel a scheduled assessment via secure link.       |
+| 4   | `/get-started`         | conversion     | Intake form — name, business, rough context before a call.        |
+| 5   | `/scorecard`           | lead-magnet    | Operations scorecard quiz / results flow for top-of-funnel leads. |
+| 6   | `/contact`             | static         | Minimal contact page — email + direct booking link.               |
+| 7   | `/404`                 | error          | Clear message, link back to home.                                 |
+| 8   | `/auth/login`          | gate           | Admin sign-in (magic link).                                       |
+| 9   | `/auth/portal-login`   | gate           | Client-portal sign-in (magic link on the portal subdomain).       |
+| 10  | `/auth/verify`         | gate           | Magic-link verification landing.                                  |
+
+## Visit modes
+
+- **Cold visitor** — first touch via ad, referral, or search. Needs to answer "what does this firm do and should I talk to them?" in the first 10 seconds above the fold.
+- **Returning prospect** — came back after an initial touch. Needs a clear path to book or start.
+- **Book-ready prospect** — email/referral told them to book directly. Lands on `/book` from a deep link.
+- **Researcher** — assistant, spouse, accountant vetting on behalf of the buyer. Needs proof of concreteness and named humans (Scott).
+- **Client** — already engaged; arrived from a stale bookmark or email. Should find their way to `portal.smd.services` without confusion.
+
+## Identity inheritance
+
+All identity rules from `.design/DESIGN.md` apply. Summary of what marketing gets automatically from the token cutover in #455:
+
+- Cabinet Grotesk display, Satoshi body, JetBrains Mono for any data readouts
+- Warm near-white `#FAFAF9` background, graphite ink, ochre primary
+- 2px radii on cards, buttons, pills
+- Flat — no elevation, no shadows
+- Motion minimal (120ms color transitions)
+
+## Identity chrome conventions (marketing interpretations)
+
+- **Global nav.** `Nav.astro` is the marketing site chrome — firm name left, primary CTA right (Book assessment). Sticky on scroll. Matches portal masthead tone: restrained, not marketing-heavy.
+- **Hero.** Oversized Cabinet Grotesk headline, one-line tagline in Satoshi, single CTA. No rotator, no gradient text, no animated keyword reveal. The headline does the work.
+- **Section labels.** Same as portal: mono-caps eyebrow above each major section (`WHAT WE DO`, `WHO WE HELP`, `HOW IT WORKS`, `PRICING`). Hairline-underlined.
+- **Cards.** 2px radius, hairline border, flat. Used sparingly — marketing prefers typographic hierarchy over boxed content.
+- **Booking / form flow.** Steps numbered visually (`1`, `2`, `3`), 2px rounded squares filled with the current step's primary or neutral tone. No progress bars.
+- **Buttons.** Primary CTA is ochre filled. Secondary CTAs are ghost buttons with `--color-border` outline. No gradient, no drop-shadow, no elevation-on-hover.
+- **Footer.** Minimal — copyright, privacy, terms, contact email, portal sign-in link. Typographic, hairline-separated, no decoration.
+
+## Anti-patterns (marketing-specific, additional to identity list)
+
+- Hero video autoplay or background video loops.
+- Parallax scroll, scroll-driven reveals, "as you scroll" animations.
+- Gradient-text headlines, text shadows, text-with-outline treatments.
+- Testimonial carousels with autoplay.
+- Trust-badge rows ("As seen in…") unless the logos are real and earned.
+- Countdown timers or urgency ticker scripts.
+- Email-gated content ("enter your email to read the rest"). Marketing is the read; intake comes after the read.
+- Stock photography of business owners with laptops.
+- Numerical claims without specifics ("10x your operations" — no).
+- Live chat widgets in the bottom-right corner.
+
+## Copy tone
+
+Voice is the same as everywhere else — guide persona, collaborative, evidence over reassurance, no em dashes, no AI filler. Marketing copy is a bit looser than admin but still calm and direct.
+
+Principles (from `CLAUDE.md` §Tone & Positioning Standard):
+
+- Objectives over problems. ("We start by understanding where you're trying to go.")
+- Collaborative, not diagnostic. ("We work alongside you.")
+- No fixed timeframes. ("We start with a conversation" beats "1-hour call".)
+- No published dollar amounts.
+- "Solution" not "systems" in positioning. ("System" is fine when literal.)
+- Always "we" / "our team."
+
+Landing-page samples (already in production, kept as tone reference):
+
+- Hero: "Operational consulting for growing businesses. Figure out what's in the way. Build the right solution together."
+- What we do: "Process design. Custom tools. Systems that talk to each other. AI when AI is the right answer — and nowhere it isn't."
+- Who we help: "$750k to $5M in revenue. Past startup. Not yet ready for a dedicated operations person."
+- CTA: "Book a conversation."
+
+## Success criteria
+
+- Every marketing page renders in Cabinet Grotesk + Satoshi + JetBrains Mono with no Inter / Plus Jakarta fallback (except via system fallback chain).
+- Palette reads warm — no cool slate or indigo anywhere.
+- All buttons render as 2px rectangles (ochre primary, neutral ghost, error red).
+- Booking wizard step indicators render as filled 2px squares with numbered labels, not circles.
+- No shadows, gradients, glow effects, or motion beyond 120ms color transitions.
+- Homepage above-the-fold answers "what does this firm do" without scrolling.
+- Desktop and mobile renders both clean at 390px and 1280px.
+
+## Open follow-ups
+
+- **Email templates** (`src/lib/email/templates.ts`, `src/lib/email/follow-up-templates.ts`, `src/lib/booking/alerts.ts`) still reference `Inter,Arial,sans-serif` inline. Email clients strip custom fonts aggressively; a safe swap to `'Satoshi',Helvetica Neue,Arial,sans-serif` is low-risk but not yet done. Do in a dedicated email-audit pass.
+- **PDF templates** (`src/lib/pdf/sow-template.tsx`, `src/lib/pdf/scorecard-template.tsx`, `src/lib/sow/service.ts`) register fonts via React-PDF; not swept. Changing requires visual regression check because SOW PDFs are client-signed contract documents. Separate PR with before/after renders before merge.
+- **Nav mobile menu** currently a single-level dropdown. If more marketing sections ship, reconsider.
+- **`/scorecard` results page** has a lead-gen email gate. Kept as-is for now (the gate IS the conversion mechanism) — flagged against the anti-pattern only so it's an explicit exception.
+- **Marketing primitive extraction.** Shared components (`Hero`, `Pricing`, `ProblemCards`, `WhoWeHelp`, `HowItWorks`, `FinalCta`, `Footer`, `Nav`) are already componentized in `src/components/`. No new extraction needed.
+
+## Approver
+
+Scott Durgan. Marketing reviewed via dev server at `localhost:4321/` (or staging Vercel build after merge).
+
+---
+
+## Appendix: Token map
+
+Marketing inherits every token from `.design/DESIGN.md` unchanged. No marketing-specific tokens.

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,22 +1,22 @@
 <section class="bg-white px-6 py-24">
   <div class="mx-auto max-w-3xl">
-    <h2 class="text-3xl font-bold text-slate-900">Who We Are</h2>
+    <h2 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Who We Are</h2>
     <div class="mt-8 flex flex-col gap-8 sm:flex-row sm:items-start">
       <img
         src="/scott-durgan.jpg"
         alt="Scott Durgan, founder of SMD Services"
-        class="h-32 w-32 flex-none rounded-full object-cover object-top grayscale"
+        class="h-32 w-32 flex-none rounded-[var(--radius-card)] object-cover object-top grayscale"
         width="128"
         height="128"
         loading="lazy"
       />
       <div class="space-y-6 border-l-4 border-primary pl-6">
-        <p class="text-lg leading-relaxed text-slate-600">
+        <p class="text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
           Scott Durgan spent 20 years building enterprise software and leading product teams. He's a
           creative technologist who listens first and gets how the pieces fit together. He started
           SMD Services because he wanted to put that experience to use for people who need it.
         </p>
-        <p class="text-lg leading-relaxed text-slate-600">
+        <p class="text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
           We're a Phoenix-based team that works with businesses past the startup phase but not yet
           big enough for a dedicated operations person. You know where you're trying to go. You just
           can't get to everything while running the business. That's what we're here for.

--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -46,8 +46,8 @@ const studies = [
 <section class="bg-white px-6 py-24">
   <div class="mx-auto max-w-5xl">
     <div class="mb-4 text-center">
-      <h2 class="text-3xl font-bold text-slate-900">What We Do</h2>
-      <p class="mx-auto mt-4 max-w-2xl text-slate-500">
+      <h2 class="text-3xl font-bold text-[color:var(--color-text-primary)]">What We Do</h2>
+      <p class="mx-auto mt-4 max-w-2xl text-[color:var(--color-text-secondary)]">
         Different businesses, similar patterns. Here's the kind of work we take on.
       </p>
     </div>
@@ -55,34 +55,40 @@ const studies = [
     <div class="mt-12 space-y-8">
       {
         studies.map((study) => (
-          <div class="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-            <div class="border-b border-slate-100 bg-slate-50 px-8 py-5">
+          <div class="overflow-hidden rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white">
+            <div class="border-b border-[color:var(--color-border-subtle)] bg-[color:var(--color-background)] px-8 py-5">
               <div class="flex flex-wrap items-center gap-3">
-                <span class="rounded-full bg-primary px-3 py-1 text-xs font-semibold text-white">
+                <span class="rounded-[var(--radius-card)] bg-primary px-3 py-1 text-xs font-semibold text-white">
                   {study.vertical}
                 </span>
-                <h3 class="text-lg font-bold text-slate-900">{study.business}</h3>
+                <h3 class="text-lg font-bold text-[color:var(--color-text-primary)]">
+                  {study.business}
+                </h3>
               </div>
               <div class="mt-3 flex flex-wrap gap-2">
                 {study.problems.map((problem) => (
-                  <span class="rounded-full bg-slate-200 px-3 py-1 text-xs font-medium text-slate-600">
+                  <span class="rounded-[var(--radius-card)] bg-[color:var(--color-border)] px-3 py-1 text-xs font-medium text-[color:var(--color-text-secondary)]">
                     {problem}
                   </span>
                 ))}
               </div>
             </div>
             <div class="grid gap-0 md:grid-cols-2">
-              <div class="border-b border-slate-100 px-8 py-6 md:border-b-0 md:border-r">
-                <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">
+              <div class="border-b border-[color:var(--color-border-subtle)] px-8 py-6 md:border-b-0 md:border-r">
+                <p class="text-xs font-semibold uppercase tracking-wider text-[color:var(--color-text-muted)]">
                   The situation
                 </p>
-                <p class="mt-3 leading-relaxed text-slate-600">{study.challenge}</p>
+                <p class="mt-3 leading-relaxed text-[color:var(--color-text-secondary)]">
+                  {study.challenge}
+                </p>
               </div>
               <div class="px-8 py-6">
                 <p class="text-xs font-semibold uppercase tracking-wider text-primary">
                   The solution
                 </p>
-                <p class="mt-3 leading-relaxed text-slate-600">{study.solution}</p>
+                <p class="mt-3 leading-relaxed text-[color:var(--color-text-secondary)]">
+                  {study.solution}
+                </p>
                 {study.result && (
                   <p class="mt-4 text-sm font-semibold text-primary">{study.result}</p>
                 )}

--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -9,9 +9,9 @@ const { variant = 'primary', href = '/book', class: className = '' } = Astro.pro
 
 const base = 'inline-flex items-center justify-center font-semibold transition-all'
 const variants = {
-  primary: 'px-8 py-4 bg-primary text-white rounded-lg hover:bg-primary-hover shadow-sm',
+  primary: 'px-8 py-4 bg-primary text-white rounded-[var(--radius-card)] hover:bg-primary-hover',
   'outline-white':
-    'px-8 py-4 border-2 border-white text-white rounded-lg hover:bg-white hover:text-slate-900',
+    'px-8 py-4 border-2 border-white text-white rounded-[var(--radius-card)] hover:bg-white hover:text-[color:var(--color-text-primary)]',
 }
 ---
 

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -5,13 +5,13 @@ import CtaButton from './CtaButton.astro'
 <section id="book" class="bg-slate-900 px-6 py-24">
   <div class="mx-auto max-w-3xl text-center">
     <h2 class="text-3xl font-bold text-white">Let's Talk About Your Business</h2>
-    <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-400">
+    <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--color-text-muted)]">
       We'll ask how things run and where you're trying to go. You'll walk away with a clearer
       picture of how to get there, whether we work together or not.
     </p>
     <div class="mt-10">
       <CtaButton variant="outline-white" href="/book">Book a Call</CtaButton>
-      <p class="mt-4 text-sm text-slate-400">
+      <p class="mt-4 text-sm text-[color:var(--color-text-muted)]">
         Not ready to schedule?
         <a href="/get-started" class="underline hover:text-white"> Tell us about your business </a>
       </p>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,13 +1,22 @@
-<footer class="border-t border-slate-200 bg-slate-50 py-12">
+<footer
+  class="border-t border-[color:var(--color-border)] bg-[color:var(--color-background)] py-12"
+>
   <div
     class="mx-auto flex w-full max-w-5xl flex-col items-center justify-between gap-6 px-6 md:flex-row"
   >
     <div>
-      <a href="/" class="text-sm font-semibold text-slate-800">SMD Services</a>
-      <p class="mt-1 text-sm text-slate-500">&copy; 2026 SMDurgan, LLC. Phoenix, Arizona.</p>
+      <a href="/" class="text-sm font-semibold text-[color:var(--color-text-primary)]"
+        >SMD Services</a
+      >
+      <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
+        &copy; 2026 SMDurgan, LLC. Phoenix, Arizona.
+      </p>
     </div>
     <nav class="flex items-center gap-6">
-      <a class="text-sm text-slate-500 hover:text-slate-900" href="/contact">Contact</a>
+      <a
+        class="text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+        href="/contact">Contact</a
+      >
       <a
         class="rounded bg-primary px-5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-80"
         href="/book">Book a Call</a

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -5,11 +5,13 @@ import CtaButton from './CtaButton.astro'
 <section class="relative overflow-hidden px-6 pb-32 pt-24">
   <div class="mx-auto max-w-4xl text-center">
     <h1
-      class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-slate-900 md:text-7xl"
+      class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-[color:var(--color-text-primary)] md:text-7xl"
     >
       Your Business Has Outgrown How You Run It.
     </h1>
-    <p class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-slate-600">
+    <p
+      class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+    >
       You know where you want to go. We help you figure out what needs to change and build it with
       you.
     </p>

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -21,8 +21,12 @@ const steps = [
 <section class="bg-white px-6 py-24">
   <div class="mx-auto max-w-3xl">
     <div class="mb-16 text-center">
-      <h2 class="text-3xl font-bold text-slate-900">How We Work Together</h2>
-      <p class="mt-4 text-slate-500">A clear process from first conversation to full handoff.</p>
+      <h2 class="text-3xl font-bold text-[color:var(--color-text-primary)]">
+        How We Work Together
+      </h2>
+      <p class="mt-4 text-[color:var(--color-text-secondary)]">
+        A clear process from first conversation to full handoff.
+      </p>
     </div>
     <div class="space-y-12">
       {
@@ -30,15 +34,19 @@ const steps = [
           <div class="flex gap-8">
             <div
               class:list={[
-                'flex h-12 w-12 flex-none items-center justify-center rounded-full text-xl font-bold',
-                i === 0 ? 'bg-primary text-white' : 'bg-slate-100 text-slate-900',
+                'flex h-12 w-12 flex-none items-center justify-center rounded-[var(--radius-card)] text-xl font-bold',
+                i === 0
+                  ? 'bg-primary text-white'
+                  : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-primary)]',
               ]}
             >
               {i + 1}
             </div>
             <div>
-              <h3 class="mb-2 text-xl font-bold text-slate-900">{step.title}</h3>
-              <p class="text-slate-600">{step.description}</p>
+              <h3 class="mb-2 text-xl font-bold text-[color:var(--color-text-primary)]">
+                {step.title}
+              </h3>
+              <p class="text-[color:var(--color-text-secondary)]">{step.description}</p>
             </div>
           </div>
         ))

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,7 +1,7 @@
 <section class="bg-slate-900 px-6 py-24 text-white">
   <div class="mx-auto max-w-4xl text-center">
     <h2 class="mb-4 text-3xl font-bold md:text-4xl">Scoped to Your Business</h2>
-    <p class="mx-auto mb-16 max-w-2xl text-lg text-slate-400">
+    <p class="mx-auto mb-16 max-w-2xl text-lg text-[color:var(--color-text-muted)]">
       Every business is different. We quote a fixed price after we understand yours. No hourly
       billing, no open-ended retainers, no surprises.
     </p>
@@ -9,25 +9,27 @@
     <div class="mb-16 grid gap-8 md:grid-cols-3">
       <div>
         <h3 class="mb-2 text-xl font-bold">Understand</h3>
-        <p class="text-slate-400">
+        <p class="text-[color:var(--color-text-muted)]">
           A conversation to learn your business and define what success looks like.
         </p>
       </div>
       <div>
         <h3 class="mb-2 text-xl font-bold">Quote</h3>
-        <p class="text-slate-400">
+        <p class="text-[color:var(--color-text-muted)]">
           Fixed price based on what we find. You see it before you commit.
         </p>
       </div>
       <div>
         <h3 class="mb-2 text-xl font-bold">Deliver</h3>
-        <p class="text-slate-400">
+        <p class="text-[color:var(--color-text-muted)]">
           Implementation, training, and handoff. All scoped to your objectives.
         </p>
       </div>
     </div>
 
-    <div class="mx-auto max-w-lg rounded-2xl bg-white p-8 text-left text-slate-900">
+    <div
+      class="mx-auto max-w-lg rounded-[var(--radius-card)] bg-white p-8 text-left text-[color:var(--color-text-primary)]"
+    >
       <h3 class="mb-6 text-center text-xl font-bold">How We Price</h3>
       <ul class="space-y-4">
         {
@@ -53,12 +55,12 @@
         }
       </ul>
       <a
-        class="mt-8 block w-full rounded-lg bg-primary py-4 text-center font-bold text-white transition-colors hover:bg-primary-hover"
+        class="mt-8 block w-full rounded-[var(--radius-card)] bg-primary py-4 text-center font-bold text-white transition-colors hover:bg-primary-hover"
         href="/book"
       >
         Book a Call
       </a>
-      <p class="mt-4 text-center text-xs text-slate-400">
+      <p class="mt-4 text-center text-xs text-[color:var(--color-text-muted)]">
         No commitment. Let's just talk about your business.
       </p>
     </div>

--- a/src/components/ProblemCards.astro
+++ b/src/components/ProblemCards.astro
@@ -12,17 +12,21 @@ const problems = [
 ]
 ---
 
-<section class="bg-slate-50 px-6 py-24">
+<section class="bg-[color:var(--color-background)] px-6 py-24">
   <div class="mx-auto max-w-5xl">
     <div class="mb-16 text-center">
-      <h2 class="text-3xl font-bold text-slate-900">Sound Familiar?</h2>
+      <h2 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Sound Familiar?</h2>
     </div>
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
       {
         problems.map((problem) => (
-          <div class="flex flex-col justify-between rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-            <p class="italic leading-relaxed text-slate-700">"{problem.quote}"</p>
-            <p class="mt-6 text-sm font-medium text-slate-500">{problem.name}</p>
+          <div class="flex flex-col justify-between rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-8">
+            <p class="italic leading-relaxed text-[color:var(--color-text-primary)]">
+              "{problem.quote}"
+            </p>
+            <p class="mt-6 text-sm font-medium text-[color:var(--color-text-secondary)]">
+              {problem.name}
+            </p>
           </div>
         ))
       }

--- a/src/components/SkipToMain.astro
+++ b/src/components/SkipToMain.astro
@@ -18,7 +18,7 @@ const { targetId = 'main', label = 'Skip to main content' } = Astro.props
 ---
 
 <a
-  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:rounded-lg focus:border focus:border-[color:var(--color-border)] focus:text-[color:var(--color-primary)] focus:font-medium"
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:rounded-[var(--radius-card)] focus:border focus:border-[color:var(--color-border)] focus:text-[color:var(--color-primary)] focus:font-medium"
   href={`#${targetId}`}
 >
   {label}

--- a/src/components/WhatYouGet.astro
+++ b/src/components/WhatYouGet.astro
@@ -12,9 +12,11 @@ const items = [
 ]
 ---
 
-<section class="bg-slate-50 px-6 py-24">
+<section class="bg-[color:var(--color-background)] px-6 py-24">
   <div class="mx-auto max-w-5xl">
-    <h2 class="mb-12 text-center text-3xl font-bold text-slate-900">What You Get</h2>
+    <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)]">
+      What You Get
+    </h2>
     <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
       {
         items.map((item) => (
@@ -28,7 +30,7 @@ const items = [
             >
               <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
             </svg>
-            <span class="text-lg text-slate-700">{item}</span>
+            <span class="text-lg text-[color:var(--color-text-primary)]">{item}</span>
           </div>
         ))
       }

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -18,23 +18,25 @@ const segments = [
 ]
 ---
 
-<section class="bg-slate-50 px-6 py-24">
+<section class="bg-[color:var(--color-background)] px-6 py-24">
   <div class="mx-auto max-w-5xl">
-    <h2 class="mb-12 text-center text-3xl font-bold text-slate-900">Who We Help</h2>
+    <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)]">
+      Who We Help
+    </h2>
     <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
       {
         segments.map((s) => (
-          <div class="rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-            <h3 class="text-xl font-bold text-slate-900">{s.title}</h3>
+          <div class="rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-8">
+            <h3 class="text-xl font-bold text-[color:var(--color-text-primary)]">{s.title}</h3>
             <div class="mt-6">
-              <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">
+              <p class="text-xs font-semibold uppercase tracking-wider text-[color:var(--color-text-secondary)]">
                 Sound familiar?
               </p>
-              <p class="mt-2 text-slate-700">{s.pain}</p>
+              <p class="mt-2 text-[color:var(--color-text-primary)]">{s.pain}</p>
             </div>
             <div class="mt-4">
               <p class="text-xs font-semibold uppercase tracking-wider text-primary">How we help</p>
-              <p class="mt-2 text-slate-700">{s.fix}</p>
+              <p class="mt-2 text-[color:var(--color-text-primary)]">{s.fix}</p>
             </div>
           </div>
         ))

--- a/src/components/booking/SlotPicker.astro
+++ b/src/components/booking/SlotPicker.astro
@@ -18,20 +18,26 @@
 
 <div id="slot-picker" class="slot-picker" data-component="slot-picker">
   <!-- Loading skeleton -->
-  <div id="sp-loading" class="flex flex-col items-center justify-center py-12 text-slate-500">
-    <div class="h-8 w-8 animate-spin rounded-full border-2 border-slate-300 border-t-primary"></div>
+  <div
+    id="sp-loading"
+    class="flex flex-col items-center justify-center py-12 text-[color:var(--color-text-secondary)]"
+  >
+    <div
+      class="h-8 w-8 animate-spin rounded-[var(--radius-card)] border-2 border-[color:var(--color-border)] border-t-primary"
+    >
+    </div>
     <p class="mt-3 text-sm">Loading available times...</p>
   </div>
 
   <!-- Error state -->
   <div id="sp-error" class="hidden py-12 text-center">
-    <p class="text-sm text-red-600" id="sp-error-msg">
+    <p class="text-sm text-[color:var(--color-error)]" id="sp-error-msg">
       Something went wrong loading available times.
     </p>
     <button
       id="sp-retry-btn"
       type="button"
-      class="mt-3 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+      class="mt-3 rounded-[var(--radius-card)] bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
     >
       Try again
     </button>
@@ -39,8 +45,10 @@
 
   <!-- No slots state -->
   <div id="sp-empty" class="hidden py-12 text-center">
-    <p class="text-sm text-slate-600">No available times in the next two weeks.</p>
-    <p class="mt-1 text-sm text-slate-500">
+    <p class="text-sm text-[color:var(--color-text-secondary)]">
+      No available times in the next two weeks.
+    </p>
+    <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
       Please email
       <a href="mailto:scott@smd.services" class="font-medium text-primary hover:text-primary-hover">
         scott@smd.services
@@ -50,7 +58,10 @@
   </div>
 
   <!-- Stale banner (data older than 5 min) -->
-  <div id="sp-stale" class="mb-4 hidden rounded-md bg-amber-50 px-4 py-2 text-sm text-amber-700">
+  <div
+    id="sp-stale"
+    class="mb-4 hidden rounded-[var(--radius-card)] bg-amber-50 px-4 py-2 text-sm text-[color:var(--color-attention)]"
+  >
     These times may be out of date.
     <button type="button" id="sp-refresh-btn" class="ml-1 font-medium underline">Refresh</button>
   </div>
@@ -58,7 +69,7 @@
   <!-- Main picker UI -->
   <div id="sp-main" class="hidden">
     <!-- Timezone label -->
-    <p class="mb-4 text-xs text-slate-500" id="sp-tz-label"></p>
+    <p class="mb-4 text-xs text-[color:var(--color-text-secondary)]" id="sp-tz-label"></p>
 
     <div class="flex flex-col gap-card sm:flex-row">
       <!-- Left: Date selector -->
@@ -67,7 +78,7 @@
           <button
             type="button"
             id="sp-prev"
-            class="rounded p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:opacity-30 disabled:cursor-not-allowed"
+            class="rounded p-1 text-[color:var(--color-text-muted)] transition-colors hover:bg-[color:var(--color-border-subtle)] hover:text-[color:var(--color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed"
             aria-label="Previous dates"
           >
             <svg
@@ -81,11 +92,13 @@
               ></path>
             </svg>
           </button>
-          <span id="sp-month-label" class="text-sm font-semibold text-slate-900"></span>
+          <span
+            id="sp-month-label"
+            class="text-sm font-semibold text-[color:var(--color-text-primary)]"></span>
           <button
             type="button"
             id="sp-next"
-            class="rounded p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:opacity-30 disabled:cursor-not-allowed"
+            class="rounded p-1 text-[color:var(--color-text-muted)] transition-colors hover:bg-[color:var(--color-border-subtle)] hover:text-[color:var(--color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed"
             aria-label="Next dates"
           >
             <svg
@@ -105,9 +118,16 @@
 
       <!-- Right: Time slots for selected date -->
       <div class="sm:w-1/2">
-        <p id="sp-date-label" class="mb-3 text-sm font-semibold text-slate-900"></p>
+        <p
+          id="sp-date-label"
+          class="mb-3 text-sm font-semibold text-[color:var(--color-text-primary)]"
+        >
+        </p>
         <div id="sp-slots" class="grid grid-cols-2 gap-2"></div>
-        <p id="sp-no-slots-day" class="hidden py-8 text-center text-sm text-slate-500">
+        <p
+          id="sp-no-slots-day"
+          class="hidden py-8 text-center text-sm text-[color:var(--color-text-secondary)]"
+        >
           No available times on this date.
         </p>
       </div>
@@ -116,11 +136,15 @@
 
   <!-- 503 fallback panel -->
   <div id="sp-unavailable" class="hidden py-12 text-center">
-    <p class="text-sm text-slate-600">Online booking is temporarily unavailable.</p>
-    <p class="mt-2 text-sm text-slate-500">Please email us directly to schedule your call:</p>
+    <p class="text-sm text-[color:var(--color-text-secondary)]">
+      Online booking is temporarily unavailable.
+    </p>
+    <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+      Please email us directly to schedule your call:
+    </p>
     <a
       href="mailto:scott@smd.services?subject=Assessment%20Call%20Request"
-      class="mt-3 inline-block rounded-md bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+      class="mt-3 inline-block rounded-[var(--radius-card)] bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
     >
       Email scott@smd.services
     </a>
@@ -291,7 +315,8 @@
       const dayAbbr = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
       dayAbbr.forEach(function (name) {
         const span = document.createElement('span')
-        span.className = 'text-[10px] font-medium text-slate-400 py-1 text-center'
+        span.className =
+          'text-[10px] font-medium text-[color:var(--color-text-muted)] py-1 text-center'
         span.textContent = name
         datesContainer.appendChild(span)
       })
@@ -322,20 +347,22 @@
         const btn = document.createElement('button')
         btn.type = 'button'
         btn.className =
-          'h-9 w-full flex items-center justify-center rounded-lg text-sm transition-colors '
+          'h-9 w-full flex items-center justify-center rounded-[var(--radius-card)] text-sm transition-colors '
 
         if (isSelected) {
           btn.className += 'bg-primary text-white font-semibold'
         } else if (isToday && hasSlots) {
-          btn.className += 'ring-2 ring-primary text-slate-900 font-semibold hover:bg-slate-100'
+          btn.className +=
+            'ring-2 ring-primary text-[color:var(--color-text-primary)] font-semibold hover:bg-[color:var(--color-border-subtle)]'
         } else if (isToday) {
-          btn.className += 'ring-2 ring-primary text-slate-300'
+          btn.className += 'ring-2 ring-primary text-[color:var(--color-text-muted)]'
         } else if (hasSlots) {
-          btn.className += 'text-slate-900 font-semibold hover:bg-slate-100'
+          btn.className +=
+            'text-[color:var(--color-text-primary)] font-semibold hover:bg-[color:var(--color-border-subtle)]'
         } else if (isPast) {
           btn.className += 'text-slate-200 cursor-not-allowed'
         } else {
-          btn.className += 'text-slate-300 cursor-not-allowed'
+          btn.className += 'text-[color:var(--color-text-muted)] cursor-not-allowed'
         }
 
         btn.textContent = day
@@ -412,12 +439,13 @@
         btn.type = 'button'
         const isSelected = selectedSlot && selectedSlot.start_utc === slot.start_utc
 
-        btn.className = 'rounded-md border px-3 py-2 text-sm font-medium transition-colors '
+        btn.className =
+          'rounded-[var(--radius-card)] border px-3 py-2 text-sm font-medium transition-colors '
         if (isSelected) {
           btn.className += 'border-primary bg-primary text-white'
         } else {
           btn.className +=
-            'border-slate-200 bg-white text-slate-700 hover:border-primary hover:text-primary'
+            'border-[color:var(--color-border)] bg-white text-[color:var(--color-text-primary)] hover:border-primary hover:text-primary'
         }
 
         btn.textContent = slot.label

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,8 +9,10 @@ import Footer from '../components/Footer.astro'
 <Base title="Page Not Found | SMD Services">
   <Nav />
   <main id="main" role="main" class="mx-auto max-w-4xl px-4 py-16 text-center">
-    <h1 class="text-3xl font-bold text-slate-900">Page not found</h1>
-    <p class="mt-4 text-lg text-slate-600">The page you're looking for doesn't exist.</p>
+    <h1 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Page not found</h1>
+    <p class="mt-4 text-lg text-[color:var(--color-text-secondary)]">
+      The page you're looking for doesn't exist.
+    </p>
     <a href="/" class="mt-8 inline-block text-sm font-medium text-primary hover:text-primary/80">
       Back to home
     </a>

--- a/src/pages/auth/login.astro
+++ b/src/pages/auth/login.astro
@@ -34,7 +34,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
     />
     <title>Sign In — SMD Services</title>
   </head>
-  <body class="min-h-screen bg-slate-50">
+  <body class="min-h-screen bg-[color:var(--color-background)]">
     <SkipToMain />
     <header
       role="banner"
@@ -54,15 +54,17 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
     >
       <div class="w-full max-w-sm">
         <div class="text-center mb-8">
-          <p class="text-sm text-slate-500">Admin sign-in</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">Admin sign-in</p>
         </div>
 
-        <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
-          <h2 class="text-lg font-semibold text-slate-900 mb-6">Sign in</h2>
+        <div
+          class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-6"
+        >
+          <h2 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-6">Sign in</h2>
 
           {
             errorMessage && (
-              <div class="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+              <div class="mb-4 px-3 py-2 bg-[color:var(--color-error)]/5 border border-[color:var(--color-error)]/30 rounded text-sm text-[color:var(--color-error)]">
                 {errorMessage}
               </div>
             )
@@ -70,7 +72,10 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
 
           <form method="POST" action="/api/auth/login" class="space-y-4">
             <div>
-              <label for="email" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="email"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Email
               </label>
               <input
@@ -79,7 +84,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
                 type="email"
                 required
                 autocomplete="email"
-                class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+                class="w-full px-3 py-2 border border-[color:var(--color-border)] rounded-[var(--radius-card)] text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
                 placeholder="you@smd.services"
@@ -87,7 +92,10 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
             </div>
 
             <div>
-              <label for="password" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="password"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Password
               </label>
               <input
@@ -96,7 +104,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
                 type="password"
                 required
                 autocomplete="current-password"
-                class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+                class="w-full px-3 py-2 border border-[color:var(--color-border)] rounded-[var(--radius-card)] text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
                 placeholder="Enter your password"
@@ -105,7 +113,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
 
             <button
               type="submit"
-              class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
+              class="w-full bg-primary text-white py-2 px-4 rounded-[var(--radius-card)] text-sm font-medium
                    hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
                    focus:ring-primary focus:ring-offset-2"
             >

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -42,7 +42,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
     />
     <title>Sign In — SMD Services Portal</title>
   </head>
-  <body class="min-h-screen bg-slate-50">
+  <body class="min-h-screen bg-[color:var(--color-background)]">
     <SkipToMain />
     <header
       role="banner"
@@ -62,12 +62,14 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
     >
       <div class="w-full max-w-sm">
         <div class="text-center mb-8">
-          <p class="text-sm text-slate-500">Client portal sign-in</p>
+          <p class="text-sm text-[color:var(--color-text-secondary)]">Client portal sign-in</p>
         </div>
 
-        <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
-          <h2 class="text-lg font-semibold text-slate-900 mb-2">Sign in</h2>
-          <p class="text-sm text-slate-500 mb-6">
+        <div
+          class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-6"
+        >
+          <h2 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-2">Sign in</h2>
+          <p class="text-sm text-[color:var(--color-text-secondary)] mb-6">
             Enter your email and we'll send you a link to sign in.
           </p>
 
@@ -77,8 +79,8 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
                 class:list={[
                   'mb-4 px-3 py-2 border rounded text-sm',
                   message.type === 'success'
-                    ? 'bg-green-50 border-green-200 text-green-700'
-                    : 'bg-red-50 border-red-200 text-red-700',
+                    ? 'bg-[color:var(--color-complete)]/5 border-[color:var(--color-complete)]/30 text-[color:var(--color-complete)]'
+                    : 'bg-[color:var(--color-error)]/5 border-[color:var(--color-error)]/30 text-[color:var(--color-error)]',
                 ]}
               >
                 {message.text}
@@ -88,7 +90,10 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
 
           <form method="POST" action="/api/auth/magic-link" class="space-y-4">
             <div>
-              <label for="email" class="block text-sm font-medium text-slate-700 mb-1">
+              <label
+                for="email"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              >
                 Email
               </label>
               <input
@@ -98,7 +103,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
                 required
                 autocomplete="email"
                 value={prefillEmail}
-                class="w-full px-3 py-2 border border-slate-300 rounded-md text-sm
+                class="w-full px-3 py-2 border border-[color:var(--color-border)] rounded-[var(--radius-card)] text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
                 placeholder="your@email.com"
@@ -107,7 +112,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
 
             <button
               type="submit"
-              class="w-full bg-primary text-white py-2 px-4 rounded-md text-sm font-medium
+              class="w-full bg-primary text-white py-2 px-4 rounded-[var(--radius-card)] text-sm font-medium
                    hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
                    focus:ring-primary focus:ring-offset-2"
             >

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -22,13 +22,15 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
   <Nav />
   <main id="main" role="main">
     <!-- Hero -->
-    <section class="bg-slate-50 px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">
         <div class="text-center">
-          <h1 class="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+          <h1
+            class="text-3xl font-bold tracking-tight text-[color:var(--color-text-primary)] sm:text-4xl"
+          >
             Let's Talk About Your Business
           </h1>
-          <p class="mx-auto mt-4 max-w-2xl text-xl text-slate-600">
+          <p class="mx-auto mt-4 max-w-2xl text-xl text-[color:var(--color-text-secondary)]">
             Pick a time that works. We'll ask how things run, where you're trying to go, and what
             the best path forward looks like.
           </p>
@@ -37,14 +39,18 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
         <!-- Booking flow container -->
         <div class="mx-auto mt-10 max-w-3xl">
           <!-- Step 1: Pick a time -->
-          <div class="rounded-xl bg-white p-card shadow-sm sm:p-section">
-            <h2 class="mb-1 text-lg font-bold text-slate-900">Pick a time</h2>
-            <p class="mb-6 text-sm text-slate-500">Choose a date and time that works for you.</p>
+          <div class="rounded-[var(--radius-card)] bg-white p-card sm:p-section">
+            <h2 class="mb-1 text-lg font-bold text-[color:var(--color-text-primary)]">
+              Pick a time
+            </h2>
+            <p class="mb-6 text-sm text-[color:var(--color-text-secondary)]">
+              Choose a date and time that works for you.
+            </p>
             <SlotPicker />
           </div>
 
           <!-- Standalone intake escape hatch -->
-          <p class="mt-4 text-center text-sm text-slate-500">
+          <p class="mt-4 text-center text-sm text-[color:var(--color-text-secondary)]">
             Not ready to pick a time?
             <a href="/get-started" class="font-medium text-primary underline hover:text-primary/80"
               >Tell us about your business</a
@@ -54,18 +60,20 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
           <!-- Step 2: Intake form (appears after slot selection) -->
           <div
             id="intake-section"
-            class="mt-6 rounded-xl bg-white p-card shadow-sm transition-opacity duration-300 sm:p-section"
+            class="mt-6 rounded-[var(--radius-card)] bg-white p-card transition-opacity duration-300 sm:p-section"
             style="display: none;"
           >
-            <h2 class="text-lg font-bold text-slate-900">Tell us about your business</h2>
-            <p class="mt-1 text-sm text-slate-500">
+            <h2 class="text-lg font-bold text-[color:var(--color-text-primary)]">
+              Tell us about your business
+            </h2>
+            <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
               The more we know, the more useful the conversation will be.
             </p>
 
             <!-- Selected slot summary -->
             <div
               id="selected-slot-banner"
-              class="mt-4 flex items-center gap-2 rounded-md bg-primary/5 px-4 py-2.5"
+              class="mt-4 flex items-center gap-2 rounded-[var(--radius-card)] bg-primary/5 px-4 py-2.5"
             >
               <svg
                 class="h-5 w-5 flex-shrink-0 text-primary"
@@ -99,7 +107,10 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
               <!-- Name + Email -->
               <div class="grid gap-5 sm:grid-cols-2">
                 <div>
-                  <label for="bf-name" class="block text-sm font-medium text-slate-700">
+                  <label
+                    for="bf-name"
+                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  >
                     Full name <span class="text-red-500">*</span>
                   </label>
                   <input
@@ -109,12 +120,15 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                     required
                     maxlength="200"
                     autocomplete="name"
-                    class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="e.g. Maria Garcia"
                   />
                 </div>
                 <div>
-                  <label for="bf-email" class="block text-sm font-medium text-slate-700">
+                  <label
+                    for="bf-email"
+                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  >
                     Work email <span class="text-red-500">*</span>
                   </label>
                   <input
@@ -124,7 +138,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                     required
                     maxlength="254"
                     autocomplete="email"
-                    class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="maria@example.com"
                   />
                 </div>
@@ -133,7 +147,10 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
               <!-- Business name + Phone -->
               <div class="grid gap-5 sm:grid-cols-2">
                 <div>
-                  <label for="bf-business" class="block text-sm font-medium text-slate-700">
+                  <label
+                    for="bf-business"
+                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  >
                     Business name <span class="text-red-500">*</span>
                   </label>
                   <input
@@ -142,12 +159,15 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                     name="business_name"
                     required
                     maxlength="200"
-                    class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="e.g. Phoenix Plumbing Co."
                   />
                 </div>
                 <div>
-                  <label for="bf-phone" class="block text-sm font-medium text-slate-700">
+                  <label
+                    for="bf-phone"
+                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  >
                     Phone <span class="text-red-500">*</span>
                   </label>
                   <input
@@ -157,7 +177,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                     required
                     maxlength="30"
                     autocomplete="tel"
-                    class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="(602) 555-0123"
                   />
                 </div>
@@ -166,13 +186,16 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
               <!-- Vertical + Employee count -->
               <div class="grid gap-5 sm:grid-cols-2">
                 <div>
-                  <label for="bf-vertical" class="block text-sm font-medium text-slate-700">
+                  <label
+                    for="bf-vertical"
+                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  >
                     What kind of business?
                   </label>
                   <select
                     id="bf-vertical"
                     name="vertical"
-                    class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   >
                     <option value="">Select one</option>
                     {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
@@ -181,18 +204,21 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                     type="text"
                     id="bf-vertical-other"
                     name="vertical_other"
-                    class="mt-2 hidden w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="Describe your business type"
                   />
                 </div>
                 <div>
-                  <label for="bf-employees" class="block text-sm font-medium text-slate-700">
+                  <label
+                    for="bf-employees"
+                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  >
                     Employee count
                   </label>
                   <select
                     id="bf-employees"
                     name="employee_count"
-                    class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   >
                     <option value="">Select one</option>
                     <option value="1-5">1 - 5</option>
@@ -206,13 +232,16 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
 
               <!-- Years in business -->
               <div class="sm:w-1/2">
-                <label for="bf-years" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="bf-years"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   Years in business
                 </label>
                 <select
                   id="bf-years"
                   name="years_in_business"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   <option value="<1">Less than 1 year</option>
@@ -225,12 +254,15 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
 
               <!-- Biggest challenge -->
               <div>
-                <label for="bf-challenge" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="bf-challenge"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   What's the single biggest operational challenge right now? <span
                     class="text-red-500">*</span
                   >
                 </label>
-                <p class="mt-0.5 text-xs text-slate-400">
+                <p class="mt-0.5 text-xs text-[color:var(--color-text-muted)]">
                   What would make the biggest difference in how your business runs day to day?
                 </p>
                 <textarea
@@ -239,20 +271,23 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                   required
                   rows="3"
                   maxlength="2000"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="e.g. I want to stop being the bottleneck for every decision..."
                 ></textarea>
               </div>
 
               <!-- How heard -->
               <div>
-                <label for="bf-how-heard" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="bf-how-heard"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   How did you hear about us?
                 </label>
                 <select
                   id="bf-how-heard"
                   name="how_heard"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   <option value="Google Search">Google Search</option>
@@ -267,7 +302,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                   type="text"
                   id="bf-how-heard-other"
                   name="how_heard_other"
-                  class="mt-2 hidden w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="Tell us more"
                 />
               </div>
@@ -276,11 +311,14 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
               <div id="turnstile-container"></div>
 
               <!-- Banners -->
-              <div id="bf-error" class="hidden rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+              <div
+                id="bf-error"
+                class="hidden rounded-[var(--radius-card)] bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]"
+              >
               </div>
               <div
                 id="bf-slot-taken"
-                class="hidden rounded-md bg-amber-50 px-4 py-3 text-sm text-amber-700"
+                class="hidden rounded-[var(--radius-card)] bg-amber-50 px-4 py-3 text-sm text-[color:var(--color-attention)]"
               >
                 That time was just taken. Please choose another time above.
               </div>
@@ -290,7 +328,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                 id="bf-submit"
                 type="submit"
                 disabled
-                class="w-full rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+                class="w-full rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Book Your Call
               </button>
@@ -300,14 +338,14 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
           <!-- Confirmation panel (replaces the form on success) -->
           <div
             id="confirmation-panel"
-            class="mt-6 hidden rounded-xl bg-white p-card shadow-sm sm:p-section"
+            class="mt-6 hidden rounded-[var(--radius-card)] bg-white p-card sm:p-section"
           >
             <div class="text-center">
               <div
-                class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-green-100"
+                class="mx-auto flex h-14 w-14 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10"
               >
                 <svg
-                  class="h-7 w-7 text-green-600"
+                  class="h-7 w-7 text-[color:var(--color-complete)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="2"
@@ -317,12 +355,14 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                   ></path>
                 </svg>
               </div>
-              <h2 class="mt-4 text-xl font-bold text-slate-900">You're all set</h2>
-              <p class="mt-2 text-sm text-slate-600">
+              <h2 class="mt-4 text-xl font-bold text-[color:var(--color-text-primary)]">
+                You're all set
+              </h2>
+              <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
                 We'll see you at your scheduled time. Check your email for a confirmation with the
                 meeting link.
               </p>
-              <p class="mt-3 text-sm text-slate-500">
+              <p class="mt-3 text-sm text-[color:var(--color-text-secondary)]">
                 <a
                   href="/get-started?booked=1"
                   class="font-medium text-primary underline hover:text-primary/80"
@@ -331,10 +371,12 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
               </p>
             </div>
 
-            <div class="mt-6 space-y-row rounded-md bg-slate-50 p-stack">
+            <div
+              class="mt-6 space-y-row rounded-[var(--radius-card)] bg-[color:var(--color-background)] p-stack"
+            >
               <div class="flex items-start gap-row">
                 <svg
-                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-slate-400"
+                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--color-text-muted)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
@@ -346,11 +388,13 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                     d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
                   ></path>
                 </svg>
-                <span id="conf-slot" class="text-sm font-medium text-slate-900"></span>
+                <span
+                  id="conf-slot"
+                  class="text-sm font-medium text-[color:var(--color-text-primary)]"></span>
               </div>
               <div id="conf-meet-row" class="hidden flex items-start gap-row">
                 <svg
-                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-slate-400"
+                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--color-text-muted)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
@@ -374,7 +418,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
               </div>
               <div id="conf-manage-row" class="hidden flex items-start gap-row">
                 <svg
-                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-slate-400"
+                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--color-text-muted)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
@@ -404,16 +448,18 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
           <!-- 503 email fallback panel -->
           <div
             id="email-fallback-panel"
-            class="mt-6 hidden rounded-xl bg-white p-card text-center shadow-sm sm:p-section"
+            class="mt-6 hidden rounded-[var(--radius-card)] bg-white p-card text-center sm:p-section"
           >
-            <p class="text-sm text-slate-600">Online booking is temporarily unavailable.</p>
-            <p class="mt-2 text-sm text-slate-500">
+            <p class="text-sm text-[color:var(--color-text-secondary)]">
+              Online booking is temporarily unavailable.
+            </p>
+            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
               Please email us directly to schedule your call.
             </p>
             <a
               id="fallback-mailto"
               href="mailto:scott@smd.services?subject=Assessment%20Call%20Request"
-              class="mt-4 inline-block rounded-md bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+              class="mt-4 inline-block rounded-[var(--radius-card)] bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
             >
               Email scott@smd.services
             </a>
@@ -425,42 +471,48 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
     <!-- What to Expect -->
     <section class="bg-white px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">
-        <h2 class="mb-12 text-center text-3xl font-bold text-slate-900">
+        <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)]">
           What Happens on the Call
         </h2>
         <div class="mx-auto grid max-w-3xl gap-section sm:grid-cols-3">
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary text-lg font-bold text-white"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-card)] bg-primary text-lg font-bold text-white"
             >
               1
             </div>
-            <h3 class="mt-4 font-bold text-slate-900">You walk us through your day</h3>
-            <p class="mt-2 text-sm text-slate-600">
+            <h3 class="mt-4 font-bold text-[color:var(--color-text-primary)]">
+              You walk us through your day
+            </h3>
+            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
               How do customers find you? How do jobs get scheduled? What happens when something goes
               wrong? We're just trying to understand how things really work day to day.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-lg font-bold text-slate-900"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] text-lg font-bold text-[color:var(--color-text-primary)]"
             >
               2
             </div>
-            <h3 class="mt-4 font-bold text-slate-900">We figure out what matters most</h3>
-            <p class="mt-2 text-sm text-slate-600">
+            <h3 class="mt-4 font-bold text-[color:var(--color-text-primary)]">
+              We figure out what matters most
+            </h3>
+            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
               Together we identify what would make the biggest difference for where you're trying to
               go, and why those things matter most right now.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-lg font-bold text-slate-900"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] text-lg font-bold text-[color:var(--color-text-primary)]"
             >
               3
             </div>
-            <h3 class="mt-4 font-bold text-slate-900">You decide if you want help</h3>
-            <p class="mt-2 text-sm text-slate-600">
+            <h3 class="mt-4 font-bold text-[color:var(--color-text-primary)]">
+              You decide if you want help
+            </h3>
+            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
               If it makes sense to work together, we'll send you a proposal with the scope, price,
               and timeline. If not, you still walked away with a useful conversation.
             </p>
@@ -470,36 +522,46 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
     </section>
 
     <!-- FAQ -->
-    <section class="bg-slate-50 px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">
-        <h2 class="mb-12 text-center text-3xl font-bold text-slate-900">Common Questions</h2>
+        <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)]">
+          Common Questions
+        </h2>
         <dl class="mx-auto max-w-2xl space-y-section">
           <div>
-            <dt class="font-semibold text-slate-900">Does the call cost anything?</dt>
-            <dd class="mt-2 text-slate-600">
+            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+              Does the call cost anything?
+            </dt>
+            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
               No. If it makes sense to work together, we'll send a proposal after the call. If not,
               you still got a useful conversation about your business. Either way it costs you
               nothing but time.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">Do I need to prepare anything?</dt>
-            <dd class="mt-2 text-slate-600">
+            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+              Do I need to prepare anything?
+            </dt>
+            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
               Just be ready to talk honestly about how things work. We'll ask questions. The less
               polished, the better. The real version of how things run is what helps us figure out
               the right path forward.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">What happens after the call?</dt>
-            <dd class="mt-2 text-slate-600">
+            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+              What happens after the call?
+            </dt>
+            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
               If it makes sense to work together, you get a proposal. Fixed price, clear scope, no
               surprises. If not, we'll tell you that too. No pressure either way.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">What size business is this for?</dt>
-            <dd class="mt-2 text-slate-600">
+            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+              What size business is this for?
+            </dt>
+            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
               Phoenix-area businesses with roughly 5 to 50 employees. Big enough that the owner
               can't do everything themselves anymore, small enough that hiring a full-time
               operations person doesn't make sense yet.
@@ -795,7 +857,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
         // Hide picker + form, show confirmation
         const pickerCard = document.querySelector('[data-component="slot-picker"]')
         if (pickerCard) {
-          const card = pickerCard.closest('.rounded-xl')
+          const card = pickerCard.closest('.rounded-[var(--radius-card)]')
           if (card) card.style.display = 'none'
         }
         intakeSection.style.display = 'none'
@@ -839,7 +901,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
         mailtoEl.textContent = 'Email ' + fallbackEmail
 
         // Hide picker + form, show fallback
-        const pickerEl = picker.closest('.rounded-xl')
+        const pickerEl = picker.closest('.rounded-[var(--radius-card)]')
         if (pickerEl) pickerEl.style.display = 'none'
         intakeSection.style.display = 'none'
         emailFallback.classList.remove('hidden')

--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -12,22 +12,26 @@ import Footer from '../../../components/Footer.astro'
 >
   <Nav />
   <main id="main" role="main">
-    <section class="bg-slate-50 px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Loading state -->
         <div id="loading" class="text-center">
           <div
-            class="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-primary"
+            class="mx-auto h-8 w-8 animate-spin rounded-[var(--radius-card)] border-4 border-[color:var(--color-border)] border-t-primary"
           >
           </div>
-          <p class="mt-4 text-sm text-slate-500">Loading your booking...</p>
+          <p class="mt-4 text-sm text-[color:var(--color-text-secondary)]">
+            Loading your booking...
+          </p>
         </div>
 
         <!-- Error state -->
         <div id="error-state" class="hidden text-center">
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+          <div
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-error)]/10"
+          >
             <svg
-              class="h-8 w-8 text-red-600"
+              class="h-8 w-8 text-[color:var(--color-error)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -39,15 +43,18 @@ import Footer from '../../../components/Footer.astro'
                 d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"></path>
             </svg>
           </div>
-          <h1 class="mt-6 text-2xl font-bold text-slate-900" id="error-title">
+          <h1
+            class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]"
+            id="error-title"
+          >
             Something went wrong
           </h1>
-          <p class="mt-3 text-slate-600" id="error-message">
+          <p class="mt-3 text-[color:var(--color-text-secondary)]" id="error-message">
             Please try again or contact us directly.
           </p>
           <a
             href="/book"
-            class="mt-6 inline-block rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
+            class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
           >
             Book a new time
           </a>
@@ -55,9 +62,11 @@ import Footer from '../../../components/Footer.astro'
 
         <!-- Cancelled state -->
         <div id="cancelled-state" class="hidden text-center">
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-slate-100">
+          <div
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)]"
+          >
             <svg
-              class="h-8 w-8 text-slate-400"
+              class="h-8 w-8 text-[color:var(--color-text-muted)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -66,11 +75,15 @@ import Footer from '../../../components/Footer.astro'
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path>
             </svg>
           </div>
-          <h1 class="mt-6 text-2xl font-bold text-slate-900">This booking was cancelled</h1>
-          <p class="mt-3 text-slate-600">Whenever you're ready, you can book a new time.</p>
+          <h1 class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]">
+            This booking was cancelled
+          </h1>
+          <p class="mt-3 text-[color:var(--color-text-secondary)]">
+            Whenever you're ready, you can book a new time.
+          </p>
           <a
             href="/book"
-            class="mt-6 inline-block rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
+            class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
           >
             Book a new time
           </a>
@@ -80,10 +93,10 @@ import Footer from '../../../components/Footer.astro'
         <div id="booking-details" class="hidden">
           <div class="text-center">
             <div
-              class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100"
+              class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-primary)]/10"
             >
               <svg
-                class="h-8 w-8 text-blue-600"
+                class="h-8 w-8 text-[color:var(--color-primary)]"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke-width="2"
@@ -96,26 +109,44 @@ import Footer from '../../../components/Footer.astro'
                 ></path>
               </svg>
             </div>
-            <h1 class="mt-6 text-2xl font-bold text-slate-900">Your Booking</h1>
-            <p class="mt-1 text-sm text-slate-500" id="meeting-label"></p>
+            <h1 class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]">
+              Your Booking
+            </h1>
+            <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]" id="meeting-label"></p>
           </div>
 
-          <div class="mt-8 rounded-xl bg-white p-card shadow-sm">
+          <div class="mt-8 rounded-[var(--radius-card)] bg-white p-card">
             <div class="space-y-stack">
               <div>
-                <p class="text-xs font-medium uppercase tracking-wide text-slate-400">When</p>
-                <p class="mt-1 text-lg font-semibold text-slate-900" id="slot-label"></p>
+                <p
+                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]"
+                >
+                  When
+                </p>
+                <p
+                  class="mt-1 text-lg font-semibold text-[color:var(--color-text-primary)]"
+                  id="slot-label"
+                >
+                </p>
               </div>
               <div>
-                <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Guest</p>
-                <p class="mt-1 text-slate-700" id="guest-name"></p>
+                <p
+                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]"
+                >
+                  Guest
+                </p>
+                <p class="mt-1 text-[color:var(--color-text-primary)]" id="guest-name"></p>
               </div>
               <div id="meet-link-container" class="hidden">
-                <p class="text-xs font-medium uppercase tracking-wide text-slate-400">Video call</p>
+                <p
+                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]"
+                >
+                  Video call
+                </p>
                 <a
                   id="meet-link"
                   href=""
-                  class="mt-1 inline-block text-sm text-blue-600 hover:text-blue-800"
+                  class="mt-1 inline-block text-sm text-[color:var(--color-primary)] hover:text-blue-800"
                   target="_blank"
                   rel="noopener"></a>
               </div>
@@ -124,13 +155,13 @@ import Footer from '../../../components/Footer.astro'
             <div class="mt-8 flex flex-col gap-row sm:flex-row">
               <button
                 id="reschedule-btn"
-                class="flex-1 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                class="flex-1 rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-background)]"
               >
                 Reschedule
               </button>
               <button
                 id="cancel-btn"
-                class="flex-1 rounded-lg border border-red-200 bg-white px-4 py-2.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
+                class="flex-1 rounded-[var(--radius-card)] border border-[color:var(--color-error)]/30 bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--color-error)] transition-colors hover:bg-[color:var(--color-error)]/5"
               >
                 Cancel Booking
               </button>
@@ -141,28 +172,37 @@ import Footer from '../../../components/Footer.astro'
         <!-- Reschedule panel -->
         <div id="reschedule-panel" class="hidden">
           <div class="text-center">
-            <h2 class="text-2xl font-bold text-slate-900">Pick a new time</h2>
-            <p class="mt-2 text-sm text-slate-500">Choose an available slot below.</p>
+            <h2 class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+              Pick a new time
+            </h2>
+            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+              Choose an available slot below.
+            </p>
           </div>
 
           <div id="slots-loading" class="mt-8 text-center">
             <div
-              class="mx-auto h-6 w-6 animate-spin rounded-full border-4 border-slate-200 border-t-primary"
+              class="mx-auto h-6 w-6 animate-spin rounded-[var(--radius-card)] border-4 border-[color:var(--color-border)] border-t-primary"
             >
             </div>
-            <p class="mt-3 text-sm text-slate-500">Loading available times...</p>
+            <p class="mt-3 text-sm text-[color:var(--color-text-secondary)]">
+              Loading available times...
+            </p>
           </div>
 
           <div id="slots-container" class="mt-8 hidden space-y-card"></div>
 
           <div id="slots-empty" class="mt-8 hidden text-center">
-            <p class="text-slate-600">
+            <p class="text-[color:var(--color-text-secondary)]">
               No available times found. Please check back later or contact us.
             </p>
           </div>
 
           <div class="mt-6 text-center">
-            <button id="back-to-details-btn" class="text-sm text-slate-500 hover:text-slate-700">
+            <button
+              id="back-to-details-btn"
+              class="text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+            >
               Back to booking details
             </button>
           </div>
@@ -173,30 +213,34 @@ import Footer from '../../../components/Footer.astro'
           id="cancel-dialog"
           class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50 p-stack"
         >
-          <div class="w-full max-w-md rounded-xl bg-white p-card shadow-xl">
-            <h3 class="text-lg font-bold text-slate-900">Cancel your booking?</h3>
-            <p class="mt-2 text-sm text-slate-600">
+          <div class="w-full max-w-md rounded-[var(--radius-card)] bg-white p-card">
+            <h3 class="text-lg font-bold text-[color:var(--color-text-primary)]">
+              Cancel your booking?
+            </h3>
+            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
               This will cancel your assessment call. You can always book a new time later.
             </p>
             <div class="mt-4">
-              <label for="cancel-reason" class="block text-sm font-medium text-slate-700"
+              <label
+                for="cancel-reason"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
                 >Reason (optional)</label
               >
               <textarea
                 id="cancel-reason"
                 rows="2"
-                class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-primary focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:ring-1 focus:ring-primary"
                 placeholder="Let us know why you're cancelling..."></textarea>
             </div>
             <div class="mt-6 flex gap-row">
               <button
                 id="cancel-dialog-dismiss"
-                class="flex-1 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                class="flex-1 rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]"
                 >Keep Booking</button
               >
               <button
                 id="cancel-dialog-confirm"
-                class="flex-1 rounded-lg bg-red-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-red-700"
+                class="flex-1 rounded-[var(--radius-card)] bg-red-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-red-700"
                 >Yes, Cancel</button
               >
             </div>
@@ -205,9 +249,11 @@ import Footer from '../../../components/Footer.astro'
 
         <!-- Success state -->
         <div id="success-state" class="hidden text-center">
-          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+          <div
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10"
+          >
             <svg
-              class="h-8 w-8 text-green-600"
+              class="h-8 w-8 text-[color:var(--color-complete)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -216,8 +262,12 @@ import Footer from '../../../components/Footer.astro'
               <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
             </svg>
           </div>
-          <h1 class="mt-6 text-2xl font-bold text-slate-900" id="success-title"></h1>
-          <p class="mt-3 text-slate-600" id="success-message"></p>
+          <h1
+            class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]"
+            id="success-title"
+          >
+          </h1>
+          <p class="mt-3 text-[color:var(--color-text-secondary)]" id="success-message"></p>
         </div>
       </div>
     </section>
@@ -361,7 +411,7 @@ import Footer from '../../../components/Footer.astro'
               day: 'numeric',
             })
             const h = document.createElement('h3')
-            h.className = 'text-sm font-semibold text-slate-700'
+            h.className = 'text-sm font-semibold text-[color:var(--color-text-primary)]'
             h.textContent = lbl
             div.appendChild(h)
             const g = document.createElement('div')
@@ -369,7 +419,7 @@ import Footer from '../../../components/Footer.astro'
             day.slots.forEach(function (slot) {
               const b = document.createElement('button')
               b.className =
-                'rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary'
+                'rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary'
               b.textContent = slot.label
               b.dataset.startUtc = slot.start_utc
               b.addEventListener('click', function () {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,8 +8,8 @@ import Footer from '../components/Footer.astro'
   <Nav />
   <main id="main" role="main" class="px-6 py-20">
     <div class="mx-auto max-w-xl">
-      <h1 class="text-3xl font-bold text-slate-900">Get in Touch</h1>
-      <p class="mt-2 text-lg text-slate-600">
+      <h1 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Get in Touch</h1>
+      <p class="mt-2 text-lg text-[color:var(--color-text-secondary)]">
         Have a question or want to talk about your business? Send us a message.
       </p>
 
@@ -17,7 +17,11 @@ import Footer from '../components/Footer.astro'
 
       <form id="contact-form" class="mt-8 space-y-5">
         <div>
-          <label for="name" class="mb-1 block text-sm font-medium text-slate-700">Name</label>
+          <label
+            for="name"
+            class="mb-1 block text-sm font-medium text-[color:var(--color-text-primary)]"
+            >Name</label
+          >
           <input
             type="text"
             id="name"
@@ -25,13 +29,17 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="200"
             autocomplete="name"
-            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="Your name"
           />
         </div>
 
         <div>
-          <label for="email" class="mb-1 block text-sm font-medium text-slate-700">Email</label>
+          <label
+            for="email"
+            class="mb-1 block text-sm font-medium text-[color:var(--color-text-primary)]"
+            >Email</label
+          >
           <input
             type="email"
             id="email"
@@ -39,20 +47,24 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="254"
             autocomplete="email"
-            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="you@example.com"
           />
         </div>
 
         <div>
-          <label for="message" class="mb-1 block text-sm font-medium text-slate-700">Message</label>
+          <label
+            for="message"
+            class="mb-1 block text-sm font-medium text-[color:var(--color-text-primary)]"
+            >Message</label
+          >
           <textarea
             id="message"
             name="message"
             required
             maxlength="5000"
             rows="6"
-            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="What's on your mind?"></textarea>
         </div>
 
@@ -64,7 +76,7 @@ import Footer from '../components/Footer.astro'
 
         <button
           type="submit"
-          class="rounded-lg bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-80"
+          class="rounded-[var(--radius-card)] bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-80"
         >
           Send Message
         </button>
@@ -101,21 +113,21 @@ import Footer from '../components/Footer.astro'
 
           if (res.ok) {
             status.innerHTML =
-              '<div class="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">Message sent. We\'ll get back to you soon.</div>'
+              '<div class="rounded-[var(--radius-card)] border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/5 px-4 py-3 text-sm text-[color:var(--color-complete)]">Message sent. We\'ll get back to you soon.</div>'
             form.reset()
             form.style.display = 'none'
           } else {
             const body = await res.json()
             if (res.status === 400 && body.fields) {
               const msgs = Object.values(body.fields).join('. ')
-              status.innerHTML = `<div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">${msgs}</div>`
+              status.innerHTML = `<div class="rounded-[var(--radius-card)] border border-[color:var(--color-error)]/30 bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]">${msgs}</div>`
             } else {
               throw new Error(body.error || 'Request failed')
             }
           }
         } catch {
           status.innerHTML =
-            '<div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">Something went wrong. Please email <a href="mailto:team@smd.services" class="underline">team@smd.services</a> directly.</div>'
+            '<div class="rounded-[var(--radius-card)] border border-[color:var(--color-error)]/30 bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]">Something went wrong. Please email <a href="mailto:team@smd.services" class="underline">team@smd.services</a> directly.</div>'
         } finally {
           button.disabled = false
           button.textContent = 'Send Message'

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -21,16 +21,16 @@ const isPostBooking = Astro.url.searchParams.has('booked')
 >
   <Nav />
   <main id="main" role="main">
-    <section class="bg-slate-50 px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Hero -->
         <div class="text-center">
           {
             isPostBooking ? (
               <Fragment>
-                <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+                <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10">
                   <svg
-                    class="h-8 w-8 text-green-600"
+                    class="h-8 w-8 text-[color:var(--color-complete)]"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke-width="2"
@@ -43,20 +43,20 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                     />
                   </svg>
                 </div>
-                <h1 class="mt-6 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                <h1 class="mt-6 text-3xl font-bold tracking-tight text-[color:var(--color-text-primary)] sm:text-4xl">
                   You're All Set
                 </h1>
-                <p class="mx-auto mt-4 max-w-xl text-lg text-slate-600">
+                <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--color-text-secondary)]">
                   We'll see you on the call. In the meantime, a few quick questions to help us
                   prepare so we can make the most of our time together.
                 </p>
               </Fragment>
             ) : (
               <Fragment>
-                <h1 class="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                <h1 class="text-3xl font-bold tracking-tight text-[color:var(--color-text-primary)] sm:text-4xl">
                   Tell Us About Your Business
                 </h1>
-                <p class="mx-auto mt-4 max-w-xl text-lg text-slate-600">
+                <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--color-text-secondary)]">
                   Not ready to schedule a call? No problem. Share a few details about your business
                   and what you're working on. We'll review it and reach out to start the
                   conversation on your terms.
@@ -67,7 +67,10 @@ const isPostBooking = Astro.url.searchParams.has('booked')
         </div>
 
         <!-- Intake form -->
-        <div id="intake-form-container" class="mt-10 rounded-xl bg-white p-6 shadow-sm sm:p-8">
+        <div
+          id="intake-form-container"
+          class="mt-10 rounded-[var(--radius-card)] bg-white p-6 sm:p-8"
+        >
           <form id="intake-form" class="space-y-5" novalidate>
             <!-- Honeypot -->
             <div class="absolute -left-[9999px]" aria-hidden="true">
@@ -77,7 +80,10 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <!-- Name + Email -->
             <div class="grid gap-5 sm:grid-cols-2">
               <div>
-                <label for="gs-name" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="gs-name"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   Full name <span class="text-red-500">*</span>
                 </label>
                 <input
@@ -87,12 +93,15 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                   required
                   maxlength="200"
                   autocomplete="name"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="e.g. Maria Garcia"
                 />
               </div>
               <div>
-                <label for="gs-email" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="gs-email"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   Work email <span class="text-red-500">*</span>
                 </label>
                 <input
@@ -102,7 +111,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                   required
                   maxlength="254"
                   autocomplete="email"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="maria@example.com"
                 />
               </div>
@@ -110,7 +119,10 @@ const isPostBooking = Astro.url.searchParams.has('booked')
 
             <!-- Business name -->
             <div>
-              <label for="gs-business" class="block text-sm font-medium text-slate-700">
+              <label
+                for="gs-business"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 Business name <span class="text-red-500">*</span>
               </label>
               <input
@@ -119,7 +131,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                 name="business_name"
                 required
                 maxlength="200"
-                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder="e.g. Phoenix Plumbing Co."
               />
             </div>
@@ -127,13 +139,16 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <!-- Vertical + Employee count -->
             <div class="grid gap-5 sm:grid-cols-2">
               <div>
-                <label for="gs-vertical" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="gs-vertical"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   What kind of business?
                 </label>
                 <select
                   id="gs-vertical"
                   name="vertical"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
@@ -142,18 +157,21 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                   type="text"
                   id="gs-vertical-other"
                   name="vertical_other"
-                  class="mt-2 hidden w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="Describe your business type"
                 />
               </div>
               <div>
-                <label for="gs-employees" class="block text-sm font-medium text-slate-700">
+                <label
+                  for="gs-employees"
+                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >
                   Employee count
                 </label>
                 <select
                   id="gs-employees"
                   name="employee_count"
-                  class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   <option value="1-5">1 - 5</option>
@@ -167,13 +185,16 @@ const isPostBooking = Astro.url.searchParams.has('booked')
 
             <!-- Years in business -->
             <div class="sm:w-1/2">
-              <label for="gs-years" class="block text-sm font-medium text-slate-700">
+              <label
+                for="gs-years"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 Years in business
               </label>
               <select
                 id="gs-years"
                 name="years_in_business"
-                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               >
                 <option value="">Select one</option>
                 <option value="<1">Less than 1 year</option>
@@ -186,11 +207,14 @@ const isPostBooking = Astro.url.searchParams.has('booked')
 
             <!-- Biggest challenge -->
             <div>
-              <label for="gs-challenge" class="block text-sm font-medium text-slate-700">
+              <label
+                for="gs-challenge"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 What's the single biggest operational challenge right now?
                 <span class="text-red-500">*</span>
               </label>
-              <p class="mt-0.5 text-xs text-slate-400">
+              <p class="mt-0.5 text-xs text-[color:var(--color-text-muted)]">
                 What would make the biggest difference in how your business runs day to day?
               </p>
               <textarea
@@ -199,20 +223,23 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                 required
                 rows="3"
                 maxlength="2000"
-                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder="e.g. I want to stop being the bottleneck for every decision..."
               ></textarea>
             </div>
 
             <!-- How heard -->
             <div>
-              <label for="gs-how-heard" class="block text-sm font-medium text-slate-700">
+              <label
+                for="gs-how-heard"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 How did you hear about us?
               </label>
               <select
                 id="gs-how-heard"
                 name="how_heard"
-                class="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               >
                 <option value="">Select one</option>
                 <option value="Google Search">Google Search</option>
@@ -227,7 +254,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                 type="text"
                 id="gs-how-heard-other"
                 name="how_heard_other"
-                class="mt-2 hidden w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder="Tell us more"
               />
             </div>
@@ -236,14 +263,17 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <div id="turnstile-container"></div>
 
             <!-- Error banner -->
-            <div id="gs-error" class="hidden rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div
+              id="gs-error"
+              class="hidden rounded-[var(--radius-card)] bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]"
+            >
             </div>
 
             <!-- Submit -->
             <button
               id="gs-submit"
               type="submit"
-              class="w-full rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+              class="w-full rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
             >
               Send
             </button>
@@ -252,9 +282,11 @@ const isPostBooking = Astro.url.searchParams.has('booked')
 
         <!-- Success state (replaces form on submit) -->
         <div id="success-panel" class="mt-10 hidden text-center">
-          <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-green-100">
+          <div
+            class="mx-auto flex h-14 w-14 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10"
+          >
             <svg
-              class="h-7 w-7 text-green-600"
+              class="h-7 w-7 text-[color:var(--color-complete)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -263,18 +295,20 @@ const isPostBooking = Astro.url.searchParams.has('booked')
               <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
             </svg>
           </div>
-          <h2 class="mt-4 text-xl font-bold text-slate-900">Thanks for sharing</h2>
+          <h2 class="mt-4 text-xl font-bold text-[color:var(--color-text-primary)]">
+            Thanks for sharing
+          </h2>
           {
             isPostBooking ? (
-              <p class="mt-2 text-base text-slate-600">
+              <p class="mt-2 text-base text-[color:var(--color-text-secondary)]">
                 We'll review this before your call so we can make the most of our time together.
               </p>
             ) : (
               <Fragment>
-                <p class="mt-2 text-base text-slate-600">
+                <p class="mt-2 text-base text-[color:var(--color-text-secondary)]">
                   We'll review this and be in touch to start the conversation.
                 </p>
-                <p class="mt-6 text-sm text-slate-500">
+                <p class="mt-6 text-sm text-[color:var(--color-text-secondary)]">
                   Ready to schedule a call?
                   <a href="/book" class="font-medium text-primary hover:text-primary/80 underline">
                     Book a time here

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,16 +30,18 @@ import Footer from '../components/Footer.astro'
     <CaseStudies />
 
     <!-- Scorecard CTA -->
-    <section class="bg-slate-50 px-6 py-20">
+    <section class="bg-[color:var(--color-background)] px-6 py-20">
       <div class="mx-auto max-w-3xl text-center">
-        <h2 class="text-2xl font-bold text-slate-900 sm:text-3xl">Not sure where to start?</h2>
-        <p class="mx-auto mt-4 max-w-xl text-lg text-slate-600">
+        <h2 class="text-2xl font-bold text-[color:var(--color-text-primary)] sm:text-3xl">
+          Not sure where to start?
+        </h2>
+        <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--color-text-secondary)]">
           Take our quick operations scorecard and see where your business stands across 6 key areas.
           Takes about 3 minutes.
         </p>
         <a
           href="/scorecard"
-          class="mt-8 inline-block rounded-lg bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+          class="mt-8 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
         >
           Take the Scorecard
         </a>

--- a/src/pages/scorecard.astro
+++ b/src/pages/scorecard.astro
@@ -69,7 +69,7 @@ for (const [i, q] of QUESTIONS.entries()) {
 
   <!-- Progress bar (hidden on landing and results) -->
   <div id="progress-wrapper" class="fixed left-0 top-14 md:top-16 z-50 hidden w-full">
-    <div id="progress-bar" class="h-1.5 w-full bg-slate-200">
+    <div id="progress-bar" class="h-1.5 w-full bg-[color:var(--color-border)]">
       <div
         id="progress-fill"
         class="h-1.5 bg-primary transition-all duration-300"
@@ -78,8 +78,9 @@ for (const [i, q] of QUESTIONS.entries()) {
       </div>
     </div>
     <div class="mx-auto flex max-w-2xl items-center justify-between px-6 pt-2">
-      <p id="progress-text" class="text-sm font-medium text-slate-500"></p>
-      <p id="progress-pct" class="text-sm text-slate-400"></p>
+      <p id="progress-text" class="text-sm font-medium text-[color:var(--color-text-secondary)]">
+      </p>
+      <p id="progress-pct" class="text-sm text-[color:var(--color-text-muted)]"></p>
     </div>
   </div>
 
@@ -90,46 +91,53 @@ for (const [i, q] of QUESTIONS.entries()) {
     <section id="landing">
       <!-- Hero -->
       <div class="px-6 py-20 text-center sm:py-28">
-        <h1 class="mx-auto max-w-3xl text-4xl font-extrabold text-slate-900 sm:text-5xl">
+        <h1
+          class="mx-auto max-w-3xl text-4xl font-extrabold text-[color:var(--color-text-primary)] sm:text-5xl"
+        >
           See where your operations stand
         </h1>
-        <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
+        <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--color-text-secondary)]">
           Answer a few questions about how your business runs. Get an instant, personalized report
           showing where you're strong and where there's room to grow.
         </p>
         <button
           data-action="start"
-          class="mt-8 inline-block rounded-lg bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
+          class="mt-8 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
         >
           Start your scorecard
         </button>
 
         <!-- Trust signals -->
         <div class="mt-8 flex flex-wrap items-center justify-center gap-8">
-          <div class="flex items-center gap-2 text-sm text-slate-500">
-            <span class="material-symbols-outlined text-slate-400">schedule</span>
+          <div class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
+            <span class="material-symbols-outlined text-[color:var(--color-text-muted)]"
+              >schedule</span
+            >
             Takes about 3 minutes
           </div>
-          <div class="flex items-center gap-2 text-sm text-slate-500">
-            <span class="material-symbols-outlined text-slate-400">block</span>
+          <div class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
+            <span class="material-symbols-outlined text-[color:var(--color-text-muted)]">block</span
+            >
             No sales pitch
           </div>
-          <div class="flex items-center gap-2 text-sm text-slate-500">
-            <span class="material-symbols-outlined text-slate-400">bolt</span>
+          <div class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
+            <span class="material-symbols-outlined text-[color:var(--color-text-muted)]">bolt</span>
             Instant results
           </div>
         </div>
       </div>
 
       <!-- Dimensions preview -->
-      <div class="bg-slate-50 px-6 py-16">
-        <h2 class="text-center text-2xl font-bold text-slate-900">What we look at</h2>
+      <div class="bg-[color:var(--color-background)] px-6 py-16">
+        <h2 class="text-center text-2xl font-bold text-[color:var(--color-text-primary)]">
+          What we look at
+        </h2>
         <div class="mx-auto mt-10 grid max-w-4xl grid-cols-2 gap-6 sm:grid-cols-3">
           {
             DIMENSIONS.map((dim) => (
-              <div class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+              <div class="rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-6">
                 <span class="material-symbols-outlined text-3xl text-primary">{dim.icon}</span>
-                <p class="mt-3 font-semibold text-slate-900">{dim.label}</p>
+                <p class="mt-3 font-semibold text-[color:var(--color-text-primary)]">{dim.label}</p>
               </div>
             ))
           }
@@ -138,10 +146,10 @@ for (const [i, q] of QUESTIONS.entries()) {
 
       <!-- Secondary CTA -->
       <div class="px-6 py-16 text-center">
-        <p class="text-xl text-slate-700">Ready to see where you stand?</p>
+        <p class="text-xl text-[color:var(--color-text-primary)]">Ready to see where you stand?</p>
         <button
           data-action="start"
-          class="mt-6 inline-block rounded-lg bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+          class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
         >
           Start your scorecard
         </button>
@@ -157,18 +165,18 @@ for (const [i, q] of QUESTIONS.entries()) {
           steps.map((step) => (
             <div data-step={step.num} class="hidden">
               {step.sectionHeader && (
-                <p class="text-sm font-medium uppercase tracking-wide text-slate-500">
+                <p class="text-sm font-medium uppercase tracking-wide text-[color:var(--color-text-secondary)]">
                   {step.sectionHeader}
                 </p>
               )}
-              <p class="mt-4 text-xl font-semibold leading-relaxed text-slate-900 sm:text-2xl">
+              <p class="mt-4 text-xl font-semibold leading-relaxed text-[color:var(--color-text-primary)] sm:text-2xl">
                 {step.text}
               </p>
               <div class="mt-8 space-y-3">
                 {step.options.map((opt) => (
                   <button
                     data-answer={opt.value}
-                    class="block w-full cursor-pointer rounded-lg border border-slate-200 px-5 py-4 text-left text-base leading-relaxed text-slate-700 transition-colors hover:bg-slate-50"
+                    class="block w-full cursor-pointer rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-5 py-4 text-left text-base leading-relaxed text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-background)]"
                   >
                     {opt.text}
                   </button>
@@ -176,7 +184,7 @@ for (const [i, q] of QUESTIONS.entries()) {
                 {step.type === 'scored' && (
                   <button
                     data-answer="-1"
-                    class="block w-full cursor-pointer rounded-lg border border-dashed border-slate-200 px-5 py-3 text-left text-sm text-slate-400 transition-colors hover:bg-slate-50"
+                    class="block w-full cursor-pointer rounded-[var(--radius-card)] border border-dashed border-[color:var(--color-border)] px-5 py-3 text-left text-sm text-[color:var(--color-text-muted)] transition-colors hover:bg-[color:var(--color-background)]"
                   >
                     Doesn't apply to my business
                   </button>
@@ -191,15 +199,17 @@ for (const [i, q] of QUESTIONS.entries()) {
     <!-- Quiz navigation (back/next) -->
     <div
       id="quiz-nav"
-      class="fixed bottom-0 left-0 hidden w-full border-t border-slate-100 bg-white px-6 py-4"
+      class="fixed bottom-0 left-0 hidden w-full border-t border-[color:var(--color-border-subtle)] bg-white px-6 py-4"
     >
       <div class="mx-auto flex max-w-2xl items-center justify-between">
-        <button id="btn-back" class="text-slate-500 transition-colors hover:text-slate-700"
+        <button
+          id="btn-back"
+          class="text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >Back</button
         >
         <button
           id="btn-next"
-          class="rounded-lg bg-primary px-6 py-2.5 font-medium text-white opacity-50 pointer-events-none transition-opacity"
+          class="rounded-[var(--radius-card)] bg-primary px-6 py-2.5 font-medium text-white opacity-50 pointer-events-none transition-opacity"
         >
           Next
         </button>
@@ -212,16 +222,23 @@ for (const [i, q] of QUESTIONS.entries()) {
     <section id="email-gate" class="hidden">
       <div class="flex min-h-[80vh] flex-col items-center justify-center px-6 py-16">
         <span class="material-symbols-outlined text-5xl text-green-500">check_circle</span>
-        <h2 class="mt-4 text-2xl font-bold text-slate-900 sm:text-3xl">Your report is ready</h2>
-        <p class="mt-2 text-base text-slate-600">Where should we send the full breakdown?</p>
+        <h2 class="mt-4 text-2xl font-bold text-[color:var(--color-text-primary)] sm:text-3xl">
+          Your report is ready
+        </h2>
+        <p class="mt-2 text-base text-[color:var(--color-text-secondary)]">
+          Where should we send the full breakdown?
+        </p>
 
         <form
           id="gate-form"
-          class="mx-auto mt-8 w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+          class="mx-auto mt-8 w-full max-w-md rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-6 sm:p-8"
         >
           <div class="space-y-4">
             <div>
-              <label for="first_name" class="block text-sm font-medium text-slate-700">
+              <label
+                for="first_name"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 First name <span class="text-red-500">*</span>
               </label>
               <input
@@ -229,11 +246,14 @@ for (const [i, q] of QUESTIONS.entries()) {
                 name="first_name"
                 id="first_name"
                 required
-                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
               />
             </div>
             <div>
-              <label for="email" class="block text-sm font-medium text-slate-700">
+              <label
+                for="email"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 Email <span class="text-red-500">*</span>
               </label>
               <input
@@ -241,11 +261,14 @@ for (const [i, q] of QUESTIONS.entries()) {
                 name="email"
                 id="email"
                 required
-                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
               />
             </div>
             <div>
-              <label for="business_name" class="block text-sm font-medium text-slate-700">
+              <label
+                for="business_name"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+              >
                 Business name <span class="text-red-500">*</span>
               </label>
               <input
@@ -253,18 +276,22 @@ for (const [i, q] of QUESTIONS.entries()) {
                 name="business_name"
                 id="business_name"
                 required
-                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
               />
             </div>
             <div>
-              <label for="phone" class="block text-sm font-medium text-slate-700">Phone</label>
+              <label
+                for="phone"
+                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                >Phone</label
+              >
               <input
                 type="tel"
                 name="phone"
                 id="phone"
-                class="mt-1 block w-full rounded-lg border border-slate-200 px-4 py-2.5 text-slate-900 focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
               />
-              <p class="mt-1 text-sm text-slate-400">
+              <p class="mt-1 text-sm text-[color:var(--color-text-muted)]">
                 In case you'd rather talk through your results
               </p>
             </div>
@@ -273,15 +300,15 @@ for (const [i, q] of QUESTIONS.entries()) {
               <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
             </div>
           </div>
-          <p id="gate-error" class="mt-4 hidden text-sm text-red-600"></p>
+          <p id="gate-error" class="mt-4 hidden text-sm text-[color:var(--color-error)]"></p>
           <button
             type="submit"
-            class="mt-6 w-full rounded-lg bg-primary py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+            class="mt-6 w-full rounded-[var(--radius-card)] bg-primary py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
           >
             See my results
           </button>
         </form>
-        <p class="mt-4 text-sm text-slate-400">
+        <p class="mt-4 text-sm text-[color:var(--color-text-muted)]">
           We'll send your detailed PDF report to this email. No spam, ever.
         </p>
       </div>


### PR DESCRIPTION
## Summary

Third and final identity sweep, closing out the portal → admin → marketing pipeline from #455 and #456. All public marketing surfaces at `smd.services` now render the Architect's Studio identity.

## What landed

- **`.design/marketing-ux-brief.md`** — Step 4 deliverable. Scope (10 public surfaces), visit modes (cold visitor, returning prospect, book-ready, researcher, client), identity inheritance, chrome conventions (nav, hero, section labels, cards, booking wizard, buttons, footer), marketing-specific anti-patterns (hero video loops, parallax, gradient text, testimonial carousels, trust-badge rows, stock imagery, chat widgets, etc.), copy-tone reference, success criteria, open follow-ups.

- **Marketing pages swept** — `index.astro`, `book.astro`, `book/manage/[token].astro`, `book/manage/index.astro`, `get-started.astro`, `scorecard.astro`, `contact.astro`, `404.astro`, `auth/login.astro`, `auth/portal-login.astro`, `auth/verify.astro`.

- **Shared components swept** — `Nav`, `Hero`, `Pricing`, `ProblemCards`, `WhoWeHelp`, `HowItWorks`, `FinalCta`, `Footer`, `About`, `CaseStudies`, `WhatYouGet`, `CtaButton`, `SkipToMain`, `booking/SlotPicker`.

- **Replacements, two passes:**
  - Pass 1 (slate + indigo + radii + shadows + fonts): 418 replacements
  - Pass 2 (Tailwind family accents: green/red/amber/blue → semantic tints; `rounded-full` → `rounded-[var(--radius-card)]`): 59 replacements
  - Every `shadow-sm/md/lg/xl/2xl` stripped
  - `font-['Plus_Jakarta_Sans']` / `font-['Inter']` → `font-display` / `font-body`

## Identity shift

| Token | Before | After |
|---|---|---|
| Palette | `bg-slate-{50..200}`, `text-slate-{300..900}`, `bg-indigo-600` primary CTA | Semantic tokens across the board; ochre primary |
| Accents | `bg-green-100 text-green-700`, `bg-red-50 text-red-800`, `bg-amber-100 text-amber-800`, `bg-blue-50 text-blue-700` | `--color-complete/error/attention/primary` tints at 5–30% opacity |
| Radii | `rounded-full` on circular step indicators, icon wrappers, avatars, status chips | All 2px rectangles (`--radius-card`) |
| Booking wizard | Circular step numbers `1` / `2` / `3` | Filled 2px squares, ochre for active step, neutral for others |
| Shadows | `shadow-lg` on hero buttons, cards, modals | None — identity is flat |
| Display font | `font-['Plus_Jakarta_Sans'] font-extrabold` | `font-display` (Cabinet Grotesk via `@layer base`) |
| Body font | `font-['Inter']` | `font-body` (Satoshi) |

## Out of marketing scope (flagged in brief §Open follow-ups)

- **Email templates** (`src/lib/email/templates.ts`, `src/lib/email/follow-up-templates.ts`, `src/lib/booking/alerts.ts`) still reference `'Inter',Arial,sans-serif` inline. Email clients strip web fonts aggressively; `Inter` fallback is safe for delivery. A separate email-audit pass can swap to `'Satoshi'` + better fallback chain.
- **PDF templates** (`src/lib/pdf/sow-template.tsx`, `src/lib/pdf/scorecard-template.tsx`, `src/lib/sow/service.ts`) register fonts via React-PDF. SOW is a client-signed contract document; visual regression check required before merge. Separate PR.
- **Nav mobile menu** remains single-level; reconsider if more marketing sections ship.
- **`/scorecard` results email gate** is an intentional exception to the "no email gates" anti-pattern (the gate is the conversion mechanism).

## Test plan

Local `npm run verify` green:
- [x] `typecheck`: 0 errors
- [x] `typecheck:workers`: clean
- [x] `format:check`: all files use Prettier code style
- [x] `lint`: 0 errors (11 pre-existing worker warnings unchanged)
- [x] `build`: complete
- [x] `test`: 1272 / 1272 pass (2 skipped, pre-existing)

## Captain visual review

Dev server, public pages:
- [ ] `/` — hero in Cabinet Grotesk, ochre CTA, warm palette, no shadows
- [ ] `/book` — wizard step indicators as filled 2px squares
- [ ] `/book/manage/[token]` — reschedule / cancel flow in new identity
- [ ] `/get-started` — intake form chrome
- [ ] `/scorecard` — quiz + results flow (results gate is intentional)
- [ ] `/contact` — minimal page reads warm
- [ ] `/404` — clear message in new typography
- [ ] `/auth/login`, `/auth/portal-login`, `/auth/verify` — magic-link flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
