### PR TITLE
feat(admin/prospect): 'Log reply' action (#464)

### DIFF
--- a/src/components/admin/LogReplyDialog.astro
+++ b/src/components/admin/LogReplyDialog.astro
@@ -1,0 +1,158 @@
+---
+/**
+ * LogReplyDialog — modal for capturing a prospect reply (issue #464).
+ *
+ * Emits a POST to /api/admin/entities/[id]/reply-log which creates a context
+ * entry of type `note` with source `reply_log` and structured metadata.
+ *
+ * Uses a native <dialog> element so it works without a JS framework.
+ * Opened by any button with `data-open-reply-dialog="<entityId>"`.
+ */
+
+export interface Props {
+  entityId: string
+  /** Display name — used in the dialog header so admin knows which entity this is for. */
+  entityName: string
+  /** Unique suffix so multiple dialogs can coexist on one page (list view). */
+  instanceId?: string
+}
+
+const { entityId, entityName, instanceId = entityId } = Astro.props
+const dialogId = `reply-dialog-${instanceId}`
+const formId = `reply-form-${instanceId}`
+---
+
+<dialog
+  id={dialogId}
+  data-reply-dialog
+  data-entity-id={entityId}
+  class="rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-0 backdrop:bg-black/40 w-full max-w-md"
+>
+  <form
+    id={formId}
+    method="POST"
+    action={`/api/admin/entities/${entityId}/reply-log`}
+    class="bg-white p-card"
+  >
+    <div class="flex items-start justify-between mb-stack">
+      <div>
+        <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">Log reply</h3>
+        <p class="text-xs text-[color:var(--color-text-muted)] mt-0.5">
+          {entityName}
+        </p>
+      </div>
+      <button
+        type="button"
+        data-close-dialog
+        class="text-xs text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] transition-colors"
+        aria-label="Close"
+      >
+        Close
+      </button>
+    </div>
+
+    <div class="space-y-stack">
+      <div>
+        <label
+          class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+          for={`${instanceId}-sentiment`}
+        >
+          Sentiment
+        </label>
+        <select
+          id={`${instanceId}-sentiment`}
+          name="sentiment"
+          required
+          class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white text-[color:var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        >
+          <option value="interested">Interested</option>
+          <option value="declined">Declined</option>
+          <option value="out_of_office">Out of office</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+
+      <div>
+        <label
+          class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+          for={`${instanceId}-next-action`}
+        >
+          Suggested next action
+        </label>
+        <select
+          id={`${instanceId}-next-action`}
+          name="next_action"
+          required
+          class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white text-[color:var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        >
+          <option value="book_meeting">Book meeting</option>
+          <option value="retry_later">Retry later</option>
+          <option value="mark_lost">Mark lost</option>
+          <option value="continue_conversation">Continue conversation</option>
+        </select>
+        <p class="text-xs text-[color:var(--color-text-muted)] mt-1">
+          No stage change happens automatically. Use the stage buttons on the entity after saving.
+        </p>
+      </div>
+
+      <div>
+        <label
+          class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+          for={`${instanceId}-notes`}
+        >
+          Notes
+        </label>
+        <textarea
+          id={`${instanceId}-notes`}
+          name="notes"
+          rows="3"
+          placeholder="Paste or summarize the reply..."
+          class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        ></textarea>
+      </div>
+    </div>
+
+    <div class="mt-card flex items-center justify-end gap-2">
+      <button
+        type="button"
+        data-close-dialog
+        class="text-sm bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="text-sm bg-primary text-white px-4 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+      >
+        Save reply
+      </button>
+    </div>
+  </form>
+</dialog>
+
+<script>
+  // Wire up open/close for every reply dialog on the page. Each trigger uses
+  // data-open-reply-dialog="<entityId>" to target its dialog.
+  const openers = document.querySelectorAll<HTMLElement>('[data-open-reply-dialog]')
+  openers.forEach((el) => {
+    el.addEventListener('click', (e) => {
+      const entityId = el.getAttribute('data-open-reply-dialog')
+      if (!entityId) return
+      // Match by data-entity-id so multiple dialogs on the same page pick the right one.
+      const dialog = document.querySelector<HTMLDialogElement>(
+        `dialog[data-reply-dialog][data-entity-id="${entityId}"]`
+      )
+      if (dialog) {
+        e.preventDefault()
+        dialog.showModal()
+      }
+    })
+  })
+
+  document.querySelectorAll<HTMLElement>('[data-close-dialog]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const dialog = btn.closest('dialog') as HTMLDialogElement | null
+      dialog?.close()
+    })
+  })
+</script>

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,5 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
+import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { EntityStage } from '../../../lib/db/entities'
@@ -51,6 +52,7 @@ for (const e of contextEntries) {
 
 const promoted = Astro.url.searchParams.get('promoted')
 const noteAdded = Astro.url.searchParams.get('note_added')
+const replyLogged = Astro.url.searchParams.get('reply_logged')
 const stageUpdated = Astro.url.searchParams.get('stage_updated')
 const dossierGenerated = Astro.url.searchParams.get('dossier')
 const error = Astro.url.searchParams.get('error')
@@ -352,6 +354,13 @@ function confidenceColor(confidence: string): string {
     )
   }
   {
+    replyLogged && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+        Reply logged.
+      </div>
+    )
+  }
+  {
     stageUpdated && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Stage updated.
@@ -492,9 +501,18 @@ function confidenceColor(confidence: string): string {
             </form>
           )
         }
