### PR TITLE
refactor(lead-gen): merge Promote+Dossier into at-ingest enrichment (#471)

### DIFF
--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -1,0 +1,699 @@
+/**
+ * Unified enrichment pipeline — issue #471.
+ *
+ * Merges what used to be two admin-triggered endpoints (`promote` and
+ * `dossier`) into a single `enrichEntity()` call that runs automatically at
+ * signal ingest time. The admin-click gate was the bottleneck — at ~8
+ * signals/day and ~$0.25/enrichment, the cost is trivial compared with the
+ * engagement value of a qualified lead, but the value only lands if every
+ * signal actually gets enriched.
+ *
+ * ### Modes
+ *
+ * - `full` (default) — the complete 12-module pipeline. Called from lead-gen
+ *   workers on newly-ingested signals and from the "promote" admin wrapper.
+ * - `reviews-and-news` — cheap refresh limited to review_analysis,
+ *   review_synthesis, and news_search. Surfaced in admin as the "Re-enrich"
+ *   button for stale-data refresh on entities that already have a full
+ *   enrichment on file.
+ *
+ * ### Idempotency / cost control
+ *
+ * Full-mode enrichment is skipped when an `intelligence_brief` context entry
+ * already exists — the brief is the last module to run in full mode, so its
+ * presence means a prior full pipeline completed. Calling `enrichEntity` a
+ * second time from a worker (dedupe race, retry, manual re-run) will not
+ * re-bill Claude for an already-enriched entity. Re-enrich mode bypasses this
+ * check by design — the caller explicitly asked for a refresh.
+ *
+ * ### Why a merge and not two calls
+ *
+ * The two endpoints fetched identical entity/context rows, ran
+ * `generateOutreachDraft` twice (dossier overwrote promote's draft), and used
+ * the same appendContext plumbing. Combining them removes the duplicate
+ * outreach call, assembles context once per stage, and gives the worker a
+ * single natural insertion point.
+ */
+
+import type { Entity } from '../db/entities'
+import { getEntity, updateEntity } from '../db/entities'
+import { appendContext, assembleEntityContext, listContext } from '../db/context'
+import { generateOutreachDraft } from '../claude/outreach'
+import { lookupGooglePlaces } from './google-places'
+import { analyzeWebsite } from './website-analyzer'
+import { lookupOutscraper } from './outscraper'
+import { lookupAcc } from './acc'
+import { lookupRoc } from './roc'
+import { analyzeReviewPatterns } from './review-analysis'
+import { benchmarkCompetitors } from './competitors'
+import { searchNews } from './news'
+import { deepWebsiteAnalysis, type DeepWebsiteAnalysis } from './deep-website'
+import { synthesizeReviews } from './review-synthesis'
+import { lookupLinkedIn } from './linkedin'
+import { generateDossier } from './dossier'
+
+export type EnrichMode = 'full' | 'reviews-and-news'
+
+export interface EnrichOptions {
+  mode?: EnrichMode
+  /**
+   * Force re-enrichment even when a prior intelligence brief exists. Admin
+   * "Re-enrich" uses this implicitly via `reviews-and-news`; this flag is
+   * available for a future "force full re-enrich" action if we add one.
+   */
+  force?: boolean
+}
+
+export interface EnrichResult {
+  entityId: string
+  mode: EnrichMode
+  /** Module source names that completed successfully in this run. */
+  completed: string[]
+  /** Module source names that were skipped (missing API key, wrong vertical, already enriched). */
+  skipped: string[]
+  /** Module source names that threw — logged but non-blocking. */
+  errors: string[]
+  /** True if the run did nothing because a prior full enrichment exists. */
+  alreadyEnriched: boolean
+}
+
+type EnrichEnv = {
+  DB: D1Database
+  ANTHROPIC_API_KEY?: string
+  GOOGLE_PLACES_API_KEY?: string
+  OUTSCRAPER_API_KEY?: string
+  PROXYCURL_API_KEY?: string
+  SERPAPI_API_KEY?: string
+}
+
+/**
+ * Run the unified enrichment pipeline for a single entity.
+ *
+ * All modules are best-effort — a single module failure does not abort the
+ * run. Callers should not await this from a hot request path: workers use
+ * `ctx.waitUntil(enrichEntity(...))` so ingest does not block on Claude.
+ */
+export async function enrichEntity(
+  env: EnrichEnv,
+  orgId: string,
+  entityId: string,
+  options: EnrichOptions = {}
+): Promise<EnrichResult> {
+  const mode: EnrichMode = options.mode ?? 'full'
+  const result: EnrichResult = {
+    entityId,
+    mode,
+    completed: [],
+    skipped: [],
+    errors: [],
+    alreadyEnriched: false,
+  }
+
+  const entity = await getEntity(env.DB, orgId, entityId)
+  if (!entity) {
+    result.errors.push('entity_not_found')
+    return result
+  }
+
+  // Idempotency: full-mode skips if a prior intelligence_brief exists. The
+  // brief is the last full-mode module, so its presence means a prior run
+  // completed. reviews-and-news intentionally bypasses this — it's the
+  // explicit "refresh" path.
+  if (mode === 'full' && !options.force) {
+    const existing = await listContext(env.DB, entityId, { type: 'enrichment' })
+    const hasBrief = existing.some((e) => e.source === 'intelligence_brief')
+    if (hasBrief) {
+      result.alreadyEnriched = true
+      return result
+    }
+  }
+
+  if (mode === 'reviews-and-news') {
+    await runReviewsAndNews(env, orgId, entity, result)
+    await regenerateOutreach(env, orgId, entity, result)
+    return result
+  }
+
+  // mode === 'full': run the full 12-module pipeline.
+  let current = entity
+
+  // --- Tier 1: Contact + tech signals (parallel-safe but sequential for
+  //             readability and because some modules update entity.phone /
+  //             website, which downstream modules rely on). ---
+
+  current = await tryPlaces(env, orgId, current, result)
+  current = await tryWebsite(env, orgId, current, result)
+  current = await tryOutscraper(env, orgId, current, result)
+  await tryAcc(env, orgId, current, result)
+  await tryRoc(env, orgId, current, result)
+
+  // --- Tier 2: Review patterns + competitors + news. ---
+
+  await tryReviewAnalysis(env, orgId, current, result)
+  await tryCompetitors(env, orgId, current, result)
+  await tryNews(env, orgId, current, result)
+
+  // --- Tier 3: Deep intelligence (the old dossier path). ---
+
+  await tryDeepWebsite(env, orgId, current, result)
+  await tryReviewSynthesis(env, orgId, current, result)
+  await tryLinkedIn(env, orgId, current, result)
+  await tryIntelligenceBrief(env, orgId, current, result)
+
+  // --- Outreach draft from the full enriched context. Runs once at the end,
+  //     not twice (the old promote+dossier pair called this at both steps). ---
+
+  await regenerateOutreach(env, orgId, current, result)
+
+  // Surface a next_action so the admin inbox shows "review and send" instead
+  // of leaving the signal inert. Only set if nothing's there already.
+  if (!current.next_action) {
+    try {
+      await updateEntity(env.DB, orgId, entityId, {
+        next_action: 'Review enrichment and send outreach email',
+        next_action_at: new Date().toISOString(),
+      })
+    } catch (err) {
+      console.error('[enrichEntity] failed to set next_action:', err)
+    }
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// reviews-and-news (cheap refresh path)
+// ---------------------------------------------------------------------------
+
+async function runReviewsAndNews(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  await tryReviewAnalysis(env, orgId, entity, result)
+  await tryReviewSynthesis(env, orgId, entity, result)
+  await tryNews(env, orgId, entity, result)
+}
+
+// ---------------------------------------------------------------------------
+// Individual module wrappers — each is best-effort and records its source
+// name in the result. Extracted from promote.ts / dossier.ts verbatim so the
+// behavioral semantics match what admins saw when clicking the buttons.
+// ---------------------------------------------------------------------------
+
+async function tryPlaces(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<Entity> {
+  if (entity.phone && entity.website) {
+    result.skipped.push('google_places')
+    return entity
+  }
+  if (!env.GOOGLE_PLACES_API_KEY) {
+    result.skipped.push('google_places')
+    return entity
+  }
+  try {
+    const places = await lookupGooglePlaces(entity.name, entity.area, env.GOOGLE_PLACES_API_KEY)
+    if (!places) return entity
+    await updateEntity(env.DB, orgId, entity.id, {
+      phone: places.phone ?? entity.phone ?? undefined,
+      website: places.website ?? entity.website ?? undefined,
+    })
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `Google Places: ${places.phone ? `Phone: ${places.phone}` : 'No phone found'}. ${places.website ? `Website: ${places.website}` : 'No website found'}. Rating: ${places.rating ?? 'N/A'} (${places.reviewCount ?? 0} reviews). Status: ${places.businessStatus ?? 'unknown'}.`,
+      source: 'google_places',
+      metadata: places as unknown as Record<string, unknown>,
+    })
+    result.completed.push('google_places')
+    const refreshed = await getEntity(env.DB, orgId, entity.id)
+    return refreshed ?? entity
+  } catch (err) {
+    console.error('[enrichEntity] google_places failed:', err)
+    result.errors.push('google_places')
+    return entity
+  }
+}
+
+async function tryWebsite(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<Entity> {
+  if (!entity.website || !env.ANTHROPIC_API_KEY) {
+    result.skipped.push('website_analysis')
+    return entity
+  }
+  try {
+    const analysis = await analyzeWebsite(entity.website, env.ANTHROPIC_API_KEY)
+    if (!analysis) return entity
+    const techTools = [
+      ...analysis.tech_stack.scheduling,
+      ...analysis.tech_stack.crm,
+      ...analysis.tech_stack.reviews,
+      ...analysis.tech_stack.payments,
+      ...analysis.tech_stack.communication,
+    ]
+    const missingTools: string[] = []
+    if (analysis.tech_stack.scheduling.length === 0) missingTools.push('No scheduling tool')
+    if (analysis.tech_stack.crm.length === 0) missingTools.push('No CRM')
+    if (analysis.tech_stack.reviews.length === 0) missingTools.push('No review management')
+
+    const contentParts = [
+      `Website analysis (${analysis.pages_analyzed.length} pages):`,
+      analysis.owner_name ? `Owner/Founder: ${analysis.owner_name}` : null,
+      analysis.team_size ? `Team size: ~${analysis.team_size} people` : null,
+      analysis.founding_year ? `Founded: ${analysis.founding_year}` : null,
+      analysis.contact_email ? `Email: ${analysis.contact_email}` : null,
+      analysis.services.length > 0 ? `Services: ${analysis.services.join(', ')}` : null,
+      `Site quality: ${analysis.quality}`,
+      techTools.length > 0
+        ? `Tools detected: ${techTools.join(', ')}`
+        : 'No business tools detected on website',
+      missingTools.length > 0 ? `Gaps: ${missingTools.join(', ')}` : null,
+      `Platform: ${analysis.tech_stack.platform.join(', ') || 'Custom/unknown'}`,
+    ].filter(Boolean)
+
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: contentParts.join('\n'),
+      source: 'website_analysis',
+      metadata: {
+        owner_name: analysis.owner_name,
+        team_size: analysis.team_size,
+        employee_count: analysis.team_size,
+        founding_year: analysis.founding_year,
+        contact_email: analysis.contact_email,
+        services: analysis.services,
+        quality: analysis.quality,
+        tech_stack: analysis.tech_stack,
+        pages_analyzed: analysis.pages_analyzed,
+      },
+    })
+    result.completed.push('website_analysis')
+    return entity
+  } catch (err) {
+    console.error('[enrichEntity] website_analysis failed:', err)
+    result.errors.push('website_analysis')
+    return entity
+  }
+}
+
+async function tryOutscraper(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<Entity> {
+  if (!env.OUTSCRAPER_API_KEY) {
+    result.skipped.push('outscraper')
+    return entity
+  }
+  try {
+    const osc = await lookupOutscraper(entity.name, entity.area, env.OUTSCRAPER_API_KEY)
+    if (!osc) return entity
+    await updateEntity(env.DB, orgId, entity.id, {
+      phone: osc.phone ?? entity.phone ?? undefined,
+      website: osc.website ?? entity.website ?? undefined,
+    })
+    const contentParts = [
+      'Outscraper business profile:',
+      osc.owner_name ? `Owner: ${osc.owner_name}` : null,
+      osc.emails.length > 0 ? `Email: ${osc.emails.join(', ')}` : null,
+      osc.phone ? `Phone: ${osc.phone}` : null,
+      osc.working_hours ? `Hours: ${osc.working_hours}` : null,
+      osc.verified ? 'Google listing: Verified' : 'Google listing: Unverified',
+      osc.rating != null ? `Rating: ${osc.rating} (${osc.review_count ?? 0} reviews)` : null,
+      osc.booking_link ? `Online booking: Yes` : 'Online booking: Not detected',
+      osc.facebook ? `Facebook: ${osc.facebook}` : null,
+      osc.instagram ? `Instagram: ${osc.instagram}` : null,
+      osc.linkedin ? `LinkedIn: ${osc.linkedin}` : null,
+      osc.website_generator ? `Platform: ${osc.website_generator}` : null,
+      osc.has_facebook_pixel ? 'Has Facebook Pixel' : null,
+      osc.has_google_tag_manager ? 'Has Google Tag Manager' : null,
+      osc.about ? `About: ${osc.about}` : null,
+    ].filter(Boolean)
+
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: contentParts.join('\n'),
+      source: 'outscraper',
+      metadata: osc as unknown as Record<string, unknown>,
+    })
+    result.completed.push('outscraper')
+    const refreshed = await getEntity(env.DB, orgId, entity.id)
+    return refreshed ?? entity
+  } catch (err) {
+    console.error('[enrichEntity] outscraper failed:', err)
+    result.errors.push('outscraper')
+    return entity
+  }
+}
+
+async function tryAcc(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  try {
+    const acc = await lookupAcc(entity.name)
+    if (!acc) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `ACC Filing: ${acc.entity_name} (${acc.entity_type ?? 'unknown type'}). Filed: ${acc.filing_date ?? 'unknown'}. Status: ${acc.status ?? 'unknown'}. Registered agent: ${acc.registered_agent ?? 'not found'}.`,
+      source: 'acc_filing',
+      metadata: acc as unknown as Record<string, unknown>,
+    })
+    result.completed.push('acc_filing')
+  } catch (err) {
+    console.error('[enrichEntity] acc failed:', err)
+    result.errors.push('acc_filing')
+  }
+}
+
+async function tryRoc(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (entity.vertical !== 'home_services' && entity.vertical !== 'contractor_trades') {
+    result.skipped.push('roc_license')
+    return
+  }
+  try {
+    const roc = await lookupRoc(entity.name)
+    if (!roc) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `ROC License: ${roc.license_number ?? 'N/A'} (${roc.classification ?? 'unknown classification'}). Status: ${roc.status ?? 'unknown'}. Complaints: ${roc.complaint_count ?? 'N/A'}.`,
+      source: 'roc_license',
+      metadata: roc as unknown as Record<string, unknown>,
+    })
+    result.completed.push('roc_license')
+  } catch (err) {
+    console.error('[enrichEntity] roc failed:', err)
+    result.errors.push('roc_license')
+  }
+}
+
+async function tryReviewAnalysis(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.ANTHROPIC_API_KEY) {
+    result.skipped.push('review_analysis')
+    return
+  }
+  try {
+    const signalContext = await assembleEntityContext(env.DB, entity.id, {
+      maxBytes: 8_000,
+      typeFilter: ['signal'],
+    })
+    if (!signalContext) {
+      result.skipped.push('review_analysis')
+      return
+    }
+    const reviewAnalysis = await analyzeReviewPatterns(signalContext, env.ANTHROPIC_API_KEY)
+    if (!reviewAnalysis) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''} ${reviewAnalysis.insights}`,
+      source: 'review_analysis',
+      metadata: reviewAnalysis as unknown as Record<string, unknown>,
+    })
+    result.completed.push('review_analysis')
+  } catch (err) {
+    console.error('[enrichEntity] review_analysis failed:', err)
+    result.errors.push('review_analysis')
+  }
+}
+
+async function tryCompetitors(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.GOOGLE_PLACES_API_KEY) {
+    result.skipped.push('competitors')
+    return
+  }
+  try {
+    const benchmark = await benchmarkCompetitors(
+      entity.name,
+      entity.vertical,
+      entity.area,
+      entity.pain_score,
+      null,
+      env.GOOGLE_PLACES_API_KEY
+    )
+    if (!benchmark) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `Competitor benchmarking: ${benchmark.summary} Top competitors: ${benchmark.competitors.map((c) => `${c.name} (${c.rating}★, ${c.review_count} reviews)`).join(', ')}.`,
+      source: 'competitors',
+      metadata: benchmark as unknown as Record<string, unknown>,
+    })
+    result.completed.push('competitors')
+  } catch (err) {
+    console.error('[enrichEntity] competitors failed:', err)
+    result.errors.push('competitors')
+  }
+}
+
+async function tryNews(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.SERPAPI_API_KEY || !env.ANTHROPIC_API_KEY) {
+    result.skipped.push('news_search')
+    return
+  }
+  try {
+    const news = await searchNews(
+      entity.name,
+      entity.area,
+      env.SERPAPI_API_KEY,
+      env.ANTHROPIC_API_KEY
+    )
+    if (!news) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
+      source: 'news_search',
+      metadata: {
+        mentions: news.mentions,
+        summary: news.summary,
+      },
+    })
+    result.completed.push('news_search')
+  } catch (err) {
+    console.error('[enrichEntity] news_search failed:', err)
+    result.errors.push('news_search')
+  }
+}
+
+async function tryDeepWebsite(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!entity.website || !env.ANTHROPIC_API_KEY) {
+    result.skipped.push('deep_website')
+    return
+  }
+  try {
+    const analysis = await deepWebsiteAnalysis(entity.website, env.ANTHROPIC_API_KEY)
+    if (!analysis) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: formatDeepWebsite(analysis),
+      source: 'deep_website',
+      metadata: analysis as unknown as Record<string, unknown>,
+    })
+    result.completed.push('deep_website')
+  } catch (err) {
+    console.error('[enrichEntity] deep_website failed:', err)
+    result.errors.push('deep_website')
+  }
+}
+
+async function tryReviewSynthesis(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.ANTHROPIC_API_KEY) {
+    result.skipped.push('review_synthesis')
+    return
+  }
+  try {
+    const allContext = await assembleEntityContext(env.DB, entity.id, {
+      maxBytes: 20_000,
+      typeFilter: ['signal', 'enrichment'],
+    })
+    if (!allContext) {
+      result.skipped.push('review_synthesis')
+      return
+    }
+    const synthesis = await synthesizeReviews(allContext, env.ANTHROPIC_API_KEY)
+    if (!synthesis) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}. Themes: ${synthesis.top_themes.join(', ')}. Problems: ${synthesis.operational_problems.map((p) => `${p.problem} (${p.confidence})`).join(', ')}.`,
+      source: 'review_synthesis',
+      metadata: synthesis as unknown as Record<string, unknown>,
+    })
+    result.completed.push('review_synthesis')
+  } catch (err) {
+    console.error('[enrichEntity] review_synthesis failed:', err)
+    result.errors.push('review_synthesis')
+  }
+}
+
+async function tryLinkedIn(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.PROXYCURL_API_KEY) {
+    result.skipped.push('linkedin')
+    return
+  }
+  try {
+    const linkedin = await lookupLinkedIn(entity.name, entity.area, env.PROXYCURL_API_KEY)
+    if (!linkedin) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: `LinkedIn: ${linkedin.company_name}. ${linkedin.employee_count ? `~${linkedin.employee_count} employees.` : ''} ${linkedin.industry ? `Industry: ${linkedin.industry}.` : ''} ${linkedin.description ? linkedin.description.slice(0, 200) : ''}`,
+      source: 'linkedin',
+      metadata: linkedin as unknown as Record<string, unknown>,
+    })
+    result.completed.push('linkedin')
+  } catch (err) {
+    console.error('[enrichEntity] linkedin failed:', err)
+    result.errors.push('linkedin')
+  }
+}
+
+async function tryIntelligenceBrief(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.ANTHROPIC_API_KEY) {
+    result.skipped.push('intelligence_brief')
+    return
+  }
+  try {
+    const fullContext = await assembleEntityContext(env.DB, entity.id, { maxBytes: 32_000 })
+    if (!fullContext) {
+      result.skipped.push('intelligence_brief')
+      return
+    }
+    const brief = await generateDossier(fullContext, entity.name, env.ANTHROPIC_API_KEY)
+    if (!brief) return
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: brief,
+      source: 'intelligence_brief',
+      metadata: { model: 'claude-sonnet-4-20250514', trigger: 'at_ingest' },
+    })
+    result.completed.push('intelligence_brief')
+  } catch (err) {
+    console.error('[enrichEntity] intelligence_brief failed:', err)
+    result.errors.push('intelligence_brief')
+  }
+}
+
+async function regenerateOutreach(
+  env: EnrichEnv,
+  orgId: string,
+  entity: Entity,
+  result: EnrichResult
+): Promise<void> {
+  if (!env.ANTHROPIC_API_KEY) {
+    result.skipped.push('outreach_draft')
+    return
+  }
+  try {
+    const context = await assembleEntityContext(env.DB, entity.id, { maxBytes: 24_000 })
+    if (!context) {
+      result.skipped.push('outreach_draft')
+      return
+    }
+    const draft = await generateOutreachDraft(env.ANTHROPIC_API_KEY, entity.name, context)
+    await appendContext(env.DB, orgId, {
+      entity_id: entity.id,
+      type: 'outreach_draft',
+      content: draft,
+      source: 'claude',
+      metadata: {
+        model: 'claude-sonnet-4-20250514',
+        trigger: result.mode === 'full' ? 'at_ingest' : 're_enrich',
+      },
+    })
+    result.completed.push('outreach_draft')
+  } catch (err) {
+    console.error('[enrichEntity] outreach_draft failed:', err)
+    result.errors.push('outreach_draft')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared formatters — copied from dossier.ts during the merge.
+// ---------------------------------------------------------------------------
+
+function formatDeepWebsite(analysis: DeepWebsiteAnalysis): string {
+  const parts: string[] = ['Deep website analysis:']
+  if (analysis.owner_profile.name)
+    parts.push(`Owner: ${analysis.owner_profile.name} (${analysis.owner_profile.title ?? 'owner'})`)
+  if (analysis.owner_profile.background)
+    parts.push(`Background: ${analysis.owner_profile.background}`)
+  if (analysis.team.size_estimate) parts.push(`Team: ~${analysis.team.size_estimate} people`)
+  if (analysis.team.named_employees.length > 0)
+    parts.push(
+      `Named staff: ${analysis.team.named_employees.map((e) => `${e.name} (${e.role})`).join(', ')}`
+    )
+  if (analysis.business_profile.services.length > 0)
+    parts.push(`Services: ${analysis.business_profile.services.join(', ')}`)
+  if (analysis.business_profile.certifications.length > 0)
+    parts.push(`Certifications: ${analysis.business_profile.certifications.join(', ')}`)
+  if (analysis.business_profile.awards.length > 0)
+    parts.push(`Awards: ${analysis.business_profile.awards.join(', ')}`)
+  parts.push(
+    `Digital maturity: ${analysis.digital_maturity.score}/10 — ${analysis.digital_maturity.reasoning}`
+  )
+  parts.push(
+    `Online booking: ${analysis.digital_maturity.online_booking ? 'Yes' : 'No'}, Chat: ${analysis.digital_maturity.chat_widget ? 'Yes' : 'No'}, Blog active: ${analysis.digital_maturity.blog_active ? 'Yes' : 'No'}`
+  )
+  if (analysis.contact_info.email) parts.push(`Email: ${analysis.contact_info.email}`)
+  return parts.join('\n')
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -55,8 +55,10 @@ const stageUpdated = Astro.url.searchParams.get('stage_updated')
 const dossierGenerated = Astro.url.searchParams.get('dossier')
 const error = Astro.url.searchParams.get('error')
 
-// Dossier available for prospect stage and beyond (not signal or lost)
-const dossierStages: string[] = [
+// Re-enrich available for prospect stage and beyond (not signal or lost).
+// Full enrichment now runs automatically at signal ingest — this button is
+// for refreshing the cheap (reviews + news) slice when the data goes stale.
+const reEnrichStages: string[] = [
   'prospect',
   'assessing',
   'proposing',
@@ -64,7 +66,7 @@ const dossierStages: string[] = [
   'delivered',
   'ongoing',
 ]
-const showDossierButton = dossierStages.includes(entity.stage)
+const showReEnrichButton = reEnrichStages.includes(entity.stage)
 
 // Stage transitions
 const TRANSITIONS: Record<
@@ -361,7 +363,8 @@ function confidenceColor(confidence: string): string {
   {
     dossierGenerated && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Intelligence dossier generated. See enrichment entries in the timeline below.
+        Re-enrichment complete. Refreshed reviews, synthesis, news, and outreach draft — see
+        timeline below.
       </div>
     )
   }
@@ -476,18 +479,19 @@ function confidenceColor(confidence: string): string {
           ))
         }
         {
-          showDossierButton && (
+          showReEnrichButton && (
             <form
               method="POST"
               action={`/api/admin/entities/${entity.id}/dossier`}
-              id="dossier-form"
+              id="re-enrich-form"
             >
               <button
                 type="submit"
-                id="dossier-btn"
+                id="re-enrich-btn"
                 class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                title="Refresh reviews and news — cheap, safe to re-run"
               >
-                Generate Dossier
+                Re-enrich (reviews + news)
               </button>
             </form>
           )
@@ -864,12 +868,12 @@ function confidenceColor(confidence: string): string {
     )
   }
   <script>
-    const form = document.getElementById('dossier-form')
-    const btn = document.getElementById('dossier-btn') as HTMLButtonElement | null
+    const form = document.getElementById('re-enrich-form')
+    const btn = document.getElementById('re-enrich-btn') as HTMLButtonElement | null
     if (form && btn) {
       form.addEventListener('submit', () => {
         btn.disabled = true
-        btn.textContent = 'Generating...'
+        btn.textContent = 'Re-enriching...'
       })
     }
 

--- a/src/pages/api/admin/entities/[id]/dossier.ts
+++ b/src/pages/api/admin/entities/[id]/dossier.ts
@@ -1,19 +1,21 @@
 import type { APIRoute } from 'astro'
-import { getEntity } from '../../../../../lib/db/entities'
-import { appendContext, assembleEntityContext } from '../../../../../lib/db/context'
-import { deepWebsiteAnalysis } from '../../../../../lib/enrichment/deep-website'
-import type { DeepWebsiteAnalysis } from '../../../../../lib/enrichment/deep-website'
-import { synthesizeReviews } from '../../../../../lib/enrichment/review-synthesis'
-import { lookupLinkedIn } from '../../../../../lib/enrichment/linkedin'
-import { generateDossier } from '../../../../../lib/enrichment/dossier'
-import { generateOutreachDraft } from '../../../../../lib/claude/outreach'
+import { enrichEntity } from '../../../../../lib/enrichment'
 import { env } from 'cloudflare:workers'
 
 /**
  * POST /api/admin/entities/[id]/dossier
  *
- * Generate a deep intelligence dossier for an entity.
- * Runs Tier 4 enrichment modules then synthesizes into a brief.
+ * Thin wrapper — the original endpoint generated the full intelligence
+ * dossier on admin click, which is now handled automatically at signal
+ * ingest (see src/lib/enrichment/index.ts). This route is kept as a
+ * "Re-enrich" action the admin can trigger for stale data refresh. It runs
+ * the cheap `reviews-and-news` mode (review patterns + review synthesis +
+ * news search + outreach draft regeneration) rather than re-billing every
+ * module on an already-enriched entity.
+ *
+ * The "Generate Dossier" button itself was removed from the admin UI in
+ * issue #471. Callers still linking to the old path end up on the entity
+ * page with a `dossier=1` query param, matching the legacy success redirect.
  */
 export const POST: APIRoute = async ({ params, locals, redirect }) => {
   const session = locals.session
@@ -28,138 +30,10 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
   if (!entityId) return redirect('/admin/entities?error=missing', 302)
 
   try {
-    const entity = await getEntity(env.DB, session.orgId, entityId)
-    if (!entity) return redirect('/admin/entities?error=not_found', 302)
-
-    const anthropicKey = env.ANTHROPIC_API_KEY as string | undefined
-    if (!anthropicKey) {
-      return redirect(`/admin/entities/${entityId}?error=no_api_key`, 302)
-    }
-
-    // Module 11: Deep website analysis (if website available)
-    if (entity.website) {
-      try {
-        const deepAnalysis = await deepWebsiteAnalysis(entity.website, anthropicKey)
-        if (deepAnalysis) {
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: formatDeepWebsite(deepAnalysis),
-            source: 'deep_website',
-            metadata: deepAnalysis as unknown as Record<string, unknown>,
-          })
-        }
-      } catch (err) {
-        console.error('[dossier] Deep website analysis failed:', err)
-      }
-    }
-
-    // Module 12: Cross-platform review synthesis
-    try {
-      const allContext = await assembleEntityContext(env.DB, entityId, {
-        maxBytes: 20_000,
-        typeFilter: ['signal', 'enrichment'],
-      })
-      if (allContext) {
-        const synthesis = await synthesizeReviews(allContext, anthropicKey)
-        if (synthesis) {
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}. Themes: ${synthesis.top_themes.join(', ')}. Problems: ${synthesis.operational_problems.map((p) => `${p.problem} (${p.confidence})`).join(', ')}.`,
-            source: 'review_synthesis',
-            metadata: synthesis as unknown as Record<string, unknown>,
-          })
-        }
-      }
-    } catch (err) {
-      console.error('[dossier] Review synthesis failed:', err)
-    }
-
-    // Module 13: LinkedIn (if API key available)
-    if (env.PROXYCURL_API_KEY) {
-      try {
-        const linkedin = await lookupLinkedIn(
-          entity.name,
-          entity.area,
-          env.PROXYCURL_API_KEY as string
-        )
-        if (linkedin) {
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: `LinkedIn: ${linkedin.company_name}. ${linkedin.employee_count ? `~${linkedin.employee_count} employees.` : ''} ${linkedin.industry ? `Industry: ${linkedin.industry}.` : ''} ${linkedin.description ? linkedin.description.slice(0, 200) : ''}`,
-            source: 'linkedin',
-            metadata: linkedin as unknown as Record<string, unknown>,
-          })
-        }
-      } catch (err) {
-        console.error('[dossier] LinkedIn lookup failed:', err)
-      }
-    }
-
-    // Module 14: Generate the intelligence brief
-    const fullContext = await assembleEntityContext(env.DB, entityId, { maxBytes: 32_000 })
-    if (fullContext) {
-      const brief = await generateDossier(fullContext, entity.name, anthropicKey)
-      if (brief) {
-        await appendContext(env.DB, session.orgId, {
-          entity_id: entityId,
-          type: 'enrichment',
-          content: brief,
-          source: 'intelligence_brief',
-          metadata: { model: 'claude-sonnet-4-20250514', trigger: 'dossier' },
-        })
-      }
-    }
-
-    // Regenerate outreach draft with full dossier context
-    try {
-      const outreachContext = await assembleEntityContext(env.DB, entityId, { maxBytes: 24_000 })
-      if (outreachContext) {
-        const draft = await generateOutreachDraft(anthropicKey, entity.name, outreachContext)
-        await appendContext(env.DB, session.orgId, {
-          entity_id: entityId,
-          type: 'outreach_draft',
-          content: draft,
-          source: 'claude',
-          metadata: { model: 'claude-sonnet-4-20250514', trigger: 'dossier' },
-        })
-      }
-    } catch (err) {
-      console.error('[dossier] Outreach draft regeneration failed:', err)
-    }
-
+    await enrichEntity(env, session.orgId, entityId, { mode: 'reviews-and-news' })
     return redirect(`/admin/entities/${entityId}?dossier=1`, 302)
   } catch (err) {
     console.error('[api/admin/entities/dossier] Error:', err)
-    return redirect(`/admin/entities/${entityId}?error=dossier_failed`, 302)
+    return redirect(`/admin/entities/${entityId}?error=re_enrich_failed`, 302)
   }
-}
-
-function formatDeepWebsite(analysis: DeepWebsiteAnalysis): string {
-  const parts: string[] = ['Deep website analysis:']
-  if (analysis.owner_profile.name)
-    parts.push(`Owner: ${analysis.owner_profile.name} (${analysis.owner_profile.title ?? 'owner'})`)
-  if (analysis.owner_profile.background)
-    parts.push(`Background: ${analysis.owner_profile.background}`)
-  if (analysis.team.size_estimate) parts.push(`Team: ~${analysis.team.size_estimate} people`)
-  if (analysis.team.named_employees.length > 0)
-    parts.push(
-      `Named staff: ${analysis.team.named_employees.map((e) => `${e.name} (${e.role})`).join(', ')}`
-    )
-  if (analysis.business_profile.services.length > 0)
-    parts.push(`Services: ${analysis.business_profile.services.join(', ')}`)
-  if (analysis.business_profile.certifications.length > 0)
-    parts.push(`Certifications: ${analysis.business_profile.certifications.join(', ')}`)
-  if (analysis.business_profile.awards.length > 0)
-    parts.push(`Awards: ${analysis.business_profile.awards.join(', ')}`)
-  parts.push(
-    `Digital maturity: ${analysis.digital_maturity.score}/10 — ${analysis.digital_maturity.reasoning}`
-  )
-  parts.push(
-    `Online booking: ${analysis.digital_maturity.online_booking ? 'Yes' : 'No'}, Chat: ${analysis.digital_maturity.chat_widget ? 'Yes' : 'No'}, Blog active: ${analysis.digital_maturity.blog_active ? 'Yes' : 'No'}`
-  )
-  if (analysis.contact_info.email) parts.push(`Email: ${analysis.contact_info.email}`)
-  return parts.join('\n')
 }

--- a/src/pages/api/admin/entities/[id]/promote.ts
+++ b/src/pages/api/admin/entities/[id]/promote.ts
@@ -1,35 +1,20 @@
 import type { APIRoute } from 'astro'
-import { getEntity, transitionStage, updateEntity } from '../../../../../lib/db/entities'
-import { appendContext, assembleEntityContext } from '../../../../../lib/db/context'
-import { generateOutreachDraft } from '../../../../../lib/claude/outreach'
+import { getEntity, transitionStage } from '../../../../../lib/db/entities'
+import { enrichEntity } from '../../../../../lib/enrichment'
 import { scheduleProspectCadence } from '../../../../../lib/follow-ups/scheduler'
-import { lookupGooglePlaces } from '../../../../../lib/enrichment/google-places'
-import { analyzeWebsite } from '../../../../../lib/enrichment/website-analyzer'
-import { lookupOutscraper } from '../../../../../lib/enrichment/outscraper'
-import { lookupAcc } from '../../../../../lib/enrichment/acc'
-import { lookupRoc } from '../../../../../lib/enrichment/roc'
-import { analyzeReviewPatterns } from '../../../../../lib/enrichment/review-analysis'
-import { benchmarkCompetitors } from '../../../../../lib/enrichment/competitors'
-import { searchNews } from '../../../../../lib/enrichment/news'
 import { env } from 'cloudflare:workers'
 
 /**
  * POST /api/admin/entities/[id]/promote
  *
- * One-click promote: signal → prospect.
- *
- * 1. Transition stage to prospect
- * 2. Run enrichment modules (all best-effort, independent)
- *    - Google Places lookup (if missing phone/website)
- *    - Website analysis + tech stack detection
- *    - Yelp Fusion cross-reference
- *    - ACC filing lookup
- *    - ROC license check (trades only)
- * 3. Generate outreach draft from enriched context
- * 4. Schedule prospect follow-up cadence
- * 5. Set next_action
- *
- * Each enrichment module is independent — failures don't block others or the promote.
+ * Thin wrapper retained as the transport for the "Promote" button on the
+ * admin signal row — it still handles the signal → prospect stage transition
+ * and schedules the prospect follow-up cadence. Enrichment itself now runs
+ * automatically at signal ingest (see src/lib/enrichment/index.ts and the
+ * lead-gen workers), so on the typical signal this endpoint finds the entity
+ * already fully enriched and `enrichEntity` returns `alreadyEnriched: true`
+ * without re-billing Claude. For entities that arrived before the at-ingest
+ * refactor shipped, the call does an on-demand backfill.
  */
 export const POST: APIRoute = async ({ params, locals, redirect }) => {
   const session = locals.session
@@ -46,7 +31,8 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
   }
 
   try {
-    // 1. Transition stage
+    // Stage transition first so the rest of the UI reads "prospect" while
+    // enrichment fills in (enrichment is idempotent and safe to re-run).
     await transitionStage(env.DB, session.orgId, entityId, 'prospect', 'Promoted from signal.')
 
     const entity = await getEntity(env.DB, session.orgId, entityId)
@@ -54,306 +40,15 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
       return redirect('/admin/entities?error=not_found', 302)
     }
 
-    // 2. Run enrichment modules (all best-effort, parallel where possible)
-    const enrichmentResults: string[] = []
+    // Backfill enrichment if this signal predates the at-ingest refactor.
+    // No-op when an intelligence_brief already exists.
+    await enrichEntity(env, session.orgId, entityId, { mode: 'full' })
 
-    // 2a. Google Places lookup (if missing phone or website)
-    if ((!entity.phone || !entity.website) && env.GOOGLE_PLACES_API_KEY) {
-      try {
-        const places = await lookupGooglePlaces(
-          entity.name,
-          entity.area,
-          env.GOOGLE_PLACES_API_KEY as string
-        )
-        if (places) {
-          // Update entity phone/website if discovered
-          await updateEntity(env.DB, session.orgId, entityId, {
-            phone: places.phone ?? entity.phone ?? undefined,
-            website: places.website ?? entity.website ?? undefined,
-          })
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: `Google Places: ${places.phone ? `Phone: ${places.phone}` : 'No phone found'}. ${places.website ? `Website: ${places.website}` : 'No website found'}. Rating: ${places.rating ?? 'N/A'} (${places.reviewCount ?? 0} reviews). Status: ${places.businessStatus ?? 'unknown'}.`,
-            source: 'google_places',
-            metadata: places as unknown as Record<string, unknown>,
-          })
-          enrichmentResults.push('google_places')
-          // Re-fetch entity to get updated phone/website for subsequent modules
-          const refreshed = await getEntity(env.DB, session.orgId, entityId)
-          if (refreshed) Object.assign(entity, refreshed)
-        }
-      } catch (err) {
-        console.error('[promote] Google Places enrichment failed:', err)
-      }
-    }
-
-    // 2b. Website analysis + tech stack (if website available)
-    const websiteUrl = entity.website
-    if (websiteUrl && env.ANTHROPIC_API_KEY) {
-      try {
-        const analysis = await analyzeWebsite(websiteUrl, env.ANTHROPIC_API_KEY)
-        if (analysis) {
-          const techTools = [
-            ...analysis.tech_stack.scheduling,
-            ...analysis.tech_stack.crm,
-            ...analysis.tech_stack.reviews,
-            ...analysis.tech_stack.payments,
-            ...analysis.tech_stack.communication,
-          ]
-          const missingTools: string[] = []
-          if (analysis.tech_stack.scheduling.length === 0) missingTools.push('No scheduling tool')
-          if (analysis.tech_stack.crm.length === 0) missingTools.push('No CRM')
-          if (analysis.tech_stack.reviews.length === 0) missingTools.push('No review management')
-
-          const contentParts = [
-            `Website analysis (${analysis.pages_analyzed.length} pages):`,
-            analysis.owner_name ? `Owner/Founder: ${analysis.owner_name}` : null,
-            analysis.team_size ? `Team size: ~${analysis.team_size} people` : null,
-            analysis.founding_year ? `Founded: ${analysis.founding_year}` : null,
-            analysis.contact_email ? `Email: ${analysis.contact_email}` : null,
-            analysis.services.length > 0 ? `Services: ${analysis.services.join(', ')}` : null,
-            `Site quality: ${analysis.quality}`,
-            techTools.length > 0
-              ? `Tools detected: ${techTools.join(', ')}`
-              : 'No business tools detected on website',
-            missingTools.length > 0 ? `Gaps: ${missingTools.join(', ')}` : null,
-            `Platform: ${analysis.tech_stack.platform.join(', ') || 'Custom/unknown'}`,
-          ].filter(Boolean)
-
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: contentParts.join('\n'),
-            source: 'website_analysis',
-            metadata: {
-              owner_name: analysis.owner_name,
-              team_size: analysis.team_size,
-              employee_count: analysis.team_size,
-              founding_year: analysis.founding_year,
-              contact_email: analysis.contact_email,
-              services: analysis.services,
-              quality: analysis.quality,
-              tech_stack: analysis.tech_stack,
-              pages_analyzed: analysis.pages_analyzed,
-            },
-          })
-          enrichmentResults.push('website_analysis')
-        }
-      } catch (err) {
-        console.error('[promote] Website analysis failed:', err)
-      }
-    }
-
-    // 2c. Outscraper full business profile (owner, social, emails, hours, tech signals)
-    if (env.OUTSCRAPER_API_KEY) {
-      try {
-        const osc = await lookupOutscraper(
-          entity.name,
-          entity.area,
-          env.OUTSCRAPER_API_KEY as string
-        )
-        if (osc) {
-          // Update entity with discovered contact info
-          await updateEntity(env.DB, session.orgId, entityId, {
-            phone: osc.phone ?? entity.phone ?? undefined,
-            website: osc.website ?? entity.website ?? undefined,
-          })
-          if (osc.website && !entity.website) {
-            const refreshed = await getEntity(env.DB, session.orgId, entityId)
-            if (refreshed) Object.assign(entity, refreshed)
-          }
-
-          const contentParts = [
-            'Outscraper business profile:',
-            osc.owner_name ? `Owner: ${osc.owner_name}` : null,
-            osc.emails.length > 0 ? `Email: ${osc.emails.join(', ')}` : null,
-            osc.phone ? `Phone: ${osc.phone}` : null,
-            osc.working_hours ? `Hours: ${osc.working_hours}` : null,
-            osc.verified ? 'Google listing: Verified' : 'Google listing: Unverified',
-            osc.rating != null ? `Rating: ${osc.rating} (${osc.review_count ?? 0} reviews)` : null,
-            osc.booking_link ? `Online booking: Yes` : 'Online booking: Not detected',
-            osc.facebook ? `Facebook: ${osc.facebook}` : null,
-            osc.instagram ? `Instagram: ${osc.instagram}` : null,
-            osc.linkedin ? `LinkedIn: ${osc.linkedin}` : null,
-            osc.website_generator ? `Platform: ${osc.website_generator}` : null,
-            osc.has_facebook_pixel ? 'Has Facebook Pixel' : null,
-            osc.has_google_tag_manager ? 'Has Google Tag Manager' : null,
-            osc.about ? `About: ${osc.about}` : null,
-          ].filter(Boolean)
-
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: contentParts.join('\n'),
-            source: 'outscraper',
-            metadata: osc as unknown as Record<string, unknown>,
-          })
-          enrichmentResults.push('outscraper')
-        }
-      } catch (err) {
-        console.error('[promote] Outscraper enrichment failed:', err)
-      }
-    }
-
-    // 2d. ACC filing lookup
-    try {
-      const acc = await lookupAcc(entity.name)
-      if (acc) {
-        await appendContext(env.DB, session.orgId, {
-          entity_id: entityId,
-          type: 'enrichment',
-          content: `ACC Filing: ${acc.entity_name} (${acc.entity_type ?? 'unknown type'}). Filed: ${acc.filing_date ?? 'unknown'}. Status: ${acc.status ?? 'unknown'}. Registered agent: ${acc.registered_agent ?? 'not found'}.`,
-          source: 'acc_filing',
-          metadata: acc as unknown as Record<string, unknown>,
-        })
-        enrichmentResults.push('acc_filing')
-      }
-    } catch (err) {
-      console.error('[promote] ACC lookup failed:', err)
-    }
-
-    // 2e. ROC license check (trades only)
-    if (entity.vertical === 'home_services' || entity.vertical === 'contractor_trades') {
-      try {
-        const roc = await lookupRoc(entity.name)
-        if (roc) {
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: `ROC License: ${roc.license_number ?? 'N/A'} (${roc.classification ?? 'unknown classification'}). Status: ${roc.status ?? 'unknown'}. Complaints: ${roc.complaint_count ?? 'N/A'}.`,
-            source: 'roc_license',
-            metadata: roc as unknown as Record<string, unknown>,
-          })
-          enrichmentResults.push('roc_license')
-        }
-      } catch (err) {
-        console.error('[promote] ROC lookup failed:', err)
-      }
-    }
-
-    // --- Tier 3: Deeper intelligence ---
-
-    // 3a. Review response analysis
-    if (env.ANTHROPIC_API_KEY) {
-      try {
-        const signalContext = await assembleEntityContext(env.DB, entityId, {
-          maxBytes: 8_000,
-          typeFilter: ['signal'],
-        })
-        if (signalContext) {
-          const reviewAnalysis = await analyzeReviewPatterns(
-            signalContext,
-            env.ANTHROPIC_API_KEY as string
-          )
-          if (reviewAnalysis) {
-            await appendContext(env.DB, session.orgId, {
-              entity_id: entityId,
-              type: 'enrichment',
-              content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''} ${reviewAnalysis.insights}`,
-              source: 'review_analysis',
-              metadata: reviewAnalysis as unknown as Record<string, unknown>,
-            })
-            enrichmentResults.push('review_analysis')
-          }
-        }
-      } catch (err) {
-        console.error('[promote] Review analysis failed:', err)
-      }
-    }
-
-    // 3b. Competitor benchmarking
-    if (env.GOOGLE_PLACES_API_KEY) {
-      try {
-        const benchmark = await benchmarkCompetitors(
-          entity.name,
-          entity.vertical,
-          entity.area,
-          entity.pain_score,
-          null,
-          env.GOOGLE_PLACES_API_KEY as string
-        )
-        if (benchmark) {
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: `Competitor benchmarking: ${benchmark.summary} Top competitors: ${benchmark.competitors.map((c) => `${c.name} (${c.rating}★, ${c.review_count} reviews)`).join(', ')}.`,
-            source: 'competitors',
-            metadata: benchmark as unknown as Record<string, unknown>,
-          })
-          enrichmentResults.push('competitors')
-        }
-      } catch (err) {
-        console.error('[promote] Competitor benchmarking failed:', err)
-      }
-    }
-
-    // 3c. News/press search
-    if (env.SERPAPI_API_KEY && env.ANTHROPIC_API_KEY) {
-      try {
-        const news = await searchNews(
-          entity.name,
-          entity.area,
-          env.SERPAPI_API_KEY as string,
-          env.ANTHROPIC_API_KEY as string
-        )
-        if (news) {
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'enrichment',
-            content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
-            source: 'news_search',
-            metadata: {
-              mentions: news.mentions,
-              summary: news.summary,
-            },
-          })
-          enrichmentResults.push('news_search')
-        }
-      } catch (err) {
-        console.error('[promote] News search failed:', err)
-      }
-    }
-
-    console.log(
-      `[promote] Enrichment complete for ${entity.name}: ${enrichmentResults.join(', ') || 'none'}`
-    )
-
-    // 4. Generate outreach draft (best-effort, uses enriched context)
-    try {
-      if (env.ANTHROPIC_API_KEY) {
-        const context = await assembleEntityContext(env.DB, entityId, { maxBytes: 16_000 })
-        if (context) {
-          const draft = await generateOutreachDraft(env.ANTHROPIC_API_KEY, entity.name, context)
-          await appendContext(env.DB, session.orgId, {
-            entity_id: entityId,
-            type: 'outreach_draft',
-            content: draft,
-            source: 'claude',
-            metadata: {
-              model: 'claude-sonnet-4-20250514',
-              trigger: 'promote',
-              enrichment_sources: enrichmentResults,
-            },
-          })
-        }
-      }
-    } catch (err) {
-      console.error('[promote] Outreach generation failed (non-blocking):', err)
-    }
-
-    // 4. Schedule prospect follow-up cadence
     try {
       await scheduleProspectCadence(env.DB, session.orgId, entityId, new Date().toISOString())
     } catch (err) {
       console.error('[promote] Follow-up cadence scheduling failed (non-blocking):', err)
     }
