### PR TITLE
revert: "fix(middleware): subdomain rewrite for nested paths" (#495)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,12 +31,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url
   const hostname = context.url.hostname
 
-  // Subdomain routing: portal.smd.services rewrites to /portal/* paths.
-  // String-path form of context.rewrite is the idiomatic Astro v5 API — it
-  // re-invokes middleware against the rewritten pathname so the auth block
-  // below runs with isPortalRoute = true. The earlier Request-wrapper form
-  // silently failed for nested paths under Workers + Static Assets,
-  // returning the 404 static asset instead of the intended portal route.
+  // Subdomain routing: portal.smd.services rewrites to /portal/* paths
   const isPortalSubdomain = hostname.startsWith('portal.')
   if (
     isPortalSubdomain &&
@@ -45,12 +40,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
     !pathname.startsWith('/auth') &&
     !pathname.startsWith('/api/auth')
   ) {
+    // Rewrite the URL to the /portal path prefix
     const portalPath = pathname === '/' ? '/portal' : `/portal${pathname}`
-    return context.rewrite(portalPath + context.url.search)
+    return context.rewrite(new Request(new URL(portalPath, context.url), context.request))
   }
 
-  // Subdomain routing: admin.smd.services rewrites to /admin/* paths.
-  // See note on the portal rewrite above — same reasoning.
+  // Subdomain routing: admin.smd.services rewrites to /admin/* paths
   const isAdminSubdomain = hostname.startsWith('admin.')
   if (
     isAdminSubdomain &&
@@ -60,7 +55,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     !pathname.startsWith('/api/auth')
   ) {
     const adminPath = pathname === '/' ? '/admin' : `/admin${pathname}`
-    return context.rewrite(adminPath + context.url.search)
+    return context.rewrite(new Request(new URL(adminPath, context.url), context.request))
   }
 
   // Backwards-compat redirects: bare apex admin/login paths → admin subdomain.


### PR DESCRIPTION
Reverts #495. The switch from `context.rewrite(new Request(...))` to the string-form `context.rewrite(pathname + search)` did NOT fix the observed 404 on nested subdomain rewrites. Post-deploy verification showed `admin.smd.services/analytics` still returning 404.

Root cause remains unidentified. The comment in #495 claimed a fix that was not, in fact, a fix — reverting rather than leaving misleading guidance in the code.

Follow-up investigation issue filed separately with full diagnostics (path-matrix test, build-output inspection, adapter config review, etc.).

No user-facing impact from the revert: the admin nav has always used full `/admin/X` hrefs, so click-through navigation is unaffected. Only the `admin.smd.services/analytics`-style typed shortcut is broken — which was already broken before #495 and remains so after this revert.