### PR TITLE
feat(admin/entities): collapse old timeline entries + open Intelligence Brief (#547 H15)

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -811,7 +811,7 @@ function confidenceColor(confidence: string): string {
         </div>
       ) : (
         <div class="space-y-row">
-          {filteredEntries.map((entry: ContextEntry) => {
+          {filteredEntries.map((entry: ContextEntry, idx: number) => {
             const meta = parseMetadata(entry.metadata)
             const problems = meta?.top_problems as string[] | undefined
             const isLong = entry.content.length > 500
@@ -820,9 +820,14 @@ function confidenceColor(confidence: string): string {
             const replyNextAction = isReplyLog
               ? (meta?.next_action as string | undefined)
               : undefined
+            // Open by default for the most recent N entries; older entries
+            // collapse so the timeline summary stays scannable. Toggle handles
+            // the rest. N=3 keeps the dense top-of-page view useful without
+            // a wall of expanded content.
+            const openByDefault = idx < 3
             return (
               <details
-                open
+                open={openByDefault}
                 class={`group bg-white rounded-[var(--radius-card)] border px-4 py-3 ${
                   isReplyLog
                     ? 'border-l-4 border-l-teal-500 border-[color:var(--color-border)]'
@@ -979,9 +984,11 @@ function confidenceColor(confidence: string): string {
           </div>
         )}
 
-        {/* Zone 3: Intelligence Brief */}
+        {/* Zone 3: Intelligence Brief — open by default. The brief is the core
+            of the dossier; collapsing it hid the highest-value research and
+            forced the operator to click before reading anything substantive. */}
         <div class="border-t border-[color:var(--color-border-subtle)] pt-4 mb-4">
-          <details>
+          <details open>
             <summary class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide mb-3 cursor-pointer">
               Intelligence Brief
             </summary>


### PR DESCRIPTION
## Summary

Closes H15 on #547. Other ACs deferred:

- **H16** (invoice rows as anchors) — admin invoice detail page doesn't exist; adding it is out of scope here.
- **H17 / H18** (Draft proposal + Send outreach in top toolbar) — will collide with #546's toolbar refactor; better to land them after that baseline.
- **H20** (stage-aware panel ordering) — needs panel extraction (Meetings/Quotes/Engagements/Invoices to component files) to keep the parent template readable; deferred.

## What changed (H15)

- Timeline entries: previously \`<details open>\` on every row, producing a wall of expanded content. Now open by default for the most recent 3 entries; older entries collapse (still expand on click). Summary row stays visible for every entry.
- Intelligence Brief: was collapsed by default at the bottom of the dossier zone. Open by default — the brief is the dossier's highest-value content; hiding it behind a click was the wrong default.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1536 passed, 2 skipped
- [ ] Manual: entity with 5+ timeline entries shows top 3 expanded, rest collapsed; click expands them
- [ ] Manual: entity with a dossier brief shows the brief expanded by default; collapse still works
- [ ] Manual: timeline entry summary row (badge + source + timestamp) renders consistently for collapsed and expanded entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)