### PR TITLE
fix(promote): run enrichment in waitUntil to avoid Error 1101

### DIFF
--- a/src/pages/api/admin/entities/[id]/promote.ts
+++ b/src/pages/api/admin/entities/[id]/promote.ts
@@ -14,7 +14,9 @@ import { env } from 'cloudflare:workers'
  * lead-gen workers), so on the typical signal this endpoint finds the entity
  * already fully enriched and `enrichEntity` returns `alreadyEnriched: true`
  * without re-billing Claude. For entities that arrived before the at-ingest
- * refactor shipped, the call does an on-demand backfill.
+ * refactor shipped, the call does an on-demand backfill — but it runs under
+ * ctx.waitUntil so a 12-module pipeline doesn't blow past Worker CPU /
+ * subrequest limits and crash the redirect (Error 1101 on admin click).
  */
 export const POST: APIRoute = async ({ params, locals, redirect }) => {
   const session = locals.session
@@ -40,9 +42,19 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
       return redirect('/admin/entities?error=not_found', 302)
     }
 
-    // Backfill enrichment if this signal predates the at-ingest refactor.
-    // No-op when an intelligence_brief already exists.
-    await enrichEntity(env, session.orgId, entityId, { mode: 'full' })
+    // Enrichment backfill runs in the background. On the typical path the
+    // entity was already enriched at ingest so this resolves immediately via
+    // the alreadyEnriched short-circuit. On backfill it can hit 10+ external
+    // APIs and multiple Claude calls — awaiting that from the request path
+    // blew past Worker limits (Error 1101) on ~50% of promotes.
+    const enrichPromise = enrichEntity(env, session.orgId, entityId, { mode: 'full' }).catch(
+      (err) => {
+        console.error('[promote] Background enrichment failed:', err)
+      }
+    )
+    if (locals.cfContext?.waitUntil) {
+      locals.cfContext.waitUntil(enrichPromise)
+    }
 
     try {
       await scheduleProspectCadence(env.DB, session.orgId, entityId, new Date().toISOString())


### PR DESCRIPTION
## Summary

- Promote endpoint was awaiting the 12-module enrichment pipeline inline. On backfill (entities without a prior `intelligence_brief`), the Worker exceeds CPU / subrequest limits mid-run: the DB writes land (entity moves to `prospect`, ~half of enrichments record) but the Worker dies before the redirect response — admin sees `Error 1101: Worker threw exception`.
- Reproduced 2026-04-24 00:01 UTC on Goodman's Landscape (Ray ID `9f10d3eb19592ff6`); entity ended up stuck at prospect with 5 of 12 enrichment modules recorded. Qualtire Plumbing squeaked through on the same build because its pipeline finished in 47 s.
- Fix: fire-and-forget via `ctx.waitUntil`. The `alreadyEnriched` idempotency guard (short-circuits when `intelligence_brief` exists) means the typical already-enriched-at-ingest path still resolves in ~0 ms. Backfill still runs to completion in the background; the redirect is instant.
- `src/lib/enrichment/index.ts:93` already documented the rule: "Callers should not await this from a hot request path: workers use `ctx.waitUntil(enrichEntity(...))` so ingest does not block on Claude." The promote endpoint was the only request-path violator.

## Test plan

- [x] `astro check` — 0 errors
- [x] `vitest run tests/enrichment-pipeline.test.ts` — 15 passed
- [ ] Post-deploy: promote a not-pre-enriched signal in admin, confirm instant redirect to entity page + enrichments fill in over the next ~30 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)