### PR TITLE
fix(design): true overlay mobile menu + 3-region footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,39 +6,40 @@ const navLinks = [
 ---
 
 <footer
-  class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)] py-12 sm:py-14 text-white"
+  class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)] text-white"
 >
-  <div class="mx-auto w-full max-w-5xl px-6 md:flex md:items-center md:justify-between md:gap-8">
-    <!-- Brand block -->
-    <div>
+  <div class="mx-auto w-full max-w-5xl px-6">
+    <!-- Region 1: Masthead — brand block. Present today; future: can grow a
+         tagline, brand statement, or secondary mark. -->
+    <div class="py-12 md:py-14">
       <a
         href="/"
-        class="inline-flex items-baseline gap-2 font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-white"
+        class="inline-flex items-baseline gap-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-white"
       >
         <span
-          class="inline-block bg-[color:var(--color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
+          class="inline-block bg-[color:var(--color-primary)] text-white px-2.5 py-1 font-black tracking-[-0.01em]"
           >SMD</span
         >
         <span>Services</span>
       </a>
-      <p
-        class="mt-3 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]"
-      >
-        &copy; 2026 SMDurgan, LLC. Phoenix, Arizona.
-      </p>
     </div>
 
-    <!-- Mobile: stacked nav with hairline dividers, then full-width CTA.
-         Desktop (md+): inline links + CTA right-aligned. -->
-    <nav aria-label="Footer primary" class="mt-10 md:mt-0 md:flex md:items-center md:gap-8">
-      <ul
-        class="flex flex-col divide-y divide-[color:rgba(245,240,227,0.14)] border-y border-[color:rgba(245,240,227,0.14)] md:flex-row md:divide-y-0 md:border-0 md:gap-8"
-      >
+    <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
+
+    <!-- Region 2: Sitemap. Architected as a grid with room for future nav
+         categories (Legal, Resources, Social, etc.). Today renders the one
+         existing Primary column + the Book a Call CTA aligned to the end.
+         Additional columns slot into the grid without a redesign. -->
+    <nav
+      aria-label="Footer primary"
+      class="py-10 md:py-14 grid grid-cols-1 gap-y-10 md:grid-cols-[1fr_auto] md:gap-x-12 md:items-start"
+    >
+      <ul class="flex flex-col gap-4">
         {
           navLinks.map((item) => (
             <li>
               <a
-                class="flex items-center min-h-12 py-3 md:py-0 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)] hover:text-white"
+                class="inline-flex items-center min-h-11 font-['Archivo'] text-base font-semibold uppercase tracking-[0.04em] text-white hover:text-[color:var(--color-primary)]"
                 href={item.href}
               >
                 {item.label}
@@ -48,9 +49,20 @@ const navLinks = [
         }
       </ul>
       <a
-        class="mt-6 md:mt-0 inline-flex items-center justify-center w-full md:w-auto whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] px-5 py-3 md:py-2 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
+        class="inline-flex items-center justify-center w-full md:w-auto whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] px-6 py-3 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-white transition-colors"
         href="/book">Book a Call</a
       >
     </nav>
+
+    <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
+
+    <!-- Region 3: Colophon — split left/right. Today: legal + location.
+         Future: can host social icons, privacy/terms links, or sister marks. -->
+    <div
+      class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]"
+    >
+      <span>&copy; 2026 SMDurgan, LLC</span>
+      <span>Phoenix, Arizona</span>
+    </div>
   </div>
 </footer>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -7,7 +7,7 @@ const navLinks = [
 
 <header
   role="banner"
-  class="sticky top-0 z-50 border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+  class="sticky top-0 z-40 border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
 >
   <div
     class="mx-auto flex h-14 md:h-16 w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6"
@@ -40,32 +40,64 @@ const navLinks = [
         href="/book"
         data-ev="nav-book">Book a Call</a
       >
-      <details class="nav-disclosure md:hidden relative">
-        <summary
-          aria-label="Toggle menu"
-          class="list-none inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 select-none"
-        >
-          <span class="nav-disclosure-label-closed">Menu</span>
-          <span class="nav-disclosure-label-open">Close</span>
-        </summary>
-      </details>
+      <button
+        type="button"
+        aria-label="Open menu"
+        aria-controls="mobile-menu-dialog"
+        aria-haspopup="dialog"
+        data-nav-open
+        class="md:hidden inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 select-none transition-colors"
+      >
+        Menu
+      </button>
     </div>
   </div>
+</header>
 
-  <!-- Mobile disclosure panel: absolute under the bar, only shown when <details> above is open.
-       We use a sibling-state CSS hook via :has() so the panel is a separate block below the bar. -->
-  <div class="nav-mobile-panel md:hidden">
-    <nav
-      aria-label="Mobile primary"
-      class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)]"
-    >
+<!-- Mobile menu: true modal overlay via native <dialog> + showModal().
+     Full-viewport ink; scrim via ::backdrop; native scroll lock, focus trap,
+     Escape-to-close. Hidden entirely at md+ where the bar nav is sufficient. -->
+<dialog
+  id="mobile-menu-dialog"
+  aria-label="Mobile navigation"
+  class="nav-dialog md:hidden"
+  data-nav-dialog
+>
+  <div class="flex h-full w-full flex-col bg-[color:var(--color-surface-inverse)] text-white">
+    <!-- Overlay header: mirrors the bar structure so there is no visual jump.
+         Brand on the left, Close on the right. -->
+    <div class="flex h-14 flex-none items-center justify-between px-4 border-b-[3px] border-white">
+      <a
+        href="/"
+        class="inline-flex items-baseline gap-2 font-['Archivo'] text-base font-black uppercase tracking-[-0.01em] text-white"
+        data-nav-link
+      >
+        <span
+          class="inline-block bg-[color:var(--color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
+          >SMD</span
+        >
+        <span>Services</span>
+      </a>
+      <button
+        type="button"
+        aria-label="Close menu"
+        data-nav-close
+        class="inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-white bg-transparent font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-white cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-inverse)]"
+      >
+        Close
+      </button>
+    </div>
+
+    <!-- Primary menu -->
+    <nav aria-label="Mobile primary" class="flex-1 overflow-y-auto">
       <ul class="flex flex-col divide-y-2 divide-[color:rgba(245,240,227,0.14)]">
         {
           navLinks.map((item, i) => (
             <li>
               <a
                 href={item.href}
-                class="flex items-baseline gap-4 px-5 py-5 min-h-[56px] font-['Archivo'] text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-background)] hover:bg-[color:rgba(245,240,227,0.06)]"
+                data-nav-link
+                class="flex items-baseline gap-4 px-5 py-6 min-h-[64px] font-['Archivo'] text-3xl font-black uppercase tracking-[-0.01em] text-white hover:bg-[color:rgba(245,240,227,0.06)]"
                 data-ev={`nav-mobile-${item.label.toLowerCase()}`}
               >
                 <span class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.12em] text-[color:var(--color-primary)] min-w-[2.5rem]">
@@ -78,30 +110,67 @@ const navLinks = [
         }
       </ul>
     </nav>
+
+    <!-- Bottom CTA -->
+    <div class="flex-none border-t-[3px] border-white p-5">
+      <a
+        href="/book"
+        data-nav-link
+        data-ev="nav-mobile-book"
+        class="flex w-full items-center justify-center whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] px-5 py-4 font-['Archivo'] text-base font-bold uppercase tracking-[0.08em] text-white transition-colors"
+        >Book a Call</a
+      >
+    </div>
   </div>
-</header>
+</dialog>
 
 <style>
-  .nav-disclosure > summary::-webkit-details-marker {
-    display: none;
+  .nav-dialog[open] {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
   }
-  .nav-disclosure > summary::marker {
-    content: '';
-  }
-  .nav-disclosure-label-open {
-    display: none;
-  }
-  .nav-disclosure[open] .nav-disclosure-label-closed {
-    display: none;
-  }
-  .nav-disclosure[open] .nav-disclosure-label-open {
-    display: inline;
-  }
-
-  .nav-mobile-panel {
-    display: none;
-  }
-  header:has(.nav-disclosure[open]) .nav-mobile-panel {
-    display: block;
+  .nav-dialog::backdrop {
+    background: rgba(26, 21, 18, 0.72);
   }
 </style>
+
+<script is:inline>
+  ;(function () {
+    const dialog = document.querySelector('[data-nav-dialog]')
+    if (!dialog) return
+    const openBtn = document.querySelector('[data-nav-open]')
+    const closeBtn = dialog.querySelector('[data-nav-close]')
+
+    if (openBtn) {
+      openBtn.addEventListener('click', () => {
+        if (typeof dialog.showModal === 'function') dialog.showModal()
+      })
+    }
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', () => {
+        dialog.close()
+      })
+    }
+
+    // Close the dialog when a link is activated so the back button does not
+    // leave a stale open state.
+    dialog.querySelectorAll('[data-nav-link]').forEach((link) => {
+      link.addEventListener('click', () => dialog.close())
+    })
+
+    // Tap on the backdrop area (clicks directly on the <dialog> element itself,
+    // not its inner children) closes.
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog) dialog.close()
+    })
+  })()
+</script>


