### PR TITLE
feat(analytics): site-wide event instrumentation + aggregate dashboard

### DIFF
--- a/migrations/0024_create_events_table.sql
+++ b/migrations/0024_create_events_table.sql
@@ -1,0 +1,46 @@
+-- Migration 0024: events
+--
+-- Site-wide event instrumentation for the marketing surface (apex
+-- `smd.services`). Captures page views and CTA clicks so the persona
+-- review can reconstruct conversion paths (parent epic #483, child #488).
+--
+-- Scope notes:
+--   - Marketing-only. NOT scoped by `org_id` or `entity_id` — these are
+--     anonymous visitors, not tenant data. Admin/portal surfaces do NOT
+--     emit events (see src/components/EventsTracker.astro and middleware
+--     subdomain rules).
+--   - No PII. `user_agent` and `referrer` are behavioural signals only;
+--     `path` is scrubbed of query strings before insert.
+--   - `metadata` is a free-form JSON blob for event-specific payload
+--     (e.g. `{"cta":"home-primary-cta","href":"/book"}`).
+--   - `country` is derived from `request.cf.country` at ingest — no IP
+--     storage.
+--
+-- Schema is intentionally additive: no foreign keys, no CHECK constraints
+-- on event_name, indexes only on session/path/event for the dashboard
+-- aggregate queries in src/pages/admin/analytics/index.astro.
+--
+-- Rollback is a clean DROP — see the `-- down` section at the bottom.
+
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  event_name TEXT NOT NULL,
+  path TEXT,
+  ts INTEGER NOT NULL,
+  metadata TEXT,
+  user_agent TEXT,
+  referrer TEXT,
+  country TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
+CREATE INDEX IF NOT EXISTS idx_events_path_ts ON events(path, ts);
+CREATE INDEX IF NOT EXISTS idx_events_name_ts ON events(event_name, ts);
+
+-- down
+-- DROP INDEX IF EXISTS idx_events_name_ts;
+-- DROP INDEX IF EXISTS idx_events_path_ts;
+-- DROP INDEX IF EXISTS idx_events_session;
+-- DROP TABLE IF EXISTS events;

--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -3,9 +3,15 @@ interface Props {
   variant?: 'primary' | 'outline-white'
   href?: string
   class?: string
+  'data-ev'?: string
 }
 
-const { variant = 'primary', href = '/book', class: className = '' } = Astro.props
+const {
+  variant = 'primary',
+  href = '/book',
+  class: className = '',
+  'data-ev': dataEv,
+} = Astro.props
 
 const base = 'inline-flex items-center justify-center font-semibold transition-all'
 const variants = {
@@ -15,6 +21,6 @@ const variants = {
 }
 ---
 
-<a href={href} class:list={[base, variants[variant], className]}>
+<a href={href} class:list={[base, variants[variant], className]} data-ev={dataEv}>
   <slot />
 </a>

--- a/src/components/EventsTracker.astro
+++ b/src/components/EventsTracker.astro
@@ -1,0 +1,206 @@
+---
+/**
+ * EventsTracker — client-side page view + CTA click instrumentation for
+ * the marketing surface (apex smd.services).
+ *
+ * Do NOT render on admin or portal pages. The admin/portal layouts
+ * intentionally omit this component (only `Base.astro` includes it), and
+ * middleware subdomain rules isolate admin/portal under their own hosts.
+ * As defense-in-depth the client script also bails out on admin./portal.
+ * hostnames at runtime.
+ *
+ * Design notes:
+ *   - Vanilla JS, no third-party libraries.
+ *   - Batches events and flushes on a 2s debounce. Unload uses
+ *     navigator.sendBeacon to avoid losing the tail of a session.
+ *   - Session id lives in a first-party cookie (`ss_sid`). Cookie is
+ *     readable by JS (HttpOnly:false) so SSR + client cooperate — either
+ *     side can set it, the other can read it.
+ *   - Metadata payloads are whitelisted on the client AND re-validated
+ *     on the server (see src/pages/api/events.ts). Never pass form
+ *     values or URL query strings into metadata.
+ */
+---
+
+<script is:inline>
+  ;(function () {
+    if (typeof window === 'undefined') return
+
+    // Defense-in-depth: if this component is ever included on an admin
+    // or portal subdomain by mistake, bail out. The marketing tracker
+    // must not fire from authenticated surfaces.
+    const host = location.hostname || ''
+    if (host.indexOf('admin.') === 0 || host.indexOf('portal.') === 0) return
+
+    const COOKIE_NAME = 'ss_sid'
+    const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+    const ENDPOINT = '/api/events'
+    const FLUSH_DEBOUNCE_MS = 2000
+    const MAX_QUEUE_SIZE = 40
+
+    function readCookie(name) {
+      const pairs = document.cookie ? document.cookie.split(';') : []
+      for (let i = 0; i < pairs.length; i++) {
+        const p = pairs[i].trim()
+        const eq = p.indexOf('=')
+        if (eq === -1) continue
+        if (p.slice(0, eq) === name) return p.slice(eq + 1)
+      }
+      return null
+    }
+
+    function writeCookie(name, value) {
+      const secure = location.protocol === 'https:' ? '; Secure' : ''
+      document.cookie =
+        name +
+        '=' +
+        value +
+        '; Path=/; Max-Age=' +
+        COOKIE_MAX_AGE_SECONDS +
+        '; SameSite=Lax' +
+        secure
+    }
+
+    function generateUuid() {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+        return window.crypto.randomUUID()
+      }
+      // Fallback for older browsers — RFC4122 v4-ish.
+      const template = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+      return template.replace(/[xy]/g, function (c) {
+        const r = (Math.random() * 16) | 0
+        const v = c === 'x' ? r : (r & 0x3) | 0x8
+        return v.toString(16)
+      })
+    }
+
+    function getSessionId() {
+      const existing = readCookie(COOKIE_NAME)
+      if (existing) return existing
+      const fresh = generateUuid()
+      writeCookie(COOKIE_NAME, fresh)
+      return fresh
+    }
+
+    function scrubPath(p) {
+      if (!p) return '/'
+      const q = p.indexOf('?')
+      const h = p.indexOf('#')
+      let end = p.length
+      if (q !== -1) end = Math.min(end, q)
+      if (h !== -1) end = Math.min(end, h)
+      return p.slice(0, end) || '/'
+    }
+
+    const sessionId = getSessionId()
+    let queue = []
+    let flushTimer = null
+
+    function enqueue(ev) {
+      queue.push(ev)
+      if (queue.length >= MAX_QUEUE_SIZE) {
+        flush()
+        return
+      }
+      if (flushTimer) clearTimeout(flushTimer)
+      flushTimer = setTimeout(flush, FLUSH_DEBOUNCE_MS)
+    }
+
+    function flush(useBeacon) {
+      if (queue.length === 0) return
+      if (flushTimer) {
+        clearTimeout(flushTimer)
+        flushTimer = null
+      }
+      const batch = queue
+      queue = []
+      const body = JSON.stringify({ session_id: sessionId, events: batch })
+
+      if (useBeacon && navigator.sendBeacon) {
+        try {
+          const blob = new Blob([body], { type: 'application/json' })
+          navigator.sendBeacon(ENDPOINT, blob)
+          return
+        } catch (e) {
+          // Fall through to fetch.
+        }
+      }
+
+      try {
+        fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: body,
+          credentials: 'same-origin',
+          keepalive: true,
+        }).catch(function () {
+          // Drop on floor. Analytics is best-effort.
+        })
+      } catch (e) {
+        // ignore
+      }
+    }
+
+    function trackPageView() {
+      enqueue({ event_name: 'page_view', path: scrubPath(location.pathname) })
+    }
+
+    function trackCtaClick(el) {
+      const label = el.getAttribute('data-ev')
+      if (!label) return
+      const meta = { cta: label }
+      const href = el.getAttribute('href')
+      if (href && typeof href === 'string' && href.length < 256) {
+        // Only capture the path portion if it's same-origin or relative.
+        if (href.indexOf('://') === -1) {
+          meta.href = href
+        } else {
+          try {
+            const u = new URL(href)
+            if (u.origin === location.origin) meta.href = u.pathname
+          } catch (e) {
+            // ignore
+          }
+        }
+      }
+      enqueue({
+        event_name: 'cta_click',
+        path: scrubPath(location.pathname),
+        metadata: meta,
+      })
+    }
+
+    // Delegate click handling. Walk up the tree to find the nearest
+    // [data-ev] ancestor so wrapping elements still trigger.
+    document.addEventListener(
+      'click',
+      function (e) {
+        let node = e.target
+        while (node && node !== document.body) {
+          if (node.nodeType === 1 && node.hasAttribute && node.hasAttribute('data-ev')) {
+            trackCtaClick(node)
+            return
+          }
+          node = node.parentNode
+        }
+      },
+      true
+    )
+
+    // Flush on page hide / unload so we don't lose the tail.
+    window.addEventListener('pagehide', function () {
+      flush(true)
+    })
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'hidden') flush(true)
+    })
+
+    // Initial page view — fire after DOM is interactive so the session
+    // cookie is definitely set before the first request.
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', trackPageView)
+    } else {
+      trackPageView()
+    }
+  })()
+</script>

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -10,10 +10,14 @@ import CtaButton from './CtaButton.astro'
       picture of how to get there, whether we work together or not.
     </p>
     <div class="mt-10">
