### PR TITLE
feat(enrichment): durable per-module run state + admin status panel + ingest-gap fix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,10 @@ wrangler.toml
 coverage/
 # Generated design baselines — preserve as-is for reference
 .design/designs/
+# Generated audit reports (UI drift snapshots, etc.) — JSON output from
+# tooling, not hand-authored, and the format may diverge from prettier
+# defaults. Same rationale as .design/designs/.
+.design/audits/
 # Documentation / spec files with embedded JSX, SQL, or pseudo-code
 # blocks that prettier-plugin-astro tries to parse as syntactically-valid
 # source and errors on. Format these files by hand.
@@ -16,3 +20,7 @@ docs/spikes/
 docs/style/UI-PATTERNS.md
 # Playwright MCP output (screenshots, console dumps, snapshots)
 .playwright-mcp/
+# Git worktrees — checked-out copies of other branches owned by parallel
+# work. The branch that owns the source is responsible for formatting it,
+# not whichever branch happens to have a worktree on disk right now.
+.worktrees/

--- a/migrations/0027_create_enrichment_runs.sql
+++ b/migrations/0027_create_enrichment_runs.sql
@@ -1,0 +1,57 @@
+-- Per-module enrichment-run state. Replaces the in-memory EnrichResult that
+-- workers/admin endpoints discarded after every call, leaving us with no way
+-- to see which modules ran for which entity (or why some — like Cactus
+-- Creative Studio's review_synthesis — silently returned null and vanished).
+--
+-- Append-only. One row per (entity_id, module) per attempt.
+--
+-- status taxonomy:
+--   running    — wrapper started a run; not yet completed.
+--   succeeded  — module produced data and a context row was written.
+--   no_data    — module ran cleanly but returned nothing useful (e.g.,
+--                Outscraper found no place; Claude returned a non-JSON body).
+--                Distinct from `succeeded` so we can tell "ran and worked"
+--                from "ran and produced nothing" — that distinction is the
+--                load-bearing fix for the silent-return bug.
+--   skipped    — wrapper did not call the module body (missing input,
+--                missing API key, lock contention).
+--   failed    — module threw. error_message holds a truncated message; reason
+--                holds a classified kind ('fetch_failed', 'parse_error',
+--                'timeout', 'api_error', 'unknown').
+--
+-- input_fingerprint: optional SHA-256 (1KB-truncated) of the module's
+-- assembled-context input. Recorded only for review_synthesis and
+-- intelligence_brief — the modules whose output materially changes when
+-- upstream context grows. Stored now; consumed (for stale-rerun decisions)
+-- later if telemetry justifies.
+
+CREATE TABLE enrichment_runs (
+  id                TEXT PRIMARY KEY,
+  org_id            TEXT NOT NULL REFERENCES organizations(id),
+  entity_id         TEXT NOT NULL,
+
+  module            TEXT NOT NULL,
+  status            TEXT NOT NULL CHECK (status IN (
+    'running', 'succeeded', 'no_data', 'skipped', 'failed'
+  )),
+  reason            TEXT,
+  error_message     TEXT,
+  input_fingerprint TEXT,
+
+  started_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  completed_at      TEXT,
+  duration_ms       INTEGER,
+
+  triggered_by      TEXT NOT NULL,
+  mode              TEXT NOT NULL CHECK (mode IN ('full', 'reviews-and-news', 'single')),
+  context_entry_id  TEXT
+);
+
+CREATE INDEX idx_enrichment_runs_entity_module
+  ON enrichment_runs(entity_id, module, started_at DESC);
+
+CREATE INDEX idx_enrichment_runs_module_status
+  ON enrichment_runs(module, status, started_at DESC);
+
+CREATE INDEX idx_enrichment_runs_org
+  ON enrichment_runs(org_id, started_at DESC);

--- a/src/components/admin/EnrichmentStatusPanel.astro
+++ b/src/components/admin/EnrichmentStatusPanel.astro
@@ -73,7 +73,7 @@ const rows: Row[] = MODULES.map((m) => {
     status,
     reason: run?.reason ?? null,
     errorMessage: run?.error_message ?? null,
-    whenLabel: ts ? relativeTime(ts) : '',
+    whenLabel: (ts ? relativeTime(ts) : '') ?? '',
   }
 })
 ---

