### PR TITLE
feat(admin/entities): stage_changed_at primary date + overdue accent + freshness (#545)

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -4,6 +4,7 @@ import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
 import { adminActionButtonClass } from '../../../lib/ui/admin-action-button'
+import { relativeTime } from '../../../lib/admin/relative-time'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
@@ -236,6 +237,16 @@ function formatDateTime(iso: string): string {
   })
 }
 
+/**
+ * Past-relative comparison for `next_action_at`. Anything strictly in the
+ * past becomes "Overdue" and renders red rather than the default amber
+ * "scheduled in the future" tone — H7 in the entity-lifecycle UX audit.
+ */
+function isOverdue(iso: string | null): boolean {
+  if (!iso) return false
+  return new Date(iso).getTime() < Date.now()
+}
+
 function parseMetadata(json: string | null): Record<string, unknown> | null {
   if (!json) return null
   try {
@@ -255,6 +266,23 @@ const outreachMeta = parseMetadata(outreachEntry?.metadata ?? null)
 const outreachFromDossier = outreachMeta?.trigger === 'dossier'
 
 const hasDossier = !!dossierBrief
+
+// --- Freshness indicators (H8) ---
+// Latest enrichment context entry — surfaces "Last enriched {relative}" near
+// the Re-enrich button so the operator can tell if the data is stale before
+// deciding to re-fetch.
+const lastEnrichmentAt =
+  contextEntries
+    .filter((e) => e.type === 'enrichment')
+    .map((e) => e.created_at)
+    .sort()
+    .pop() ?? null
+// Latest sent quote — surfaces "Quote sent {relative}" on Proposing-stage
+// detail so the operator knows how warm the proposal still is.
+const latestSentQuote = quotes
+  .filter((q) => q.sent_at)
+  .sort((a, b) => (b.sent_at ?? '').localeCompare(a.sent_at ?? ''))[0]
+const latestSentQuoteAt = latestSentQuote?.sent_at ?? null
 const reviewMeta = parseMetadata(reviewSynthEntry?.metadata ?? null) as {
   unified_rating?: number | null
   total_reviews_across_platforms?: number
@@ -463,7 +491,27 @@ function confidenceColor(confidence: string): string {
               </span>
             )
           }
-          <span>Created {formatDate(entity.created_at)}</span>
+          {
+            entity.stage === 'signal' || entity.stage === 'lost' ? (
+              <span>
+                {entity.stage === 'lost'
+                  ? `Lost ${formatDate(entity.stage_changed_at)}`
+                  : `Created ${formatDate(entity.created_at)}`}
+              </span>
+            ) : (
+              <span>
+                {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage} since{' '}
+                {formatDate(entity.stage_changed_at)}
+              </span>
+            )
+          }
+          {
+            entity.stage === 'proposing' && latestSentQuoteAt && (
+              <span title={`Quote sent ${formatDate(latestSentQuoteAt)}`}>
+                Quote sent {relativeTime(latestSentQuoteAt)}
+              </span>
+            )
+          }
           {entity.phone && <span>{entity.phone}</span>}
           {
             entity.website && (
@@ -482,9 +530,22 @@ function confidenceColor(confidence: string): string {
 
         {
           entity.next_action && (
-            <div class="mt-3 bg-amber-50 border border-amber-200 px-3 py-2 rounded text-sm">
-              <span class="font-medium text-amber-800">Next:</span>
-              <span class="text-amber-700">
+            <div
+              class={`mt-3 px-3 py-2 rounded text-sm ${
+                isOverdue(entity.next_action_at)
+                  ? 'bg-red-50 border border-red-200'
+                  : 'bg-amber-50 border border-amber-200'
+              }`}
+            >
+              <span
+                class={`font-medium ${
+                  isOverdue(entity.next_action_at) ? 'text-red-800' : 'text-amber-800'
+                }`}
+              >
+                {isOverdue(entity.next_action_at) ? 'Overdue:' : 'Next:'}
+              </span>
+              <span class={isOverdue(entity.next_action_at) ? 'text-red-700' : 'text-amber-700'}>
+                {' '}
                 {entity.next_action}
                 {entity.next_action_at && ` — ${formatDate(entity.next_action_at)}`}
               </span>
@@ -567,6 +628,7 @@ function confidenceColor(confidence: string): string {
               method="POST"
               action={`/api/admin/entities/${entity.id}/dossier`}
               id="re-enrich-form"
+              class="flex items-center gap-2"
             >
               <button
                 type="submit"
@@ -576,6 +638,14 @@ function confidenceColor(confidence: string): string {
               >
                 Re-enrich (reviews + news)
               </button>
+              {lastEnrichmentAt && (
+                <span
+                  class="text-xs text-[color:var(--color-text-muted)]"
+                  title={`Last enriched ${formatDate(lastEnrichmentAt)}`}
+                >
+                  Last enriched {relativeTime(lastEnrichmentAt)}
+                </span>
+              )}
             </form>
           )
         }
@@ -867,9 +937,19 @@ function confidenceColor(confidence: string): string {
   {
     hasDossier && (
       <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6">
-        <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
-          Dossier Summary
-        </h3>
+        <div class="flex items-baseline justify-between gap-2 mb-4 flex-wrap">
+          <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+            Dossier Summary
+          </h3>
+          {dossierBrief && (
+            <span
+              class="text-xs text-[color:var(--color-text-muted)]"
+              title={`Generated ${formatDate(dossierBrief.created_at)}`}
+            >
+              Generated {relativeTime(dossierBrief.created_at)}
+            </span>
+          )}
+        </div>
 
         {/* Zone 1: Quick Stats */}
         <div class="grid grid-cols-2 md:grid-cols-4 gap-stack mb-5">

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -187,6 +187,16 @@ function formatDate(iso: string): string {
 }
 
 /**
+ * Past-relative comparison for `next_action_at`. Anything strictly in the
+ * past becomes "Overdue" and renders red rather than the default amber
+ * "scheduled in the future" tone — H7 in the entity-lifecycle UX audit.
+ */
+function isOverdue(iso: string | null): boolean {
+  if (!iso) return false
+  return new Date(iso).getTime() < Date.now()
+}
+
+/**
  * Resolve a problem ID (current or legacy schema) to its human label.
  * Returns null when the id matches neither schema — callers must skip
  * rendering rather than display the raw id.
@@ -435,8 +445,17 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                     )}
 
                     {e.next_action && (
-                      <p class="text-xs text-amber-600 mb-1">
-                        <span class="font-medium">Next:</span> {e.next_action}
+                      <p
+                        class={`text-xs mb-1 ${
+                          isOverdue(e.next_action_at)
+                            ? 'text-red-600 font-medium'
+                            : 'text-amber-600'
+                        }`}
+                      >
+                        <span class="font-medium">
+                          {isOverdue(e.next_action_at) ? 'Overdue:' : 'Next:'}
+                        </span>{' '}
+                        {e.next_action}
                         {e.next_action_at && ` — ${formatDate(e.next_action_at)}`}
                       </p>
                     )}
@@ -444,8 +463,13 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                     <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1 flex-wrap">
                       {isSignal && lastActivity ? (
                         <span>Last activity {formatDate(lastActivity)}</span>
-                      ) : (
+                      ) : isSignal ? (
                         <span>{formatDate(e.created_at)}</span>
+                      ) : (
+                        <span>
+                          {ENTITY_STAGES.find((s) => s.value === e.stage)?.label ?? e.stage} since{' '}
+                          {formatDate(e.stage_changed_at)}
+                        </span>
                       )}
                       {e.area && <span>{e.area}</span>}
                       {e.vertical && (


### PR DESCRIPTION
## Summary

Closes all three ACs on #545.

- **H6** — Replaced \`created_at\` as primary date on entity list rows + detail summary with stage-relative phrasing: "{Stage} since {date}" for active stages, "Lost {date}" for terminal, "Created {date}" for Signal.
- **H7** — \`next_action_at\` past dates render red with "Overdue:" label (was amber regardless of past/future). Detail page background flips red. \`isOverdue\` helper added in both list and detail.
- **H8** — Three freshness indicators on detail: "Last enriched {relative}" by Re-enrich, "Generated {relative}" on Dossier heading, "Quote sent {relative}" on Proposing-stage meta line. All carry absolute-date \`title\` for hover.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1536 passed, 2 skipped
- [x] \`prettier --check\` — clean
- [x] \`eslint\` — clean
- [ ] Manual: prospect/meetings/proposing rows show "{Stage} since {date}" instead of bare creation date
- [ ] Manual: row with past \`next_action_at\` reads red "Overdue:" instead of amber "Next:"
- [ ] Manual: detail page on entity with enrichment shows "Last enriched 3d ago" by the Re-enrich button
- [ ] Manual: dossier heading shows "Generated {relative}"
- [ ] Manual: Proposing-stage detail with sent quote shows "Quote sent {relative}" in meta row

🤖 Generated with [Claude Code](https://claude.com/claude-code)