### PR TITLE
feat(marketing): stacked hero headline, smaller right column

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -9,10 +9,12 @@ import CtaButton from './CtaButton.astro'
         class="md:col-span-8 py-16 md:py-24 md:pr-10 border-b-[3px] md:border-b-0 border-[color:var(--color-text-primary)]"
       >
         <h1
-          class="font-['Archivo'] font-black uppercase text-[clamp(2rem,7vw,3.75rem)] leading-[0.92] tracking-[-0.03em] text-[color:var(--color-text-primary)]"
+          class="font-['Archivo'] font-black uppercase text-[clamp(2.5rem,8vw,6.5rem)] leading-[0.88] tracking-[-0.04em] text-[color:var(--color-text-primary)]"
         >
-          <span class="block">Your&nbsp;Business</span>
-          <span class="block">Has&nbsp;Outgrown</span>
+          <span class="block">Your</span>
+          <span class="block">Business</span>
+          <span class="block">Has</span>
+          <span class="block">Outgrown</span>
           <span class="block">How&nbsp;You</span>
           <span class="block text-[color:var(--color-primary)]">Run&nbsp;It.</span>
         </h1>
@@ -31,14 +33,19 @@ import CtaButton from './CtaButton.astro'
         </div>
       </div>
       <div
-        class="md:col-span-4 flex items-center py-10 md:py-14 md:pl-10 md:border-l-[3px] md:border-[color:var(--color-text-primary)]"
+        class="md:col-span-4 flex flex-col items-start py-10 md:pt-24 md:pb-14 md:pl-10 md:border-l-[3px] md:border-[color:var(--color-text-primary)]"
       >
         <p
-          class="font-['Archivo'] text-lg md:text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+          class="font-['Archivo'] text-sm md:text-base leading-relaxed text-[color:var(--color-text-secondary)]"
         >
           You know where you want to go. We help you figure out what needs to change and build it
           with you.
         </p>
+        <div
+          class="hidden md:block mt-8 w-12 border-t-[3px] border-[color:var(--color-text-primary)]"
+          aria-hidden="true"
+        >
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Match the original mockup composition: split headline into 6 lines so the four biggest words each get their own line (YOUR / BUSINESS / HAS / OUTGROWN / HOW YOU / RUN IT.)
- Raise headline font cap from 3.75rem to 6.5rem and tighten leading/tracking so the type dominates the frame
- Drop right-column paragraph from 18/20px → 14/16px, top-align it, and add a small decorative rule below it (no fabricated client-facing content)

## Test plan
- [x] `npm run verify` passes
- [x] Visual: /  at 1440/1280/390 viewport widths — stack renders, "OUTGROWN" does not cross the column divider, right column reads correctly
- [ ] Preview deploy spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)