--- a/src/components/admin/EnrichmentStatusPanel.astro
+++ b/src/components/admin/EnrichmentStatusPanel.astro
@@ -1,0 +1,194 @@
+---
+/**
+ * Enrichment Status Panel — admin debug surface that shows the durable
+ * per-module run state for a single entity. Replaces "guess from the
+ * timeline" with "read the runs table."
+ *
+ * Designed as an internal operator tool: simple table, status pills, per-row
+ * Retry, page-level "Run full enrichment". No design rigor beyond the
+ * existing badge / button helpers — this is not a client-facing surface.
+ */
+import { MODULES } from '../../lib/enrichment/modules'
+import type { ModuleId } from '../../lib/enrichment/modules'
+import { latestRunByModule } from '../../lib/db/enrichment-runs'
+import type { EnrichmentRun, RunStatus } from '../../lib/db/enrichment-runs'
+import { adminActionButtonClass } from '../../lib/ui/admin-action-button'
+import { relativeTime } from '../../lib/admin/relative-time'
+import { env } from 'cloudflare:workers'
+
+interface Props {
+  entityId: string
+}
+const { entityId } = Astro.props
+
+const latest = await latestRunByModule(env.DB, entityId)
+
+type DisplayStatus = RunStatus | 'not_yet_run'
+
+function tone(status: DisplayStatus): string {
+  switch (status) {
+    case 'succeeded':
+      return 'bg-[color:var(--color-complete)] text-white'
+    case 'no_data':
+      return 'bg-[color:var(--color-attention)] text-white'
+    case 'failed':
+      return 'bg-[color:var(--color-error)] text-white'
+    case 'running':
+      return 'bg-[color:var(--color-primary)] text-white'
+    case 'skipped':
+    case 'not_yet_run':
+    default:
+      return 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
+  }
+}
+
+function statusPillClass(status: DisplayStatus): string {
+  return (
+    'inline-flex items-center px-2 py-0.5 rounded-[var(--radius-badge)] ' +
+    'font-mono text-[0.6875rem] uppercase tracking-wider font-semibold whitespace-nowrap ' +
+    tone(status)
+  )
+}
+
+interface Row {
+  id: ModuleId
+  displayName: string
+  tier: number
+  run: EnrichmentRun | undefined
+  status: DisplayStatus
+  reason: string | null
+  errorMessage: string | null
+  whenLabel: string
+}
+
+const rows: Row[] = MODULES.map((m) => {
+  const run = latest.get(m.id)
+  const status: DisplayStatus = run?.status ?? 'not_yet_run'
+  const ts = run?.completed_at ?? run?.started_at
+  return {
+    id: m.id,
+    displayName: m.displayName,
+    tier: m.tier,
+    run,
+    status,
+    reason: run?.reason ?? null,
+    errorMessage: run?.error_message ?? null,
+    whenLabel: ts ? relativeTime(ts) : '',
+  }
+})
+---
+
+<div
+  class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+>
+  <div class="flex items-baseline justify-between gap-2 mb-3 flex-wrap">
+    <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+      Enrichment status
+    </h3>
+    <form method="POST" action={`/api/admin/entities/${entityId}/enrichment/run-full`} class="m-0">
+      <button type="submit" class={adminActionButtonClass('ghost')} data-enrichment-run-full>
+        Run full enrichment
+      </button>
+    </form>
+  </div>
+
+  <div
+    class="overflow-hidden border border-[color:var(--color-border-subtle)] rounded-[var(--radius-card)]"
+  >
+    <table class="w-full text-sm">
+      <thead
+        class="bg-[color:var(--color-background)] text-left text-xs text-[color:var(--color-text-muted)]"
+      >
+        <tr>
+          <th class="px-3 py-2 font-medium">Module</th>
+          <th class="px-3 py-2 font-medium">Status</th>
+          <th class="px-3 py-2 font-medium">When</th>
+          <th class="px-3 py-2 font-medium text-right">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          rows.map((row) => (
+            <>
+              <tr class="border-t border-[color:var(--color-border-subtle)]">
+                <td class="px-3 py-2 align-top">
+                  <div class="font-medium text-[color:var(--color-text-primary)]">
+                    {row.displayName}
+                  </div>
+                  <div class="text-[0.6875rem] text-[color:var(--color-text-muted)]">
+                    Tier {row.tier} · {row.id}
+                  </div>
+                </td>
+                <td class="px-3 py-2 align-top">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class={statusPillClass(row.status)}>
+                      {row.status === 'not_yet_run' ? 'not yet run' : row.status.replace('_', ' ')}
+                    </span>
+                    {row.reason && (
+                      <span class="text-xs text-[color:var(--color-text-muted)]">{row.reason}</span>
+                    )}
+                  </div>
+                  {row.errorMessage && (
+                    <details class="mt-1">
+                      <summary class="text-xs text-[color:var(--color-text-muted)] cursor-pointer hover:text-[color:var(--color-text-secondary)]">
+                        Error detail
+                      </summary>
+                      <pre class="mt-1 p-2 text-xs bg-[color:var(--color-background)] rounded overflow-x-auto whitespace-pre-wrap break-words">
+                        {row.errorMessage}
+                      </pre>
+                    </details>
+                  )}
+                </td>
+                <td class="px-3 py-2 align-top text-xs text-[color:var(--color-text-secondary)]">
+                  {row.whenLabel ? (
+                    <>
+                      <div>{row.whenLabel}</div>
+                      {row.run?.triggered_by && (
+                        <div class="text-[0.6875rem] text-[color:var(--color-text-muted)] mt-0.5">
+                          {row.run.triggered_by}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <span class="text-[color:var(--color-text-muted)]">—</span>
+                  )}
+                </td>
+                <td class="px-3 py-2 align-top text-right">
+                  <form
+                    method="POST"
+                    action={`/api/admin/entities/${entityId}/enrichment/${row.id}/retry`}
+                    class="m-0 inline"
+                  >
+                    <button
+                      type="submit"
+                      class={adminActionButtonClass('ghost')}
+                      data-enrichment-retry={row.id}
+                    >
+                      {row.status === 'not_yet_run' ? 'Run' : 'Retry'}
+                    </button>
+                  </form>
+                </td>
+              </tr>
+            </>
+          ))
+        }
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script is:inline>
+  // Disable the button + show pending state while the redirect resolves so a
+  // double-click doesn't double-bill Claude. The startRun lock in the DAL is
+  // the durable backstop; this is the UX touch.
+  document
+    .querySelectorAll('[data-enrichment-retry], [data-enrichment-run-full]')
+    .forEach((btn) => {
+      const form = btn.closest('form')
+      if (!form) return
+      form.addEventListener('submit', () => {
+        btn.setAttribute('disabled', 'true')
+        btn.textContent = 'Running…'
+      })
+    })
+</script>

--- a/src/lib/db/enrichment-runs.ts
+++ b/src/lib/db/enrichment-runs.ts
@@ -1,0 +1,196 @@
+/**
+ * Enrichment runs DAL.
+ *
+ * INVARIANT: APPEND-ONLY for completed rows. The only mutation is
+ * `running → terminal status` via `completeRun`; once a row has a non-null
+ * `completed_at`, it is immutable. Future history is added as new rows.
+ *
+ * Concurrency: `startRun` checks for an existing in-flight `running` row
+ * for the same (entity_id, module) within the last 5 minutes and returns
+ * `null` instead of inserting. Callers treat that as `skipped, reason:
+ * 'in_progress'`. This prevents double-click money-burn on the admin
+ * Retry / Run-full buttons and races between concurrent triggers
+ * (e.g. cron worker fires while admin clicks Retry).
+ *
+ * The 5-minute ceiling on the lock means a crashed run leaves a stale
+ * `running` row but the next attempt after the timeout proceeds. We do
+ * not actively reap stale rows — the cost is one extra row per crash
+ * and an inaccurate "still running" display in the admin UI for up to
+ * 5 minutes. Worth it for not having to introduce a sweeper.
+ */
+
+import type { ModuleId } from '../enrichment/modules'
+
+export type RunStatus = 'running' | 'succeeded' | 'no_data' | 'skipped' | 'failed'
+export type RunMode = 'full' | 'reviews-and-news' | 'single'
+
+export interface EnrichmentRun {
+  id: string
+  org_id: string
+  entity_id: string
+  module: ModuleId
+  status: RunStatus
+  reason: string | null
+  error_message: string | null
+  input_fingerprint: string | null
+  started_at: string
+  completed_at: string | null
+  duration_ms: number | null
+  triggered_by: string
+  mode: RunMode
+  context_entry_id: string | null
+}
+
+export interface StartRunInput {
+  org_id: string
+  entity_id: string
+  module: ModuleId
+  mode: RunMode
+  triggered_by: string
+  input_fingerprint?: string | null
+}
+
+export interface CompleteRunInput {
+  status: Exclude<RunStatus, 'running'>
+  reason?: string | null
+  error_message?: string | null
+  context_entry_id?: string | null
+}
+
+const LOCK_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * Insert a `running` row, unless an in-flight row exists for the same
+ * (entity_id, module) within the lock window. Returns the new run id, or
+ * `null` if locked out.
+ */
+export async function startRun(db: D1Database, input: StartRunInput): Promise<string | null> {
+  const now = new Date()
+  const cutoff = new Date(now.getTime() - LOCK_WINDOW_MS).toISOString()
+
+  const existing = await db
+    .prepare(
+      `SELECT id FROM enrichment_runs
+       WHERE entity_id = ? AND module = ? AND status = 'running'
+         AND started_at > ?
+       LIMIT 1`
+    )
+    .bind(input.entity_id, input.module, cutoff)
+    .first<{ id: string }>()
+
+  if (existing) return null
+
+  const id = crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO enrichment_runs (
+        id, org_id, entity_id, module, status, reason, error_message,
+        input_fingerprint, started_at, completed_at, duration_ms,
+        triggered_by, mode, context_entry_id
+      ) VALUES (?, ?, ?, ?, 'running', NULL, NULL, ?, ?, NULL, NULL, ?, ?, NULL)`
+    )
+    .bind(
+      id,
+      input.org_id,
+      input.entity_id,
+      input.module,
+      input.input_fingerprint ?? null,
+      now.toISOString(),
+      input.triggered_by,
+      input.mode
+    )
+    .run()
+
+  return id
+}
+
+/**
+ * Transition a run from `running` to a terminal status. No-op if the row
+ * is already completed (i.e. completed_at is non-null) — protects against
+ * double-completion races.
+ */
+export async function completeRun(
+  db: D1Database,
+  runId: string,
+  input: CompleteRunInput
+): Promise<void> {
+  const row = await db
+    .prepare('SELECT started_at, completed_at FROM enrichment_runs WHERE id = ?')
+    .bind(runId)
+    .first<{ started_at: string; completed_at: string | null }>()
+
+  if (!row || row.completed_at) return
+
+  const now = new Date()
+  const startedAt = new Date(row.started_at)
+  const duration = Math.max(0, now.getTime() - startedAt.getTime())
+
+  const truncatedError = input.error_message ? input.error_message.slice(0, 512) : null
+
+  await db
+    .prepare(
+      `UPDATE enrichment_runs
+       SET status = ?, reason = ?, error_message = ?,
+           completed_at = ?, duration_ms = ?, context_entry_id = ?
+       WHERE id = ?`
+    )
+    .bind(
+      input.status,
+      input.reason ?? null,
+      truncatedError,
+      now.toISOString(),
+      duration,
+      input.context_entry_id ?? null,
+      runId
+    )
+    .run()
+}
+
+/**
+ * Return the most-recent run row per module for a given entity. Used by
+ * the admin Enrichment Status panel.
+ */
+export async function latestRunByModule(
+  db: D1Database,
+  entityId: string
+): Promise<Map<ModuleId, EnrichmentRun>> {
+  const rows = await db
+    .prepare(
+      `SELECT * FROM enrichment_runs
+       WHERE entity_id = ?
+       ORDER BY module ASC, started_at DESC`
+    )
+    .bind(entityId)
+    .all<EnrichmentRun>()
+
+  const out = new Map<ModuleId, EnrichmentRun>()
+  for (const row of rows.results ?? []) {
+    if (!out.has(row.module)) {
+      out.set(row.module, row)
+    }
+  }
+  return out
+}
+
+/**
+ * Return the most-recent SUCCESSFUL run for a single module, or null. Used
+ * for narrow checks like "did review_synthesis ever succeed for this
+ * entity" without loading every row.
+ */
+export async function lastSuccessfulRun(
+  db: D1Database,
+  entityId: string,
+  module: ModuleId
+): Promise<EnrichmentRun | null> {
+  return (
+    (await db
+      .prepare(
+        `SELECT * FROM enrichment_runs
+         WHERE entity_id = ? AND module = ? AND status = 'succeeded'
+         ORDER BY started_at DESC
+         LIMIT 1`
+      )
+      .bind(entityId, module)
+      .first<EnrichmentRun>()) ?? null
+  )
+}

--- a/src/lib/enrichment/acc.ts
+++ b/src/lib/enrichment/acc.ts
@@ -24,47 +24,43 @@ const ACC_SEARCH_URL = 'https://ecorp.azcc.gov/EntitySearch/Index'
  * and handled gracefully.
  */
 export async function lookupAcc(businessName: string): Promise<AccEnrichment | null> {
-  try {
-    // ACC uses a form POST for search
-    const searchParams = new URLSearchParams({
-      BusinessName: businessName.replace(/\b(llc|inc|corp|ltd)\b\.?/gi, '').trim(),
-      SearchType: 'Contains',
-    })
+  // ACC uses a form POST for search
+  const searchParams = new URLSearchParams({
+    BusinessName: businessName.replace(/\b(llc|inc|corp|ltd)\b\.?/gi, '').trim(),
+    SearchType: 'Contains',
+  })
 
-    const response = await fetch(ACC_SEARCH_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'User-Agent': 'Mozilla/5.0 (compatible)',
-      },
-      body: searchParams.toString(),
-      redirect: 'follow',
-      signal: AbortSignal.timeout(10000),
-    })
+  const response = await fetch(ACC_SEARCH_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'Mozilla/5.0 (compatible)',
+    },
+    body: searchParams.toString(),
+    redirect: 'follow',
+    signal: AbortSignal.timeout(10000),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const html = await response.text()
+  const html = await response.text()
 
-    // Extract first result from the table
-    // ACC renders results in a table with class "table table-striped"
-    const nameMatch = html.match(/EntityName[^>]*>([^<]+)</i)
-    const typeMatch = html.match(/EntityType[^>]*>([^<]+)</i)
-    const dateMatch = html.match(/ApprovalDate[^>]*>([^<]+)</i)
-    const statusMatch = html.match(/EntityStatus[^>]*>([^<]+)</i)
-    const agentMatch =
-      html.match(/StatutoryAgent[^>]*>([^<]+)</i) ?? html.match(/RegisteredAgent[^>]*>([^<]+)</i)
+  // Extract first result from the table
+  // ACC renders results in a table with class "table table-striped"
+  const nameMatch = html.match(/EntityName[^>]*>([^<]+)</i)
+  const typeMatch = html.match(/EntityType[^>]*>([^<]+)</i)
+  const dateMatch = html.match(/ApprovalDate[^>]*>([^<]+)</i)
+  const statusMatch = html.match(/EntityStatus[^>]*>([^<]+)</i)
+  const agentMatch =
+    html.match(/StatutoryAgent[^>]*>([^<]+)</i) ?? html.match(/RegisteredAgent[^>]*>([^<]+)</i)
 
-    if (!nameMatch) return null
+  if (!nameMatch) return null
 
-    return {
-      entity_name: nameMatch[1].trim(),
-      entity_type: typeMatch?.[1]?.trim() ?? null,
-      filing_date: dateMatch?.[1]?.trim() ?? null,
-      status: statusMatch?.[1]?.trim() ?? null,
-      registered_agent: agentMatch?.[1]?.trim() ?? null,
-    }
-  } catch {
-    return null
+  return {
+    entity_name: nameMatch[1].trim(),
+    entity_type: typeMatch?.[1]?.trim() ?? null,
+    filing_date: dateMatch?.[1]?.trim() ?? null,
+    status: statusMatch?.[1]?.trim() ?? null,
+    registered_agent: agentMatch?.[1]?.trim() ?? null,
   }
 }

--- a/src/lib/enrichment/competitors.ts
+++ b/src/lib/enrichment/competitors.ts
@@ -37,79 +37,75 @@ export async function benchmarkCompetitors(
   const locationQuery = area || 'Phoenix, AZ'
   const query = `${verticalQuery} ${locationQuery}`
 
-  try {
-    const response = await fetch(PLACES_API_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Goog-Api-Key': apiKey,
-        'X-Goog-FieldMask': 'places.displayName,places.rating,places.userRatingCount',
-      },
-      body: JSON.stringify({
-        textQuery: query,
-        locationBias: {
-          circle: {
-            center: { latitude: 33.4484, longitude: -112.074 },
-            radius: 25000,
-          },
+  const response = await fetch(PLACES_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Goog-Api-Key': apiKey,
+      'X-Goog-FieldMask': 'places.displayName,places.rating,places.userRatingCount',
+    },
+    body: JSON.stringify({
+      textQuery: query,
+      locationBias: {
+        circle: {
+          center: { latitude: 33.4484, longitude: -112.074 },
+          radius: 25000,
         },
-        maxResultCount: 10,
-      }),
-    })
+      },
+      maxResultCount: 10,
+    }),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const data = (await response.json()) as {
-      places?: Array<{
-        displayName?: { text: string }
-        rating?: number
-        userRatingCount?: number
-      }>
-    }
+  const data = (await response.json()) as {
+    places?: Array<{
+      displayName?: { text: string }
+      rating?: number
+      userRatingCount?: number
+    }>
+  }
 
-    const competitors = (data.places ?? [])
-      .filter((p) => p.displayName?.text?.toLowerCase() !== entityName.toLowerCase())
-      .map((p) => ({
-        name: p.displayName?.text ?? '',
-        rating: p.rating ?? 0,
-        review_count: p.userRatingCount ?? 0,
-      }))
-      .slice(0, 5)
+  const competitors = (data.places ?? [])
+    .filter((p) => p.displayName?.text?.toLowerCase() !== entityName.toLowerCase())
+    .map((p) => ({
+      name: p.displayName?.text ?? '',
+      rating: p.rating ?? 0,
+      review_count: p.userRatingCount ?? 0,
+    }))
+    .slice(0, 5)
 
-    if (competitors.length === 0) return null
+  if (competitors.length === 0) return null
 
-    // Rank entity among competitors
-    let rankByReviews: number | null = null
-    let rankByRating: number | null = null
+  // Rank entity among competitors
+  let rankByReviews: number | null = null
+  let rankByRating: number | null = null
 
-    if (entityReviewCount != null) {
-      const allByReviews = [...competitors.map((c) => c.review_count), entityReviewCount].sort(
-        (a, b) => b - a
-      )
-      rankByReviews = allByReviews.indexOf(entityReviewCount) + 1
-    }
+  if (entityReviewCount != null) {
+    const allByReviews = [...competitors.map((c) => c.review_count), entityReviewCount].sort(
+      (a, b) => b - a
+    )
+    rankByReviews = allByReviews.indexOf(entityReviewCount) + 1
+  }
 
-    if (entityRating != null) {
-      const allByRating = [...competitors.map((c) => c.rating), entityRating].sort((a, b) => b - a)
-      rankByRating = allByRating.indexOf(entityRating) + 1
-    }
+  if (entityRating != null) {
+    const allByRating = [...competitors.map((c) => c.rating), entityRating].sort((a, b) => b - a)
+    rankByRating = allByRating.indexOf(entityRating) + 1
+  }
 
-    const avgRating = competitors.reduce((sum, c) => sum + c.rating, 0) / competitors.length
-    const avgReviews = competitors.reduce((sum, c) => sum + c.review_count, 0) / competitors.length
+  const avgRating = competitors.reduce((sum, c) => sum + c.rating, 0) / competitors.length
+  const avgReviews = competitors.reduce((sum, c) => sum + c.review_count, 0) / competitors.length
 
-    const parts: string[] = []
-    if (rankByRating) parts.push(`Ranked #${rankByRating} of ${competitors.length + 1} by rating`)
-    if (rankByReviews) parts.push(`#${rankByReviews} by review count`)
-    parts.push(`Local avg: ${avgRating.toFixed(1)} stars, ${Math.round(avgReviews)} reviews`)
+  const parts: string[] = []
+  if (rankByRating) parts.push(`Ranked #${rankByRating} of ${competitors.length + 1} by rating`)
+  if (rankByReviews) parts.push(`#${rankByReviews} by review count`)
+  parts.push(`Local avg: ${avgRating.toFixed(1)} stars, ${Math.round(avgReviews)} reviews`)
 
-    return {
-      competitors,
-      entity_rank_by_reviews: rankByReviews,
-      entity_rank_by_rating: rankByRating,
-      total_competitors: competitors.length,
-      summary: parts.join('. ') + '.',
-    }
-  } catch {
-    return null
+  return {
+    competitors,
+    entity_rank_by_reviews: rankByReviews,
+    entity_rank_by_rating: rankByRating,
+    total_competitors: competitors.length,
+    summary: parts.join('. ') + '.',
   }
 }

--- a/src/lib/enrichment/deep-website.ts
+++ b/src/lib/enrichment/deep-website.ts
@@ -134,39 +134,43 @@ export async function deepWebsiteAnalysis(
   const combined = pages.map((p) => `=== ${p.url} ===\n${cleanHtml(p.html)}`).join('\n\n')
   const truncated = combined.slice(0, 50_000) // Larger budget for Sonnet
 
-  try {
-    const response = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': anthropicKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        system: DEEP_ANALYSIS_PROMPT,
-        messages: [{ role: 'user', content: `Analyze this business website:\n\n${truncated}` }],
-      }),
-    })
+  // No outer try/catch: errors propagate to the instrumentation wrapper in
+  // src/lib/enrichment/index.ts which classifies them (parse_error,
+  // fetch_failed, etc.) and persists a failure row in enrichment_runs.
+  // Returning null here means "API ran cleanly but had no useful data"
+  // (recorded as `no_data`); throws mean "something broke" (recorded as
+  // `failed` with classified kind).
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': anthropicKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: DEEP_ANALYSIS_PROMPT,
+      messages: [{ role: 'user', content: `Analyze this business website:\n\n${truncated}` }],
+    }),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const result = (await response.json()) as {
-      content?: Array<{ type: string; text?: string }>
-    }
-    let text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
-    if (!text) return null
-    if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
-
-    const parsed = JSON.parse(text)
-    return { ...parsed, pages_analyzed: pages.map((p) => p.url) }
-  } catch {
-    return null
+  const result = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>
   }
