### PR TITLE
feat(admin/lost): structured 'Lost reason' capture + filter (#477)

### DIFF
--- a/src/lib/db/entities.ts
+++ b/src/lib/db/entities.ts
@@ -13,6 +13,7 @@
 import { computeSlug } from '../entities/slug.js'
 import { recomputeDeterministicCache } from '../entities/recompute.js'
 import { appendContext } from './context.js'
+import { isLostReasonCode, type LostReasonCode } from './lost-reasons.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -136,6 +137,21 @@ export type FindOrCreateResult =
 export interface TransitionStageOptions {
   /** Override reason — bypasses pre-condition checks where documented. */
   force?: string
+  /**
+   * Structured metadata for `lost` transitions. Captured on the
+   * `stage_change` context entry's JSON metadata so the Lost tab can
+   * filter and future reporting can roll up "why we lost" without
+   * parsing free text.
+   *
+   * Required when `newStage === 'lost'`. Enforced at the DAL layer
+   * rather than the API so every caller (admin UI, scripts, future
+   * background jobs) is held to the same contract.
+   */
+  lostReason?: {
+    code: LostReasonCode
+    /** Optional operator note. Trimmed. Empty → stored as null. */
+    detail?: string | null
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -429,6 +445,28 @@ export async function transitionStage(
     )
   }
 
+  // Lost reason is required when transitioning to lost. Captured as
+  // structured metadata on the stage_change context entry so the Lost
+  // tab can filter and "why we lost" rollups are queryable.
+  let lostReasonCode: LostReasonCode | null = null
+  let lostReasonDetail: string | null = null
+  if (newStage === 'lost') {
+    if (!options?.lostReason?.code) {
+      throw new Error(
+        'Lost reason is required: provide options.lostReason.code when transitioning to lost.'
+      )
+    }
+    if (!isLostReasonCode(options.lostReason.code)) {
+      throw new Error(
+        `Invalid lost reason code: ${options.lostReason.code}. See src/lib/db/lost-reasons.ts.`
+      )
+    }
+    lostReasonCode = options.lostReason.code
+    const rawDetail = options.lostReason.detail
+    lostReasonDetail =
+      typeof rawDetail === 'string' && rawDetail.trim().length > 0 ? rawDetail.trim() : null
+  }
+
   // ---------------------------------------------------------------------------
   // Lifecycle invariant pre-conditions
   // ---------------------------------------------------------------------------
@@ -490,26 +528,80 @@ export async function transitionStage(
   // Record stage change as context entry
   const contextId = crypto.randomUUID()
   const content = `Stage: ${entity.stage} → ${newStage}. ${reason}`
+  const metadata: Record<string, unknown> = {
+    from: entity.stage,
+    to: newStage,
+    reason,
+  }
+  if (lostReasonCode) {
+    metadata.lost_reason = lostReasonCode
+    if (lostReasonDetail) metadata.lost_detail = lostReasonDetail
+  }
   await db
     .prepare(
       `INSERT INTO context (id, entity_id, org_id, type, content, source, content_size, metadata, created_at)
       VALUES (?, ?, ?, 'stage_change', ?, 'system', ?, ?, ?)`
     )
-    .bind(
-      contextId,
-      entityId,
-      orgId,
-      content,
-      content.length,
-      JSON.stringify({ from: entity.stage, to: newStage, reason }),
-      now
-    )
+    .bind(contextId, entityId, orgId, content, content.length, JSON.stringify(metadata), now)
     .run()
 
   // Recompute cache after stage change
   await recomputeDeterministicCache(db, orgId, entityId)
 
   return getEntity(db, orgId, entityId)
+}
+
+/**
+ * Returns the latest captured Lost reason code per entity, keyed by
+ * entity_id. Reads from `stage_change` context entries where
+ * `metadata.to = 'lost'`. Entities with no structured reason (e.g.
+ * legacy Lost rows captured before #477) are absent from the map.
+ *
+ * This is the one place that rolls up structured Lost metadata for
+ * list-rendering. Keep the query tight — it runs on every Lost-tab
+ * page render.
+ */
+export async function getLatestLostReasonsByEntity(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, { code: LostReasonCode; detail: string | null }>> {
+  const result = new Map<string, { code: LostReasonCode; detail: string | null }>()
+  if (entityIds.length === 0) return result
+
+  const placeholders = entityIds.map(() => '?').join(', ')
+  // For each entity, pick the newest stage_change row whose metadata
+  // marks a transition INTO lost. D1/SQLite supports json_extract.
+  const rows = await db
+    .prepare(
+      `SELECT c.entity_id,
+              json_extract(c.metadata, '$.lost_reason') AS lost_reason,
+              json_extract(c.metadata, '$.lost_detail') AS lost_detail
+         FROM context c
+        WHERE c.org_id = ?
+          AND c.type = 'stage_change'
+          AND c.entity_id IN (${placeholders})
+          AND json_extract(c.metadata, '$.to') = 'lost'
+          AND c.created_at = (
+            SELECT MAX(c2.created_at) FROM context c2
+             WHERE c2.org_id = c.org_id
+               AND c2.entity_id = c.entity_id
+               AND c2.type = 'stage_change'
+               AND json_extract(c2.metadata, '$.to') = 'lost'
+          )`
+    )
+    .bind(orgId, ...entityIds)
+    .all<{ entity_id: string; lost_reason: string | null; lost_detail: string | null }>()
+
+  for (const row of rows.results) {
+    if (row.lost_reason && isLostReasonCode(row.lost_reason)) {
+      result.set(row.entity_id, {
+        code: row.lost_reason,
+        detail: row.lost_detail ?? null,
+      })
+    }
+  }
+  return result
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/db/lost-reasons.ts
+++ b/src/lib/db/lost-reasons.ts
@@ -1,0 +1,116 @@
+/**
+ * Structured Lost-reason taxonomy for the admin pipeline.
+ *
+ * When an entity transitions to the `lost` stage, the admin picks one of
+ * these codes. The code is stored in the `metadata` JSON on the
+ * `stage_change` context entry produced by {@link transitionStage}:
+ *
+ *     metadata = {
+ *       from: EntityStage,
+ *       to: 'lost',
+ *       reason: string,       // free-text (admin jargon)
+ *       lost_reason: LostReasonCode,
+ *       lost_detail?: string, // optional operator note
+ *     }
+ *
+ * These codes are admin jargon — they power filtering on the Lost tab and
+ * a future "why we lost" review. They are NEVER rendered to clients. Do
+ * not reuse these strings in any portal / marketing surface.
+ *
+ * Flow B is in learning mode. Adding / renaming codes is fine — just
+ * keep this file as the single source of truth and update the type.
+ */
+
+export type LostReasonCode =
+  | 'not-a-fit'
+  | 'no-budget'
+  | 'no-response'
+  | 'declined-quote'
+  | 'unreachable'
+  | 'wrong-contact'
+  | 'other'
+
+export interface LostReasonDef {
+  value: LostReasonCode
+  label: string
+  /** Short prose we can surface next to the chip when helpful. */
+  description: string
+}
+
+export const LOST_REASONS: LostReasonDef[] = [
+  {
+    value: 'not-a-fit',
+    label: 'Not a fit',
+    description: 'Outside our ICP or scope — wrong industry, size, or problem.',
+  },
+  {
+    value: 'no-budget',
+    label: 'No budget',
+    description: 'Interested but cannot fund the engagement right now.',
+  },
+  {
+    value: 'no-response',
+    label: 'No response',
+    description: 'Reached a live contact once, then went dark.',
+  },
+  {
+    value: 'declined-quote',
+    label: 'Declined quote',
+    description: 'Received a proposal and declined.',
+  },
+  {
+    value: 'unreachable',
+    label: 'Unreachable',
+    description: 'Never made contact — bad number, bounced email, etc.',
+  },
+  {
+    value: 'wrong-contact',
+    label: 'Wrong contact',
+    description: 'Reached someone, but not the decision-maker, and could not route.',
+  },
+  {
+    value: 'other',
+    label: 'Other',
+    description: 'Anything else — use the detail field to explain.',
+  },
+]
+
+const VALID_CODES = new Set<LostReasonCode>(LOST_REASONS.map((r) => r.value))
+
+export function isLostReasonCode(value: unknown): value is LostReasonCode {
+  return typeof value === 'string' && VALID_CODES.has(value as LostReasonCode)
+}
+
+export function lostReasonLabel(code: string | null | undefined): string | null {
+  if (!code) return null
+  const match = LOST_REASONS.find((r) => r.value === code)
+  return match ? match.label : null
+}
+
+/**
+ * Admin-surface chip tone for each reason. Admin UI uses raw Tailwind
+ * (see `docs/style/UI-PATTERNS.md` — portal uses StatusPill tokens; admin
+ * stays on raw Tailwind per the source-of-truth contract). Tones reflect
+ * recoverability: outreach issues (recoverable, bluish) vs.
+ * disqualified (grey) vs. explicit no (red).
+ */
+export function lostReasonChipClass(code: string | null | undefined): string {
+  switch (code) {
+    case 'not-a-fit':
+      return 'bg-slate-100 text-slate-700'
+    case 'no-budget':
+      return 'bg-amber-100 text-amber-700'
+    case 'no-response':
+      return 'bg-blue-100 text-blue-700'
+    case 'declined-quote':
+      return 'bg-red-100 text-red-700'
+    case 'unreachable':
+      return 'bg-indigo-100 text-indigo-700'
+    case 'wrong-contact':
+      return 'bg-purple-100 text-purple-700'
+    case 'other':
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+    default:
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  }
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -3,6 +3,7 @@ import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { EntityStage } from '../../../lib/db/entities'
+import { LOST_REASONS, lostReasonLabel, lostReasonChipClass } from '../../../lib/db/lost-reasons'
 import { listContext, CONTEXT_TYPES } from '../../../lib/db/context'
 import type { ContextEntry } from '../../../lib/db/context'
 import { listContacts } from '../../../lib/db/contacts'
@@ -47,6 +48,29 @@ const filteredEntries = typeFilter
 const typeCounts: Record<string, number> = {}
 for (const e of contextEntries) {
   typeCounts[e.type] = (typeCounts[e.type] ?? 0) + 1
+}
+
+// Surface the most recent structured lost reason when this entity is
+// currently at the lost stage. Parsed from the latest stage_change
+// context entry's metadata — same source the Lost tab rolls up.
+let currentLostReason: { code: string; detail: string | null } | null = null
+if (entity.stage === 'lost') {
+  const lostEntries = [...contextEntries].reverse().filter((c) => c.type === 'stage_change')
+  for (const entry of lostEntries) {
+    if (!entry.metadata) continue
+    try {
+      const meta = JSON.parse(entry.metadata) as Record<string, unknown>
+      if (meta.to === 'lost' && typeof meta.lost_reason === 'string') {
+        currentLostReason = {
+          code: meta.lost_reason,
+          detail: typeof meta.lost_detail === 'string' ? meta.lost_detail : null,
+        }
+        break
+      }
+    } catch {
+      // ignore malformed metadata
+    }
+  }
 }
 
 const promoted = Astro.url.searchParams.get('promoted')
@@ -387,6 +411,16 @@ function confidenceColor(confidence: string): string {
             {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
           </span>
           {
+            currentLostReason && (
+              <span
+                class={`text-xs px-2 py-0.5 rounded ${lostReasonChipClass(currentLostReason.code)}`}
+                title={currentLostReason.detail ?? undefined}
+              >
+                {lostReasonLabel(currentLostReason.code) ?? currentLostReason.code}
+              </span>
+            )
+          }
+          {
             entity.tier && (
               <span
                 class={`text-xs px-2 py-0.5 rounded ${
@@ -462,18 +496,67 @@ function confidenceColor(confidence: string): string {
       {/* Stage transition buttons */}
       <div class="flex items-center gap-2 shrink-0">
         {
-          TRANSITIONS[entity.stage]?.map((t) => (
-            <form method="POST" action={t.action ?? `/api/admin/entities/${entity.id}/stage`}>
-              <input type="hidden" name="stage" value={t.stage} />
-              <input type="hidden" name="reason" value={`${t.label} by admin.`} />
-              <button
-                type="submit"
-                class={`text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors ${t.style}`}
-              >
-                {t.label}
-              </button>
-            </form>
-          ))
+          TRANSITIONS[entity.stage]?.map((t) =>
+            t.stage === 'lost' ? (
+              <details class="relative lost-picker">
+                <summary
+                  class={`list-none text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors cursor-pointer select-none ${t.style}`}
+                >
+                  {t.label}
+                </summary>
+                <form
+                  method="POST"
+                  action={t.action ?? `/api/admin/entities/${entity.id}/stage`}
+                  class="absolute right-0 mt-1 z-10 w-72 bg-white border border-[color:var(--color-border)] rounded-[var(--radius-card)] shadow-lg p-3 space-y-2"
+                >
+                  <input type="hidden" name="stage" value="lost" />
+                  <input type="hidden" name="reason" value={`${t.label} by admin.`} />
+                  <label class="block text-xs font-medium text-[color:var(--color-text-secondary)]">
+                    Lost reason
+                    <select
+                      name="lost_reason"
+                      required
+                      class="mt-1 block w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+                    >
+                      <option value="" disabled selected>
+                        Select a reason…
+                      </option>
+                      {LOST_REASONS.map((r) => (
+                        <option value={r.value}>{r.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label class="block text-xs font-medium text-[color:var(--color-text-secondary)]">
+                    Detail (optional)
+                    <textarea
+                      name="lost_detail"
+                      rows="2"
+                      class="mt-1 block w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1.5 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                    />
+                  </label>
+                  <div class="flex justify-end gap-2">
+                    <button
+                      type="submit"
+                      class="text-xs bg-[color:var(--color-text-primary)] text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-black transition-colors"
+                    >
+                      {t.label}
+                    </button>
+                  </div>
+                </form>
+              </details>
+            ) : (
+              <form method="POST" action={t.action ?? `/api/admin/entities/${entity.id}/stage`}>
+                <input type="hidden" name="stage" value={t.stage} />
+                <input type="hidden" name="reason" value={`${t.label} by admin.`} />
+                <button
+                  type="submit"
+                  class={`text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors ${t.style}`}
+                >
+                  {t.label}
+                </button>
+              </form>
+            )
+          )
         }
         {
           showDossierButton && (

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -1,7 +1,19 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
-import { listEntities, countEntitiesByStage, ENTITY_STAGES } from '../../../lib/db/entities'
+import {
+  listEntities,
+  countEntitiesByStage,
+  getLatestLostReasonsByEntity,
+  ENTITY_STAGES,
+} from '../../../lib/db/entities'
 import type { Entity, EntityStage } from '../../../lib/db/entities'
+import {
+  LOST_REASONS,
+  isLostReasonCode,
+  lostReasonLabel,
+  lostReasonChipClass,
+  type LostReasonCode,
+} from '../../../lib/db/lost-reasons'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import { env } from 'cloudflare:workers'
@@ -16,17 +28,37 @@ import { env } from 'cloudflare:workers'
 const session = Astro.locals.session!
 const filterStage = (Astro.url.searchParams.get('stage') ?? 'signal') as EntityStage
 const filterPipeline = Astro.url.searchParams.get('pipeline') ?? ''
+const rawLostReason = Astro.url.searchParams.get('lost_reason') ?? ''
+const filterLostReason: LostReasonCode | '' = isLostReasonCode(rawLostReason) ? rawLostReason : ''
 
-const entities = await listEntities(env.DB, session.orgId, {
+const rawEntities = await listEntities(env.DB, session.orgId, {
   stage: filterStage,
   ...(filterPipeline ? { source_pipeline: filterPipeline } : {}),
 })
+
+// For the Lost tab, roll up the latest structured reason per entity so
+// we can render a chip inline and filter by reason code.
+const lostReasonMap =
+  filterStage === 'lost'
+    ? await getLatestLostReasonsByEntity(
+        env.DB,
+        session.orgId,
+        rawEntities.map((e) => e.id)
+      )
+    : new Map<string, { code: LostReasonCode; detail: string | null }>()
+
+const entities =
+  filterStage === 'lost' && filterLostReason
+    ? rawEntities.filter((e) => lostReasonMap.get(e.id)?.code === filterLostReason)
+    : rawEntities
 
 const signalCount = await countEntitiesByStage(env.DB, session.orgId, 'signal')
 
 const promoted = Astro.url.searchParams.get('promoted')
 const dismissed = Astro.url.searchParams.get('dismissed')
-const error = Astro.url.searchParams.get('error')
+const rawError = Astro.url.searchParams.get('error')
+const error =
+  rawError === 'lost_reason_required' ? 'Pick a lost reason before dismissing.' : rawError
 
 const LEAD_PIPELINES = [
   { value: 'review_mining', label: 'Review Mining' },
@@ -136,25 +168,53 @@ function formatDate(iso: string): string {
     )
   }
 
-  <div class="flex items-center justify-between mb-6">
+  <div class="flex items-center justify-between mb-6 flex-wrap gap-2">
     <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Entities</h2>
-    <form method="GET" class="flex items-center gap-2">
-      <input type="hidden" name="stage" value={filterStage} />
-      <select
-        name="pipeline"
-        class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
-        onchange="this.form.submit()"
-      >
-        <option value="">All pipelines</option>
+    <div class="flex items-center gap-2 flex-wrap">
+      <form method="GET" class="flex items-center gap-2">
+        <input type="hidden" name="stage" value={filterStage} />
         {
-          LEAD_PIPELINES.map((p) => (
-            <option value={p.value} selected={filterPipeline === p.value}>
-              {p.label}
-            </option>
-          ))
+          filterStage === 'lost' && filterLostReason && (
+            <input type="hidden" name="lost_reason" value={filterLostReason} />
+          )
         }
-      </select>
-    </form>
+        <select
+          name="pipeline"
+          class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+          onchange="this.form.submit()"
+        >
+          <option value="">All pipelines</option>
+          {
+            LEAD_PIPELINES.map((p) => (
+              <option value={p.value} selected={filterPipeline === p.value}>
+                {p.label}
+              </option>
+            ))
+          }
+        </select>
+      </form>
+      {
+        filterStage === 'lost' && (
+          <form method="GET" class="flex items-center gap-2">
+            <input type="hidden" name="stage" value="lost" />
+            {filterPipeline && <input type="hidden" name="pipeline" value={filterPipeline} />}
+            <select
+              name="lost_reason"
+              aria-label="Filter by lost reason"
+              class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+              onchange="this.form.submit()"
+            >
+              <option value="">All lost reasons</option>
+              {LOST_REASONS.map((r) => (
+                <option value={r.value} selected={filterLostReason === r.value}>
+                  {r.label}
+                </option>
+              ))}
+            </select>
+          </form>
+        )
+      }
+    </div>
   </div>
 
   {/* Stage tabs */}
@@ -190,89 +250,134 @@ function formatDate(iso: string): string {
       </div>
     ) : (
       <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
-        {entities.map((e: Entity) => (
-          <div class="px-6 py-4">
-            <div class="flex items-start justify-between gap-stack">
-              <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-2 mb-1 flex-wrap">
-                  <a
-                    href={`/admin/entities/${e.id}`}
-                    class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary transition-colors"
-                  >
-                    {e.name}
-                  </a>
-                  {e.source_pipeline && (
-                    <span
-                      class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
+        {entities.map((e: Entity) => {
+          const lostInfo = lostReasonMap.get(e.id)
+          return (
+            <div class="px-6 py-4">
+              <div class="flex items-start justify-between gap-stack">
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2 mb-1 flex-wrap">
+                    <a
+                      href={`/admin/entities/${e.id}`}
+                      class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary transition-colors"
                     >
-                      {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
-                    </span>
+                      {e.name}
+                    </a>
+                    {e.source_pipeline && (
+                      <span
+                        class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
+                      >
+                        {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
+                      </span>
+                    )}
+                    {filterStage === 'lost' && lostInfo && (
+                      <span
+                        class={`text-xs px-2 py-0.5 rounded ${lostReasonChipClass(lostInfo.code)}`}
+                        title={lostInfo.detail ?? undefined}
+                      >
+                        {lostReasonLabel(lostInfo.code)}
+                      </span>
+                    )}
+                    {e.pain_score && (
+                      <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
+                        Pain: {e.pain_score}/10
+                      </span>
+                    )}
+                    {e.tier && (
+                      <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
+                        {e.tier}
+                      </span>
+                    )}
+                  </div>
+
+                  {e.summary && (
+                    <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2">
+                      {e.summary}
+                    </p>
                   )}
-                  {e.pain_score && (
-                    <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
-                      Pain: {e.pain_score}/10
-                    </span>
+
+                  {e.next_action && (
+                    <p class="text-xs text-amber-600 mb-1">
+                      <span class="font-medium">Next:</span> {e.next_action}
+                      {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
+                    </p>
                   )}
-                  {e.tier && (
-                    <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
-                      {e.tier}
-                    </span>
-                  )}
+
+                  <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1">
+                    <span>{formatDate(e.created_at)}</span>
+                    {e.area && <span>{e.area}</span>}
+                    {e.vertical && <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>}
+                    {e.employee_count && <span>~{e.employee_count} employees</span>}
+                  </div>
                 </div>
 
-                {e.summary && (
-                  <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2">
-                    {e.summary}
-                  </p>
-                )}
-
-                {e.next_action && (
-                  <p class="text-xs text-amber-600 mb-1">
-                    <span class="font-medium">Next:</span> {e.next_action}
-                    {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
-                  </p>
-                )}
-
-                <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1">
-                  <span>{formatDate(e.created_at)}</span>
-                  {e.area && <span>{e.area}</span>}
-                  {e.vertical && <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>}
-                  {e.employee_count && <span>~{e.employee_count} employees</span>}
+                <div class="flex items-center gap-2 shrink-0">
+                  {e.stage === 'signal' ? (
+                    <>
+                      <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
+                        <button
+                          type="submit"
+                          class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                        >
+                          Promote
+                        </button>
+                      </form>
+                      <details class="relative dismiss-picker">
+                        <summary class="list-none text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors cursor-pointer select-none">
+                          Dismiss
+                        </summary>
+                        <form
+                          method="POST"
+                          action={`/api/admin/entities/${e.id}/dismiss`}
+                          class="absolute right-0 mt-1 z-10 w-72 bg-white border border-[color:var(--color-border)] rounded-[var(--radius-card)] shadow-lg p-3 space-y-2"
+                        >
+                          <label class="block text-xs font-medium text-[color:var(--color-text-secondary)]">
+                            Lost reason
+                            <select
+                              name="lost_reason"
+                              required
+                              class="mt-1 block w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+                            >
+                              <option value="" disabled selected>
+                                Select a reason…
+                              </option>
+                              {LOST_REASONS.map((r) => (
+                                <option value={r.value}>{r.label}</option>
+                              ))}
+                            </select>
+                          </label>
+                          <label class="block text-xs font-medium text-[color:var(--color-text-secondary)]">
+                            Detail (optional)
+                            <textarea
+                              name="lost_detail"
+                              rows="2"
+                              class="mt-1 block w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1.5 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                            />
+                          </label>
+                          <div class="flex justify-end gap-2">
+                            <button
+                              type="submit"
+                              class="text-xs bg-[color:var(--color-text-primary)] text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-black transition-colors"
+                            >
+                              Dismiss
+                            </button>
+                          </div>
+                        </form>
+                      </details>
+                    </>
+                  ) : (
+                    <a
+                      href={`/admin/entities/${e.id}`}
+                      class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                    >
+                      View
+                    </a>
+                  )}
                 </div>
-              </div>
-
-              <div class="flex items-center gap-2 shrink-0">
-                {e.stage === 'signal' ? (
-                  <>
-                    <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
-                      <button
-                        type="submit"
-                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
-                      >
-                        Promote
-                      </button>
-                    </form>
-                    <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
-                      <button
-                        type="submit"
-                        class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
-                      >
-                        Dismiss
-                      </button>
-                    </form>
-                  </>
-                ) : (
-                  <a
-                    href={`/admin/entities/${e.id}`}
-                    class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
-                  >
-                    View
-                  </a>
-                )}
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     )
   }

--- a/src/pages/api/admin/assessments/[id]/complete.ts
+++ b/src/pages/api/admin/assessments/[id]/complete.ts
@@ -121,7 +121,11 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
       source_ref: assessmentId,
     })
 
-    // If disqualified, transition to lost and redirect back
+    // If disqualified, transition to lost and redirect back.
+    // Disqualification during assessment maps to the `not-a-fit` lost
+    // reason code — see src/lib/db/lost-reasons.ts. The extraction's
+    // free-text explanation is carried in `lost_detail` so the admin
+    // can still read the LLM's reasoning when reviewing the Lost tab.
     if (disqualified) {
       try {
         await updateAssessmentStatus(env.DB, session.orgId, assessmentId, 'disqualified')
@@ -130,7 +134,13 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
           session.orgId,
           entity.id,
           'lost',
-          `Disqualified during assessment: ${extraction.disqualify_reason ?? 'No reason provided'}`
+          `Disqualified during assessment: ${extraction.disqualify_reason ?? 'No reason provided'}`,
+          {
+            lostReason: {
+              code: 'not-a-fit',
+              detail: extraction.disqualify_reason ?? null,
+            },
+          }
         )
       } catch {
         // Stage transition may fail if already in lost state

--- a/src/pages/api/admin/entities/[id]/dismiss.ts
+++ b/src/pages/api/admin/entities/[id]/dismiss.ts
@@ -1,11 +1,18 @@
 import type { APIRoute } from 'astro'
 import { transitionStage } from '../../../../../lib/db/entities'
+import { isLostReasonCode } from '../../../../../lib/db/lost-reasons'
 import { env } from 'cloudflare:workers'
 
 /**
  * POST /api/admin/entities/[id]/dismiss
  *
- * Dismiss a signal entity (stage → lost with reason).
+ * Dismiss a signal entity (stage → lost with structured reason).
+ *
+ * Form fields:
+ * - `lost_reason` (required): one of the codes in LOST_REASONS
+ * - `lost_detail` (optional): free-text operator note
+ * - `reason` (optional, legacy): free-text summary captured on the
+ *   stage_change content. Falls back to the selected code's human label.
  */
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
   const session = locals.session
@@ -23,17 +30,33 @@ export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
 
   try {
     const formData = await request.formData()
-    const reason = formData.get('reason')
-    const reasonStr =
-      reason && typeof reason === 'string' && reason.trim()
-        ? reason.trim()
-        : 'Dismissed from inbox.'
+    const rawReasonCode = formData.get('lost_reason')
+    const lostReasonCode = typeof rawReasonCode === 'string' ? rawReasonCode : null
 
-    await transitionStage(env.DB, session.orgId, entityId, 'lost', reasonStr)
+    if (!lostReasonCode || !isLostReasonCode(lostReasonCode)) {
+      return redirect('/admin/entities?error=lost_reason_required', 302)
+    }
+
+    const rawDetail = formData.get('lost_detail')
+    const lostDetail =
+      rawDetail && typeof rawDetail === 'string' && rawDetail.trim().length > 0
+        ? rawDetail.trim()
+        : null
+
+    const rawSummary = formData.get('reason')
+    const reasonSummary =
+      rawSummary && typeof rawSummary === 'string' && rawSummary.trim().length > 0
+        ? rawSummary.trim()
+        : `Dismissed: ${lostReasonCode}${lostDetail ? ` — ${lostDetail}` : ''}`
+
+    await transitionStage(env.DB, session.orgId, entityId, 'lost', reasonSummary, {
+      lostReason: { code: lostReasonCode, detail: lostDetail },
+    })
 
     return redirect('/admin/entities?dismissed=1', 302)
   } catch (err) {
     console.error('[api/admin/entities/dismiss] Error:', err)
-    return redirect('/admin/entities?error=server', 302)
+    const message = err instanceof Error ? err.message : 'server'
+    return redirect(`/admin/entities?error=${encodeURIComponent(message)}`, 302)
   }
 }

--- a/src/pages/api/admin/entities/[id]/stage.ts
+++ b/src/pages/api/admin/entities/[id]/stage.ts
@@ -1,5 +1,10 @@
 import type { APIRoute } from 'astro'
-import { transitionStage, type EntityStage } from '../../../../../lib/db/entities'
+import {
+  transitionStage,
+  type EntityStage,
+  type TransitionStageOptions,
+} from '../../../../../lib/db/entities'
+import { isLostReasonCode } from '../../../../../lib/db/lost-reasons'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -7,6 +12,9 @@ import { env } from 'cloudflare:workers'
  *
  * Generic stage transition endpoint.
  * Validates against allowed transitions defined in entities.ts.
+ *
+ * When `stage === 'lost'`, a structured `lost_reason` form field is
+ * required. The `lost_detail` field is optional free-text context.
  */
 export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
   const session = locals.session
@@ -35,7 +43,25 @@ export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
       return redirect(`/admin/entities/${entityId}?error=missing_stage`, 302)
     }
 
-    await transitionStage(env.DB, session.orgId, entityId, stage, reasonStr)
+    const options: TransitionStageOptions = {}
+    if (stage === 'lost') {
+      const rawCode = formData.get('lost_reason')
+      const lostReasonCode = typeof rawCode === 'string' ? rawCode : null
+      if (!lostReasonCode || !isLostReasonCode(lostReasonCode)) {
+        return redirect(
+          `/admin/entities/${entityId}?error=${encodeURIComponent('lost_reason_required')}`,
+          302
+        )
+      }
+      const rawDetail = formData.get('lost_detail')
+      const lostDetail =
+        rawDetail && typeof rawDetail === 'string' && rawDetail.trim().length > 0
+          ? rawDetail.trim()
+          : null
+      options.lostReason = { code: lostReasonCode, detail: lostDetail }
+    }
+
+    await transitionStage(env.DB, session.orgId, entityId, stage, reasonStr, options)
 
     return redirect(`/admin/entities/${entityId}?stage_updated=1`, 302)
   } catch (err) {

--- a/tests/lost-reason.test.ts
+++ b/tests/lost-reason.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Lost-reason structured capture tests.
+ *
+ * Covers issue #477:
+ * - transitionStage(..., 'lost', ...) requires a structured lost reason
+ * - the stage_change context entry carries lost_reason + lost_detail
+ *   as JSON metadata, queryable via json_extract
+ * - getLatestLostReasonsByEntity rolls up the freshest code per entity
+ * - invalid codes are rejected
+ *
+ * Uses @venturecrane/crane-test-harness for in-memory D1 with real
+ * SQL execution against the actual migration schema — mirrors
+ * lifecycle-guards.test.ts.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import {
+  createEntity,
+  transitionStage,
+  getLatestLostReasonsByEntity,
+  type EntityStage,
+} from '../src/lib/db/entities'
+import { LOST_REASONS, isLostReasonCode } from '../src/lib/db/lost-reasons'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-lost-test'
+
+describe('structured lost reason', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Lost Test Org', 'lost-test-org')
+      .run()
+  })
+
+  describe('taxonomy module', () => {
+    it('exposes the seven canonical codes', () => {
+      const codes = LOST_REASONS.map((r) => r.value).sort()
+      expect(codes).toEqual(
+        [
+          'declined-quote',
+          'no-budget',
+          'no-response',
+          'not-a-fit',
+          'other',
+          'unreachable',
+          'wrong-contact',
+        ].sort()
+      )
+    })
+
+    it('isLostReasonCode validates codes strictly', () => {
+      expect(isLostReasonCode('not-a-fit')).toBe(true)
+      expect(isLostReasonCode('other')).toBe(true)
+      expect(isLostReasonCode('not_a_fit')).toBe(false)
+      expect(isLostReasonCode('')).toBe(false)
+      expect(isLostReasonCode(null)).toBe(false)
+      expect(isLostReasonCode(42)).toBe(false)
+    })
+  })
+
+  describe('transitionStage → lost', () => {
+    it('throws when no lost reason is provided', async () => {
+      const entity = await createEntity(db, ORG_ID, {
+        name: 'No-Reason Biz',
+        stage: 'signal' as EntityStage,
+      })
+      await expect(transitionStage(db, ORG_ID, entity.id, 'lost', 'Dismissed.')).rejects.toThrow(
+        'Lost reason is required'
+      )
+    })
+
+    it('throws when the provided code is not in the taxonomy', async () => {
+      const entity = await createEntity(db, ORG_ID, {
+        name: 'Bad-Code Biz',
+        stage: 'signal' as EntityStage,
+      })
+      await expect(
+        transitionStage(db, ORG_ID, entity.id, 'lost', 'Dismissed.', {
+          // Cast around the type to exercise runtime validation.
+          lostReason: { code: 'ghost' as never },
+        })
+      ).rejects.toThrow('Invalid lost reason code')
+    })
+
+    it('persists lost_reason + lost_detail on the stage_change metadata', async () => {
+      const entity = await createEntity(db, ORG_ID, {
+        name: 'Persist Biz',
+        stage: 'signal' as EntityStage,
+      })
+      await transitionStage(db, ORG_ID, entity.id, 'lost', 'Dismissed from inbox.', {
+        lostReason: { code: 'no-budget', detail: 'Said they could fund it next quarter.' },
+      })
+
+      const row = await db
+        .prepare(
+          `SELECT metadata FROM context
+            WHERE entity_id = ? AND type = 'stage_change'
+            ORDER BY created_at DESC LIMIT 1`
+        )
+        .bind(entity.id)
+        .first<{ metadata: string }>()
+      expect(row).not.toBeNull()
+      const meta = JSON.parse(row!.metadata) as Record<string, unknown>
+      expect(meta.to).toBe('lost')
+      expect(meta.lost_reason).toBe('no-budget')
+      expect(meta.lost_detail).toBe('Said they could fund it next quarter.')
+    })
+
+    it('trims whitespace detail and stores empty detail as absent', async () => {
+      const entity = await createEntity(db, ORG_ID, {
+        name: 'Trim Biz',
+        stage: 'signal' as EntityStage,
+      })
+      await transitionStage(db, ORG_ID, entity.id, 'lost', 'Dismissed.', {
+        lostReason: { code: 'unreachable', detail: '   ' },
+      })
+      const row = await db
+        .prepare(
+          `SELECT metadata FROM context WHERE entity_id = ? AND type = 'stage_change' LIMIT 1`
+        )
+        .bind(entity.id)
+        .first<{ metadata: string }>()
+      const meta = JSON.parse(row!.metadata) as Record<string, unknown>
+      expect(meta.lost_reason).toBe('unreachable')
+      expect('lost_detail' in meta).toBe(false)
+    })
+
+    it('non-lost transitions ignore lostReason option and still succeed', async () => {
+      // Create a signal entity and promote — must not require a lost reason.
+      const entity = await createEntity(db, ORG_ID, {
+        name: 'Promote Biz',
+        stage: 'signal' as EntityStage,
+      })
+      const result = await transitionStage(
+        db,
+        ORG_ID,
+        entity.id,
+        'prospect',
+        'Promoted from signal.'
+      )
+      expect(result).not.toBeNull()
+      expect(result!.stage).toBe('prospect')
+    })
+  })
+
+  describe('getLatestLostReasonsByEntity', () => {
+    it('returns an empty map when no entity IDs are provided', async () => {
+      const map = await getLatestLostReasonsByEntity(db, ORG_ID, [])
+      expect(map.size).toBe(0)
+    })
+
+    it('rolls up the most recent lost reason per entity', async () => {
+      const a = await createEntity(db, ORG_ID, {
+        name: 'Entity A',
+        stage: 'signal' as EntityStage,
+      })
+      const b = await createEntity(db, ORG_ID, {
+        name: 'Entity B',
+        stage: 'signal' as EntityStage,
+      })
+
+      await transitionStage(db, ORG_ID, a.id, 'lost', 'A', {
+        lostReason: { code: 'no-response' },
+      })
+      // Re-engage A and then mark lost again with a different code.
+      await transitionStage(db, ORG_ID, a.id, 'prospect', 'Re-engaged')
+      await transitionStage(db, ORG_ID, a.id, 'lost', 'A2', {
+        lostReason: { code: 'declined-quote', detail: 'Sent SOW; owner passed.' },
+      })
+
+      await transitionStage(db, ORG_ID, b.id, 'lost', 'B', {
+        lostReason: { code: 'wrong-contact' },
+      })
+
+      const map = await getLatestLostReasonsByEntity(db, ORG_ID, [a.id, b.id])
+      expect(map.size).toBe(2)
+      expect(map.get(a.id)?.code).toBe('declined-quote')
+      expect(map.get(a.id)?.detail).toBe('Sent SOW; owner passed.')
+      expect(map.get(b.id)?.code).toBe('wrong-contact')
+      expect(map.get(b.id)?.detail).toBeNull()
+    })
+
+    it('omits entities whose latest stage_change has no lost_reason (legacy rows)', async () => {
+      const entity = await createEntity(db, ORG_ID, {
+        name: 'Legacy Biz',
+        stage: 'signal' as EntityStage,
+      })
+      // Simulate a legacy Lost row: insert stage_change metadata without
+      // lost_reason. Bypasses transitionStage() which would now enforce.
+      await db
+        .prepare(
+          `INSERT INTO context (id, entity_id, org_id, type, content, source, content_size, metadata, created_at)
+            VALUES (?, ?, ?, 'stage_change', ?, 'system', ?, ?, datetime('now'))`
+        )
+        .bind(
+          crypto.randomUUID(),
+          entity.id,
+          ORG_ID,
+          'Stage: signal → lost. Legacy row.',
+          30,
+          JSON.stringify({ from: 'signal', to: 'lost', reason: 'Legacy row.' })
+        )
+        .run()
+      // Also flip the entity's stage column so it shows on the Lost tab.
+      await db.prepare(`UPDATE entities SET stage = 'lost' WHERE id = ?`).bind(entity.id).run()
+
+      const map = await getLatestLostReasonsByEntity(db, ORG_ID, [entity.id])
+      expect(map.has(entity.id)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Closes #477.

## Summary

Flow B is in learning mode — the most valuable signal we can capture is **why** a lead goes Lost. This PR replaces the free-text reason that was logged to context with a structured taxonomy and surfaces it as a filter + chip on the Lost tab.

- New taxonomy in [`src/lib/db/lost-reasons.ts`](src/lib/db/lost-reasons.ts): `not-a-fit`, `no-budget`, `no-response`, `declined-quote`, `unreachable`, `wrong-contact`, `other`. Admin jargon only — never rendered to clients (CLAUDE.md no-fabricated-content rule).
- `transitionStage()` now requires `options.lostReason` when `newStage === 'lost'` and persists the code (plus optional free-text detail) on the existing `stage_change` context entry's JSON `metadata`. No new table, reuses the append-only context log as requested.
- `getLatestLostReasonsByEntity()` queries the latest reason per entity via `json_extract`, used by the Lost-tab row chip and the filter.
- Dismiss (signal tab) and every "Lost" stage-transition button (detail page) now open a compact inline `<details>` picker with a required dropdown + optional detail textarea. Native HTML; no JS dependency; matches the admin's raw-Tailwind UI convention per `docs/style/UI-PATTERNS.md`.
- Assessment-completion disqualification flow updated to tag `not-a-fit` and carry the extractor's explanation as `lost_detail`.

## Decisions

- **Required, with `other` as the escape valve.** The AC allowed an explicit "skip" option; picked required-with-`other` instead. Simpler contract at the DAL layer, and `other` + detail is strictly more informative than a skip bit.
- **No modal component.** Repo has no existing dialog primitive and CLAUDE.md warns against inventing visual patterns. Went with `<details>` progressive disclosure — ships today, no JS, predictable focus semantics, easy to swap to a real popover later.
- **Chip styling uses raw Tailwind.** Admin surfaces import from `src/lib/ui/status-badge.ts` per UI-PATTERNS Rule 7 source-of-truth contract, so I added the new tones directly in `lost-reasons.ts` rather than touching the portal StatusPill.

## Acceptance criteria

- [x] Can't dismiss without selecting a reason (enforced at the DAL and rejected at the API with a friendly error banner)
- [x] Reasons roll up to the Lost tab as filter (dropdown at the top of the tab; respects other filters)
- [x] Data is queryable for monthly "why we lost" review (`json_extract(metadata, '$.lost_reason')` on `context` where `type='stage_change'`)

## Test plan

- [x] `npm run verify` green (1288 passed, 2 skipped, 0 lint/type errors)
- [x] New tests: `tests/lost-reason.test.ts` — 10 cases covering taxonomy validation, required-reason enforcement, metadata shape, whitespace handling, `getLatestLostReasonsByEntity` rollup, and legacy-row tolerance
- [ ] Manual admin UI smoke: confirm the picker opens, blocks empty submission, and the chip + filter render on the Lost tab after merge

## Out of scope (not blocking)

- Monthly "why we lost" reporting dashboard — the data is now queryable, but building the report UI is separate work.
- Backfilling legacy Lost rows with a code — left as a no-op; `getLatestLostReasonsByEntity` tolerates them by omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)