### PR TITLE
fix(security): rate-limit auth + contact endpoints

### DIFF
--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { verifyPassword } from '../../../lib/auth/password'
 import { createSession, buildSessionCookie } from '../../../lib/auth/session'
+import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import { env } from 'cloudflare:workers'
 
 interface UserRow {
@@ -30,6 +31,13 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     const isLocalDev = requestHost === 'localhost' || requestHost === '127.0.0.1'
     if (!isLocalDev && !requestHost.startsWith('admin.')) {
       return redirect('/auth/login?error=wrong_host', 302)
+    }
+
+    // Rate limit: 10 attempts/hour per IP — checked before any DB lookup
+    const clientIp = request.headers.get('cf-connecting-ip') ?? undefined
+    const rateLimitResult = await rateLimitByIp(env.BOOKING_CACHE, 'auth-login', clientIp, 10)
+    if (!rateLimitResult.allowed) {
+      return redirect('/auth/login?error=rate_limited', 302)
     }
 
     const formData = await request.formData()

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -3,6 +3,7 @@ import { createMagicLink } from '../../../lib/auth/magic-link'
 import { requirePortalBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, magicLinkEmailHtml } from '../../../lib/email/templates'
+import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import { env } from 'cloudflare:workers'
 
 interface UserRow {
@@ -28,6 +29,13 @@ interface UserRow {
  */
 export const POST: APIRoute = async ({ request, redirect }) => {
   try {
+    // Rate limit: 5 requests/hour per IP — checked first, before any DB lookup
+    const clientIp = request.headers.get('cf-connecting-ip') ?? undefined
+    const rateLimitResult = await rateLimitByIp(env.BOOKING_CACHE, 'auth-magic', clientIp, 5)
+    if (!rateLimitResult.allowed) {
+      return redirect('/auth/portal-login?error=rate_limited', 302)
+    }
+
     const formData = await request.formData()
     const email = formData.get('email')
 

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro'
 import { sendEmail } from '../../lib/email/resend'
+import { rateLimitByIp } from '../../lib/booking/rate-limit'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -18,6 +19,13 @@ const CONTROL_CHAR_RE = /[\r\n\0]/
 const NOTIFY_EMAIL = 'team@smd.services'
 
 export const POST: APIRoute = async ({ request }) => {
+  // Rate limit: 3 requests/hour per IP
+  const clientIp = request.headers.get('cf-connecting-ip') ?? undefined
+  const rateLimitResult = await rateLimitByIp(env.BOOKING_CACHE, 'contact', clientIp, 3)
+  if (!rateLimitResult.allowed) {
+    return jsonResponse(429, { error: 'Too many requests, please try again later.' })
+  }
+
   let body: Record<string, unknown>
   try {
     body = (await request.json()) as Record<string, unknown>

--- a/src/pages/auth/login.astro
+++ b/src/pages/auth/login.astro
@@ -16,6 +16,7 @@ const errorMessages: Record<string, string> = {
   missing: 'Please enter both email and password.',
   server: 'Something went wrong. Please try again.',
   wrong_host: 'Admin sign-in must be done at admin.smd.services. Please use that URL.',
+  rate_limited: 'Too many sign-in attempts. Please wait a few minutes and try again.',
 }
 
 const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : null

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -24,6 +24,10 @@ const statusMessages: Record<string, { text: string; type: 'success' | 'error' }
     type: 'error',
   },
   server: { text: 'Something went wrong. Please try again.', type: 'error' },
+  rate_limited: {
+    text: 'Too many requests. Please wait a few minutes and try again.',
+    type: 'error',
+  },
 }
 
 const message = status ? statusMessages[status] : error ? statusMessages[error] : null

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -256,3 +256,36 @@ describe('auth: env.d.ts types', () => {
     expect(source).toContain('session: AuthSession | null')
   })
 })
+
+describe('auth: login endpoint rate limiting', () => {
+  it('login endpoint imports rateLimitByIp', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/login.ts'), 'utf-8')
+    expect(source).toContain('rateLimitByIp')
+    expect(source).toContain('rate-limit')
+  })
+
+  it('login endpoint rate limit uses auth-login bucket', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/login.ts'), 'utf-8')
+    expect(source).toContain('auth-login')
+  })
+
+  it('login endpoint redirects to rate_limited error on block', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/login.ts'), 'utf-8')
+    expect(source).toContain('rate_limited')
+  })
+
+  it('login page has rate_limited error message', () => {
+    const source = readFileSync(resolve('src/pages/auth/login.astro'), 'utf-8')
+    expect(source).toContain('rate_limited')
+    expect(source).toContain('Too many sign-in attempts')
+  })
+
+  it('rate limit check occurs before DB lookup', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/login.ts'), 'utf-8')
+    const rateLimitIdx = source.indexOf('rateLimitByIp')
+    const dbLookupIdx = source.indexOf('SELECT * FROM users')
+    expect(rateLimitIdx).toBeGreaterThan(-1)
+    expect(dbLookupIdx).toBeGreaterThan(-1)
+    expect(rateLimitIdx).toBeLessThan(dbLookupIdx)
+  })
+})