-      <CtaButton variant="outline-white" href="/book">Book a Call</CtaButton>
+      <CtaButton variant="outline-white" href="/book" data-ev="final-cta-book">
+        Book a Call
+      </CtaButton>
       <p class="mt-4 text-sm text-[color:var(--color-text-muted)]">
         Not ready to schedule?
-        <a href="/get-started" class="underline hover:text-white"> Tell us about your business </a>
+        <a href="/get-started" class="underline hover:text-white" data-ev="final-cta-get-started">
+          Tell us about your business
+        </a>
       </p>
     </div>
   </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -15,6 +15,6 @@ import CtaButton from './CtaButton.astro'
       You know where you want to go. We help you figure out what needs to change and build it with
       you.
     </p>
-    <CtaButton href="/book">Book a Call</CtaButton>
+    <CtaButton href="/book" data-ev="home-primary-cta">Book a Call</CtaButton>
   </div>
 </section>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,15 +11,18 @@
     <div class="flex items-center gap-5">
       <a
         class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
-        href="/ai">AI</a
+        href="/ai"
+        data-ev="nav-ai">AI</a
       >
       <a
         class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded"
-        href="/contact">Contact</a
+        href="/contact"
+        data-ev="nav-contact">Contact</a
       >
       <a
         class="inline-flex items-center min-h-11 bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] active:bg-[color:var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 px-5 py-2 rounded font-medium text-white transition-opacity"
