### PR TITLE
feat(admin/entities): per-stage list sort + inert prospect cluster (#543 H13)

### DIFF
--- a/src/lib/entities/list-sort.ts
+++ b/src/lib/entities/list-sort.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-stage in-memory re-sort for the entity list. The DAL returns rows
+ * ordered by `tier → pain_score → updated_at` — fine for stages without
+ * an explicit operator workflow, but several stages have a sharper
+ * sort signal hidden in hydrated row data:
+ *
+ *   prospect : "inert" rows (no outreach drafted yet) cluster at the top —
+ *              these are the ones the operator most likely dropped on
+ *              the floor. Within each cluster, oldest next_action_at first
+ *              (most overdue at the top), nulls trailing.
+ *   meetings : sub-state priority — "completed-awaiting-proposal" first
+ *              (hottest, "draft now"), then past-due, then upcoming, then
+ *              awaiting-booking. Within "upcoming" we order by scheduled
+ *              date ascending.
+ *   lost     : most-recently-lost first — operators almost always want
+ *              "what just fell out" rather than the tiered ordering.
+ *
+ * Other stages keep the DAL order. Each helper is pure and stable: rows
+ * tied on the primary key fall back to the array's incoming order.
+ */
+
+import type { Entity } from '../db/entities'
+import type { Meeting } from '../db/meetings'
+import type { Quote } from '../db/quotes'
+import type { ContextEntry } from '../db/context'
+import { getMeetingSubstate, type MeetingSubstate } from './meeting-substate'
+
+const MEETING_SUBSTATE_RANK: Record<MeetingSubstate, number> = {
+  'completed-awaiting-proposal': 0,
+  'past-due': 1,
+  upcoming: 2,
+  'awaiting-booking': 3,
+  other: 4,
+}
+
+/**
+ * Stable sort by a key extractor. `Array#sort` in V8 is already stable as
+ * of ES2019, but this helper keeps the call sites self-documenting and
+ * avoids accidentally returning non-numeric comparator results.
+ */
+function stableSortBy<T>(arr: T[], key: (item: T) => number): T[] {
+  return [...arr]
+    .map((item, idx) => ({ item, idx, k: key(item) }))
+    .sort((a, b) => a.k - b.k || a.idx - b.idx)
+    .map((x) => x.item)
+}
+
+export function sortProspectRows(
+  entities: Entity[],
+  outreachByEntityId: Map<string, ContextEntry>
+): Entity[] {
+  // Two-pass: split inert vs not-inert (preserving DAL order within
+  // each), then sort each by next_action_at ASC NULLS LAST, then
+  // concatenate.
+  const inert: Entity[] = []
+  const active: Entity[] = []
+  for (const e of entities) {
+    if (outreachByEntityId.has(e.id)) active.push(e)
+    else inert.push(e)
+  }
+
+  const byNextActionAsc = (e: Entity): number => {
+    if (!e.next_action_at) return Number.MAX_SAFE_INTEGER
+    return new Date(e.next_action_at).getTime()
+  }
+
+  return [...stableSortBy(inert, byNextActionAsc), ...stableSortBy(active, byNextActionAsc)]
+}
+
+export function sortMeetingsRows(
+  entities: Entity[],
+  meetingsByEntityId: Map<string, Meeting[]>,
+  quotesByEntityId: Map<string, Quote[]>,
+  now: Date = new Date()
+): Entity[] {
+  const rank = (e: Entity): number => {
+    const meetings = meetingsByEntityId.get(e.id) ?? []
+    const quotes = quotesByEntityId.get(e.id) ?? []
+    const sub = getMeetingSubstate(meetings, quotes, now)
+    if (!sub) return MEETING_SUBSTATE_RANK.other + 1
+    return MEETING_SUBSTATE_RANK[sub]
+  }
+
+  // Within "upcoming" rows, secondary order by scheduled_at ASC.
+  // We compute a composite key: rank * LARGE + (date offset).
+  const PRIORITY_WEIGHT = 1e15
+  const composite = (e: Entity): number => {
+    const r = rank(e)
+    if (r !== MEETING_SUBSTATE_RANK.upcoming) return r * PRIORITY_WEIGHT
+    const meetings = meetingsByEntityId.get(e.id) ?? []
+    const earliestFuture = meetings
+      .filter((m) => m.status === 'scheduled' && m.scheduled_at)
+      .map((m) => new Date(m.scheduled_at as string).getTime())
+      .filter((t) => t >= now.getTime())
+      .sort((a, b) => a - b)[0]
+    return r * PRIORITY_WEIGHT + (earliestFuture ?? 0)
+  }
+
+  return stableSortBy(entities, composite)
+}
+
+export function sortLostRows(entities: Entity[]): Entity[] {
+  // Most recently lost first — string comparison works because
+  // stage_changed_at is ISO 8601.
+  return [...entities].sort((a, b) => b.stage_changed_at.localeCompare(a.stage_changed_at))
+}

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -24,6 +24,7 @@ import {
   MEETING_SUBSTATE_LABEL,
   type MeetingSubstate,
 } from '../../../lib/entities/meeting-substate'
+import { sortProspectRows, sortMeetingsRows, sortLostRows } from '../../../lib/entities/list-sort'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
 import {
@@ -90,8 +91,6 @@ if (filterStage === 'proposing' && entities.length > 0) {
     return 0 // preserve DAL order (tier, pain_score, updated_at DESC)
   })
 }
