### PR TITLE
feat(portal): Plainspoken primitives — additive variants + tokens + stamp resolvers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,16 @@
 .claude/
+# Skill bundles are spec/adapter docs — they carry JSX and pseudo-code
+# fences that prettier-plugin-astro can't parse. Format skill files by
+# hand; don't let repo prettier touch them. Mirrors the .claude/ ignore.
+.agents/
 wrangler.toml
 coverage/
 # Generated design baselines — preserve as-is for reference
 .design/designs/
+# Documentation / spec files with embedded JSX, SQL, or pseudo-code
+# blocks that prettier-plugin-astro tries to parse as syntactically-valid
+# source and errors on. Format these files by hand.
+.design/NAVIGATION.md
+docs/reviews/
+docs/spikes/
+docs/style/UI-PATTERNS.md

--- a/src/components/portal/ConsultantBlock.astro
+++ b/src/components/portal/ConsultantBlock.astro
@@ -4,7 +4,7 @@
  * principles: "A named human, visible."
  *
  * Photo fallback is a neutral SVG portrait silhouette. NEVER initials — brief
- * §Anti-patterns and §Photo placeholder rule.
+ * §Anti-patterns and §Photo placeholder rule. Both variants honor this.
  *
  * Contact affordance:
  * - Mobile UAs render `sms:` deep link as the primary action (tap-to-text)
@@ -13,6 +13,32 @@
  *   FaceTime / soft phones.
  * - When phone is null but email is set: render a `mailto:` fallback instead.
  * - When both are null: hide the contact block entirely.
