### PR TITLE
feat(marketing): Claude-first stance on /ai + generalize CaseStudies patterns

### DIFF
--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -2,42 +2,38 @@
 const studies = [
   {
     vertical: 'Home Services',
-    business: 'HVAC Company, 18 employees',
+    pattern: 'Owner as dispatcher',
     challenge:
-      "The owner was dispatching every job personally. The schedule lived in three places: a whiteboard, a shared Google Calendar, and text messages. Leads from the website sat in a Gmail inbox until someone got around to checking it. The owner hadn't taken a full day off in two years because every question came back to them.",
+      'The owner dispatches every job. The schedule lives in three places: a whiteboard, a shared calendar, and text threads. Website leads sit in a Gmail inbox until someone gets to them. The owner rarely takes a full day off because every question routes back to them.',
     solution:
-      "One dispatching workflow the whole crew can see, in the office or out in the field. Lead capture that puts new inquiries into a tracked pipeline with same-day follow-up. A daily check-in so the owner knows what's happening without picking up the phone.",
-    result: '12 hours/week freed for the owner',
+      'One dispatching workflow the whole crew can see, in the office or in the field. Lead capture with tracked follow-up so nothing sits unread. A daily check-in so the owner stays informed without being the hub for every question.',
     problems: ['Owner bottleneck', 'Disconnected tools', 'Process design'],
   },
   {
     vertical: 'Professional Services',
-    business: 'Accounting Firm, 12 employees',
+    pattern: 'Partner in every decision',
     challenge:
-      'Every client question went straight to the founding partner, even routine ones the team could handle. The sales pipeline was a mental list. Client onboarding took weeks because every step was manual and different every time. The partner wanted to focus on advisory work but spent most of the day fielding questions and approving things.',
+      "Every client question routes to the founding partner, even the routine ones. The sales pipeline lives in someone's head. Client onboarding takes weeks because every step is manual and different every time. The partner wants to focus on advisory work but spends most of the day as the bottleneck for routine decisions.",
     solution:
-      "A documented intake and onboarding process the team can follow without asking the partner. A visible pipeline so everyone knows where prospects stand. Templated communication for routine client questions, so the partner's time goes to work that actually needs them.",
-    result: 'Partner reclaimed 15+ hours/week for advisory work',
+      "A documented intake and onboarding process the team can run without the partner. A visible pipeline everyone can see. Templated communication for routine client questions so the partner's time goes to work that actually needs them.",
     problems: ['Owner bottleneck', 'Process design', 'Systems integration'],
   },
   {
     vertical: 'Home Services',
-    business: 'Plumbing Company, 14 employees',
+    pattern: 'Lead capture and lost jobs',
     challenge:
-      'Website leads came in through a contact form and sat unread for days. Double-bookings happened weekly because the office and field crews were on different calendars. The owner had no idea which jobs were profitable. The books were months behind and pricing was based on gut feel.',
+      'Website leads come in through a contact form and sit unread for days. Double-bookings happen because the office and the field crew are on different calendars. Nobody knows which jobs are profitable. The books are behind and pricing is gut feel.',
     solution:
-      'Lead capture tied to automatic assignment and follow-up, so nothing sits unread. One scheduling tool the whole crew can get to from the field. Clean books with job-level profitability, so pricing decisions come from real numbers instead of gut feel.',
-    result: 'Zero missed leads in first month after go-live',
+      'Lead capture tied to automatic assignment and follow-up so nothing sits unread. One scheduling tool the whole crew can get to from the field. Clean books with job-level profitability so pricing decisions come from numbers, not feel.',
     problems: ['Customers falling through', 'Disconnected tools', 'Operational visibility'],
   },
   {
     vertical: 'Professional Services',
-    business: 'Insurance Agency, 15 employees',
+    pattern: 'Turnover under pressure',
     challenge:
-      'The agency lost four staff members in a year. The owner chalked it up to pay and the job market. But the pattern was clear: new hires had no structured onboarding and were left to figure things out on their own. Every account manager handled policies differently. There was no way to know if you were doing a good job until a client complained. Good people moved on to places where they felt more supported.',
+      'New hires have no structured onboarding and are left to figure things out on their own. Every team member handles policies differently. Nobody knows if someone is doing a good job until a client complains. Good people move on to places where they feel more supported.',
     solution:
-      "A structured onboarding process so new hires know exactly what to expect and aren't guessing from day one. Documented workflows for common policy types so the team handles things the same way. Simple tracking so managers can see workload and the owner can spot problems before they turn into resignations.",
-    result: 'Zero turnover in the 6 months following delivery',
+      "A structured onboarding process so new hires know what to expect and aren't guessing from day one. Documented workflows for common policy types so the team handles things consistently. Simple tracking so managers can see workload and spot problems before they turn into resignations.",
     problems: ['Talent gaps', 'Process design', 'Operational visibility'],
   },
 ]
