### PR TITLE
feat(admin/entities): engaged + delivered + lost row data (#543 H14)

### DIFF
--- a/src/lib/db/engagements.ts
+++ b/src/lib/db/engagements.ts
@@ -95,6 +95,46 @@ export interface UpdateEngagementData {
 }
 
 /**
+ * For a batch of entity ids, return a Map keyed by entity_id whose
+ * value is the most recent non-terminal engagement (status NOT IN
+ * 'completed', 'cancelled'). Used by the Engaged-stage list to render
+ * engagement progress (`actual / estimated hours`) on each row without
+ * an N+1.
+ *
+ * If an entity has no active engagement (e.g. it's at engaged stage
+ * but the engagement was just cancelled), it's absent from the Map.
+ *
+ * Empty input returns an empty Map without touching the DB.
+ */
+export async function getActiveEngagementForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, Engagement>> {
+  const result = new Map<string, Engagement>()
+  if (entityIds.length === 0) return result
+
+  const entityIdsJson = JSON.stringify(entityIds)
+  const rows = await db
+    .prepare(
+      `SELECT * FROM engagements
+       WHERE org_id = ?
+         AND status NOT IN ('completed', 'cancelled')
+         AND entity_id IN (SELECT value FROM json_each(?))
+       ORDER BY entity_id ASC, created_at DESC`
+    )
+    .bind(orgId, entityIdsJson)
+    .all<Engagement>()
+
+  for (const row of rows.results ?? []) {
+    if (!result.has(row.entity_id)) {
+      result.set(row.entity_id, row)
+    }
+  }
+  return result
+}
+
+/**
  * List engagements for an organization, optionally filtered by entity.
  */
 export async function listEngagements(

--- a/src/lib/db/invoices.ts
+++ b/src/lib/db/invoices.ts
@@ -86,6 +86,63 @@ export interface InvoiceFilters {
 }
 
 /**
+ * For a batch of entity ids, return per-entity invoice rollup used by
+ * the Engaged-stage list rows: outstanding count + sum of outstanding
+ * amount, plus an `overdue` flag if any of those outstanding invoices
+ * has status='overdue'.
+ *
+ * "Outstanding" = status IN ('sent', 'overdue'). Drafts and voids are
+ * not yet a payment expectation; paid is settled. Returns Map values
+ * only for entities with at least one outstanding invoice.
+ *
+ * Empty input returns an empty Map without touching the DB.
+ */
+export interface InvoiceRollup {
+  outstanding_count: number
+  outstanding_amount: number
+  has_overdue: boolean
+}
+
+export async function getInvoiceRollupForEntities(
+  db: D1Database,
+  orgId: string,
+  entityIds: string[]
+): Promise<Map<string, InvoiceRollup>> {
+  const result = new Map<string, InvoiceRollup>()
+  if (entityIds.length === 0) return result
+
+  const entityIdsJson = JSON.stringify(entityIds)
+  const rows = await db
+    .prepare(
+      `SELECT entity_id,
+              COUNT(*)              AS outstanding_count,
+              COALESCE(SUM(amount), 0) AS outstanding_amount,
+              SUM(CASE WHEN status = 'overdue' THEN 1 ELSE 0 END) AS overdue_count
+       FROM invoices
+       WHERE org_id = ?
+         AND status IN ('sent', 'overdue')
+         AND entity_id IN (SELECT value FROM json_each(?))
+       GROUP BY entity_id`
+    )
+    .bind(orgId, entityIdsJson)
+    .all<{
+      entity_id: string
+      outstanding_count: number
+      outstanding_amount: number
+      overdue_count: number
+    }>()
+
+  for (const row of rows.results ?? []) {
+    result.set(row.entity_id, {
+      outstanding_count: row.outstanding_count,
+      outstanding_amount: row.outstanding_amount,
+      has_overdue: row.overdue_count > 0,
+    })
+  }
+  return result
+}
+
+/**
  * List invoices for an organization, optionally filtered by entity, engagement, or status.
  */
 export async function listInvoices(

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -4,6 +4,7 @@ import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import {
   listEntities,
   countEntitiesPerStage,
+  getLatestLostReasonsByEntity,
   getSignalMetadataForEntities,
   ENTITY_STAGES,
 } from '../../../lib/db/entities'
@@ -12,7 +13,12 @@ import { getActiveQuotesForEntities, getQuotesForEntities } from '../../../lib/d
 import type { Quote } from '../../../lib/db/quotes'
 import { getMeetingsForEntities } from '../../../lib/db/meetings'
 import type { Meeting } from '../../../lib/db/meetings'
-import { LOST_REASONS } from '../../../lib/db/lost-reasons'
+import { getActiveEngagementForEntities } from '../../../lib/db/engagements'
+import type { Engagement } from '../../../lib/db/engagements'
+import { getInvoiceRollupForEntities } from '../../../lib/db/invoices'
+import type { InvoiceRollup } from '../../../lib/db/invoices'
+import { LOST_REASONS, lostReasonLabel, lostReasonChipClass } from '../../../lib/db/lost-reasons'
+import type { LostReasonCode } from '../../../lib/db/lost-reasons'
 import { getLatestOutreachDraftForEntities } from '../../../lib/db/context'
 import type { ContextEntry } from '../../../lib/db/context'
 import { getFirstContactWithEmailForEntities } from '../../../lib/db/contacts'
@@ -119,6 +125,33 @@ if (filterStage === 'meetings' && entities.length > 0) {
     getMeetingsForEntities(env.DB, session.orgId, ids),
     getQuotesForEntities(env.DB, session.orgId, ids),
   ])
+}
+
+// Engaged-stage row hydration. Two batch queries — the active
+// engagement per entity (powers progress: actual / estimated hours,
+// status pill) and the invoice rollup per entity (outstanding count +
+// amount + overdue flag). Both gated to engaged stage; no effect on
+// other tabs.
+let activeEngagementByEntityId = new Map<string, Engagement>()
+let invoiceRollupByEntityId = new Map<string, InvoiceRollup>()
+if (filterStage === 'engaged' && entities.length > 0) {
+  const ids = entities.map((e) => e.id)
+  ;[activeEngagementByEntityId, invoiceRollupByEntityId] = await Promise.all([
+    getActiveEngagementForEntities(env.DB, session.orgId, ids),
+    getInvoiceRollupForEntities(env.DB, session.orgId, ids),
+  ])
+}
+
+// Lost-stage row hydration. The structured lost-reason rollup that
+// already powers the detail page's lost-reason chip — surface it on
+// the row so the operator can scan "why" without clicking through.
+let lostReasonByEntityId = new Map<string, { code: LostReasonCode; detail: string | null }>()
+if (filterStage === 'lost' && entities.length > 0) {
+  lostReasonByEntityId = await getLatestLostReasonsByEntity(
+    env.DB,
+    session.orgId,
+    entities.map((e) => e.id)
+  )
 }
 
 // Per-stage display order. Hydrators above feed the in-memory re-sorts
@@ -475,6 +508,21 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             const rowDraftableMeeting = isMeetings
               ? findDraftableMeeting(rowMeetings, rowQuotes)
               : null
+            const isEngaged = e.stage === 'engaged'
+            const rowEngagement = isEngaged ? (activeEngagementByEntityId.get(e.id) ?? null) : null
+            const rowInvoiceRollup = isEngaged ? (invoiceRollupByEntityId.get(e.id) ?? null) : null
+            const isLost = e.stage === 'lost'
+            const rowLostReason = isLost ? (lostReasonByEntityId.get(e.id) ?? null) : null
+            // Days since the entity transitioned to delivered. Stabilization
+            // tradition is a 2-week window after handoff; the day count keeps
+            // the operator aware of how far in we are without needing to
+            // open the engagement.
+            const isDelivered = e.stage === 'delivered'
+            const stabilizationDays = isDelivered
+              ? Math.floor(
+                  (Date.now() - new Date(e.stage_changed_at).getTime()) / (1000 * 60 * 60 * 24)
+                )
+              : null
             const activeQuote =
               filterStage === 'proposing' ? (activeQuoteByEntityId.get(e.id) ?? null) : null
             const quoteTimestamp =
@@ -544,6 +592,24 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           {MEETING_SUBSTATE_LABEL[rowSubstate]}
                         </span>
                       )}