+  let text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+  if (!text) return null
+  if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+
+  const parsed = JSON.parse(text)
+  return { ...parsed, pages_analyzed: pages.map((p) => p.url) }
 }
 
 async function safeFetch(url: string): Promise<string | null> {
+  // Per-page best-effort within deep_website. Returning null for one page
+  // is normal (404 on /careers, etc.) and must not poison the whole module.
   try {
     const response = await fetch(url, {
       headers: { 'User-Agent': 'Mozilla/5.0 (compatible; SMDBot/1.0)' },

--- a/src/lib/enrichment/dossier.ts
+++ b/src/lib/enrichment/dossier.ts
@@ -51,34 +51,30 @@ export async function generateDossier(
   entityName: string,
   anthropicKey: string
 ): Promise<string | null> {
-  try {
-    const response = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': anthropicKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        system: DOSSIER_PROMPT,
-        messages: [
-          {
-            role: 'user',
-            content: `Generate an intelligence brief for: ${entityName}\n\nAll available intelligence:\n\n${assembledContext}`,
-          },
-        ],
-      }),
-    })
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': anthropicKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: DOSSIER_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: `Generate an intelligence brief for: ${entityName}\n\nAll available intelligence:\n\n${assembledContext}`,
+        },
+      ],
+    }),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const result = (await response.json()) as {
-      content?: Array<{ type: string; text?: string }>
-    }
-    return result?.content?.find((b) => b.type === 'text')?.text?.trim() ?? null
-  } catch {
-    return null
+  const result = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>
   }
+  return result?.content?.find((b) => b.type === 'text')?.text?.trim() ?? null
 }

--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -51,6 +51,13 @@ import { deepWebsiteAnalysis, type DeepWebsiteAnalysis } from './deep-website'
 import { synthesizeReviews } from './review-synthesis'
 import { lookupLinkedIn } from './linkedin'
 import { generateDossier } from './dossier'
+import {
+  instrumentModule,
+  fingerprint,
+  type ModuleOutcome,
+  type InstrumentResult,
+} from './instrument'
+import type { ModuleId } from './modules'
 
 export type EnrichMode = 'full' | 'reviews-and-news'
 
