### PR TITLE
hotfix: migration 0026 translate 'assessing' inside INSERT SELECT

### DIFF
--- a/migrations/0026_rename_stage_assessing_to_meetings.sql
+++ b/migrations/0026_rename_stage_assessing_to_meetings.sql
@@ -8,30 +8,23 @@
 --
 -- `entities.stage` has a CHECK constraint listing every allowed stage value
 -- (from migration 0008), so swapping the value requires rebuilding the CHECK.
--- SQLite cannot ALTER a CHECK constraint in place — the standard workaround
--- is table-rewrite via PRAGMA legacy_alter_table, which D1 supports.
+-- SQLite cannot ALTER a CHECK constraint in place and there is no PRAGMA to
+-- disable CHECK on a live table, so we do the standard table-rewrite dance:
 --
--- Strategy (no data rewrite, no FK drama):
---   1. Temporarily disable strict legacy CHECK enforcement.
---   2. Update the 'assessing' rows to 'meetings'.
---   3. Rebuild the CHECK by copying into a shadow table with the new clause
---      and swapping names — preserves every column, default, and index.
+--   1. Build a shadow table with the NEW CHECK allow-list.
+--   2. Copy every row, translating 'assessing' → 'meetings' in the SELECT.
+--   3. Drop the old table and rename the shadow.
+--   4. Recreate indexes (they are dropped along with the old table).
 --
--- Rollback: reverse the UPDATE and rebuild the CHECK with 'assessing' back
--- in the allow-list. Data is preserved.
-
--- ---- Phase 1: backfill the data ----
+-- Order matters: the translate-in-SELECT must happen when inserting into the
+-- shadow table, because the ORIGINAL table's CHECK still forbids 'meetings'.
+-- An earlier version of this migration attempted `UPDATE ... SET stage =
+-- 'meetings'` against the old table first; that fails with the pre-rewrite
+-- CHECK constraint. See CI run 24861522944 for the postmortem.
 --
--- Run this BEFORE the CHECK rewrite so we aren't trying to insert 'meetings'
--- into a table whose CHECK still forbids it.
-
--- Turn OFF the check temporarily. D1 honors this just like upstream SQLite.
-PRAGMA defer_foreign_keys = ON;
-
-UPDATE entities SET stage = 'meetings' WHERE stage = 'assessing';
-
-
--- ---- Phase 2: rebuild CHECK with the new allow-list ----
+-- Rollback: same shape — build a shadow with the legacy 'assessing' value,
+-- translate 'meetings' → 'assessing' in the SELECT, swap tables, recreate
+-- indexes. Data is preserved.
 
 CREATE TABLE entities_new (
   id                TEXT PRIMARY KEY,
@@ -77,7 +70,8 @@ INSERT INTO entities_new (
 )
 SELECT
   id, org_id, name, slug, phone, website,
-  stage, stage_changed_at,
+  CASE WHEN stage = 'assessing' THEN 'meetings' ELSE stage END AS stage,
+  stage_changed_at,
   pain_score, vertical, area, employee_count,
   tier, summary,
   next_action, next_action_at,

--- a/tests/meetings.test.ts
+++ b/tests/meetings.test.ts
@@ -187,6 +187,41 @@ describe('migration 0026: rename stage assessing → meetings', () => {
         .run()
     ).rejects.toThrow()
   })
+
+  // Regression for prod deploy 2026-04-23: the original 0026 ran an UPDATE
+  // against the old CHECK before the shadow-table swap, which failed the
+  // constraint. The fix translates 'assessing' → 'meetings' inside the
+  // INSERT SELECT that populates the shadow table. Simulate the pre-rename
+  // state by bypassing the migration runner, then run 0026 directly and
+  // verify the data survives.
+  it('translates existing assessing rows to meetings without violating CHECK', async () => {
+    const isolated = createTestD1()
+    const files = discoverNumericMigrations(migrationsDir)
+    const basename = (f: { name?: string } | string) =>
+      typeof f === 'string' ? (f.split('/').pop() ?? f) : (f.name ?? '')
+    // Run every migration EXCEPT 0026.
+    const pre = files.filter((f) => !basename(f).startsWith('0026_'))
+    await runMigrations(isolated, { files: pre })
+    await seedOrg(isolated)
+
+    // Insert a row with the legacy stage, which was valid pre-0026.
+    await isolated
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+         VALUES ('e-preexisting', ?, 'PreExisting', 'pre', 'assessing', datetime('now'), datetime('now'), datetime('now'))`
+      )
+      .bind(ORG_ID)
+      .run()
+
+    // Now run 0026 on a DB that already contains 'assessing' data.
+    const only0026 = files.filter((f) => basename(f).startsWith('0026_'))
+    await runMigrations(isolated, { files: only0026 })
+
+    const row = await isolated
+      .prepare(`SELECT stage FROM entities WHERE id = 'e-preexisting'`)
+      .first<{ stage: string }>()
+    expect(row?.stage).toBe('meetings')
+  })
 })
 
 describe('meetings DAL', () => {


### PR DESCRIPTION
## Incident

CI deploy run 24861302143 → 24861522944 for #511 integration merge succeeded on migration 0025 (meetings table) but FAILED on 0026. Prod rolled back cleanly.

## Root cause

Original 0026 ran `UPDATE entities SET stage = 'meetings' WHERE stage = 'assessing'` BEFORE rebuilding the CHECK constraint. The old CHECK still forbade 'meetings', so the UPDATE tripped SQLITE_CONSTRAINT_CHECK.

The comment in the original migration claimed `PRAGMA defer_foreign_keys = ON` would defer the check. That PRAGMA only defers foreign keys, not CHECK constraints. Misleading.

Local passed because local D1 had no 'assessing' rows, so the broken UPDATE was a no-op and the migration proceeded.

## Fix

Move the value translation inside the INSERT SELECT that populates the shadow table:

    CASE WHEN stage = 'assessing' THEN 'meetings' ELSE stage END AS stage

The shadow table has the new CHECK allow-list from the start, so 'meetings' is legal there. No PRAGMA needed, no pre-swap UPDATE.

## State

- Prod D1: migration 0025 applied, 0026 rolled back (not in migration ledger)
- Prod Worker: still on pre-integration code
- Local D1: 0026 applied (silent no-op — no legacy rows)

## Post-merge expected sequence

1. Deploy workflow applies 0026 with the fixed SQL → prod D1 complete
2. Deploy workflow runs `wrangler deploy` → Worker code catches up to main

## Regression test

Added `tests/meetings.test.ts > translates existing assessing rows to meetings without violating CHECK` — pre-seeds an 'assessing' row against migrations 0001–0025, then runs 0026 and asserts the row survives with stage='meetings'. Locks the fix.

## Test plan
- [x] `npm run verify` local: green
- [ ] CI deploy workflow re-runs against prod D1
- [ ] Worker deploy completes and main is current

🤖 Generated with [Claude Code](https://claude.com/claude-code)