### PR TITLE
feat(admin/entities): meetings list hydration — sub-state, next meeting, Draft proposal row action (#549)

### DIFF
--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -73,6 +73,46 @@ export interface UpdateMeetingData {
 }
 
 /**
+ * For a batch of entity ids, return a Map keyed by entity_id whose value
+ * is the list of all meetings (any status) for that entity, ordered with
+ * the most recent meeting first within each entity.
+ *
+ * Recency uses scheduled_at when set, falling back to created_at — same
+ * order the meetings panel renders. The list page uses this to compute
+ * (a) the next scheduled meeting date and (b) the meeting sub-state
+ * (awaiting-booking / upcoming / completed-awaiting-proposal) on
+ * meetings-stage rows, without an N+1.
+ *
+ * Empty input returns an empty Map without touching the DB.
+ */
+export async function getMeetingsForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, Meeting[]>> {
+  const result = new Map<string, Meeting[]>()
+  if (entityIds.length === 0) return result
+
+  const entityIdsJson = JSON.stringify(entityIds)
+  const rows = await db
+    .prepare(
+      `SELECT * FROM meetings
+       WHERE org_id = ?
+         AND entity_id IN (SELECT value FROM json_each(?))
+       ORDER BY entity_id ASC, COALESCE(scheduled_at, created_at) DESC`
+    )
+    .bind(orgId, entityIdsJson)
+    .all<Meeting>()
+
+  for (const row of rows.results ?? []) {
+    const list = result.get(row.entity_id)
+    if (list) list.push(row)
+    else result.set(row.entity_id, [row])
+  }
+  return result
+}
+
+/**
  * List meetings for an organization, optionally filtered by entity.
  */
 export async function listMeetings(

--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -554,6 +554,48 @@ export async function getActiveQuotesForEntities(
 }
 
 /**
+ * For a batch of entity ids, return a Map keyed by entity_id whose value
+ * is the list of all quotes (any status) for that entity. Used by the
+ * meetings-stage list to ask, per row, "is there any quote already
+ * linked to a completed meeting?" — which is what makes that meeting
+ * NOT draftable.
+ *
+ * Distinct from `getActiveQuotesForEntities` (top-1 active quote per
+ * entity for the proposing tab badge): this returns all quotes,
+ * including terminal statuses (declined, expired, superseded). A
+ * declined quote means the operator already drafted once — the
+ * meeting isn't draftable a second time.
+ *
+ * Empty input returns an empty Map without touching the DB.
+ */
+export async function getQuotesForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, Quote[]>> {
+  const result = new Map<string, Quote[]>()
+  if (entityIds.length === 0) return result
+
+  const entityIdsJson = JSON.stringify(entityIds)
+  const rows = await db
+    .prepare(
+      `SELECT * FROM quotes
+       WHERE org_id = ?
+         AND entity_id IN (SELECT value FROM json_each(?))
+       ORDER BY entity_id ASC, created_at ASC`
+    )
+    .bind(orgId, entityIdsJson)
+    .all<Quote>()
+
+  for (const row of rows.results ?? []) {
+    const list = result.get(row.entity_id)
+    if (list) list.push(row)
+    else result.set(row.entity_id, [row])
+  }
+  return result
+}
+
+/**
  * List quotes for a specific entity (portal access).
  *
  * Scoped by both `entity_id` and `org_id` — entity IDs are expected unique,

--- a/src/lib/entities/meeting-substate.ts
+++ b/src/lib/entities/meeting-substate.ts
@@ -1,0 +1,96 @@
+/**
+ * Meeting-stage sub-state classifier. The Meetings list and detail both
+ * need one rule for "what stage of the meeting flow is this row in?".
+ * Three named buckets:
+ *
+ *   awaiting-booking            — booking link sent, prospect hasn't booked
+ *   upcoming                    — meeting is scheduled in the future
+ *   completed-awaiting-proposal — meeting completed, no quote linked yet
+ *
+ * Returns `null` when the entity has no meetings at all (legacy edge — a
+ * meetings-stage entity without a meeting row shouldn't exist post-#467,
+ * but the caller should render nothing rather than guess).
+ *
+ * "Hottest" sub-state (i.e., the one the operator should act on) is
+ * `completed-awaiting-proposal` — that's the moment "Draft proposal from
+ * meeting" makes sense. The list page sorts on this priority in #543 H13.
+ */
+
+import { findDraftableMeeting } from './draftable-meeting'
+
+interface MeetingShape {
+  id: string
+  status: string
+  scheduled_at: string | null
+  completed_at: string | null
+  created_at: string
+}
+
+interface QuoteShape {
+  meeting_id: string | null
+  assessment_id: string
+}
+
+export type MeetingSubstate =
+  | 'awaiting-booking'
+  | 'upcoming'
+  | 'completed-awaiting-proposal'
+  | 'past-due'
+  | 'other'
+
+export const MEETING_SUBSTATE_LABEL: Record<MeetingSubstate, string> = {
+  'awaiting-booking': 'Awaiting booking',
+  upcoming: 'Upcoming',
+  'completed-awaiting-proposal': 'Awaiting proposal',
+  'past-due': 'Past scheduled time',
+  other: '',
+}
+
+export function getMeetingSubstate<M extends MeetingShape, Q extends QuoteShape>(
+  meetings: M[],
+  quotes: Q[],
+  now: Date = new Date()
+): MeetingSubstate | null {
+  if (meetings.length === 0) return null
+
+  // A draftable meeting (completed without a quote) wins regardless of
+  // any newer scheduled-but-not-yet-happened meeting. The operator's
+  // most valuable next action is drafting the proposal from completed
+  // notes — they can deal with the next scheduled meeting after.
+  if (findDraftableMeeting(meetings, quotes)) {
+    return 'completed-awaiting-proposal'
+  }
+
+  // Most-recent-first by scheduled_at then created_at. The DAL helper
+  // already returns rows in this order, but we don't trust ordering
+  // when running against a different caller's array.
+  const sorted = [...meetings].sort((a, b) => {
+    const aKey = a.scheduled_at ?? a.created_at
+    const bKey = b.scheduled_at ?? b.created_at
+    return bKey.localeCompare(aKey)
+  })
+  const head = sorted[0]
+
+  if (head.status === 'scheduled') {
+    if (!head.scheduled_at) return 'awaiting-booking'
+    return new Date(head.scheduled_at).getTime() < now.getTime() ? 'past-due' : 'upcoming'
+  }
+
+  // Completed/cancelled/etc. — nothing actionable left at this stage.
+  return 'other'
+}
+
+/**
+ * Return the next scheduled meeting (status='scheduled', scheduled_at in the
+ * future), or null. Used to populate "Next meeting {date}" on a row.
+ */
+export function findNextScheduledMeeting<M extends MeetingShape>(
+  meetings: M[],
+  now: Date = new Date()
+): M | null {
+  const future = meetings
+    .filter((m) => m.status === 'scheduled' && m.scheduled_at)
+    .filter((m) => new Date(m.scheduled_at as string).getTime() >= now.getTime())
+    .sort((a, b) => (a.scheduled_at as string).localeCompare(b.scheduled_at as string))
+  return future[0] ?? null
+}

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -8,13 +8,22 @@ import {
   ENTITY_STAGES,
 } from '../../../lib/db/entities'
 import type { Entity, EntityStage, EntitySignalMetadata } from '../../../lib/db/entities'
-import { getActiveQuotesForEntities } from '../../../lib/db/quotes'
+import { getActiveQuotesForEntities, getQuotesForEntities } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
+import { getMeetingsForEntities } from '../../../lib/db/meetings'
+import type { Meeting } from '../../../lib/db/meetings'
 import { LOST_REASONS } from '../../../lib/db/lost-reasons'
 import { getLatestOutreachDraftForEntities } from '../../../lib/db/context'
 import type { ContextEntry } from '../../../lib/db/context'
 import { getFirstContactWithEmailForEntities } from '../../../lib/db/contacts'
 import type { Contact } from '../../../lib/db/contacts'
+import { findDraftableMeeting } from '../../../lib/entities/draftable-meeting'
+import {
+  findNextScheduledMeeting,
+  getMeetingSubstate,
+  MEETING_SUBSTATE_LABEL,
+  type MeetingSubstate,
+} from '../../../lib/entities/meeting-substate'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import {
@@ -98,6 +107,21 @@ if (filterStage === 'prospect' && entities.length > 0) {
   ])
 }
 
+// Meetings-stage row hydration. Pull every meeting + every quote for
+// the page's rows in two batch queries; the row template then derives
+// per-row sub-state, next-meeting date, and "is there a draftable
+// meeting?" via pure helpers. Reusing the same data for three things
+// avoids both the N+1 trap and a SQL specialised per render concern.
+let meetingsByEntityId = new Map<string, Meeting[]>()
+let quotesByEntityId = new Map<string, Quote[]>()
+if (filterStage === 'meetings' && entities.length > 0) {
+  const ids = entities.map((e) => e.id)
+  ;[meetingsByEntityId, quotesByEntityId] = await Promise.all([
+    getMeetingsForEntities(env.DB, session.orgId, ids),
+    getQuotesForEntities(env.DB, session.orgId, ids),
+  ])
+}
+
 /**
  * Build a `mailto:` URL that pre-fills recipient, subject, and body for
  * the operator's mail client. Returns null when either the contact email
@@ -175,6 +199,27 @@ const EMPTY_STATE_COPY: Record<EntityStage, { headline: string; hint: string }> 
     headline: 'No lost prospects.',
     hint: 'Prospects marked Lost (with a reason) appear here.',
   },
+}
+
+/**
+ * Tone for the per-row meetings sub-state badge. The "completed-awaiting-
+ * proposal" state is the hottest at this stage (operator should draft the
+ * proposal next) — green to read as forward-action available. "Past
+ * scheduled time" reads red so operator can spot meetings that should
+ * already have happened. Other sub-states are neutral.
+ */
+function meetingSubstateBadgeClass(s: MeetingSubstate): string {
+  switch (s) {
+    case 'completed-awaiting-proposal':
+      return 'bg-green-100 text-green-700'
+    case 'past-due':
+      return 'bg-red-100 text-red-700'
+    case 'upcoming':
+      return 'bg-blue-100 text-blue-700'
+    case 'awaiting-booking':
+    default:
+      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  }
 }
 
 function tierBadgeClass(tier: string | null): string {
@@ -396,6 +441,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             const website = displayWebsite(e.website)
             const isSignal = e.stage === 'signal'
             const isProspect = e.stage === 'prospect'
+            const isMeetings = e.stage === 'meetings'
             const rowOutreachDraft = isProspect ? (outreachDraftByEntityId.get(e.id) ?? null) : null
             const rowContactEmail = isProspect
               ? (contactEmailByEntityId.get(e.id)?.email ?? null)
@@ -405,6 +451,15 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
               rowContactEmail,
               rowOutreachDraft?.content
             )
+            const rowMeetings = isMeetings ? (meetingsByEntityId.get(e.id) ?? []) : []
+            const rowQuotes = isMeetings ? (quotesByEntityId.get(e.id) ?? []) : []
+            const rowSubstate: MeetingSubstate | null = isMeetings
+              ? getMeetingSubstate(rowMeetings, rowQuotes)
+              : null
+            const rowNextMeeting = isMeetings ? findNextScheduledMeeting(rowMeetings) : null
+            const rowDraftableMeeting = isMeetings
+              ? findDraftableMeeting(rowMeetings, rowQuotes)
+              : null
             const activeQuote =
               filterStage === 'proposing' ? (activeQuoteByEntityId.get(e.id) ?? null) : null
             const quoteTimestamp =
@@ -467,6 +522,13 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           {e.tier}
                         </span>
                       )}
