### PR TITLE
feat(admin/entities): 'New quote' action (#472)

### DIFF
--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -105,6 +105,13 @@ export interface CreateQuoteData {
   deliverables?: DeliverableRow[]
   engagementOverview?: string
   milestoneLabel?: string
+  /**
+   * Optional reference to a prior quote this one supersedes. Used by the
+   * repeat-quote flow (#472) to link v2 → v1 after a decline/expiry. The
+   * caller is responsible for explicitly transitioning the parent to
+   * `superseded` — createQuote does not mutate the parent record.
+   */
+  parentQuoteId?: string | null
 }
 
 export interface UpdateQuoteData {
@@ -178,6 +185,33 @@ export function getMissingAuthoredContent(quote: Quote): string[] {
 }
 
 /**
+ * Quote statuses that block a new draft from being created on the same entity.
+ * Draft and sent are "open" — actively in play in the sales flow. Other
+ * statuses (accepted, declined, expired, superseded) are terminal and do not
+ * block a repeat quote (#472).
+ */
+export const OPEN_QUOTE_STATUSES: QuoteStatus[] = ['draft', 'sent']
+
+/**
+ * Return true if the entity has at least one draft or sent quote.
+ * Used by the repeat-quote flow (#472) to gate the "New quote" action on the
+ * entity detail page — admins shouldn't be creating v2 while v1 is still live.
+ */
+export async function hasOpenQuoteForEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<boolean> {
+  const placeholders = OPEN_QUOTE_STATUSES.map(() => '?').join(', ')
+  const sql = `SELECT 1 FROM quotes WHERE entity_id = ? AND org_id = ? AND status IN (${placeholders}) LIMIT 1`
+  const result = await db
+    .prepare(sql)
+    .bind(entityId, orgId, ...OPEN_QUOTE_STATUSES)
+    .first<{ '1': number }>()
+  return result !== null
+}
+
+/**
  * List quotes for an organization, optionally filtered by entity.
  */
 export async function listQuotes(
@@ -244,17 +278,34 @@ export async function createQuote(
     data.deliverables && data.deliverables.length > 0 ? JSON.stringify(data.deliverables) : null
   const engagementOverview = data.engagementOverview ?? null
   const milestoneLabel = data.milestoneLabel ?? null
+  const parentQuoteId = data.parentQuoteId ?? null
+
+  // Derive the next version number when superseding a prior quote so the
+  // portal's "latest version" lookup (parent_quote_id OR assessment_id + version)
+  // still resolves correctly. Standalone new quotes start at version 1.
+  let version = 1
+  if (parentQuoteId) {
+    const parent = await db
+      .prepare('SELECT version FROM quotes WHERE id = ? AND org_id = ?')
+      .bind(parentQuoteId, orgId)
+      .first<{ version: number }>()
+    if (parent) {
+      version = (parent.version ?? 1) + 1
+    }
+  }
 
   await db
     .prepare(
-      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, version, line_items, total_hours, rate, total_price, deposit_pct, deposit_amount, status, schedule, deliverables, engagement_overview, milestone_label, created_at, updated_at)
-     VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, version, parent_quote_id, line_items, total_hours, rate, total_price, deposit_pct, deposit_amount, status, schedule, deliverables, engagement_overview, milestone_label, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?)`
     )
     .bind(
       id,
       orgId,
       data.entityId,
       data.assessmentId,
+      version,
+      parentQuoteId,
       JSON.stringify(data.lineItems),
       totalHours,
       data.rate,

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -8,7 +8,7 @@ import type { ContextEntry } from '../../../lib/db/context'
 import { listContacts } from '../../../lib/db/contacts'
 import { listAssessments } from '../../../lib/db/assessments'
 import { listEngagements } from '../../../lib/db/engagements'
-import { listQuotes } from '../../../lib/db/quotes'
+import { listQuotes, hasOpenQuoteForEntity } from '../../../lib/db/quotes'
 import { listInvoices } from '../../../lib/db/invoices'
 import { env } from 'cloudflare:workers'
 
@@ -65,6 +65,21 @@ const dossierStages: string[] = [
   'ongoing',
 ]
 const showDossierButton = dossierStages.includes(entity.stage)
+
+// "New quote" action (#472): enabled when entity is in Proposing or earlier,
+// no open (draft/sent) quote exists, and at least one assessment is on file
+// (schema requires assessment_id NOT NULL on quotes).
+const newQuoteStages: string[] = ['signal', 'prospect', 'assessing', 'proposing']
+const hasOpenQuote = await hasOpenQuoteForEntity(env.DB, session.orgId, entityId)
+const showNewQuoteButton =
+  newQuoteStages.includes(entity.stage) && !hasOpenQuote && assessments.length > 0
+
+// Prior quotes eligible for an explicit supersede link — terminal-status
+// quotes the admin might be replacing with v2. We do NOT auto-select one;
+// default is "none" so supersede stays an explicit opt-in.
+const supersedeCandidates = showNewQuoteButton
+  ? quotes.filter((q) => q.status === 'declined' || q.status === 'expired')
+  : []
 
 // Stage transitions
 const TRANSITIONS: Record<
@@ -488,6 +503,39 @@ function confidenceColor(confidence: string): string {
                 class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Generate Dossier
+              </button>
+            </form>
+          )
+        }
+        {
+          showNewQuoteButton && (
+            <form
+              method="POST"
+              action={`/api/admin/entities/${entity.id}/quotes`}
+              class="flex items-center gap-2"
+            >
+              {supersedeCandidates.length > 0 && (
+                <label class="text-xs text-[color:var(--color-text-secondary)] flex items-center gap-1">
+                  <span class="sr-only">Supersede prior quote</span>
+                  <select
+                    name="parent_quote_id"
+                    class="text-xs border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1 bg-white"
+                    title="Optional: link to a prior quote this one supersedes"
+                  >
+                    <option value="">No supersede link</option>
+                    {supersedeCandidates.map((q) => (
+                      <option value={q.id}>
+                        Supersede v{q.version} ({q.status})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+              <button
+                type="submit"
+                class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]"
+              >
+                New quote
               </button>
             </form>
           )

--- a/src/pages/api/admin/entities/[id]/quotes.ts
+++ b/src/pages/api/admin/entities/[id]/quotes.ts
@@ -1,0 +1,125 @@
+import type { APIRoute } from 'astro'
+import { getEntity } from '../../../../../lib/db/entities'
+import { listAssessments } from '../../../../../lib/db/assessments'
+import { createQuote, getQuote, hasOpenQuoteForEntity } from '../../../../../lib/db/quotes'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/entities/[id]/quotes
+ *
+ * Creates a new draft quote shell for an existing entity (#472). Supports the
+ * repeat-quote-after-decline sales flow without forcing a second assessment.
+ *
+ * Preconditions enforced here:
+ * - Entity exists and is in stage `proposing` or earlier (signal, prospect,
+ *   assessing, proposing). Further-along stages already have an accepted quote
+ *   or are out of the sales motion.
+ * - No open (draft or sent) quote exists for the entity.
+ * - Entity has at least one prior assessment — `quotes.assessment_id` is
+ *   NOT NULL in the schema, so a first quote must still flow through the
+ *   assessment builder. The earliest assessment on file is reused.
+ *
+ * The resulting quote is intentionally empty: zero line items, default rate,
+ * no schedule, no deliverables, no engagement overview. All client-facing
+ * fields default to NULL/empty. The quote builder enforces authored content
+ * before sending (see updateQuoteStatus send-gating). This preserves the
+ * "no fabricated client-facing content" invariant — shells never ship.
+ *
+ * The admin may optionally pass `parent_quote_id` to link the new quote as
+ * a supersede of a prior quote. This mirrors the portal's version lookup
+ * (`parent_quote_id = ?`) and does NOT transition the parent to
+ * `superseded` — that remains an explicit admin action.
+ *
+ * Protected by auth middleware (requires admin role).
+ */
+
+const ELIGIBLE_STAGES = ['signal', 'prospect', 'assessing', 'proposing']
+
+/** Default hourly rate at launch (per Decision Stack #16, evolved). */
+const DEFAULT_RATE = 175
+
+export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) {
+    return redirect('/admin/entities?error=missing', 302)
+  }
+
+  try {
+    const entity = await getEntity(env.DB, session.orgId, entityId)
+    if (!entity) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    if (!ELIGIBLE_STAGES.includes(entity.stage)) {
+      return redirect(
+        `/admin/entities/${entityId}?error=${encodeURIComponent(
+          'Cannot create a new quote from this stage. Entity must be in Proposing or earlier.'
+        )}`,
+        302
+      )
+    }
+
+    const openQuote = await hasOpenQuoteForEntity(env.DB, session.orgId, entityId)
+    if (openQuote) {
+      return redirect(
+        `/admin/entities/${entityId}?error=${encodeURIComponent(
+          'Cannot create a new quote: an existing draft or sent quote is still active. Decline, expire, or supersede it first.'
+        )}`,
+        302
+      )
+    }
+
+    // Reuse the most recent assessment on file. `assessment_id` is NOT NULL in
+    // the schema, so we cannot create a quote for an entity that has never had
+    // one. If we ever support assessment-less quotes, the schema will need a
+    // migration first — not in scope for #472.
+    const assessments = await listAssessments(env.DB, session.orgId, entityId)
+    if (assessments.length === 0) {
+      return redirect(
+        `/admin/entities/${entityId}?error=${encodeURIComponent(
+          'Cannot create a new quote: this entity has no assessment on file. Book an assessment before creating a quote.'
+        )}`,
+        302
+      )
+    }
+    // listAssessments orders by created_at DESC, so [0] is the most recent.
+    const latestAssessmentId = assessments[0].id
+
+    // Parse optional supersede reference from form data. The admin explicitly
+    // opts into supersede by picking a prior quote in the form; absence means
+    // this is a standalone new quote and no supersede link is set.
+    const formData = await request.formData().catch(() => null)
+    const parentQuoteIdRaw = formData?.get('parent_quote_id')
+    let parentQuoteId: string | null = null
+    if (typeof parentQuoteIdRaw === 'string' && parentQuoteIdRaw.trim() !== '') {
+      // Validate the referenced quote exists on this entity/org. Silently drop
+      // if it doesn't — we don't want to persist a broken foreign key.
+      const parent = await getQuote(env.DB, session.orgId, parentQuoteIdRaw.trim())
+      if (parent && parent.entity_id === entityId) {
+        parentQuoteId = parent.id
+      }
+    }
+
+    const quote = await createQuote(env.DB, session.orgId, {
+      entityId,
+      assessmentId: latestAssessmentId,
+      lineItems: [],
+      rate: DEFAULT_RATE,
+      parentQuoteId,
+    })
+
+    return redirect(`/admin/entities/${entityId}/quotes/${quote.id}?saved=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/entities/[id]/quotes] Error:', err)
+    const message = err instanceof Error ? err.message : 'server'
+    return redirect(`/admin/entities/${entityId}?error=${encodeURIComponent(message)}`, 302)
+  }
+}

