### PR TITLE
fix(design): proper mobile treatment for Nav, Hero, Footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,9 +1,15 @@
+---
+const navLinks = [
+  { href: '/ai', label: 'AI' },
+  { href: '/contact', label: 'Contact' },
+]
+---
+
 <footer
-  class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)] py-14 text-white"
+  class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)] py-12 sm:py-14 text-white"
 >
-  <div
-    class="mx-auto flex w-full max-w-5xl flex-col items-start justify-between gap-8 px-6 md:flex-row md:items-center"
-  >
+  <div class="mx-auto w-full max-w-5xl px-6 md:flex md:items-center md:justify-between md:gap-8">
+    <!-- Brand block -->
     <div>
       <a
         href="/"
@@ -21,17 +27,28 @@
         &copy; 2026 SMDurgan, LLC. Phoenix, Arizona.
       </p>
     </div>
-    <nav class="flex flex-wrap items-center gap-x-6 gap-y-4 sm:gap-x-8">
-      <a
-        class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)] hover:text-white"
-        href="/ai">AI</a
+
+    <!-- Mobile: stacked nav with hairline dividers, then full-width CTA.
+         Desktop (md+): inline links + CTA right-aligned. -->
+    <nav aria-label="Footer primary" class="mt-10 md:mt-0 md:flex md:items-center md:gap-8">
+      <ul
+        class="flex flex-col divide-y divide-[color:rgba(245,240,227,0.14)] border-y border-[color:rgba(245,240,227,0.14)] md:flex-row md:divide-y-0 md:border-0 md:gap-8"
       >