+                      {rowSubstate && rowSubstate !== 'other' && (
+                        <span
+                          class={`text-xs px-1.5 py-0.5 rounded ${meetingSubstateBadgeClass(rowSubstate)}`}
+                        >
+                          {MEETING_SUBSTATE_LABEL[rowSubstate]}
+                        </span>
+                      )}
                     </div>
 
                     {isSignal && problems.length > 0 && (
@@ -518,6 +580,9 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           {formatDate(e.stage_changed_at)}
                         </span>
                       )}
+                      {rowNextMeeting && rowNextMeeting.scheduled_at && (
+                        <span>Next meeting {formatDate(rowNextMeeting.scheduled_at)}</span>
+                      )}
                       {e.area && <span>{e.area}</span>}
                       {e.vertical && (
                         <span class="capitalize">{e.vertical.replace(/_/g, ' ')}</span>
@@ -562,7 +627,8 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                   {(() => {
                     const showProspectActions =
                       isProspect && (rowOutreachMailto || rowOutreachDraft)
-                    if (!isSignal && !showProspectActions) return null
+                    const showMeetingsActions = isMeetings && rowDraftableMeeting
+                    if (!isSignal && !showProspectActions && !showMeetingsActions) return null
                     return (
                       <div class="relative z-10 flex items-center gap-2 shrink-0">
                         {isSignal ? (
@@ -584,6 +650,19 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                               </button>
                             </form>
                           </>
+                        ) : isMeetings && rowDraftableMeeting ? (
+                          <form
+                            method="POST"
+                            action={`/api/admin/entities/${e.id}/meetings/${rowDraftableMeeting.id}/draft-quote`}
+                          >
+                            <button
+                              type="submit"
+                              class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                              title="Create a draft quote from the most recent completed meeting's notes"
+                            >
+                              Draft proposal
+                            </button>
+                          </form>
                         ) : (
                           <>
                             {rowOutreachMailto && (

--- a/tests/admin-entities-proposing.test.ts
+++ b/tests/admin-entities-proposing.test.ts
@@ -12,7 +12,12 @@ describe('admin/entities/index: Proposing tab quote status', () => {
 
   it('imports the batch active-quote loader', () => {
     const code = source()
-    expect(code).toContain("import { getActiveQuotesForEntities } from '../../../lib/db/quotes'")
+    // The same import statement may also pull sibling batch helpers
+    // (getQuotesForEntities for the meetings stage) — match the symbol
+    // and module path rather than the literal one-symbol form.
+    expect(code).toMatch(
+      /import\s*\{[^}]*\bgetActiveQuotesForEntities\b[^}]*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/lib\/db\/quotes['"]/
+    )
   })
 
   it('imports the shared admin status badge class', () => {

--- a/tests/entities-meetings-hydrators.test.ts
+++ b/tests/entities-meetings-hydrators.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the meetings-stage batch hydrators that the entity list uses
+ * to compute per-row sub-state, next-meeting date, and draftable-meeting
+ * presence:
+ *
+ *   - getMeetingsForEntities
+ *   - getQuotesForEntities
+ *
+ * Both follow the same pattern as the prospect-row hydrators: keyed by
+ * org + entity_id IN (json_each(?)), returns Map<entityId, list>. The
+ * tests use the real D1 schema so the SQL exercised here matches prod.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../src/lib/db/entities'
+import { createMeeting, getMeetingsForEntities } from '../src/lib/db/meetings'
+import { getQuotesForEntities } from '../src/lib/db/quotes'
+
+/**
+ * Insert a quote row directly, bypassing createQuote's assessment FK
+ * chain. The hydrator only reads from `quotes`; we don't need a real
+ * assessments / clients graph behind it for this batch-helper contract
+ * test. We disable foreign_keys for the duration of the insert so the
+ * `assessment_id` column doesn't reject the synthetic id.
+ */
+async function insertQuoteRaw(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  status: string
+): Promise<void> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+  await db.prepare('PRAGMA foreign_keys = OFF').run()
+  await db
+    .prepare(
+      `INSERT INTO quotes (
+         id, org_id, entity_id, assessment_id, meeting_id, version,
+         line_items, total_hours, rate, total_price, deposit_pct,
+         deposit_amount, status, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, 1, '[]', 0, 0, 0, 0.5, 0, ?, ?, ?)`
+    )
+    .bind(id, orgId, entityId, crypto.randomUUID(), null, status, now, now)
+    .run()
+  await db.prepare('PRAGMA foreign_keys = ON').run()
+}
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-test'
+
+async function setup() {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(ORG_ID, 'Test Org', 'test-org')
+    .run()
+  return db
+}
+
+describe('getMeetingsForEntities', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await setup()
+  })
+
+  it('returns an empty map for empty input', async () => {
+    const result = await getMeetingsForEntities(db, ORG_ID, [])
+    expect(result.size).toBe(0)
+  })
+
+  it('groups meetings by entity_id', async () => {
+    const a = await createEntity(db, ORG_ID, { name: 'A' })
+    const b = await createEntity(db, ORG_ID, { name: 'B' })
+    await createMeeting(db, ORG_ID, a.id, { meeting_type: 'discovery' })
+    await createMeeting(db, ORG_ID, a.id, { meeting_type: 'follow_up' })
+    await createMeeting(db, ORG_ID, b.id, { meeting_type: 'review' })
+
+    const result = await getMeetingsForEntities(db, ORG_ID, [a.id, b.id])
+    expect(result.get(a.id)?.length).toBe(2)
+    expect(result.get(b.id)?.length).toBe(1)
+  })
+
+  it('orders by COALESCE(scheduled_at, created_at) DESC within each entity', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'Acme' })
+    await createMeeting(db, ORG_ID, e.id, {
+      scheduled_at: '2026-05-01T00:00:00Z',
+      meeting_type: 'newer',
+    })
+    await createMeeting(db, ORG_ID, e.id, {
+      scheduled_at: '2026-04-01T00:00:00Z',
+      meeting_type: 'older',
+    })
+    const result = await getMeetingsForEntities(db, ORG_ID, [e.id])
+    const list = result.get(e.id) ?? []
+    expect(list.map((m) => m.meeting_type)).toEqual(['newer', 'older'])
+  })
+
+  it('does not leak meetings across orgs', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other', 'other')
+      .run()
+    const e = await createEntity(db, 'org-other', { name: 'Leak' })
+    await createMeeting(db, 'org-other', e.id, { meeting_type: 'leak' })
+
+    const result = await getMeetingsForEntities(db, ORG_ID, [e.id])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('getQuotesForEntities', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await setup()
+  })
+
+  it('returns an empty map for empty input', async () => {
+    const result = await getQuotesForEntities(db, ORG_ID, [])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns all quotes (any status) keyed by entity_id', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'Quotes' })
+    await insertQuoteRaw(db, ORG_ID, e.id, 'draft')
+    await insertQuoteRaw(db, ORG_ID, e.id, 'declined')
+
+    const result = await getQuotesForEntities(db, ORG_ID, [e.id])
+    const quotes = result.get(e.id) ?? []
+    expect(quotes.length).toBe(2)
+    expect(quotes.every((q) => q.entity_id === e.id)).toBe(true)
+    // Includes terminal-status quotes too — that's the point versus
+    // getActiveQuotesForEntities, which filters them out.
+    expect(quotes.map((q) => q.status).sort()).toEqual(['declined', 'draft'])
+  })
+
+  it('does not leak quotes across orgs', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other', 'other')
+      .run()
+    const e = await createEntity(db, 'org-other', { name: 'Leak' })
+    await insertQuoteRaw(db, 'org-other', e.id, 'draft')
+
+    const result = await getQuotesForEntities(db, ORG_ID, [e.id])
+    expect(result.size).toBe(0)
+  })
+})

--- a/tests/meeting-substate.test.ts
+++ b/tests/meeting-substate.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure-helper tests for getMeetingSubstate / findNextScheduledMeeting.
+ * No DB — both helpers operate on already-loaded meetings + quotes
+ * arrays. Covers the rule both surfaces (entity meetings list and detail
+ * page) need to agree on for sub-state classification.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { findNextScheduledMeeting, getMeetingSubstate } from '../src/lib/entities/meeting-substate'
+
+type M = {
+  id: string
+  status: string
+  scheduled_at: string | null
+  completed_at: string | null
+  created_at: string
+}
+type Q = { meeting_id: string | null; assessment_id: string }
+
+const NOW = new Date('2026-04-24T12:00:00Z')
+
+const meeting = (overrides: Partial<M> & { id: string }): M => ({
+  status: 'scheduled',
+  scheduled_at: null,
+  completed_at: null,
+  created_at: '2026-04-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('getMeetingSubstate', () => {
+  it('returns null when there are no meetings', () => {
+    expect(getMeetingSubstate([], [], NOW)).toBeNull()
+  })
+
+  it('returns completed-awaiting-proposal when a draftable meeting exists', () => {
+    const m = meeting({
+      id: 'm1',
+      status: 'completed',
+      completed_at: '2026-04-10T00:00:00Z',
+    })
+    expect(getMeetingSubstate([m], [], NOW)).toBe('completed-awaiting-proposal')
+  })
+
+  it('prefers awaiting-proposal even when a future meeting is also scheduled', () => {
+    const completed = meeting({
+      id: 'old',
+      status: 'completed',
+      completed_at: '2026-04-10T00:00:00Z',
+    })
+    const future = meeting({
+      id: 'new',
+      status: 'scheduled',
+      scheduled_at: '2026-05-01T00:00:00Z',
+    })
+    expect(getMeetingSubstate([future, completed], [], NOW)).toBe('completed-awaiting-proposal')
+  })
+
+  it('returns upcoming when most-recent meeting is scheduled in the future', () => {
+    const m = meeting({ id: 'm1', scheduled_at: '2026-05-01T00:00:00Z' })
+    expect(getMeetingSubstate([m], [], NOW)).toBe('upcoming')
+  })
+
+  it('returns past-due when most-recent scheduled meeting is in the past', () => {
+    const m = meeting({ id: 'm1', scheduled_at: '2026-04-20T00:00:00Z' })
+    expect(getMeetingSubstate([m], [], NOW)).toBe('past-due')
+  })
+
+  it('returns awaiting-booking when scheduled but no scheduled_at set', () => {
+    const m = meeting({ id: 'm1', scheduled_at: null })
+    expect(getMeetingSubstate([m], [], NOW)).toBe('awaiting-booking')
+  })
+
+  it('returns "other" for terminal states with no actionable next step', () => {
+    const m = meeting({
+      id: 'm1',
+      status: 'cancelled',
+      scheduled_at: '2026-04-10T00:00:00Z',
+    })
+    expect(getMeetingSubstate([m], [], NOW)).toBe('other')
+  })
+
+  it('treats a completed meeting that already has a quote as not-draftable', () => {
+    const m = meeting({
+      id: 'm1',
+      status: 'completed',
+      completed_at: '2026-04-10T00:00:00Z',
+    })
+    const q: Q = { meeting_id: 'm1', assessment_id: 'a1' }
+    // No draftable meeting → falls through to head classification → "other"
+    // (status is 'completed', no future scheduled rows)
+    expect(getMeetingSubstate([m], [q], NOW)).toBe('other')
+  })
+})
+
+describe('findNextScheduledMeeting', () => {
+  it('returns null when there are no future scheduled meetings', () => {
+    const past = meeting({ id: 'm1', scheduled_at: '2026-03-01T00:00:00Z' })
+    expect(findNextScheduledMeeting([past], NOW)).toBeNull()
+  })
+
+  it('returns the closest future scheduled meeting', () => {
+    const farther = meeting({ id: 'far', scheduled_at: '2026-06-01T00:00:00Z' })
+    const closer = meeting({ id: 'close', scheduled_at: '2026-05-01T00:00:00Z' })
+    expect(findNextScheduledMeeting([farther, closer], NOW)?.id).toBe('close')
+  })
+
+  it('skips meetings whose status is not "scheduled"', () => {
+    const cancelled = meeting({
+      id: 'cx',
+      status: 'cancelled',
+      scheduled_at: '2026-05-01T00:00:00Z',
+    })
+    const upcoming = meeting({
+      id: 'up',
+      scheduled_at: '2026-06-01T00:00:00Z',
+    })
+    expect(findNextScheduledMeeting([cancelled, upcoming], NOW)?.id).toBe('up')
+  })
+
+  it('skips scheduled meetings without a scheduled_at', () => {
+    const noDate = meeting({ id: 'no-date', scheduled_at: null })
+    const dated = meeting({ id: 'dated', scheduled_at: '2026-05-01T00:00:00Z' })
+    expect(findNextScheduledMeeting([noDate, dated], NOW)?.id).toBe('dated')
+  })
+})


### PR DESCRIPTION
## Summary

Step 2 of the entity-list DAL work. Closes most of #549's list ship-nows. Sort (#543 H13) is next.

- **Pure helpers** in \`src/lib/entities/meeting-substate.ts\`: \`getMeetingSubstate\` (5 named buckets, prioritises \`completed-awaiting-proposal\`), \`findNextScheduledMeeting\`. 12 unit tests.
- **Batch DAL** \`getMeetingsForEntities\` + \`getQuotesForEntities\` using the \`json_each(?)\` pattern. The quotes helper returns ALL statuses (distinct from \`getActiveQuotesForEntities\` which is top-1 active per entity) — needed to know whether a completed meeting already has any quote. 7 D1-harness tests.
- **List wiring**: meetings-stage rows render a sub-state badge, "Next meeting {date}" in the meta line, and a "Draft proposal" primary row action when a draftable meeting exists. Form posts to the same endpoint the detail toolbar uses; auto-transitions to proposing.
- **Detail/list parity**: both surfaces now share \`findDraftableMeeting\` (from #564) — one source of truth for "draftable" semantics.
- Hydration gated on \`filterStage === 'meetings' && entities.length > 0\`. Two parallel queries.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1574 passed, 2 skipped (19 new since #564)
- [x] \`prettier --check\` — clean
- [x] \`eslint\` — clean
- [ ] Manual: meetings tab with a row that has a completed meeting + no quote → green "Awaiting proposal" badge + Draft proposal button
- [ ] Manual: clicking Draft proposal creates a quote and the entity transitions to proposing
- [ ] Manual: meetings row with future scheduled meeting → blue "Upcoming" badge + "Next meeting {date}" in meta
- [ ] Manual: meetings row with past scheduled meeting → red "Past scheduled time" badge
- [ ] Manual: other stage tabs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)