### PR TITLE
feat(design): DF migration PR 1 — token + font skin

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -26,7 +26,7 @@ const ogImageUrl = new URL('/og-image.png', 'https://smd.services')
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,35 +2,38 @@
 
 @theme {
   /* ------------------------------------------------------------------
-   * SMD Services — Modern Institutional identity
-   * Cut over from .design/theme.css on 2026-04-19.
+   * SMD Services — Desert Functional identity
+   * Migrated from Modern Institutional on 2026-04-23 (issue #516 PR 1).
    * Full token documentation: .design/DESIGN.md
    * ------------------------------------------------------------------ */
 
   /* ---------- Color roles ---------- */
-  --color-background: #f9f7f1;
-  --color-surface: #ffffff;
-  --color-surface-inverse: #2a2520; /* warm umber, softer than graphite for dark-section backgrounds */
-  --color-border: #d8d4c8;
-  --color-border-subtle: #ece8dd;
+  --color-background: #ede6d6; /* warm sand */
+  --color-surface: #f6f1e4; /* soft cream card */
+  --color-surface-inverse: #22201c; /* umber, slightly warmer than MI graphite */
+  --color-border: rgba(34, 32, 28, 0.14);
+  --color-border-subtle: rgba(34, 32, 28, 0.08);
 
-  --color-text-primary: #1a1a1a;
-  --color-text-secondary: #52514c;
-  --color-text-muted: #8e8c85;
+  --color-text-primary: #22201c;
+  --color-text-secondary: #5c564d;
+  --color-text-muted: #928a7c;
 
-  --color-meta: #52514c;
+  --color-meta: #5c564d;
 
-  --color-primary: #2c5282;
-  --color-primary-hover: #1f3a62;
-  --color-action: #2c5282;
-  --color-attention: #2c5282;
-  --color-complete: #2f6e42;
+  --color-primary: #b8852a; /* ochre */
+  --color-primary-hover: #96701f;
+  --color-action: #b8852a;
+  --color-attention: #b8852a;
+  --color-complete: #6a7a68; /* sage */
   --color-error: #a02a2a;
 
+  --color-status-sage: #6a7a68;
+
   /* ---------- Typography families ---------- */
-  --font-display: 'Crimson Pro', Georgia, 'Times New Roman', serif;
-  --font-body: 'Public Sans', system-ui, sans-serif;
-  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+  --font-display: 'Inter', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, sans-serif;
+  --font-accent-serif: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* ---------- Typography scale ---------- */
   --text-display: 3rem; /* 48px */


### PR DESCRIPTION
## Summary

PR 1 of the Desert Functional migration (#516). **Token values and font loading only** — nothing else. Component internals, composition patterns, and page copy are untouched. This is the fastest empirical test of whether the DF palette + type holds up against the existing site's content and layouts before investing in PR 2's shared-component work.

### What changed

- `src/styles/global.css` — every `--color-*` value mapped MI → DF per the issue swap table. New `--color-status-sage` (#6A7A68) added. New `--font-accent-serif` (Instrument Serif) added. `--font-display` and `--font-body` are now Inter. IBM Plex Mono dropped from font loading; `--font-mono` falls back to system mono stack (no live code referenced Plex Mono outside the global token).
- `src/layouts/Base.astro` — Google Fonts link swapped from Crimson Pro + Public Sans + IBM Plex Mono to Inter + Instrument Serif, per the issue's exact query string.

### Scope discipline

- **Zero files under `src/pages/**` touched.** AdminLayout, portal pages, auth login pages, and design-preview files retained their existing font contracts — out of scope for this issue.
- **No prototype copy carried over** from PR #510's DF preview. The "Claude Partner Network Services applicant", "Single operator, not an agency", "$6,500 / $9,500 / From $12,000", "within one business day", and 2025 count claims remain isolated in the preview file.
- Derived token choices for names not in the issue's table: `--color-border-subtle` → lighter hairline `rgba(34,32,28,0.08)`; `--color-meta` → text-secondary DF value; `--color-action`/`--color-attention` → DF ochre; `--color-complete` → DF sage; `--color-error` → kept MI red (distinguishable error signal must stay).

### Verify

`npm run verify` green: typecheck, typecheck:workers, format:check, lint (0 errors, 11 pre-existing warnings), build, test (1278 passed, 2 skipped). Forbidden-strings regression test stays green.

## Test plan

- [ ] Preview deploy loads without visual regressions on `/`, `/contact`, `/get-started`, `/book`, `/ai`, `/patterns`, `/scorecard`
- [ ] Typography renders as Inter (body + display) with Instrument Serif available for any component that opts into `--font-accent-serif` in PR 2
- [ ] Palette reads warm-sand / cream / umber / ochre — no navy, no cold gray artifacts
- [ ] Before/after screenshot pair attached (MI live vs. DF live) for visual diff review

## Next

If PR 1 looks right on the live content, proceed to PR 2 — shared-component composition updates (`Hero`, `ProblemCards`, `HowItWorks`, `Pricing`, `Nav`, `Footer`).

## References

- Issue: #516
- Reference preview (source-of-truth spec, copy is NOT authoritative): PR #510, branch `feat/claude-design-handoff-r1`, file `src/pages/design-preview/desert-functional/index.astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)