### PR TITLE
docs(decisions): Phase 1 vertical selection memo — home services, HVAC-first

### DIFF
--- a/docs/decisions/vertical-selection-phase-1.md
+++ b/docs/decisions/vertical-selection-phase-1.md
@@ -1,0 +1,174 @@
+---
+title: Phase 1 Vertical Selection
+date: 2026-04-19
+status: proposed
+captain: Scott Durgan
+---
+
+# Phase 1 Vertical Selection
+
+**Status:** Proposed (this memo). Awaiting Captain sign-off in the "Decision" section below.
+
+**Question:** Which single vertical does SMD Services target first? The Decision Stack narrowed the field to three candidates (home services, professional services, contractor/trades). CLAUDE.md Priority 2 calls for picking ONE. This memo surfaces the trade-offs and recommends.
+
+**Why now:** Every Priority 2 go-to-market execution item — outreach routing, referral cultivation, copy specificity, case-study target — gets sharper the moment a vertical is locked. Without this pick, the outreach plan stays generic.
+
+---
+
+## Recommendation
+
+**Target home services for Phase 1, lead with HVAC.**
+
+Within that, prioritize Phoenix-metro shops doing $1M–$4M with 8–25 employees and a bookkeeper (internal or external). Specifically: residential + light-commercial HVAC first, plumbing second, electrical third. These three share enough operational DNA that wins with one transfer immediately to the others.
+
+Keep contractor/trades as a near-miss reopen path if home-services traction stalls after the first 90 days. Professional services deprioritized for Phase 1 for reasons below; revisit in Phase 2.
+
+---
+
+## Criteria
+
+What a winning Phase 1 vertical needs, in order of weight:
+
+1. **Phoenix density** — we're geography-locked to Phoenix metro for Phase 1 (in-person default, per CLAUDE.md and decision stack). If a vertical is nationally common but under-represented locally, it hurts our pipeline math.
+2. **Referral access to the buyer** — the outreach plan leads with bookkeepers and CPAs (per Decision #22 and `outreach-plan.md`). The vertical must concentrate around the referral channels we can actually open this quarter.
+3. **Pain clarity** — we should be able to diagnose the 2–3 most acute gaps within the first 20 minutes of the assessment call. If the pain pattern is too variable, assessment quality drops.
+4. **Revenue-band fit** — $750k–$5M is the buy box (CLAUDE.md). A vertical where the typical shop is $8M or $400k is a bad fit.
+5. **Owner-buyer profile** — the owner writes the check. The vertical needs owners who are reachable, decide in one call, and aren't protected by a gatekeeper.
+6. **Time to first sale** — we need 3 free case-study engagements in the first 90 days. Verticals with long research/decision cycles hurt this.
+7. **Scott's fit** — the delivery team is Scott. His background (20+ years enterprise product + tech, creative technologist, service-driven) matters less than vertical fit in Phase 1; the assessment call pattern is transferable. Marked as the lightest criterion but non-zero.
+
+Explicitly NOT on the list: margin, deal size, repeatability, scalability. Those matter for Phase 2+. Phase 1 is about getting three case studies shipped with real clients and a real price on a real invoice.
+
+---
+
+## Candidate analysis
+
+### Home services (HVAC, plumbing, electrical, pool, roofing, garage)
+
+| Criterion           | Score | Notes                                                                                                                                    |
+| ------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Phoenix density     | ★★★★★ | HVAC alone is a massive Phoenix sector (climate-driven). Pool service is year-round. Plumbing and electrical fragmented and plentiful.   |
+| Referral access     | ★★★★  | External bookkeepers are the norm. CPA firms serving trades are a known referral path. Trade associations active locally.                |
+| Pain clarity        | ★★★★★ | Scheduling dispatch, lead-follow-up, talent retention, owner bottleneck, spreadsheet-driven operations. Pattern-matches CLAUDE.md.       |
+| Revenue-band fit    | ★★★★  | Typical 8–25-person shop lands in band. Some larger (multi-truck, multi-region) cross $5M; that's the ceiling, acceptable overflow.      |
+| Owner-buyer profile | ★★★★  | Owner-operators. Reachable. Decision in 1–2 calls. No gatekeeper (maybe office manager).                                                 |
+| Time to first sale  | ★★★★  | Fast. Trades owners respect results over process — if we show up with a referral and speak plainly, we're in.                            |
+| Scott's fit         | ★★★   | Neutral — he doesn't have trade vocabulary but trades owners don't need that from a consultant. Creative-technologist positioning lands. |
+
+**Risks:**
+
+- Peak season is April–September. HVAC owners are maxed out on operations; selling them on an operational engagement during peak may stall. Counter: book discovery in May-June, start in July-August (slower shoulder), deliver October.
+- Some owners distrust consultants on principle. Our "guide alongside, not audit" positioning needs to come through in every touch.
+- Tool adoption risk — some trade operations are paper-based by culture. Scope-awareness: avoid over-engineering.
+
+### Professional services (accountants, attorneys, small consulting firms)
+
+| Criterion           | Score | Notes                                                                                                                                 |
+| ------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Phoenix density     | ★★★   | Moderate. Concentrated in downtown / Scottsdale business districts. Smaller than home services in total addressable firms.            |
+| Referral access     | ★★    | Accountants refer accountants; attorneys refer attorneys. Cross-referrals harder. Our bookkeeper-referral channel doesn't serve here. |
+| Pain clarity        | ★★★   | Owner bottleneck and partner-level capacity issues, yes. Scheduling less acute. Financial visibility usually already strong.          |
+| Revenue-band fit    | ★★★   | Wider spread. Some small, some $10M+. Professional-services firms in the exact $750k–$5M band are a narrower subset.                  |
+| Owner-buyer profile | ★★    | Partners may have multiple decision-makers. Research-heavy buying pattern. Longer cycle.                                              |
+| Time to first sale  | ★★    | Slow. Professional services buy from peers and industry-specific vendors. They'll research us for months.                             |
+| Scott's fit         | ★★★★  | Strong. Scott's enterprise background translates directly to understanding professional-services operations.                          |
+
+**Risks:**
+
+- Selling operational expertise to people who sell operational expertise is a positioning landmine. They compete with us by framing.
+- Long sales cycle hurts our 3-case-study-in-90-days goal.
+
+### Contractor / trades (GCs, specialty subs, commercial construction)
+
+| Criterion           | Score | Notes                                                                                                                           |
+| ------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Phoenix density     | ★★★   | Real but cyclical. Growth-sensitive. Currently strong but volatile.                                                             |
+| Referral access     | ★★★   | Construction-specific CPAs exist. Insurance agents. Trade associations. Not as mature a network as home-services CPA referrals. |
+| Pain clarity        | ★★★★  | Estimating, scheduling, subcontractor coordination, invoicing, project margin visibility. Strong pattern.                       |
+| Revenue-band fit    | ★★    | High variance. Single-job volume can push contractors above $5M fast. More projects mean more variance.                         |
+| Owner-buyer profile | ★★★   | Owner-operator typical. Reachable. But project-based life means they're intermittently hard to reach.                           |
+| Time to first sale  | ★★★   | Moderate. Seasonality matters (construction is calendar-driven).                                                                |
+| Scott's fit         | ★★    | Construction has its own vocabulary. Steeper learning curve.                                                                    |
+
+**Risks:**
+
+- Project-based revenue patterns make "ongoing operational improvements" a harder sell — wins can vanish at project turnover.
+- Subcontractor coordination is a whole specialty that our current toolkit doesn't fully cover.
+
+---
+
+## Why home services wins
+
+Stacking the scores:
+
+| Vertical              | Phoenix density | Referral access | Pain clarity | Revenue fit | Buyer profile | Time to sale | Total |
+| --------------------- | --------------- | --------------- | ------------ | ----------- | ------------- | ------------ | ----- |
+| Home services         | 5               | 4               | 5            | 4           | 4             | 4            | 26    |
+| Professional services | 3               | 2               | 3            | 3           | 2             | 2            | 15    |
+| Contractor / trades   | 3               | 3               | 4            | 2           | 3             | 3            | 18    |
+
+Home services wins on every criterion except "Scott's fit," which we've already rated lightest. And the criteria where home services wins biggest (Phoenix density, pain clarity) are the structural ones we can't change.
+
+The referral-channel alignment is the real tiebreaker. The outreach plan's Week 1 move is bookkeeper DM outreach. Bookkeepers serving Phoenix-metro businesses in our revenue band serve trades disproportionately; that's where the first three warm intros will come from.
+
+---
+
+## Why lead with HVAC inside home services
+
+Home services is a cluster, not a single vertical. Within it, sub-vertical sequence matters:
+
+1. **HVAC (residential + light-commercial)** — Phoenix climate makes HVAC near-universal. 8–25-person shops are common. Operational patterns (dispatch, service calls, maintenance contracts, seasonal staffing) are well-documented. Industry-specific tools (ServiceTitan, Housecall Pro, Jobber) are mature — we configure, we don't build.
+2. **Plumbing** — similar shape, slightly less density than HVAC in Phoenix, very similar operational pain. Cross-sells from HVAC case studies easily.
+3. **Electrical** — third because the customer mix skews more commercial, which stretches our scope awareness.
+
+Pool service, roofing, garage are close-in but operationally different (pool is year-round and low-margin; roofing is storm-driven; garage is low-repeat). Keep as Phase 2 expansions if Phase 1 wins.
+
+---
+
+## Signal-to-switch
+
+Conditions that would make us revisit this pick:
+
+- **90 days, zero paid engagements in home services.** Our pipeline math projects 2 assessments per week → 27 engagements/year. If we're not hitting 2 assessments per week by Day 60, the channel assumption is wrong. Reassess outreach before vertical.
+- **3+ organic warm intros from bookkeeper network into professional services.** We don't need to chase professional services to end up there if the network delivers them. Test one.
+- **Explicit "can't deliver" signal during an engagement.** If a home-services engagement reveals we can't land the outcome — e.g., tools we're recommending don't fit the actual workflow — pause further home-services outreach until we've fixed the delivery model.
+- **Captain learns something direct.** Vistage group, EO Arizona, or networking conversation that changes the bet. Easy to reverse.
+
+---
+
+## What this decision locks for downstream work
+
+Once locked, the following collateral tightens to home services / HVAC-first:
+
+- `outreach-plan.md` — bookkeeper DM messaging mentions "HVAC, plumbing, electrical" specifically instead of generic "trades"
+- One-pager — add an HVAC-adjacent example to the "What We Hear" list
+- Landing page — first case-study placeholder slot should be home-services-voiced
+- Proposal / SOW template — "what we heard" example language shifts toward dispatch / service-call / maintenance-contract vocabulary
+- Google Business Profile — category selection: "Business Management Consultant" primary, "HVAC Contractor" never (we're not the HVAC vendor; we're their consultant)
+- CRM / lead automation — lead scoring prioritizes home-services signals in the four existing pipelines
+
+None of these require rewrites — they're small surgical updates that become trivial once the bet is locked.
+
+---
+
+## Decision
+
+> **To lock this decision:** replace the `status: proposed` in the frontmatter with `status: accepted`, add a `decided` date, and add one sentence below confirming the bet. Then the downstream collateral updates can land in a single follow-up PR.
+
+**Captain's decision:** _(pending)_
+
+- [ ] Accept recommendation (home services, HVAC-first)
+- [ ] Accept with sub-vertical change (home services, but lead with **\_\_** instead of HVAC)
+- [ ] Override recommendation (pick **\_\_** instead)
+- [ ] Defer (need more data — specify)
+
+**Captain's notes:** _(pending)_
+
+---
+
+## Related
+
+- [Decision Stack](../adr/decision-stack.md) — the 29 locked decisions feeding this memo
+- [Outreach Plan](../collateral/outreach-plan.md) — the execution plan this decision tunes
+- [Pricing Framework](../collateral/pricing-framework.md) — pricing methodology, vertical-agnostic
+- [Assessment Call Script](../collateral/assessment-call-script.md) — includes vertical-specific pain-cluster reference at the bottom


### PR DESCRIPTION
## Summary

Closes the last open Priority 2 go-to-market item: vertical selection. This is a strategic decision (legitimately Captain's call) but it needs a structured artifact in front of it, not a slack message. Memo authored to `docs/decisions/vertical-selection-phase-1.md` with full analysis and a recommendation.

## Recommendation

**Home services, HVAC-first.** Phoenix density is overwhelming for HVAC (climate-driven); pain pattern pattern-matches CLAUDE.md cleanly; bookkeeper-referral channel from the outreach plan serves trades disproportionately; revenue band fits typical 8–25-person shop. Within home services, ordering is HVAC → plumbing → electrical.

Score tally (7 criteria):
- Home services: 26
- Contractor / trades: 18
- Professional services: 15

## What the memo contains

- Weighted criteria (Phoenix density → referral access → pain clarity → revenue-band fit → owner profile → time to sale → Scott's fit)
- Scored tables for each of the three candidates
- Risks per candidate (HVAC peak season; professional-services positioning landmine; construction project variance)
- Sub-vertical ordering rationale
- 4 signal-to-switch conditions
- Downstream-lock list (which collateral items get sharpened once locked)
- Captain decision section at the bottom with four explicit options

## Next step

Memo ships as `status: proposed`. Captain locks by editing the memo (flip to `status: accepted`, add `decided` date, pick an option in the Decision section). Once locked, a follow-up surgical PR updates the downstream collateral to reflect the chosen vertical.

## Test plan

- [x] Local `npm run verify` green — 0 errors everywhere; 1272/1272 tests pass
- [x] Markdown formatted (Prettier)
- [x] Links check: points to decision-stack.md, outreach-plan.md, pricing-framework.md, assessment-call-script.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)