### PR TITLE
feat(admin/entities): quote status + age on Proposing rows (#473)

### DIFF
--- a/src/lib/admin/relative-time.ts
+++ b/src/lib/admin/relative-time.ts
@@ -1,0 +1,27 @@
+/**
+ * Admin-facing relative-time formatter. Renders short tokens suitable for
+ * inline list metadata ("2d ago", "3h ago", "just now").
+ *
+ * Centralized so admin surfaces don't keep redefining inline variants — the
+ * pattern that was drifting across src/pages/admin/index.astro and the
+ * generators dashboard before this util existed. Portal-facing date captions
+ * live in src/lib/portal/formatters.ts; keep admin and portal formatters
+ * separate because their wording and conventions differ.
+ *
+ * Returns null for invalid / missing input so callers can chain without
+ * guarding — and render nothing rather than a placeholder.
+ */
+
+export function relativeTime(iso: string | null | undefined): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  const ms = d.getTime()
+  if (Number.isNaN(ms)) return null
+
+  const hours = (Date.now() - ms) / 3_600_000
+  if (hours < 0) return 'just now' // future timestamp — treat as current
+  if (hours < 1) return 'just now'
+  if (hours < 24) return `${Math.round(hours)}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}

--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -408,6 +408,71 @@ export async function updateQuote(
 const PORTAL_VISIBLE_STATUSES = ['sent', 'accepted', 'declined', 'expired'] as const
 
 /**
+ * For a set of entity ids, return the "top active" quote per entity — the one
+ * an admin scanning a list would care about. Priority:
+ *
+ *   1. Most recently sent `sent` quote (the one in the client's hands)
+ *   2. Otherwise most recently updated `accepted` quote
+ *   3. Otherwise most recently updated `draft` quote
+ *
+ * Terminal non-useful statuses (declined, expired, superseded) are ignored.
+ * Returns a Map keyed by entity_id so the caller can render badges inline on
+ * a list without an N+1 per-row query.
+ *
+ * Scoped by org_id for tenant isolation. Empty id list short-circuits to an
+ * empty map (D1 rejects `IN ()`).
+ */
+export async function getActiveQuotesForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, Quote>> {
+  const result = new Map<string, Quote>()
+  if (entityIds.length === 0) return result
+
+  const placeholders = entityIds.map(() => '?').join(', ')
+  // Priority: sent (0) > accepted (1) > draft (2). We order by priority then by
+  // `sent_at` DESC (for sent), else `updated_at` DESC. One row per entity via
+  // the ROW_NUMBER() window function. D1 supports SQLite window functions.
+  const sql = `
+    SELECT id, org_id, entity_id, assessment_id, version, parent_quote_id,
+           line_items, total_hours, rate, total_price, deposit_pct,
+           deposit_amount, status, sent_at, expires_at, accepted_at,
+           schedule, deliverables, engagement_overview, milestone_label,
+           created_at, updated_at
+    FROM (
+      SELECT q.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY q.entity_id
+          ORDER BY
+            CASE q.status
+              WHEN 'sent'     THEN 0
+              WHEN 'accepted' THEN 1
+              WHEN 'draft'    THEN 2
+              ELSE 9
+            END,
+            COALESCE(q.sent_at, q.updated_at) DESC
+        ) AS rn
+      FROM quotes q
+      WHERE q.org_id = ?
+        AND q.entity_id IN (${placeholders})
+        AND q.status IN ('sent', 'accepted', 'draft')
+    )
+    WHERE rn = 1
+  `
+
+  const rows = await db
+    .prepare(sql)
+    .bind(orgId, ...entityIds)
+    .all<Quote>()
+
+  for (const row of rows.results) {
+    result.set(row.entity_id, row)
+  }
+  return result
+}
+
+/**
  * List quotes for a specific entity (portal access).
  *
  * Scoped by both `entity_id` and `org_id` — entity IDs are expected unique,

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -2,8 +2,12 @@
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import { listEntities, countEntitiesByStage, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { Entity, EntityStage } from '../../../lib/db/entities'
+import { getActiveQuotesForEntities } from '../../../lib/db/quotes'
+import type { Quote } from '../../../lib/db/quotes'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
+import { statusBadgeClass } from '../../../lib/ui/status-badge'
+import { relativeTime } from '../../../lib/admin/relative-time'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -23,6 +27,32 @@ const entities = await listEntities(env.DB, session.orgId, {
 })
 
 const signalCount = await countEntitiesByStage(env.DB, session.orgId, 'signal')
+
+// Proposing tab: pull the top active quote per entity for inline status + age,
+// and reorder rows by "oldest sent first" so quotes about to expire surface
+// at the top. Drafts (no sent_at) go after sent rows, preserving the DAL's
+// tier/updated_at order among themselves as a tiebreaker.
+let activeQuoteByEntityId = new Map<string, Quote>()
+let proposingRows: Entity[] = entities
+if (filterStage === 'proposing' && entities.length > 0) {
+  activeQuoteByEntityId = await getActiveQuotesForEntities(
+    env.DB,
+    session.orgId,
+    entities.map((e) => e.id)
+  )
+  proposingRows = [...entities].sort((a, b) => {
+    const qa = activeQuoteByEntityId.get(a.id)
+    const qb = activeQuoteByEntityId.get(b.id)
+    const sa = qa?.sent_at ?? null
+    const sb = qb?.sent_at ?? null
+    // Sent rows come before non-sent, oldest sent first within.
+    if (sa && sb) return sa.localeCompare(sb)
+    if (sa) return -1
+    if (sb) return 1
+    return 0 // preserve DAL order (tier, pain_score, updated_at DESC)
+  })
+}
+const displayEntities = filterStage === 'proposing' ? proposingRows : entities
 
 const promoted = Astro.url.searchParams.get('promoted')
 const dismissed = Astro.url.searchParams.get('dismissed')
@@ -182,7 +212,7 @@ function formatDate(iso: string): string {
 
   {/* Entity list */}
   {
-    entities.length === 0 ? (
+    displayEntities.length === 0 ? (
       <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
         <p class="text-[color:var(--color-text-secondary)] text-sm">
           No entities at the <strong>{filterStage}</strong> stage.
@@ -190,89 +220,115 @@ function formatDate(iso: string): string {
       </div>
     ) : (
       <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
-        {entities.map((e: Entity) => (
-          <div class="px-6 py-4">
-            <div class="flex items-start justify-between gap-stack">
-              <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-2 mb-1 flex-wrap">
-                  <a
-                    href={`/admin/entities/${e.id}`}
-                    class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary transition-colors"
-                  >
-                    {e.name}
-                  </a>
-                  {e.source_pipeline && (
-                    <span
-                      class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
+        {displayEntities.map((e: Entity) => {
+          const activeQuote =
+            filterStage === 'proposing' ? (activeQuoteByEntityId.get(e.id) ?? null) : null
+          // Draft quotes have no sent_at; show the draft's updated_at. Sent /
+          // accepted quotes show their sent_at (falling back to updated_at if
+          // somehow null). Render nothing if no active quote — per CLAUDE.md
+          // we render nothing rather than invent a placeholder.
+          const quoteTimestamp =
+            activeQuote?.status === 'draft'
+              ? activeQuote.updated_at
+              : (activeQuote?.sent_at ?? activeQuote?.updated_at ?? null)
+          const quoteAge = relativeTime(quoteTimestamp)
+          return (
+            <div class="px-6 py-4">
+              <div class="flex items-start justify-between gap-stack">
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2 mb-1 flex-wrap">
+                    <a
+                      href={`/admin/entities/${e.id}`}
+                      class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary transition-colors"
                     >
-                      {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
-                    </span>
+                      {e.name}
+                    </a>
+                    {activeQuote && (
+                      <>
+                        <span class={statusBadgeClass(activeQuote.status)}>
+                          {activeQuote.status}
+                          {activeQuote.version > 1 ? ` v${activeQuote.version}` : ''}
+                        </span>
+                        {quoteAge && (
+                          <span class="text-xs text-[color:var(--color-text-muted)]">
+                            {quoteAge}
+                          </span>
+                        )}
+                      </>
+                    )}
+                    {e.source_pipeline && (
+                      <span
+                        class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
+                      >
+                        {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
+                      </span>
+                    )}
+                    {e.pain_score && (
+                      <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
+                        Pain: {e.pain_score}/10
+                      </span>
+                    )}
+                    {e.tier && (
+                      <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
+                        {e.tier}
+                      </span>
+                    )}
+                  </div>
+
+                  {e.summary && (
+                    <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2">
+                      {e.summary}
+                    </p>
                   )}
-                  {e.pain_score && (
-                    <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
-                      Pain: {e.pain_score}/10
-                    </span>
+
+                  {e.next_action && (
+                    <p class="text-xs text-amber-600 mb-1">
+                      <span class="font-medium">Next:</span> {e.next_action}
+                      {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
+                    </p>
                   )}
-                  {e.tier && (
-                    <span class={`text-xs px-1.5 py-0.5 rounded ${tierBadgeClass(e.tier)}`}>
-                      {e.tier}
-                    </span>
-                  )}
+
+                  <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1">
+                    <span>{formatDate(e.created_at)}</span>
+                    {e.area && <span>{e.area}</span>}
+                    {e.vertical && <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>}
+                    {e.employee_count && <span>~{e.employee_count} employees</span>}
+                  </div>
                 </div>
 
-                {e.summary && (
-                  <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2">
-                    {e.summary}
-                  </p>
-                )}
-
-                {e.next_action && (
-                  <p class="text-xs text-amber-600 mb-1">
-                    <span class="font-medium">Next:</span> {e.next_action}
-                    {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
-                  </p>
-                )}
-
-                <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1">
-                  <span>{formatDate(e.created_at)}</span>
-                  {e.area && <span>{e.area}</span>}
-                  {e.vertical && <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>}
-                  {e.employee_count && <span>~{e.employee_count} employees</span>}
+                <div class="flex items-center gap-2 shrink-0">
+                  {e.stage === 'signal' ? (
+                    <>
+                      <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
+                        <button
+                          type="submit"
+                          class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                        >
+                          Promote
+                        </button>
+                      </form>
+                      <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
+                        <button
+                          type="submit"
+                          class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                        >
+                          Dismiss
+                        </button>
+                      </form>
+                    </>
+                  ) : (
+                    <a
+                      href={`/admin/entities/${e.id}`}
+                      class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                    >
+                      View
+                    </a>
+                  )}
                 </div>
-              </div>
-
-              <div class="flex items-center gap-2 shrink-0">
-                {e.stage === 'signal' ? (
-                  <>
-                    <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
-                      <button
-                        type="submit"
-                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
-                      >
-                        Promote
-                      </button>
-                    </form>
-                    <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
-                      <button
-                        type="submit"
-                        class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
-                      >
-                        Dismiss
-                      </button>
-                    </form>
-                  </>
-                ) : (
-                  <a
-                    href={`/admin/entities/${e.id}`}
-                    class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
-                  >
-                    View
-                  </a>
-                )}
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     )
   }

--- a/tests/admin-entities-proposing.test.ts
+++ b/tests/admin-entities-proposing.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Source-level tests for the Proposing-tab inline quote status + age on the
+ * admin entities list. Surface-level in the same style as tests/quotes.test.ts
+ * so we can guard the wiring without spinning up D1 / Astro SSR in CI.
+ */
+describe('admin/entities/index: Proposing tab quote status', () => {
+  const source = () => readFileSync(resolve('src/pages/admin/entities/index.astro'), 'utf-8')
+
+  it('imports the batch active-quote loader', () => {
+    const code = source()
+    expect(code).toContain("import { getActiveQuotesForEntities } from '../../../lib/db/quotes'")
+  })
+
+  it('imports the shared admin status badge class', () => {
+    expect(source()).toContain("import { statusBadgeClass } from '../../../lib/ui/status-badge'")
+  })
+
+  it('imports the admin relativeTime helper (not a local variant)', () => {
+    expect(source()).toContain("import { relativeTime } from '../../../lib/admin/relative-time'")
+  })
+
+  it('only fetches active quotes when on the Proposing tab', () => {
+    // Guarded so other tabs keep their current DAL footprint.
+    expect(source()).toMatch(/filterStage === 'proposing'[\s\S]+?getActiveQuotesForEntities/)
+  })
+
+  it('sorts Proposing rows by oldest sent_at first', () => {
+    const code = source()
+    // Sent rows come before non-sent; within sent, oldest first via localeCompare.
+    expect(code).toContain('sa.localeCompare(sb)')
+    expect(code).toMatch(/if \(sa\) return -1/)
+    expect(code).toMatch(/if \(sb\) return 1/)
+  })
+
+  it('renders the status badge inline on Proposing rows', () => {
+    expect(source()).toContain('statusBadgeClass(activeQuote.status)')
+  })
+
+  it('renders nothing when no active quote is present (no placeholder copy)', () => {
+    // CLAUDE.md: render nothing rather than a fabricated "No quote yet" string.
+    const code = source()
+    expect(code).not.toContain('No quote yet')
+    expect(code).toContain('{activeQuote && (')
+  })
+})

--- a/tests/quotes.test.ts
+++ b/tests/quotes.test.ts
@@ -165,6 +165,35 @@ describe('quotes: data access layer', () => {
     expect(code).toContain('effectiveItems')
     expect(code).toContain('effectiveRate')
   })
+
+  it('exports getActiveQuotesForEntities batch helper', () => {
+    expect(source()).toContain('export async function getActiveQuotesForEntities')
+  })
+
+  it('getActiveQuotesForEntities returns empty for empty id list', () => {
+    const code = source()
+    // Short-circuit guard: D1 rejects `IN ()`, so we must bail early.
+    expect(code).toMatch(/entityIds\.length === 0[\s\S]+?return result/)
+  })
+
+  it('getActiveQuotesForEntities prioritizes sent > accepted > draft', () => {
+    const code = source()
+    expect(code).toContain("WHEN 'sent'     THEN 0")
+    expect(code).toContain("WHEN 'accepted' THEN 1")
+    expect(code).toContain("WHEN 'draft'    THEN 2")
+  })
+
+  it('getActiveQuotesForEntities ignores terminal statuses (declined/expired/superseded)', () => {
+    const code = source()
+    // Only the three "active" statuses should appear in the SQL filter.
+    expect(code).toContain("q.status IN ('sent', 'accepted', 'draft')")
+  })
+
+  it('getActiveQuotesForEntities is scoped to org_id', () => {
+    const code = source()
+    // The new query must bind org_id — prevent cross-tenant leakage (#399 class).
+    expect(code).toMatch(/getActiveQuotesForEntities[\s\S]+?q\.org_id = \?/)
+  })
 })
 
 describe('quotes: R2 storage helpers', () => {

--- a/tests/relative-time.test.ts
+++ b/tests/relative-time.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { relativeTime } from '../src/lib/admin/relative-time'
+
+/**
+ * Narrow behavior tests for the admin relative-time formatter.
+ * Pinned to a fixed "now" so output is deterministic in CI.
+ */
+describe('admin/relative-time', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-23T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns null for null / undefined / empty string', () => {
+    expect(relativeTime(null)).toBeNull()
+    expect(relativeTime(undefined)).toBeNull()
+    expect(relativeTime('')).toBeNull()
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(relativeTime('not-a-date')).toBeNull()
+  })
+
+  it('renders "just now" for the very recent past', () => {
+    expect(relativeTime('2026-04-23T11:45:00Z')).toBe('just now')
+  })
+
+  it('renders "Xh ago" within the same day', () => {
+    expect(relativeTime('2026-04-23T09:00:00Z')).toBe('3h ago')
+  })
+
+  it('renders "Xd ago" for multi-day age', () => {
+    expect(relativeTime('2026-04-21T12:00:00Z')).toBe('2d ago')
+  })
+
+  it('treats future timestamps as "just now" (does not render negative ages)', () => {
+    expect(relativeTime('2026-04-23T13:00:00Z')).toBe('just now')
+  })
+})


### PR DESCRIPTION
Closes #473.

## Summary

Admins scanning the Proposing tab now see each entity's top-active quote
status + age inline, and rows are reordered so the quote closest to the
5-day expiry surfaces at the top.

- Status badge + relative age rendered on each Proposing row (reuses the
  shared `statusBadgeClass`, no new visual pattern).
- New `getActiveQuotesForEntities` batch DAL helper uses a SQLite window
  function (priority: sent > accepted > draft, then `sent_at` DESC) so
  the whole list loads in one query — no N+1 per row.
- New `src/lib/admin/relative-time.ts` util consolidates the `Xh ago` /
  `Xd ago` variants that were drifting inline across admin surfaces.
- Sort: oldest `sent_at` first. Drafts (no `sent_at`) fall below sent
  rows; among drafts we preserve the DAL's existing tier + `updated_at`
  order as a tiebreaker.
- Renders nothing when an entity has no active quote — per CLAUDE.md we
  do not fabricate a "No quote yet" placeholder.

Scope is intentionally limited to the Proposing tab. Other tabs are
untouched; the extra DAL query only fires when `filterStage === 'proposing'`.

## Acceptance criteria

- [x] Inline status badge on each Proposing row
- [x] Age shown in relative format (`2d ago`)
- [x] Sort behavior makes sense for admin scanning (oldest sent first;
      drafts after sent rows, preserving DAL order among themselves)

## Test plan

- [x] `npm run verify` — typecheck, lint, format, build, 1296 tests passing
- [x] New targeted tests:
  - `tests/quotes.test.ts` — surface checks on the new batch helper
    (empty-id guard, status priority, org-scoping, ignores terminal
    statuses)
  - `tests/relative-time.test.ts` — behavior matrix against a pinned clock
  - `tests/admin-entities-proposing.test.ts` — wiring checks on
    `entities/index.astro` (imports the shared badge + admin relativeTime
    utils, fetches only on Proposing, sorts by `sent_at`, renders no
    placeholder copy)
- [ ] Visual spot-check in the admin console after merge (Proposing tab
      with 2-5 quotes across draft / sent / accepted states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)