+                      {rowEngagement && (
+                        <span class={statusBadgeClass(rowEngagement.status)}>
+                          {rowEngagement.status}
+                        </span>
+                      )}
+                      {rowInvoiceRollup && rowInvoiceRollup.has_overdue && (
+                        <span class="text-xs px-1.5 py-0.5 rounded bg-red-100 text-red-700">
+                          Invoice overdue
+                        </span>
+                      )}
+                      {rowLostReason && (
+                        <span
+                          class={`text-xs px-2 py-0.5 rounded ${lostReasonChipClass(rowLostReason.code)}`}
+                          title={rowLostReason.detail ?? undefined}
+                        >
+                          {lostReasonLabel(rowLostReason.code) ?? rowLostReason.code}
+                        </span>
+                      )}
                     </div>
 
                     {isSignal && problems.length > 0 && (
@@ -597,6 +663,21 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                       )}
                       {rowNextMeeting && rowNextMeeting.scheduled_at && (
                         <span>Next meeting {formatDate(rowNextMeeting.scheduled_at)}</span>
+                      )}
+                      {rowEngagement && rowEngagement.estimated_hours != null && (
+                        <span>
+                          {rowEngagement.actual_hours}/{rowEngagement.estimated_hours} hrs
+                        </span>
+                      )}
+                      {rowInvoiceRollup && (
+                        <span>
+                          ${rowInvoiceRollup.outstanding_amount.toLocaleString()} outstanding
+                          {rowInvoiceRollup.outstanding_count > 1 &&
+                            ` (${rowInvoiceRollup.outstanding_count})`}
+                        </span>
+                      )}
+                      {stabilizationDays != null && (
+                        <span>Day {stabilizationDays + 1} of stabilization</span>
                       )}
                       {e.area && <span>{e.area}</span>}
                       {e.vertical && (

--- a/tests/entities-bulk.test.ts
+++ b/tests/entities-bulk.test.ts
@@ -135,7 +135,13 @@ describe('admin/entities/index.astro: bulk UI wiring', () => {
   const source = () => readFileSync(resolve('src/pages/admin/entities/index.astro'), 'utf-8')
 
   it('imports LOST_REASONS from the canonical module', () => {
-    expect(source()).toContain("import { LOST_REASONS } from '../../../lib/db/lost-reasons'")
+    // The same import line may also pull sibling exports (lost-reason
+    // label / chip helpers used to render the structured reason chip on
+    // Lost-tab rows) — match the symbol and module path rather than a
+    // literal one-symbol form.
+    expect(source()).toMatch(
+      /import\s*\{[^}]*\bLOST_REASONS\b[^}]*\}\s*from\s*['"]\.\.\/\.\.\/\.\.\/lib\/db\/lost-reasons['"]/
+    )
   })
 
   it('defines BULK_ENABLED_STAGES = signal/prospect/assessing only', () => {

--- a/tests/entities-engaged-hydrators.test.ts
+++ b/tests/entities-engaged-hydrators.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the engaged-stage list hydrators that drive the Engaged
+ * tab's per-row engagement progress + invoice rollup:
+ *
+ *   - getActiveEngagementForEntities
+ *   - getInvoiceRollupForEntities
+ *
+ * Real D1 schema, FK chains bypassed via raw SQL inserts where the
+ * helper's contract doesn't depend on the FK invariants.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../src/lib/db/entities'
+import { getActiveEngagementForEntities } from '../src/lib/db/engagements'
+import { getInvoiceRollupForEntities } from '../src/lib/db/invoices'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-test'
+
+async function setup() {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(ORG_ID, 'Test Org', 'test-org')
+    .run()
+  return db
+}
+
+/**
+ * Insert an engagement row directly so we can pick the status without
+ * walking the createEngagement transition machine. The hydrator's
+ * contract is "WHERE org_id AND status NOT IN (...) AND entity_id IN
+ * (...)" — only entity_id and status matter for the test.
+ */
+async function insertEngagementRaw(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  status: string,
+  estimatedHours: number | null = 40,
+  actualHours = 0,
+  createdAt = new Date().toISOString()
+): Promise<string> {
+  const id = crypto.randomUUID()
+  await db.prepare('PRAGMA foreign_keys = OFF').run()
+  await db
+    .prepare(
+      `INSERT INTO engagements (
+         id, org_id, entity_id, quote_id, status, estimated_hours, actual_hours,
+         created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      orgId,
+      entityId,
+      crypto.randomUUID(),
+      status,
+      estimatedHours,
+      actualHours,
+      createdAt,
+      createdAt
+    )
+    .run()
+  await db.prepare('PRAGMA foreign_keys = ON').run()
+  return id
+}
+
+async function insertInvoiceRaw(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  status: string,
+  amount: number,
+  type = 'deposit'
+): Promise<void> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+  await db.prepare('PRAGMA foreign_keys = OFF').run()
+  await db
+    .prepare(
+      `INSERT INTO invoices (
+         id, org_id, entity_id, engagement_id, type, amount, description,
+         status, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(id, orgId, entityId, null, type, amount, null, status, now, now)
+    .run()
+  await db.prepare('PRAGMA foreign_keys = ON').run()
+}
+
+describe('getActiveEngagementForEntities', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await setup()
+  })
+
+  it('returns an empty map for empty input', async () => {
+    expect((await getActiveEngagementForEntities(db, ORG_ID, [])).size).toBe(0)
+  })
+
+  it('returns the most recent non-terminal engagement per entity', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'A' })
+    await insertEngagementRaw(db, ORG_ID, e.id, 'scheduled', 40, 0, '2026-01-01T00:00:00Z')
+    await insertEngagementRaw(db, ORG_ID, e.id, 'active', 40, 12, '2026-04-01T00:00:00Z')
+
+    const result = await getActiveEngagementForEntities(db, ORG_ID, [e.id])
+    expect(result.get(e.id)?.status).toBe('active')
+    expect(result.get(e.id)?.actual_hours).toBe(12)
+  })
+
+  it('skips engagements with terminal status (completed, cancelled)', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'B' })
+    await insertEngagementRaw(db, ORG_ID, e.id, 'completed')
+
+    const result = await getActiveEngagementForEntities(db, ORG_ID, [e.id])
+    expect(result.has(e.id)).toBe(false)
+  })
+
+  it('does not leak engagements across orgs', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other', 'other')
+      .run()
+    const e = await createEntity(db, 'org-other', { name: 'Leak' })
+    await insertEngagementRaw(db, 'org-other', e.id, 'active')
+
+    const result = await getActiveEngagementForEntities(db, ORG_ID, [e.id])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('getInvoiceRollupForEntities', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await setup()
+  })
+
+  it('returns an empty map for empty input', async () => {
+    expect((await getInvoiceRollupForEntities(db, ORG_ID, [])).size).toBe(0)
+  })
+
+  it('rolls up outstanding count + amount from sent + overdue invoices', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'A' })
+    await insertInvoiceRaw(db, ORG_ID, e.id, 'sent', 1000)
+    await insertInvoiceRaw(db, ORG_ID, e.id, 'overdue', 2000)
+    // paid + draft + void should not contribute
+    await insertInvoiceRaw(db, ORG_ID, e.id, 'paid', 9999)
+    await insertInvoiceRaw(db, ORG_ID, e.id, 'draft', 9999)
+
+    const result = await getInvoiceRollupForEntities(db, ORG_ID, [e.id])
+    const rollup = result.get(e.id)
+    expect(rollup?.outstanding_count).toBe(2)
+    expect(rollup?.outstanding_amount).toBe(3000)
+    expect(rollup?.has_overdue).toBe(true)
+  })
+
+  it('omits entities with no outstanding invoices', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'B' })
+    await insertInvoiceRaw(db, ORG_ID, e.id, 'paid', 500)
+    const result = await getInvoiceRollupForEntities(db, ORG_ID, [e.id])
+    expect(result.has(e.id)).toBe(false)
+  })
+
+  it('marks has_overdue=false when only sent (not overdue) invoices exist', async () => {
+    const e = await createEntity(db, ORG_ID, { name: 'C' })
+    await insertInvoiceRaw(db, ORG_ID, e.id, 'sent', 750)
+    const rollup = (await getInvoiceRollupForEntities(db, ORG_ID, [e.id])).get(e.id)
+    expect(rollup?.has_overdue).toBe(false)
+    expect(rollup?.outstanding_count).toBe(1)
+  })
+
+  it('does not leak invoices across orgs', async () => {
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind('org-other', 'Other', 'other')
+      .run()
+    const e = await createEntity(db, 'org-other', { name: 'Leak' })
+    await insertInvoiceRaw(db, 'org-other', e.id, 'sent', 100)
+
+    const result = await getInvoiceRollupForEntities(db, ORG_ID, [e.id])
+    expect(result.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #543 H14. Step 4 of the DAL track. With this, #543 has all 5 ACs (H1, H11, H12, H13, H14) shipped.

- **Engaged**: \`getActiveEngagementForEntities\` (most recent non-terminal engagement) + \`getInvoiceRollupForEntities\` (sent/overdue rollup with has_overdue flag). Row shows engagement status pill, \`actual / estimated\` hours, and \`$X outstanding\` (red "Invoice overdue" pill when applicable).
- **Delivered**: "Day N of stabilization" derived from \`stage_changed_at\` — no query.
- **Lost**: structured lost-reason chip on each row via existing \`getLatestLostReasonsByEntity\`. Same shape as detail page's chip.
- 9 new tests in \`tests/entities-engaged-hydrators.test.ts\`.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 1592 passed (9 new)
- [x] \`prettier --check\` — clean
- [ ] Manual: engaged tab → row with active engagement shows status pill + hours progress; row with overdue invoice shows red "Invoice overdue" pill + outstanding $
- [ ] Manual: delivered tab → row meta shows "Day N of stabilization"
- [ ] Manual: lost tab → row name line shows lost-reason chip with detail tooltip
- [ ] Manual: other tabs (signal/prospect/meetings/proposing/ongoing) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)