+        <button
+          type="button"
+          data-open-reply-dialog={entity.id}
+          class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]"
+        >
+          Log reply
+        </button>
       </div>
     </div>
   </div>
+
+  <LogReplyDialog entityId={entity.id} entityName={entity.name} />
 
   {/* Add Note */}
   <div
@@ -680,12 +698,29 @@ function confidenceColor(confidence: string): string {
           {filteredEntries.map((entry: ContextEntry) => {
             const meta = parseMetadata(entry.metadata)
             const problems = meta?.top_problems as string[] | undefined
+            const isReplyLog = entry.type === 'note' && entry.source === 'reply_log'
+            const replySentiment = isReplyLog ? (meta?.sentiment as string | undefined) : undefined
+            const replyNextAction = isReplyLog
+              ? (meta?.next_action as string | undefined)
+              : undefined
             return (
-              <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-3">
-                <div class="flex items-center gap-2 mb-1.5">
-                  <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
-                    {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
-                  </span>
+              <div
+                class={`bg-white rounded-[var(--radius-card)] border px-4 py-3 ${
+                  isReplyLog
+                    ? 'border-l-4 border-l-teal-500 border-[color:var(--color-border)]'
+                    : 'border-[color:var(--color-border)]'
+                }`}
+              >
+                <div class="flex items-center gap-2 mb-1.5 flex-wrap">
+                  {isReplyLog ? (
+                    <span class="text-xs px-2 py-0.5 rounded bg-teal-100 text-teal-700 font-semibold">
+                      Reply
+                    </span>
+                  ) : (
+                    <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
+                      {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
+                    </span>
+                  )}
                   <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
                   <span class="text-xs text-[color:var(--color-text-muted)]">
                     {formatDateTime(entry.created_at)}
@@ -693,6 +728,16 @@ function confidenceColor(confidence: string): string {
                   {entry.type === 'signal' && meta?.pain_score && (
                     <span class="text-xs font-semibold text-red-600">
                       Pain: {String(meta.pain_score)}/10
+                    </span>
+                  )}
+                  {replySentiment && (
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] capitalize">
+                      {replySentiment.replace(/_/g, ' ')}
+                    </span>
+                  )}
+                  {replyNextAction && (
+                    <span class="text-xs text-[color:var(--color-text-secondary)]">
+                      Next: <span class="capitalize">{replyNextAction.replace(/_/g, ' ')}</span>
                     </span>
                   )}
                 </div>

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -1,5 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
+import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { listEntities, countEntitiesByStage, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { Entity, EntityStage } from '../../../lib/db/entities'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
@@ -26,6 +27,7 @@ const signalCount = await countEntitiesByStage(env.DB, session.orgId, 'signal')
 
 const promoted = Astro.url.searchParams.get('promoted')
 const dismissed = Astro.url.searchParams.get('dismissed')
+const replyLogged = Astro.url.searchParams.get('reply_logged')
 const error = Astro.url.searchParams.get('error')
 
 const LEAD_PIPELINES = [
@@ -125,6 +127,13 @@ function formatDate(iso: string): string {
     dismissed && (
       <div class="bg-[color:var(--color-background)] border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
         Entity dismissed.
+      </div>
+    )
+  }
+  {
+    replyLogged && (
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+        Reply logged.
       </div>
     )
   }
@@ -262,12 +271,23 @@ function formatDate(iso: string): string {
                     </form>
                   </>
                 ) : (
-                  <a
-                    href={`/admin/entities/${e.id}`}
-                    class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
-                  >
-                    View
-                  </a>
+                  <>
+                    {e.stage === 'prospect' && (
+                      <button
+                        type="button"
+                        data-open-reply-dialog={e.id}
+                        class="text-xs border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+                      >
+                        Log reply
+                      </button>
+                    )}
+                    <a
+                      href={`/admin/entities/${e.id}`}
+                      class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                    >
+                      View
+                    </a>
+                  </>
                 )}
               </div>
             </div>
@@ -275,5 +295,12 @@ function formatDate(iso: string): string {
         ))}
       </div>
     )
+  }
+
+  {
+    /* One dialog per prospect row — triggered by data-open-reply-dialog */
+    entities
+      .filter((e: Entity) => e.stage === 'prospect')
+      .map((e: Entity) => <LogReplyDialog entityId={e.id} entityName={e.name} />)
   }
 </AdminLayout>

--- a/src/pages/api/admin/entities/[id]/reply-log.ts
+++ b/src/pages/api/admin/entities/[id]/reply-log.ts
@@ -1,0 +1,84 @@
+import type { APIRoute } from 'astro'
+import { appendContext } from '../../../../../lib/db/context'
+import { getEntity } from '../../../../../lib/db/entities'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/entities/[id]/reply-log
+ *
+ * Log a prospect reply received via Gmail (or other inbox). Creates a context
+ * entry of type `note` with source `reply_log` and structured metadata capturing
+ * sentiment + suggested next action.
+ *
+ * Does NOT auto-transition entity stage — admin picks the next move manually
+ * (see issue #464 AC).
+ */
+
+export const REPLY_SENTIMENTS = ['interested', 'declined', 'out_of_office', 'other'] as const
+export type ReplySentiment = (typeof REPLY_SENTIMENTS)[number]
+
+export const REPLY_NEXT_ACTIONS = [
+  'book_meeting',
+  'retry_later',
+  'mark_lost',
+  'continue_conversation',
+] as const
+export type ReplyNextAction = (typeof REPLY_NEXT_ACTIONS)[number]
+
+export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) {
+    return redirect('/admin/entities?error=missing', 302)
+  }
+
+  try {
+    const entity = await getEntity(env.DB, session.orgId, entityId)
+    if (!entity) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const sentimentRaw = formData.get('sentiment')
+    const nextActionRaw = formData.get('next_action')
+    const notesRaw = formData.get('notes')
+
+    const sentiment = typeof sentimentRaw === 'string' ? sentimentRaw : ''
+    const nextAction = typeof nextActionRaw === 'string' ? nextActionRaw : ''
+    const notes = typeof notesRaw === 'string' ? notesRaw.trim() : ''
+
+    if (!REPLY_SENTIMENTS.includes(sentiment as ReplySentiment)) {
+      return redirect(`/admin/entities/${entityId}?error=invalid_sentiment`, 302)
+    }
+    if (!REPLY_NEXT_ACTIONS.includes(nextAction as ReplyNextAction)) {
+      return redirect(`/admin/entities/${entityId}?error=invalid_next_action`, 302)
+    }
+
+    // Content is a human-readable summary. If the admin provided notes, use them
+    // verbatim; otherwise record the structured signal without inventing prose.
+    const content = notes.length > 0 ? notes : `Reply logged: ${sentiment} / ${nextAction}`
+
+    await appendContext(env.DB, session.orgId, {
+      entity_id: entityId,
+      type: 'note',
+      content,
+      source: 'reply_log',
+      metadata: {
+        sentiment,
+        next_action: nextAction,
+      },
+    })
+
+    return redirect(`/admin/entities/${entityId}?reply_logged=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/entities/reply-log] POST Error:', err)
+    return redirect(`/admin/entities/${entityId}?error=server`, 302)
+  }
+}

--- a/tests/reply-log.test.ts
+++ b/tests/reply-log.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Reply-log endpoint — structural tests (issue #464).
+ *
+ * Verifies the API shape and wiring without booting D1. Behavioral
+ * verification (context row insertion) lives in integration tests.
+ */
+
+const endpoint = () =>
+  readFileSync(resolve('src/pages/api/admin/entities/[id]/reply-log.ts'), 'utf-8')
+const detailPage = () => readFileSync(resolve('src/pages/admin/entities/[id].astro'), 'utf-8')
+const listPage = () => readFileSync(resolve('src/pages/admin/entities/index.astro'), 'utf-8')
+const dialog = () => readFileSync(resolve('src/components/admin/LogReplyDialog.astro'), 'utf-8')
+
+describe('reply-log endpoint: allowed values', () => {
+  it('exports the four sentiment values from the issue', () => {
+    const code = endpoint()
+    expect(code).toContain("'interested'")
+    expect(code).toContain("'declined'")
+    expect(code).toContain("'out_of_office'")
+    expect(code).toContain("'other'")
+  })
+
+  it('exports the four next-action values from the issue', () => {
+    const code = endpoint()
+    expect(code).toContain("'book_meeting'")
+    expect(code).toContain("'retry_later'")
+    expect(code).toContain("'mark_lost'")
+    expect(code).toContain("'continue_conversation'")
+  })
+})
+
+describe('reply-log endpoint: context entry shape', () => {
+  it('writes a context entry via appendContext', () => {
+    expect(endpoint()).toContain('appendContext')
+  })
+
+  it("uses type 'note' as the issue specifies", () => {
+    expect(endpoint()).toContain("type: 'note'")
+  })
+
+  it("uses source 'reply_log' as the issue specifies", () => {
+    expect(endpoint()).toContain("source: 'reply_log'")
+  })
+
+  it('stores sentiment and next_action in metadata', () => {
+    const code = endpoint()
+    expect(code).toContain('sentiment')
+    expect(code).toContain('next_action')
+    expect(code).toMatch(/metadata:\s*\{/)
+  })
+
+  it('does not transition entity stage (AC: admin picks next action manually)', () => {
+    const code = endpoint()
+    // The endpoint never calls updateEntityStage or emits a stage_change context entry
+    expect(code).not.toMatch(/updateEntityStage|stage_change|updateStage/)
+  })
+})
+
+describe('reply-log endpoint: auth and validation', () => {
+  it('rejects non-admin sessions', () => {
+    const code = endpoint()
+    expect(code).toContain("session.role !== 'admin'")
+  })
+
+  it('validates sentiment against allowed list', () => {
+    expect(endpoint()).toContain('REPLY_SENTIMENTS.includes')
+  })
+
+  it('validates next_action against allowed list', () => {
+    expect(endpoint()).toContain('REPLY_NEXT_ACTIONS.includes')
+  })
+
+  it('verifies entity exists before writing context', () => {
+    expect(endpoint()).toContain('getEntity')
+  })
+})
+
+describe('reply-log UI: dialog component', () => {
+  it('renders a native <dialog> so it works without a framework', () => {
+    expect(dialog()).toMatch(/<dialog[\s>]/)
+  })
+
+  it('POSTs to the reply-log endpoint', () => {
+    expect(dialog()).toContain('/reply-log')
+  })
+
+  it('has a sentiment select with all four options', () => {
+    const code = dialog()
+    expect(code).toContain('name="sentiment"')
+    expect(code).toContain('value="interested"')
+    expect(code).toContain('value="declined"')
+    expect(code).toContain('value="out_of_office"')
+    expect(code).toContain('value="other"')
+  })
+
+  it('has a next_action select with all four options', () => {
+    const code = dialog()
+    expect(code).toContain('name="next_action"')
+    expect(code).toContain('value="book_meeting"')
+    expect(code).toContain('value="retry_later"')
+    expect(code).toContain('value="mark_lost"')
+    expect(code).toContain('value="continue_conversation"')
+  })
+
+  it('has a notes textarea', () => {
+    expect(dialog()).toContain('name="notes"')
+  })
+})
+
+describe('reply-log UI: entity detail surfaces reply entries with distinct badge', () => {
+  it('imports the LogReplyDialog component', () => {
+    expect(detailPage()).toContain('LogReplyDialog')
+  })
+
+  it('exposes a Log reply trigger', () => {
+    expect(detailPage()).toContain('data-open-reply-dialog')
+  })
+
+  it('renders a distinct Reply badge for reply_log entries', () => {
+    const code = detailPage()
+    expect(code).toContain("entry.source === 'reply_log'")
+    expect(code).toContain('isReplyLog')
+  })
+})
+
+describe('reply-log UI: entities list (prospect rows)', () => {
+  it('adds a Log reply button for prospect-stage rows', () => {
+    const code = listPage()
+    expect(code).toContain("e.stage === 'prospect'")
+    expect(code).toContain('data-open-reply-dialog')
+  })
+
+  it('imports the dialog component', () => {
+    expect(listPage()).toContain('LogReplyDialog')
+  })
+})


### PR DESCRIPTION
Closes #464.

## Summary

Adds structured capture for prospect replies received via Gmail (or any inbox) so conversion data accumulates while the cold-outreach build/buy decision is deferred.

- New `POST /api/admin/entities/[id]/reply-log` writes a context entry of type `note`, source `reply_log`, with `{ sentiment, next_action }` metadata.
- New reusable `LogReplyDialog.astro` component — native `<dialog>` modal with sentiment select, suggested-next-action select, and free-text notes.
- Entity detail: `Log reply` button in the header; reply-log timeline entries get a teal border-left + distinct `Reply` badge, with sentiment and next-action surfaced inline.
- Entities list (prospect tab): `Log reply` button on every prospect row; one dialog per row.
- 21 structural tests verifying endpoint shape, metadata schema, the no-auto-stage-transition AC, and UI wiring.

## Acceptance criteria

- [x] Log reply creates a typed context entry (`type=note`, `source=reply_log`)
- [x] Metadata includes sentiment + next-action fields
- [x] Entity detail shows reply log entries with clear badge (teal border-left + Reply pill + sentiment chip + next-action caption)
- [x] No auto-transition of entity stage — endpoint never touches entity stage; admin uses existing stage buttons after saving. Dialog copy reinforces this ("No stage change happens automatically").

## Key decisions

- **Component reuse.** Admin surfaces hand-roll Tailwind classes (per `docs/style/UI-PATTERNS.md` Rule 7: portal uses `PortalListItem`, admin imports from `src/lib/ui/status-badge.ts`). I followed that split — the new dialog is a local admin component, not a portal primitive.
- **Metadata schema.** Flat `{ sentiment, next_action }` keys, values are the underscore-style jargon (`out_of_office`, `continue_conversation`). Matches existing metadata conventions (e.g., `kind` on booking alerts) and keeps JSON-extract queries simple.
- **Content field.** If the admin types notes, they're used verbatim; otherwise a minimal machine-readable `Reply logged: <sentiment> / <next_action>` — no fabricated prose. Admin-only UI, no client exposure.
- **Modal.** Native `<dialog>` + one inline script inside the component. No new framework or component library.

## Adjacent findings (not addressed in this PR)

- `docs/style/UI-PATTERNS.md` Rule 2 (redundancy) could eventually apply if both the `Reply` pill and sentiment chip convey overlapping state — for now the pill indicates "this row is a reply log," and the sentiment chip indicates "the reply's tone." Separate facts, not redundant.

## Test plan

- [x] `npm run verify` green (1299 tests, 0 failures)
- [ ] Manual: on `/admin/entities?stage=prospect`, click Log reply on a prospect row, submit, verify redirect with `reply_logged=1` flash and the timeline entry rendering on detail page
- [ ] Manual: on entity detail page, confirm Log reply button opens dialog, form submits, entry renders with teal border + Reply badge
- [ ] Manual: confirm entity stage is unchanged after submit (issue AC)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>