-        href="/book">Book a Call</a
+        href="/book"
+        data-ev="nav-book">Book a Call</a
       >
     </div>
   </div>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -101,6 +101,14 @@ declare namespace Cloudflare {
     JOB_MONITOR_WORKER_URL?: string
     REVIEW_MINING_WORKER_URL?: string
     SOCIAL_LISTENING_WORKER_URL?: string
+    /**
+     * Feature flag for the public /patterns aggregate page. Off by default.
+     * Set to "1" or "true" in wrangler.toml once the unlock condition
+     * documented in src/pages/patterns.astro is met (>=20 real assessments
+     * with cross-vertical diversity, per CLAUDE.md no-fabrication rule).
+     * Any other value keeps the page returning 404.
+     */
+    ENABLE_PUBLIC_PATTERNS?: string
   }
 }
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css'
 import JsonLd from '../components/JsonLd.astro'
 import SkipToMain from '../components/SkipToMain.astro'
+import EventsTracker from '../components/EventsTracker.astro'
 
 interface Props {
   title: string
@@ -53,5 +54,6 @@ const ogImageUrl = new URL('/og-image.png', 'https://smd.services')
   <body>
     <SkipToMain />
     <slot />
+    <EventsTracker />
   </body>
 </html>

--- a/src/lib/db/events-analytics.ts
+++ b/src/lib/db/events-analytics.ts
@@ -1,0 +1,166 @@
+/**
+ * Aggregate queries against the `events` table (migration 0024) for the
+ * admin analytics dashboard. Unlike the rest of the analytics module,
+ * these queries are NOT org-scoped — events are anonymous marketing-side
+ * signals, not tenant data.
+ *
+ * All queries are parameterized, ranged by timestamp, and return empty
+ * arrays / zeros gracefully so the dashboard renders cleanly on a fresh
+ * install.
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface TopPathRow {
+  path: string
+  views: number
+}
+
+export interface TopCtaRow {
+  cta: string
+  clicks: number
+}
+
+export interface DailyUniqueRow {
+  day: string
+  uniques: number
+}
+
+export interface FunnelCounts {
+  landing: number
+  scorecard_start: number
+  book_start: number
+  book_complete: number
+}
+
+/**
+ * Top N paths by page_view count in the last `days` days.
+ */
+export async function getTopPaths(db: D1Database, days = 7, limit = 10): Promise<TopPathRow[]> {
+  const since = Date.now() - days * MS_PER_DAY
+  const result = await db
+    .prepare(
+      `SELECT path, COUNT(*) as views
+       FROM events
+       WHERE event_name = 'page_view' AND ts >= ? AND path IS NOT NULL
+       GROUP BY path
+       ORDER BY views DESC
+       LIMIT ?`
+    )
+    .bind(since, limit)
+    .all<{ path: string; views: number }>()
+  return (result.results ?? []).map((r) => ({ path: r.path, views: r.views }))
+}
+
+/**
+ * Top N CTAs by cta_click count in the last `days` days.
+ * Pulls `cta` out of the JSON metadata blob via SQLite's json_extract.
+ */
+export async function getTopCtas(db: D1Database, days = 7, limit = 10): Promise<TopCtaRow[]> {
+  const since = Date.now() - days * MS_PER_DAY
+  const result = await db
+    .prepare(
+      `SELECT json_extract(metadata, '$.cta') as cta, COUNT(*) as clicks
+       FROM events
+       WHERE event_name = 'cta_click' AND ts >= ? AND metadata IS NOT NULL
+       GROUP BY cta
+       HAVING cta IS NOT NULL
+       ORDER BY clicks DESC
+       LIMIT ?`
+    )
+    .bind(since, limit)
+    .all<{ cta: string; clicks: number }>()
+  return (result.results ?? []).map((r) => ({ cta: r.cta, clicks: r.clicks }))
+}
+
+/**
+ * Daily unique session counts for the last `days` days, oldest first.
+ * Zero-fills missing days so the bar chart renders a continuous axis.
+ */
+export async function getDailyUniques(db: D1Database, days = 30): Promise<DailyUniqueRow[]> {
+  const since = Date.now() - days * MS_PER_DAY
+  const result = await db
+    .prepare(
+      `SELECT date(ts / 1000, 'unixepoch') as day, COUNT(DISTINCT session_id) as uniques
+       FROM events
+       WHERE ts >= ?
+       GROUP BY day
+       ORDER BY day ASC`
+    )
+    .bind(since)
+    .all<{ day: string; uniques: number }>()
+
+  const byDay = new Map<string, number>()
+  for (const row of result.results ?? []) {
+    byDay.set(row.day, row.uniques)
+  }
+
+  const out: DailyUniqueRow[] = []
+  const today = new Date()
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today.getTime() - i * MS_PER_DAY)
+    const key = d.toISOString().slice(0, 10)
+    out.push({ day: key, uniques: byDay.get(key) ?? 0 })
+  }
+  return out
+}
+
+/**
+ * Simple conversion funnel over the last `days` days. Counts distinct
+ * sessions that reached each step. Steps are ordered:
+ *
+ *   landing         — any page_view
+ *   scorecard_start — click on scorecard-start-* CTA
+ *   book_start      — page_view of /book
+ *   book_complete   — click on book-submit CTA (the actual booking POST
+ *                     happens server-side but the client CTA is the
+ *                     nearest user-visible signal)
+ */
+export async function getFunnelCounts(db: D1Database, days = 7): Promise<FunnelCounts> {
+  const since = Date.now() - days * MS_PER_DAY
+  const [landing, scorecardStart, bookStart, bookComplete] = await Promise.all([
+    db
+      .prepare(
+        `SELECT COUNT(DISTINCT session_id) as n
+         FROM events
+         WHERE event_name = 'page_view' AND ts >= ?`
+      )
+      .bind(since)
+      .first<{ n: number }>(),
+    db
+      .prepare(
+        `SELECT COUNT(DISTINCT session_id) as n
+         FROM events
+         WHERE event_name = 'cta_click'
+           AND ts >= ?
+           AND json_extract(metadata, '$.cta') LIKE 'scorecard-start-%'`
+      )
+      .bind(since)
+      .first<{ n: number }>(),
+    db
+      .prepare(
+        `SELECT COUNT(DISTINCT session_id) as n
+         FROM events
+         WHERE event_name = 'page_view' AND ts >= ? AND path = '/book'`
+      )
+      .bind(since)
+      .first<{ n: number }>(),
+    db
+      .prepare(
+        `SELECT COUNT(DISTINCT session_id) as n
+         FROM events
+         WHERE event_name = 'cta_click'
+           AND ts >= ?
+           AND json_extract(metadata, '$.cta') = 'book-submit'`
+      )
+      .bind(since)
+      .first<{ n: number }>(),
+  ])
+
+  return {
+    landing: landing?.n ?? 0,
+    scorecard_start: scorecardStart?.n ?? 0,
+    book_start: bookStart?.n ?? 0,
+    book_complete: bookComplete?.n ?? 0,
+  }
+}

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -7,6 +7,12 @@ import {
   getEngagementHealth,
   getFollowUpCompliance,
 } from '../../../lib/db/analytics'