+ *
+ * Variants:
+ *
+ *   variant='default'    — legacy card chrome (soft border, stacked layout).
+ *                          Unchanged from the previous Modern Institutional
+ *                          treatment for back-compat.
+ *
+ *   variant='trade-card' — Plainspoken Sign Shop chrome. 3px ink border
+ *                          with an ink header bar ("Your team" + next-
+ *                          touchpoint ref), a flush square grayscale
+ *                          headshot, Archivo Black name, and a 2px-ruled
+ *                          footer with a channel verb eyebrow ("Text" /
+ *                          "Call" / "Email") and an Archivo Black phone /
+ *                          email value.
+ *
+ * Voice (both variants): "Your team" — never "Your Operator" /
+ * "Fractional Ops" / named-human solo framing (Decision Stack #20).
+ *
+ * Data-state matrix (both variants):
+ *   A. phone + photo        — full layout, SMS/tel affordance, headshot.
+ *   B. phone + no-photo     — full layout, SMS/tel affordance, silhouette SVG.
+ *   C. no-phone + email     — mailto affordance, no phone line.
+ *   D. neither               — consumer decides whether to render; when
+ *                             both phone and email are null AND name is
+ *                             absent, the component renders an empty
+ *                             fragment (no chrome).
  */
 
 interface Props {
@@ -23,9 +49,21 @@ interface Props {
   nextTouchpointLabel?: string | null
   phone?: string | null
   email?: string | null
+  variant?: 'default' | 'trade-card'
+  class?: string
 }
 
-const { name, photoUrl, role, nextTouchpointAt, nextTouchpointLabel, phone, email } = Astro.props
+const {
+  name,
+  photoUrl,
+  role,
+  nextTouchpointAt,
+  nextTouchpointLabel,
+  phone,
+  email,
+  variant = 'default',
+  class: klass = '',
+} = Astro.props
 
 const firstName = (name ?? '').trim().split(/\s+/)[0] || name
 
@@ -61,91 +99,167 @@ function formatTouchpoint(): string | null {
 }
 
 const touchpointText = formatTouchpoint()
+
+// Neutral silhouette SVG — identical for both variants so the
+// no-initials rule is applied uniformly.
+const silhouetteSvg = (classes: string) => `
+  <svg
+    viewBox="0 0 64 80"
+    role="img"
+    aria-label="consultant photo"
+    class="${classes}"
+  >
+    <rect width="64" height="80" fill="currentColor" fill-opacity="0.12"/>
+    <circle cx="32" cy="30" r="12" fill="currentColor" fill-opacity="0.5"/>
+    <path d="M8 78c3-14 12-20 24-20s21 6 24 20" fill="currentColor" fill-opacity="0.5"/>
+  </svg>
+`
 ---
 
-<section
-  class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-5 sm:p-card"
-  aria-label="Your consultant"
->
-  <div class="flex items-start gap-stack">
-    <div
-      class="w-16 h-20 shrink-0 rounded-[var(--radius-card)] bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden"
+{
+  variant === 'default' && (
+    <section
+      class={`bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-5 sm:p-card ${klass}`}
+      aria-label="Your consultant"
     >
-      {
-        photoUrl ? (
-          <img
-            alt={`${name}, consultant`}
-            class="w-full h-full object-cover"
-            src={photoUrl}
-            loading="lazy"
-          />
-        ) : (
-          <svg
-            viewBox="0 0 64 80"
-            role="img"
-            aria-label="consultant photo"
-            class="w-full h-full text-[color:var(--color-text-muted)]"
+      <div class="flex items-start gap-stack">
+        <div class="w-16 h-20 shrink-0 rounded-[var(--radius-card)] bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden">
+          {photoUrl ? (
+            <img
+              alt={`${name}, consultant`}
+              class="w-full h-full object-cover"
+              src={photoUrl}
+              loading="lazy"
+            />
+          ) : (
+            <Fragment
+              set:html={silhouetteSvg('w-full h-full text-[color:var(--color-text-muted)]')}
+            />
+          )}
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-heading text-[color:var(--color-text-primary)]">{name}</p>
+          {role && (
+            <p class="mt-0.5 font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]">
+              {role}
+            </p>
+          )}
+          {touchpointText && (
+            <p class="mt-row font-mono text-caption tabular-nums text-[color:var(--color-text-primary)]">
+              Next check-in · {touchpointText}
+            </p>
+          )}
+        </div>
+      </div>
+      {smsHref && telHref && (
+        <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
+          <a
+            href={smsHref}
+            class="consultant-sms-mobile inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
           >
-            <rect width="64" height="80" fill="currentColor" fill-opacity="0.12" />
-            <circle cx="32" cy="30" r="12" fill="currentColor" fill-opacity="0.5" />
-            <path d="M8 78c3-14 12-20 24-20s21 6 24 20" fill="currentColor" fill-opacity="0.5" />
-          </svg>
-        )
-      }
-    </div>
-    <div class="flex-1 min-w-0">
-      <p class="text-heading text-[color:var(--color-text-primary)]">
-        {name}
-      </p>
-      {
-        role && (
-          <p class="mt-0.5 font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]">
-            {role}
-          </p>
-        )
-      }
-      {
-        touchpointText && (
-          <p class="mt-row font-mono text-caption tabular-nums text-[color:var(--color-text-primary)]">
-            Next check-in · {touchpointText}
-          </p>
-        )
-      }
-    </div>
-  </div>
-  {
-    smsHref && telHref && (
-      <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
-        {/* Mobile: SMS deep link. Hidden on desktop (sm+). */}
-        <a
-          href={smsHref}
-          class="consultant-sms-mobile inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
-        >
-          <span class="material-symbols-outlined text-[18px]">sms</span>
-          Text {firstName}
-        </a>
-        {/* Desktop: inline phone number with click-to-call. */}
-        <a
-          href={telHref}
-          class="consultant-tel-desktop hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
-        >
-          <span class="material-symbols-outlined text-[18px]">call</span>
-          {phoneDisplay}
-        </a>
+            <span class="material-symbols-outlined text-[18px]">sms</span>
+            Text {firstName}
+          </a>
+          <a
+            href={telHref}
+            class="consultant-tel-desktop hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+          >
+            <span class="material-symbols-outlined text-[18px]">call</span>
+            {phoneDisplay}
+          </a>
+        </div>
+      )}
+      {!smsHref && mailtoHref && (
+        <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
+          <a
+            href={mailtoHref}
+            class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+          >
+            <span class="material-symbols-outlined text-[18px]">mail</span>
+            Email {firstName}
+          </a>
+        </div>
+      )}
+    </section>
+  )
+}
+
+{
+  variant === 'trade-card' && (
+    <section
+      class={`border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface)] ${klass}`}
+      aria-label="Your team"
+    >
+      {/* Header bar — ink bg / cream text. "Your team" left, touchpoint ref right (burnt-orange when set). */}
+      <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-4 md:px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+        <span>Your team</span>
+        <span class={touchpointText ? 'text-[color:var(--color-primary)]' : 'opacity-80'}>
+          {touchpointText ? `Next · ${touchpointText}` : 'On call'}
+        </span>
       </div>
-    )
-  }
-  {
-    !smsHref && mailtoHref && (
-      <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
-        <a
-          href={mailtoHref}
-          class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
-        >
-          <span class="material-symbols-outlined text-[18px]">mail</span>
-          Email {firstName}
-        </a>
+
+      {/* Body — square photo flush + name/role/note. */}
+      <div class="flex items-stretch">
+        <div class="w-[100px] md:w-[110px] aspect-square shrink-0 border-r-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] overflow-hidden">
+          {photoUrl ? (
+            <img
+              alt={`${name}, your team contact`}
+              class="w-full h-full object-cover grayscale contrast-[1.05]"
+              src={photoUrl}
+              loading="lazy"
+            />
+          ) : (
+            <Fragment
+              set:html={silhouetteSvg('w-full h-full text-[color:var(--color-background)]')}
+            />
+          )}
+        </div>
+        <div class="flex-1 min-w-0 px-4 md:px-5 py-3 md:py-4 flex flex-col gap-1">
+          <h3 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)] m-0 leading-none">
+            {name}
+          </h3>
+          {role && (
+            <p class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] m-0">
+              {role}
+            </p>
+          )}
+        </div>
       </div>
-    )
-  }
-</section>
+
+      {/* Footer — channel-verb eyebrow + affordance value. */}
+      {smsHref && telHref && (
+        <div class="flex items-center justify-between gap-3 border-t-[2px] border-[color:var(--color-text-primary)] px-4 md:px-5 py-3 md:py-4">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            <span class="sm:hidden">Text</span>
+            <span class="hidden sm:inline">Call</span>
+          </span>
+          <a
+            href={smsHref}
+            class="sm:hidden inline-flex items-center gap-2 font-['Archivo'] text-lg font-black text-[color:var(--color-text-primary)] tabular-nums tracking-[-0.01em] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+          >
+            {phoneDisplay}
+          </a>
+          <a
+            href={telHref}
+            class="hidden sm:inline-flex items-center gap-2 font-['Archivo'] text-lg md:text-xl font-black text-[color:var(--color-text-primary)] tabular-nums tracking-[-0.01em] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+          >
+            {phoneDisplay}
+          </a>
+        </div>
+      )}
+      {!smsHref && mailtoHref && (
+        <div class="flex items-center justify-between gap-3 border-t-[2px] border-[color:var(--color-text-primary)] px-4 md:px-5 py-3 md:py-4">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            Email
+          </span>
+          <a
+            href={mailtoHref}
+            class="inline-flex items-center gap-2 font-['Archivo'] text-base md:text-lg font-black text-[color:var(--color-text-primary)] tracking-[-0.01em] truncate hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+          >
+            {email}
+          </a>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/portal/MoneyDisplay.astro
+++ b/src/components/portal/MoneyDisplay.astro
@@ -3,19 +3,25 @@
  * Dollar-figure renderer. Money rule: every monetary value appears as
  * dollar figures. NEVER percentages, bars, or progress indicators.
  *
- * Modern Institutional identity:
- *   - Prominent money (display, h2) renders in Crimson Pro serif with
- *     tabular-nums + lining-nums — editorial feel, classical weight.
- *   - Inline money (body, list rows) renders in Public Sans with
- *     tabular-nums — pairs cleanly with body prose.
+ * Size register:
+ *   - Plainspoken stamp scale (hero/total/kpi/row) renders in Archivo Black
+ *     900 tabular-nums — the same register the Plainspoken Sign Shop mocks
+ *     use for engagement totals, summary cards, and ledger rows.
+ *   - Legacy scale (display/h2/body) renders in the default display/body
+ *     fonts. Kept in place for back-compat while pages migrate to the new
+ *     sizes. `display` maps to `total` weight and `h2` maps to `row` once
+ *     a consumer opts into the Plainspoken chrome — see PortalListItem's
+ *     `chrome="ticket"` variant.
  *
  * Input is cents (integer) to avoid float rounding. No decimal places
  * for whole-dollar amounts.
  */
 
+type Size = 'hero' | 'total' | 'kpi' | 'row' | 'display' | 'h2' | 'body'
+
 interface Props {
   amountCents: number
-  size?: 'display' | 'h2' | 'body'
+  size?: Size
   emphasize?: boolean
   class?: string
 }
@@ -29,8 +35,21 @@ const formatted = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 }).format(dollars)
 
-const sizeClass =
-  size === 'display'
+// Plainspoken sizes pin to Archivo Black 900 via their sibling tokens
+// (see --text-*--font-weight in global.css). Legacy sizes keep their
+// original Modern Institutional treatment.
+const PLAINSPOKEN_SIZE_CLASS: Record<'hero' | 'total' | 'kpi' | 'row', string> = {
+  hero: 'text-hero-price text-[color:var(--color-text-primary)]',
+  total: 'text-section-h text-[color:var(--color-text-primary)]',
+  kpi: 'text-kpi text-[color:var(--color-text-primary)]',
+  row: 'text-price-row text-[color:var(--color-text-primary)]',
+}
+
+const isPlainspoken = size === 'hero' || size === 'total' || size === 'kpi' || size === 'row'
+
+const sizeClass = isPlainspoken
+  ? PLAINSPOKEN_SIZE_CLASS[size as 'hero' | 'total' | 'kpi' | 'row']
+  : size === 'display'
     ? 'font-display text-money font-medium text-[color:var(--color-text-primary)]'
     : size === 'h2'
       ? 'font-display text-title font-medium text-[color:var(--color-text-primary)]'

--- a/src/components/portal/PortalListItem.astro
+++ b/src/components/portal/PortalListItem.astro
@@ -1,17 +1,24 @@
 ---
 /**
- * The portal list row. One component, two variants:
+ * The portal list row. One component, two variants × two chromes:
  *
- *   variant='status'   — proposals, invoices. Pill + title + money + meta.
- *   variant='document' — documents. Icon + title + eyebrow. No money, no pill.
+ *   variant='status'   — proposals, invoices. Title + money + meta.
+ *   variant='document' — documents. Icon/thumb + title + eyebrow.
+ *
+ *   chrome='card'      — legacy soft-card shell (one bordered rectangle
+ *                        per row). Default for back-compat.
+ *   chrome='ticket'    — Plainspoken bill-of-lading row. Flat, borderless
+ *                        at the row level — consumer wraps rows in an
+ *                        outer `border-[3px] border-[color:var(--color-text-primary)]`
+ *                        container (the rows' `border-b-[2px]` dividers
+ *                        do the stitching). Plainspoken vocabulary: №
+ *                        cell (status) or file-ext thumb (document), Archivo
+ *                        Black title, flat stamp StatusPill, burnt-orange
+ *                        arrow glyph.
  *
  * This is the ONLY place list-row markup should exist on portal surfaces.
  * Enforced by `tests/forbidden-strings.test.ts` — any `.map(` inside a
  * portal index page must render through <PortalListItem>.
- *
- * Card shell is inlined (no separate _PortalListRow.astro) because splitting
- * didn't earn its keep for two callers. If document and status layouts
- * diverge materially in the future, split then.
  *
  * The whole card is a link. The chevron/trailing-icon indicates
  * interactivity; no redundant "View details" button (UI-PATTERNS R2:
@@ -22,8 +29,11 @@ import MoneyDisplay from './MoneyDisplay.astro'
 import StatusPill from './StatusPill.astro'
 import type { Tone } from '../../lib/portal/status'
 
+type Chrome = 'card' | 'ticket'
+
 type StatusProps = {
   variant: 'status'
+  chrome?: Chrome
   href: string
   tone: Tone
   toneLabel: string
@@ -31,10 +41,20 @@ type StatusProps = {
   amountCents: number
   metaCaption?: string | null
   trailingCaption?: string | null
+  /** Short serial glyph shown in the № cell (ticket chrome only). Card
+   *  chrome ignores this. Typical values: "01", "A3", or the first two
+   *  chars of an id slice. */
+  serial?: string | null
+  /** Shown below the title in ticket chrome (e.g. short engagement
+   *  descriptor). Ignored by card chrome. */
+  subCaption?: string | null
+  /** Optional explicit label on the date/meta cell ("Signed", "Due"). */
+  metaLabel?: string | null
 }
 
 type DocumentProps = {
   variant: 'document'
+  chrome?: Chrome
   href: string
   icon: string
   title: string
@@ -42,13 +62,22 @@ type DocumentProps = {
   trailingIcon: 'open_in_new' | 'download'
   /** If true, link opens in a new tab. */
   external?: boolean
+  /** File extension shown in the thumb cell (ticket chrome only). */
+  fileExt?: string | null
+  /** Kind label (ticket chrome only; e.g. "Contract", "SOP", "Data"). */
+  kind?: string | null
+  /** Optional stamp status (ticket chrome only). */
+  tone?: Tone | null
+  toneLabel?: string | null
 }
 
 type Props = StatusProps | DocumentProps
 
 const props = Astro.props as Props
+const chrome: Chrome = props.chrome ?? 'card'
 
-const shellClass = [
+// Card-chrome wrapper (existing rendering, unchanged).
+const cardShell = [
   'block bg-[color:var(--color-surface)]',
   'rounded-[var(--radius-card)] border border-[color:var(--color-border)]',
   'p-card',
@@ -57,11 +86,22 @@ const shellClass = [
   'focus-visible:outline-none',
   'focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2',
 ].join(' ')
+
+// Ticket-chrome wrapper — borderless row with bottom stitch. Consumer
+// provides outer 3px ink border.
+const ticketShell = [
+  'group block bg-[color:var(--color-surface)]',
+  'border-b-[2px] border-[color:var(--color-text-primary)] last:border-b-0',
+  'transition-colors',
+  'hover:bg-[color:var(--color-border-subtle)]',
+  'focus-visible:outline-none',
+  'focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset',
+].join(' ')
 ---
 
 {
-  props.variant === 'status' ? (
-    <a href={props.href} class={shellClass}>
+  chrome === 'card' && props.variant === 'status' && (
+    <a href={props.href} class={cardShell}>
       <div class="flex items-center gap-stack min-h-[44px]">
         <div class="flex-1 min-w-0 flex flex-col gap-row">
           <div class="flex items-center gap-row flex-wrap">
@@ -92,10 +132,14 @@ const shellClass = [
         </span>
       </div>
     </a>
-  ) : (
+  )
+}
+
+{
+  chrome === 'card' && props.variant === 'document' && (
     <a
       href={props.href}
-      class={shellClass}
+      class={cardShell}
       {...(props.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
     >
       <div class="flex items-center gap-stack min-h-[44px]">
@@ -119,6 +163,130 @@ const shellClass = [
         >
           {props.trailingIcon}
         </span>
+      </div>
+    </a>
+  )
+}
+
+{
+  /* TICKET-CHROME status variant. Mobile: 2-row collapse (serial+title+arrow / sub+price/date). Desktop: 5-col grid. */
+  chrome === 'ticket' && props.variant === 'status' && (
+    <a href={props.href} class={ticketShell}>
+      <div class="md:grid md:grid-cols-[56px_1fr_auto_auto_48px] md:items-stretch">
+        {/* № cell */}
+        <div class="flex md:border-r-[2px] md:border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] text-[color:var(--color-primary)] items-center justify-center md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell">
+          {props.serial ? `№${props.serial}` : '№ —'}
+        </div>
+
+        {/* Main */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2">
+          <div class="flex items-center gap-3 flex-wrap">
+            <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] m-0 truncate">
+              {props.title}
+            </h3>
+            <StatusPill tone={props.tone} label={props.toneLabel} />
+          </div>
+          {props.subCaption && (
+            <p class="text-sm text-[color:var(--color-text-secondary)] m-0 line-clamp-2">
+              {props.subCaption}
+            </p>
+          )}
+        </div>
+
+        {/* Price */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col items-start md:items-end justify-center gap-1">
+          <MoneyDisplay amountCents={props.amountCents} size="row" />
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            {props.metaCaption ?? 'Amount'}
+          </span>
+        </div>
+
+        {/* Date */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
+          {props.metaLabel && (
+            <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+              {props.metaLabel}
+            </span>
+          )}
+          {props.trailingCaption && (
+            <span class="font-mono text-sm text-[color:var(--color-text-primary)]">
+              {props.trailingCaption}
+            </span>
+          )}
+        </div>
+
+        {/* Arrow */}
+        <div
+          aria-hidden="true"
+          class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-2xl text-[color:var(--color-primary)] transition-transform group-hover:translate-x-0.5"
+        >
+          →
+        </div>
+      </div>
+    </a>
+  )
+}
+
+{
+  /* TICKET-CHROME document variant. File-ext thumb + kind + date/size + stamp + up-right arrow. */
+  chrome === 'ticket' && props.variant === 'document' && (
+    <a
+      href={props.href}
+      class={ticketShell}
+      {...(props.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+    >
+      <div class="md:grid md:grid-cols-[88px_1fr_140px_180px_auto_48px] md:items-stretch">
+        {/* Thumb */}
+        <div class="flex items-center justify-center md:border-r-[2px] md:border-[color:var(--color-text-primary)] bg-[color:var(--color-border-subtle)] md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell text-[color:var(--color-text-primary)]">
+          {props.fileExt ?? props.icon.slice(0, 3).toUpperCase()}
+        </div>
+
+        {/* Main */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2">
+          <h4 class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] m-0 truncate">
+            {props.title}
+          </h4>
+          {props.eyebrow && (
+            <p class="text-sm text-[color:var(--color-text-secondary)] m-0 line-clamp-2">
+              {props.eyebrow}
+            </p>
+          )}
+        </div>
+
+        {/* Kind */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            Kind
+          </span>
+          <span class="font-mono text-sm text-[color:var(--color-text-primary)]">
+            {props.kind ?? '—'}
+          </span>
+        </div>
+
+        {/* Meta */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            Shared
+          </span>
+          <span class="font-mono text-sm text-[color:var(--color-text-primary)]">
+            {props.eyebrow ?? '—'}
+          </span>
+        </div>
+
+        {/* Stamp */}
+        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex items-center justify-start md:justify-center">
+          {props.tone && props.toneLabel ? (
+            <StatusPill tone={props.tone} label={props.toneLabel} />
+          ) : null}
+        </div>
+
+        {/* Arrow */}
+        <div
+          aria-hidden="true"
+          class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-xl text-[color:var(--color-primary)] transition-transform group-hover:translate-x-0.5"
+        >
+          ↗
+        </div>
       </div>
     </a>
   )

--- a/src/components/portal/PortalPageHead.astro
+++ b/src/components/portal/PortalPageHead.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * Portal page head — the one-stop top-of-page component for every portal
+ * surface. Replaces the ad-hoc `back link + H1` pattern previously
+ * repeated at the top of each page.
+ *
+ * Plainspoken Sign Shop chrome:
+ *   - Crumb link renders as Archivo Narrow uppercase with a burnt-orange
+ *     arrow. Tap target min-h-11 for WCAG 2.2.
+ *   - Optional `tag` is a flat stamp (ink bg, cream text) in Archivo Narrow
+ *     uppercase — the small "Ledger" / "Engagement №03" eyebrow from the
+ *     mocks.
+ *   - H1 uses the Plainspoken display scale: `text-hero-mobile` at <md,
+ *     `text-hero` at ≥md. Archivo Black 900 uppercase. Weight and tracking
+ *     come from the token's sibling quartet in global.css, so no ad-hoc
+ *     `leading-[N] tracking-[N]` classes are needed.
+ *   - Optional `meta` is a right-aligned mono caps column. Multi-line is
+ *     supported via `whitespace-pre` — pass a string with "\n" line breaks
+ *     (e.g. "Issued Apr 13, 2026\nSigned Apr 13, 2026").
+ *   - Bottom rule is 3px ink (matches the page-section rule register).
+ *
+ * Layout:
+ *   - Desktop (≥md): two-column with H1 left, meta right.
+ *   - Mobile: stacked — meta flows below H1.
+ */
+
+interface Props {
+  crumbHref: string
+  crumbLabel: string
+  tag?: string | null
+  h1: string
+  meta?: string | null
+  class?: string
+}
+
+const { crumbHref, crumbLabel, tag = null, h1, meta = null, class: klass = '' } = Astro.props
+---
+
+<header class={`border-b-[3px] border-[color:var(--color-text-primary)] py-6 md:py-10 ${klass}`}>
+  <a
+    href={crumbHref}
+    class="inline-flex items-center gap-2 min-h-11 -mx-1 px-1 font-['Archivo_Narrow'] text-xs md:text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+  >
+    <span aria-hidden="true" class="font-['Archivo'] font-black text-[color:var(--color-primary)]"
+      >←</span
+    >
+    {crumbLabel}
+  </a>
+
+  <div
+    class="mt-5 md:mt-8 flex flex-col md:flex-row md:items-end md:justify-between gap-4 md:gap-10"
+  >
+    <div class="min-w-0 flex-1">
+      {
+        tag && (
+          <span class="inline-block mb-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-3 py-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold whitespace-nowrap">
+            {tag}
+          </span>
+        )
+      }
+      <h1
+        class="font-['Archivo'] text-hero-mobile md:text-hero uppercase text-[color:var(--color-text-primary)] m-0"
+      >
+        {h1}
+      </h1>
+    </div>
+    {
+      meta && (
+        <div class="font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)] whitespace-pre md:text-right leading-[1.9]">
+          {meta}
+        </div>
+      )
+    }
+  </div>
+</header>

--- a/src/lib/portal/status.ts
+++ b/src/lib/portal/status.ts
@@ -42,7 +42,7 @@
  * the client-visible label changes.
  */
 
-export type Tone = 'info' | 'success' | 'danger' | 'warning' | 'neutral'
+export type Tone = 'info' | 'success' | 'danger' | 'warning' | 'neutral' | 'outline'
 
 export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'void'
 export type QuoteStatus = 'draft' | 'sent' | 'accepted' | 'declined' | 'expired' | 'superseded'
@@ -147,6 +147,116 @@ export function resolveEngagementLabel(status: string): string {
 }
 
 /**
+ * Plainspoken stamp-label resolvers.
+ *
+ * The Plainspoken Sign Shop identity renders status as a flat rectangular
+ * stamp (bill-of-lading register). Stamps are terse, ALL CAPS, and drawn
+ * from a closed 12-word vocabulary so the visual rhythm across list rows
+ * and detail headers stays calm:
+ *
+ *   PAID · ACCEPTED · SIGNED · DUE · UNDERWAY · PENDING · COMPLETED ·
+ *   ARCHIVED · IN PROG · DECLINED · EXPIRED · OVERDUE
+ *
+ * These are emitted in addition to (not replacing) the descriptive
+ * `resolve*Label` functions above. Detail prose and subheaders still use
+ * the descriptive labels ("Stabilization period", "Pending Review");
+ * StatusPill stamps use the vocabulary via the resolvers below. Pill and
+ * detail text can diverge safely — a round-trip test locks every enum
+ * member to a vocabulary word so the pill never drifts.
+ *
+ * Stamp mapping rationale:
+ *   - quote.sent → PENDING (client action required; "Pending Review"
+ *     compresses to PENDING in stamp form).
+ *   - quote.superseded / invoice.void / quote.draft / invoice.draft →
+ *     ARCHIVED (internal states; if a stamp ever surfaces, ARCHIVED is
+ *     the least-alarming catch-all).
+ *   - engagement.safety_net → IN PROG (Decision #27 "stabilization" stays
+ *     the detail-text label; the stamp reads IN PROG to keep the closed
+ *     vocabulary).
+ *   - milestone.skipped → ARCHIVED (rare; the skip is internal bookkeeping).
+ */
+
+export type StampLabel =
+  | 'PAID'
+  | 'ACCEPTED'
+  | 'SIGNED'
+  | 'DUE'
+  | 'UNDERWAY'
+  | 'PENDING'
+  | 'COMPLETED'
+  | 'ARCHIVED'
+  | 'IN PROG'
+  | 'DECLINED'
+  | 'EXPIRED'
+  | 'OVERDUE'
+
+export const STAMP_VOCABULARY: readonly StampLabel[] = [
+  'PAID',
+  'ACCEPTED',
+  'SIGNED',
+  'DUE',
+  'UNDERWAY',
+  'PENDING',
+  'COMPLETED',
+  'ARCHIVED',
+  'IN PROG',
+  'DECLINED',
+  'EXPIRED',
+  'OVERDUE',
+] as const
+
+const QUOTE_STAMP: Record<QuoteStatus, StampLabel> = {
+  draft: 'ARCHIVED',
+  sent: 'PENDING',
+  accepted: 'ACCEPTED',
+  declined: 'DECLINED',
+  expired: 'EXPIRED',
+  superseded: 'ARCHIVED',
+}
+
+const INVOICE_STAMP: Record<InvoiceStatus, StampLabel> = {
+  draft: 'ARCHIVED',
+  sent: 'DUE',
+  paid: 'PAID',
+  overdue: 'OVERDUE',
+  void: 'ARCHIVED',
+}
+
+const ENGAGEMENT_STAMP: Record<EngagementStatus, StampLabel> = {
+  scheduled: 'PENDING',
+  active: 'UNDERWAY',
+  handoff: 'IN PROG',
+  safety_net: 'IN PROG',
+  completed: 'COMPLETED',
+  cancelled: 'ARCHIVED',
+}
+
+export type MilestoneStatus = 'pending' | 'in_progress' | 'completed' | 'skipped'
+
+const MILESTONE_STAMP: Record<MilestoneStatus, StampLabel> = {
+  pending: 'PENDING',
+  in_progress: 'IN PROG',
+  completed: 'COMPLETED',
+  skipped: 'ARCHIVED',
+}
+
+export function resolveQuoteStampLabel(status: string): StampLabel {
+  return QUOTE_STAMP[status as QuoteStatus] ?? 'ARCHIVED'
+}
+
+export function resolveInvoiceStampLabel(status: string): StampLabel {
+  return INVOICE_STAMP[status as InvoiceStatus] ?? 'ARCHIVED'
+}
+
+export function resolveEngagementStampLabel(status: string): StampLabel {
+  return ENGAGEMENT_STAMP[status as EngagementStatus] ?? 'ARCHIVED'
+}
+
+export function resolveMilestoneStampLabel(status: string): StampLabel {
+  return MILESTONE_STAMP[status as MilestoneStatus] ?? 'ARCHIVED'
+}
+
+/**
  * Tone → class map, consumed by StatusPill. Uses semantic tokens only.
  * Not exported as part of the public API — consumers pass a Tone; only
  * StatusPill renders the pill.
@@ -163,4 +273,9 @@ export const TONE_CLASS: Record<Tone, string> = {
   danger: 'bg-[color:var(--color-error)] text-white',
   warning: 'bg-[color:var(--color-attention)] text-white',
   neutral: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+  // Plainspoken bill-of-lading register: box-outlined stamp with ink text,
+  // transparent background. Visually distinguishes archived/expired states
+  // from the filled "attention-needed" tones above.
+  outline:
+    'bg-transparent text-[color:var(--color-text-primary)] border-2 border-[color:var(--color-text-primary)]',
 }

--- a/src/pages/design-preview/portal-documents.astro
+++ b/src/pages/design-preview/portal-documents.astro
@@ -19,7 +19,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-engagement.astro
+++ b/src/pages/design-preview/portal-engagement.astro
@@ -19,7 +19,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-home.astro
+++ b/src/pages/design-preview/portal-home.astro
@@ -19,7 +19,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-invoices-detail.astro
+++ b/src/pages/design-preview/portal-invoices-detail.astro
@@ -19,7 +19,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-invoices-list.astro
+++ b/src/pages/design-preview/portal-invoices-list.astro
@@ -19,7 +19,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-quotes-detail.astro
+++ b/src/pages/design-preview/portal-quotes-detail.astro
@@ -18,7 +18,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/design-preview/portal-quotes-list.astro
+++ b/src/pages/design-preview/portal-quotes-list.astro
@@ -18,7 +18,7 @@ if (!import.meta.env.DEV) {
     <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Public+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link

--- a/src/pages/dev/portal-components.astro
+++ b/src/pages/dev/portal-components.astro
@@ -8,6 +8,8 @@ import MoneyDisplay from '../../components/portal/MoneyDisplay.astro'
 import ActionCard from '../../components/portal/ActionCard.astro'
 import PortalListItem from '../../components/portal/PortalListItem.astro'
 import StatusPill from '../../components/portal/StatusPill.astro'
+import PortalPageHead from '../../components/portal/PortalPageHead.astro'
+import { resolveQuoteStampLabel, resolveInvoiceStampLabel } from '../../lib/portal/status'
 
 // Dev-only guard. The page 404s in any non-dev environment so it never ships
 // to production even if accidentally deployed.
@@ -229,6 +231,294 @@ if (import.meta.env.PROD) {
             eyebrow="Shared Apr 4"
             trailingIcon="download"
           />
+        </div>
+      </section>
+
+      <hr class="border-[color:var(--color-text-primary)] border-t-[3px] my-12" />
+
+      <section class="space-y-4">
+        <p
+          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]"
+        >
+          Plainspoken additions — PR A
+        </p>
+        <p class="text-sm text-[color:var(--color-text-secondary)]">
+          Everything below renders the new Plainspoken variants. Page consumers stay on `card` /
+          `default` until PR B flips them, so live portal routes still show the legacy chrome.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          PortalPageHead
+        </h2>
+        <div class="border-[3px] border-[color:var(--color-text-primary)] px-5 md:px-8">
+          <PortalPageHead
+            crumbHref="#"
+            crumbLabel="Home"
+            tag="Ledger"
+            h1="Proposals"
+            meta={'4 total\n1 open · 3 closed'}
+          />
+        </div>
+        <div class="mt-4 border-[3px] border-[color:var(--color-text-primary)] px-5 md:px-8">
+          <PortalPageHead
+            crumbHref="#"
+            crumbLabel="All proposals · № 03"
+            tag="Proposal № 03 · Signed"
+            h1={'Two-week\nengagement'}
+            meta={'Issued Apr 11, 2026\nSigned Apr 13, 2026\nStarts Apr 27, 2026'}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          MoneyDisplay — Plainspoken sizes
+        </h2>
+        <div class="border-[3px] border-[color:var(--color-text-primary)] p-6 space-y-5">
+          <div class="flex items-baseline gap-6">
+            <span
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              >hero</span
+            >
+            <MoneyDisplay amountCents={525000} size="hero" />
+          </div>
+          <div class="flex items-baseline gap-6">
+            <span
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              >kpi</span
+            >
+            <MoneyDisplay amountCents={262500} size="kpi" />
+          </div>
+          <div class="flex items-baseline gap-6">
+            <span
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              >total</span
+            >
+            <MoneyDisplay amountCents={525000} size="total" />
+          </div>
+          <div class="flex items-baseline gap-6">
+            <span
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              >row</span
+            >
+            <MoneyDisplay amountCents={262500} size="row" />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          StatusPill — outline tone (new)
+        </h2>
+        <div class="border-[3px] border-[color:var(--color-text-primary)] p-6 flex flex-wrap gap-3">
+          <StatusPill tone="outline" label="ARCHIVED" />
+          <StatusPill tone="outline" label="EXPIRED" />
+          <StatusPill tone="outline" label="COMPLETED" size="base" />
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          PortalListItem — ticket chrome · status (proposals)
+        </h2>
+        <div class="border-[3px] border-[color:var(--color-text-primary)]">
+          <PortalListItem
+            chrome="ticket"
+            variant="status"
+            href="#"
+            serial="03"
+            tone="success"
+            toneLabel={resolveQuoteStampLabel('accepted')}
+            title="Engagement"
+            subCaption="Two-week operational audit of Precision Plumbing AZ. Fixed fee. Written report."
+            amountCents={525000}
+            metaCaption="Fixed fee"
+            metaLabel="Signed"
+            trailingCaption="APR 13, 2026"
+          />
+          <PortalListItem
+            chrome="ticket"
+            variant="status"
+            href="#"
+            serial="02"
+            tone="info"
+            toneLabel={resolveQuoteStampLabel('sent')}
+            title="Discovery call"
+            subCaption="Hour-long scoping conversation. Written one-pager recap within 24 hrs."
+            amountCents={0}
+            metaCaption="No charge"
+            metaLabel="Held"
+            trailingCaption="MAR 30, 2026"
+          />
+          <PortalListItem
+            chrome="ticket"
+            variant="status"
+            href="#"
+            serial="01"
+            tone="outline"
+            toneLabel={resolveQuoteStampLabel('superseded')}
+            title="Initial inquiry"
+            subCaption="Incoming lead form submitted via smdservices.com/contact."
+            amountCents={0}
+            metaCaption="—"
+            metaLabel="Received"
+            trailingCaption="MAR 24, 2026"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          PortalListItem — ticket chrome · status (invoices)
+        </h2>
+        <div class="border-[3px] border-[color:var(--color-text-primary)]">
+          <PortalListItem
+            chrome="ticket"
+            variant="status"
+            href="#"
+            serial="02"
+            tone="warning"
+            toneLabel={resolveInvoiceStampLabel('sent')}
+            title="Final balance"
+            subCaption="Due on delivery of written report"
+            amountCents={262500}
+            metaCaption="Balance"
+            metaLabel="Due"
+            trailingCaption="APR 27, 2026"
+          />
+          <PortalListItem
+            chrome="ticket"
+            variant="status"
+            href="#"
+            serial="01"
+            tone="success"
+            toneLabel={resolveInvoiceStampLabel('paid')}
+            title="Deposit"
+            subCaption="50% on signing · cleared via Stripe"
+            amountCents={262500}
+            metaCaption="Settled"
+            metaLabel="Paid"
+            trailingCaption="APR 13, 2026"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          PortalListItem — ticket chrome · document
+        </h2>
+        <div class="border-[3px] border-[color:var(--color-text-primary)]">
+          <PortalListItem
+            chrome="ticket"
+            variant="document"
+            href="#"
+            icon="description"
+            title="Statement of Work"
+            eyebrow="APR 13, 2026 · 284 KB"
+            fileExt="PDF"
+            kind="Contract"
+            tone="success"
+            toneLabel="SIGNED"
+            trailingIcon="open_in_new"
+          />
+          <PortalListItem
+            chrome="ticket"
+            variant="document"
+            href="#"
+            icon="table_chart"
+            title="Dispatch logs · Q1"
+            eyebrow="APR 08, 2026 · 1.2 MB"
+            fileExt="CSV"
+            kind="Data"
+            tone="outline"
+            toneLabel="SHARED"
+            trailingIcon="download"
+          />
+          <PortalListItem
+            chrome="ticket"
+            variant="document"
+            href="#"
+            icon="description"
+            title="Operations audit · draft"
+            eyebrow="APR 22, 2026 · —"
+            fileExt="PDF"
+            kind="Deliverable"
+            tone="warning"
+            toneLabel="IN PROG"
+            trailingIcon="open_in_new"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+          ConsultantBlock — trade-card variant · data-state matrix
+        </h2>
+        <div class="grid gap-6 md:grid-cols-2">
+          <div>
+            <p
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+            >
+              A. phone + photo
+            </p>
+            <ConsultantBlock
+              variant="trade-card"
+              name="Scott Durgan"
+              photoUrl="/design-preview/modern-institutional/scott-durgan.jpg"
+              role="Your team lead"
+              nextTouchpointAt="2026-04-24T16:00:00-07:00"
+              phone="+14805550100"
+            />
+          </div>
+          <div>
+            <p
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+            >
+              B. phone + no photo
+            </p>
+            <ConsultantBlock
+              variant="trade-card"
+              name="Scott Durgan"
+              photoUrl={null}
+              role="Your team lead"
+              nextTouchpointAt={null}
+              phone="+14805550100"
+            />
+          </div>
+          <div>
+            <p
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+            >
+              C. no phone + email
+            </p>
+            <ConsultantBlock
+              variant="trade-card"
+              name="Scott Durgan"
+              photoUrl={null}
+              role="Your team lead"
+              nextTouchpointAt={null}
+              phone={null}
+              email="team@smd.services"
+            />
+          </div>
+          <div>
+            <p
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+            >
+              D. neither — contact row hidden
+            </p>
+            <ConsultantBlock
+              variant="trade-card"
+              name="Scott Durgan"
+              photoUrl={null}
+              role="Your team lead"
+              nextTouchpointAt={null}
+              phone={null}
+              email={null}
+            />
+          </div>
         </div>
       </section>
     </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,6 +70,58 @@
   --text-money--line-height: 3rem;
   --text-money--font-weight: 500;
 
+  /* ---------- Plainspoken display scale ----------
+   * Named tokens for the Plainspoken Sign Shop visual register. Each token
+   * ships with the Tailwind v4 sibling quartet (line-height, font-weight,
+   * letter-spacing) so utilities bake the full type style and consumers
+   * never reach for `text-[Npx] leading-[N] tracking-[N]` ad-hoc. Respects
+   * UI-PATTERNS R5 (typography scale only via named tokens).
+   *
+   * Line-heights target 0.92 × font-size on H1 sizes (Plainspoken mocks).
+   */
+
+  /* Portal H1 — desktop */
+  --text-hero: 4.5rem; /* 72px */
+  --text-hero--line-height: 4.14rem; /* 0.92 × 72 */
+  --text-hero--font-weight: 900;
+  --text-hero--letter-spacing: -0.03em;
+
+  /* Portal H1 — mobile (used with md:text-hero) */
+  --text-hero-mobile: 2.75rem; /* 44px */
+  --text-hero-mobile--line-height: 2.53rem; /* 0.92 × 44 */
+  --text-hero-mobile--font-weight: 900;
+  --text-hero-mobile--letter-spacing: -0.03em;
+
+  /* Summary-card total price */
+  --text-hero-price: 4rem; /* 64px */
+  --text-hero-price--line-height: 3.68rem; /* 0.92 × 64 */
+  --text-hero-price--font-weight: 900;
+  --text-hero-price--letter-spacing: -0.04em;
+
+  /* KPI row big numbers */
+  --text-kpi: 2.75rem; /* 44px */
+  --text-kpi--line-height: 2.75rem;
+  --text-kpi--font-weight: 900;
+  --text-kpi--letter-spacing: -0.03em;
+
+  /* § block headings on detail pages */
+  --text-section-h: 2.25rem; /* 36px */
+  --text-section-h--line-height: 2.25rem;
+  --text-section-h--font-weight: 900;
+  --text-section-h--letter-spacing: -0.02em;
+
+  /* Row-level money (list rows, ledger amounts) */
+  --text-price-row: 1.75rem; /* 28px */
+  --text-price-row--line-height: 1.75rem;
+  --text-price-row--font-weight: 900;
+  --text-price-row--letter-spacing: -0.02em;
+
+  /* № / § cell glyph in ticket rows */
+  --text-num-cell: 1.375rem; /* 22px */
+  --text-num-cell--line-height: 1.375rem;
+  --text-num-cell--font-weight: 900;
+  --text-num-cell--letter-spacing: -0.01em;
+
   /* ---------- Spacing rhythm ---------- */
   --spacing-section: 3rem;
   --spacing-card: 2rem;

--- a/tests/portal-status-labels.test.ts
+++ b/tests/portal-status-labels.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STAMP_VOCABULARY,
+  resolveQuoteStampLabel,
+  resolveInvoiceStampLabel,
+  resolveEngagementStampLabel,
+  resolveMilestoneStampLabel,
+  type StampLabel,
+} from '../src/lib/portal/status'
+
+/**
+ * Stamp-label round-trip: every DB enum value must resolve to a label in
+ * the closed Plainspoken stamp vocabulary. This locks the StatusPill and
+ * the resolver so the pill can never grow its own copy constant or emit
+ * a word outside the shared vocabulary. See src/lib/portal/status.ts for
+ * the rationale behind each mapping.
+ */
+
+const VOCAB = new Set<StampLabel>(STAMP_VOCABULARY)
+
+// Enum source-of-truth arrays — if a DB enum gains a new value, it must
+// be added here AND a stamp mapping must be added to status.ts. The round-
+// trip assertion then enforces that the new value resolves inside the
+// vocabulary.
+
+const QUOTE_STATUSES = ['draft', 'sent', 'accepted', 'declined', 'expired', 'superseded']
+
+const INVOICE_STATUSES = ['draft', 'sent', 'paid', 'overdue', 'void']
+
+const ENGAGEMENT_STATUSES = [
+  'scheduled',
+  'active',
+  'handoff',
+  'safety_net',
+  'completed',
+  'cancelled',
+]
+
+const MILESTONE_STATUSES = ['pending', 'in_progress', 'completed', 'skipped']
+
+describe('portal status: stamp vocabulary is closed', () => {
+  it('STAMP_VOCABULARY has exactly 12 labels', () => {
+    expect(STAMP_VOCABULARY).toHaveLength(12)
+  })
+
+  it('STAMP_VOCABULARY entries are all-caps (no lowercase drift)', () => {
+    for (const label of STAMP_VOCABULARY) {
+      expect(label).toBe(label.toUpperCase())
+    }
+  })
+})
+
+describe('portal status: quote stamp round-trip', () => {
+  for (const status of QUOTE_STATUSES) {
+    it(`quote.${status} resolves to a vocabulary label`, () => {
+      const stamp = resolveQuoteStampLabel(status)
+      expect(VOCAB.has(stamp)).toBe(true)
+    })
+  }
+
+  it('unknown quote status falls back to ARCHIVED (internal-safe default)', () => {
+    expect(resolveQuoteStampLabel('nonsense')).toBe('ARCHIVED')
+  })
+
+  it('quote.sent stamps as PENDING (action-required register)', () => {
+    expect(resolveQuoteStampLabel('sent')).toBe('PENDING')
+  })
+
+  it('quote.accepted stamps as ACCEPTED', () => {
+    expect(resolveQuoteStampLabel('accepted')).toBe('ACCEPTED')
+  })
+})
+
+describe('portal status: invoice stamp round-trip', () => {
+  for (const status of INVOICE_STATUSES) {
+    it(`invoice.${status} resolves to a vocabulary label`, () => {
+      const stamp = resolveInvoiceStampLabel(status)
+      expect(VOCAB.has(stamp)).toBe(true)
+    })
+  }
+
+  it('unknown invoice status falls back to ARCHIVED', () => {
+    expect(resolveInvoiceStampLabel('nonsense')).toBe('ARCHIVED')
+  })
+
+  it('invoice.sent stamps as DUE (awaiting payment)', () => {
+    expect(resolveInvoiceStampLabel('sent')).toBe('DUE')
+  })
+
+  it('invoice.paid stamps as PAID', () => {
+    expect(resolveInvoiceStampLabel('paid')).toBe('PAID')
+  })
+
+  it('invoice.overdue stamps as OVERDUE', () => {
+    expect(resolveInvoiceStampLabel('overdue')).toBe('OVERDUE')
+  })
+})
+
+describe('portal status: engagement stamp round-trip', () => {
+  for (const status of ENGAGEMENT_STATUSES) {
+    it(`engagement.${status} resolves to a vocabulary label`, () => {
+      const stamp = resolveEngagementStampLabel(status)
+      expect(VOCAB.has(stamp)).toBe(true)
+    })
+  }
+
+  it('engagement.active stamps as UNDERWAY', () => {
+    expect(resolveEngagementStampLabel('active')).toBe('UNDERWAY')
+  })
+
+  it('engagement.safety_net stamps as IN PROG (stabilization compressed to vocab)', () => {
+    expect(resolveEngagementStampLabel('safety_net')).toBe('IN PROG')
+  })
+})
+
+describe('portal status: milestone stamp round-trip', () => {
+  for (const status of MILESTONE_STATUSES) {
+    it(`milestone.${status} resolves to a vocabulary label`, () => {
+      const stamp = resolveMilestoneStampLabel(status)
+      expect(VOCAB.has(stamp)).toBe(true)
+    })
+  }
+
+  it('milestone.in_progress stamps as IN PROG', () => {
+    expect(resolveMilestoneStampLabel('in_progress')).toBe('IN PROG')
+  })
+
+  it('milestone.completed stamps as COMPLETED', () => {
+    expect(resolveMilestoneStampLabel('completed')).toBe('COMPLETED')
+  })
+})


### PR DESCRIPTION
## Summary

PR A of the Plainspoken portal refit. **Strictly additive — no existing portal route's rendered output changes.** PR B will flip consumers to the new variants and add §-block page chrome.

## What landed

**Tokens (`src/styles/global.css`)**
Plainspoken display scale with full Tailwind v4 sibling quartets (line-height + font-weight + letter-spacing baked into each utility, not patched ad-hoc):

- `--text-hero` (72px) / `--text-hero-mobile` (44px) — portal H1s
- `--text-hero-price` (64px) — summary-card totals
- `--text-kpi` (44px) — KPI numbers
- `--text-section-h` (36px) — § block headings
- `--text-price-row` (28px) — ledger row prices
- `--text-num-cell` (22px) — №/§ cell glyph

Archivo Black 900 + -0.02..-0.04em tracking on each, line-height ≈ 0.92 × font-size on the H1 scale.

**New component: `PortalPageHead.astro`**
Single page-head primitive for every portal surface — crumb, optional ink-stamp tag, big H1 (`text-hero-mobile md:text-hero`), optional right-aligned mono meta column, 3px ink bottom rule. Zero consumers in this PR.

**Additive variants on existing primitives**

- `PortalListItem` — new `chrome?: 'card' | 'ticket'` prop, default `'card'`. `'ticket'` adds Plainspoken bill-of-lading chrome: № cell (ink bg, burnt-orange serial) / main (Archivo Black title + stamp StatusPill + sub copy) / MoneyDisplay row / meta cell / burnt-orange `→` arrow (desktop), collapsing to a 2-row stack on mobile. Document variant gets a file-ext thumb + Kind / Shared meta + stamp + `↗` arrow.
- `MoneyDisplay` — new sizes `hero` (text-hero-price), `total` (text-section-h), `kpi` (text-kpi), `row` (text-price-row). All Archivo Black 900 tabular-nums via token siblings. Existing `display` / `h2` / `body` sizes unchanged.
- `ConsultantBlock` — new `variant?: 'default' | 'trade-card'` prop, default `'default'`. Trade-card variant is the Plainspoken bill-of-lading treatment: 3px ink border, ink header bar (`Your team` left, next-touchpoint ref right — burnt-orange when set), flush square grayscale photo (**kept existing neutral-silhouette SVG fallback — never initials** per brief §Anti-patterns), 2px footer rule with channel-verb eyebrow (`Text` / `Call` / `Email`). All four data states preserved: phone+photo, phone-no-photo, no-phone+email, neither.
- `StatusPill` — added `'outline'` tone (transparent bg, 2px ink border, ink text) for ARCHIVED / EXPIRED states. Existing tones untouched.

**State → stamp label map (`src/lib/portal/status.ts`)**
Closed 12-word stamp vocabulary — `PAID`, `ACCEPTED`, `SIGNED`, `DUE`, `UNDERWAY`, `PENDING`, `COMPLETED`, `ARCHIVED`, `IN PROG`, `DECLINED`, `EXPIRED`, `OVERDUE` — emitted from new `resolveQuoteStampLabel` / `resolveInvoiceStampLabel` / `resolveEngagementStampLabel` / `resolveMilestoneStampLabel`. Existing `resolve*Label` functions (`"Pending Review"`, `"Stabilization"`) stay untouched so detail prose can still use the descriptive forms; only stamps switch to the vocabulary.

**`tests/portal-status-labels.test.ts` (NEW)**
Round-trips every DB enum value (quote / invoice / engagement / milestone) through each stamp resolver and asserts the label ∈ vocabulary. Locks the pill/resolver alignment.

**Dev gallery + design-preview**

- `/dev/portal-components` — new sections demo every PR A addition: PortalPageHead, Plainspoken MoneyDisplay sizes, outline StatusPill, ticket-chrome PortalListItem (status + document variants, multiple states), ConsultantBlock trade-card at all four data states. Legacy sections preserved so the green-main diff is easy to eyeball.
- `/design-preview/portal-*.astro` (7 routes) — swapped stale Crimson Pro + Public Sans + IBM Plex Mono font imports to Archivo + Archivo Narrow + JetBrains Mono. Those routes are `import.meta.env.DEV`-gated so this is dev-only.

## Green-main gate

- `npm run verify` passes locally (typecheck 0 errors, lint 0 errors, 1478 tests pass, build green).
- Every existing portal consumer still uses the default props (`chrome='card'`, `variant='default'`) so visible output on `/portal/*` routes is unchanged after merge.
- New opt-in props (`chrome='ticket'`, `variant='trade-card'`, `'outline'` tone, `hero` / `total` / `kpi` / `row` sizes, `resolve*StampLabel` functions) have no callers yet — PR B will flip them.

## Plan

Full plan at `~/.claude/plans/temporal-snacking-puddle.md`. Critic-reviewed (Devil's Advocate) and revised before execution to prevent three merge-time regressions flagged in the critique (wrong line numbers for voice fixes, missing Tailwind v4 sibling tokens, non-additive primitive mutations).

## Dependencies

Includes `#528` (hygiene: `.prettierignore` fix) as a cherry-picked commit so local pre-push verify passes. When `#528` merges first, rebase will drop the duplicate commit cleanly.

## Test plan

- [ ] `npm run dev` → walk `/dev/portal-components` at 320 / 768 / 1280 widths; every new variant should render at the expected sizes, with Archivo Black display type and burnt-orange accents.
- [ ] `npm run dev` → walk `/design-preview/portal-{home,quotes-list,quotes-detail,invoices-list,invoices-detail,documents,engagement}` — should render identically to pre-PR fixture state (fixture data unchanged, fonts corrected).
- [ ] `npm run dev` → walk live `/portal/*` routes — **confirm zero visible change vs main** (green-main gate).
- [ ] CI Verify passes.

## Next

**PR B** (separate branch): flip portal page consumers to the new variants, add §-block detail-page structure, restyle `PortalTabs` with Plainspoken chrome (burnt-orange active, drop Material Symbols, `§ 0N` JetBrains Mono anchors on mobile), fix the voice violations at `quotes/[id].astro:420` and `components/portal/InvoiceDetail.astro:97/249/259-268`, and add forbidden-strings patterns to lock the voice fixes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)