### PR TITLE
feat(admin/entities): batch hydrators + Log reply gate + Send outreach row action (#546 H3, #548)

### DIFF
--- a/src/lib/db/contacts.ts
+++ b/src/lib/db/contacts.ts
@@ -34,6 +34,44 @@ export interface UpdateContactData {
 }
 
 /**
+ * For a batch of entity ids, return a Map keyed by entity_id whose value
+ * is the first (alphabetical-by-name) contact that has a non-empty email.
+ * Used by the entity list to know — without an N+1 — whether a row should
+ * surface a "Send outreach" mailto and which address it targets.
+ *
+ * Entities with no email-bearing contact are simply absent from the Map.
+ * Empty input returns an empty Map without touching the DB.
+ */
+export async function getFirstContactWithEmailForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, Contact>> {
+  const result = new Map<string, Contact>()
+  if (entityIds.length === 0) return result
+
+  const placeholders = entityIds.map(() => '?').join(', ')
+  const rows = await db
+    .prepare(
+      `SELECT * FROM contacts
+       WHERE org_id = ? AND entity_id IN (${placeholders})
+         AND email IS NOT NULL AND email <> ''
+       ORDER BY entity_id ASC, name ASC`
+    )
+    .bind(orgId, ...entityIds)
+    .all<Contact>()
+
+  // ORDER BY entity_id, name means the first row per entity is the
+  // alphabetical-name pick; subsequent rows we ignore.
+  for (const row of rows.results ?? []) {
+    if (!result.has(row.entity_id)) {
+      result.set(row.entity_id, row)
+    }
+  }
+  return result
+}
+
+/**
  * List contacts for an entity, scoped to an organization.
  */
 export async function listContacts(

--- a/src/lib/db/context.ts
+++ b/src/lib/db/context.ts
@@ -228,6 +228,53 @@ export async function listContext(
 }
 
 /**
+ * For a batch of entity ids, return a Map keyed by entity_id whose value
+ * is the latest `outreach_draft` context entry for that entity. Used by
+ * the entity list to gate "Log reply" (existence check via Map.has) and
+ * to build a "Send outreach" mailto (content from Map.get) without an
+ * N+1.
+ *
+ * Outreach-drafted is the practical proxy for "outreach exists" because
+ * we don't yet record send events explicitly (the mailto: button kicks
+ * the user into their mail client and we can't observe what happens
+ * next). A drafted but never-sent outreach overcounts slightly; that's
+ * the conservative direction — we'd rather show a Log reply button on
+ * a row that's *almost* ready than hide it on a row where outreach
+ * actually happened.
+ *
+ * Empty input returns an empty Map without touching the DB.
+ */
+export async function getLatestOutreachDraftForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, ContextEntry>> {
+  const result = new Map<string, ContextEntry>()
+  if (entityIds.length === 0) return result
+
+  const placeholders = entityIds.map(() => '?').join(', ')
+  // Order entity_id, created_at DESC so the first row per entity is the
+  // most recent draft; later rows we ignore. Cheaper than a window
+  // function on D1 for this volume.
+  const rows = await db
+    .prepare(
+      `SELECT * FROM context
+       WHERE org_id = ? AND type = 'outreach_draft'
+         AND entity_id IN (${placeholders})
+       ORDER BY entity_id ASC, created_at DESC`
+    )
+    .bind(orgId, ...entityIds)
+    .all<ContextEntry>()
+
+  for (const row of rows.results ?? []) {
+    if (!result.has(row.entity_id)) {
+      result.set(row.entity_id, row)
+    }
+  }
+  return result
+}
+
+/**
  * Count context entries for an entity.
  */
 export async function countContext(db: D1Database, entityId: string): Promise<number> {

--- a/src/lib/entities/draftable-meeting.ts
+++ b/src/lib/entities/draftable-meeting.ts
@@ -1,0 +1,51 @@
+/**
+ * "Draftable meeting" rule: a completed meeting whose notes haven't yet been
+ * turned into a quote. Surfacing one of these to the operator (in the entity
+ * list row, in the detail toolbar, in the meetings panel) is the primary
+ * forward-action signal at the meetings stage.
+ *
+ * The detail page and the entity list both need this rule. Keeping it as a
+ * pure helper means the SQL stays dumb (just `listMeetings` + `listQuotes`)
+ * and both surfaces agree on what counts. If a single meeting maps to a
+ * single quote (current invariant), `meeting.id` matching either
+ * `quote.meeting_id` or the legacy `quote.assessment_id` is sufficient.
+ *
+ * Returns the most recent draftable meeting, or `null` if none exist.
+ * Callers that want all draftables can use `findDraftableMeetings` instead.
+ */
+
+interface MeetingShape {
+  id: string
+  status: string
+  completed_at: string | null
+  created_at: string
+}
+
+interface QuoteShape {
+  meeting_id: string | null
+  assessment_id: string
+}
+
+export function findDraftableMeetings<M extends MeetingShape, Q extends QuoteShape>(
+  meetings: M[],
+  quotes: Q[]
+): M[] {
+  const meetingIdsWithQuotes = new Set(quotes.map((q) => q.meeting_id ?? q.assessment_id))
+  return meetings
+    .filter((m) => m.status === 'completed' && !meetingIdsWithQuotes.has(m.id))
+    .sort((a, b) => {
+      // Completed-most-recently first. Fall back to created_at when
+      // completed_at is missing — `completed` status without a completed_at
+      // is legacy data, but we still want stable ordering.
+      const aKey = a.completed_at ?? a.created_at
+      const bKey = b.completed_at ?? b.created_at
+      return bKey.localeCompare(aKey)
+    })
+}
+
+export function findDraftableMeeting<M extends MeetingShape, Q extends QuoteShape>(
+  meetings: M[],
+  quotes: Q[]
+): M | null {
+  return findDraftableMeetings(meetings, quotes)[0] ?? null
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -17,6 +17,7 @@ import { listMeetings } from '../../../lib/db/meetings'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listQuotes, hasOpenQuoteForEntity } from '../../../lib/db/quotes'
 import { listInvoices } from '../../../lib/db/invoices'
+import { findDraftableMeeting } from '../../../lib/entities/draftable-meeting'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -41,13 +42,18 @@ const [contextEntries, contacts, meetings, engagements, quotes, invoices] = awai
   listInvoices(env.DB, session.orgId, { entityId }),
 ])
 
-// A meeting is "draft-able" if it was completed (has extraction or completion
-// notes) and no quote has been derived from it yet. See issue #470 — proposal
-// drafting is an explicit admin action, never a side effect of completion.
-const completedMeetings = meetings.filter((m) => m.status === 'completed')
-const meetingIdsWithQuotes = new Set(quotes.map((q) => q.meeting_id ?? q.assessment_id))
-const draftableMeetings = completedMeetings.filter((m) => !meetingIdsWithQuotes.has(m.id))
-const mostRecentDraftableMeeting = draftableMeetings[0] ?? null
+// A meeting is "draft-able" if it was completed and no quote has been
+// derived from it yet. See issue #470 — proposal drafting is an explicit
+// admin action, never a side effect of completion. Logic lives in
+// `src/lib/entities/draftable-meeting.ts` so the entity list and detail
+// share one source of truth.
+const mostRecentDraftableMeeting = findDraftableMeeting(meetings, quotes)
+
+// "Has outreach" = at least one outreach_draft context entry exists. Used
+// to gate the "Log reply" toolbar action: if the operator hasn't drafted
+// outreach yet, there's nothing for the prospect to be replying to. See
+// `getEntityIdsWithOutreach` for the batch version used on the list.
+const hasOutreach = contextEntries.some((e) => e.type === 'outreach_draft')
 
 // Reverse for newest-first display
 const timelineEntries = [...contextEntries].reverse()
@@ -708,7 +714,10 @@ function confidenceColor(confidence: string): string {
           )
         }
         {
-          entity.stage === 'prospect' && (
+          /* H3 — Log reply is hidden until outreach has been drafted. The
+             button only makes sense once there's something the prospect
+             could reply *to*. `hasOutreach` is the practical proxy. */
+          entity.stage === 'prospect' && hasOutreach && (
             <button
               type="button"
               data-open-reply-dialog={entity.id}

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -11,6 +11,10 @@ import type { Entity, EntityStage, EntitySignalMetadata } from '../../../lib/db/
 import { getActiveQuotesForEntities } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
 import { LOST_REASONS } from '../../../lib/db/lost-reasons'
+import { getLatestOutreachDraftForEntities } from '../../../lib/db/context'
+import type { ContextEntry } from '../../../lib/db/context'
+import { getFirstContactWithEmailForEntities } from '../../../lib/db/contacts'
+import type { Contact } from '../../../lib/db/contacts'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import {
@@ -78,6 +82,39 @@ if (filterStage === 'proposing' && entities.length > 0) {
   })
 }
 const displayEntities = filterStage === 'proposing' ? proposingRows : entities
+
+// Prospect-stage row hydration. Two batch queries — latest outreach draft
+// per entity (existence gates Log reply, content powers Send outreach
+// mailto), and the first contact with an email per entity (gates Send
+// outreach and provides the recipient). Both bounded by the page's
+// prospect rows; skipped entirely on other stages or when empty.
+let outreachDraftByEntityId = new Map<string, ContextEntry>()
+let contactEmailByEntityId = new Map<string, Contact>()
+if (filterStage === 'prospect' && entities.length > 0) {
+  const ids = entities.map((e) => e.id)
+  ;[outreachDraftByEntityId, contactEmailByEntityId] = await Promise.all([
+    getLatestOutreachDraftForEntities(env.DB, session.orgId, ids),
+    getFirstContactWithEmailForEntities(env.DB, session.orgId, ids),
+  ])
+}
+
+/**
+ * Build a `mailto:` URL that pre-fills recipient, subject, and body for
+ * the operator's mail client. Returns null when either the contact email
+ * or the outreach draft is missing — caller hides the button.
+ */
+function buildOutreachMailto(
+  entityName: string,
+  contactEmail: string | null | undefined,
+  draftContent: string | null | undefined
+): string | null {
+  if (!contactEmail || !draftContent) return null
+  return (
+    `mailto:${encodeURIComponent(contactEmail)}` +
+    `?subject=${encodeURIComponent(`Reaching out — ${entityName}`)}` +
+    `&body=${encodeURIComponent(draftContent)}`
+  )
+}
 
 // `dismissed=1&name=...` lands here from /api/admin/entities/[id]/dismiss.
 // Promote redirects to the detail page (/admin/entities/[id]?promoted=1)
@@ -358,6 +395,16 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             const lastActivity = meta?.last_activity_at ?? null
             const website = displayWebsite(e.website)
             const isSignal = e.stage === 'signal'
+            const isProspect = e.stage === 'prospect'
+            const rowOutreachDraft = isProspect ? (outreachDraftByEntityId.get(e.id) ?? null) : null
+            const rowContactEmail = isProspect
+              ? (contactEmailByEntityId.get(e.id)?.email ?? null)
+              : null
+            const rowOutreachMailto = buildOutreachMailto(
+              e.name,
+              rowContactEmail,
+              rowOutreachDraft?.content
+            )
             const activeQuote =
               filterStage === 'proposing' ? (activeQuoteByEntityId.get(e.id) ?? null) : null
             const quoteTimestamp =
@@ -512,38 +559,56 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                     </div>
                   </div>
 
-                  {(isSignal || e.stage === 'prospect') && (
-                    <div class="relative z-10 flex items-center gap-2 shrink-0">
-                      {isSignal ? (
-                        <>
-                          <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
-                            <button
-                              type="submit"
-                              class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
-                            >
-                              Promote
-                            </button>
-                          </form>
-                          <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
-                            <button
-                              type="submit"
-                              class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
-                            >
-                              Dismiss
-                            </button>
-                          </form>
-                        </>
-                      ) : (
-                        <button
-                          type="button"
-                          data-open-reply-dialog={e.id}
-                          class="text-xs border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
-                        >
-                          Log reply
-                        </button>
-                      )}
-                    </div>
-                  )}
+                  {(() => {
+                    const showProspectActions =
+                      isProspect && (rowOutreachMailto || rowOutreachDraft)
+                    if (!isSignal && !showProspectActions) return null
+                    return (
+                      <div class="relative z-10 flex items-center gap-2 shrink-0">
+                        {isSignal ? (
+                          <>
+                            <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
+                              <button
+                                type="submit"
+                                class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                              >
+                                Promote
+                              </button>
+                            </form>
+                            <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
+                              <button
+                                type="submit"
+                                class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                              >
+                                Dismiss
+                              </button>
+                            </form>
+                          </>
+                        ) : (
+                          <>
+                            {rowOutreachMailto && (
+                              <a
+                                href={rowOutreachMailto}
+                                class="text-xs border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+                                title={`Open mail to ${rowContactEmail} with the draft pre-filled`}
+                              >
+                                Send outreach
+                              </a>
+                            )}
+                            {rowOutreachDraft && (
+                              <button
+                                type="button"
+                                data-open-reply-dialog={e.id}
+                                class="text-xs border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+                              >
+                                Log reply
+                              </button>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    )
+                  })()}
                 </div>
               </div>
             )
@@ -554,9 +619,11 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
   }
 
   {
-    /* One dialog per prospect row — triggered by data-open-reply-dialog */
+    /* One dialog per prospect row that actually exposes a Log reply
+       button — H3 hides the button when no outreach has been drafted,
+       so we don't need the dialog markup for those rows either. */
     displayEntities
-      .filter((e: Entity) => e.stage === 'prospect')
+      .filter((e: Entity) => e.stage === 'prospect' && outreachDraftByEntityId.has(e.id))
       .map((e: Entity) => <LogReplyDialog entityId={e.id} entityName={e.name} />)
   }
 

--- a/tests/draftable-meeting.test.ts
+++ b/tests/draftable-meeting.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure-helper tests for findDraftableMeeting / findDraftableMeetings.
+ * No DB — the helper takes already-loaded meetings and quotes and returns
+ * a filtered+sorted view. Covers the rule both surfaces (entity detail
+ * page and entity list row) need to agree on.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { findDraftableMeeting, findDraftableMeetings } from '../src/lib/entities/draftable-meeting'
+
+type M = {
+  id: string
+  status: string
+  completed_at: string | null
+  created_at: string
+}
+type Q = { meeting_id: string | null; assessment_id: string }
+
+const completed = (id: string, completedAt: string | null = null, createdAt = '2026-01-01'): M => ({
+  id,
+  status: 'completed',
+  completed_at: completedAt,
+  created_at: createdAt,
+})
+
+describe('findDraftableMeetings', () => {
+  it('returns empty when there are no meetings', () => {
+    expect(findDraftableMeetings([], [])).toEqual([])
+  })
+
+  it('excludes meetings whose id matches a quote.meeting_id', () => {
+    const m1 = completed('m1', '2026-04-01')
+    const m2 = completed('m2', '2026-04-02')
+    const result = findDraftableMeetings([m1, m2], [{ meeting_id: 'm1', assessment_id: 'a1' }])
+    expect(result.map((m) => m.id)).toEqual(['m2'])
+  })
+
+  it('excludes meetings whose id matches a quote.assessment_id (legacy)', () => {
+    // A quote whose meeting_id is null but assessment_id matches the
+    // meeting id — the legacy linkage we still honor.
+    const m1 = completed('m1', '2026-04-01')
+    const result = findDraftableMeetings([m1], [{ meeting_id: null, assessment_id: 'm1' }])
+    expect(result).toEqual([])
+  })
+
+  it('only considers meetings with status === "completed"', () => {
+    const m1 = completed('m1', '2026-04-01')
+    const m2: M = {
+      id: 'm2',
+      status: 'scheduled',
+      completed_at: null,
+      created_at: '2026-04-02',
+    }
+    const result = findDraftableMeetings([m1, m2], [])
+    expect(result.map((m) => m.id)).toEqual(['m1'])
+  })
+
+  it('sorts most-recently-completed first', () => {
+    const earlier = completed('m1', '2026-03-01')
+    const later = completed('m2', '2026-04-01')
+    const result = findDraftableMeetings([earlier, later], [])
+    expect(result.map((m) => m.id)).toEqual(['m2', 'm1'])
+  })
+
+  it('falls back to created_at when completed_at is missing', () => {
+    const a = completed('a', null, '2026-03-01')
+    const b = completed('b', null, '2026-04-01')
+    const result = findDraftableMeetings([a, b], [])
+    expect(result.map((m) => m.id)).toEqual(['b', 'a'])
+  })
+})
+
+describe('findDraftableMeeting', () => {
+  it('returns null when the list is empty', () => {
+    expect(findDraftableMeeting([], [])).toBeNull()
+  })
+
+  it('returns the most recent draftable meeting', () => {
+    const earlier = completed('m1', '2026-03-01')
+    const later = completed('m2', '2026-04-01')
+    expect(findDraftableMeeting([earlier, later], [])?.id).toBe('m2')
+  })
+
+  it('returns null when every completed meeting has a quote', () => {
+    const m1 = completed('m1', '2026-04-01')
+    const result = findDraftableMeeting([m1], [{ meeting_id: 'm1', assessment_id: 'a1' }])
+    expect(result).toBeNull()
+  })
+})

--- a/tests/entities-row-hydrators.test.ts
+++ b/tests/entities-row-hydrators.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the prospect-row batch hydrators that gate the Log reply and
+ * Send outreach actions on the entity list:
+ *
+ *   - getLatestOutreachDraftForEntities
+ *   - getFirstContactWithEmailForEntities
+ *
+ * Uses @venturecrane/crane-test-harness for in-memory D1 with the real
+ * migration schema so the SQL exercised here matches production.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../src/lib/db/entities'
+import { appendContext, getLatestOutreachDraftForEntities } from '../src/lib/db/context'
+import { createContact, getFirstContactWithEmailForEntities } from '../src/lib/db/contacts'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-test'
+
+async function setup() {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(ORG_ID, 'Test Org', 'test-org')
+    .run()
+  return db
+}
+
+describe('getLatestOutreachDraftForEntities', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await setup()
+  })
+
+  it('returns an empty map for an empty input', async () => {
+    const result = await getLatestOutreachDraftForEntities(db, ORG_ID, [])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns no entry for an entity that has no outreach_draft', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'No Outreach' })
+    await appendContext(db, ORG_ID, {
+      entity_id: e.id,
+      type: 'note',
+      content: 'just a note',
+      source: 'admin',
+    })
+    const result = await getLatestOutreachDraftForEntities(db, ORG_ID, [e.id])
+    expect(result.has(e.id)).toBe(false)
+  })
+
+  it('returns the latest draft when an entity has multiple', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'Has Outreach' })
+    await appendContext(db, ORG_ID, {
+      entity_id: e.id,
+      type: 'outreach_draft',
+      content: 'first draft',
+      source: 'enrichment',
+    })
+    // Sleep just enough to ensure created_at differs at the second resolution
+    await new Promise((r) => setTimeout(r, 1100))
+    await appendContext(db, ORG_ID, {
+      entity_id: e.id,
+      type: 'outreach_draft',
+      content: 'second draft',
+      source: 'enrichment',
+    })
+
+    const result = await getLatestOutreachDraftForEntities(db, ORG_ID, [e.id])
+    const draft = result.get(e.id)
+    expect(draft?.content).toBe('second draft')
+  })
+
+  it('keys returned drafts by entity_id when multiple entities are queried', async () => {
+    const a = await createEntity(db, ORG_ID, { name: 'A' })
+    const b = await createEntity(db, ORG_ID, { name: 'B' })
+    await appendContext(db, ORG_ID, {
+      entity_id: a.id,
+      type: 'outreach_draft',
+      content: 'a-draft',
+      source: 'enrichment',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: b.id,
+      type: 'outreach_draft',
+      content: 'b-draft',
+      source: 'enrichment',
+    })
+    const result = await getLatestOutreachDraftForEntities(db, ORG_ID, [a.id, b.id])
+    expect(result.get(a.id)?.content).toBe('a-draft')
+    expect(result.get(b.id)?.content).toBe('b-draft')
+  })
+
+  it('does not leak drafts across orgs', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other Org', 'other')
+      .run()
+    const e = await createEntity(db, 'org-other', { name: 'Other Outreach' })
+    await appendContext(db, 'org-other', {
+      entity_id: e.id,
+      type: 'outreach_draft',
+      content: 'should-not-leak',
+      source: 'enrichment',
+    })
+    // Query under a different org id; expect no result.
+    const result = await getLatestOutreachDraftForEntities(db, ORG_ID, [e.id])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('getFirstContactWithEmailForEntities', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await setup()
+  })
+
+  it('returns an empty map for empty input', async () => {
+    const result = await getFirstContactWithEmailForEntities(db, ORG_ID, [])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns the alphabetical-first contact whose email is non-empty', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'Acme' })
+    await createContact(db, ORG_ID, e.id, { name: 'Bart', email: 'bart@acme.test' })
+    await createContact(db, ORG_ID, e.id, { name: 'Alice', email: 'alice@acme.test' })
+
+    const result = await getFirstContactWithEmailForEntities(db, ORG_ID, [e.id])
+    expect(result.get(e.id)?.name).toBe('Alice')
+  })
+
+  it('skips contacts with null or empty email', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'Acme' })
+    await createContact(db, ORG_ID, e.id, { name: 'Aaron', email: null })
+    await createContact(db, ORG_ID, e.id, { name: 'Aaron2', email: '' })
+    await createContact(db, ORG_ID, e.id, { name: 'Brenda', email: 'brenda@acme.test' })
+
+    const result = await getFirstContactWithEmailForEntities(db, ORG_ID, [e.id])
+    expect(result.get(e.id)?.name).toBe('Brenda')
+  })
+
+  it('omits entities that have no email-bearing contact', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'Empty' })
+    await createContact(db, ORG_ID, e.id, { name: 'Nobody', email: null })
+
+    const result = await getFirstContactWithEmailForEntities(db, ORG_ID, [e.id])
+    expect(result.has(e.id)).toBe(false)
+  })
+
+  it('does not leak contacts across orgs', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other', 'other')
+      .run()
+    const e = await createEntity(db, 'org-other', { name: 'Other' })
+    await createContact(db, 'org-other', e.id, { name: 'Leak', email: 'leak@x.test' })
+
+    const result = await getFirstContactWithEmailForEntities(db, ORG_ID, [e.id])
+    expect(result.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Step 1 of the entity-list DAL work. Closes #546 H3 ("Log reply" state-gate) and ships the "Send outreach" row action from #548. Lays the foundation that #549 (meetings hydration) and #543 H13/H14 will build on.

- **Pure helper** \`findDraftableMeeting(meetings, quotes)\` in \`src/lib/entities/draftable-meeting.ts\`. Detail page imports it; list will compose against the batch version next PR.
- **Batch DAL** \`getLatestOutreachDraftForEntities\` (returns \`Map<entityId, ContextEntry>\` — single \`entity_id IN (?, ?, …)\` keyed by org + type='outreach_draft'). Powers both the gate and the mailto body.
- **Batch DAL** \`getFirstContactWithEmailForEntities\` (returns \`Map<entityId, Contact>\` — alphabetical-first contact with a non-empty email).
- **H3** Detail toolbar's "Log reply" hides until an \`outreach_draft\` exists; same gate on list rows. Per-row LogReplyDialog also skipped for gated rows.
- **#548 Send outreach row action** Prospect rows render a mailto link when both signals are present. Mirrors the detail-toolbar mailto from #562.
- Hydration runs only when \`filterStage === 'prospect' && entities.length > 0\` (two parallel queries via \`Promise.all\`).

**"Outreach exists" definition**: presence of an \`outreach_draft\` context entry. Imperfect proxy — we don't yet record send events explicitly. Conservative direction (overcount Log reply availability rather than undercount); documented in the helper comment for the next iteration.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1555 passed, 2 skipped (19 new)
- [x] \`prettier --check\` — clean
- [ ] Manual: prospect row with no outreach_draft → no Log reply, no Send outreach
- [ ] Manual: prospect row with outreach_draft + contact email → both buttons render; clicking Send outreach opens mailto with body pre-filled
- [ ] Manual: prospect row with outreach_draft but no contact email → only Log reply renders
- [ ] Manual: detail toolbar Log reply hidden for entities without outreach_draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)