### PR TITLE
feat(admin/entities): Rule 2 redundancy + Rule 5 pipeline badge (#544)

### DIFF
--- a/src/lib/ui/pipeline-badge.ts
+++ b/src/lib/ui/pipeline-badge.ts
@@ -1,0 +1,30 @@
+/**
+ * Tailwind class list for a source-pipeline badge. Used anywhere we need
+ * to render which lead-gen pipeline (review mining, job monitor, etc.)
+ * produced an entity. Shared between the entity list and entity detail
+ * surfaces so both read the same colored-badge treatment — see
+ * docs/style/UI-PATTERNS.md Rule 5 (typography scale) and Rule 7 (shared
+ * primitives for repeated patterns).
+ *
+ *   <span class={pipelineBadgeClass(entity.source_pipeline)}>
+ *     {PIPELINE_LABELS[entity.source_pipeline] ?? entity.source_pipeline}
+ *   </span>
+ */
+
+const STRUCTURE = 'text-xs px-2 py-0.5 rounded'
+
+const TONE: Record<string, string> = {
+  review_mining: 'bg-amber-100 text-amber-700',
+  job_monitor: 'bg-blue-100 text-blue-700',
+  new_business: 'bg-green-100 text-green-700',
+  social_listening: 'bg-purple-100 text-purple-700',
+  website_booking: 'bg-indigo-100 text-indigo-700',
+  website_scorecard: 'bg-violet-100 text-violet-700',
+  website_intake: 'bg-teal-100 text-teal-700',
+}
+
+const FALLBACK = 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+
+export function pipelineBadgeClass(pipeline: string): string {
+  return `${STRUCTURE} ${TONE[pipeline] ?? FALLBACK}`
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -2,6 +2,9 @@
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
+import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
+import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
+import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
 import type { EntityStage } from '../../../lib/db/entities'
 import { LOST_REASONS, lostReasonLabel, lostReasonChipClass } from '../../../lib/db/lost-reasons'
@@ -477,16 +480,6 @@ function confidenceColor(confidence: string): string {
         <div
           class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)] mb-2 flex-wrap"
         >
-          {
-            entity.pain_score && (
-              <span>
-                Pain:{' '}
-                <strong class="text-[color:var(--color-text-primary)]">
-                  {entity.pain_score}/10
-                </strong>
-              </span>
-            )
-          }
           {entity.vertical && <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>}
           {entity.area && <span>{entity.area}</span>}
           {entity.employee_count && <span>~{entity.employee_count} employees</span>}
@@ -495,7 +488,9 @@ function confidenceColor(confidence: string): string {
         <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)]">
           {
             entity.source_pipeline && (
-              <span>Source: {entity.source_pipeline.replace(/_/g, ' ')}</span>
+              <span class={pipelineBadgeClass(entity.source_pipeline)}>
+                {PIPELINE_LABELS[entity.source_pipeline as PipelineId] ?? entity.source_pipeline}
+              </span>
             )
           }
           <span>Created {formatDate(entity.created_at)}</span>
@@ -848,11 +843,6 @@ function confidenceColor(confidence: string): string {
                   <span class="text-xs text-[color:var(--color-text-muted)]">
                     {formatDateTime(entry.created_at)}
                   </span>
-                  {entry.type === 'signal' && meta?.pain_score && (
-                    <span class="text-xs font-semibold text-red-600">
-                      Pain: {String(meta.pain_score)}/10
-                    </span>
-                  )}
                   {replySentiment && (
                     <span class="text-xs px-1.5 py-0.5 rounded bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] capitalize">
                       {replySentiment.replace(/_/g, ' ')}

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -18,6 +18,7 @@ import {
   LEGACY_PROBLEM_LABELS,
 } from '../../../portal/assessments/extraction-schema'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
+import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
 import { relativeTime } from '../../../lib/admin/relative-time'
 import { env } from 'cloudflare:workers'
 
@@ -96,27 +97,6 @@ const LEAD_PIPELINES = [
   { value: 'social_listening', label: 'Social Listening' },
 ]
 
-function pipelineBadgeClass(pipeline: string): string {
-  switch (pipeline) {
-    case 'review_mining':
-      return 'bg-amber-100 text-amber-700'
-    case 'job_monitor':
-      return 'bg-blue-100 text-blue-700'
-    case 'new_business':
-      return 'bg-green-100 text-green-700'
-    case 'social_listening':
-      return 'bg-purple-100 text-purple-700'
-    case 'website_booking':
-      return 'bg-indigo-100 text-indigo-700'
-    case 'website_scorecard':
-      return 'bg-violet-100 text-violet-700'
-    case 'website_intake':
-      return 'bg-teal-100 text-teal-700'
-    default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
-  }
-}
-
 function tierBadgeClass(tier: string | null): string {
   switch (tier) {
     case 'hot':
@@ -130,13 +110,6 @@ function tierBadgeClass(tier: string | null): string {
     default:
       return ''
   }
-}
-
-function painScoreClass(score: number | null): string {
-  if (!score) return 'text-[color:var(--color-text-muted)]'
-  if (score >= 8) return 'text-red-600 font-bold'
-  if (score >= 6) return 'text-amber-600 font-semibold'
-  return 'text-[color:var(--color-text-secondary)]'
 }
 
 function stageBadgeClass(stage: string): string {
@@ -379,15 +352,8 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                         </>
                       )}
                       {e.source_pipeline && (
-                        <span
-                          class={`text-xs px-2 py-0.5 rounded ${pipelineBadgeClass(e.source_pipeline)}`}
-                        >
+                        <span class={pipelineBadgeClass(e.source_pipeline)}>
                           {PIPELINE_LABELS[e.source_pipeline as PipelineId] ?? e.source_pipeline}
-                        </span>
-                      )}
-                      {e.pain_score && (
-                        <span class={`text-xs ${painScoreClass(e.pain_score)}`}>
-                          Pain: {e.pain_score}/10
                         </span>
                       )}
                       {e.tier && (


### PR DESCRIPTION
## Summary

- **H2 — Rule 2 redundancy ban:** Drop the "Pain: N/10" text where it co-exists with the tier pill. Three surfaces (entity list row, entity detail summary card, entity detail timeline signal entries). Tier pill preserved in all three.
- **H5 — Rule 5 pipeline badge consistency:** Entity detail now renders `source_pipeline` as a colored badge matching the list treatment (was plain "Source: {pipeline}" text).
- Extracted `pipelineBadgeClass` into `src/lib/ui/pipeline-badge.ts`, mirroring `src/lib/ui/status-badge.ts` (Rule 7 — shared primitives). Dropped unused `painScoreClass` from the list page.

Audit: [docs/audits/entity-lifecycle-ux-2026-04-24.md](../blob/main/docs/audits/entity-lifecycle-ux-2026-04-24.md#cross-cutting-synthesis) (H2, H5). Closes #544.

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm test` — 1536 passed, 2 skipped, 0 failures
- [x] `eslint` on changed files — clean
- [ ] Manual: entity list row renders pipeline badge + tier pill, no "Pain: N/10" text
- [ ] Manual: entity detail summary card renders tier pill in header, no "Pain: N/10" line
- [ ] Manual: entity detail meta line renders pipeline as colored badge (not plain "Source: x")
- [ ] Manual: timeline signal entry shows source + timestamp, no "Pain: N/10" chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)