@@ -46,9 +42,12 @@ const studies = [
 <section class="bg-white px-6 py-24">
   <div class="mx-auto max-w-5xl">
     <div class="mb-4 text-center">
-      <h2 class="text-3xl font-bold text-[color:var(--color-text-primary)]">What We Do</h2>
+      <h2 class="text-3xl font-bold text-[color:var(--color-text-primary)]">
+        The Kind of Work We Take On
+      </h2>
       <p class="mx-auto mt-4 max-w-2xl text-[color:var(--color-text-secondary)]">
-        Different businesses, similar patterns. Here's the kind of work we take on.
+        Different businesses, similar patterns. These are the shapes we see, not specific
+        engagements.
       </p>
     </div>
 
@@ -62,7 +61,7 @@ const studies = [
                   {study.vertical}
                 </span>
                 <h3 class="text-lg font-bold text-[color:var(--color-text-primary)]">
-                  {study.business}
+                  {study.pattern}
                 </h3>
               </div>
               <div class="mt-3 flex flex-wrap gap-2">
@@ -89,9 +88,6 @@ const studies = [
                 <p class="mt-3 leading-relaxed text-[color:var(--color-text-secondary)]">
                   {study.solution}
                 </p>
-                {study.result && (
-                  <p class="mt-4 text-sm font-semibold text-primary">{study.result}</p>
-                )}
               </div>
             </div>
           </div>

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -83,6 +83,22 @@ import CtaButton from '../components/CtaButton.astro'
       </div>
     </section>
 
+    <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-3xl text-center">
+        <h2 class="mb-8 text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl">
+          When AI is part of the answer, Claude is our default.
+        </h2>
+        <div class="space-y-6 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+          <p>Not every engagement calls for AI. The ones that do, Claude is what we reach for.</p>
+          <p>
+            Staying with one platform frees us to be direct. When we tell you AI isn't the right
+            fit, it's not because we don't know any. When we tell you it is, we're building on
+            ground we already know.
+          </p>
+        </div>
+      </div>
+    </section>
+
     <FinalCta />
   </main>
   <Footer />

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -97,6 +97,41 @@ const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp | string }> = [
     label: "Pattern B: hardcoded default consultantFirstName = 'Scott'",
     pattern: /consultantFirstName\s*=\s*['"]Scott['"]/,
   },
+  // --- Specific phrases removed from CaseStudies.astro (2026-04-22) ---
+  // CaseStudies shipped four fabricated case studies with specific
+  // quantified results. Real case studies belong in an authored data
+  // source per engagement, not committed to source. These patterns
+  // guard against reintroduction of the exact phrases removed.
+  {
+    label: 'Pattern A: fabricated "X hours/week freed" result',
+    pattern: /hours\/week freed/,
+  },
+  {
+    label: 'Pattern A: fabricated "Zero missed leads in [period]" result',
+    pattern: /Zero missed leads in /,
+  },
+  {
+    label: 'Pattern A: fabricated "Zero turnover in [period]" result',
+    // Matches both "Zero turnover in 6 months" and "Zero turnover in the 6 months"
+    // (the original fabrication used the latter phrasing). Still shape-bound —
+    // honest general copy like "Zero turnover in isolation" would not match.
+    pattern: /Zero turnover in (?:the |\d)/,
+  },
+  {
+    label: 'Pattern A: fabricated "Partner reclaimed N+ hours" result',
+    pattern: /Partner reclaimed \d+\+? hours/,
+  },
+  // --- Structural pattern: quantified time-savings results at large ---
+  // Catches "12 hours/week freed", "15 hrs per month saved",
+  // "10+ hours/day reclaimed", etc. Drift resistance to the pattern-class,
+  // not just today's exact wording. Narrowly scoped to the
+  // freed/saved/reclaimed/back verbs to avoid false positives on honest
+  // general copy about "hours per week".
+  {
+    label: 'Pattern A: fabricated quantified time-savings result (structural)',
+    pattern:
+      /\d+\+?\s*(?:hours?|hrs?)\s*(?:per|\/)\s*(?:week|wk|month|mo|day)\s+(?:freed|saved|reclaimed|back)/i,
+  },
 ]
 
 const sourceFiles = collectSourceFiles(SRC_ROOT)


### PR DESCRIPTION
## Summary

Three changes ship together. Scope narrowed against an earlier draft through stress-test (/critique round).

**1. /ai gains a Claude-first section.** New section is appended AFTER the existing honest-broker caveat ("Is AI Actually the Right Answer?") and before FinalCta. Reading order becomes: hero → how we work → is AI actually the right answer? (honest-broker gate) → when AI IS the answer, Claude is our default (platform preference downstream of the gate) → book a call. Doctrine preserved: gate first, platform choice conditional on passing the gate. Stays abstract on the technical stack; no partnership, credential, or named-component claims. New section uses ` + '`bg-white`' + `, preserving the beige-white-beige-white-inverse rhythm — no existing section's bg changes.

**2. CaseStudies.astro drops fabricated client specifics.** Pre-existing honesty gap. Business descriptors ("HVAC Company, 18 employees"), quantified results ("12 hours/week freed", "Zero turnover in the 6 months following delivery"), and narrative past-tense framing are removed. Section retitled **"The Kind of Work We Take On"** with subtitle **"Different businesses, similar patterns. These are the shapes we see, not specific engagements."** The disclaimer clause is load-bearing — it reframes the section from implicit-case-study to explicit-pattern. Scene-level archetypal detail (whiteboard, Gmail inbox, gut-feel pricing) is retained; that's pattern texture, not client-attributed claim. Data model loses ` + '`business`' + ` and ` + '`result`' + ` fields; gains a ` + '`pattern`' + ` field used in the card header.

**3. Forbidden-strings guardrail.** ` + '`tests/forbidden-strings.test.ts`' + ` gains five FORBIDDEN_PATTERNS entries: four specifics for the exact removed phrases (` + '`hours/week freed`' + `, ` + '`Zero missed leads in `' + `, ` + '`Zero turnover in (the |\\d)`' + `, ` + '`Partner reclaimed \\d+\\+? hours`' + `) plus one structural pattern (` + '`\\d+\\+?\\s*(?:hours?|hrs?)\\s*(?:per|/)\\s*(?:week|wk|month|mo|day)\\s+(?:freed|saved|reclaimed|back)`' + `) for drift resistance to the class of quantified-time-savings fabrication. Self-checked against pre-change content: all five patterns match the old fabrications; all pass against the new content.

## Scope discipline

**Explicitly out of scope** (user-confirmed narrow positioning):
- Firm shape — operator+agent-workforce model stays undisclosed
- Partnership pipeline language — silent on the site
- Individual credential (CCA pursuit) — not mentioned
- Named technical components — no Agent SDK / MCP / Claude Code / Managed Agents by name
- CLAUDE.md doctrine — unchanged
- Hero / How We Work / About / Pricing / Nav / Footer / WhoWeHelp / WhatYouGet content

Resolves a pre-existing CLAUDE.md no-fabrication violation alongside the Claude-first positioning work.

## Test plan

- [x] ` + '`npm run verify`' + ` passes — typecheck, lint, Prettier, 1277 tests pass (5 added)
- [x] Forbidden-strings self-check — all 5 new patterns match pre-change CaseStudies content; all pass against new content
- [x] Voice rules scan — 0 em dashes, 0 AI-polish words (leverage/cutting-edge/transformational/seamlessly/unlock/empower), 0 dollar amounts, 0 fixed-timeframe promises, 0 parallel-structure "-ing X and -ing Y" tells
- [ ] Visual check on preview: /ai renders with 5-section alternation at 375/768/1024
- [ ] Visual check on preview: homepage CaseStudies section renders with new heading + subtitle, no fabricated specifics, problem-tag chips still populate
- [ ] FinalCta coherence — current FinalCta is business-focused ("Let's Talk About Your Business"), not AI-specific, so reads fine after the new Claude-first section

🤖 Generated with [Claude Code](https://claude.com/claude-code)