### PR TITLE
content(diagnostic): post-engagement artifact template + content rules

### DIFF
--- a/docs/style/diagnostic-artifact-content-rules.md
+++ b/docs/style/diagnostic-artifact-content-rules.md
@@ -1,0 +1,450 @@
+# Diagnostic artifact content rules
+
+Content-scope rules governing what can and cannot appear in a diagnostic
+artifact — the post-engagement deliverable that documents SMD Services'
+thinking process on a completed engagement. Each rule is narrow, cited to
+the project [CLAUDE.md](../../CLAUDE.md) or a public authority, and
+documented with a concrete out-of-bounds phrase that would fail review.
+
+This document exists because SMD Services is pre-launch with zero
+completed engagements. Every target-client persona that reviewed
+`smd.services` in April 2026 named "no case studies" as the credibility
+gap. CLAUDE.md § "No fabricated client-facing content" forbids the
+obvious fix (inventing case studies). The diagnostic artifact is the
+compliant substitute: a real post-engagement deliverable that shows
+thinking process rather than invented results. For the plan, see the
+parent epic [#483](https://github.com/venturecrane/ss-console/issues/483)
+and the child issue [#487](https://github.com/venturecrane/ss-console/issues/487).
+
+The typed template scaffold lives at
+[`src/lib/diagnostic/artifact-template.ts`](../../src/lib/diagnostic/artifact-template.ts).
+Every rule in this document is reflected in that file's placeholder
+comments and validation helpers.
+
+It pairs with two existing specs:
+
+- [`empty-state-pattern.md`](./empty-state-pattern.md) — when a section
+  lacks authored data, render nothing or an explicit marker. The same
+  rule applies to diagnostic artifacts: an observation slot without a
+  real observation is omitted, never padded.
+- [`UI-PATTERNS.md`](./UI-PATTERNS.md) — visual and component rules for
+  rendered surfaces. When Phase 2 renders the artifact to PDF, the
+  typography and spacing rules in that doc govern the visual treatment.
+
+## Scope
+
+These rules bind all diagnostic-artifact content authored in this repo,
+including the typed template scaffold, any populated artifact TypeScript
+modules, and the rendered PDFs. They do not govern internal engagement
+notes, draft VCMS entries, or private working documents. The moment an
+artifact is prepared for external distribution — shown to a prospect,
+linked from the site, sent in a proposal — these rules apply.
+
+## Authority anchors
+
+Every rule cites either the project CLAUDE.md or a public,
+URL-resolvable authority.
+
+- **CLAUDE.md § "No fabricated client-facing content"** — the governing
+  project rule. Pattern A (committed template sentences that imply
+  uncontracted commitments) and Pattern B (runtime fabrication from
+  non-authoritative fields) are the two violation shapes this document
+  guards against.
+- **CLAUDE.md § "Tone & Positioning Standard"** — voice rules (we / our
+  team), collaborative posture, objectives-first framing.
+- **CLAUDE.md § "Respect business owners"** (via global memory) — never
+  shame the client whose engagement is being documented.
+- **NN/g — Evidence-based design writing** —
+  <https://www.nngroup.com/articles/evidence-based-design-writing/>.
+  Traceable observations, not asserted conclusions.
+- **Nielsen & Tahir, Homepage Usability, evidence principle** —
+  <https://www.nngroup.com/articles/ten-usability-heuristics/>. Heuristic
+  10, "Help and documentation," on the broader point that claims without
+  traceable source lose trust on inspection.
+
+---
+
+## Rule 1 — Consent gates client attribution
+
+**Rule.** A diagnostic artifact may name the client, describe the client's
+business specifically, or quote the client only when written consent is on
+file. Without written consent, the artifact is anonymous: no business
+name, no identifiable details, no direct quotes.
+
+**Authority.**
+
+- CLAUDE.md § "No fabricated client-facing content": "Any information
+  displayed to a client ... MUST come from data authored for that
+  specific engagement."
+- The template type `ClientAttribution` requires a `consent` record with
+  `written: true`, `capturedAt`, and `storageRef`. See
+  [`src/lib/diagnostic/artifact-template.ts`](../../src/lib/diagnostic/artifact-template.ts).
+
+**In-bounds.**
+
+- "Phoenix-area HVAC contractor, 12 field technicians" — when the
+  client has given written consent to this level of identifiable detail.
+- "A Phoenix-area home services business" — when consent has not been
+  given. The artifact can describe the engagement without naming the
+  business.
+
+**Out-of-bounds.**
+
+- Inventing a business name, even a plausible one ("Acme HVAC"). The
+  empty-state pattern applies: no name is acceptable; a stand-in name
+  is not.
+- Naming the client in any section of the artifact when consent is not
+  on file — not in the title, not in observations, not in quotes.
+- Partial consent applied in full. If the client consented to be named
+  but not quoted, the artifact can name them but cannot quote them.
+
+**Detection.** `findConsentViolations()` in the template scaffold
+enforces the type-level gate. A human reviewer verifies the consent
+record matches what is actually on file before the artifact ships.
+
+---
+
+## Rule 2 — Observations must trace to a source
+
+**Rule.** Every observed signal cites its source. A source is a
+conversation (with date), a system that was directly inspected, a
+document the client provided, or a direct quote (with written consent).
+An observation without a source is speculation and does not belong in
+the artifact.
+
+**Authority.**
+
+- CLAUDE.md Pattern B violation: "Values rendered from sources never
+  authored as client-facing content." A sourceless observation is a
+  Pattern B violation because the claim is ungrounded.
+- NN/g on evidence-based writing: claims that cannot be traced to a
+  source lose trust on inspection.
+
+**In-bounds sources.**
+
+- "Assessment call, 2026-05-03" — a conversation we were in.
+- "QuickBooks walkthrough, 2026-05-10" — a system we directly
+  inspected.
+- "Shared Drive: 'SOP - Intake.docx'" — a document the client gave us.
+- "Owner's own words, written consent on file" — a direct quote, used
+  only when Rule 1's consent gate is open.
+
+**Out-of-bounds sources.**
+
+- "Industry benchmark" — we do not publish benchmark claims we cannot
+  verify.
+- "Common pattern in HVAC" — speculation about other businesses is
+  out-of-bounds under Rule 5.
+- "Owner mentioned off-hand" — if it is worth citing, get consent to
+  cite it. If it is not worth citing, omit it.
+- No source named at all. Any observation without a source fails
+  review.
+
+**Detection.** The template type `ObservedSignal` requires both
+`observation` and `source` fields. The placeholder prompts name the
+in-bounds and out-of-bounds source lists inline.
+
+---
+
+## Rule 3 — No character claims about the client
+
+**Rule.** A pattern diagnosis describes the business, not the owner. A
+structural problem lives in systems, workflows, and data flows. It does
+not live in the owner's judgment, competence, or past decisions.
+
+**Authority.**
+
+- CLAUDE.md via global memory: "Respect business owners ... never write
+  copy that judges owners; they're doing their best, frame gaps as
+  normal growth pains."
+- CLAUDE.md § "Tone & Positioning Standard" rule 2: "We are a peer
+  working alongside the owner, not an expert arriving to audit them."
+
+**In-bounds.**
+
+- "Intake and production systems do not share a customer identifier, so
+  handoffs happen by memory."
+- "Quotes are drafted in Google Docs and re-typed into QuickBooks."
+- "The team has no standard for what constitutes a qualified lead."
+
+**Out-of-bounds.**
+
+- "The owner never built a real system" — character claim.
+- "The owner hasn't prioritized data hygiene" — judgment claim.
+- "Leadership has been reactive for years" — a claim about the owner's
+  track record, not about the business's current state.
+- Any phrasing that implies the owner should have known better or done
+  differently before we got there. Patterns live in the business; the
+  artifact documents patterns, not blame.
+
+**Detection.** Human review. No automated check catches tonal
+violations — this is what the review gate in issue #487 AC #4 exists
+for.
+
+---
+
+## Rule 4 — No outcome claims that post-date handoff
+
+**Rule.** The artifact documents what was observable at the time of
+handoff. Anything that requires follow-up verification — a month-later
+metric, a quarter-later revenue change, a testimonial arriving after
+the engagement closed — is out of scope for the artifact and belongs
+in a follow-up artifact if it belongs anywhere.
+
+**Authority.**
+
+- CLAUDE.md Pattern B: "Runtime fabrication from non-authoritative
+  fields." A forward-looking claim on a handoff artifact is a Pattern
+  B violation because the claim is not yet observable.
+- CLAUDE.md § "No fabricated client-facing content": we cannot verify
+  what we did not observe, and an artifact that asserts verified
+  outcomes we have not checked is the exact fabrication pattern that
+  hotfix #378 removed from the proposal flow.
+
+**In-bounds.**
+
+- "New intake form went live on 2026-05-28 and processed 14 leads by
+  handoff on 2026-06-02." A counted fact with a time anchor.
+- "Office manager completed training and demonstrated the new workflow
+  end-to-end during the handoff session." An observed event.
+- "At handoff, the team reported the new process was operational; we
+  did not observe a full production cycle before closing the
+  engagement." An explicit statement of what was and was not
+  observable.
+
+**Out-of-bounds.**
+
+- "Revenue increased by 30% the following quarter." Requires follow-up
+  we did not perform.
+- "Response time improved from 2 days to 2 hours." Requires a baseline
+  and a post-measurement we did not take.
+- "Client reported higher team morale." A follow-up testimonial, not a
+  handoff observation.
+- Any projection ("will reduce," "should improve," "expected to"). The
+  artifact is a record of observation, not a forecast.
+
+**Detection.** The template type `OutcomeObservedAtHandoff` requires
+an `observedAt` date. Slot prompts explicitly call out projection
+language as out-of-bounds. Human review catches the rest.
+
+---
+
+## Rule 5 — No speculation about other businesses or verticals
+
+**Rule.** The artifact describes one engagement. It does not generalize
+to other clients, other verticals, or other businesses "like this one."
+Whatever pattern we observed, we observed in one place under one set of
+conditions. Inference beyond that is out of scope.
+
+**Authority.**
+
+- CLAUDE.md § "No fabricated client-facing content": generalizations
+  beyond the engagement are claims we cannot author from the engagement
+  record.
+- CLAUDE.md § "Tone & Positioning Standard" rule 1: we lead with the
+  client's specific objectives, not with industry-wide claims.
+
+**In-bounds.**
+
+- "The contractor ran intake, scheduling, and quoting on three
+  unconnected tools." One business's configuration, stated plainly.
+- "The owner chose to keep QuickBooks rather than migrate, citing the
+  six years of transaction history." One decision, with the reason
+  given at the time.
+
+**Out-of-bounds.**
+
+- "Most HVAC contractors run this way." Speculation about other
+  businesses.
+- "In our experience, salons usually struggle with this." Generalization
+  from one engagement to a vertical.
+- "Similar patterns appear in professional services firms." Claims we
+  cannot support from a single engagement.
+- Any framing that positions this engagement as a proxy for all
+  engagements in the vertical. One artifact is one artifact.
+
+**Detection.** Human review. Vertical-generalization phrases are
+recognizable on a read-through.
+
+---
+
+## Rule 6 — No invented advice
+
+**Rule.** The artifact documents the advice we gave during the
+engagement, not advice we would have given, could have given, or think
+we should have given. If it was not in the engagement record, it does
+not belong in the artifact.
+
+**Authority.**
+
+- CLAUDE.md Pattern A: "Committed template sentences that imply
+  uncontracted commitments." Advice we did not give is uncontracted.
+- Issue #487 scope: "Template must be ... specific enough to produce a
+  document worth keeping" — kept by being accurate to the engagement,
+  not by being rounded out with post-hoc recommendations.
+
+**In-bounds.**
+
+- "We recommended patching the existing intake form rather than
+  rebuilding in HubSpot." A real decision point, a real
+  recommendation, given during the engagement.
+- "We deliberately did not propose a CRM migration. The objective was
+  intake cleanup, not platform change." A scope choice we made at the
+  time.
+
+**Out-of-bounds.**
+
+- "A further step would have been to automate the follow-up
+  sequence." We did not give this advice; adding it here is invention.
+- "In hindsight, we should have addressed X first." Hindsight is not
+  engagement advice.
+- "Future work could include ..." The artifact is about what happened,
+  not about upsell.
+
+**Detection.** The template types `TradeoffConsidered` and
+`DeliberatelyNotDone` ask "what did we decide during the engagement,"
+not "what might be done." Human review catches drift.
+
+---
+
+## Rule 7 — Voice discipline
+
+**Rule.** The artifact uses SMD Services' voice standard. "We" and "our
+team" throughout. Never "I" or "the consultant." Never "SMD Services
+did X" (third-person self-reference). The tone is collaborative, not
+diagnostic — we worked alongside the client, we did not audit them.
+
+**Authority.**
+
+- CLAUDE.md § "Tone & Positioning Standard" rule 6 and Decision Stack
+  #20.
+- CLAUDE.md § "Tone & Positioning Standard" rule 2: "We are a peer
+  working alongside the owner, not an expert arriving to audit them."
+
+**In-bounds.**
+
+- "We observed that intake was manual from first touch to job site
+  creation."
+- "We chose the patch over the rebuild because the rebuild would have
+  displaced the office manager mid-season."
+- "We decided not to migrate historical quote records."
+
+**Out-of-bounds.**
+
+- "I noticed that ..." First-person singular.
+- "SMD Services designed ..." Third-person self-reference.
+- "The consultant recommended ..." Neither first-person nor natural
+  voice.
+- "We audited the intake process." Diagnostic framing; the collaborative
+  verb is "worked through" or "observed," not "audited."
+
+**Detection.** Human review. Grep for `\bI\b` and `consultant` on
+populated artifacts as a soft check.
+
+---
+
+## Rule 8 — No AI prose
+
+**Rule.** The artifact is written the way a human writes. No em dashes.
+No parallel-structure sentences of the "not X, but Y" shape. No rhythmic
+triplets ("fast, clean, and clear"). No corporate-polished phrases like
+"leverage," "unlock," "synergy," "streamline," "empower." The artifact
+sounds like someone who did the work wrote it.
+
+**Authority.**
+
+- CLAUDE.md via global memory: "No AI copy ... no em dashes, no parallel
+  structures, no polished AI phrasing; copy must sound human-written."
+
+**In-bounds.**
+
+- "We saw quotes get drafted in one place and re-typed in another. That
+  is where data was drifting."
+- "The owner asked for an intake fix. We looked at the whole intake
+  flow before touching anything."
+
+**Out-of-bounds.**
+
+- "We streamlined their intake, empowered their team, and unlocked new
+  velocity." Corporate-polished verbs stacked.
+- "Not just faster — smarter." The "not X, but Y" shape.
+- "Observed. Diagnosed. Delivered." Rhythmic triplet.
+- Any sentence with an em dash used as a rhetorical pivot. Use a period
+  or a comma.
+
+**Detection.** Human review. A read-aloud test surfaces most violations
+within the first paragraph.
+
+---
+
+## In-bounds summary
+
+A diagnostic artifact CAN contain:
+
+- Observations traceable to a named source (conversation with date,
+  system inspected, document seen, quote with written consent)
+- Owner's own words, paraphrased or quoted, only with written consent
+  on file
+- Trade-offs considered during the engagement, including roads not
+  taken
+- Thinking process and reasoning applied at the time of the decision
+- What was delivered, described neutrally and concretely
+- Things observable at the time of handoff, anchored to the handoff
+  date
+- Explicit acknowledgment of what was not observable at handoff
+
+## Out-of-bounds summary
+
+A diagnostic artifact must never contain:
+
+- Client name or identifiable details without written consent (Rule 1)
+- Fabricated or stand-in client names (Rule 1, CLAUDE.md Pattern B)
+- Observations without a traceable source (Rule 2)
+- Character claims, judgment claims, or blame directed at the client
+  (Rule 3)
+- Outcome metrics requiring follow-up verification after handoff
+  (Rule 4, CLAUDE.md Pattern B)
+- Projections, forecasts, or "will improve" language (Rule 4)
+- Generalizations to other clients, verticals, or "businesses like
+  this one" (Rule 5)
+- Advice we did not actually give during the engagement (Rule 6,
+  CLAUDE.md Pattern A)
+- Hindsight recommendations or "future work could include" upsell
+  framing (Rule 6)
+- First-person singular, third-person self-reference, or diagnostic
+  verbs like "audited" (Rule 7)
+- Em dashes, parallel structures, rhythmic triplets, or corporate
+  polish verbs (Rule 8)
+- Any other Pattern A (committed sentence implying uncontracted
+  commitment) or Pattern B (runtime fabrication from non-authoritative
+  fields) violation as defined in CLAUDE.md
+
+## Enforcement
+
+- **Type-level** — the TypeScript template at
+  [`src/lib/diagnostic/artifact-template.ts`](../../src/lib/diagnostic/artifact-template.ts)
+  requires sourced observations, consent records on client attribution,
+  and handoff-dated outcomes. `findUnfilledPlaceholders`,
+  `findSectionsBelowMinimum`, and `findConsentViolations` block the
+  obvious mechanical failures.
+- **Review gate** — no diagnostic artifact ships without Captain review
+  against this document. Issue #487 AC #4 is the gate for first-time
+  sign-off on the in-bounds / out-of-bounds lists.
+- **Follow-up issue** — a child issue files after the first engagement
+  completes to populate the first artifact. Population happens inside
+  the bounds defined here; no relaxation of rules to fit whatever
+  engagement comes first.
+
+## Relationship to other specs
+
+- [`empty-state-pattern.md`](./empty-state-pattern.md) — the
+  render-nothing / marker pattern applies to unpopulated diagnostic
+  artifact sections identically to how it applies to portal surfaces.
+  An observation slot with no real observation is omitted, never
+  padded.
+- [`UI-PATTERNS.md`](./UI-PATTERNS.md) — when Phase 2 renders the
+  artifact to PDF via the existing Forme pipeline, the typography and
+  spacing rules govern the visual treatment.
+- [`CLAUDE.md`](../../CLAUDE.md) — the project governing document.
+  Pattern A and Pattern B violation definitions live there; this
+  document applies them to the diagnostic-artifact surface.

--- a/src/lib/diagnostic/artifact-template.ts
+++ b/src/lib/diagnostic/artifact-template.ts
@@ -1,0 +1,560 @@
+/**
+ * Diagnostic Artifact — typed template scaffold.
+ *
+ * A diagnostic artifact is a real post-engagement deliverable that documents
+ * SMD Services' thinking process on a completed engagement. It is the
+ * pre-launch compliant substitute for case studies: we cannot write case
+ * studies until we have signed, completed, consented engagements, and
+ * CLAUDE.md forbids fabricated client-facing content. See the parent epic
+ * #483 and child issue #487 for context.
+ *
+ * What this file is.
+ *   - The typed shape of a populated artifact.
+ *   - An unpopulated `EMPTY_ARTIFACT` scaffold with placeholder prompts on
+ *     every slot, matched one-for-one to `docs/style/diagnostic-artifact-content-rules.md`.
+ *   - Validation helpers that block obvious out-of-bounds content (fabricated
+ *     names, unsourced observations, outcome metrics claimed after handoff).
+ *
+ * What this file is NOT.
+ *   - A populated artifact. No example artifact ships until the first real
+ *     engagement completes (CLAUDE.md "No fabricated client-facing content").
+ *   - A PDF renderer. Rendering lands in Phase 2 — see the PDF rendering
+ *     path notes at the bottom of this file and `TODO(phase-2)` markers.
+ *
+ * Authority anchors:
+ *   - CLAUDE.md § "No fabricated client-facing content" — governing rule.
+ *   - CLAUDE.md § "Tone & Positioning Standard" — voice, collaborative
+ *     posture, "we" / "our team" never "I".
+ *   - `docs/style/diagnostic-artifact-content-rules.md` — the in-bounds /
+ *     out-of-bounds lists this scaffold enforces.
+ *   - `docs/style/empty-state-pattern.md` — when a slot lacks authored data,
+ *     the template renders nothing or a `TBD` marker, never a fallback
+ *     sentence. Same rule applies here.
+ *
+ * @see docs/style/diagnostic-artifact-content-rules.md
+ * @see CLAUDE.md
+ */
+
+// ---------------------------------------------------------------------------
+// Section primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * An observed signal — something SMD Services saw, heard, or directly
+ * inspected during the engagement. Every observation MUST trace to a
+ * source. Sources are the audit trail: if a reader asks "how do you know
+ * that," the source answers.
+ *
+ * In-bounds sources (non-exhaustive):
+ *   - "Assessment call, 2026-05-03" — a conversation we were in
+ *   - "QuickBooks walkthrough" — a system we directly inspected
+ *   - "Shared Drive: 'SOP - Intake.docx'" — a document the client gave us
+ *   - "Owner's own words" — a direct quote, used only with written consent
+ *
+ * Out-of-bounds sources:
+ *   - "Industry benchmark" — we do not publish benchmark claims we cannot verify
+ *   - "Common pattern in {vertical}" — speculation about other businesses
+ *   - "Owner mentioned off-hand" — if it is worth citing, get consent to cite it
+ */
+export interface ObservedSignal {
+  /**
+   * The observation itself. Neutral language, descriptive, non-judgmental.
+   * CAN: describe what was observed ("Quotes are drafted in Google Docs
+   * and re-typed into QuickBooks").
+   * CANNOT: characterize the owner's judgment ("The owner never built a
+   * real system"). Respect-owners rule applies — engagements are not
+   * vehicles for shaming clients.
+   */
+  observation: string
+
+  /**
+   * Where the observation came from. A reader should be able to ask "how
+   * do you know that" and the source answers. See ObservedSignal docstring
+   * for the in-bounds / out-of-bounds source list.
+   */
+  source: string
+}
+
+/**
+ * A pattern diagnosis — the problem(s) SMD Services identified from the
+ * observed signals. Diagnoses are observations about the business, never
+ * claims about the owner's character or past decisions.
+ *
+ * A diagnosis must be supported by observations. If a diagnosis has no
+ * signals behind it, it is speculation and belongs elsewhere (or nowhere).
+ */
+export interface PatternDiagnosis {
+  /**
+   * The pattern. Descriptive, specific, traceable to one or more signals.
+   * CAN: name a structural problem ("Intake and production systems do not
+   * share a customer identifier, so handoffs happen by memory").
+   * CANNOT: attribute the pattern to the owner's judgment ("The owner
+   * hasn't prioritized data hygiene"). Patterns live in the business,
+   * not in people.
+   */
+  pattern: string
+
+  /**
+   * Which observed signals support this diagnosis. Reference by the
+   * signals' order in the ObservedSignal[] array (0-indexed), or leave
+   * empty if the diagnosis is too broad for a single-signal trace.
+   * Empty support arrays are a yellow flag — most diagnoses should cite
+   * at least one signal.
+   */
+  supportingSignalIndices: number[]
+}
+
+/**
+ * A trade-off considered during the engagement. Shows thinking process.
+ * The artifact's differentiator from a generic deliverables list is that
+ * it documents the decisions, not just the outputs.
+ */
+export interface TradeoffConsidered {
+  /**
+   * The decision point. Phrased as the question that was open.
+   * CAN: "Rebuild the intake form in HubSpot vs. patch the existing Google
+   * Form with a Zapier route to QuickBooks."
+   * CANNOT: rewrite history to make every decision look obvious in
+   * retrospect. If the right answer was not clear at the time, say so.
+   */
+  decisionPoint: string
+
+  /**
+   * Why the chosen path was chosen. Reasoning that a reader can evaluate.
+   * CAN: "We chose the patch because the HubSpot rebuild would have
+   * displaced the office manager's workflow mid-season."
+   * CANNOT: invent a rationale we did not actually apply at the time.
+   */
+  rationale: string
+}
+
+/**
+ * A concrete deliverable that shipped at handoff. Descriptive, not
+ * promotional. Names what was built, not what it will achieve.
+ */
+export interface ShippedDeliverable {
+  /**
+   * The deliverable.
+   * CAN: "Zapier route from Google Form to QuickBooks customer record,
+   * with deduplication on email match."
+   * CANNOT: make efficacy claims ("Will save 5 hours/week" — that is a
+   * Pattern B projection, not an observable).
+   */
+  description: string
+}
+
+/**
+ * Something SMD Services deliberately chose NOT to do during the
+ * engagement. This is the restraint signal that personas cite as the
+ * trust-earning move — it demonstrates scope discipline and shows the
+ * engagement was scoped around the objective, not around selling more
+ * work.
+ */
+export interface DeliberatelyNotDone {
+  /**
+   * What was not done. Specific.
+   * CAN: "Did not migrate historical quote records into QuickBooks."
+   * CANNOT: frame the omission as a judgment on the client ("The owner
+   * did not want to pay for data migration"). The omission is ours.
+   */
+  item: string
+
+  /**
+   * Why it was not done. The reasoning is the signal.
+   * CAN: "Historical quotes would not reach the new intake flow anyway,
+   * so the migration cost was not justified by the objective."
+   * CANNOT: invent a post-hoc rationalization. If the reason was cost or
+   * time, say so plainly.
+   */
+  rationale: string
+}
+
+/**
+ * An outcome that was observable at the time of handoff. Tightly scoped.
+ *
+ * This is the slot most vulnerable to Pattern B violations. A reader
+ * wants to know "did it work" and the temptation is to say "yes." The
+ * honest answer at handoff is almost always "here is what we can see
+ * today, here is what we cannot yet see."
+ *
+ * In-bounds (observable at handoff):
+ *   - "New intake form went live on 2026-05-28 and processed 14 leads by
+ *     handoff on 2026-06-02."
+ *   - "Office manager completed training and demonstrated the new workflow
+ *     end-to-end during the handoff session."
+ *
+ * Out-of-bounds (requires follow-up to verify, not in scope here):
+ *   - "Revenue increased by X% in the following quarter."
+ *   - "Response time improved from 2 days to 2 hours."
+ *   - "Client reported higher team morale."
+ *
+ * If follow-up observations land later and are authored with the client's
+ * consent, they belong in a follow-up artifact, not this one.
+ */
+export interface OutcomeObservedAtHandoff {
+  /** The observable fact as of `observedAt`. */
+  outcome: string
+
+  /**
+   * The handoff date. Anchors the claim in time — a reader should see
+   * that this is what we observed on day X, not a forward-looking
+   * projection.
+   */
+  observedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Top-level artifact shape
+// ---------------------------------------------------------------------------
+
+export interface DiagnosticArtifact {
+  /**
+   * Engagement title. Descriptive phrase, not a product name.
+   * CAN: "Intake rebuild for a Phoenix HVAC contractor."
+   * CANNOT: brand the engagement ("SMD's Flagship HVAC Solution").
+   */
+  title: string
+
+  /**
+   * Engagement date range, pre-formatted. Both dates are required.
+   * Example: "May 2026 – June 2026".
+   */
+  dateRange: string
+
+  /**
+   * Who the engagement was with. Renders only when explicit written
+   * consent to name the client has been received. Without consent, the
+   * field is `null` and the "Who we worked with" section renders with the
+   * generic context line only — never a fabricated business name.
+   *
+   * See CLAUDE.md "No fabricated client-facing content" and
+   * `docs/style/empty-state-pattern.md`.
+   */
+  client: ClientAttribution | null
+
+  observedSignals: ObservedSignal[]
+  patternDiagnoses: PatternDiagnosis[]
+  tradeoffsConsidered: TradeoffConsidered[]
+  shippedDeliverables: ShippedDeliverable[]
+  deliberatelyNotDone: DeliberatelyNotDone[]
+  outcomesObservedAtHandoff: OutcomeObservedAtHandoff[]
+}
+
+export interface ClientAttribution {
+  /**
+   * The client's business name. Required when `consent.written === true`.
+   * Never render a placeholder or stand-in name.
+   */
+  businessName: string
+
+  /**
+   * One-line context. Vertical, size class, geography if relevant. No
+   * client quotes go here — those live under observed signals with
+   * source attribution.
+   * Example: "Phoenix-area HVAC contractor, 12 field technicians."
+   */
+  contextLine: string
+
+  /**
+   * Consent record. `written` must be `true` for the client name and
+   * context line to render. Anything less than written consent means
+   * the consumer must treat this artifact as anonymous.
+   */
+  consent: {
+    /** Did the client sign a consent form or email an explicit yes? */
+    written: boolean
+    /** ISO date of consent capture. */
+    capturedAt: string
+    /** Where the consent record is stored (VCMS ref, filename, etc.). */
+    storageRef: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty scaffold — the authored starting point for a new artifact
+// ---------------------------------------------------------------------------
+
+/**
+ * The scaffold an author copies when starting a new artifact. Every slot
+ * carries a visible placeholder prompt that names what CAN go there and
+ * what CANNOT. The scaffold is not a template to fill — it is a checklist
+ * of questions to answer with real observations from a real engagement.
+ *
+ * Slot counts follow the issue #487 spec:
+ *   - observedSignals: 3–5 slots
+ *   - patternDiagnoses: 2–3 slots
+ *   - tradeoffsConsidered: 2–4 slots
+ *   - shippedDeliverables: 3–5 slots
+ *   - deliberatelyNotDone: 1–3 slots
+ *   - outcomesObservedAtHandoff: 2–3 slots
+ *
+ * If an engagement does not produce enough material to fill the minimum
+ * counts, the artifact is not ready to ship. That is a feature, not a
+ * constraint — an artifact with two thin observations is not a proof of
+ * thinking, it is a proof of nothing.
+ */
+export const EMPTY_ARTIFACT: DiagnosticArtifact = {
+  // PLACEHOLDER — replace with descriptive engagement phrase.
+  // CAN: "Intake rebuild for a Phoenix HVAC contractor."
+  // CANNOT: invent a branded engagement name or a superlative.
+  title: '{ENGAGEMENT TITLE — descriptive phrase, not a branded name}',
+
+  // PLACEHOLDER — replace with the real engagement dates.
+  // CAN: "May 2026 – June 2026"
+  // CANNOT: leave as a month range we did not actually work.
+  dateRange: '{START MONTH YEAR – END MONTH YEAR}',
+
+  // PLACEHOLDER — leave as `null` until written consent is on file. If the
+  // client has consented, replace with a populated ClientAttribution
+  // object. Never render a stand-in name.
+  client: null,
+
+  observedSignals: [
+    // Slot 1 of 3–5.
+    // CAN: a specific, neutral observation tied to a source.
+    // CANNOT: a character claim about the owner. The observation lives in
+    // the business, not in people.
+    {
+      observation: '{OBSERVATION 1 — specific, neutral, descriptive}',
+      source: '{SOURCE — conversation date, system inspected, document seen}',
+    },
+    {
+      observation: '{OBSERVATION 2}',
+      source: '{SOURCE}',
+    },
+    {
+      observation: '{OBSERVATION 3}',
+      source: '{SOURCE}',
+    },
+    // Add slots 4 and 5 as needed. If the engagement did not produce five
+    // observations worth citing, three is fine — do not pad.
+  ],
+
+  patternDiagnoses: [
+    // Slot 1 of 2–3.
+    // CAN: a structural pattern supported by one or more observed signals.
+    // CANNOT: a diagnosis of the owner's competence, judgment, or past
+    // decisions. Respect-owners rule applies.
+    {
+      pattern: '{DIAGNOSIS 1 — structural, observation-supported}',
+      supportingSignalIndices: [],
+    },
+    {
+      pattern: '{DIAGNOSIS 2}',
+      supportingSignalIndices: [],
+    },
+  ],
+
+  tradeoffsConsidered: [
+    // Slot 1 of 2–4.
+    // CAN: a real decision point and the reasoning applied at the time.
+    // CANNOT: a rewritten narrative where the chosen path was obvious. If
+    // the answer was not clear at the time, say so in the rationale.
+    {
+      decisionPoint: '{DECISION 1 — the question that was open during the engagement}',
+      rationale: '{RATIONALE — why we chose what we chose, at the time we chose it}',
+    },
+    {
+      decisionPoint: '{DECISION 2}',
+      rationale: '{RATIONALE}',
+    },
+  ],
+
+  shippedDeliverables: [
+    // Slot 1 of 3–5.
+    // CAN: a concrete, descriptive name for what was built or set up.
+    // CANNOT: an efficacy claim ("Will save X hours/week"). Projections
+    // about the future are Pattern B violations.
+    {
+      description: '{DELIVERABLE 1 — descriptive, not promotional}',
+    },
+    {
+      description: '{DELIVERABLE 2}',
+    },
+    {
+      description: '{DELIVERABLE 3}',
+    },
+  ],
+
+  deliberatelyNotDone: [
+    // Slot 1 of 1–3.
+    // CAN: something we chose not to do, with the reason we chose not to.
+    // CANNOT: frame the choice as the client's fault or a limitation they
+    // imposed. The choice was ours.
+    {
+      item: '{ITEM NOT DONE 1 — what was out of scope by design}',
+      rationale: '{RATIONALE — why we decided against it, at the time}',
+    },
+  ],
+
+  outcomesObservedAtHandoff: [
+    // Slot 1 of 2–3.
+    // CAN: an observable fact as of the handoff date. If a number can be
+    // cited, cite the source (e.g., "processed 14 leads between 2026-05-28
+    // and 2026-06-02 per the new intake log").
+    // CANNOT: a claim about what happens next. "Will reduce intake time"
+    // is a Pattern B violation. "Observed 14 leads in the first five days"
+    // is in-bounds because it is a counted fact with a time anchor.
+    {
+      outcome: '{OUTCOME 1 — observable fact as of the handoff date}',
+      observedAt: '{HANDOFF DATE — YYYY-MM-DD}',
+    },
+    {
+      outcome: '{OUTCOME 2}',
+      observedAt: '{HANDOFF DATE}',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Flags that a populated artifact still contains unfilled placeholder
+ * prompts. The validator looks for the literal `{` ... `}` brace pattern
+ * used in `EMPTY_ARTIFACT` — if any remain in a populated artifact, the
+ * artifact is not ready to ship.
+ *
+ * This is a presence check, not a fabrication check. It cannot stop an
+ * author from inventing a quote and putting it in an observation — only
+ * human review can do that. See content rules doc.
+ */
+export function findUnfilledPlaceholders(artifact: DiagnosticArtifact): string[] {
+  const unfilled: string[] = []
+  const placeholderPattern = /\{[A-Z][^}]*\}/
+
+  if (placeholderPattern.test(artifact.title)) {
+    unfilled.push('title')
+  }
+  if (placeholderPattern.test(artifact.dateRange)) {
+    unfilled.push('dateRange')
+  }
+  artifact.observedSignals.forEach((s, i) => {
+    if (placeholderPattern.test(s.observation)) unfilled.push(`observedSignals[${i}].observation`)
+    if (placeholderPattern.test(s.source)) unfilled.push(`observedSignals[${i}].source`)
+  })
+  artifact.patternDiagnoses.forEach((d, i) => {
+    if (placeholderPattern.test(d.pattern)) unfilled.push(`patternDiagnoses[${i}].pattern`)
+  })
+  artifact.tradeoffsConsidered.forEach((t, i) => {
+    if (placeholderPattern.test(t.decisionPoint))
+      unfilled.push(`tradeoffsConsidered[${i}].decisionPoint`)
+    if (placeholderPattern.test(t.rationale)) unfilled.push(`tradeoffsConsidered[${i}].rationale`)
+  })
+  artifact.shippedDeliverables.forEach((d, i) => {
+    if (placeholderPattern.test(d.description))
+      unfilled.push(`shippedDeliverables[${i}].description`)
+  })
+  artifact.deliberatelyNotDone.forEach((x, i) => {
+    if (placeholderPattern.test(x.item)) unfilled.push(`deliberatelyNotDone[${i}].item`)
+    if (placeholderPattern.test(x.rationale)) unfilled.push(`deliberatelyNotDone[${i}].rationale`)
+  })
+  artifact.outcomesObservedAtHandoff.forEach((o, i) => {
+    if (placeholderPattern.test(o.outcome)) unfilled.push(`outcomesObservedAtHandoff[${i}].outcome`)
+    if (placeholderPattern.test(o.observedAt))
+      unfilled.push(`outcomesObservedAtHandoff[${i}].observedAt`)
+  })
+
+  return unfilled
+}
+
+/**
+ * Counts slots against the issue #487 minimums. An artifact below any
+ * minimum is not ready to ship — see the `EMPTY_ARTIFACT` docstring for
+ * why minimums exist.
+ *
+ * Returns the list of sections below their minimum, empty when the
+ * artifact meets all minimums.
+ */
+export function findSectionsBelowMinimum(artifact: DiagnosticArtifact): string[] {
+  const below: string[] = []
+  if (artifact.observedSignals.length < 3) below.push('observedSignals (< 3)')
+  if (artifact.patternDiagnoses.length < 2) below.push('patternDiagnoses (< 2)')
+  if (artifact.tradeoffsConsidered.length < 2) below.push('tradeoffsConsidered (< 2)')
+  if (artifact.shippedDeliverables.length < 3) below.push('shippedDeliverables (< 3)')
+  if (artifact.deliberatelyNotDone.length < 1) below.push('deliberatelyNotDone (< 1)')
+  if (artifact.outcomesObservedAtHandoff.length < 2) below.push('outcomesObservedAtHandoff (< 2)')
+  return below
+}
+
+/**
+ * Enforces the consent gate. When `client` is non-null, `consent.written`
+ * must be `true`. Returns a list of consent violations; empty when the
+ * artifact is compliant.
+ */
+export function findConsentViolations(artifact: DiagnosticArtifact): string[] {
+  const violations: string[] = []
+  if (artifact.client !== null) {
+    if (!artifact.client.consent.written) {
+      violations.push('client.consent.written is not true; client attribution must be removed')
+    }
+    if (!artifact.client.consent.capturedAt) {
+      violations.push('client.consent.capturedAt is missing')
+    }
+    if (!artifact.client.consent.storageRef) {
+      violations.push('client.consent.storageRef is missing')
+    }
+  }
+  return violations
+}
+
+// ---------------------------------------------------------------------------
+// PDF rendering path notes — Phase 2
+// ---------------------------------------------------------------------------
+//
+// The diagnostic artifact will render to PDF through the same Forme WASM
+// pipeline that produces SOWs and scorecard reports. The rendering
+// implementation lands in Phase 2, after the first real engagement has
+// populated an artifact and we can verify the visual treatment against
+// real content.
+//
+// Integration shape (sketch):
+//
+//   1. New file: `src/lib/pdf/diagnostic-artifact-template.tsx`
+//      - Mirrors `sow-template.tsx` structure: a React function component
+//        that consumes `DiagnosticArtifact` props and emits Forme JSX
+//        (`<Document>`, `<Page>`, `<View>`, `<Text>`).
+//      - Reuses the shared color, font, margin, and heading styles from
+//        `sow-template.tsx` and `scorecard-template.tsx` so all three
+//        client-facing PDFs feel like one document family.
+//      - Enforces the consent gate at render time: if `client !== null`
+//        and `client.consent.written !== true`, throw before rendering.
+//        The consent gate belongs in the renderer because that is the
+//        last place the decision is reversible.
+//
+//   2. New export in `src/lib/pdf/render.ts`:
+//
+//      export async function renderDiagnosticArtifact(
+//        artifact: DiagnosticArtifact
+//      ): Promise<Uint8Array> {
+//        await ensureWasm()
+//        return renderDocument(DiagnosticArtifactTemplate(artifact))
+//      }
+//
+//   3. Pre-render validation: call `findUnfilledPlaceholders`,
+//      `findSectionsBelowMinimum`, and `findConsentViolations` before
+//      handing the artifact to `renderDocument`. Any non-empty result
+//      aborts the render with an error message pointing to the specific
+//      slot. We have never shipped a PDF with a placeholder in it; we
+//      should not start here.
+//
+//   4. Page layout (sketch — finalized against real content in Phase 2):
+//      - Page 1: Title + date range. "Who we worked with" block. Observed
+//        signals as a numbered list, each with its source line in muted
+//        type underneath.
+//      - Page 2: Pattern diagnoses. Trade-offs considered.
+//      - Page 3: What shipped. What we decided not to do. Outcomes observed
+//        at handoff with explicit "observed at: {date}" labels.
+//      The artifact is deliberately short. If it runs past three pages,
+//      the engagement's thinking is not being surfaced — it is being
+//      buried.
+//
+// TODO(phase-2): implement `src/lib/pdf/diagnostic-artifact-template.tsx`.
+// TODO(phase-2): implement `renderDiagnosticArtifact` in `render.ts`.
+// TODO(phase-2): add pre-render validation calls that block unfilled /
+//   below-minimum / consent-violating artifacts.
+// TODO(phase-2): verify the layout against the first populated artifact.
+//   Do not finalize the design against the empty scaffold.
+// TODO(phase-2): file a follow-up issue to populate the first artifact
+//   after the first engagement completes, per issue #487 AC #5.


### PR DESCRIPTION
Closes #487
Parent epic: #483

## Summary

Scaffolds the post-engagement diagnostic artifact — the Phase-2 proof artifact that ships after SMD Services' first real engagement completes. Pre-launch, SMD has zero delivered engagements, and CLAUDE.md forbids fabricated case studies. The diagnostic artifact is the compliant substitute: a real post-engagement deliverable that shows thinking process (observed signals, trade-offs considered, what was deliberately not done) rather than invented results.

No populated artifact ships here. Population happens in a follow-up issue after the first engagement completes.

## Files added

- `src/lib/diagnostic/artifact-template.ts` — typed shape for `DiagnosticArtifact`, unpopulated `EMPTY_ARTIFACT` scaffold with placeholder prompts on every slot, and three validation helpers (`findUnfilledPlaceholders`, `findSectionsBelowMinimum`, `findConsentViolations`). Includes PDF rendering path notes with `TODO(phase-2)` markers that hook into the existing Forme pipeline in `src/lib/pdf/render.ts`.
- `docs/style/diagnostic-artifact-content-rules.md` — eight content rules with in-bounds / out-of-bounds lists, structured like `empty-state-pattern.md` and `UI-PATTERNS.md`, cited to CLAUDE.md and NN/g authority anchors.

## Template sections (all required, each with visible placeholder prompts)

- Title + engagement date range
- Who we worked with (gated on written consent; `null` without)
- Observed signals (3–5, each with a traceable source)
- Pattern diagnoses (2–3, supported by signal references)
- Trade-offs considered (2–4)
- What shipped (3–5)
- What we decided not to do and why (1–3 — the restraint signal)
- Outcomes observed at handoff (2–3, each with `observedAt` date anchor)

## Content rules (eight)

1. Consent gates client attribution
2. Observations must trace to a source
3. No character claims about the client
4. No outcome claims that post-date handoff
5. No speculation about other businesses or verticals
6. No invented advice
7. Voice discipline ("we" / "our team")
8. No AI prose

## Verify

- `npx astro check` — 0 errors, 0 warnings in my files
- `npx eslint src/lib/diagnostic/artifact-template.ts` — clean
- `npx prettier --check` on new files — clean
- `npm run build` — succeeds
- `npm test` — 1277 passed, 2 skipped

Full `npm run verify` could not run green end-to-end because the worktree has pre-existing untracked / modified files outside this PR's scope (skills, migrations, unrelated pages) that trip `prettier --check` on markdown code-block snippets. None of those files were touched by this change.

## Captain review request

Please focus review on the **in-bounds / out-of-bounds** boundary in `docs/style/diagnostic-artifact-content-rules.md`. Specific lines I am least sure about:

- **Rule 2 — `"Owner's own words, written consent on file"` as an in-bounds source.** The consent gate in Rule 1 covers this, but I want confirmation that a direct quote sourced this way is acceptable in an observation slot, or if quotes should live only in a dedicated "client voice" section (there is no such section today).
- **Rule 4 — the `"processed 14 leads between 2026-05-28 and 2026-06-02 per the new intake log"` example** as in-bounds at handoff. It is a counted fact with a time anchor, but it is close to the Pattern B line. Confirm this framing or tighten.
- **Rule 6 — `"In hindsight, we should have addressed X first"` as out-of-bounds.** This may read as genuinely disqualifying post-hoc reflection that has engagement value. Confirm we want hindsight fully out-of-bounds, or carve out space for it under a tightly-labeled section.
- **`ClientAttribution.contextLine` granularity.** The `"Phoenix-area HVAC contractor, 12 field technicians"` example names a metro plus a headcount. Confirm this is in-bounds with written consent, or tighten to vertical + region only.

## Follow-ups (filed after merge)

Per issue #487 AC #5, a follow-up child issue will file after the first engagement completes to populate the first artifact. The `TODO(phase-2)` markers in `artifact-template.ts` also track the PDF renderer implementation.