### PR TITLE
feat(admin/entities): action toolbar hierarchy + honest labels + named banners + back-link (#546)

### DIFF
--- a/src/lib/ui/admin-action-button.ts
+++ b/src/lib/ui/admin-action-button.ts
@@ -1,0 +1,36 @@
+/**
+ * Admin action-button class system. Implements `docs/style/UI-PATTERNS.md`
+ * Rule 3 (one primary per view) by collapsing the four ad-hoc colour
+ * choices that had drifted across the entity detail toolbar into three
+ * named variants:
+ *
+ *   primary     — the stage's forward action (Promote, Mark as Proposing, …).
+ *                 Solid brand colour. Should appear at most once per view.
+ *   destructive — Lost / Dismiss. Subtle by default so it doesn't compete
+ *                 with the primary; click reveals the structured picker.
+ *   ghost       — every secondary action (Re-enrich, Log reply, Add note,
+ *                 New quote, Send booking link from a meetings-stage row).
+ *                 Bordered, dark text, white background. Indicates "you
+ *                 *can* do this" without competing with the primary.
+ *
+ * Returns the full Tailwind class list — callers spread directly onto
+ * `<button>` / `<summary>` and never add padding, radius, or hover state
+ * on top.
+ */
+
+export type AdminActionVariant = 'primary' | 'destructive' | 'ghost'
+
+const STRUCTURE =
+  'inline-flex items-center text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors cursor-pointer select-none'
+
+const TONE: Record<AdminActionVariant, string> = {
+  primary: 'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
+  destructive:
+    'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-red-50 hover:text-[color:var(--color-error)]',
+  ghost:
+    'bg-white border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]',
+}
+
+export function adminActionButtonClass(variant: AdminActionVariant): string {
+  return `${STRUCTURE} ${TONE[variant]}`
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -3,6 +3,7 @@ import AdminLayout from '../../../layouts/AdminLayout.astro'
 import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
+import { adminActionButtonClass } from '../../../lib/ui/admin-action-button'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
@@ -121,24 +122,33 @@ const supersedeCandidates = showNewQuoteButton
   ? quotes.filter((q) => q.status === 'declined' || q.status === 'expired')
   : []
 
-// Stage transitions
-const TRANSITIONS: Record<
-  string,
-  { label: string; stage: EntityStage; style: string; action?: string }[]
-> = {
+// Stage transitions. `variant` keys into the admin action-button system
+// (Rule 3 — one primary per view): the forward stage action is `primary`,
+// Lost/Dismiss is `destructive`. Forward labels were renamed from "Send
+// Proposal" / "Engaged" / "Delivered" to "Mark as ..." — the prior labels
+// promised actions (sending the proposal, recording an engagement) but
+// only transitioned the stage. "Mark as ..." is honest about what the
+// click does. The actual proposal-send / engagement-start / delivery-handoff
+// flows live in their own buttons elsewhere on the page.
+type Transition = {
+  label: string
+  stage: EntityStage
+  variant: 'primary' | 'destructive'
+  action?: string
+}
+
+const TRANSITIONS: Record<string, Transition[]> = {
   signal: [
     {
       label: 'Promote',
       stage: 'prospect',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
+      variant: 'primary',
       action: `/api/admin/entities/${entity.id}/promote`,
     },
     {
       label: 'Dismiss',
       stage: 'lost',
-      style:
-        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
+      variant: 'destructive',
     },
   ],
   prospect: [
@@ -147,85 +157,29 @@ const TRANSITIONS: Record<
     // row in `scheduled` status and signs a booking URL, then transitions the
     // stage. #504's "Start Meeting" button is not needed; the booking flow
     // already produces a meeting row and moves the entity to `meetings`.
-    {
-      label: 'Lost',
-      stage: 'lost',
-      style:
-        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
-    },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
   ],
   meetings: [
-    {
-      label: 'Send Proposal',
-      stage: 'proposing',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
-    {
-      label: 'Lost',
-      stage: 'lost',
-      style:
-        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
-    },
+    { label: 'Mark as Proposing', stage: 'proposing', variant: 'primary' },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
   ],
   proposing: [
-    {
-      label: 'Engaged',
-      stage: 'engaged',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
-    {
-      label: 'Lost',
-      stage: 'lost',
-      style:
-        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
-    },
+    { label: 'Mark as Engaged', stage: 'engaged', variant: 'primary' },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
   ],
-  engaged: [
-    {
-      label: 'Delivered',
-      stage: 'delivered',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
-  ],
+  engaged: [{ label: 'Mark as Delivered', stage: 'delivered', variant: 'primary' }],
   delivered: [
-    {
-      label: 'Ongoing',
-      stage: 'ongoing',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
-    {
-      label: 'Re-engage',
-      stage: 'prospect',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
+    { label: 'Mark as Ongoing', stage: 'ongoing', variant: 'primary' },
+    // Re-engage from delivered is a deliberate move backward — keep it
+    // available but as a secondary affordance so it doesn't compete with
+    // the natural forward path into Ongoing.
+    { label: 'Re-engage', stage: 'prospect', variant: 'destructive' },
   ],
   ongoing: [
-    {
-      label: 'Re-engage',
-      stage: 'prospect',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
-    {
-      label: 'Lost',
-      stage: 'lost',
-      style:
-        'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]',
-    },
+    { label: 'Re-engage', stage: 'prospect', variant: 'primary' },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
   ],
-  lost: [
-    {
-      label: 'Re-engage',
-      stage: 'prospect',
-      style:
-        'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
-    },
-  ],
+  lost: [{ label: 'Re-engage', stage: 'prospect', variant: 'primary' }],
 }
 
 function contextTypeBadge(type: string): string {
@@ -392,37 +346,53 @@ function confidenceColor(confidence: string): string {
   ]}
 >
   {
+    /* H19 — back-link to the stage list. Breadcrumbs cover this in
+      principle but reduce to a small text trail; an inline back link
+      gives the operator a one-click escape hatch from a deep detail
+      page back to the work queue they came from. */
+  }
+  <a
+    href={`/admin/entities?stage=${entity.stage}`}
+    class="inline-flex items-center gap-1 text-xs text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] mb-3"
+  >
+    <span aria-hidden="true">←</span>
+    <span>
+      Back to {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage} list
+    </span>
+  </a>
+  {
     promoted && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Entity promoted to prospect.
+        {entity.name} promoted to prospect.
       </div>
     )
   }
   {
     noteAdded && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Note added.
+        Note added to {entity.name}.
       </div>
     )
   }
   {
     replyLogged && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Reply logged.
+        Reply logged on {entity.name}.
       </div>
     )
   }
   {
     stageUpdated && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Stage updated.
+        {entity.name} moved to{' '}
+        {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}.
       </div>
     )
   }
   {
     dossierGenerated && (
       <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Re-enrichment complete. Refreshed reviews, synthesis, news, and outreach draft — see
+        Re-enriched {entity.name}. Refreshed reviews, synthesis, news, and outreach draft — see
         timeline below.
       </div>
     )
@@ -530,7 +500,7 @@ function confidenceColor(confidence: string): string {
             <button
               type="button"
               id="send-booking-link-btn"
-              class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]"
+              class={adminActionButtonClass('primary')}
             >
               Send booking link
             </button>
@@ -540,9 +510,7 @@ function confidenceColor(confidence: string): string {
           TRANSITIONS[entity.stage]?.map((t) =>
             t.stage === 'lost' ? (
               <details class="relative lost-picker">
-                <summary
-                  class={`list-none text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors cursor-pointer select-none ${t.style}`}
-                >
+                <summary class={`list-none ${adminActionButtonClass(t.variant)}`}>
                   {t.label}
                 </summary>
                 <form
@@ -576,10 +544,7 @@ function confidenceColor(confidence: string): string {
                     />
                   </label>
                   <div class="flex justify-end gap-2">
-                    <button
-                      type="submit"
-                      class="text-xs bg-[color:var(--color-text-primary)] text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-black transition-colors"
-                    >
+                    <button type="submit" class={adminActionButtonClass('destructive')}>
                       {t.label}
                     </button>
                   </div>
@@ -589,10 +554,7 @@ function confidenceColor(confidence: string): string {
               <form method="POST" action={t.action ?? `/api/admin/entities/${entity.id}/stage`}>
                 <input type="hidden" name="stage" value={t.stage} />
                 <input type="hidden" name="reason" value={`${t.label} by admin.`} />
-                <button
-                  type="submit"
-                  class={`text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors ${t.style}`}
-                >
+                <button type="submit" class={adminActionButtonClass(t.variant)}>
                   {t.label}
                 </button>
               </form>
@@ -609,7 +571,7 @@ function confidenceColor(confidence: string): string {
               <button
                 type="submit"
                 id="re-enrich-btn"
-                class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-cyan-600 text-white hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                class={`${adminActionButtonClass('ghost')} disabled:opacity-50 disabled:cursor-not-allowed`}
                 title="Refresh reviews and news — cheap, safe to re-run"
               >
                 Re-enrich (reviews + news)
@@ -622,7 +584,7 @@ function confidenceColor(confidence: string): string {
             <button
               type="button"
               data-open-reply-dialog={entity.id}
-              class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]"
+              class={adminActionButtonClass('ghost')}
             >
               Log reply
             </button>
@@ -652,10 +614,7 @@ function confidenceColor(confidence: string): string {
                   </select>
                 </label>
               )}
-              <button
-                type="submit"
-                class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]"
-              >
+              <button type="submit" class={adminActionButtonClass('ghost')}>
                 New quote
               </button>
             </form>
@@ -763,10 +722,7 @@ function confidenceColor(confidence: string): string {
         rows="2"
         class="flex-1 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
       ></textarea>
-      <button
-        type="submit"
-        class="self-end text-sm bg-primary text-white px-4 py-2 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
-      >
+      <button type="submit" class={`self-end ${adminActionButtonClass('ghost')}`}>
         Add Note
       </button>
     </form>

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -79,8 +79,11 @@ if (filterStage === 'proposing' && entities.length > 0) {
 }
 const displayEntities = filterStage === 'proposing' ? proposingRows : entities
 
-const promoted = Astro.url.searchParams.get('promoted')
+// `dismissed=1&name=...` lands here from /api/admin/entities/[id]/dismiss.
+// Promote redirects to the detail page (/admin/entities/[id]?promoted=1)
+// and never lands here, so there's no `promoted` param to read on the list.
 const dismissed = Astro.url.searchParams.get('dismissed')
+const dismissedName = Astro.url.searchParams.get('name')
 const error = Astro.url.searchParams.get('error')
 
 // Tabs where multi-select + bulk actions are enabled. Later stages
@@ -219,16 +222,9 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
   breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Entities' }]}
 >
   {
-    promoted && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Entity promoted to prospect.
-      </div>
-    )
-  }
-  {
     dismissed && (
       <div class="bg-[color:var(--color-background)] border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
-        Entity dismissed.
+        {dismissedName ? `${dismissedName} dismissed.` : 'Entity dismissed.'}
       </div>
     )
   }

--- a/src/pages/api/admin/entities/[id]/dismiss.ts
+++ b/src/pages/api/admin/entities/[id]/dismiss.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro'
-import { transitionStage } from '../../../../../lib/db/entities'
+import { getEntity, transitionStage } from '../../../../../lib/db/entities'
 import { isLostReasonCode } from '../../../../../lib/db/lost-reasons'
 import { env } from 'cloudflare:workers'
 
@@ -49,11 +49,18 @@ export const POST: APIRoute = async ({ params, request, locals, redirect }) => {
         ? rawSummary.trim()
         : `Dismissed: ${lostReasonCode}${lostDetail ? ` — ${lostDetail}` : ''}`
 
+    // Read the entity's name BEFORE the transition so the post-redirect
+    // banner can identify which row was just dismissed (H4 — banner
+    // context). The signal-stage list strip-away after dismiss makes
+    // this the last chance the operator has to see the name.
+    const entity = await getEntity(env.DB, session.orgId, entityId)
+
     await transitionStage(env.DB, session.orgId, entityId, 'lost', reasonSummary, {
       lostReason: { code: lostReasonCode, detail: lostDetail },
     })
 
-    return redirect('/admin/entities?dismissed=1', 302)
+    const nameParam = entity ? `&name=${encodeURIComponent(entity.name)}` : ''
+    return redirect(`/admin/entities?dismissed=1${nameParam}`, 302)
   } catch (err) {
     console.error('[api/admin/entities/dismiss] Error:', err)
     const message = err instanceof Error ? err.message : 'server'


### PR DESCRIPTION
## Summary

Closes 4 of 5 ACs on #546. H3 (Log reply state-gate needing a `has_outreach` DAL flag) is deferred.

- **H10** — Collapsed the four ad-hoc toolbar button colours into three named variants in \`src/lib/ui/admin-action-button.ts\`: \`primary\` (solid, stage's forward action only), \`destructive\` (Lost/Dismiss, subtle → red on hover), \`ghost\` (every secondary action). \`TRANSITIONS\` now carries \`variant\` instead of ad-hoc Tailwind. One primary per view is enforceable in data, not reviewer discipline.
- **H9** — Renamed misleading stage-transition labels: "Send Proposal" → "Mark as Proposing", "Engaged" → "Mark as Engaged", "Delivered" → "Mark as Delivered", "Ongoing" → "Mark as Ongoing". The prior labels promised actions; now they describe what the click actually does.
- **H4** — Detail-page banners include the entity name. List-page dismiss banner reads name from a new URL param threaded by the dismiss endpoint. Dead list-page \`promoted\` banner removed.
- **H19** — Inline back-link ("← Back to {Stage} list") above the flash-banner stack on detail pages.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1536 passed, 2 skipped
- [x] \`prettier --check\` on changed files — clean
- [x] eslint on changed files — clean
- [ ] Manual: each stage's toolbar shows exactly one primary button
- [ ] Manual: meetings/proposing/engaged/delivered transition buttons read "Mark as ..."
- [ ] Manual: promote → detail banner shows "{name} promoted to prospect."
- [ ] Manual: dismiss from signal list → list banner shows "{name} dismissed."
- [ ] Manual: detail page shows "← Back to {Stage} list" above banners
- [ ] Manual: Lost picker on each stage opens the structured-reason form on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)