### PR TITLE
hotfix: migration 0026 use PRAGMA foreign_keys=off (D1 docs pattern)

### DIFF
--- a/migrations/0026_rename_stage_assessing_to_meetings.sql
+++ b/migrations/0026_rename_stage_assessing_to_meetings.sql
@@ -26,18 +26,24 @@
 -- translate 'meetings' → 'assessing' in the SELECT, swap tables, recreate
 -- indexes. Data is preserved.
 --
--- Foreign-key deferral:
+-- Foreign-key handling:
 -- Other tables (contacts, meetings, assessments, engagements, quotes, invoices,
 -- context entries, stage_changes, ...) hold foreign keys to entities(id).
 -- DROP TABLE entities would trip SQLITE_CONSTRAINT_FOREIGNKEY mid-transaction
--- even though every referenced id is preserved by the shadow-copy. PRAGMA
--- defer_foreign_keys = ON defers those checks to commit time; by commit, the
--- shadow has been renamed to `entities` with identical ids, so every FK
--- resolves. Unlike PRAGMA foreign_keys = OFF (which cannot toggle inside a
--- transaction), defer_foreign_keys is transaction-scoped and valid inside
--- D1's migrate-apply transaction. See deploy run 24861817054 postmortem.
+-- even though every referenced id is preserved by the shadow-copy.
+--
+-- D1 supports `PRAGMA foreign_keys=off` inside a migration transaction — see
+-- Cloudflare's D1 docs "Disable Foreign Keys and Drop Tables" example which
+-- uses exactly this pattern for table drops. Stock upstream SQLite forbids
+-- toggling foreign_keys inside a transaction, but D1 allows it for the
+-- duration of a single migration-apply run. We previously tried
+-- `PRAGMA defer_foreign_keys = ON` here; it returned a D1 engine-side
+-- internal error on remote (deploy run 24862074143), while foreign_keys=off
+-- is the docs-sanctioned path for this exact scenario. See that run's
+-- postmortem. FK enforcement restores automatically when the transaction
+-- commits — no need to toggle back on.
 
-PRAGMA defer_foreign_keys = ON;
+PRAGMA foreign_keys=off;
 
 CREATE TABLE entities_new (
   id                TEXT PRIMARY KEY,


### PR DESCRIPTION
## Third attempt — switching to D1's sanctioned pattern

Previous two hotfix attempts (PR #512, #513) fixed real bugs but the remote D1 run returns `internal error; reference=e_cxGqYy_...` reproducibly when the migration includes `PRAGMA defer_foreign_keys = ON`. Not transient (retry produced the same error with a different reference ID).

Per Cloudflare's D1 docs (\"Disable Foreign Keys and Drop Tables in D1 SQL\"), the docs-sanctioned pattern for migrations that drop and rebuild a table with FK dependents is:

    PRAGMA foreign_keys=off;
    DROP TABLE ...;

Upstream SQLite forbids toggling `foreign_keys` inside a transaction; D1 special-cases it for migrate-apply. I switched from `defer_foreign_keys` to `foreign_keys=off` to match the docs.

If this still fails, I'll stop iterating and revert the integration merge to restore the prod baseline, then investigate against a copy of prod D1 offline.

## Test plan
- [x] `npm run verify` local: green (14 tests in tests/meetings.test.ts, including the FK regression)
- [ ] CI deploy applies 0026 against prod D1
- [ ] Worker deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)