### PR TITLE
fix: 404 page must be SSR so middleware runs on subdomain fallback

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,14 @@
 ---
-export const prerender = true
+// Must NOT be prerendered. When `prerender = true`, the 404 route is built
+// to dist/client/404.html as a static asset and Astro's error-page fallback
+// (`renderError` with `errorRouteData.prerender === true`) serves that static
+// HTML via `prerenderedErrorPageFetch` — bypassing middleware entirely. That
+// breaks subdomain rewrite middleware for every path that does not match a
+// concrete Astro route (admin.smd.services/analytics, portal.smd.services/
+// quotes/abc, etc.). Keeping 404 server-rendered guarantees middleware runs
+// on fallback so the subdomain rewrite still applies.
+// Regression lock-in: tests/middleware.test.ts.
+export const prerender = false
 
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -27,8 +27,11 @@ describe('build output guard', () => {
   })
 
   it('$2,500 does not appear in any built HTML file', () => {
+    // Note: the built site has no prerendered HTML in dist/client/ (404 is
+    // SSR, index is SSR, book/contact/scorecard/ai are all SSR). This
+    // assertion passes trivially when nothing is prerendered. Kept in place
+    // so that any future prerendered page gets scanned automatically.
     const htmlFiles = collectHtmlFiles(distDir)
-    expect(htmlFiles.length).toBeGreaterThan(0)
     for (const filePath of htmlFiles) {
       const content = readFileSync(filePath, 'utf-8')
       expect(content, `$2,500 leaked into ${filePath}`).not.toContain('$2,500')

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -130,6 +130,22 @@ describe('middleware: portal rewrite preserved (regression)', () => {
   })
 })
 
+describe('middleware: 404 route must be SSR (regression lock-in)', () => {
+  // If 404.astro is prerendered, Astro's renderError fallback serves the
+  // static dist/client/404.html via the ASSETS binding and BYPASSES
+  // middleware. That breaks subdomain rewrite for every path that doesn't
+  // match a concrete Astro route (admin.smd.services/analytics etc.) and
+  // users see the marketing-layout 404 instead of the intended admin
+  // redirect. Keep 404 server-rendered — middleware must always run.
+  const source = () => readFileSync(resolve('src/pages/404.astro'), 'utf-8')
+
+  it('404.astro must have prerender = false', () => {
+    const code = source()
+    expect(code).toMatch(/export\s+const\s+prerender\s*=\s*false/)
+    expect(code).not.toMatch(/export\s+const\s+prerender\s*=\s*true/)
+  })
+})
+
 describe('middleware: session resolution gating (#20)', () => {
   const source = () => readFileSync(resolve('src/middleware.ts'), 'utf-8')
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -70,9 +70,16 @@ describe('cloudflare SSR scaffolding', () => {
     expect(existsSync(resolve('src/pages/api/health.ts'))).toBe(true)
   })
 
-  it('static pages are marked for prerendering', () => {
+  it('404 page must be SSR (never prerendered — middleware dependency)', () => {
+    // If 404.astro is prerendered, Astro's error-page fallback serves the
+    // static dist/client/404.html via the ASSETS binding and BYPASSES
+    // middleware entirely. That breaks every subdomain rewrite that depends
+    // on the fallback path (admin.smd.services/analytics, portal.smd.services/
+    // quotes/abc, etc.). Keep 404 server-rendered so middleware always runs.
+    // Same guard duplicated in tests/middleware.test.ts for discoverability.
     const notFound = readFileSync(resolve('src/pages/404.astro'), 'utf-8')
-    expect(notFound).toContain('export const prerender = true')
+    expect(notFound).toContain('export const prerender = false')
+    expect(notFound).not.toMatch(/export\s+const\s+prerender\s*=\s*true/)
   })
 
   it('book page is SSR (needs runtime env for Turnstile key)', () => {


### PR DESCRIPTION
## Summary

- Root cause identified: `src/pages/404.astro` had `prerender = true`, which caused Astro's error-page fallback to serve the static `dist/client/404.html` directly via the ASSETS binding — **bypassing middleware entirely** for every non-matching path. That broke admin/portal subdomain rewrite on every nested typed URL (`admin.smd.services/analytics`, `portal.smd.services/quotes/abc`, etc.).
- Fix: flip 404 to `prerender = false`. Middleware now runs on every fallback request and `context.rewrite(...)` lands cleanly on the real route.
- Middleware code itself does not change — the original rewrite form works once middleware is actually invoked. Supersedes the reverted PR #495, which was chasing a symptom.
- URLs stay clean — no redirect, no URL-bar prefix change.

Closes #497
Supersedes #495 (reverted in #496)

## Why the investigation was hard

The symptom (404 on nested subdomain paths) pointed at middleware. Multiple plausible hypotheses — Request-wrapper form of `context.rewrite`, CF asset intercept, Astro upstream issue #11461 — none were the root cause. Adding a diagnostic `console.log` to middleware against local `wrangler dev` proved it: middleware was never executing for the failing paths. Traced back through the built Worker (`dist/server/chunks/worker-entry_*.mjs`) to `renderError` and found `errorRouteData.prerender === true` → `prerenderedErrorPageFetch` → static-asset return, before middleware ever runs.

## Verification (local)

```
admin.smd.services/analytics       → 302 /auth/login         (was: 404)
admin.smd.services/entities        → 302 /auth/login         (was: 404)
portal.smd.services/quotes/abc     → 302 /auth/portal-login  (was: 404)
admin.smd.services/                → 302 /auth/login         (unchanged)
admin.smd.services/admin/analytics → 302 /auth/login         (unchanged)
smd.services/nonexistent-page      → 404 marketing chrome    (unchanged, SSR'd)
smd.services/                      → 200                     (unchanged)
```

`npm run verify` green: 1278 tests pass, typecheck clean, lint clean, format clean, build clean.

## Test additions

- `tests/middleware.test.ts` — adds a regression lock-in: `404.astro` must have `prerender = false`. Duplicated from `tests/scaffold.test.ts` intentionally, for discoverability during middleware edits.
- `tests/scaffold.test.ts` — inverts the existing "404 is prerendered" assertion with a comment explaining the middleware dependency.
- `tests/build-output.test.ts` — drops the `htmlFiles.length > 0` guard on the leak-scan test. With nothing prerendered the scan is trivially empty; the `.not.toContain` checks still apply to any future prerendered page.

## Test plan

- [x] `npm run verify` green
- [x] Local `npm run preview` + curl for all seven cases above
- [ ] Post-deploy prod smoke: same seven curls against live URLs
- [ ] Close #497 with summary