### PR DESCRIPTION
## Summary

Two design problems from the last mobile review:

1. **Mobile menu disorientation.** Inline push-down drawer's ink bg blended with the FinalCta section ink bg below. Users could not tell a menu had opened — it read as \"the nav rearranged.\"
2. **Footer felt architecturally limiting.** Flat single-row with no structural room to grow. User: *\"we may never need it, but it feels like we don't have room to grow.\"*

## Nav — true modal overlay (native HTML \`<dialog>\`)

Replaces the \`<details>/<summary>\` disclosure with a real modal:
- \`<button aria-controls aria-haspopup=\"dialog\">\` opens the dialog via \`.showModal()\`
- Native affordances: scroll lock, focus trap, Escape-to-close, \`::backdrop\` scrim
- Full-viewport ink overlay with 72%-opacity ink scrim over the page underneath — clear layering
- Overlay structure mirrors the bar (brand block left, Close button right) so there is no visual jump when it opens
- Menu rows: big Archivo Black with burnt-orange \`§ 01\` / \`§ 02\` anchors
- Bottom: full-width Book a Call CTA
- Hidden at md+ (inline bar nav is sufficient there)
- ~20 lines of \`is:inline\` script binds open / close / backdrop-click. No framework. No hydration cost.

## Footer — 3-region architecture

Replaces the flat nav row with three stacked regions separated by hairline rules:

- **Region 1 (Masthead)**: brand mark with generous padding. Future: tagline, brand statement, secondary mark.
- **Region 2 (Sitemap)**: \`grid\` with Primary nav column on the left + Book a Call on the right. Today one column; additional categories (Legal, Resources, Social) slot in as new grid columns with zero redesign.
- **Region 3 (Colophon)**: legal on the left, location on the right. Future: privacy/terms, social icons.

The structure signals \"we have rooms\" without claiming content we don't have. Splitting the existing \"© 2026 SMDurgan, LLC. Phoenix, Arizona.\" copyright line into two bookends of a colophon strip is repositioning — no new text.

## Scope

- No new copy
- No new pages
- No new CTAs
- Content discipline intact: no fabricated section labels, no invented category names

## Verify

\`npm run verify\` green: typecheck, typecheck:workers, format:check, lint (0 errors), build, test (1444 passed).

## Test plan

- [ ] iPhone: tap Menu → ink overlay opens cleanly above page content (scrim visible, backdrop dim)
- [ ] Tap Close or a link → dialog closes
- [ ] Tap scrim (outside the overlay content) → dialog closes
- [ ] Escape key → closes (native behavior)
- [ ] md+: overlay entirely hidden; desktop nav unchanged
- [ ] Footer: three distinct regions visible with rules between them; CTA doesn't clip; no orphan gap-wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)