@@ -62,11 +69,20 @@ export interface EnrichOptions {
    * available for a future "force full re-enrich" action if we add one.
    */
   force?: boolean
+  /**
+   * Provenance string written to every enrichment_runs row produced during
+   * this call. Examples: 'cron:new-business', 'admin:promote',
+   * 'admin:re-enrich', 'admin:retry:deep_website', 'ingest:signals'.
+   * Defaults to 'unknown' if not provided — callers should set it.
+   */
+  triggered_by?: string
 }
 
 export interface EnrichResult {
   entityId: string
   mode: EnrichMode
+  /** Provenance — same value passed in EnrichOptions.triggered_by. */
+  triggered_by: string
   /** Module source names that completed successfully in this run. */
   completed: string[]
   /** Module source names that were skipped (missing API key, wrong vertical, already enriched). */
@@ -75,6 +91,30 @@ export interface EnrichResult {
   errors: string[]
   /** True if the run did nothing because a prior full enrichment exists. */
   alreadyEnriched: boolean
+}
+
+/**
+ * Map a wrapper outcome into the legacy in-memory EnrichResult arrays so
+ * existing callers (workers, promote endpoint) that read result.completed
+ * continue to work. The persisted enrichment_runs row is the durable
+ * record; this is best-effort accounting for the in-memory return value.
+ */
+function applyOutcome(result: EnrichResult, module: ModuleId, outcome: InstrumentResult): void {
+  switch (outcome.status) {
+    case 'succeeded':
+      result.completed.push(module)
+      return
+    case 'no_data':
+    case 'skipped':
+      result.skipped.push(module)
+      return
+    case 'failed':
+      result.errors.push(module)
+      return
+    case 'running':
+      // Unreachable under instrumentModule (always settles to terminal).
+      return
+  }
 }
 
 type EnrichEnv = {
@@ -103,6 +143,7 @@ export async function enrichEntity(
   const result: EnrichResult = {
     entityId,
     mode,
+    triggered_by: options.triggered_by ?? 'unknown',
     completed: [],
     skipped: [],
     errors: [],
@@ -218,36 +259,41 @@ async function tryPlaces(
   entity: Entity,
   result: EnrichResult
 ): Promise<Entity> {
-  if (entity.phone && entity.website) {
-    result.skipped.push('google_places')
-    return entity
-  }
-  if (!env.GOOGLE_PLACES_API_KEY) {
-    result.skipped.push('google_places')
-    return entity
-  }
-  try {
-    const places = await lookupGooglePlaces(entity.name, entity.area, env.GOOGLE_PLACES_API_KEY)
-    if (!places) return entity
-    await updateEntity(env.DB, orgId, entity.id, {
-      phone: places.phone ?? entity.phone ?? undefined,
-      website: places.website ?? entity.website ?? undefined,
-    })
-    await appendContext(env.DB, orgId, {
+  let refreshedEntity: Entity = entity
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `Google Places: ${places.phone ? `Phone: ${places.phone}` : 'No phone found'}. ${places.website ? `Website: ${places.website}` : 'No website found'}. Rating: ${places.rating ?? 'N/A'} (${places.reviewCount ?? 0} reviews). Status: ${places.businessStatus ?? 'unknown'}.`,
-      source: 'google_places',
-      metadata: places as unknown as Record<string, unknown>,
-    })
-    result.completed.push('google_places')
-    const refreshed = await getEntity(env.DB, orgId, entity.id)
-    return refreshed ?? entity
-  } catch (err) {
-    console.error('[enrichEntity] google_places failed:', err)
-    result.errors.push('google_places')
-    return entity
-  }
+      module: 'google_places',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (entity.phone && entity.website)
+        return { kind: 'skipped', reason: 'already_have_phone_and_website' }
+      if (!env.GOOGLE_PLACES_API_KEY)
+        return { kind: 'skipped', reason: 'missing_api_key:google_places' }
+      const places = await lookupGooglePlaces(entity.name, entity.area, env.GOOGLE_PLACES_API_KEY)
+      if (!places) return { kind: 'no_data', reason: 'no_match' }
+      await updateEntity(env.DB, orgId, entity.id, {
+        phone: places.phone ?? entity.phone ?? undefined,
+        website: places.website ?? entity.website ?? undefined,
+      })
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `Google Places: ${places.phone ? `Phone: ${places.phone}` : 'No phone found'}. ${places.website ? `Website: ${places.website}` : 'No website found'}. Rating: ${places.rating ?? 'N/A'} (${places.reviewCount ?? 0} reviews). Status: ${places.businessStatus ?? 'unknown'}.`,
+        source: 'google_places',
+        metadata: places as unknown as Record<string, unknown>,
+      })
+      const refreshed = await getEntity(env.DB, orgId, entity.id)
+      if (refreshed) refreshedEntity = refreshed
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'google_places', outcome)
+  return refreshedEntity
 }
 
 async function tryWebsite(
@@ -256,64 +302,69 @@ async function tryWebsite(
   entity: Entity,
   result: EnrichResult
 ): Promise<Entity> {
-  if (!entity.website || !env.ANTHROPIC_API_KEY) {
-    result.skipped.push('website_analysis')
-    return entity
-  }
-  try {
-    const analysis = await analyzeWebsite(entity.website, env.ANTHROPIC_API_KEY)
-    if (!analysis) return entity
-    const techTools = [
-      ...analysis.tech_stack.scheduling,
-      ...analysis.tech_stack.crm,
-      ...analysis.tech_stack.reviews,
-      ...analysis.tech_stack.payments,
-      ...analysis.tech_stack.communication,
-    ]
-    const missingTools: string[] = []
-    if (analysis.tech_stack.scheduling.length === 0) missingTools.push('No scheduling tool')
-    if (analysis.tech_stack.crm.length === 0) missingTools.push('No CRM')
-    if (analysis.tech_stack.reviews.length === 0) missingTools.push('No review management')
-
-    const contentParts = [
-      `Website analysis (${analysis.pages_analyzed.length} pages):`,
-      analysis.owner_name ? `Owner/Founder: ${analysis.owner_name}` : null,
-      analysis.team_size ? `Team size: ~${analysis.team_size} people` : null,
-      analysis.founding_year ? `Founded: ${analysis.founding_year}` : null,
-      analysis.contact_email ? `Email: ${analysis.contact_email}` : null,
-      analysis.services.length > 0 ? `Services: ${analysis.services.join(', ')}` : null,
-      `Site quality: ${analysis.quality}`,
-      techTools.length > 0
-        ? `Tools detected: ${techTools.join(', ')}`
-        : 'No business tools detected on website',
-      missingTools.length > 0 ? `Gaps: ${missingTools.join(', ')}` : null,
-      `Platform: ${analysis.tech_stack.platform.join(', ') || 'Custom/unknown'}`,
-    ].filter(Boolean)
-
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: contentParts.join('\n'),
-      source: 'website_analysis',
-      metadata: {
-        owner_name: analysis.owner_name,
-        team_size: analysis.team_size,
-        employee_count: analysis.team_size,
-        founding_year: analysis.founding_year,
-        contact_email: analysis.contact_email,
-        services: analysis.services,
-        quality: analysis.quality,
-        tech_stack: analysis.tech_stack,
-        pages_analyzed: analysis.pages_analyzed,
-      },
-    })
-    result.completed.push('website_analysis')
-    return entity
-  } catch (err) {
-    console.error('[enrichEntity] website_analysis failed:', err)
-    result.errors.push('website_analysis')
-    return entity
-  }
+      module: 'website_analysis',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!entity.website) return { kind: 'skipped', reason: 'missing_input:website' }
+      if (!env.ANTHROPIC_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:anthropic' }
+      const analysis = await analyzeWebsite(entity.website, env.ANTHROPIC_API_KEY)
+      if (!analysis) return { kind: 'no_data', reason: 'no_analysis' }
+      const techTools = [
+        ...analysis.tech_stack.scheduling,
+        ...analysis.tech_stack.crm,
+        ...analysis.tech_stack.reviews,
+        ...analysis.tech_stack.payments,
+        ...analysis.tech_stack.communication,
+      ]
+      const missingTools: string[] = []
+      if (analysis.tech_stack.scheduling.length === 0) missingTools.push('No scheduling tool')
+      if (analysis.tech_stack.crm.length === 0) missingTools.push('No CRM')
+      if (analysis.tech_stack.reviews.length === 0) missingTools.push('No review management')
+
+      const contentParts = [
+        `Website analysis (${analysis.pages_analyzed.length} pages):`,
+        analysis.owner_name ? `Owner/Founder: ${analysis.owner_name}` : null,
+        analysis.team_size ? `Team size: ~${analysis.team_size} people` : null,
+        analysis.founding_year ? `Founded: ${analysis.founding_year}` : null,
+        analysis.contact_email ? `Email: ${analysis.contact_email}` : null,
+        analysis.services.length > 0 ? `Services: ${analysis.services.join(', ')}` : null,
+        `Site quality: ${analysis.quality}`,
+        techTools.length > 0
+          ? `Tools detected: ${techTools.join(', ')}`
+          : 'No business tools detected on website',
+        missingTools.length > 0 ? `Gaps: ${missingTools.join(', ')}` : null,
+        `Platform: ${analysis.tech_stack.platform.join(', ') || 'Custom/unknown'}`,
+      ].filter(Boolean)
+
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: contentParts.join('\n'),
+        source: 'website_analysis',
+        metadata: {
+          owner_name: analysis.owner_name,
+          team_size: analysis.team_size,
+          employee_count: analysis.team_size,
+          founding_year: analysis.founding_year,
+          contact_email: analysis.contact_email,
+          services: analysis.services,
+          quality: analysis.quality,
+          tech_stack: analysis.tech_stack,
+          pages_analyzed: analysis.pages_analyzed,
+        },
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'website_analysis', outcome)
+  return entity
 }
 
 async function tryOutscraper(
@@ -322,50 +373,56 @@ async function tryOutscraper(
   entity: Entity,
   result: EnrichResult
 ): Promise<Entity> {
-  if (!env.OUTSCRAPER_API_KEY) {
-    result.skipped.push('outscraper')
-    return entity
-  }
-  try {
-    const osc = await lookupOutscraper(entity.name, entity.area, env.OUTSCRAPER_API_KEY)
-    if (!osc) return entity
-    await updateEntity(env.DB, orgId, entity.id, {
-      phone: osc.phone ?? entity.phone ?? undefined,
-      website: osc.website ?? entity.website ?? undefined,
-    })
-    const contentParts = [
-      'Outscraper business profile:',
-      osc.owner_name ? `Owner: ${osc.owner_name}` : null,
-      osc.emails.length > 0 ? `Email: ${osc.emails.join(', ')}` : null,
-      osc.phone ? `Phone: ${osc.phone}` : null,
-      osc.working_hours ? `Hours: ${osc.working_hours}` : null,
-      osc.verified ? 'Google listing: Verified' : 'Google listing: Unverified',
-      osc.rating != null ? `Rating: ${osc.rating} (${osc.review_count ?? 0} reviews)` : null,
-      osc.booking_link ? `Online booking: Yes` : 'Online booking: Not detected',
-      osc.facebook ? `Facebook: ${osc.facebook}` : null,
-      osc.instagram ? `Instagram: ${osc.instagram}` : null,
-      osc.linkedin ? `LinkedIn: ${osc.linkedin}` : null,
-      osc.website_generator ? `Platform: ${osc.website_generator}` : null,
-      osc.has_facebook_pixel ? 'Has Facebook Pixel' : null,
-      osc.has_google_tag_manager ? 'Has Google Tag Manager' : null,
-      osc.about ? `About: ${osc.about}` : null,
-    ].filter(Boolean)
-
-    await appendContext(env.DB, orgId, {
+  let refreshedEntity: Entity = entity
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: contentParts.join('\n'),
-      source: 'outscraper',
-      metadata: osc as unknown as Record<string, unknown>,
-    })
-    result.completed.push('outscraper')
-    const refreshed = await getEntity(env.DB, orgId, entity.id)
-    return refreshed ?? entity
-  } catch (err) {
-    console.error('[enrichEntity] outscraper failed:', err)
-    result.errors.push('outscraper')
-    return entity
-  }
+      module: 'outscraper',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.OUTSCRAPER_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:outscraper' }
+      const osc = await lookupOutscraper(entity.name, entity.area, env.OUTSCRAPER_API_KEY)
+      if (!osc) return { kind: 'no_data', reason: 'no_match' }
+      await updateEntity(env.DB, orgId, entity.id, {
+        phone: osc.phone ?? entity.phone ?? undefined,
+        website: osc.website ?? entity.website ?? undefined,
+      })
+      const contentParts = [
+        'Outscraper business profile:',
+        osc.owner_name ? `Owner: ${osc.owner_name}` : null,
+        osc.emails.length > 0 ? `Email: ${osc.emails.join(', ')}` : null,
+        osc.phone ? `Phone: ${osc.phone}` : null,
+        osc.working_hours ? `Hours: ${osc.working_hours}` : null,
+        osc.verified ? 'Google listing: Verified' : 'Google listing: Unverified',
+        osc.rating != null ? `Rating: ${osc.rating} (${osc.review_count ?? 0} reviews)` : null,
+        osc.booking_link ? `Online booking: Yes` : 'Online booking: Not detected',
+        osc.facebook ? `Facebook: ${osc.facebook}` : null,
+        osc.instagram ? `Instagram: ${osc.instagram}` : null,
+        osc.linkedin ? `LinkedIn: ${osc.linkedin}` : null,
+        osc.website_generator ? `Platform: ${osc.website_generator}` : null,
+        osc.has_facebook_pixel ? 'Has Facebook Pixel' : null,
+        osc.has_google_tag_manager ? 'Has Google Tag Manager' : null,
+        osc.about ? `About: ${osc.about}` : null,
+      ].filter(Boolean)
+
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: contentParts.join('\n'),
+        source: 'outscraper',
+        metadata: osc as unknown as Record<string, unknown>,
+      })
+      const refreshed = await getEntity(env.DB, orgId, entity.id)
+      if (refreshed) refreshedEntity = refreshed
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'outscraper', outcome)
+  return refreshedEntity
 }
 
 async function tryAcc(
@@ -374,21 +431,29 @@ async function tryAcc(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  try {
-    const acc = await lookupAcc(entity.name)
-    if (!acc) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `ACC Filing: ${acc.entity_name} (${acc.entity_type ?? 'unknown type'}). Filed: ${acc.filing_date ?? 'unknown'}. Status: ${acc.status ?? 'unknown'}. Registered agent: ${acc.registered_agent ?? 'not found'}.`,
-      source: 'acc_filing',
-      metadata: acc as unknown as Record<string, unknown>,
-    })
-    result.completed.push('acc_filing')
-  } catch (err) {
-    console.error('[enrichEntity] acc failed:', err)
-    result.errors.push('acc_filing')
-  }
+      module: 'acc_filing',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      const acc = await lookupAcc(entity.name)
+      if (!acc) return { kind: 'no_data', reason: 'no_filing_match' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `ACC Filing: ${acc.entity_name} (${acc.entity_type ?? 'unknown type'}). Filed: ${acc.filing_date ?? 'unknown'}. Status: ${acc.status ?? 'unknown'}. Registered agent: ${acc.registered_agent ?? 'not found'}.`,
+        source: 'acc_filing',
+        metadata: acc as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'acc_filing', outcome)
 }
 
 async function tryRoc(
@@ -397,25 +462,32 @@ async function tryRoc(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (entity.vertical !== 'home_services' && entity.vertical !== 'contractor_trades') {
-    result.skipped.push('roc_license')
-    return
-  }
-  try {
-    const roc = await lookupRoc(entity.name)
-    if (!roc) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `ROC License: ${roc.license_number ?? 'N/A'} (${roc.classification ?? 'unknown classification'}). Status: ${roc.status ?? 'unknown'}. Complaints: ${roc.complaint_count ?? 'N/A'}.`,
-      source: 'roc_license',
-      metadata: roc as unknown as Record<string, unknown>,
-    })
-    result.completed.push('roc_license')
-  } catch (err) {
-    console.error('[enrichEntity] roc failed:', err)
-    result.errors.push('roc_license')
-  }
+      module: 'roc_license',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (entity.vertical !== 'home_services' && entity.vertical !== 'contractor_trades') {
+        return { kind: 'skipped', reason: 'wrong_vertical' }
+      }
+      const roc = await lookupRoc(entity.name)
+      if (!roc) return { kind: 'no_data', reason: 'no_license_match' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `ROC License: ${roc.license_number ?? 'N/A'} (${roc.classification ?? 'unknown classification'}). Status: ${roc.status ?? 'unknown'}. Complaints: ${roc.complaint_count ?? 'N/A'}.`,
+        source: 'roc_license',
+        metadata: roc as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'roc_license', outcome)
 }
 
 async function tryReviewAnalysis(

--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -496,33 +496,35 @@ async function tryReviewAnalysis(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!env.ANTHROPIC_API_KEY) {
-    result.skipped.push('review_analysis')
-    return
-  }
-  try {
-    const signalContext = await assembleEntityContext(env.DB, entity.id, {
-      maxBytes: 8_000,
-      typeFilter: ['signal'],
-    })
-    if (!signalContext) {
-      result.skipped.push('review_analysis')
-      return
-    }
-    const reviewAnalysis = await analyzeReviewPatterns(signalContext, env.ANTHROPIC_API_KEY)
-    if (!reviewAnalysis) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''} ${reviewAnalysis.insights}`,
-      source: 'review_analysis',
-      metadata: reviewAnalysis as unknown as Record<string, unknown>,
-    })
-    result.completed.push('review_analysis')
-  } catch (err) {
-    console.error('[enrichEntity] review_analysis failed:', err)
-    result.errors.push('review_analysis')
-  }
+      module: 'review_analysis',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.ANTHROPIC_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:anthropic' }
+      const signalContext = await assembleEntityContext(env.DB, entity.id, {
+        maxBytes: 8_000,
+        typeFilter: ['signal'],
+      })
+      if (!signalContext) return { kind: 'skipped', reason: 'no_signal_context' }
+      const reviewAnalysis = await analyzeReviewPatterns(signalContext, env.ANTHROPIC_API_KEY)
+      if (!reviewAnalysis) return { kind: 'no_data', reason: 'no_analysis' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''} ${reviewAnalysis.insights}`,
+        source: 'review_analysis',
+        metadata: reviewAnalysis as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'review_analysis', outcome)
 }
 
 async function tryCompetitors(
@@ -531,32 +533,38 @@ async function tryCompetitors(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!env.GOOGLE_PLACES_API_KEY) {
-    result.skipped.push('competitors')
-    return
-  }
-  try {
-    const benchmark = await benchmarkCompetitors(
-      entity.name,
-      entity.vertical,
-      entity.area,
-      entity.pain_score,
-      null,
-      env.GOOGLE_PLACES_API_KEY
-    )
-    if (!benchmark) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `Competitor benchmarking: ${benchmark.summary} Top competitors: ${benchmark.competitors.map((c) => `${c.name} (${c.rating}★, ${c.review_count} reviews)`).join(', ')}.`,
-      source: 'competitors',
-      metadata: benchmark as unknown as Record<string, unknown>,
-    })
-    result.completed.push('competitors')
-  } catch (err) {
-    console.error('[enrichEntity] competitors failed:', err)
-    result.errors.push('competitors')
-  }
+      module: 'competitors',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.GOOGLE_PLACES_API_KEY)
+        return { kind: 'skipped', reason: 'missing_api_key:google_places' }
+      const benchmark = await benchmarkCompetitors(
+        entity.name,
+        entity.vertical,
+        entity.area,
+        entity.pain_score,
+        null,
+        env.GOOGLE_PLACES_API_KEY
+      )
+      if (!benchmark) return { kind: 'no_data', reason: 'no_benchmark' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `Competitor benchmarking: ${benchmark.summary} Top competitors: ${benchmark.competitors.map((c) => `${c.name} (${c.rating}★, ${c.review_count} reviews)`).join(', ')}.`,
+        source: 'competitors',
+        metadata: benchmark as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'competitors', outcome)
 }
 
 async function tryNews(
@@ -565,33 +573,36 @@ async function tryNews(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!env.SERPAPI_API_KEY || !env.ANTHROPIC_API_KEY) {
-    result.skipped.push('news_search')
-    return
-  }
-  try {
-    const news = await searchNews(
-      entity.name,
-      entity.area,
-      env.SERPAPI_API_KEY,
-      env.ANTHROPIC_API_KEY
-    )
-    if (!news) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
-      source: 'news_search',
-      metadata: {
-        mentions: news.mentions,
-        summary: news.summary,
-      },
-    })
-    result.completed.push('news_search')
-  } catch (err) {
-    console.error('[enrichEntity] news_search failed:', err)
-    result.errors.push('news_search')
-  }
+      module: 'news_search',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.SERPAPI_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:serpapi' }
+      if (!env.ANTHROPIC_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:anthropic' }
+      const news = await searchNews(
+        entity.name,
+        entity.area,
+        env.SERPAPI_API_KEY,
+        env.ANTHROPIC_API_KEY
+      )
+      if (!news) return { kind: 'no_data', reason: 'no_results' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
+        source: 'news_search',
+        metadata: { mentions: news.mentions, summary: news.summary },
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'news_search', outcome)
 }
 
 async function tryDeepWebsite(
@@ -600,25 +611,31 @@ async function tryDeepWebsite(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!entity.website || !env.ANTHROPIC_API_KEY) {
-    result.skipped.push('deep_website')
-    return
-  }
-  try {
-    const analysis = await deepWebsiteAnalysis(entity.website, env.ANTHROPIC_API_KEY)
-    if (!analysis) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: formatDeepWebsite(analysis),
-      source: 'deep_website',
-      metadata: analysis as unknown as Record<string, unknown>,
-    })
-    result.completed.push('deep_website')
-  } catch (err) {
-    console.error('[enrichEntity] deep_website failed:', err)
-    result.errors.push('deep_website')
-  }
+      module: 'deep_website',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!entity.website) return { kind: 'skipped', reason: 'missing_input:website' }
+      if (!env.ANTHROPIC_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:anthropic' }
+      const analysis = await deepWebsiteAnalysis(entity.website, env.ANTHROPIC_API_KEY)
+      if (!analysis) return { kind: 'no_data', reason: 'no_analysis' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: formatDeepWebsite(analysis),
+        source: 'deep_website',
+        metadata: analysis as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'deep_website', outcome)
 }
 
 async function tryReviewSynthesis(
@@ -627,33 +644,47 @@ async function tryReviewSynthesis(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!env.ANTHROPIC_API_KEY) {
-    result.skipped.push('review_synthesis')
-    return
-  }
+  let inputFingerprint: string | null = null
   try {
-    const allContext = await assembleEntityContext(env.DB, entity.id, {
+    const ctx = await assembleEntityContext(env.DB, entity.id, {
       maxBytes: 20_000,
       typeFilter: ['signal', 'enrichment'],
     })
-    if (!allContext) {
-      result.skipped.push('review_synthesis')
-      return
-    }
-    const synthesis = await synthesizeReviews(allContext, env.ANTHROPIC_API_KEY)
-    if (!synthesis) return
-    await appendContext(env.DB, orgId, {
-      entity_id: entity.id,
-      type: 'enrichment',
-      content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}. Themes: ${synthesis.top_themes.join(', ')}. Problems: ${synthesis.operational_problems.map((p) => `${p.problem} (${p.confidence})`).join(', ')}.`,
-      source: 'review_synthesis',
-      metadata: synthesis as unknown as Record<string, unknown>,
-    })
-    result.completed.push('review_synthesis')
-  } catch (err) {
-    console.error('[enrichEntity] review_synthesis failed:', err)
-    result.errors.push('review_synthesis')
+    if (ctx) inputFingerprint = await fingerprint(ctx)
+  } catch {
+    // Fingerprint is informational; do not block the run on failure.
   }
+
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
+      entity_id: entity.id,
+      module: 'review_synthesis',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+      input_fingerprint: inputFingerprint,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.ANTHROPIC_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:anthropic' }
+      const allContext = await assembleEntityContext(env.DB, entity.id, {
+        maxBytes: 20_000,
+        typeFilter: ['signal', 'enrichment'],
+      })
+      if (!allContext) return { kind: 'skipped', reason: 'no_context' }
+      const synthesis = await synthesizeReviews(allContext, env.ANTHROPIC_API_KEY)
+      if (!synthesis) return { kind: 'no_data', reason: 'no_synthesis' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}. Themes: ${synthesis.top_themes.join(', ')}. Problems: ${synthesis.operational_problems.map((p) => `${p.problem} (${p.confidence})`).join(', ')}.`,
+        source: 'review_synthesis',
+        metadata: synthesis as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'review_synthesis', outcome)
 }
 
 async function tryLinkedIn(
@@ -662,25 +693,30 @@ async function tryLinkedIn(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!env.PROXYCURL_API_KEY) {
-    result.skipped.push('linkedin')
-    return
-  }
-  try {
-    const linkedin = await lookupLinkedIn(entity.name, entity.area, env.PROXYCURL_API_KEY)
-    if (!linkedin) return
-    await appendContext(env.DB, orgId, {
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
       entity_id: entity.id,
-      type: 'enrichment',
-      content: `LinkedIn: ${linkedin.company_name}. ${linkedin.employee_count ? `~${linkedin.employee_count} employees.` : ''} ${linkedin.industry ? `Industry: ${linkedin.industry}.` : ''} ${linkedin.description ? linkedin.description.slice(0, 200) : ''}`,
-      source: 'linkedin',
-      metadata: linkedin as unknown as Record<string, unknown>,
-    })
-    result.completed.push('linkedin')
-  } catch (err) {
-    console.error('[enrichEntity] linkedin failed:', err)
-    result.errors.push('linkedin')
-  }
+      module: 'linkedin',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.PROXYCURL_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:proxycurl' }
+      const linkedin = await lookupLinkedIn(entity.name, entity.area, env.PROXYCURL_API_KEY)
+      if (!linkedin) return { kind: 'no_data', reason: 'no_match' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: `LinkedIn: ${linkedin.company_name}. ${linkedin.employee_count ? `~${linkedin.employee_count} employees.` : ''} ${linkedin.industry ? `Industry: ${linkedin.industry}.` : ''} ${linkedin.description ? linkedin.description.slice(0, 200) : ''}`,
+        source: 'linkedin',
+        metadata: linkedin as unknown as Record<string, unknown>,
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'linkedin', outcome)
 }
 
 async function tryIntelligenceBrief(
@@ -689,30 +725,41 @@ async function tryIntelligenceBrief(
   entity: Entity,
   result: EnrichResult
 ): Promise<void> {
-  if (!env.ANTHROPIC_API_KEY) {
-    result.skipped.push('intelligence_brief')
-    return
-  }
+  let inputFingerprint: string | null = null
   try {
-    const fullContext = await assembleEntityContext(env.DB, entity.id, { maxBytes: 32_000 })
-    if (!fullContext) {
-      result.skipped.push('intelligence_brief')
-      return
-    }
-    const brief = await generateDossier(fullContext, entity.name, env.ANTHROPIC_API_KEY)
-    if (!brief) return
-    await appendContext(env.DB, orgId, {
-      entity_id: entity.id,
-      type: 'enrichment',
-      content: brief,
-      source: 'intelligence_brief',
-      metadata: { model: 'claude-sonnet-4-20250514', trigger: 'at_ingest' },
-    })
-    result.completed.push('intelligence_brief')
-  } catch (err) {
-    console.error('[enrichEntity] intelligence_brief failed:', err)
-    result.errors.push('intelligence_brief')
+    const ctx = await assembleEntityContext(env.DB, entity.id, { maxBytes: 32_000 })
+    if (ctx) inputFingerprint = await fingerprint(ctx)
+  } catch {
+    // Informational only.
   }
+
+  const outcome = await instrumentModule(
+    {
+      db: env.DB,
+      org_id: orgId,
+      entity_id: entity.id,
+      module: 'intelligence_brief',
+      mode: result.mode,
+      triggered_by: result.triggered_by,
+      input_fingerprint: inputFingerprint,
+    },
+    async (): Promise<ModuleOutcome> => {
+      if (!env.ANTHROPIC_API_KEY) return { kind: 'skipped', reason: 'missing_api_key:anthropic' }
+      const fullContext = await assembleEntityContext(env.DB, entity.id, { maxBytes: 32_000 })
+      if (!fullContext) return { kind: 'skipped', reason: 'no_context' }
+      const brief = await generateDossier(fullContext, entity.name, env.ANTHROPIC_API_KEY)
+      if (!brief) return { kind: 'no_data', reason: 'no_brief' }
+      const ce = await appendContext(env.DB, orgId, {
+        entity_id: entity.id,
+        type: 'enrichment',
+        content: brief,
+        source: 'intelligence_brief',
+        metadata: { model: 'claude-sonnet-4-20250514', trigger: 'at_ingest' },
+      })
+      return { kind: 'succeeded', context_entry_id: ce.id }
+    }
+  )
+  applyOutcome(result, 'intelligence_brief', outcome)
 }
 
 async function regenerateOutreach(
@@ -747,6 +794,67 @@ async function regenerateOutreach(
     console.error('[enrichEntity] outreach_draft failed:', err)
     result.errors.push('outreach_draft')
   }
+}
+
+// ---------------------------------------------------------------------------
+// Single-module runner — used by the admin "Retry" button per module.
+// ---------------------------------------------------------------------------
+
+const SINGLE_RUNNERS: Record<
+  ModuleId,
+  (env: EnrichEnv, orgId: string, entity: Entity, result: EnrichResult) => Promise<unknown>
+> = {
+  google_places: tryPlaces,
+  website_analysis: tryWebsite,
+  outscraper: tryOutscraper,
+  acc_filing: tryAcc,
+  roc_license: tryRoc,
+  review_analysis: tryReviewAnalysis,
+  competitors: tryCompetitors,
+  news_search: tryNews,
+  deep_website: tryDeepWebsite,
+  review_synthesis: tryReviewSynthesis,
+  linkedin: tryLinkedIn,
+  intelligence_brief: tryIntelligenceBrief,
+}
+
+/**
+ * Execute a single named module against an entity. Used by the admin
+ * per-module Retry button. Records a row in enrichment_runs with the
+ * provided triggered_by. Bypasses the full-mode brief idempotency check
+ * (the caller explicitly asked to re-run this one module).
+ */
+export async function runSingleModule(
+  env: EnrichEnv,
+  orgId: string,
+  entityId: string,
+  module: ModuleId,
+  options: { triggered_by: string } = { triggered_by: 'admin:retry' }
+): Promise<EnrichResult> {
+  const result: EnrichResult = {
+    entityId,
+    mode: 'reviews-and-news',
+    triggered_by: options.triggered_by,
+    completed: [],
+    skipped: [],
+    errors: [],
+    alreadyEnriched: false,
+  }
+
+  const entity = await getEntity(env.DB, orgId, entityId)
+  if (!entity) {
+    result.errors.push('entity_not_found')
+    return result
+  }
+
+  const runner = SINGLE_RUNNERS[module]
+  if (!runner) {
+    result.errors.push('unknown_module')
+    return result
+  }
+
+  await runner(env, orgId, entity, result)
+  return result
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/enrichment/instrument.ts
+++ b/src/lib/enrichment/instrument.ts
@@ -1,0 +1,136 @@
+/**
+ * Wrapper that turns each "best-effort" enrichment-module call into a
+ * persisted run row. Exists because the pre-existing
+ * `result.completed/skipped/errors` arrays were in-memory only — workers
+ * discarded the result, leaving zero record of which modules ran for which
+ * entity, which is why partial-enrichment prospects (e.g. Cactus Creative
+ * Studio) were undebuggable.
+ *
+ * Module body returns one of three terminal outcomes; throws are caught
+ * and classified as `failed`. Lock contention (a running row already
+ * exists for this entity+module) yields `skipped, reason: 'in_progress'`.
+ */
+
+import type { ModuleId } from './modules'
+import { startRun, completeRun, type RunMode, type RunStatus } from '../db/enrichment-runs'
+
+export class ModuleError extends Error {
+  constructor(
+    public readonly kind: 'fetch_failed' | 'parse_error' | 'timeout' | 'api_error' | 'unknown',
+    message?: string,
+    public readonly cause?: unknown
+  ) {
+    super(message ?? kind)
+    this.name = 'ModuleError'
+  }
+}
+
+export function classifyError(err: unknown): ModuleError {
+  if (err instanceof ModuleError) return err
+  if (err instanceof Error) {
+    if (err.name === 'AbortError' || /aborted|timeout/i.test(err.message)) {
+      return new ModuleError('timeout', err.message, err)
+    }
+    if (err instanceof SyntaxError) {
+      return new ModuleError('parse_error', err.message, err)
+    }
+    if (err instanceof TypeError && /fetch|network/i.test(err.message)) {
+      return new ModuleError('fetch_failed', err.message, err)
+    }
+    return new ModuleError('unknown', err.message, err)
+  }
+  return new ModuleError('unknown', String(err), err)
+}
+
+export type ModuleOutcome =
+  | { kind: 'succeeded'; context_entry_id?: string | null }
+  | { kind: 'no_data'; reason?: string }
+  | { kind: 'skipped'; reason: string }
+
+export interface InstrumentOptions {
+  db: D1Database
+  org_id: string
+  entity_id: string
+  module: ModuleId
+  mode: RunMode
+  triggered_by: string
+  input_fingerprint?: string | null
+}
+
+export interface InstrumentResult {
+  status: RunStatus
+  reason?: string
+}
+
+/**
+ * Run the module body under instrumentation. Always settles to one of:
+ * succeeded | no_data | skipped | failed. Never throws.
+ */
+export async function instrumentModule(
+  opts: InstrumentOptions,
+  body: () => Promise<ModuleOutcome>
+): Promise<InstrumentResult> {
+  const runId = await startRun(opts.db, {
+    org_id: opts.org_id,
+    entity_id: opts.entity_id,
+    module: opts.module,
+    mode: opts.mode,
+    triggered_by: opts.triggered_by,
+    input_fingerprint: opts.input_fingerprint ?? null,
+  })
+
+  if (!runId) {
+    return { status: 'skipped', reason: 'in_progress' }
+  }
+
+  try {
+    const outcome = await body()
+    if (outcome.kind === 'succeeded') {
+      await completeRun(opts.db, runId, {
+        status: 'succeeded',
+        context_entry_id: outcome.context_entry_id ?? null,
+      })
+      return { status: 'succeeded' }
+    }
+    if (outcome.kind === 'no_data') {
+      await completeRun(opts.db, runId, {
+        status: 'no_data',
+        reason: outcome.reason ?? null,
+      })
+      return { status: 'no_data', reason: outcome.reason }
+    }
+    await completeRun(opts.db, runId, {
+      status: 'skipped',
+      reason: outcome.reason,
+    })
+    return { status: 'skipped', reason: outcome.reason }
+  } catch (err) {
+    const me = classifyError(err)
+    console.error('[enrichment] module threw', {
+      module: opts.module,
+      message: me.message,
+      cause: me.cause,
+    })
+    await completeRun(opts.db, runId, {
+      status: 'failed',
+      reason: me.kind,
+      error_message: me.message,
+    })
+    return { status: 'failed', reason: me.kind }
+  }
+}
+
+/**
+ * Stable 1KB-truncated SHA-256 of an input string. Used as the
+ * `input_fingerprint` for review_synthesis and intelligence_brief so we
+ * can later detect when upstream context has grown enough to justify
+ * re-running a module that already succeeded.
+ */
+export async function fingerprint(input: string): Promise<string> {
+  const truncated = input.slice(0, 1024)
+  const bytes = new TextEncoder().encode(truncated)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/src/lib/enrichment/linkedin.ts
+++ b/src/lib/enrichment/linkedin.ts
@@ -19,39 +19,35 @@ export async function lookupLinkedIn(
   location: string | null,
   apiKey: string
 ): Promise<LinkedInEnrichment | null> {
-  try {
-    const params = new URLSearchParams({
-      company_name: companyName,
-      company_location: location ?? 'Phoenix, Arizona',
-    })
+  const params = new URLSearchParams({
+    company_name: companyName,
+    company_location: location ?? 'Phoenix, Arizona',
+  })
 
-    const response = await fetch(`${PROXYCURL_API_URL}?${params.toString()}`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: AbortSignal.timeout(10000),
-    })
+  const response = await fetch(`${PROXYCURL_API_URL}?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(10000),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const data = (await response.json()) as {
-      url?: string
-      name?: string
-      company_size?: number[]
-      industry?: string
-      description?: string
-    }
+  const data = (await response.json()) as {
+    url?: string
+    name?: string
+    company_size?: number[]
+    industry?: string
+    description?: string
+  }
 
-    if (!data.url) return null
+  if (!data.url) return null
 
-    return {
-      linkedin_url: data.url,
-      company_name: data.name ?? companyName,
-      employee_count: data.company_size
-        ? Math.round((data.company_size[0] + (data.company_size[1] ?? data.company_size[0])) / 2)
-        : null,
-      industry: data.industry ?? null,
-      description: data.description ?? null,
-    }
-  } catch {
-    return null
+  return {
+    linkedin_url: data.url,
+    company_name: data.name ?? companyName,
+    employee_count: data.company_size
+      ? Math.round((data.company_size[0] + (data.company_size[1] ?? data.company_size[0])) / 2)
+      : null,
+    industry: data.industry ?? null,
+    description: data.description ?? null,
   }
 }

--- a/src/lib/enrichment/modules.ts
+++ b/src/lib/enrichment/modules.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical enrichment module list. Single source of truth used by both the
+ * pipeline (src/lib/enrichment/index.ts) and the admin UI panel
+ * (src/components/admin/EnrichmentStatusPanel.astro). When the pipeline
+ * grows a module, add it here so the panel renders it as `not_yet_run`
+ * instead of silently omitting it.
+ *
+ * `tier` is informational — the runtime ordering still lives in
+ * enrichEntity(). It exists so the UI can group modules visually.
+ */
+
+export const MODULES = [
+  { id: 'google_places', tier: 1, displayName: 'Google Places' },
+  { id: 'website_analysis', tier: 1, displayName: 'Website Analysis' },
+  { id: 'outscraper', tier: 1, displayName: 'Outscraper' },
+  { id: 'acc_filing', tier: 1, displayName: 'ACC Filing' },
+  { id: 'roc_license', tier: 1, displayName: 'ROC License' },
+  { id: 'review_analysis', tier: 2, displayName: 'Review Analysis' },
+  { id: 'competitors', tier: 2, displayName: 'Competitors' },
+  { id: 'news_search', tier: 2, displayName: 'News Search' },
+  { id: 'deep_website', tier: 3, displayName: 'Deep Website' },
+  { id: 'review_synthesis', tier: 3, displayName: 'Review Synthesis' },
+  { id: 'linkedin', tier: 3, displayName: 'LinkedIn' },
+  { id: 'intelligence_brief', tier: 3, displayName: 'Intelligence Brief' },
+] as const
+
+export type ModuleId = (typeof MODULES)[number]['id']
+
+export const MODULE_IDS: ModuleId[] = MODULES.map((m) => m.id)
+
+export function isModuleId(value: string): value is ModuleId {
+  return (MODULE_IDS as readonly string[]).includes(value)
+}

--- a/src/lib/enrichment/news.ts
+++ b/src/lib/enrichment/news.ts
@@ -23,71 +23,67 @@ export async function searchNews(
 ): Promise<NewsEnrichment | null> {
   const query = `"${entityName}" ${area ?? 'Phoenix AZ'}`
 
-  try {
-    // SerpAPI Google Search
-    const params = new URLSearchParams({
-      engine: 'google',
-      q: query,
-      location: 'Phoenix, Arizona, United States',
-      num: '5',
-      api_key: serpApiKey,
-    })
+  // SerpAPI Google Search
+  const params = new URLSearchParams({
+    engine: 'google',
+    q: query,
+    location: 'Phoenix, Arizona, United States',
+    num: '5',
+    api_key: serpApiKey,
+  })
 
-    const response = await fetch(`https://serpapi.com/search?${params.toString()}`)
-    if (!response.ok) return null
+  const response = await fetch(`https://serpapi.com/search?${params.toString()}`)
+  if (!response.ok) return null
 
-    const data = (await response.json()) as {
-      organic_results?: Array<{
-        title?: string
-        source?: string
-        snippet?: string
-        link?: string
-      }>
-    }
-
-    const results = data.organic_results ?? []
-    if (results.length === 0) return null
-
-    const mentions = results
-      .filter((r) => r.title && r.snippet)
-      .map((r) => ({
-        title: r.title!,
-        source: r.source ?? new URL(r.link ?? '').hostname,
-        snippet: r.snippet!,
-      }))
-
-    if (mentions.length === 0) return null
-
-    // Claude Haiku to summarize relevance
-    const summaryResponse = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': anthropicKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: HAIKU_MODEL,
-        max_tokens: 256,
-        messages: [
-          {
-            role: 'user',
-            content: `Summarize what these search results reveal about "${entityName}" in 1-2 sentences. Focus on awards, community involvement, growth signals, or reputation. If results are irrelevant (wrong business, ads), say "No relevant mentions found."\n\n${mentions.map((m) => `${m.title}: ${m.snippet}`).join('\n')}`,
-          },
-        ],
-      }),
-    })
-
-    let summary = 'Search results found but not summarized.'
-    if (summaryResponse.ok) {
-      const summaryResult = (await summaryResponse.json()) as {
-        content?: Array<{ type: string; text?: string }>
-      }
-      summary = summaryResult?.content?.find((b) => b.type === 'text')?.text?.trim() ?? summary
-    }
-
-    return { mentions, summary }
-  } catch {
-    return null
+  const data = (await response.json()) as {
+    organic_results?: Array<{
+      title?: string
+      source?: string
+      snippet?: string
+      link?: string
+    }>
   }
+
+  const results = data.organic_results ?? []
+  if (results.length === 0) return null
+
+  const mentions = results
+    .filter((r) => r.title && r.snippet)
+    .map((r) => ({
+      title: r.title!,
+      source: r.source ?? new URL(r.link ?? '').hostname,
+      snippet: r.snippet!,
+    }))
+
+  if (mentions.length === 0) return null
+
+  // Claude Haiku to summarize relevance
+  const summaryResponse = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': anthropicKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: HAIKU_MODEL,
+      max_tokens: 256,
+      messages: [
+        {
+          role: 'user',
+          content: `Summarize what these search results reveal about "${entityName}" in 1-2 sentences. Focus on awards, community involvement, growth signals, or reputation. If results are irrelevant (wrong business, ads), say "No relevant mentions found."\n\n${mentions.map((m) => `${m.title}: ${m.snippet}`).join('\n')}`,
+        },
+      ],
+    }),
+  })
+
+  let summary = 'Search results found but not summarized.'
+  if (summaryResponse.ok) {
+    const summaryResult = (await summaryResponse.json()) as {
+      content?: Array<{ type: string; text?: string }>
+    }
+    summary = summaryResult?.content?.find((b) => b.type === 'text')?.text?.trim() ?? summary
+  }
+
+  return { mentions, summary }
 }