+        {
+          navLinks.map((item) => (
+            <li>
+              <a
+                class="flex items-center min-h-12 py-3 md:py-0 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)] hover:text-white"
+                href={item.href}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
       <a
-        class="font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)] hover:text-white"
-        href="/contact">Contact</a
-      >
-      <a
-        class="inline-flex items-center whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] px-4 sm:px-5 py-2 font-['Archivo'] text-xs sm:text-sm font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
+        class="mt-6 md:mt-0 inline-flex items-center justify-center w-full md:w-auto whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] px-5 py-3 md:py-2 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
         href="/book">Book a Call</a
       >
     </nav>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,28 +2,34 @@
 import CtaButton from './CtaButton.astro'
 ---
 
-<section class="relative overflow-hidden px-6 pb-32 pt-24 bg-[color:var(--color-background)]">
+<section
+  class="relative overflow-hidden px-6 pb-24 pt-16 sm:pb-32 sm:pt-24 bg-[color:var(--color-background)]"
+>
   <div class="mx-auto max-w-5xl text-center">
     <h1
-      class="mb-10 font-['Archivo'] text-5xl font-black uppercase leading-[0.92] tracking-[-0.025em] text-[color:var(--color-text-primary)] md:text-[7rem]"
+      class="mb-8 sm:mb-10 font-['Archivo'] font-black uppercase leading-[0.95] sm:leading-[0.92] tracking-[-0.025em] text-[color:var(--color-text-primary)] text-[clamp(2.5rem,11vw,7rem)]"
     >
       Your Business Has Outgrown How You <span class="text-[color:var(--color-primary)]"
         >Run It.</span
       >
     </h1>
     <p
-      class="mx-auto mb-12 max-w-2xl font-['Archivo'] text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+      class="mx-auto mb-10 sm:mb-12 max-w-2xl font-['Archivo'] text-lg sm:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
     >
       You know where you want to go. We help you figure out what needs to change and build it with
       you.
     </p>
-    <div class="flex flex-col sm:flex-row items-center justify-center gap-0">
-      <CtaButton href="/book" data-ev="home-primary-cta">Book a Call</CtaButton>
+    <div
+      class="mx-auto flex flex-col sm:flex-row sm:inline-flex max-w-sm sm:max-w-none items-stretch sm:items-center justify-center"
+    >
+      <CtaButton href="/book" data-ev="home-primary-cta" class="w-full sm:w-auto">
+        Book a Call
+      </CtaButton>
       <CtaButton
         variant="secondary"
         href="/get-started"
         data-ev="home-secondary-cta"
-        class="sm:border-l-0"
+        class="w-full sm:w-auto border-t-0 sm:border-t-[3px] sm:border-l-0"
       >
         Tell us about your business
       </CtaButton>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,8 +1,17 @@
+---
+const navLinks = [
+  { href: '/ai', label: 'AI' },
+  { href: '/contact', label: 'Contact' },
+]
+---
+
 <header
   role="banner"
-  class="sticky top-0 z-50 h-14 md:h-16 border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+  class="sticky top-0 z-50 border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
 >
-  <div class="mx-auto flex h-full w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6">
+  <div
+    class="mx-auto flex h-14 md:h-16 w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6"
+  >
     <a
       href="/"
       class="inline-flex items-baseline gap-2 font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
@@ -13,22 +22,86 @@
       >
       <span>Services</span>
     </a>
+
     <div class="flex items-center gap-3 md:gap-6">
-      <a
-        class="hidden sm:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-        href="/ai"
-        data-ev="nav-ai">AI</a
-      >
-      <a
-        class="hidden sm:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
-        href="/contact"
-        data-ev="nav-contact">Contact</a
-      >
+      {
+        navLinks.map((item) => (
+          <a
+            class="hidden md:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            href={item.href}
+            data-ev={`nav-${item.label.toLowerCase()}`}
+          >
+            {item.label}
+          </a>
+        ))
+      }
       <a
         class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] active:bg-[color:var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
         href="/book"
         data-ev="nav-book">Book a Call</a
       >
+      <details class="nav-disclosure md:hidden relative">
+        <summary
+          aria-label="Toggle menu"
+          class="list-none inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 select-none"
+        >
+          <span class="nav-disclosure-label-closed">Menu</span>
+          <span class="nav-disclosure-label-open">Close</span>
+        </summary>
+      </details>
     </div>
   </div>
+
+  <!-- Mobile disclosure panel: absolute under the bar, only shown when <details> above is open.
+       We use a sibling-state CSS hook via :has() so the panel is a separate block below the bar. -->
+  <div class="nav-mobile-panel md:hidden">
+    <nav
+      aria-label="Mobile primary"
+      class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)]"
+    >
+      <ul class="flex flex-col divide-y-2 divide-[color:rgba(245,240,227,0.14)]">
+        {
+          navLinks.map((item, i) => (
+            <li>
+              <a
+                href={item.href}
+                class="flex items-baseline gap-4 px-5 py-5 min-h-[56px] font-['Archivo'] text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-background)] hover:bg-[color:rgba(245,240,227,0.06)]"
+                data-ev={`nav-mobile-${item.label.toLowerCase()}`}
+              >
+                <span class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.12em] text-[color:var(--color-primary)] min-w-[2.5rem]">
+                  § 0{i + 1}
+                </span>
+                <span>{item.label}</span>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+  </div>
 </header>
+
+<style>
+  .nav-disclosure > summary::-webkit-details-marker {
+    display: none;
+  }
+  .nav-disclosure > summary::marker {
+    content: '';
+  }
+  .nav-disclosure-label-open {
+    display: none;
+  }
+  .nav-disclosure[open] .nav-disclosure-label-closed {
+    display: none;
+  }
+  .nav-disclosure[open] .nav-disclosure-label-open {
+    display: inline;
+  }
+
+  .nav-mobile-panel {
+    display: none;
+  }
+  header:has(.nav-disclosure[open]) .nav-mobile-panel {
+    display: block;
+  }
+</style>


### PR DESCRIPTION
## Summary

PR #523 was a patch that hid menu items and flex-wrapped the footer. This PR is a proper design pass on mobile.

## Nav — WAI-ARIA disclosure pattern

**Mobile**: Brand block + Menu/Close toggle + Book a Call, all visible at 375px viewport. The toggle is a native \`<details>/<summary>\` element with 3px ink border. When open, a full-width ink drawer below the bar reveals AI and Contact as 56px-tall rows with burnt-orange \`§01\` / \`§02\` anchors and Archivo Black 24px link text. Sibling-state CSS via \`:has()\` — no JS framework, no hydration overhead. Keyboard + screen-reader accessible.

**Desktop (md+)**: unchanged. AI + Contact visible inline, disclosure hidden.

## Hero — fluid type + equal-width stacked CTAs

- **Display**: \`text-[clamp(2.5rem,11vw,7rem)]\` replaces the hardcoded \`text-5xl md:text-[7rem]\` step. Math: Archivo Black uppercase \"OUTGROWN\" (8 chars × ~0.6em per char) needs ≤68px to fit in a 327px mobile content width. Clamp gives 40–44px at phone widths — no more 5-line wrap.
- **Leading**: 0.95 on mobile (tighter descenders at small size), 0.92 on sm+.
- **CTAs**: \`max-w-sm\` container on mobile so both buttons are equal width when stacked; side-by-side at sm+. Border seam handled correctly — secondary gets \`border-t-0\` on mobile (single 3px rule between stacked buttons), \`border-l-0\` on sm+ (single 3px rule between inline buttons). No double-stacked borders.

## Footer — clean mobile stack

- Brand + copyright on top.
- Nav links: proper \`<ul>\` with \`divide-y\` hairlines + \`border-y\` on mobile, inline on md+. Each link is a 48px-min tap target.
- Book a Call: full-width on mobile, auto-width inline on md+.
- Replaces PR #523's \`gap-y-4\` wrapping orphans.

## Scope

- No content changes
- No new pages or CTAs
- Pure mobile composition work
- WAI-ARIA compliance: disclosure pattern uses \`<details>/<summary>\` native semantics

## Verify

\`npm run verify\` green: typecheck, typecheck:workers, format:check, lint, build, test (1444 passed, 2 skipped).

## Test plan

- [ ] iPhone 375px: hero fits on 3 lines max; CTAs stack equal-width; Menu toggle reveals drawer
- [ ] Tablet 768px+: desktop layout unchanged
- [ ] Keyboard-only: Tab reaches Menu toggle, Enter opens, Tab goes into drawer links
- [ ] Screen reader: \`<details>\` announces 'collapsed/expanded'

🤖 Generated with [Claude Code](https://claude.com/claude-code)