-const displayEntities = filterStage === 'proposing' ? proposingRows : entities
-
 // Prospect-stage row hydration. Two batch queries — latest outreach draft
 // per entity (existence gates Log reply, content powers Send outreach
 // mailto), and the first contact with an email per entity (gates Send
@@ -120,6 +119,22 @@ if (filterStage === 'meetings' && entities.length > 0) {
     getMeetingsForEntities(env.DB, session.orgId, ids),
     getQuotesForEntities(env.DB, session.orgId, ids),
   ])
+}
+
+// Per-stage display order. Hydrators above feed the in-memory re-sorts
+// for prospect / meetings / lost; proposing already uses its own sort
+// (oldest sent_at first). Other stages keep DAL order.
+let displayEntities: Entity[]
+if (filterStage === 'proposing') {
+  displayEntities = proposingRows
+} else if (filterStage === 'prospect') {
+  displayEntities = sortProspectRows(entities, outreachDraftByEntityId)
+} else if (filterStage === 'meetings') {
+  displayEntities = sortMeetingsRows(entities, meetingsByEntityId, quotesByEntityId)
+} else if (filterStage === 'lost') {
+  displayEntities = sortLostRows(entities)
+} else {
+  displayEntities = entities
 }
 
 /**

--- a/tests/entities-list-sort.test.ts
+++ b/tests/entities-list-sort.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Pure-helper tests for the per-stage entity-list re-sorts.
+ * No DB — each helper takes already-loaded entities + hydrated maps and
+ * returns a re-ordered array.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { sortProspectRows, sortMeetingsRows, sortLostRows } from '../src/lib/entities/list-sort'
+import type { Entity } from '../src/lib/db/entities'
+import type { Meeting } from '../src/lib/db/meetings'
+import type { ContextEntry } from '../src/lib/db/context'
+
+const NOW = new Date('2026-04-24T12:00:00Z')
+
+const entity = (id: string, overrides: Partial<Entity> = {}): Entity =>
+  ({
+    id,
+    org_id: 'org',
+    name: id.toUpperCase(),
+    slug: id,
+    phone: null,
+    website: null,
+    stage: 'prospect',
+    stage_changed_at: '2026-04-01T00:00:00Z',
+    pain_score: null,
+    vertical: null,
+    area: null,
+    employee_count: null,
+    tier: null,
+    summary: null,
+    next_action: null,
+    next_action_at: null,
+    source_pipeline: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  }) as Entity
+
+describe('sortProspectRows', () => {
+  it('clusters inert (no outreach drafted) rows above active rows', () => {
+    const a = entity('a-active', { next_action_at: '2026-04-15T00:00:00Z' })
+    const b = entity('b-inert', { next_action_at: '2026-04-15T00:00:00Z' })
+    const c = entity('c-active', { next_action_at: '2026-04-10T00:00:00Z' })
+    const outreach = new Map<string, ContextEntry>([
+      ['a-active', {} as ContextEntry],
+      ['c-active', {} as ContextEntry],
+    ])
+    const result = sortProspectRows([a, b, c], outreach)
+    expect(result.map((e) => e.id)).toEqual(['b-inert', 'c-active', 'a-active'])
+  })
+
+  it('orders within each cluster by next_action_at ASC, nulls trailing', () => {
+    const noDate = entity('no-date', { next_action_at: null })
+    const earlier = entity('earlier', { next_action_at: '2026-04-10T00:00:00Z' })
+    const later = entity('later', { next_action_at: '2026-04-15T00:00:00Z' })
+    const outreach = new Map<string, ContextEntry>()
+    const result = sortProspectRows([noDate, later, earlier], outreach)
+    expect(result.map((e) => e.id)).toEqual(['earlier', 'later', 'no-date'])
+  })
+
+  it('returns the same array order when there are no rows', () => {
+    expect(sortProspectRows([], new Map())).toEqual([])
+  })
+})
+
+describe('sortMeetingsRows', () => {
+  const meeting = (id: string, overrides: Partial<Meeting> = {}): Meeting =>
+    ({
+      id,
+      org_id: 'org',
+      entity_id: 'e',
+      meeting_type: null,
+      scheduled_at: null,
+      completed_at: null,
+      duration_minutes: null,
+      transcript_path: null,
+      extraction: null,
+      live_notes: null,
+      completion_notes: null,
+      status: 'scheduled',
+      created_at: '2026-04-01T00:00:00Z',
+      ...overrides,
+    }) as Meeting
+
+  it('puts completed-awaiting-proposal rows first', () => {
+    const drafty = entity('drafty')
+    const future = entity('future')
+    const meetingsMap = new Map<string, Meeting[]>([
+      ['drafty', [meeting('m1', { status: 'completed', completed_at: '2026-04-15T00:00:00Z' })]],
+      ['future', [meeting('m2', { scheduled_at: '2026-05-01T00:00:00Z' })]],
+    ])
+    const result = sortMeetingsRows([future, drafty], meetingsMap, new Map(), NOW)
+    expect(result.map((e) => e.id)).toEqual(['drafty', 'future'])
+  })
+
+  it('orders upcoming rows by earliest scheduled_at first', () => {
+    const farther = entity('far')
+    const closer = entity('close')
+    const meetingsMap = new Map<string, Meeting[]>([
+      ['far', [meeting('mf', { scheduled_at: '2026-06-01T00:00:00Z' })]],
+      ['close', [meeting('mc', { scheduled_at: '2026-05-01T00:00:00Z' })]],
+    ])
+    const result = sortMeetingsRows([farther, closer], meetingsMap, new Map(), NOW)
+    expect(result.map((e) => e.id)).toEqual(['close', 'far'])
+  })
+
+  it('puts past-due ahead of upcoming', () => {
+    const pastDue = entity('past')
+    const upcoming = entity('up')
+    const meetingsMap = new Map<string, Meeting[]>([
+      ['past', [meeting('mp', { scheduled_at: '2026-04-20T00:00:00Z' })]],
+      ['up', [meeting('mu', { scheduled_at: '2026-05-01T00:00:00Z' })]],
+    ])
+    const result = sortMeetingsRows([upcoming, pastDue], meetingsMap, new Map(), NOW)
+    expect(result.map((e) => e.id)).toEqual(['past', 'up'])
+  })
+
+  it('preserves DAL order on ties', () => {
+    const a = entity('a')
+    const b = entity('b')
+    const meetingsMap = new Map<string, Meeting[]>([
+      ['a', [meeting('ma', { status: 'cancelled' })]],
+      ['b', [meeting('mb', { status: 'cancelled' })]],
+    ])
+    const result = sortMeetingsRows([a, b], meetingsMap, new Map(), NOW)
+    expect(result.map((e) => e.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('sortLostRows', () => {
+  it('orders most-recently-lost first', () => {
+    const earlier = entity('earlier', { stage_changed_at: '2026-03-01T00:00:00Z' })
+    const later = entity('later', { stage_changed_at: '2026-04-01T00:00:00Z' })
+    const result = sortLostRows([earlier, later])
+    expect(result.map((e) => e.id)).toEqual(['later', 'earlier'])
+  })
+
+  it('returns an empty array unchanged', () => {
+    expect(sortLostRows([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Closes #543 H13. Each stage now orders rows by the workflow signal the operator scans for, replacing the generic \`tier → pain_score → updated_at\` DAL order.

- **\`sortProspectRows\`** — inert rows (no outreach drafted) cluster on top. Within each cluster, oldest \`next_action_at\` first; nulls trail. The audit's literal "Needs triage = \`next_action_at IS NULL\`" rule didn't fit (next_action_at is auto-set by enrichment); the actual triage signal is "promoted but inert" — exactly what the row-action gates from #564 surface.
- **\`sortMeetingsRows\`** — sub-state priority: \`completed-awaiting-proposal\` first, then \`past-due\`, then \`upcoming\` (ordered by earliest \`scheduled_at\`), then \`awaiting-booking\`, then \`other\`.
- **\`sortLostRows\`** — most-recently-lost first by \`stage_changed_at DESC\`.

All sorts stable: rows tied on the primary key keep their incoming DAL order. No new queries — reuses the hydrator maps already loaded.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1583 passed (9 new)
- [x] \`prettier --check\` — clean
- [ ] Manual: prospect tab → inert rows (no Send outreach / Log reply buttons) appear on top
- [ ] Manual: meetings tab → row with completed-awaiting-proposal sub-state appears above upcoming rows
- [ ] Manual: lost tab → most recently lost row appears at the top
- [ ] Manual: signal/proposing/engaged/delivered/ongoing tabs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)