--- a/src/lib/enrichment/outscraper.ts
+++ b/src/lib/enrichment/outscraper.ts
@@ -143,8 +143,11 @@ export async function lookupOutscraper(
       photos_count: typeof place.photos_count === 'number' ? place.photos_count : null,
     }
   } catch (err) {
-    console.error(`[outscraper] Error for "${name}":`, err)
-    return null
+    console.error('[outscraper] error', {
+      name,
+      message: err instanceof Error ? err.message : String(err),
+    })
+    throw err
   }
 }
 

--- a/src/lib/enrichment/review-analysis.ts
+++ b/src/lib/enrichment/review-analysis.ts
@@ -27,41 +27,37 @@ export async function analyzeReviewPatterns(
   signalContent: string,
   anthropicKey: string
 ): Promise<ReviewAnalysis | null> {
-  try {
-    const response = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': anthropicKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        system: ANALYSIS_PROMPT,
-        messages: [{ role: 'user', content: `Review signals:\n\n${signalContent}` }],
-      }),
-    })
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': anthropicKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: ANALYSIS_PROMPT,
+      messages: [{ role: 'user', content: `Review signals:\n\n${signalContent}` }],
+    }),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const result = (await response.json()) as { content?: Array<{ type: string; text?: string }> }
-    const text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
-    if (!text) return null
+  const result = (await response.json()) as { content?: Array<{ type: string; text?: string }> }
+  const text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+  if (!text) return null
 
