### PR TITLE
hotfix: migration 0026 defer FK checks for DROP TABLE entities

### DIFF
--- a/.playwright-mcp/console-2026-04-23T22-20-15-110Z.log
+++ b/.playwright-mcp/console-2026-04-23T22-20-15-110Z.log
@@ -1,0 +1,3 @@
+[    3082ms] [INFO] %cDownload the React DevTools for a better development experience: https://reactjs.org/link/react-devtools font-weight:bold @ https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js:29904
+[    3262ms] [WARNING] You are using the in-browser Babel transformer. Be sure to precompile your scripts for production - https://babeljs.io/docs/setup/ @ https://unpkg.com/@babel/standalone@7.29.0/babel.min.js:2
+[    3915ms] [ERROR] Failed to load resource: the server responded with a status of 404 () @ https://09b5a8c7-5c15-4c84-af3f-76d8dac6fe8e.claudeusercontent.com/v1/design/projects/09b5a8c7-5c15-4c84-af3f-76d8dac6fe8e/serve/ui_kits/comparison/.design-canvas.state.json:0

--- a/migrations/0026_rename_stage_assessing_to_meetings.sql
+++ b/migrations/0026_rename_stage_assessing_to_meetings.sql
@@ -25,6 +25,19 @@
 -- Rollback: same shape — build a shadow with the legacy 'assessing' value,
 -- translate 'meetings' → 'assessing' in the SELECT, swap tables, recreate
 -- indexes. Data is preserved.
+--
+-- Foreign-key deferral:
+-- Other tables (contacts, meetings, assessments, engagements, quotes, invoices,
+-- context entries, stage_changes, ...) hold foreign keys to entities(id).
+-- DROP TABLE entities would trip SQLITE_CONSTRAINT_FOREIGNKEY mid-transaction
+-- even though every referenced id is preserved by the shadow-copy. PRAGMA
+-- defer_foreign_keys = ON defers those checks to commit time; by commit, the
+-- shadow has been renamed to `entities` with identical ids, so every FK
+-- resolves. Unlike PRAGMA foreign_keys = OFF (which cannot toggle inside a
+-- transaction), defer_foreign_keys is transaction-scoped and valid inside
+-- D1's migrate-apply transaction. See deploy run 24861817054 postmortem.
+
+PRAGMA defer_foreign_keys = ON;
 
 CREATE TABLE entities_new (
   id                TEXT PRIMARY KEY,

--- a/tests/meetings.test.ts
+++ b/tests/meetings.test.ts
@@ -194,7 +194,7 @@ describe('migration 0026: rename stage assessing → meetings', () => {
   // INSERT SELECT that populates the shadow table. Simulate the pre-rename
   // state by bypassing the migration runner, then run 0026 directly and
   // verify the data survives.
-  it('translates existing assessing rows to meetings without violating CHECK', async () => {
+  it('translates existing assessing rows to meetings and preserves FKs', async () => {
     const isolated = createTestD1()
     const files = discoverNumericMigrations(migrationsDir)
     const basename = (f: { name?: string } | string) =>
@@ -213,7 +213,21 @@ describe('migration 0026: rename stage assessing → meetings', () => {
       .bind(ORG_ID)
       .run()
 
-    // Now run 0026 on a DB that already contains 'assessing' data.
+    // Insert an FK-dependent row so the DROP TABLE path exercises the FK
+    // deferral pragma. Regression for deploy run 24861817054: without
+    // PRAGMA defer_foreign_keys = ON the DROP tripped SQLITE_CONSTRAINT_FOREIGNKEY.
+    // meetings.entity_id is an ordinary column (no explicit FK constraint) so
+    // for a stronger test we use assessments.entity_id which was the populated
+    // shape in prod at the time of the failure.
+    await isolated
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, status, created_at)
+         VALUES ('a-dep', ?, 'e-preexisting', 'scheduled', datetime('now'))`
+      )
+      .bind(ORG_ID)
+      .run()
+
+    // Now run 0026 on a DB that already contains 'assessing' data AND FK-dependent rows.
     const only0026 = files.filter((f) => basename(f).startsWith('0026_'))
     await runMigrations(isolated, { files: only0026 })
 
@@ -221,6 +235,12 @@ describe('migration 0026: rename stage assessing → meetings', () => {
       .prepare(`SELECT stage FROM entities WHERE id = 'e-preexisting'`)
       .first<{ stage: string }>()
     expect(row?.stage).toBe('meetings')
+
+    // The FK-dependent row still resolves — the entity id survived the shadow swap.
+    const assessment = await isolated
+      .prepare(`SELECT entity_id FROM assessments WHERE id = 'a-dep'`)
+      .first<{ entity_id: string }>()
+    expect(assessment?.entity_id).toBe('e-preexisting')
   })
 })
 


### PR DESCRIPTION
## Incident (continued)

Second deploy attempt (run 24861817054) for migration 0026 hit a different error than the first — SQLITE_CONSTRAINT_FOREIGNKEY instead of CHECK.

## Root cause

Other tables (assessments, meetings, quotes, engagements, invoices, etc.) hold foreign keys pointing to entities(id). The shadow-table swap in 0026 drops the old entities table; mid-transaction that trips SQLITE_CONSTRAINT_FOREIGNKEY even though every FK-referenced id is restored the moment the shadow is renamed.

## Fix

Add `PRAGMA defer_foreign_keys = ON` at the start of the migration. Unlike `PRAGMA foreign_keys`, which cannot be toggled inside a transaction, `defer_foreign_keys` is transaction-scoped and defers FK checks to commit time. By commit, the shadow has been renamed to entities with the same row ids, and every FK resolves.

## State

- Prod D1: 0025 applied, 0026 still not applied (rolled back a second time)
- Prod Worker: still on pre-integration code
- Local: 0026 was applied silently (no FK-dependent rows in that transaction)

## Regression test (strengthened)

The previous PR added a test for the CHECK translation. This PR adds an FK-dependent row (`assessments.entity_id → entities.id`) before running 0026. Without the pragma, the test would fail the same way prod did.

## Test plan
- [x] `npm run verify` local: green
- [x] `tests/meetings.test.ts > translates existing assessing rows to meetings and preserves FKs` exercises both failure modes
- [ ] CI deploy workflow applies 0026 successfully
- [ ] Worker deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)