--- a/tests/contact-endpoint.test.ts
+++ b/tests/contact-endpoint.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('contact: API endpoint', () => {
+  it('contact endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/contact.ts'))).toBe(true)
+  })
+
+  it('handles POST requests', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain('export const POST')
+  })
+
+  it('validates required fields: name, email, message', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain('name')
+    expect(source).toContain('email')
+    expect(source).toContain('message')
+  })
+
+  it('has honeypot check to reject bots', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain('honeypot')
+    expect(source).toContain('website')
+  })
+
+  it('sends notification email via Resend', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain('sendEmail')
+  })
+})
+
+describe('contact: rate limiting', () => {
+  it('contact endpoint imports rateLimitByIp', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain('rateLimitByIp')
+    expect(source).toContain('rate-limit')
+  })
+
+  it('contact endpoint rate limit uses contact bucket', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain("'contact'")
+  })
+
+  it('contact endpoint returns 429 JSON on rate limit block', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    expect(source).toContain('429')
+    expect(source).toContain('Too many requests')
+  })
+
+  it('rate limit check occurs before JSON parse and validation', () => {
+    const source = readFileSync(resolve('src/pages/api/contact.ts'), 'utf-8')
+    const rateLimitIdx = source.indexOf('rateLimitByIp')
+    const jsonParseIdx = source.indexOf('request.json()')
+    expect(rateLimitIdx).toBeGreaterThan(-1)
+    expect(jsonParseIdx).toBeGreaterThan(-1)
+    expect(rateLimitIdx).toBeLessThan(jsonParseIdx)
+  })
+})

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -389,3 +389,36 @@ describe('magic-link: D1 schema', () => {
     expect(sql).toContain('idx_magic_links_expires')
   })
 })
+
+describe('magic-link: rate limiting', () => {
+  it('magic-link endpoint imports rateLimitByIp', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('rateLimitByIp')
+    expect(source).toContain('rate-limit')
+  })
+
+  it('magic-link endpoint rate limit uses auth-magic bucket', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('auth-magic')
+  })
+
+  it('magic-link endpoint redirects to rate_limited error on block', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    expect(source).toContain('rate_limited')
+  })
+
+  it('portal-login page has rate_limited error message', () => {
+    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
+    expect(source).toContain('rate_limited')
+    expect(source).toContain('Too many requests')
+  })
+
+  it('rate limit check occurs before DB lookup (enumeration guard)', () => {
+    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
+    const rateLimitIdx = source.indexOf('rateLimitByIp')
+    const dbLookupIdx = source.indexOf('SELECT * FROM users')
+    expect(rateLimitIdx).toBeGreaterThan(-1)
+    expect(dbLookupIdx).toBeGreaterThan(-1)
+    expect(rateLimitIdx).toBeLessThan(dbLookupIdx)
+  })
+})


### PR DESCRIPTION
## Summary

- Applies the existing `rateLimitByIp` helper (KV-backed `BOOKING_CACHE`) to three previously unlimited public endpoints
- `/api/auth/login` — 10 attempts/hour per IP; on block redirects to `?error=rate_limited`
- `/api/auth/magic-link` — 5 requests/hour per IP; rate check placed **first** (before any DB lookup) so the block path cannot be used to infer email existence; on block redirects to `?error=rate_limited`
- `/api/contact` — 3 requests/hour per IP; on block returns `429 { error: 'Too many requests, please try again later.' }`

Error messages added to `login.astro` and `portal-login.astro`. Dev-mode bypass unchanged (KV undefined → allowed).

Closes #535
Closes #536

## Test plan

- [ ] Brute-force protection on login: submit 10 failed login attempts from the same IP; the 11th should redirect to `?error=rate_limited` showing "Too many sign-in attempts. Please wait a few minutes and try again."
- [ ] Magic-link enumeration still hidden: with a registered email and an unregistered email, both the rate-limited path and the normal path return the same portal-login redirect — no difference in response observable to an attacker
- [ ] Contact form 429: submit 3 contact form requests from the same IP; the 4th should return HTTP 429 JSON `{ error: 'Too many requests, please try again later.' }`
- [ ] Dev mode bypass: confirm local dev (no KV binding) still allows all requests through without errors
- [ ] Existing tests pass: `npm run test` green; new tests in `tests/auth.test.ts`, `tests/magic-link.test.ts`, `tests/contact-endpoint.test.ts` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)