### PR TITLE
content(ai): explicit 'what we won't do' + Claude-line reframe

### DIFF
--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -84,16 +84,67 @@ import CtaButton from '../components/CtaButton.astro'
     </section>
 
     <section class="bg-white px-6 py-24">
+      <div class="mx-auto max-w-4xl">
+        <h2
+          class="mb-4 text-center text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl"
+        >
+          What We Won't Do
+        </h2>
+        <p
+          class="mx-auto mb-12 max-w-2xl text-center text-lg leading-relaxed text-[color:var(--color-text-secondary)]"
+        >
+          A few lines we hold because they matter more than a sale.
+        </p>
+        <div class="space-y-10 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+          <div>
+            <h3 class="mb-3 text-xl font-semibold text-[color:var(--color-text-primary)]">
+              We won't automate judgment.
+            </h3>
+            <p>
+              Some decisions should stay with a person who knows your business. We'll build a tool
+              that gets the right information to the right person faster. We won't build one that
+              makes the call for them and hides how it got there.
+            </p>
+          </div>
+          <div>
+            <h3 class="mb-3 text-xl font-semibold text-[color:var(--color-text-primary)]">
+              We won't replace people.
+            </h3>
+            <p>
+              The goal is to give your team back the hours they're losing to busywork, so they can
+              spend that time on the work that actually needs a human. If an engagement is really a
+              headcount decision wearing a tech coat, we'll tell you that instead of selling you the
+              tech.
+            </p>
+          </div>
+          <div>
+            <h3 class="mb-3 text-xl font-semibold text-[color:var(--color-text-primary)]">
+              We won't hand over a dashboard and call it strategy.
+            </h3>
+            <p>
+              A dashboard shows you what's happening. It doesn't tell you what to do about it.
+              Visibility is part of the work, not the whole of it. You should leave an engagement
+              with a clearer picture and a plan for acting on it.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-[color:var(--color-background)] px-6 py-24">
       <div class="mx-auto max-w-3xl text-center">
         <h2 class="mb-8 text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl">
           When AI is part of the answer, Claude is our default.
         </h2>
         <div class="space-y-6 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
-          <p>Not every engagement calls for AI. The ones that do, Claude is what we reach for.</p>
           <p>
-            Staying with one platform frees us to be direct. When we tell you AI isn't the right
-            fit, it's not because we don't know any. When we tell you it is, we're building on
-            ground we already know.
+            Not every engagement calls for AI. When one does, Claude is what we reach for because
+            it's the best fit for most of the work we do.
+          </p>
+          <p>
+            That's a preference, not a lock-in. If your situation is better served by a different
+            model, a different tool, or no AI at all, we'll say so and build accordingly. What we
+            won't do is bend the answer to match a stack we already like.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Closes #484. Parent epic: #483.

## Summary

- Adds a discrete "What We Won't Do" section to `/ai` with three principled non-offerings: won't automate judgment, won't replace people, won't hand over a dashboard and call it strategy. Framed as principles (headed H3 with supporting prose), not marketing bullets.
- Reframes the "When AI is part of the answer, Claude is our default" section with a visible *why* that resolves the persona-review split signal:
  - **Restraint read** (law-firm partner archetype) — first paragraph says Claude is the default "because it's the best fit for most of the work we do," not the reflex for every problem.
  - **Lock-in read** (HVAC owner archetype) — second paragraph names it directly: "That's a preference, not a lock-in. If your situation is better served by a different model, a different tool, or no AI at all, we'll say so and build accordingly."
- Preserves all existing conversion-earning copy: hero headline, anti-hype subhead, "What Working With Us Looks Like", and "Is AI Actually the Right Answer?" sections unchanged.

## Constraints honored

- No em dashes, no "simply/seamlessly/robust", no parallel AI structures, no fabricated content, no fixed timeframes, no dollar amounts.
- Claude-first narrow scope: framed as platform preference only, not firm shape or partnership status.
- Guide persona + collaborative peer voice maintained throughout. Owner-respectful framing.

## Acceptance criteria

- [x] `/ai` ships with a "what we won't do" section naming three specific non-offerings.
- [x] The "Claude is what we reach for" line is reframed with a visible *why*.
- [x] Existing conversion-earning copy retained.
- [ ] Cold-entry conversion rate holds or improves within 4 weeks (requires #2.5 instrumentation, tracked separately).

## Verification

- `npm run verify` passes (45 test files, 1277 tests, exit 0).
- Pre-push hook re-ran verify, passed.

## Review

Awaiting Captain review — do not merge without approval.