### PR TITLE
refactor(admin/entities): context timeline expanded by default (#465)

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -361,7 +361,7 @@ function confidenceColor(confidence: string): string {
   {
     dossierGenerated && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Intelligence dossier generated. See enrichment entries in the timeline below.
+        Intelligence dossier generated. See enrichment entries in the timeline.
       </div>
     )
   }
@@ -517,6 +517,116 @@ function confidenceColor(confidence: string): string {
     </form>
   </div>
 
+  {/* Context Timeline */}
+  <div class="mb-6">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+        Context Timeline
+        <span class="text-sm font-normal text-[color:var(--color-text-muted)]"
+          >({contextEntries.length})</span
+        >
+      </h3>
+    </div>
+
+    {/* Type filter pills */}
+    <div class="flex gap-1 mb-4 flex-wrap">
+      <a
+        href={`/admin/entities/${entity.id}`}
+        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]'}`}
+      >
+        All ({contextEntries.length})
+      </a>
+      {
+        Object.entries(typeCounts).map(([type, count]) => (
+          <a
+            href={`/admin/entities/${entity.id}?type=${type}`}
+            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-slate-900 text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
+          >
+            {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
+          </a>
+        ))
+      }
+    </div>
+
+    {/* Timeline entries */}
+    {
+      filteredEntries.length === 0 ? (
+        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack">
+          <p class="text-[color:var(--color-text-secondary)] text-sm">No context entries yet.</p>
+        </div>
+      ) : (
+        <div class="space-y-row">
+          {filteredEntries.map((entry: ContextEntry) => {
+            const meta = parseMetadata(entry.metadata)
+            const problems = meta?.top_problems as string[] | undefined
+            const isLong = entry.content.length > 500
+            return (
+              <details
+                open
+                class="group bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-3"
+              >
+                <summary class="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+                  <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
+                    {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
+                  </span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
+                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                    {formatDateTime(entry.created_at)}
+                  </span>
+                  {entry.type === 'signal' && meta?.pain_score && (
+                    <span class="text-xs font-semibold text-red-600">
+                      Pain: {String(meta.pain_score)}/10
+                    </span>
+                  )}
+                  <svg
+                    class="ml-auto h-3.5 w-3.5 shrink-0 text-[color:var(--color-text-muted)] transition-transform group-open:rotate-180"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                  <span class="sr-only">Toggle entry</span>
+                </summary>
+
+                <div class="mt-1.5">
+                  {problems && problems.length > 0 && (
+                    <div class="flex gap-1 mb-1.5 flex-wrap">
+                      {problems.map((p: string) => (
+                        <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded">
+                          {p.replace(/_/g, ' ')}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  <div
+                    class={`text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap${isLong ? ' js-truncated' : ''}`}
+                    data-long={isLong ? 'true' : 'false'}
+                  >
+                    {entry.content}
+                  </div>
+                  {isLong && (
+                    <button
+                      type="button"
+                      class="js-toggle-long text-xs mt-2 text-[color:var(--color-primary)] hover:underline cursor-pointer"
+                    >
+                      Show more
+                    </button>
+                  )}
+                </div>
+              </details>
+            )
+          })}
+        </div>
+      )
+    }
+  </div>
+
   {/* Dossier Summary */}
   {
     hasDossier && (
@@ -637,88 +747,6 @@ function confidenceColor(confidence: string): string {
       </div>
     )
   }
-
-  {/* Context Timeline */}
-  <div class="mb-6">
-    <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
-        Context Timeline
-        <span class="text-sm font-normal text-[color:var(--color-text-muted)]"
-          >({contextEntries.length})</span
-        >
-      </h3>
-    </div>
-
-    {/* Type filter pills */}
-    <div class="flex gap-1 mb-4 flex-wrap">
-      <a
-        href={`/admin/entities/${entity.id}`}
-        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]'}`}
-      >
-        All ({contextEntries.length})
-      </a>
-      {
-        Object.entries(typeCounts).map(([type, count]) => (
-          <a
-            href={`/admin/entities/${entity.id}?type=${type}`}
-            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-slate-900 text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
-          >
-            {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
-          </a>
-        ))
-      }
-    </div>
-
-    {/* Timeline entries */}
-    {
-      filteredEntries.length === 0 ? (
-        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack">
-          <p class="text-[color:var(--color-text-secondary)] text-sm">No context entries yet.</p>
-        </div>
-      ) : (
-        <div class="space-y-row">
-          {filteredEntries.map((entry: ContextEntry) => {
-            const meta = parseMetadata(entry.metadata)
-            const problems = meta?.top_problems as string[] | undefined
-            return (
-              <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-3">
-                <div class="flex items-center gap-2 mb-1.5">
-                  <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
-                    {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
-                  </span>
-                  <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
-                  <span class="text-xs text-[color:var(--color-text-muted)]">
-                    {formatDateTime(entry.created_at)}
-                  </span>
-                  {entry.type === 'signal' && meta?.pain_score && (
-                    <span class="text-xs font-semibold text-red-600">
-                      Pain: {String(meta.pain_score)}/10
-                    </span>
-                  )}
-                </div>
-
-                {problems && problems.length > 0 && (
-                  <div class="flex gap-1 mb-1.5">
-                    {problems.map((p: string) => (
-                      <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded">
-                        {p.replace(/_/g, ' ')}
-                      </span>
-                    ))}
-                  </div>
-                )}
-
-                <details class="group">
-                  <summary class="text-sm text-[color:var(--color-text-primary)] cursor-pointer line-clamp-3 group-open:line-clamp-none whitespace-pre-wrap">
-                    {entry.content}
-                  </summary>
-                </details>
-              </div>
-            )
-          })}
-        </div>
-      )
-    }
-  </div>
 
   {/* Related Data Panels */}
   {
@@ -863,6 +891,22 @@ function confidenceColor(confidence: string): string {
       </details>
     )
   }
+  <style>
+    /* Timeline long-entry truncation: visible by default, expands on toggle. */
+    .js-truncated {
+      display: -webkit-box;
+      -webkit-line-clamp: 6;
+      line-clamp: 6;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .js-truncated.is-expanded {
+      display: block;
+      -webkit-line-clamp: unset;
+      line-clamp: unset;
+      overflow: visible;
+    }
+  </style>
   <script>
     const form = document.getElementById('dossier-form')
     const btn = document.getElementById('dossier-btn') as HTMLButtonElement | null
@@ -884,5 +928,15 @@ function confidenceColor(confidence: string): string {
         }, 2000)
       })
     }
+
+    // Timeline long-entry read-more toggles
+    document.querySelectorAll<HTMLButtonElement>('.js-toggle-long').forEach((toggle) => {
+      toggle.addEventListener('click', () => {
+        const body = toggle.previousElementSibling as HTMLElement | null
+        if (!body || !body.classList.contains('js-truncated')) return
+        const expanded = body.classList.toggle('is-expanded')
+        toggle.textContent = expanded ? 'Show less' : 'Show more'
+      })
+    })
   </script>
 </AdminLayout>


### PR DESCRIPTION
## Summary

Closes #465.

Inverts the `<details>` default state on `src/pages/admin/entities/[id].astro` so Context Timeline entries render expanded on first visit. Long entries (>500 chars) get a "Show more" toggle inside the open body so the default-open state doesn't become a wall of text. Each entry is itself a `<details open>` element — the header row (type pill / source / timestamp / pain badge) is the clickable summary with a rotating chevron, so individual entries can still be collapsed.

Also performs the minor reshuffle called out in the issue: the Dossier Summary card now sits **below** the Context Timeline rather than above it. This aligns with the file's own documented intent ("Context timeline is the centerpiece; operational data in collapsible panels") and brings the timeline higher on the page without burying the dossier, which is still available beneath.

## Acceptance criteria

- [x] First-time visit shows all timeline entries expanded — each entry uses `<details open>`.
- [x] Entries with >500 chars still truncate to avoid wall-of-text — CSS `-webkit-line-clamp: 6` on the content div, inline "Show more" button toggles `.is-expanded`.
- [x] Can toggle individual entries closed — clicking the header row (summary) collapses the whole entry; chevron icon rotates.

## Implementation notes

- The summary row uses `list-none` + `[&::-webkit-details-marker]:hidden` so the native disclosure triangle doesn't clash with the existing badge layout; we render our own chevron SVG with `group-open:rotate-180`.
- Truncation uses line-clamp (6 lines ≈ comfortably under a screenful) with a JS toggle. Per-entry: if the content string length is >500 chars, the entry renders truncated-by-default with a button; otherwise no button is rendered. 500 chars is the issue-specified threshold; the 6-line visual clamp is a reasonable proxy because content width varies by viewport — we want the visible height to be the guardrail, not the character count alone.
- No authored client-facing strings added or modified — timeline `entry.content` is admin-authored data pulled from the context table.
- `Intelligence dossier generated` toast string updated from "See enrichment entries in the timeline **below**" to "…in the timeline" now that the timeline sits above the dossier card.

## Test plan

- [ ] Visit an entity with multiple timeline entries (`/admin/entities/{id}`) — all render expanded on first load.
- [ ] Click any entry's header row — the body collapses; chevron rotates.
- [ ] Click again — expands. Works per-entry.
- [ ] Visit an entity that has an enrichment/dossier entry with long content (>500 chars) — entry is expanded but clamped to ~6 lines with "Show more"; clicking expands fully and the button becomes "Show less".
- [ ] Verify Context Timeline sits above Dossier Summary and above Related Data Panels.
- [ ] `npm run verify` — green (typecheck, format, lint, build, tests: 1278 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)