+import {
+  getTopPaths,
+  getTopCtas,
+  getDailyUniques,
+  getFunnelCounts,
+} from '../../../lib/db/events-analytics'
 import { ENTITY_VERTICALS } from '../../../lib/db/entities'
 import { env } from 'cloudflare:workers'
 
@@ -16,17 +22,98 @@ import { env } from 'cloudflare:workers'
  * All data is rendered server-side. No JavaScript charting libraries.
  * Charts use Tailwind width classes for horizontal bar rendering.
  * Protected by auth middleware (requires admin role).
+ *
+ * Site-traffic aggregates (top paths/CTAs, funnel, daily uniques) read
+ * from the `events` table populated by src/pages/api/events.ts. Those
+ * queries are NOT org-scoped — events are anonymous marketing signals.
  */
 
 const session = Astro.locals.session!
 // Fetch all analytics data in parallel
-const [pipeline, quoteAccuracy, revenue, health, compliance] = await Promise.all([
+const [
+  pipeline,
+  quoteAccuracy,
+  revenue,
+  health,
+  compliance,
+  topPaths,
+  topCtas,
+  funnel,
+  dailyUniques,
+] = await Promise.all([
   getPipelineConversion(env.DB, session.orgId),
   getQuoteAccuracy(env.DB, session.orgId),
   getRevenueReport(env.DB, session.orgId),
   getEngagementHealth(env.DB, session.orgId),
   getFollowUpCompliance(env.DB, session.orgId),
+  getTopPaths(env.DB, 7, 10),
+  getTopCtas(env.DB, 7, 10),
+  getFunnelCounts(env.DB, 7),
+  getDailyUniques(env.DB, 30),
 ])
+
+// ── Site traffic helpers ─────────────────────────────────────────
+const maxPathViews = topPaths.length > 0 ? Math.max(...topPaths.map((r) => r.views)) : 0
+const maxCtaClicks = topCtas.length > 0 ? Math.max(...topCtas.map((r) => r.clicks)) : 0
+const maxDailyUniques =
+  dailyUniques.length > 0 ? Math.max(...dailyUniques.map((r) => r.uniques)) : 0
+
+function pathBarWidth(views: number): string {
+  if (maxPathViews === 0 || views === 0) return '0%'
+  return `${Math.max((views / maxPathViews) * 100, 4)}%`
+}
+
+function ctaBarWidth(clicks: number): string {
+  if (maxCtaClicks === 0 || clicks === 0) return '0%'
+  return `${Math.max((clicks / maxCtaClicks) * 100, 4)}%`
+}
+
+interface FunnelStep {
+  key: keyof typeof funnel
+  label: string
+}
+
+const funnelSteps: FunnelStep[] = [
+  { key: 'landing', label: 'Landed on site' },
+  { key: 'scorecard_start', label: 'Started scorecard' },
+  { key: 'book_start', label: 'Reached /book' },
+  { key: 'book_complete', label: 'Submitted booking' },
+]
+
+const funnelTop = funnel.landing
+
+function funnelBarWidth(n: number): string {
+  if (funnelTop === 0 || n === 0) return '0%'
+  return `${Math.max((n / funnelTop) * 100, 4)}%`
+}
+
+function dropOff(current: number, previous: number): string {
+  if (previous === 0) return '—'
+  if (current >= previous) return '0%'
+  const pct = ((previous - current) / previous) * 100
+  return `-${Math.round(pct)}%`
+}
+
+// ── Daily-uniques SVG chart dims ─────────────────────────────────
+const dailyChartWidth = 560
+const dailyChartHeight = 120
+const dailyBarGap = 2
+const dailyBarWidth =
+  dailyUniques.length > 0
+    ? Math.max((dailyChartWidth - (dailyUniques.length - 1) * dailyBarGap) / dailyUniques.length, 2)
+    : 0
+
+function dailyBarHeight(n: number): number {
+  if (maxDailyUniques === 0) return 0
+  return Math.max((n / maxDailyUniques) * dailyChartHeight, n > 0 ? 2 : 0)
+}
+
+function formatShortDate(iso: string): string {
+  // iso is YYYY-MM-DD
+  const parts = iso.split('-')
+  if (parts.length !== 3) return iso
+  return `${parts[1]}/${parts[2]}`
+}
 
 // ── Pipeline helpers ─────────────────────────────────────────────
 const pipelineStages = [
@@ -428,6 +515,170 @@ function complianceBarWidth(pct: number): string {
                 </tr>
               </tfoot>
             </table>
+          </div>
+        )
+      }
+    </div>
+  </div>
+
+  {/* ── Site Traffic ─────────────────────────────────────── */}
+  <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mt-10 mb-4">
+    Site Traffic
+  </h3>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-card">
+    {/* ── Top pages (7d) ────────────────────────────────── */}
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">Top Pages</h3>
+      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">Last 7 days, by page views</p>
+      {
+        topPaths.length === 0 ? (
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No page views yet.</p>
+        ) : (
+          <div class="space-y-2">
+            {topPaths.map((row) => (
+              <div class="flex items-center gap-row">
+                <span class="text-sm text-[color:var(--color-text-secondary)] w-36 shrink-0 truncate font-mono">
+                  {row.path}
+                </span>
+                <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-5 overflow-hidden">
+                  <div
+                    class="h-full rounded-full bg-blue-500 flex items-center justify-end pr-2"
+                    style={`width: ${pathBarWidth(row.views)}`}
+                  >
+                    {row.views > 0 && (
+                      <span class="text-xs font-medium text-white">
+                        {row.views.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    </div>
+
+    {/* ── Top CTAs (7d) ─────────────────────────────────── */}
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">Top CTAs</h3>
+      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">Last 7 days, by click count</p>
+      {
+        topCtas.length === 0 ? (
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No CTA clicks yet.</p>
+        ) : (
+          <div class="space-y-2">
+            {topCtas.map((row) => (
+              <div class="flex items-center gap-row">
+                <span class="text-sm text-[color:var(--color-text-secondary)] w-36 shrink-0 truncate font-mono">
+                  {row.cta}
+                </span>
+                <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-5 overflow-hidden">
+                  <div
+                    class="h-full rounded-full bg-amber-500 flex items-center justify-end pr-2"
+                    style={`width: ${ctaBarWidth(row.clicks)}`}
+                  >
+                    {row.clicks > 0 && (
+                      <span class="text-xs font-medium text-white">
+                        {row.clicks.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      }
+    </div>
+
+    {/* ── Conversion funnel (7d) ────────────────────────── */}
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card md:col-span-2"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">
+        Conversion Funnel
+      </h3>
+      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">
+        Distinct sessions per step, last 7 days
+      </p>
+      {
+        funnelTop === 0 ? (
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No funnel data yet.</p>
+        ) : (
+          <div class="space-y-row">
+            {funnelSteps.map((step, idx) => {
+              const count = funnel[step.key]
+              const drop = idx === 0 ? '—' : dropOff(count, funnel[funnelSteps[idx - 1].key])
+              return (
+                <div class="flex items-center gap-row">
+                  <span class="text-sm text-[color:var(--color-text-secondary)] w-44 shrink-0">
+                    {step.label}
+                  </span>
+                  <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-6 overflow-hidden">
+                    <div
+                      class="h-full rounded-full bg-emerald-500 flex items-center justify-end pr-2"
+                      style={`width: ${funnelBarWidth(count)}`}
+                    >
+                      {count > 0 && (
+                        <span class="text-xs font-medium text-white">{count.toLocaleString()}</span>
+                      )}
+                    </div>
+                  </div>
+                  <span class="text-xs text-[color:var(--color-text-muted)] w-14 text-right">
+                    {drop}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )
+      }
+    </div>
+
+    {/* ── Daily uniques (30d) ───────────────────────────── */}
+    <div
+      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card md:col-span-2"
+    >
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">
+        Daily Uniques
+      </h3>
+      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">
+        Distinct sessions per day, last 30 days
+      </p>
+      {
+        maxDailyUniques === 0 ? (
+          <p class="text-sm text-[color:var(--color-text-secondary)]">No session data yet.</p>
+        ) : (
+          <div>
+            <svg
+              viewBox={`0 0 ${dailyChartWidth} ${dailyChartHeight + 24}`}
+              class="w-full h-auto"
+              role="img"
+              aria-label="Daily unique sessions over the last 30 days"
+            >
+              {dailyUniques.map((row, i) => {
+                const h = dailyBarHeight(row.uniques)
+                const x = i * (dailyBarWidth + dailyBarGap)
+                const y = dailyChartHeight - h
+                return (
+                  <g>
+                    <rect x={x} y={y} width={dailyBarWidth} height={h} fill="#6366f1" rx={1}>
+                      <title>{`${row.day}: ${row.uniques} unique sessions`}</title>
+                    </rect>
+                  </g>
+                )
+              })}
+            </svg>
+            <div class="mt-2 flex justify-between text-xs text-[color:var(--color-text-muted)]">
+              <span>{formatShortDate(dailyUniques[0].day)}</span>
+              <span>{formatShortDate(dailyUniques[dailyUniques.length - 1].day)}</span>
+            </div>
           </div>
         )
       }

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -27,7 +27,7 @@ import CtaButton from '../components/CtaButton.astro'
           Some of what you're hearing about AI is useful. A lot of it is noise. We help you sort it
           out and build what fits how your business actually works.
         </p>
-        <CtaButton href="/book">Book a Call</CtaButton>
+        <CtaButton href="/book" data-ev="ai-primary-cta">Book a Call</CtaButton>
       </div>
     </section>
 

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,0 +1,299 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/events
+ *
+ * Batched event ingestion for the marketing surface (apex smd.services).
+ * Persists page views and CTA clicks to D1 for the admin aggregate
+ * dashboard and future public aggregate-patterns page (parent epic #483,
+ * child #488).
+ *
+ * Privacy posture:
+ *   - No PII. Metadata is whitelisted-shape only; form field values are
+ *     never captured. The client-side tracker (EventsTracker.astro) is
+ *     the authoritative gate on payload shape; this endpoint additionally
+ *     validates and strips anything outside that contract.
+ *   - No third-party analytics, no fingerprinting. User-agent is stored
+ *     for aggregate browser-class queries only; IP is never written —
+ *     geo is derived from request.cf.country.
+ *   - Paths are scrubbed of query strings before insert, so auth tokens,
+ *     booking IDs, etc. that leak into URLs do not land in the events
+ *     table.
+ *
+ * Rate limit: 100 events per session_id per minute (D1-backed fixed
+ * window). Bursts above that are silently clamped — the endpoint returns
+ * 204 regardless to keep the client script simple.
+ *
+ * Request shape:
+ *   {
+ *     session_id: string,        // client-generated UUID (optional; if
+ *                                //   missing, server sets a cookie and
+ *                                //   generates one)
+ *     events: Array<{
+ *       event_name: string,      // e.g. "page_view", "cta_click"
+ *       path?: string,           // scrubbed server-side
+ *       metadata?: object        // small JSON object (stringified server-side)
+ *     }>
+ *   }
+ *
+ * Response: 204 No Content on success. 400 on malformed input. 500 on
+ * D1 failure — errors are logged, client-side tracker treats all non-2xx
+ * as drop-on-floor.
+ */
+
+const COOKIE_NAME = 'ss_sid'
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days
+const MAX_EVENTS_PER_BATCH = 50
+const MAX_EVENT_NAME_LEN = 64
+const MAX_PATH_LEN = 512
+const MAX_METADATA_BYTES = 2048
+const MAX_UA_LEN = 512
+const MAX_REFERRER_LEN = 512
+const RATE_LIMIT_PER_MINUTE = 100
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const SAFE_STRING_RE = /^[a-zA-Z0-9_\-.:/]+$/
+
+interface IncomingEvent {
+  event_name: string
+  path?: string
+  metadata?: Record<string, unknown>
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const rawEvents = Array.isArray(body.events) ? body.events : null
+  if (!rawEvents || rawEvents.length === 0) {
+    return new Response(JSON.stringify({ error: 'events array required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Resolve session id: client-supplied (if valid UUID) or cookie or new.
+  const cookieSid = parseCookie(request.headers.get('cookie'), COOKIE_NAME)
+  const clientSid = typeof body.session_id === 'string' ? body.session_id : null
+  const sessionId =
+    (clientSid && UUID_RE.test(clientSid) && clientSid) ||
+    (cookieSid && UUID_RE.test(cookieSid) && cookieSid) ||
+    crypto.randomUUID()
+  const needSetCookie = sessionId !== cookieSid
+
+  // Rate limit per session.
+  const allowed = await checkRateLimit(env.DB, sessionId)
+  if (!allowed) {
+    return buildResponse(204, needSetCookie ? sessionId : null, request)
+  }
+
+  // Cap per-batch size before validation to keep loops bounded.
+  const events = rawEvents.slice(0, MAX_EVENTS_PER_BATCH)
+
+  const userAgent = truncate(request.headers.get('user-agent'), MAX_UA_LEN)
+  const referrer = truncate(request.headers.get('referer'), MAX_REFERRER_LEN)
+  const country = readCfCountry(request)
+  const now = Date.now()
+
+  const rows: Array<{
+    id: string
+    event_name: string
+    path: string | null
+    metadata: string | null
+  }> = []
+
+  for (const raw of events) {
+    const parsed = validateEvent(raw)
+    if (!parsed) continue
+    rows.push({
+      id: crypto.randomUUID(),
+      event_name: parsed.event_name,
+      path: parsed.path ?? null,
+      metadata: parsed.metadata ? JSON.stringify(parsed.metadata) : null,
+    })
+  }
+
+  if (rows.length === 0) {
+    return buildResponse(204, needSetCookie ? sessionId : null, request)
+  }
+
+  try {
+    const stmts = rows.map((row) =>
+      env.DB.prepare(
+        `INSERT INTO events (id, session_id, event_name, path, ts, metadata, user_agent, referrer, country)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        row.id,
+        sessionId,
+        row.event_name,
+        row.path,
+        now,
+        row.metadata,
+        userAgent,
+        referrer,
+        country
+      )
+    )
+    await env.DB.batch(stmts)
+  } catch (err) {
+    console.error('[api/events] D1 insert failed:', err)
+    return new Response(JSON.stringify({ error: 'Failed to persist events' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  return buildResponse(204, needSetCookie ? sessionId : null, request)
+}
+
+function validateEvent(raw: unknown): IncomingEvent | null {
+  if (!raw || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+
+  const eventName = typeof obj.event_name === 'string' ? obj.event_name.trim() : ''
+  if (!eventName || eventName.length > MAX_EVENT_NAME_LEN || !SAFE_STRING_RE.test(eventName)) {
+    return null
+  }
+
+  let path: string | undefined
+  if (typeof obj.path === 'string' && obj.path.length > 0) {
+    path = scrubPath(obj.path).slice(0, MAX_PATH_LEN)
+  }
+
+  let metadata: Record<string, unknown> | undefined
+  if (obj.metadata && typeof obj.metadata === 'object' && !Array.isArray(obj.metadata)) {
+    const filtered = filterMetadata(obj.metadata as Record<string, unknown>)
+    if (filtered) metadata = filtered
+  }
+
+  return { event_name: eventName, path, metadata }
+}
+
+/**
+ * Strip query strings and fragments. Defensive even though the client
+ * already does this — an attacker bypassing the client could submit raw
+ * URLs with tokens or PII in query params.
+ */
+function scrubPath(input: string): string {
+  const qIdx = input.indexOf('?')
+  const hIdx = input.indexOf('#')
+  let end = input.length
+  if (qIdx !== -1) end = Math.min(end, qIdx)
+  if (hIdx !== -1) end = Math.min(end, hIdx)
+  const stripped = input.slice(0, end)
+  // Force leading slash; reject anything that looks like a full URL.
+  if (stripped.startsWith('http://') || stripped.startsWith('https://')) {
+    try {
+      return new URL(stripped).pathname
+    } catch {
+      return '/'
+    }
+  }
+  return stripped.startsWith('/') ? stripped : `/${stripped}`
+}
+
+/**
+ * Only pass through simple scalar values (string/number/boolean). Drop
+ * nested objects, arrays, and anything oversized. This is the defense
+ * against a client accidentally (or deliberately) passing form values,
+ * full payloads, etc.
+ */
+function filterMetadata(input: Record<string, unknown>): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {}
+  let count = 0
+  for (const [key, value] of Object.entries(input)) {
+    if (count >= 16) break
+    if (typeof key !== 'string' || key.length > 64) continue
+    if (typeof value === 'string') {
+      if (value.length > 256) continue
+      out[key] = value
+    } else if (typeof value === 'number' && Number.isFinite(value)) {
+      out[key] = value
+    } else if (typeof value === 'boolean') {
+      out[key] = value
+    } else {
+      continue
+    }
+    count++
+  }
+  if (count === 0) return null
+  const serialized = JSON.stringify(out)
+  if (serialized.length > MAX_METADATA_BYTES) return null
+  return out
+}
+
+async function checkRateLimit(db: D1Database, sessionId: string): Promise<boolean> {
+  // Fixed-window minute bucket in D1. The events table itself is the
+  // source of truth — counting rows for this session in the last minute
+  // avoids a separate rate-limit table.
+  const windowStart = Date.now() - 60_000
+  try {
+    const row = await db
+      .prepare('SELECT COUNT(*) as count FROM events WHERE session_id = ? AND ts >= ?')
+      .bind(sessionId, windowStart)
+      .first<{ count: number }>()
+    return (row?.count ?? 0) < RATE_LIMIT_PER_MINUTE
+  } catch (err) {
+    // If the count query fails, allow the write. Better to accept a
+    // small number of extra events than to drop legitimate traffic
+    // because of a transient D1 hiccup.
+    console.error('[api/events] rate-limit count failed:', err)
+    return true
+  }
+}
+
+function readCfCountry(request: Request): string | null {
+  const cf = (request as unknown as { cf?: { country?: string } }).cf
+  const country = cf?.country
+  if (typeof country !== 'string') return null
+  if (country.length !== 2) return null
+  return country
+}
+
+function parseCookie(header: string | null, name: string): string | null {
+  if (!header) return null
+  const parts = header.split(';')
+  for (const part of parts) {
+    const trimmed = part.trim()
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx === -1) continue
+    if (trimmed.slice(0, eqIdx) === name) {
+      return trimmed.slice(eqIdx + 1)
+    }
+  }
+  return null
+}
+
+function buildSessionCookie(sessionId: string, secure: boolean): string {
+  const attrs = [
+    `${COOKIE_NAME}=${sessionId}`,
+    'Path=/',
+    `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
+    'SameSite=Lax',
+  ]
+  if (secure) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+function buildResponse(status: number, setSessionId: string | null, request: Request): Response {
+  const headers = new Headers()
+  if (setSessionId) {
+    const url = new URL(request.url)
+    const secure = url.protocol === 'https:'
+    headers.append('Set-Cookie', buildSessionCookie(setSessionId, secure))
+  }
+  return new Response(null, { status, headers })
+}
+
+function truncate(value: string | null, max: number): string | null {
+  if (!value) return null
+  return value.length > max ? value.slice(0, max) : value
+}

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -328,6 +328,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                 id="bf-submit"
                 type="submit"
                 disabled
+                data-ev="book-submit"
                 class="w-full rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Book Your Call
@@ -366,7 +367,7 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
                 <a
                   href="/get-started?booked=1"
                   class="font-medium text-primary underline hover:text-primary/80"
-                  >Help us prepare for your call</a
+                  data-ev="book-post-confirm-intake">Help us prepare for your call</a
                 > — a few quick questions so we can make the most of our time together.
               </p>
             </div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -76,6 +76,7 @@ import Footer from '../components/Footer.astro'
 
         <button
           type="submit"
+          data-ev="contact-submit"
           class="rounded-[var(--radius-card)] bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-80"
         >
           Send Message

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,6 +42,7 @@ import Footer from '../components/Footer.astro'
         <a
           href="/scorecard"
           class="mt-8 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+          data-ev="home-scorecard-cta"
         >
           Take the Scorecard
         </a>

--- a/src/pages/patterns.astro
+++ b/src/pages/patterns.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * /patterns — public aggregate-patterns page.
+ *
+ * Scaffolded for parent epic #483 / child #488. The page stays 404 until
+ * the `ENABLE_PUBLIC_PATTERNS` env var is set truthy.
+ *
+ * UNLOCK CONDITION (per CLAUDE.md "No fabricated client-facing content"):
+ *   Do not enable until >=20 real assessments exist with cross-vertical
+ *   diversity. Publishing aggregate patterns before that point would
+ *   either (a) leak individual clients' signals as if they were trends,
+ *   or (b) require invented filler data to reach a credible sample
+ *   size. Both are prohibited by CLAUDE.md. The public dataset must be
+ *   large enough and diverse enough that no single engagement is
+ *   identifiable from the aggregate output.
+ *
+ * Rendering of the actual aggregates is deferred — see the TODO below.
+ */
+
+export const prerender = false
+
+import { env } from 'cloudflare:workers'
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+
+const flagValue = (env as { ENABLE_PUBLIC_PATTERNS?: string }).ENABLE_PUBLIC_PATTERNS
+const enabled = flagValue === '1' || flagValue === 'true'
+
+if (!enabled) {
+  return new Response(null, { status: 404 })
+}
+---
+
+<Base
+  title="Patterns | SMD Services"
+  description="Aggregate patterns from operations assessments with growing businesses."
+>
+  <Nav />
+  <main id="main" role="main" class="px-6 py-20">
+    <div class="mx-auto max-w-3xl">
+      <h1 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Patterns</h1>
+      <p class="mt-2 text-lg text-[color:var(--color-text-secondary)]">
+        What we're seeing across the businesses we've worked with.
+      </p>
+
+      {
+        /* TODO when flag enables — render aggregate-only views from the
+          events table and engagement data. Never surface individual
+          engagements. Minimum bucket size per facet (e.g. 5) to avoid
+          reidentification. */
+      }
+
+      <div
+        class="mt-10 rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-8 text-center"
+      >
+        <p class="text-base text-[color:var(--color-text-secondary)]">
+          Patterns will appear here once we've worked with enough businesses to share them without
+          identifying any one of them.
+        </p>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</Base>

--- a/src/pages/scorecard.astro
+++ b/src/pages/scorecard.astro
@@ -102,6 +102,7 @@ for (const [i, q] of QUESTIONS.entries()) {
         </p>
         <button
           data-action="start"
+          data-ev="scorecard-start-primary"
           class="mt-8 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
         >
           Start your scorecard
@@ -149,6 +150,7 @@ for (const [i, q] of QUESTIONS.entries()) {
         <p class="text-xl text-[color:var(--color-text-primary)]">Ready to see where you stand?</p>
         <button
           data-action="start"
+          data-ev="scorecard-start-secondary"
           class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
         >
           Start your scorecard

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -48,6 +48,13 @@ NEW_BUSINESS_WORKER_URL = "https://ss-new-business.automation-ab6.workers.dev"
 JOB_MONITOR_WORKER_URL = "https://ss-job-monitor.automation-ab6.workers.dev"
 REVIEW_MINING_WORKER_URL = "https://ss-review-mining.automation-ab6.workers.dev"
 
+# Feature flag for the public /patterns aggregate page. Off by default.
+# Flip to "1" or "true" only after the unlock condition documented in
+# src/pages/patterns.astro is met (>=20 real assessments with cross-vertical
+# diversity, per CLAUDE.md no-fabrication rule). Any other value keeps the
+# page returning 404.
+ENABLE_PUBLIC_PATTERNS = "0"
+
 # ---------- D1 (structured data) ----------
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

Site-wide event instrumentation with D1 persistence, admin aggregate dashboard, and a scaffolded (feature-flagged off) public aggregate-patterns page.

- Closes #488, parent epic #483
- `migrations/0024_create_events_table.sql` — additive, reversible schema for anonymous marketing events (no org scoping; no PII). Must be applied post-merge via `wrangler d1 migrations apply ss-console-db --remote`.
- `POST /api/events` — batched ingest with per-session rate limit (100/min), path scrubbing, metadata whitelisting, first-party `ss_sid` cookie.
- `src/components/EventsTracker.astro` — vanilla-JS tracker wired into `Base.astro` only. Fires `page_view` on load, `cta_click` for any `[data-ev]` element. Debounced 2s batching, `sendBeacon` on page hide. Bails out on `admin.` / `portal.` subdomains as defense-in-depth.
- Data-ev attributes on key CTAs across `/`, `/ai`, `/scorecard`, `/book`, `/contact`, and the shared Nav.
- Admin `/admin/analytics` extended with: top pages (7d), top CTAs (7d), conversion funnel (landing → scorecard start → /book → book-submit), and a 30-day daily-uniques inline SVG chart. No client-side fetching, server-rendered D1 queries.
- `src/pages/patterns.astro` — scaffold only. Returns 404 unless `ENABLE_PUBLIC_PATTERNS` is truthy. Default is `"0"` in `wrangler.toml`. Unlock condition is documented in the file per CLAUDE.md no-fabrication rule: ≥20 real assessments with cross-vertical diversity.

## Flag default

`ENABLE_PUBLIC_PATTERNS = "0"` in `wrangler.toml`. Do not flip until the documented unlock condition is met.

## Test plan

- [ ] `npm run verify` passes locally (typecheck, workers typecheck, format check, lint, build, tests) — verified green.
- [ ] Apply the migration to staging: `wrangler d1 migrations apply ss-console-db --remote --env staging`.
- [ ] Load `/`, click the primary CTA, reload. Confirm `ss_sid` cookie is present and events appear in the staging DB.
- [ ] Visit `/admin/analytics` on staging and confirm the new sections render (empty-state copy when no events, bars when data exists).
- [ ] Visit `/patterns` on apex — should 404 with the flag off. Flip `ENABLE_PUBLIC_PATTERNS` to `"1"` locally and confirm the placeholder renders.
- [ ] Visit `/admin` and `/portal` — confirm no `/api/events` requests fire (tracker must be apex-only).

## Notes

- Marketing-side events are anonymous by design: no `org_id`, no `entity_id`, no PII, no third-party analytics. `user_agent` and `referrer` are stored in aggregate only; geo is derived from `request.cf.country`.
- Do NOT merge automatically; migration must be applied after the PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)