### PR TITLE
feat(marketing): Plainspoken masthead hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ coverage/
 
 # Ephemeral agent worktrees (created by EnterWorktree tool)
 .claude/worktrees/
+
+# Playwright MCP output (screenshots, console dumps, snapshots)
+.playwright-mcp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,5 @@ coverage/
 docs/reviews/
 docs/spikes/
 docs/style/UI-PATTERNS.md
+# Playwright MCP output (screenshots, console dumps, snapshots)
+.playwright-mcp/

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,37 +2,44 @@
 import CtaButton from './CtaButton.astro'
 ---
 
-<section
-  class="relative overflow-hidden px-6 pb-24 pt-16 sm:pb-32 sm:pt-24 bg-[color:var(--color-background)]"
->
-  <div class="mx-auto max-w-5xl text-center">
-    <h1
-      class="mb-8 sm:mb-10 font-['Archivo'] font-black uppercase leading-[0.95] sm:leading-[0.92] tracking-[-0.025em] text-[color:var(--color-text-primary)] text-[clamp(2.5rem,11vw,7rem)]"
-    >
-      Your Business Has Outgrown How You <span class="text-[color:var(--color-primary)]"
-        >Run It.</span
+<section class="bg-[color:var(--color-background)]">
+  <div class="mx-auto max-w-7xl">
+    <div class="grid grid-cols-1 md:grid-cols-12">
+      <div
+        class="md:col-span-8 px-6 md:px-10 py-12 md:py-20 border-b-[3px] md:border-b-0 border-[color:var(--color-text-primary)]"
       >
