### PR TITLE
chore(marketing): align all section containers to max-w-5xl

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,7 +1,7 @@
 <section
   class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
 >
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-5xl">
     <div class="mb-12">
       <span
         class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -3,7 +3,7 @@ import CtaButton from './CtaButton.astro'
 ---
 
 <section id="book" class="bg-[color:var(--color-surface-inverse)] px-6 py-24">
-  <div class="mx-auto max-w-3xl text-center">
+  <div class="mx-auto max-w-5xl text-center">
     <h2 class="text-3xl font-bold text-white">Let's Talk About Your Business</h2>
     <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--color-text-muted)]">
       We'll ask how things run and where you're trying to go. You'll walk away with a clearer

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,7 +3,7 @@ import CtaButton from './CtaButton.astro'
 ---
 
 <section class="bg-[color:var(--color-background)]">
-  <div class="mx-auto max-w-7xl">
+  <div class="mx-auto max-w-5xl">
     <div class="grid grid-cols-1 md:grid-cols-12">
       <div
         class="md:col-span-8 px-6 md:px-10 py-12 md:py-20 border-b-[3px] md:border-b-0 border-[color:var(--color-text-primary)]"

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -21,7 +21,7 @@ const steps = [
 <section
   class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
 >
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-5xl">
     <div class="mb-16">
       <span
         class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,7 +1,7 @@
 <section
   class="bg-[color:var(--color-surface-inverse)] px-6 py-24 text-white border-t-[3px] border-[color:var(--color-text-primary)]"
 >
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-5xl">
     <div class="mb-16 text-center">
       <p
         class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-primary)] flex items-center justify-center gap-3"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ import Footer from '../components/Footer.astro'
 
     <!-- Scorecard CTA -->
     <section class="bg-[color:var(--color-background)] px-6 py-20">
-      <div class="mx-auto max-w-3xl text-center">
+      <div class="mx-auto max-w-5xl text-center">
         <h2 class="text-2xl font-bold text-[color:var(--color-text-primary)] sm:text-3xl">
           Not sure where to start?
         </h2>


### PR DESCRIPTION
## Summary
- Homepage sections had inconsistent container widths (Hero 7xl, three sections 4xl, two CTA bars 3xl, rest 5xl). Ragged right edge looked sloppy.
- Aligns every top-level section to `max-w-5xl` (matches Nav + Footer). Inner `<p class="max-w-2xl">` wrappers keep text reading measure intact.

## Test plan
- [x] `npm run verify` passes
- [x] Live-walked at 1280 + 768 via Playwright — all sections align to the same edges
- [ ] Eyeball prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)