--- a/tests/quotes.test.ts
+++ b/tests/quotes.test.ts
@@ -242,6 +242,96 @@ describe('quotes: API routes', () => {
   })
 })
 
+describe('quotes: repeat-quote flow (#472)', () => {
+  const dalSource = () => readFileSync(resolve('src/lib/db/quotes.ts'), 'utf-8')
+  const apiSource = () =>
+    readFileSync(resolve('src/pages/api/admin/entities/[id]/quotes.ts'), 'utf-8')
+  const entityPageSource = () =>
+    readFileSync(resolve('src/pages/admin/entities/[id].astro'), 'utf-8')
+
+  it('exports hasOpenQuoteForEntity helper', () => {
+    expect(dalSource()).toContain('export async function hasOpenQuoteForEntity')
+  })
+
+  it('OPEN_QUOTE_STATUSES covers draft and sent', () => {
+    const code = dalSource()
+    expect(code).toContain('OPEN_QUOTE_STATUSES')
+    expect(code).toMatch(/OPEN_QUOTE_STATUSES[^=]*=\s*\[[^\]]*'draft'[^\]]*'sent'/)
+  })
+
+  it('createQuote accepts optional parentQuoteId', () => {
+    const code = dalSource()
+    expect(code).toContain('parentQuoteId?: string | null')
+    expect(code).toContain('parent_quote_id')
+  })
+
+  it('createQuote does not mutate the parent quote status', () => {
+    // Supersede is an explicit admin action, not a side effect of create.
+    const code = dalSource()
+    // No UPDATE ... SET status = 'superseded' inside createQuote body.
+    const createFn = code.slice(code.indexOf('export async function createQuote'))
+    const endIdx = createFn.indexOf('export async function updateQuote')
+    const body = createFn.slice(0, endIdx)
+    expect(body).not.toMatch(/UPDATE\s+quotes[\s\S]*superseded/i)
+  })
+
+  it('new-quote API endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/entities/[id]/quotes.ts'))).toBe(true)
+  })
+
+  it('new-quote endpoint requires admin session', () => {
+    expect(apiSource()).toContain("session.role !== 'admin'")
+  })
+
+  it('new-quote endpoint gates on stage (signal through proposing)', () => {
+    const code = apiSource()
+    expect(code).toContain("'signal'")
+    expect(code).toContain("'prospect'")
+    expect(code).toContain("'assessing'")
+    expect(code).toContain("'proposing'")
+  })
+
+  it('new-quote endpoint rejects when an open quote exists', () => {
+    expect(apiSource()).toContain('hasOpenQuoteForEntity')
+  })
+
+  it('new-quote endpoint reuses the most recent assessment', () => {
+    const code = apiSource()
+    expect(code).toContain('listAssessments')
+    // Most-recent comes from listAssessments order; first element.
+    expect(code).toContain('assessments[0]')
+  })
+
+  it('new-quote endpoint creates an empty draft shell', () => {
+    const code = apiSource()
+    expect(code).toContain('createQuote')
+    expect(code).toContain('lineItems: []')
+  })
+
+  it('new-quote endpoint accepts optional parent_quote_id without auto-superseding', () => {
+    const code = apiSource()
+    expect(code).toContain('parent_quote_id')
+    expect(code).toContain('parentQuoteId')
+    // Parent status mutation is NOT part of this endpoint.
+    expect(code).not.toContain("'superseded'")
+  })
+
+  it('entity detail page computes showNewQuoteButton with correct preconditions', () => {
+    const code = entityPageSource()
+    expect(code).toContain('showNewQuoteButton')
+    expect(code).toContain('hasOpenQuoteForEntity')
+    expect(code).toContain('newQuoteStages')
+    expect(code).toContain("'proposing'")
+  })
+
+  it('entity detail page renders button behind showNewQuoteButton guard', () => {
+    const code = entityPageSource()
+    // Button is inside a conditional block driven by the computed guard.
+    expect(code).toMatch(/showNewQuoteButton\s*&&/)
+    expect(code).toContain('New quote')
+  })
+})
+
 describe('quotes: email template', () => {
   const source = () => readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
 


### PR DESCRIPTION
Closes #472.

## Summary

Unblocks the repeat-quote-after-decline flow. Admin can create v2 for an entity whose v1 was declined/expired without running SQL or booking a second assessment.

## Acceptance criteria

- [x] Button renders contextually (hidden unless entity is in `signal|prospect|assessing|proposing`, has no open draft/sent quote, and has at least one assessment on file)
- [x] Creates a valid draft quote shell — zero line items, default rate, all authored client-facing fields NULL. The quote builder handles completion; send-gating (`updateQuoteStatus`) still requires authored schedule + deliverables before the draft can leave the admin surface.
- [x] Does NOT auto-supersede an existing quote. The supersede link is an explicit dropdown in the new-quote form, defaulted to "No supersede link". Parent status remains untouched until the admin transitions it themselves.

## Key decisions

- **"Open quote"** = status in `{draft, sent}`. All other statuses (accepted, declined, expired, superseded) are terminal and do not block a repeat.
- **"Past Proposing"** excludes `engaged`, `delivered`, `ongoing`, `lost` — those are out of the sales motion.
- **Assessment reuse.** `quotes.assessment_id` is `NOT NULL`, so the repeat-quote endpoint reuses the entity's most recent assessment. A migration to relax this is not in scope.
- **New endpoint vs. reuse of `POST /api/admin/quotes`.** The existing endpoint expects a full quote payload (line items, rate, etc.) from the quote builder. The new endpoint is scoped to "create the shell from the entity detail" with zero admin input beyond the optional supersede link. Clean separation.
- **Supersede UX.** Inline `<select>` next to the button, defaulted to no link. Avoids a modal; matches the existing admin pattern of dense action buttons on the entity header.
- **Versioning.** When `parent_quote_id` is set, the new quote's `version` is `parent.version + 1` so the portal's superseding-quote lookup (`parent_quote_id = ? OR (assessment_id = ? AND version > ? ...)`) resolves correctly.

## Test plan

- [x] `npm run verify` green locally (typecheck, typecheck:workers, format:check, lint, build, test — 1291 passed, 2 skipped)
- [ ] Manual: entity in `proposing` with a declined v1 → button visible with v1 in the supersede dropdown
- [ ] Manual: entity in `proposing` with a draft v1 → button hidden
- [ ] Manual: entity in `engaged` → button hidden
- [ ] Manual: entity in `signal` with no assessment → button hidden
- [ ] Manual: create shell without supersede link → lands on the quote builder at version 1, no parent link
- [ ] Manual: create shell with supersede link → lands on the quote builder at `parent.version + 1`, `parent_quote_id` set, parent status still `declined`/`expired` (not mutated)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>