### PR TITLE
fix(middleware): subdomain rewrite for nested paths under Workers + Static Assets

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,7 +31,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url
   const hostname = context.url.hostname
 
-  // Subdomain routing: portal.smd.services rewrites to /portal/* paths
+  // Subdomain routing: portal.smd.services rewrites to /portal/* paths.
+  // String-path form of context.rewrite is the idiomatic Astro v5 API — it
+  // re-invokes middleware against the rewritten pathname so the auth block
+  // below runs with isPortalRoute = true. The earlier Request-wrapper form
+  // silently failed for nested paths under Workers + Static Assets,
+  // returning the 404 static asset instead of the intended portal route.
   const isPortalSubdomain = hostname.startsWith('portal.')
   if (
     isPortalSubdomain &&
@@ -40,12 +45,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
     !pathname.startsWith('/auth') &&
     !pathname.startsWith('/api/auth')
   ) {
-    // Rewrite the URL to the /portal path prefix
     const portalPath = pathname === '/' ? '/portal' : `/portal${pathname}`
-    return context.rewrite(new Request(new URL(portalPath, context.url), context.request))
+    return context.rewrite(portalPath + context.url.search)
   }
 
-  // Subdomain routing: admin.smd.services rewrites to /admin/* paths
+  // Subdomain routing: admin.smd.services rewrites to /admin/* paths.
+  // See note on the portal rewrite above — same reasoning.
   const isAdminSubdomain = hostname.startsWith('admin.')
   if (
     isAdminSubdomain &&
@@ -55,7 +60,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     !pathname.startsWith('/api/auth')
   ) {
     const adminPath = pathname === '/' ? '/admin' : `/admin${pathname}`
-    return context.rewrite(new Request(new URL(adminPath, context.url), context.request))
+    return context.rewrite(adminPath + context.url.search)
   }
 
   // Backwards-compat redirects: bare apex admin/login paths → admin subdomain.


### PR DESCRIPTION
## Summary

- `admin.smd.services/analytics` (and every nested path on admin/portal subdomains) returned 404 instead of rewriting to `/admin/analytics`.
- Root cause: the Request-wrapper form of `context.rewrite(...)` silently failed under the Workers + Static Assets adapter. The rewrite target never re-invoked middleware, so the route handler never ran and the edge fell through to the static 404 asset. The root-path case (`/`) masked the bug because it was a trivial identity-like rewrite.
- Fix: use the idiomatic string form `context.rewrite(pathname + search)`, which re-invokes middleware against the rewritten pathname and preserves query string.
- Same fix applied to the portal rewrite for symmetry.

## Verification

- `npm run verify` green — 1277 tests pass, typecheck clean, lint clean, format clean, build clean.
- Middleware tests unchanged in intent; existing structural-pattern checks still match.
- Manual repro: `curl -I https://admin.smd.services/analytics` returned `404 HIT` before; expected `302 → /auth/login` after deploy.

## Test plan

- [ ] Deploy completes
- [ ] `curl -I https://admin.smd.services/analytics` returns 302 when unauthenticated
- [ ] `curl -I https://admin.smd.services/dashboard-does-not-exist` returns 404 (actual missing route, not rewrite failure)
- [ ] `curl -I https://portal.smd.services/quotes/x` exercises the portal path
- [ ] admin.smd.services/ still 302s to login (root-path case unbroken)