### PR TITLE
chore(admin/entities): drop ~N employees + Add Note form polish (#548)

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -494,7 +494,6 @@ function confidenceColor(confidence: string): string {
         >
           {entity.vertical && <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>}
           {entity.area && <span>{entity.area}</span>}
-          {entity.employee_count && <span>~{entity.employee_count} employees</span>}
         </div>
 
         <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)]">
@@ -839,7 +838,13 @@ function confidenceColor(confidence: string): string {
     )
   }
 
-  {/* Add Note */}
+  {
+    /* Add Note — `rows="4"` and a non-resize textarea give the operator
+      enough room to draft a real note (the prior `rows="2"` was a single-
+      line nudge that fought against any actual writing). The Clear button
+      resets the textarea without submitting; the form's native reset
+      handles the clearing logic. */
+  }
   <div
     class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack mb-6"
   >
@@ -848,12 +853,13 @@ function confidenceColor(confidence: string): string {
       <textarea
         name="content"
         placeholder="Add a note..."
-        rows="2"
-        class="flex-1 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        rows="4"
+        class="flex-1 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
       ></textarea>
-      <button type="submit" class={`self-end ${adminActionButtonClass('ghost')}`}>
-        Add Note
-      </button>
+      <div class="flex flex-col gap-2 self-end">
+        <button type="submit" class={adminActionButtonClass('ghost')}>Add Note</button>
+        <button type="reset" class={adminActionButtonClass('ghost')}> Clear </button>
+      </div>
     </form>
   </div>
 

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -475,7 +475,6 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                       {e.vertical && (
                         <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>
                       )}
-                      {e.employee_count && <span>~{e.employee_count} employees</span>}
                       {isSignal && website && (
                         <a
                           href={website.href}


### PR DESCRIPTION
## Summary

Two ship-now items from #548 (Prospect audit). Applies broadly — both surfaces touch every stage, not just prospect.

- Drop \`~N employees\` from the entity row meta line and detail summary. SS targets the \$750k–\$5M revenue band; employee count is noise we don't sell on and steals a slot from \`vertical · area · stage_changed_at\`.
- Add Note form: bumped textarea from \`rows="2" resize-none\` → \`rows="4" resize-y\` so notes can actually be drafted in place. Added a Clear button (native \`<button type="reset">\`, no JS) using the ghost variant — Add Note + Clear stack on the right.

Per-stage data-loading items from #548 (outreach row action, why-this-is-here one-liner) stay open — they need batched DAL queries on prospect list rows.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1536 passed
- [x] \`prettier --check\` — clean
- [ ] Manual: list rows + entity detail meta no longer show "~N employees"
- [ ] Manual: Add Note textarea reads as 4 rows tall and resizes vertically
- [ ] Manual: Clear button empties the textarea without submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)