-
-    // 5. Set next action
-    await updateEntity(env.DB, session.orgId, entityId, {
-      next_action: 'Review and send outreach email',
-      next_action_at: new Date().toISOString(),
-    })
 
     return redirect(`/admin/entities/${entityId}?promoted=1`, 302)
   } catch (err) {

--- a/tests/enrichment-pipeline.test.ts
+++ b/tests/enrichment-pipeline.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Lock-in tests for issue #471 — merge Promote + Dossier into a single
+ * at-ingest enrichment pipeline.
+ *
+ * These tests assert the structural contract: one unified entry point,
+ * idempotency on re-runs, both admin endpoints delegating to it, and every
+ * per-entity lead-gen worker wiring enrichment at ingest time. A regression
+ * on any of these silently returns us to the 2-button admin-gated world.
+ */
+describe('enrichment pipeline (issue #471)', () => {
+  const enrichmentSrc = () => readFileSync(resolve('src/lib/enrichment/index.ts'), 'utf-8')
+  const promoteSrc = () =>
+    readFileSync(resolve('src/pages/api/admin/entities/[id]/promote.ts'), 'utf-8')
+  const dossierSrc = () =>
+    readFileSync(resolve('src/pages/api/admin/entities/[id]/dossier.ts'), 'utf-8')
+
+  describe('unified entry point', () => {
+    it('src/lib/enrichment/index.ts exists', () => {
+      expect(existsSync(resolve('src/lib/enrichment/index.ts'))).toBe(true)
+    })
+
+    it('exports enrichEntity function', () => {
+      expect(enrichmentSrc()).toContain('export async function enrichEntity')
+    })
+
+    it('supports both "full" and "reviews-and-news" modes', () => {
+      const code = enrichmentSrc()
+      expect(code).toContain("'full'")
+      expect(code).toContain("'reviews-and-news'")
+    })
+
+    it('idempotency: full-mode skips when an intelligence_brief already exists', () => {
+      // Full re-enrichment must not re-bill Claude for the same signal.
+      const code = enrichmentSrc()
+      expect(code).toMatch(/hasBrief/)
+      expect(code).toMatch(/alreadyEnriched/)
+    })
+
+    it('covers the 12 modules from the old promote + dossier pair', () => {
+      // If a module is removed, it is either a Captain-approved feature
+      // deprecation or a regression. This list encodes the baseline contract.
+      const code = enrichmentSrc()
+      for (const source of [
+        'google_places',
+        'website_analysis',
+        'outscraper',
+        'acc_filing',
+        'roc_license',
+        'review_analysis',
+        'competitors',
+        'news_search',
+        'deep_website',
+        'review_synthesis',
+        'linkedin',
+        'intelligence_brief',
+      ]) {
+        expect(code).toContain(source)
+      }
+    })
+  })
+
+  describe('admin endpoints delegate to enrichEntity', () => {
+    it('promote.ts calls enrichEntity instead of running modules inline', () => {
+      const code = promoteSrc()
+      expect(code).toContain("from '../../../../../lib/enrichment'")
+      expect(code).toContain('enrichEntity(')
+      // The old inline imports must be gone — otherwise promote.ts is still
+      // running a parallel pipeline and drift will reappear.
+      expect(code).not.toContain('analyzeWebsite')
+      expect(code).not.toContain('lookupOutscraper')
+      expect(code).not.toContain('searchNews')
+    })
+
+    it('dossier.ts calls enrichEntity in reviews-and-news mode', () => {
+      const code = dossierSrc()
+      expect(code).toContain("from '../../../../../lib/enrichment'")
+      expect(code).toContain("mode: 'reviews-and-news'")
+      expect(code).not.toContain('deepWebsiteAnalysis')
+      expect(code).not.toContain('synthesizeReviews(')
+      expect(code).not.toContain('generateDossier(')
+    })
+  })
+
+  describe('admin UI — Generate Dossier button replaced with Re-enrich', () => {
+    const astroSrc = () => readFileSync(resolve('src/pages/admin/entities/[id].astro'), 'utf-8')
+
+    it('removes the "Generate Dossier" label', () => {
+      expect(astroSrc()).not.toContain('Generate Dossier')
+    })
+
+    it('exposes a Re-enrich (reviews + news) button', () => {
+      expect(astroSrc()).toContain('Re-enrich')
+    })
+  })
+
+  describe('lead-gen workers run enrichEntity at ingest', () => {
+    const workers = ['new-business', 'job-monitor', 'review-mining']
+
+    for (const worker of workers) {
+      it(`${worker} worker imports enrichEntity`, () => {
+        const code = readFileSync(resolve(`workers/${worker}/src/index.ts`), 'utf-8')
+        expect(code).toContain("from '../../../src/lib/enrichment/index.js'")
+        expect(code).toContain('enrichEntity(')
+      })
+
+      it(`${worker} worker uses ctx.waitUntil to avoid blocking ingest`, () => {
+        const code = readFileSync(resolve(`workers/${worker}/src/index.ts`), 'utf-8')
+        expect(code).toContain('ctx.waitUntil(')
+      })
+    }
+  })
+})

--- a/workers/job-monitor/src/index.ts
+++ b/workers/job-monitor/src/index.ts
@@ -15,6 +15,7 @@ import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
 import type { JobMonitorConfig } from '../../../src/lib/generators/types.js'
+import { enrichEntity } from '../../../src/lib/enrichment/index.js'
 import { searchJobs } from './serpapi.js'
 import { qualifyJob, derivePainScore } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -26,9 +27,13 @@ export interface Env {
   ANTHROPIC_API_KEY: string
   RESEND_API_KEY: string
   LEAD_INGEST_API_KEY: string
+  // Optional API keys consumed by the at-ingest enrichment pipeline.
+  GOOGLE_PLACES_API_KEY?: string
+  OUTSCRAPER_API_KEY?: string
+  PROXYCURL_API_KEY?: string
 }
 
-async function run(env: Env): Promise<RunSummary> {
+async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   const summary: RunSummary = {
     queries: 0,
     totalResults: 0,
@@ -159,6 +164,16 @@ async function run(env: Env): Promise<RunSummary> {
       })
 
       summary.written++
+
+      // At-ingest enrichment (issue #471). Detached so the ingest loop is not
+      // blocked by N Claude round-trips. Idempotent — no-op if a prior brief
+      // exists on this entity already.
+      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, { mode: 'full' }).catch((err) => {
+        console.error('[job_monitor] enrichment failed for', entity.id, err)
+      })
+      if (ctx) {
+        ctx.waitUntil(enrichPromise)
+      }
     } catch (err) {
       summary.errors++
       const msg = err instanceof Error ? err.message : String(err)
@@ -182,7 +197,7 @@ async function run(env: Env): Promise<RunSummary> {
 
 export default {
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    const summary = await run(env)
+    const summary = await run(env, ctx)
     if (summary.written === 0 && summary.errors > 0 && env.RESEND_API_KEY) {
       ctx.waitUntil(sendFailureAlert(summary, env.RESEND_API_KEY))
     }
@@ -193,7 +208,7 @@ export default {
     if (auth !== `Bearer ${env.LEAD_INGEST_API_KEY}`) {
       return new Response('Unauthorized', { status: 401 })
     }
-    const summary = await run(env)
+    const summary = await run(env, ctx)
     return new Response(JSON.stringify(summary, null, 2), {
       headers: { 'Content-Type': 'application/json' },
     })

--- a/workers/new-business/src/index.ts
+++ b/workers/new-business/src/index.ts
@@ -16,6 +16,7 @@ import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
 import type { NewBusinessConfig } from '../../../src/lib/generators/types.js'
+import { enrichEntity } from '../../../src/lib/enrichment/index.js'
 import { fetchAllPermits, type SodaCity } from './soda.js'
 import { qualifyNewBusiness } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -25,9 +26,16 @@ export interface Env {
   ANTHROPIC_API_KEY: string
   RESEND_API_KEY: string
   LEAD_INGEST_API_KEY: string
+  // Optional API keys consumed by the at-ingest enrichment pipeline. When any
+  // are missing the corresponding module is skipped — enrichment is
+  // best-effort, never a hard dependency.
+  GOOGLE_PLACES_API_KEY?: string
+  OUTSCRAPER_API_KEY?: string
+  SERPAPI_API_KEY?: string
+  PROXYCURL_API_KEY?: string
 }
 
-async function run(env: Env): Promise<RunSummary> {
+async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   const summary: RunSummary = {
     sources: 5,
     totalPermits: 0,
@@ -125,6 +133,19 @@ async function run(env: Env): Promise<RunSummary> {
       })
 
       summary.written++
+
+      // At-ingest enrichment (issue #471). Fire-and-forget via waitUntil when
+      // we have an ExecutionContext so the 50-state cron loop is not blocked
+      // by N Claude round-trips. On the /run fetch path we also detach;
+      // enrichment errors are self-contained and should not turn a successful
+      // ingest into a failed run. Idempotent: the pipeline no-ops once a
+      // prior intelligence_brief exists.
+      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, { mode: 'full' }).catch((err) => {
+        console.error('[new_business] enrichment failed for', entity.id, err)
+      })
+      if (ctx) {
+        ctx.waitUntil(enrichPromise)
+      }
     } catch (err) {
       summary.errors++
       const msg = err instanceof Error ? err.message : String(err)
@@ -147,7 +168,7 @@ async function run(env: Env): Promise<RunSummary> {
 
 export default {
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    const summary = await run(env)
+    const summary = await run(env, ctx)
     if (summary.written === 0 && summary.errors > 0 && env.RESEND_API_KEY) {
       ctx.waitUntil(sendFailureAlert(summary, env.RESEND_API_KEY))
     }
@@ -158,7 +179,7 @@ export default {
     if (auth !== `Bearer ${env.LEAD_INGEST_API_KEY}`) {
       return new Response('Unauthorized', { status: 401 })
     }
-    const summary = await run(env)
+    const summary = await run(env, ctx)
     return new Response(JSON.stringify(summary, null, 2), {
       headers: { 'Content-Type': 'application/json' },
     })

--- a/workers/review-mining/src/index.ts
+++ b/workers/review-mining/src/index.ts
@@ -16,6 +16,7 @@ import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
 import type { ReviewMiningConfig } from '../../../src/lib/generators/types.js'
+import { enrichEntity } from '../../../src/lib/enrichment/index.js'
 import { discoverBusinesses, fetchReviews } from './outscraper.js'
 import { scoreReviews } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
@@ -30,9 +31,12 @@ export interface Env {
   ANTHROPIC_API_KEY: string
   RESEND_API_KEY: string
   LEAD_INGEST_API_KEY: string
+  // Optional keys used by the at-ingest enrichment pipeline.
+  SERPAPI_API_KEY?: string
+  PROXYCURL_API_KEY?: string
 }
 
-async function run(env: Env): Promise<RunSummary> {
+async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   const summary: RunSummary = {
     queries: 0,
     discovered: 0,
@@ -184,6 +188,17 @@ async function run(env: Env): Promise<RunSummary> {
       })
 
       summary.written++
+
+      // At-ingest enrichment (issue #471). Detached — the review-mining run
+      // already pays for Outscraper per business, and enrichment adds the
+      // Claude-powered dossier so the admin has something to act on without
+      // a second button click. Idempotent on re-runs.
+      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, { mode: 'full' }).catch((err) => {
+        console.error('[review_mining] enrichment failed for', entity.id, err)
+      })
+      if (ctx) {
+        ctx.waitUntil(enrichPromise)
+      }
     } catch (err) {
       summary.errors++
       const msg = err instanceof Error ? err.message : String(err)
@@ -206,7 +221,7 @@ async function run(env: Env): Promise<RunSummary> {
 
 export default {
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    const summary = await run(env)
+    const summary = await run(env, ctx)
     if (summary.written === 0 && summary.errors > 0 && env.RESEND_API_KEY) {
       ctx.waitUntil(sendFailureAlert(summary, env.RESEND_API_KEY))
     }
@@ -217,7 +232,7 @@ export default {
     if (auth !== `Bearer ${env.LEAD_INGEST_API_KEY}`) {
       return new Response('Unauthorized', { status: 401 })
     }
-    const summary = await run(env)
+    const summary = await run(env, ctx)
     return new Response(JSON.stringify(summary, null, 2), {
       headers: { 'Content-Type': 'application/json' },
     })


### PR DESCRIPTION
## Summary

Closes #471. Two parallel admin-click enrichment flows (`/api/admin/entities/[id]/promote` and `/api/admin/entities/[id]/dossier`) are collapsed into a single `enrichEntity()` function that runs automatically at signal ingest from every per-entity lead-gen worker. The admin-click gate was the bottleneck — at ~8 signals/day and ~$0.25/enrichment, total spend is ~$60/mo, trivial against engagement value, but only if every signal actually gets enriched.

- New `src/lib/enrichment/index.ts` — `enrichEntity(env, orgId, entityId, { mode })` with `full` and `reviews-and-news` modes, covering all 12 modules from the old pair (google_places, website_analysis, outscraper, acc_filing, roc_license, review_analysis, competitors, news_search, deep_website, review_synthesis, linkedin, intelligence_brief) plus outreach_draft regeneration.
- Workers (`new-business`, `job-monitor`, `review-mining`) call `enrichEntity` via `ctx.waitUntil` after the initial `appendContext` so ingest is not blocked on Claude round-trips. `social-listening` is unchanged — it writes to the system entity, not per-entity rows.
- `/api/admin/entities/[id]/promote` and `/dossier` both preserved as thin wrappers. Promote still owns the signal→prospect stage transition and prospect cadence scheduling; its `enrichEntity` call is a no-op on already-enriched entities. Dossier endpoint powers the new "Re-enrich (reviews + news)" admin button.
- `src/pages/admin/entities/[id].astro`: "Generate Dossier" button removed; replaced with "Re-enrich (reviews + news)" labeled for the stale-data refresh use case. The signal-row "Promote" button is preserved as the stage transition action.
- `tests/enrichment-pipeline.test.ts`: 15-test lock-in contract (module coverage, idempotency, endpoint delegation, worker wiring, UI button swap).

## Investigation findings

**Overlap:** Both endpoints called `generateOutreachDraft` (dossier overwrote promote's draft), fetched the same entity+context rows, and used the same `appendContext` plumbing. Only one outreach call now runs per enrichment, at the end. Review modules (`review_analysis` in promote vs `review_synthesis` in dossier) are different prompts and both preserved — different output contracts.

**Intentionally deferred / gated:** None. Competitor benchmarking runs at ingest as before; the old promote flow already ran it, and benchmark cost is Google Places query quota rather than Claude tokens. If cost pressure emerges we'd gate by `stage === 'prospect'` in a follow-up, but no evidence of that yet.

**Cost estimate per enrichment (full mode):** ~4 Sonnet calls (website_analyzer, review_analysis, review_synthesis, deep_website, intelligence_brief, outreach_draft ≈ 6 Claude calls total at ~$0.04 each with 4k avg output) + Outscraper ($0.002/lookup) + SerpAPI news ($0.0015) + Google Places (free tier). Call it ~$0.25/enrichment, matching the issue estimate. 8/day × 30 = ~$60/mo. `reviews-and-news` mode is 3 Claude calls — ~$0.12.

**Idempotency:** Full-mode enrichment skips when a prior `intelligence_brief` context entry exists (it's the last module to run in full mode, so its presence means a prior run completed). Workers calling `enrichEntity` twice (dedupe race, retry, manual re-run) will not re-bill Claude. `reviews-and-news` bypasses the check — callers explicitly asked for a refresh.

## Backfill strategy

**Option (a): on-demand backfill when admin acts on the signal.** The `/api/admin/entities/[id]/promote` wrapper runs `enrichEntity(..., { mode: 'full' })` after the stage transition. For entities that existed before this PR shipped, clicking Promote enriches them before they move to prospect. No standalone backfill script is committed — cohort is small, admin clicks the button when they engage, the 2-min one-time delay per signal is acceptable. If a bulk backfill becomes necessary, a `scripts/backfill-enrichment.ts` can be added in a follow-on.

## Constraints addressed

- 5-category lead-gen taxonomy (issue #433) is **not** migrated. None of `tests/extraction-prompt.test.ts`, `src/lib/enrichment/review-synthesis.ts`, or `src/lead-gen/prompts/job-qualification-prompt.ts` were touched — confirmed with `git diff --name-only main..HEAD`.
- No `--no-verify`. `npm run verify` green. `npm run typecheck:workers` green across all four workers.
- Old endpoints preserved as thin wrappers — no external callers found in repo grep, but keeping them is cheap and cost-free.

## Test plan

- [ ] Deploy to a staging worker, trigger `/run` on each of the three per-entity workers with test auth, confirm signals come back with at least `intelligence_brief` + `outreach_draft` context entries.
- [ ] Click "Re-enrich (reviews + news)" on an existing prospect, confirm new `review_analysis`, `review_synthesis`, `news_search`, and refreshed `outreach_draft` entries appear; confirm other enrichment sources are NOT re-run.
- [ ] Promote a signal created before this PR: confirm stage transitions + full enrichment backfills in one action.
- [ ] Retry a worker run immediately (simulate dedupe race): confirm `alreadyEnriched: true` short-circuit, no duplicate module calls, no double Claude spend.
- [ ] Confirm ingest latency is unchanged — enrichment runs via `ctx.waitUntil`, not in the request path.

Ruler summary:
- ACs met: single `enrichEntity` entry point, auto-called from each per-entity worker, dossier/promote endpoints delegate, buttons swapped, idempotent, 5-category taxonomy preserved.
- `npm run verify` green (1293 tests pass, including 15 new lock-in tests).
- Scope kept tight — no drive-by fixes outside #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)