### PR TITLE
feat(marketing): /ai landing page + AI nav link + homepage AI bullet

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -15,6 +15,10 @@
     <nav class="flex items-center gap-6">
       <a
         class="text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+        href="/ai">AI</a
+      >
+      <a
+        class="text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
         href="/contact">Contact</a
       >
       <a

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,6 +11,10 @@
     <div class="flex items-center gap-5">
       <a
         class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
+        href="/ai">AI</a
+      >
+      <a
+        class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
         href="/contact">Contact</a
       >
       <a

--- a/src/components/WhatYouGet.astro
+++ b/src/components/WhatYouGet.astro
@@ -4,6 +4,7 @@ const items = [
   'Tool selection, configuration, and integration',
   'Custom internal tools and dashboards built for how you work',
   'System integrations that eliminate manual data entry',
+  "AI and automation where it actually helps, nothing where it doesn't",
   'Vendor evaluation and selection when off-the-shelf fits better',
   'Data migration and setup',
   'Hands-on team training and walkthrough',

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -1,0 +1,89 @@
+---
+export const prerender = false
+
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import FinalCta from '../components/FinalCta.astro'
+import Footer from '../components/Footer.astro'
+import CtaButton from '../components/CtaButton.astro'
+---
+
+<Base
+  title="AI & Automation | SMD Services"
+  description="AI strategy, tool selection, custom automation, and team training for growing businesses. Sometimes the answer is AI. Sometimes it's something simpler. Let's figure out which."
+>
+  <Nav />
+  <main id="main" role="main">
+    <section class="relative overflow-hidden px-6 pb-32 pt-24">
+      <div class="mx-auto max-w-4xl text-center">
+        <h1
+          class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-[color:var(--color-text-primary)] md:text-7xl"
+        >
+          AI and Automation for Growing Businesses.
+        </h1>
+        <p
+          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+        >
+          Some of what you're hearing about AI is useful. A lot of it is noise. We help you sort it
+          out and build what fits how your business actually works.
+        </p>
+        <CtaButton href="/book">Book a Call</CtaButton>
+      </div>
+    </section>
+
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-4xl">
+        <h2
+          class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl"
+        >
+          What Working With Us Looks Like
+        </h2>
+        <div class="space-y-10 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+          <p>
+            <span class="font-semibold text-[color:var(--color-text-primary)]"
+              >A conversation first.</span
+            > We walk through what you're trying to do and where things are getting stuck. Then we figure
+            out together whether AI is the right answer or whether something simpler would serve you better.
+          </p>
+          <p>
+            <span class="font-semibold text-[color:var(--color-text-primary)]"
+              >The right tool, not the loudest one.</span
+            > Dozens of AI tools are marketed at businesses your size every month. We help you tell which
+            ones actually fit your work and which are solving someone else's problem.
+          </p>
+          <p>
+            <span class="font-semibold text-[color:var(--color-text-primary)]"
+              >Built for how your team already works.</span
+            >
+            If we build something custom, whether it's an AI assistant, a script that cleans up a recurring
+            task, or an integration between tools, it fits into how your team already operates instead
+            of asking them to change.
+          </p>
+          <p>
+            <span class="font-semibold text-[color:var(--color-text-primary)]"
+              >Training your team to use it.</span
+            > A tool nobody uses is worse than no tool at all. We make sure your team can actually run
+            what we build after we're gone.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-[color:var(--color-background)] px-6 py-24">
+      <div class="mx-auto max-w-3xl text-center">
+        <h2 class="mb-8 text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl">
+          Is AI Actually the Right Answer?
+        </h2>
+        <p class="text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+          Sometimes yes. Other times the answer is a simple script, a better process, or just
+          getting two of your tools to talk to each other. And sometimes the answer is not yet.
+          That's the conversation. If you walk out of it thinking AI isn't where you should spend
+          money this quarter, that's a win too. Clarity is the point.
+        </p>
+      </div>
+    </section>
+
+    <FinalCta />
+  </main>
+  <Footer />
+</Base>


### PR DESCRIPTION
## Summary

- Supersedes stale PR #432 (branched 2026-04-17, conflicts with current Modern Institutional identity after three intervening sweeps).
- Ports the `/ai` landing page, nav link, footer link, and homepage AI bullet forward against current tokens — Crimson Pro + Public Sans + navy + warm-umber inverse.
- Doctrine (the six-category solution taxonomy with AI & automation) already landed on main via an earlier path; this PR ships the public surface.

## What's in the PR

- **`src/pages/ai.astro`** — four-section landing. Hero, "what working with us looks like", "is AI actually the right answer", reused `FinalCta`. Honest-broker posture. Copy follows the tone standard: collaborative "we", no dollar amounts, no fixed timeframes, no AI-polish register.
- **`src/components/Nav.astro`** — AI link before Contact. Nav reads AI / Contact / Book a Call.
- **`src/components/Footer.astro`** — matching AI link.
- **`src/components/WhatYouGet.astro`** — outcome-voiced bullet: "AI and automation where it actually helps, nothing where it doesn't".

## After merge

- Close PR #432 and delete `feat/widen-scope-add-ai` branch.
- Follow-ons remain open and unblocked: #433 (lead-gen 5→6 taxonomy), #435 (scorecard copy alignment).

## Test plan

- [x] `npm run verify` — typecheck (0 errors), lint, Prettier, 1272 tests pass, 2 skipped.
- [ ] Visual check on preview: /ai renders at 320/375/768/1024.
- [ ] Nav shows AI before Contact on mobile and desktop.
- [ ] Homepage WhatYouGet includes AI bullet between integrations and vendor eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)