### PR TITLE
fix(design): mobile Nav/Footer — button wrap + footer clip

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -21,7 +21,7 @@
         &copy; 2026 SMDurgan, LLC. Phoenix, Arizona.
       </p>
     </div>
-    <nav class="flex items-center gap-8">
+    <nav class="flex flex-wrap items-center gap-x-6 gap-y-4 sm:gap-x-8">
       <a
         class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)] hover:text-white"
         href="/ai">AI</a
@@ -31,7 +31,7 @@
         href="/contact">Contact</a
       >
       <a
-        class="inline-flex items-center border-[3px] border-white bg-[color:var(--color-primary)] px-5 py-2 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
+        class="inline-flex items-center whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] px-4 sm:px-5 py-2 font-['Archivo'] text-xs sm:text-sm font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
         href="/book">Book a Call</a
       >
     </nav>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -2,10 +2,10 @@
   role="banner"
   class="sticky top-0 z-50 h-14 md:h-16 border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
 >
-  <div class="mx-auto flex h-full w-full max-w-5xl items-center justify-between px-4 md:px-6">
+  <div class="mx-auto flex h-full w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6">
     <a
       href="/"
-      class="inline-flex items-baseline gap-2 font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+      class="inline-flex items-baseline gap-2 font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
     >
       <span
         class="inline-block bg-[color:var(--color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
@@ -13,19 +13,19 @@
       >
       <span>Services</span>
     </a>
-    <div class="flex items-center gap-6">
+    <div class="flex items-center gap-3 md:gap-6">
       <a
-        class="inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+        class="hidden sm:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
         href="/ai"
         data-ev="nav-ai">AI</a
       >
       <a
-        class="inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+        class="hidden sm:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
         href="/contact"
         data-ev="nav-contact">Contact</a
       >
       <a
-        class="inline-flex items-center min-h-11 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] active:bg-[color:var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-sm transition-colors"
+        class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] active:bg-[color:var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
         href="/book"
         data-ev="nav-book">Book a Call</a
       >


### PR DESCRIPTION
## Summary

Two responsive layout bugs spotted on iPhone-width viewports after PS iteration deploy:

1. **Nav header**: \`BOOK A CALL\` button wraps vertically as B/O/O/K because the uppercase-tracked text has no room alongside AI + CONTACT text links.
2. **Footer nav**: the button row overflows and the \`Book a Call\` button clips the right edge of the viewport.

## Fixes

**Nav.astro**
- Brand text scales: \`text-base\` mobile / \`text-lg\` md+
- AI + Contact text links hidden on \`<sm\` (still present in footer for reachability)
- Book a Call button: \`whitespace-nowrap\`, \`px-3 md:px-5\`, \`text-xs md:text-sm\`
- Container \`gap-3\` on mobile, \`gap-6\` on md+

**Footer.astro**
- Link group uses \`flex-wrap gap-x-6 gap-y-4\` so the button drops to a new row cleanly instead of clipping
- Button: \`whitespace-nowrap\`, \`px-4 sm:px-5\`, \`text-xs sm:text-sm\`

## Scope

- No copy changes
- No new components
- No new destinations (AI + Contact hiding on mobile is a visibility change only — links still exist in footer)

## Verify

\`npm run verify\` green: typecheck, typecheck:workers, format:check, lint, build, test (1444 passed).

## Test plan

- [ ] iPhone-width (~375px): Nav shows brand + Book a Call only, button renders inline
- [ ] Tablet+ (md+): AI + Contact visible again, same as before
- [ ] Footer: button never clips right edge at any breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)