-    let jsonText = text
-    if (jsonText.startsWith('```')) {
-      jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
-    }
+  let jsonText = text
+  if (jsonText.startsWith('```')) {
+    jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+  }
 
-    const parsed = JSON.parse(jsonText)
-    return {
-      response_pattern: parsed.response_pattern ?? 'unknown',
-      engagement_level: parsed.engagement_level ?? 'unknown',
-      owner_accessible: parsed.owner_accessible ?? false,
-      insights: parsed.insights ?? '',
-    }
-  } catch {
-    return null
+  const parsed = JSON.parse(jsonText)
+  return {
+    response_pattern: parsed.response_pattern ?? 'unknown',
+    engagement_level: parsed.engagement_level ?? 'unknown',
+    owner_accessible: parsed.owner_accessible ?? false,
+    insights: parsed.insights ?? '',
   }
 }

--- a/src/lib/enrichment/review-synthesis.ts
+++ b/src/lib/enrichment/review-synthesis.ts
@@ -21,18 +21,17 @@ export async function synthesizeReviews(
   contextEntries: string,
   anthropicKey: string
 ): Promise<ReviewSynthesis | null> {
-  try {
-    const response = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': anthropicKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        system: `Synthesize all review data for this business across platforms. Map operational issues to these 5 solution areas: process_design, tool_systems, data_visibility, customer_pipeline, team_operations. Return ONLY valid JSON:
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': anthropicKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: `Synthesize all review data for this business across platforms. Map operational issues to these 5 solution areas: process_design, tool_systems, data_visibility, customer_pipeline, team_operations. Return ONLY valid JSON:
 {
   "unified_rating": "number 1-5 or null",
   "total_reviews_across_platforms": "number",
@@ -41,26 +40,23 @@ export async function synthesizeReviews(
   "operational_problems": [{"problem": "problem_id", "confidence": "high|medium|low", "evidence": "brief quote or pattern"}],
   "customer_sentiment": "1-2 sentence overall assessment"
 }`,
-        messages: [
-          {
-            role: 'user',
-            content: `All available review and enrichment data:\n\n${contextEntries}`,
-          },
-        ],
-      }),
-    })
+      messages: [
+        {
+          role: 'user',
+          content: `All available review and enrichment data:\n\n${contextEntries}`,
+        },
+      ],
+    }),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const result = (await response.json()) as {
-      content?: Array<{ type: string; text?: string }>
-    }
-    let text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
-    if (!text) return null
-    if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
-
-    return JSON.parse(text)
-  } catch {
-    return null
+  const result = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>
   }
+  let text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+  if (!text) return null
+  if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+
+  return JSON.parse(text)
 }

--- a/src/lib/enrichment/roc.ts
+++ b/src/lib/enrichment/roc.ts
@@ -21,38 +21,34 @@ const ROC_SEARCH_URL = 'https://roc.az.gov/contractor-search'
  * Returns first matching result, or null.
  */
 export async function lookupRoc(businessName: string): Promise<RocEnrichment | null> {
-  try {
-    const params = new URLSearchParams({
-      company_name: businessName.replace(/\b(llc|inc|corp|ltd)\b\.?/gi, '').trim(),
-    })
+  const params = new URLSearchParams({
+    company_name: businessName.replace(/\b(llc|inc|corp|ltd)\b\.?/gi, '').trim(),
+  })
 
-    const response = await fetch(`${ROC_SEARCH_URL}?${params.toString()}`, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible)' },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(10000),
-    })
+  const response = await fetch(`${ROC_SEARCH_URL}?${params.toString()}`, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible)' },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(10000),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const html = await response.text()
+  const html = await response.text()
 
-    // Extract license data from ROC results page
-    const licenseMatch = html.match(/License\s*#?\s*:?\s*(\w+)/i)
-    const classMatch = html.match(/Classification[^:]*:\s*([^<\n]+)/i)
-    const statusMatch = html.match(/Status[^:]*:\s*([^<\n]+)/i)
-    const nameMatch = html.match(/Business\s*Name[^:]*:\s*([^<\n]+)/i)
-    const complaintMatch = html.match(/Complaints?\s*:?\s*(\d+)/i)
+  // Extract license data from ROC results page
+  const licenseMatch = html.match(/License\s*#?\s*:?\s*(\w+)/i)
+  const classMatch = html.match(/Classification[^:]*:\s*([^<\n]+)/i)
+  const statusMatch = html.match(/Status[^:]*:\s*([^<\n]+)/i)
+  const nameMatch = html.match(/Business\s*Name[^:]*:\s*([^<\n]+)/i)
+  const complaintMatch = html.match(/Complaints?\s*:?\s*(\d+)/i)
 
-    if (!licenseMatch && !nameMatch) return null
+  if (!licenseMatch && !nameMatch) return null
 
-    return {
-      license_number: licenseMatch?.[1]?.trim() ?? null,
-      classification: classMatch?.[1]?.trim() ?? null,
-      status: statusMatch?.[1]?.trim() ?? null,
-      business_name: nameMatch?.[1]?.trim() ?? businessName,
-      complaint_count: complaintMatch ? parseInt(complaintMatch[1]) : null,
-    }
-  } catch {
-    return null
+  return {
+    license_number: licenseMatch?.[1]?.trim() ?? null,
+    classification: classMatch?.[1]?.trim() ?? null,
+    status: statusMatch?.[1]?.trim() ?? null,
+    business_name: nameMatch?.[1]?.trim() ?? businessName,
+    complaint_count: complaintMatch ? parseInt(complaintMatch[1]) : null,
   }
 }

--- a/src/lib/enrichment/website-analyzer.ts
+++ b/src/lib/enrichment/website-analyzer.ts
@@ -84,6 +84,8 @@ export async function analyzeWebsite(
 }
 
 async function fetchPage(url: string): Promise<string | null> {
+  // Per-page best-effort. Returning null for one page is normal (404 on
+  // /careers, etc.) and must not poison the whole module.
   try {
     const response = await fetch(url, {
       headers: { 'User-Agent': 'Mozilla/5.0 (compatible; SMDBot/1.0)' },
@@ -115,49 +117,45 @@ async function extractWithHaiku(
   htmlText: string,
   apiKey: string
 ): Promise<Omit<WebsiteEnrichment, 'tech_stack' | 'pages_analyzed'> | null> {
-  try {
-    const response = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': apiKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        system: EXTRACTION_PROMPT,
-        messages: [
-          { role: 'user', content: `Analyze this business website content:\n\n${htmlText}` },
-        ],
-      }),
-    })
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: EXTRACTION_PROMPT,
+      messages: [
+        { role: 'user', content: `Analyze this business website content:\n\n${htmlText}` },
+      ],
+    }),
+  })
 
-    if (!response.ok) return null
+  if (!response.ok) return null
 
-    const result = (await response.json()) as {
-      content?: Array<{ type: string; text?: string }>
-    }
+  const result = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>
+  }
 
-    const text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
-    if (!text) return null
+  const text = result?.content?.find((b) => b.type === 'text')?.text?.trim()
+  if (!text) return null
 
-    // Strip code fences if present
-    let jsonText = text
-    if (jsonText.startsWith('```')) {
-      jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
-    }
+  // Strip code fences if present
+  let jsonText = text
+  if (jsonText.startsWith('```')) {
+    jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+  }
 
-    const parsed = JSON.parse(jsonText)
-    return {
-      owner_name: typeof parsed.owner_name === 'string' ? parsed.owner_name : null,
-      team_size: typeof parsed.team_size === 'number' ? parsed.team_size : null,
-      founding_year: typeof parsed.founding_year === 'number' ? parsed.founding_year : null,
-      contact_email: typeof parsed.contact_email === 'string' ? parsed.contact_email : null,
-      services: Array.isArray(parsed.services) ? parsed.services : [],
-      quality: typeof parsed.quality === 'string' ? parsed.quality : 'unknown',
-    }
-  } catch {
-    return null
+  const parsed = JSON.parse(jsonText)
+  return {
+    owner_name: typeof parsed.owner_name === 'string' ? parsed.owner_name : null,
+    team_size: typeof parsed.team_size === 'number' ? parsed.team_size : null,
+    founding_year: typeof parsed.founding_year === 'number' ? parsed.founding_year : null,
+    contact_email: typeof parsed.contact_email === 'string' ? parsed.contact_email : null,
+    services: Array.isArray(parsed.services) ? parsed.services : [],
+    quality: typeof parsed.quality === 'string' ? parsed.quality : 'unknown',
   }
 }

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,6 +1,7 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
+import EnrichmentStatusPanel from '../../../components/admin/EnrichmentStatusPanel.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
 import { adminActionButtonClass } from '../../../lib/ui/admin-action-button'
@@ -1006,6 +1007,9 @@ function confidenceColor(confidence: string): string {
       )
     }
   </div>