-    </h1>
-    <p
-      class="mx-auto mb-10 sm:mb-12 max-w-2xl font-['Archivo'] text-lg sm:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
-    >
-      You know where you want to go. We help you figure out what needs to change and build it with
-      you.
-    </p>
-    <div
-      class="mx-auto flex flex-col sm:flex-row sm:inline-flex max-w-sm sm:max-w-none items-stretch sm:items-center justify-center"
-    >
-      <CtaButton href="/book" data-ev="home-primary-cta" class="w-full sm:w-auto">
-        Book a Call
-      </CtaButton>
-      <CtaButton
-        variant="secondary"
-        href="/get-started"
-        data-ev="home-secondary-cta"
-        class="w-full sm:w-auto border-t-0 sm:border-t-[3px] sm:border-l-0"
-      >
-        Tell us about your business
-      </CtaButton>
+        <h1
+          class="font-['Archivo'] font-black uppercase text-[clamp(2rem,9vw,4.5rem)] leading-[0.92] tracking-[-0.03em] text-[color:var(--color-text-primary)]"
+        >
+          <span class="block">Your&nbsp;Business</span>
+          <span class="block">Has&nbsp;Outgrown</span>
+          <span class="block">How&nbsp;You</span>
+          <span class="block text-[color:var(--color-primary)]">Run&nbsp;It.</span>
+        </h1>
+        <div class="mt-10 md:mt-12 flex flex-col sm:flex-row items-stretch sm:inline-flex">
+          <CtaButton href="/book" data-ev="home-primary-cta" class="w-full sm:w-auto">
+            Book a Call
+          </CtaButton>
+          <CtaButton
+            variant="secondary"
+            href="/get-started"
+            data-ev="home-secondary-cta"
+            class="w-full sm:w-auto border-t-0 sm:border-t-[3px] sm:border-l-0"
+          >
+            Tell us about your business
+          </CtaButton>
+        </div>
+      </div>
+      <div class="md:col-span-4 flex items-center px-6 md:px-0 py-10 md:py-14">
+        <div class="md:border-l-[3px] md:border-[color:var(--color-text-primary)] md:pl-10">
+          <p
+            class="font-['Archivo'] text-lg md:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+          >
+            You know where you want to go. We help you figure out what needs to change and build it
+            with you.
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/src/pages/dev/hero-variants.astro
+++ b/src/pages/dev/hero-variants.astro
@@ -1,0 +1,274 @@
+---
+import '../../styles/global.css'
+import CtaButton from '../../components/CtaButton.astro'
+
+// Dev-only guard. 404s in any non-dev environment so it never ships
+// to production even if accidentally deployed.
+if (import.meta.env.PROD) {
+  return new Response('Not found', { status: 404 })
+}
+
+const headlineLines = ['Your Business', 'Has Outgrown', 'How You', 'Run It.']
+const subtext =
+  'You know where you want to go. We help you figure out what needs to change and build it with you.'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <title>Hero variants — dev</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--color-background)]">
+    <!-- Dev header strip -->
+    <header
+      class="border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] px-6 py-4"
+    >
+      <p
+        class="font-['JetBrains_Mono'] text-xs uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+      >
+        § dev — hero variants
+      </p>
+      <p
+        class="mt-1 font-['Archivo_Narrow'] text-sm uppercase tracking-[0.12em] text-[color:var(--color-background)]"
+      >
+        Three Plainspoken mastheads. Not live on smd.services.
+      </p>
+    </header>
+
+    <!-- ================================================================ -->
+    <!-- VARIANT A — Masthead (stacked headline / vertical rule / subtext right) -->
+    <!-- ================================================================ -->
+    <section class="px-4 md:px-10 pt-12 pb-6">
+      <p
+        class="font-['JetBrains_Mono'] text-sm uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+      >
+        Variant A — Masthead
+      </p>
+      <p
+        class="mt-1 font-['Archivo_Narrow'] text-sm uppercase tracking-[0.10em] text-[color:var(--color-text-secondary)]"
+      >
+        7/5 split · 3px vertical ink rule · eyebrow in right column
+      </p>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 md:px-10 pb-24">
+      <div
+        class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+      >
+        <!-- Top meta strip -->
+        <div
+          class="flex items-center justify-between border-b-[3px] border-[color:var(--color-text-primary)] px-6 py-3 md:px-10"
+        >
+          <p
+            class="font-['JetBrains_Mono'] text-xs uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+          >
+            § 01 — Phoenix, Arizona
+          </p>
+          <p
+            class="hidden md:block font-['Archivo_Narrow'] text-xs uppercase tracking-[0.14em] font-bold text-[color:var(--color-text-secondary)]"
+          >
+            Solutions consulting
+          </p>
+        </div>
+        <!-- Body grid -->
+        <div class="grid grid-cols-1 md:grid-cols-12">
+          <!-- Headline column (7) -->
+          <div
+            class="md:col-span-7 md:border-r-[3px] md:border-[color:var(--color-text-primary)] border-b-[3px] md:border-b-0 border-[color:var(--color-text-primary)] px-6 md:px-10 py-10 md:py-14"
+          >
+            <h1
+              class="font-['Archivo'] font-black uppercase text-hero-mobile md:text-hero text-[color:var(--color-text-primary)]"
+            >
+              {headlineLines.map((line) => <span class="block">{line}</span>)}
+            </h1>
+          </div>
+          <!-- Right column (5) -->
+          <div class="md:col-span-5 px-6 md:px-10 py-10 md:py-14 flex flex-col">
+            <p
+              class="font-['Archivo_Narrow'] text-xs uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]"
+            >
+              For the owner
+            </p>
+            <p
+              class="mt-6 font-['Archivo'] text-lg md:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+            >
+              {subtext}
+            </p>
+            <div class="mt-auto pt-10 flex flex-col sm:flex-row gap-0 sm:gap-0 items-stretch">
+              <CtaButton href="/book" data-ev="hero-variant-a-primary" class="w-full sm:w-auto">
+                Book a call
+              </CtaButton>
+              <CtaButton
+                variant="secondary"
+                href="/get-started"
+                data-ev="hero-variant-a-secondary"
+                class="w-full sm:w-auto border-t-0 sm:border-t-[3px] sm:border-l-0"
+              >
+                Tell us about your business
+              </CtaButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================================================================ -->
+    <!-- VARIANT B — Hung headline (no vertical rule, offset right column) -->
+    <!-- ================================================================ -->
+    <section
+      class="px-4 md:px-10 pt-6 pb-6 border-t-[3px] border-[color:var(--color-text-primary)]"
+    >
+      <p
+        class="font-['JetBrains_Mono'] text-sm uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+      >
+        Variant B — Hung from top rule
+      </p>
+      <p
+        class="mt-1 font-['Archivo_Narrow'] text-sm uppercase tracking-[0.10em] text-[color:var(--color-text-secondary)]"
+      >
+        Headline hangs below a 3px top rule · no vertical divider · right column offset by
+        whitespace
+      </p>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 md:px-10 pb-24">
+      <div class="bg-[color:var(--color-background)]">
+        <!-- Top rule + eyebrow hanging above it -->
+        <div
+          class="flex items-end justify-between pb-4 border-b-[3px] border-[color:var(--color-text-primary)]"
+        >
+          <p
+            class="font-['JetBrains_Mono'] text-xs uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+          >
+            § 01 — Phoenix, Arizona
+          </p>
+          <p
+            class="hidden md:block font-['Archivo_Narrow'] text-xs uppercase tracking-[0.14em] font-bold text-[color:var(--color-text-secondary)]"
+          >
+            Solutions consulting
+          </p>
+        </div>
+        <!-- Body -->
+        <div class="grid grid-cols-1 md:grid-cols-12 mt-10 md:mt-14 gap-10 md:gap-12">
+          <div class="md:col-span-7">
+            <h1
+              class="font-['Archivo'] font-black uppercase text-hero-mobile md:text-hero text-[color:var(--color-text-primary)]"
+            >
+              {headlineLines.map((line) => <span class="block">{line}</span>)}
+            </h1>
+          </div>
+          <div class="md:col-span-5 md:pt-3 flex flex-col">
+            <p
+              class="font-['Archivo'] text-lg md:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+            >
+              {subtext}
+            </p>
+            <div class="mt-10 flex flex-col sm:flex-row items-stretch">
+              <CtaButton href="/book" data-ev="hero-variant-b-primary" class="w-full sm:w-auto">
+                Book a call
+              </CtaButton>
+              <CtaButton
+                variant="secondary"
+                href="/get-started"
+                data-ev="hero-variant-b-secondary"
+                class="w-full sm:w-auto border-t-0 sm:border-t-[3px] sm:border-l-0"
+              >
+                Tell us about your business
+              </CtaButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================================================================ -->
+    <!-- VARIANT C — Burnt accent, CTAs under headline, short vertical rule -->
+    <!-- ================================================================ -->
+    <section
+      class="px-4 md:px-10 pt-6 pb-6 border-t-[3px] border-[color:var(--color-text-primary)]"
+    >
+      <p
+        class="font-['JetBrains_Mono'] text-sm uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+      >
+        Variant C — Burnt accent (revised)
+      </p>
+      <p
+        class="mt-1 font-['Archivo_Narrow'] text-sm uppercase tracking-[0.10em] text-[color:var(--color-text-secondary)]"
+      >
+        CTAs under headline (left column) · vertical rule only spans right-column content
+      </p>
+    </section>
+    <section class="mx-auto max-w-7xl px-4 md:px-10 pb-24">
+      <div
+        class="border-t-[3px] border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+      >
+        <div class="grid grid-cols-1 md:grid-cols-12">
+          <!-- Left column: headline + CTAs -->
+          <div
+            class="md:col-span-8 px-6 md:px-10 py-10 md:py-14 border-b-[3px] md:border-b-0 border-[color:var(--color-text-primary)]"
+          >
+            <h1
+              class="font-['Archivo'] font-black uppercase text-[clamp(2rem,9vw,4.5rem)] leading-[0.92] tracking-[-0.03em] text-[color:var(--color-text-primary)]"
+            >
+              <span class="block">Your&nbsp;Business</span>
+              <span class="block">Has&nbsp;Outgrown</span>
+              <span class="block">How&nbsp;You</span>
+              <span class="block text-[color:var(--color-primary)]">Run&nbsp;It.</span>
+            </h1>
+            <div class="mt-10 md:mt-12 flex flex-col sm:flex-row items-stretch sm:inline-flex">
+              <CtaButton href="/book" data-ev="hero-variant-c-primary" class="w-full sm:w-auto">
+                Book a call
+              </CtaButton>
+              <CtaButton
+                variant="secondary"
+                href="/get-started"
+                data-ev="hero-variant-c-secondary"
+                class="w-full sm:w-auto border-t-0 sm:border-t-[3px] sm:border-l-0"
+              >
+                Tell us about your business
+              </CtaButton>
+            </div>
+          </div>
+          <!-- Right column: subtext vertically centered, short left rule -->
+          <div class="md:col-span-4 flex items-center px-6 md:px-0 py-10 md:py-14">
+            <div class="md:border-l-[3px] md:border-[color:var(--color-text-primary)] md:pl-10">
+              <p
+                class="font-['Archivo'] text-lg md:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+              >
+                {subtext}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Footer note -->
+    <footer
+      class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] px-6 py-6"
+    >
+      <p
+        class="font-['JetBrains_Mono'] text-xs uppercase tracking-[0.14em] text-[color:var(--color-primary)]"
+      >
+        § Notes
+      </p>
+      <ul class="mt-3 font-['Archivo'] text-sm text-[color:var(--color-background)] space-y-2">
+        <li>
+          — Headline lines are authored breaks, not responsive wraps. Future copy changes are
+          typesetting decisions.
+        </li>
+        <li>
+          — Mobile collapses to 1 column. Vertical rule becomes a horizontal rule between sections.
+        </li>
+        <li>— Current hero copy maps to 4 lines of roughly equal width in all caps.</li>
+        <li>— All three variants reuse existing CtaButton — no new component chrome.</li>
+      </ul>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Stacked 4-line headline (Archivo Black, burnt "Run It.") with CTAs directly below and a short vertical-rule subtext block on the right
- Fluid `clamp(2rem, 9vw, 4.5rem)` on the headline — no mobile overflow at 390px, caps at 72px desktop
- Neighbour sections provide top/bottom rules (Nav + ProblemCards), so the hero has no outer box

## Test plan
- [x] `npm run verify` passes (1480 tests)
- [x] Live-walked at 1280 / 768 / 390 via Playwright
- [x] `/dev/hero-variants` compares A (masthead), B (hung), C (burnt accent — the shipped direction)
- [ ] Eyeball `portal.smd.services` apex marketing hero on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)