+
+  {/* Enrichment status — debug surface for the runs table */}
+  <EnrichmentStatusPanel entityId={entityId} />
 
   {/* Dossier Summary */}
   {

--- a/src/pages/api/admin/entities/[id]/dossier.ts
+++ b/src/pages/api/admin/entities/[id]/dossier.ts
@@ -30,7 +30,10 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
   if (!entityId) return redirect('/admin/entities?error=missing', 302)
 
   try {
-    await enrichEntity(env, session.orgId, entityId, { mode: 'reviews-and-news' })
+    await enrichEntity(env, session.orgId, entityId, {
+      mode: 'reviews-and-news',
+      triggered_by: 'admin:re-enrich',
+    })
     return redirect(`/admin/entities/${entityId}?dossier=1`, 302)
   } catch (err) {
     console.error('[api/admin/entities/dossier] Error:', err)

--- a/src/pages/api/admin/entities/[id]/enrichment/[module]/retry.ts
+++ b/src/pages/api/admin/entities/[id]/enrichment/[module]/retry.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro'
+import { runSingleModule } from '../../../../../../lib/enrichment'
+import { isModuleId } from '../../../../../../lib/enrichment/modules'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/entities/[id]/enrichment/[module]/retry
+ *
+ * Re-run a single enrichment module against an entity. Records a
+ * `enrichment_runs` row with `triggered_by = 'admin:retry:<module>'`.
+ * Concurrency-safe: the wrapper's startRun lock prevents racing a
+ * cron-triggered run.
+ */
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  const moduleParam = params.module
+  if (!entityId || !moduleParam || !isModuleId(moduleParam)) {
+    return redirect(`/admin/entities/${entityId ?? ''}?error=invalid_module`, 302)
+  }
+
+  try {
+    await runSingleModule(env, session.orgId, entityId, moduleParam, {
+      triggered_by: `admin:retry:${moduleParam}`,
+    })
+    return redirect(`/admin/entities/${entityId}?enrichment_retried=${moduleParam}`, 302)
+  } catch (err) {
+    console.error('[api/admin/entities/enrichment/retry] error', { error: err })
+    return redirect(`/admin/entities/${entityId}?error=enrichment_retry_failed`, 302)
+  }
+}

--- a/src/pages/api/admin/entities/[id]/enrichment/[module]/retry.ts
+++ b/src/pages/api/admin/entities/[id]/enrichment/[module]/retry.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
-import { runSingleModule } from '../../../../../../lib/enrichment'
-import { isModuleId } from '../../../../../../lib/enrichment/modules'
+import { runSingleModule } from '../../../../../../../lib/enrichment'
+import { isModuleId } from '../../../../../../../lib/enrichment/modules'
 import { env } from 'cloudflare:workers'
 
 /**

--- a/src/pages/api/admin/entities/[id]/enrichment/run-full.ts
+++ b/src/pages/api/admin/entities/[id]/enrichment/run-full.ts
@@ -1,0 +1,41 @@
+import type { APIRoute } from 'astro'
+import { enrichEntity } from '../../../../../lib/enrichment'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/entities/[id]/enrichment/run-full
+ *
+ * Force-run the full 12-module enrichment pipeline against an entity,
+ * bypassing the `intelligence_brief` idempotency short-circuit. Used when
+ * an entity was partially enriched and the operator wants to fill in the
+ * missing modules without waiting for a cron pass.
+ *
+ * Detached via locals.cfContext.waitUntil — full enrichment can take 30+
+ * seconds across 12 modules and several Claude calls; awaiting that on
+ * the request path blew past Worker limits in the past (Error 1101).
+ */
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) return redirect('/admin/entities?error=missing', 302)
+
+  const enrichPromise = enrichEntity(env, session.orgId, entityId, {
+    mode: 'full',
+    force: true,
+    triggered_by: 'admin:run-full',
+  }).catch((err) => {
+    console.error('[api/admin/entities/enrichment/run-full] background error', { error: err })
+  })
+  if (locals.cfContext?.waitUntil) {
+    locals.cfContext.waitUntil(enrichPromise)
+  }
+
+  return redirect(`/admin/entities/${entityId}?enrichment_run_full=1`, 302)
+}

--- a/src/pages/api/admin/entities/[id]/enrichment/run-full.ts
+++ b/src/pages/api/admin/entities/[id]/enrichment/run-full.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro'
-import { enrichEntity } from '../../../../../lib/enrichment'
+import { enrichEntity } from '../../../../../../lib/enrichment'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -30,7 +30,7 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
     mode: 'full',
     force: true,
     triggered_by: 'admin:run-full',
-  }).catch((err) => {
+  }).catch((err: unknown) => {
     console.error('[api/admin/entities/enrichment/run-full] background error', { error: err })
   })
   if (locals.cfContext?.waitUntil) {

--- a/src/pages/api/admin/entities/[id]/promote.ts
+++ b/src/pages/api/admin/entities/[id]/promote.ts
@@ -47,11 +47,12 @@ export const POST: APIRoute = async ({ params, locals, redirect }) => {
     // the alreadyEnriched short-circuit. On backfill it can hit 10+ external
     // APIs and multiple Claude calls — awaiting that from the request path
     // blew past Worker limits (Error 1101) on ~50% of promotes.
-    const enrichPromise = enrichEntity(env, session.orgId, entityId, { mode: 'full' }).catch(
-      (err) => {
-        console.error('[promote] Background enrichment failed:', err)
-      }
-    )
+    const enrichPromise = enrichEntity(env, session.orgId, entityId, {
+      mode: 'full',
+      triggered_by: 'admin:promote',
+    }).catch((err) => {
+      console.error('[promote] Background enrichment failed', { error: err })
+    })
     if (locals.cfContext?.waitUntil) {
       locals.cfContext.waitUntil(enrichPromise)
     }

--- a/src/pages/api/ingest/signals.ts
+++ b/src/pages/api/ingest/signals.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro'
 import { validateApiKey } from '../../../lib/auth/api-key'
 import { findOrCreateEntity } from '../../../lib/db/entities'
 import { appendContext, type ContextType } from '../../../lib/db/context'
+import { enrichEntity } from '../../../lib/enrichment'
 import { ORG_ID } from '../../../lib/constants'
 import { env } from 'cloudflare:workers'
 
@@ -20,7 +21,7 @@ const MAX_BODY_SIZE = 10 * 1024 // 10KB
 
 const ALLOWED_PIPELINES = ['review_mining', 'job_monitor', 'new_business', 'social_listening']
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   // Reject oversized payloads
   const contentLength = request.headers.get('content-length')
   if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
@@ -114,6 +115,26 @@ export const POST: APIRoute = async ({ request }) => {
       source: sourcePipeline,
       metadata,
     })
+
+    // At-ingest enrichment for newly-created entities. The lead-gen workers
+    // (new_business, review_mining) already trigger enrichment from their own
+    // ingest paths, but the generic /api/ingest/signals endpoint is the
+    // catch-all for any external signal source — and prior to this it created
+    // entities without ever calling enrichEntity, so they were born with no
+    // dossier (and no `intelligence_brief` context entry, so the admin
+    // Dossier Summary panel never appeared). Detached via locals.cfContext
+    // so a 12-module Claude pipeline doesn't block the ingest response.
+    if (result.status === 'created') {
+      const enrichPromise = enrichEntity(env, ORG_ID, result.entity.id, {
+        mode: 'full',
+        triggered_by: 'ingest:signals',
+      }).catch((err) => {
+        console.error('[api/ingest/signals] background enrichment failed', { error: err })
+      })
+      if (locals.cfContext?.waitUntil) {
+        locals.cfContext.waitUntil(enrichPromise)
+      }
+    }
 
     return jsonResponse(result.status === 'created' ? 201 : 200, {
       status: result.status === 'created' ? 'created' : 'appended',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,12 +12,13 @@ export default defineConfig({
     },
   },
   test: {
-    // Exclude git worktrees from test discovery. `.claude/worktrees/*` are
-    // checkouts of other feature branches — their test expectations drift
-    // relative to main and cause spurious failures during `npm run verify`.
-    // Tests that belong to this branch live in `tests/`; anything else under
-    // `.claude/` is not ours to validate.
-    exclude: ['**/node_modules/**', '**/dist/**', '.claude/worktrees/**'],
+    // Exclude git worktrees from test discovery. Worktrees under
+    // `.claude/worktrees/*` and `.worktrees/*` are checkouts of other
+    // feature branches — their test expectations drift relative to main
+    // and cause spurious failures during `npm run verify`. Tests that
+    // belong to this branch live in `tests/`; anything inside a worktree
+    // dir belongs to whatever branch is checked out there.
+    exclude: ['**/node_modules/**', '**/dist/**', '.claude/worktrees/**', '.worktrees/**'],
     // The crane-test-harness package imports from `node:sqlite`. The
     // vitest 1.x + vite 6 combo trips on bare `node:` imports inside
     // transformed-then-loaded modules, so we externalize the harness
@@ -64,6 +65,7 @@ export default defineConfig({
         // Config files
         '*.config.*',
         '.claude/worktrees/**',
+        '.worktrees/**',
       ],
     },
   },

--- a/workers/new-business/src/index.ts
+++ b/workers/new-business/src/index.ts
@@ -140,8 +140,11 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
       // enrichment errors are self-contained and should not turn a successful
       // ingest into a failed run. Idempotent: the pipeline no-ops once a
       // prior intelligence_brief exists.
-      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, { mode: 'full' }).catch((err) => {
-        console.error('[new_business] enrichment failed for', entity.id, err)
+      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, {
+        mode: 'full',
+        triggered_by: 'cron:new-business',
+      }).catch((err) => {
+        console.error('[new_business] enrichment failed', { entityId: entity.id, error: err })
       })
       if (ctx) {
         ctx.waitUntil(enrichPromise)

--- a/workers/review-mining/src/index.ts
+++ b/workers/review-mining/src/index.ts
@@ -193,8 +193,11 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
       // already pays for Outscraper per business, and enrichment adds the
       // Claude-powered dossier so the admin has something to act on without
       // a second button click. Idempotent on re-runs.
-      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, { mode: 'full' }).catch((err) => {
-        console.error('[review_mining] enrichment failed for', entity.id, err)
+      const enrichPromise = enrichEntity(env, ORG_ID, entity.id, {
+        mode: 'full',
+        triggered_by: 'cron:review-mining',
+      }).catch((err) => {
+        console.error('[review_mining] enrichment failed', { entityId: entity.id, error: err })
       })
       if (ctx) {
         ctx.waitUntil(enrichPromise)


### PR DESCRIPTION
## Summary

Fixes the "some prospects have a Dossier Summary, others don't" problem at the root: the enrichment pipeline was silently degrading and we had **zero persistent record** of what ran, what failed, or why. Cactus Creative Studio (the canonical bug case) had partial enrichment with no way to debug or repair it.

Three confirmed defects, all addressed:

- **Ingest gap.** `src/pages/api/ingest/signals.ts` created entities without ever calling `enrichEntity`. Generic signal-source entities were born unenriched, leaving them with no `intelligence_brief` and no Dossier Summary panel. Fixed via detached `locals.cfContext.waitUntil`.
- **Silent degradation.** When a module ran but the API/LLM returned null, the run was recorded in *no* bucket — vanished. The legacy in-memory `EnrichResult` returned to `ctx.waitUntil(...)` was then discarded entirely.
- **Idempotency by terminal artifact.** Once an `intelligence_brief` existed, full mode short-circuited — no way to refill missing tier-1/2 modules without bypass.

## What changes

**New durable state model**
- `migrations/0027_create_enrichment_runs.sql` — append-only per-module run table. Five statuses (`running` | `succeeded` | `no_data` | `skipped` | `failed`); `succeeded` vs `no_data` is the load-bearing distinction that fixes the silent-return bug.
- `src/lib/db/enrichment-runs.ts` — `startRun` / `completeRun` / `latestRunByModule`. `startRun` checks for an in-flight `running` row within a 5-minute window and refuses to start a duplicate — concurrency lock prevents double-click money-burn.
- `src/lib/enrichment/instrument.ts` — wrapper + `ModuleError` classifier + SHA-256 input fingerprint helper.
- `src/lib/enrichment/modules.ts` — canonical module list (single source of truth for pipeline + UI).

**Pipeline instrumentation**
- Every `try*` helper in `src/lib/enrichment/index.ts` now runs through `instrumentModule(...)`. Outcomes map to `succeeded` / `no_data` / `skipped` / `failed` rows.
- Module files now let errors propagate (no more bare `} catch { return null }` that swallowed everything). `no_data` is reserved for legitimate "API ran, found nothing"; `failed` carries a classified `error_message`.
- `EnrichOptions.triggered_by` threaded through all 5 callers: `cron:new-business`, `cron:review-mining`, `admin:promote`, `admin:re-enrich`, `ingest:signals`.
- `runSingleModule(...)` exported for the per-module Retry endpoint.
- `input_fingerprint` recorded for `review_synthesis` and `intelligence_brief` (two modules whose output materially changes when upstream context grows). Stored now; consumption deferred.

**Admin UI**
- New `EnrichmentStatusPanel.astro` on the entity detail page (between Timeline and Dossier). Shows every module's current status, last error (collapsible), last run timestamp, `triggered_by`, plus per-row Retry and a page-level "Run full enrichment" button.
- `POST /api/admin/entities/[id]/enrichment/[module]/retry` — calls `runSingleModule` with `triggered_by: 'admin:retry:<module>'`.
- `POST /api/admin/entities/[id]/enrichment/run-full` — force-runs full pipeline with `triggered_by: 'admin:run-full'`, detached via `waitUntil`.

**Hygiene**
- `.prettierignore` now skips `.worktrees/` (parallel-branch worktrees) and `.design/audits/` (generated reports). Pre-push hook now passes when other branches' work is checked out alongside yours.

## What's intentionally NOT in this PR

- No DAG walker / dependency-graph backfill. Twelve modules with four real deps don't earn it. Manual Retry handles backfill at this scale.
- No historical batch backfill job. Use the new "Run full enrichment" button on partial entities. If the population turns out to be large, file a follow-up for a paginated admin endpoint.
- No `force` flag semantic change for existing callers. The new admin button sets it explicitly.
- No retention policy code. ~3,000 rows/month at current volume; revisit at 100 rows per `(entity, module)`.
- No tier/cost gating.

## Test plan

- [ ] `npm run typecheck` (passes — 0 errors)
- [ ] `npm run typecheck:workers` (passes)
- [ ] `npm run lint` (passes — 0 errors)
- [ ] `npm run test` (3,184 tests pass)
- [ ] `npm run build` (passes)
- [ ] Apply migration: `npx wrangler d1 migrations apply ss-console-db --local`
- [ ] Boot dev, navigate to Cactus Creative Studio entity page → confirm Enrichment Status panel renders, modules show `not_yet_run` for the missing ones, `succeeded` for the present ones
- [ ] Click "Run full enrichment" on Cactus → confirm rows appear with `triggered_by: 'admin:run-full'` and the Dossier Summary panel materializes
- [ ] POST a synthetic signal to `/api/ingest/signals` → confirm rows appear within ~10s with `triggered_by: 'ingest:signals'`
- [ ] Concurrency: trigger two simultaneous Run-full clicks on the same entity → second invocation records `skipped, reason: 'in_progress'` for in-flight modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)