### PR TITLE
feat(design-system): C5 PR B — codemod to --ss-* tokens (path B: @theme inline aliases)

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,14 +1,14 @@
 <section
-  class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-12">
       <span
-        class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+        class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
         >§ 04</span
       >
       <h2
-        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
         Who We Are
       </h2>
@@ -17,19 +17,21 @@
       <img
         src="/scott-durgan.jpg"
         alt="Scott Durgan, founder of SMD Services"
-        class="h-40 w-40 flex-none border-[3px] border-[color:var(--color-text-primary)] object-cover object-top grayscale"
+        class="h-40 w-40 flex-none border-[3px] border-[color:var(--ss-color-text-primary)] object-cover object-top grayscale"
         width="160"
         height="160"
         loading="lazy"
       />
-      <div class="space-y-6 border-l-[3px] border-[color:var(--color-primary)] pl-8">
-        <p class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--color-text-primary)]">
+      <div class="space-y-6 border-l-[3px] border-[color:var(--ss-color-primary)] pl-8">
+        <p
+          class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+        >
           Scott Durgan spent 20 years building enterprise software and leading product teams. He's a
           creative technologist who listens first and gets how the pieces fit together. He started
           SMD Services because he wanted to put that experience to use for people who need it.
         </p>
         <p
-          class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--color-text-secondary)]"
+          class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           We're a Phoenix-based team that works with businesses past the startup phase but not yet
           big enough for a dedicated operations person. You know where you're trying to go. You just

--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -40,20 +40,20 @@ const studies = [
 ---
 
 <section
-  class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-4">
       <span
-        class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+        class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
         >§ 06</span
       >
       <h2
-        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
         The Kind of Work We Take On
       </h2>
-      <p class="mt-6 max-w-2xl font-['Archivo'] text-[color:var(--color-text-secondary)]">
+      <p class="mt-6 max-w-2xl font-['Archivo'] text-[color:var(--ss-color-text-secondary)]">
         Different businesses, similar patterns. These are the shapes we see, not specific
         engagements.
       </p>
@@ -62,10 +62,10 @@ const studies = [
     <div class="mt-16 space-y-12">
       {
         studies.map((study) => (
-          <div class="border-[3px] border-[color:var(--color-text-primary)]">
-            <div class="border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)] px-8 py-5 text-white">
+          <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
+            <div class="border-b-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-surface-inverse)] px-8 py-5 text-white">
               <div class="flex flex-wrap items-center gap-4">
-                <span class="inline-block bg-[color:var(--color-primary)] px-3 py-1 font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.12em] text-white">
+                <span class="inline-block bg-[color:var(--ss-color-primary)] px-3 py-1 font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.12em] text-white">
                   {study.vertical}
                 </span>
                 <h3 class="font-['Archivo'] text-lg font-bold uppercase tracking-[-0.01em]">
@@ -74,26 +74,26 @@ const studies = [
               </div>
               <div class="mt-4 flex flex-wrap gap-2">
                 {study.problems.map((problem) => (
-                  <span class="font-['JetBrains_Mono'] text-[11px] font-medium uppercase tracking-[0.08em] text-[color:var(--color-text-muted)] border border-[color:rgba(245,240,227,0.24)] px-2 py-1">
+                  <span class="font-['JetBrains_Mono'] text-[11px] font-medium uppercase tracking-[0.08em] text-[color:var(--ss-color-text-muted)] border border-[color:rgba(245,240,227,0.24)] px-2 py-1">
                     {problem}
                   </span>
                 ))}
               </div>
             </div>
             <div class="grid gap-0 md:grid-cols-2">
-              <div class="border-b-[3px] border-[color:var(--color-text-primary)] px-8 py-8 md:border-b-0 md:border-r-[3px]">
-                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
+              <div class="border-b-[3px] border-[color:var(--ss-color-text-primary)] px-8 py-8 md:border-b-0 md:border-r-[3px]">
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]">
                   The situation
                 </p>
-                <p class="mt-4 font-['Archivo'] leading-relaxed text-[color:var(--color-text-primary)]">
+                <p class="mt-4 font-['Archivo'] leading-relaxed text-[color:var(--ss-color-text-primary)]">
                   {study.challenge}
                 </p>
               </div>
               <div class="px-8 py-8">
-                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--color-primary)]">
+                <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
                   The solution
                 </p>
-                <p class="mt-4 font-['Archivo'] leading-relaxed text-[color:var(--color-text-primary)]">
+                <p class="mt-4 font-['Archivo'] leading-relaxed text-[color:var(--ss-color-text-primary)]">
                   {study.solution}
                 </p>
               </div>

--- a/src/components/CtaButton.astro
+++ b/src/components/CtaButton.astro
@@ -17,11 +17,11 @@ const base =
   "inline-flex items-center justify-center font-bold uppercase tracking-[0.08em] font-['Archivo'] transition-colors"
 const variants = {
   primary:
-    'px-8 py-4 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
+    'px-8 py-4 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] text-white hover:bg-[color:var(--ss-color-primary-hover)]',
   secondary:
-    'px-8 py-4 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-text-primary)] hover:text-[color:var(--color-background)]',
+    'px-8 py-4 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]',
   'outline-white':
-    'px-8 py-4 border-[3px] border-white bg-transparent text-white hover:bg-white hover:text-[color:var(--color-text-primary)]',
+    'px-8 py-4 border-[3px] border-white bg-transparent text-white hover:bg-white hover:text-[color:var(--ss-color-text-primary)]',
 }
 ---
 

--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -2,10 +2,10 @@
 import CtaButton from './CtaButton.astro'
 ---
 
-<section id="book" class="bg-[color:var(--color-surface-inverse)] px-6 py-24">
+<section id="book" class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
   <div class="mx-auto max-w-5xl text-center">
     <h2 class="text-3xl font-bold text-white">Let's Talk About Your Business</h2>
-    <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--color-text-muted)]">
+    <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
       We'll ask how things run and where you're trying to go. You'll walk away with a clearer
       picture of how to get there, whether we work together or not.
     </p>
@@ -13,7 +13,7 @@ import CtaButton from './CtaButton.astro'
       <CtaButton variant="outline-white" href="/book" data-ev="final-cta-book">
         Book a Call
       </CtaButton>
-      <p class="mt-4 text-sm text-[color:var(--color-text-muted)]">
+      <p class="mt-4 text-sm text-[color:var(--ss-color-text-muted)]">
         Not ready to schedule?
         <a href="/get-started" class="underline hover:text-white" data-ev="final-cta-get-started">
           Tell us about your business

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 <footer
-  class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface-inverse)] text-white"
+  class="border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-surface-inverse)] text-white"
 >
   <div class="mx-auto w-full max-w-5xl px-6">
     <!-- Region 1: Masthead — brand mark. -->
@@ -9,7 +9,7 @@
         class="inline-flex items-baseline gap-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-white"
       >
         <span
-          class="inline-block bg-[color:var(--color-primary)] text-white px-2.5 py-1 font-black tracking-[-0.01em]"
+          class="inline-block bg-[color:var(--ss-color-primary)] text-white px-2.5 py-1 font-black tracking-[-0.01em]"
           >SMD</span
         >
         <span>Services</span>
@@ -25,7 +25,7 @@
          footer content exists (Legal, Privacy, Terms, Social), it slots in
          as a third region above this colophon. -->
     <div
-      class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]"
+      class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >
       <span>&copy; 2026 SMDurgan, LLC</span>
       <span>Phoenix, Arizona</span>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,21 +2,21 @@
 import CtaButton from './CtaButton.astro'
 ---
 
-<section class="bg-[color:var(--color-background)] px-6">
+<section class="bg-[color:var(--ss-color-background)] px-6">
   <div class="mx-auto max-w-5xl">
     <div class="grid grid-cols-1 md:grid-cols-12">
       <div
-        class="md:col-span-8 py-16 md:py-24 md:pr-10 border-b-[3px] md:border-b-0 border-[color:var(--color-text-primary)]"
+        class="md:col-span-8 py-16 md:py-24 md:pr-10 border-b-[3px] md:border-b-0 border-[color:var(--ss-color-text-primary)]"
       >
         <h1
-          class="font-['Archivo'] font-black uppercase text-[clamp(2.5rem,8vw,6.5rem)] leading-[0.88] tracking-[-0.04em] text-[color:var(--color-text-primary)]"
+          class="font-['Archivo'] font-black uppercase text-[clamp(2.5rem,8vw,6.5rem)] leading-[0.88] tracking-[-0.04em] text-[color:var(--ss-color-text-primary)]"
         >
           <span class="block">Your</span>
           <span class="block">Business</span>
           <span class="block">Has</span>
           <span class="block">Outgrown</span>
           <span class="block">How&nbsp;You</span>
-          <span class="block text-[color:var(--color-primary)]">Run&nbsp;It.</span>
+          <span class="block text-[color:var(--ss-color-primary)]">Run&nbsp;It.</span>
         </h1>
         <div class="mt-10 md:mt-12 flex flex-col sm:flex-row items-stretch sm:inline-flex">
           <CtaButton href="/book" data-ev="home-primary-cta" class="w-full sm:w-auto">
@@ -33,16 +33,16 @@ import CtaButton from './CtaButton.astro'
         </div>
       </div>
       <div
-        class="md:col-span-4 flex flex-col items-start py-10 md:pt-24 md:pb-14 md:pl-10 md:border-l-[3px] md:border-[color:var(--color-text-primary)]"
+        class="md:col-span-4 flex flex-col items-start py-10 md:pt-24 md:pb-14 md:pl-10 md:border-l-[3px] md:border-[color:var(--ss-color-text-primary)]"
       >
         <p
-          class="font-['Archivo'] text-sm md:text-base leading-relaxed text-[color:var(--color-text-secondary)]"
+          class="font-['Archivo'] text-sm md:text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           You know where you want to go. We help you figure out what needs to change and build it
           with you.
         </p>
         <div
-          class="hidden md:block mt-8 w-12 border-t-[3px] border-[color:var(--color-text-primary)]"
+          class="hidden md:block mt-8 w-12 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
           aria-hidden="true"
         >
         </div>

--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -19,35 +19,37 @@ const steps = [
 ---
 
 <section
-  class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-16">
       <span
-        class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+        class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
         >§ 02</span
       >
       <h2
-        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
         How We Work Together
       </h2>
-      <p class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--color-text-secondary)]">
+      <p
+        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-secondary)]"
+      >
         A clear process from first conversation to full handoff.
       </p>
     </div>
-    <div class="space-y-0 border-t-[3px] border-[color:var(--color-text-primary)]">
+    <div class="space-y-0 border-t-[3px] border-[color:var(--ss-color-text-primary)]">
       {
         steps.map((step, i) => (
-          <div class="flex gap-8 py-10 border-b-[3px] border-[color:var(--color-text-primary)]">
-            <div class="font-['Archivo'] text-6xl font-black leading-none text-[color:var(--color-primary)] tracking-[-0.03em] min-w-[5rem]">
+          <div class="flex gap-8 py-10 border-b-[3px] border-[color:var(--ss-color-text-primary)]">
+            <div class="font-['Archivo'] text-6xl font-black leading-none text-[color:var(--ss-color-primary)] tracking-[-0.03em] min-w-[5rem]">
               {String(i + 1).padStart(2, '0')}
             </div>
             <div class="flex-1">
-              <h3 class="mb-3 font-['Archivo'] text-2xl font-bold uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              <h3 class="mb-3 font-['Archivo'] text-2xl font-bold uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
                 {step.title}
               </h3>
-              <p class="font-['Archivo'] leading-relaxed text-[color:var(--color-text-secondary)]">
+              <p class="font-['Archivo'] leading-relaxed text-[color:var(--ss-color-text-secondary)]">
                 {step.description}
               </p>
             </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -7,17 +7,17 @@ const navLinks = [
 
 <header
   role="banner"
-  class="sticky top-0 z-40 border-b-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+  class="sticky top-0 z-40 border-b-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
 >
   <div
     class="mx-auto flex h-14 md:h-16 w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6"
   >
     <a
       href="/"
-      class="inline-flex items-baseline gap-2 font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+      class="inline-flex items-baseline gap-2 font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
     >
       <span
-        class="inline-block bg-[color:var(--color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
+        class="inline-block bg-[color:var(--ss-color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
         >SMD</span
       >
       <span>Services</span>
@@ -27,7 +27,7 @@ const navLinks = [
       {
         navLinks.map((item) => (
           <a
-            class="hidden md:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            class="hidden md:inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
             href={item.href}
             data-ev={`nav-${item.label.toLowerCase()}`}
           >
@@ -36,7 +36,7 @@ const navLinks = [
         ))
       }
       <a
-        class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] active:bg-[color:var(--color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
+        class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] active:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
         href="/book"
         data-ev="nav-book">Book a Call</a
       >
@@ -46,7 +46,7 @@ const navLinks = [
         aria-controls="mobile-menu-dialog"
         aria-haspopup="dialog"
         data-nav-open
-        class="md:hidden inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 select-none transition-colors"
+        class="md:hidden inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 select-none transition-colors"
       >
         Menu
       </button>
@@ -63,7 +63,7 @@ const navLinks = [
   class="nav-dialog md:hidden"
   data-nav-dialog
 >
-  <div class="flex h-full w-full flex-col bg-[color:var(--color-surface-inverse)] text-white">
+  <div class="flex h-full w-full flex-col bg-[color:var(--ss-color-surface-inverse)] text-white">
     <!-- Overlay header: mirrors the bar structure so there is no visual jump.
          Brand on the left, Close on the right. -->
     <div class="flex h-14 flex-none items-center justify-between px-4 border-b-[3px] border-white">
@@ -73,7 +73,7 @@ const navLinks = [
         data-nav-link
       >
         <span
-          class="inline-block bg-[color:var(--color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
+          class="inline-block bg-[color:var(--ss-color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
           >SMD</span
         >
         <span>Services</span>
@@ -82,7 +82,7 @@ const navLinks = [
         type="button"
         aria-label="Close menu"
         data-nav-close
-        class="inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-white bg-transparent font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-white cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-inverse)]"
+        class="inline-flex items-center justify-center min-w-11 min-h-11 px-3 border-[3px] border-white bg-transparent font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-white cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
       >
         Close
       </button>
@@ -100,7 +100,7 @@ const navLinks = [
                 class="flex items-baseline gap-4 px-5 py-6 min-h-[64px] font-['Archivo'] text-3xl font-black uppercase tracking-[-0.01em] text-white hover:bg-[color:rgba(245,240,227,0.06)]"
                 data-ev={`nav-mobile-${item.label.toLowerCase()}`}
               >
-                <span class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.12em] text-[color:var(--color-primary)] min-w-[2.5rem]">
+                <span class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.12em] text-[color:var(--ss-color-primary)] min-w-[2.5rem]">
                   § 0{i + 1}
                 </span>
                 <span>{item.label}</span>
@@ -117,7 +117,7 @@ const navLinks = [
         href="/book"
         data-nav-link
         data-ev="nav-mobile-book"
-        class="flex w-full items-center justify-center whitespace-nowrap border-[3px] border-white bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] px-5 py-4 font-['Archivo'] text-base font-bold uppercase tracking-[0.08em] text-white transition-colors"
+        class="flex w-full items-center justify-center whitespace-nowrap border-[3px] border-white bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] px-5 py-4 font-['Archivo'] text-base font-bold uppercase tracking-[0.08em] text-white transition-colors"
         >Book a Call</a
       >
     </div>

--- a/src/components/Pricing.astro
+++ b/src/components/Pricing.astro
@@ -1,12 +1,12 @@
 <section
-  class="bg-[color:var(--color-surface-inverse)] px-6 py-24 text-white border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24 text-white border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-16 text-center">
       <p
-        class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-primary)] flex items-center justify-center gap-3"
+        class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-primary)] flex items-center justify-center gap-3"
       >
-        <span class="inline-block w-2 h-2 bg-[color:var(--color-primary)]"></span>
+        <span class="inline-block w-2 h-2 bg-[color:var(--ss-color-primary)]"></span>
         Pricing Model
       </p>
       <h2
@@ -15,14 +15,16 @@
         Scoped to Your Business
       </h2>
       <p
-        class="mx-auto mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--color-text-muted)]"
+        class="mx-auto mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-muted)]"
       >
         Every business is different. We quote a fixed price after we understand yours. No hourly
         billing, no open-ended retainers, no surprises.
       </p>
     </div>
 
-    <div class="mb-16 grid gap-0 md:grid-cols-3 border-y-[3px] border-[color:var(--color-primary)]">
+    <div
+      class="mb-16 grid gap-0 md:grid-cols-3 border-y-[3px] border-[color:var(--ss-color-primary)]"
+    >
       {
         [
           {
@@ -44,27 +46,29 @@
           <div
             class:list={['p-8', i !== 2 && 'md:border-r md:border-[color:rgba(245,240,227,0.16)]']}
           >
-            <p class="font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--color-primary)]">
+            <p class="font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
               {stage.label}
             </p>
             <h3 class="mt-3 font-['Archivo'] text-2xl font-bold uppercase tracking-[-0.01em]">
               {stage.title}
             </h3>
-            <p class="mt-3 font-['Archivo'] text-[color:var(--color-text-muted)]">{stage.body}</p>
+            <p class="mt-3 font-['Archivo'] text-[color:var(--ss-color-text-muted)]">
+              {stage.body}
+            </p>
           </div>
         ))
       }
     </div>
 
     <div
-      class="mx-auto max-w-lg bg-[color:var(--color-background)] p-10 text-left text-[color:var(--color-text-primary)] border-[3px] border-[color:var(--color-primary)]"
+      class="mx-auto max-w-lg bg-[color:var(--ss-color-background)] p-10 text-left text-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-primary)]"
     >
       <p
-        class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-primary)] text-center"
+        class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-primary)] text-center"
       >
         How We Price
       </p>
-      <div class="my-6 h-[2px] bg-[color:var(--color-text-primary)]"></div>
+      <div class="my-6 h-[2px] bg-[color:var(--ss-color-text-primary)]"></div>
       <ul class="space-y-5">
         {
           [
@@ -74,20 +78,20 @@
             'No commitment until after the first conversation',
           ].map((item) => (
             <li class="flex items-start gap-4">
-              <span class="mt-2 inline-block w-3 h-3 shrink-0 bg-[color:var(--color-primary)]" />
+              <span class="mt-2 inline-block w-3 h-3 shrink-0 bg-[color:var(--ss-color-primary)]" />
               <span class="font-['Archivo'] leading-snug">{item}</span>
             </li>
           ))
         }
       </ul>
       <a
-        class="mt-10 block w-full bg-[color:var(--color-primary)] border-[3px] border-[color:var(--color-text-primary)] py-4 text-center font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--color-primary-hover)]"
+        class="mt-10 block w-full bg-[color:var(--ss-color-primary)] border-[3px] border-[color:var(--ss-color-text-primary)] py-4 text-center font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)]"
         href="/book"
       >
         Book a Call
       </a>
       <p
-        class="mt-4 text-center font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]"
+        class="mt-4 text-center font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]"
       >
         No commitment. Let's just talk about your business.
       </p>

--- a/src/components/ProblemCards.astro
+++ b/src/components/ProblemCards.astro
@@ -13,38 +13,38 @@ const problems = [
 ---
 
 <section
-  class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-16">
       <span
-        class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+        class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
         >§ 01</span
       >
       <h2
-        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
         Sound Familiar?
       </h2>
     </div>
     <div
-      class="grid grid-cols-1 gap-0 md:grid-cols-3 border-t-[3px] border-[color:var(--color-text-primary)]"
+      class="grid grid-cols-1 gap-0 md:grid-cols-3 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
     >
       {
         problems.map((problem, i) => (
           <div
             class:list={[
-              'flex flex-col gap-6 bg-[color:var(--color-background)] p-8 min-h-[14rem] border-b-[3px] border-[color:var(--color-text-primary)]',
-              i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--color-text-primary)]',
+              'flex flex-col gap-6 bg-[color:var(--ss-color-background)] p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+              i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
             ]}
           >
-            <p class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.08em] text-[color:var(--color-primary)]">
+            <p class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.08em] text-[color:var(--ss-color-primary)]">
               {String(i + 1).padStart(2, '0')}.
             </p>
-            <p class="font-['Archivo'] italic text-lg leading-relaxed text-[color:var(--color-text-primary)]">
+            <p class="font-['Archivo'] italic text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]">
               "{problem.quote}"
             </p>
-            <p class="mt-auto pt-4 border-t border-[color:var(--color-border)] font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--color-primary)]">
+            <p class="mt-auto pt-4 border-t border-[color:var(--ss-color-border)] font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
               {problem.name}
             </p>
           </div>

--- a/src/components/SkipToMain.astro
+++ b/src/components/SkipToMain.astro
@@ -18,7 +18,7 @@ const { targetId = 'main', label = 'Skip to main content' } = Astro.props
 ---
 
 <a
-  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:rounded-[var(--radius-card)] focus:border focus:border-[color:var(--color-border)] focus:text-[color:var(--color-primary)] focus:font-medium"
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:rounded-[var(--ss-radius-card)] focus:border focus:border-[color:var(--ss-color-border)] focus:text-[color:var(--ss-color-primary)] focus:font-medium"
   href={`#${targetId}`}
 >
   {label}

--- a/src/components/WhatYouGet.astro
+++ b/src/components/WhatYouGet.astro
@@ -14,32 +14,34 @@ const items = [
 ---
 
 <section
-  class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-16">
       <span
-        class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+        class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
         >§ 03</span
       >
       <h2
-        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
         What You Get
       </h2>
     </div>
-    <div class="grid grid-cols-1 gap-0 md:grid-cols-2 border-t border-[color:var(--color-border)]">
+    <div
+      class="grid grid-cols-1 gap-0 md:grid-cols-2 border-t border-[color:var(--ss-color-border)]"
+    >
       {
         items.map((item, i) => (
           <div
             class:list={[
-              'flex items-start gap-4 py-5 px-1 border-b border-[color:var(--color-border)]',
-              i % 2 === 0 && 'md:border-r md:pr-8 md:border-[color:var(--color-border)]',
+              'flex items-start gap-4 py-5 px-1 border-b border-[color:var(--ss-color-border)]',
+              i % 2 === 0 && 'md:border-r md:pr-8 md:border-[color:var(--ss-color-border)]',
               i % 2 === 1 && 'md:pl-8',
             ]}
           >
-            <span class="mt-2 inline-block w-3 h-3 shrink-0 bg-[color:var(--color-primary)]" />
-            <span class="font-['Archivo'] text-lg text-[color:var(--color-text-primary)]">
+            <span class="mt-2 inline-block w-3 h-3 shrink-0 bg-[color:var(--ss-color-primary)]" />
+            <span class="font-['Archivo'] text-lg text-[color:var(--ss-color-text-primary)]">
               {item}
             </span>
           </div>

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -19,45 +19,47 @@ const segments = [
 ---
 
 <section
-  class="bg-[color:var(--color-background)] px-6 py-24 border-t-[3px] border-[color:var(--color-text-primary)]"
+  class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
     <div class="mb-16">
       <span
-        class="inline-block bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
+        class="inline-block bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] px-2 py-1 mb-4"
         >§ 05</span
       >
       <h2
-        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
         Who We Help
       </h2>
     </div>
     <div
-      class="grid grid-cols-1 gap-0 md:grid-cols-3 border-t-[3px] border-[color:var(--color-text-primary)]"
+      class="grid grid-cols-1 gap-0 md:grid-cols-3 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
     >
       {
         segments.map((s, i) => (
           <div
             class:list={[
-              'p-8 bg-[color:var(--color-background)] border-b-[3px] border-[color:var(--color-text-primary)]',
-              i !== 2 && 'md:border-r-[3px] md:border-[color:var(--color-text-primary)]',
+              'p-8 bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+              i !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
             ]}
           >
-            <h3 class="font-['Archivo'] text-xl font-bold uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+            <h3 class="font-['Archivo'] text-xl font-bold uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
               {s.title}
             </h3>
             <div class="mt-6">
-              <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+              <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
                 Sound familiar?
               </p>
-              <p class="mt-2 font-['Archivo'] text-[color:var(--color-text-primary)]">{s.pain}</p>
+              <p class="mt-2 font-['Archivo'] text-[color:var(--ss-color-text-primary)]">
+                {s.pain}
+              </p>
             </div>
-            <div class="mt-6 pt-6 border-t border-[color:var(--color-border)]">
-              <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--color-primary)]">
+            <div class="mt-6 pt-6 border-t border-[color:var(--ss-color-border)]">
+              <p class="font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)]">
                 How we help
               </p>
-              <p class="mt-2 font-['Archivo'] text-[color:var(--color-text-primary)]">{s.fix}</p>
+              <p class="mt-2 font-['Archivo'] text-[color:var(--ss-color-text-primary)]">{s.fix}</p>
             </div>
           </div>
         ))

--- a/src/components/admin/LogReplyDialog.astro
+++ b/src/components/admin/LogReplyDialog.astro
@@ -26,7 +26,7 @@ const formId = `reply-form-${instanceId}`
   id={dialogId}
   data-reply-dialog
   data-entity-id={entityId}
-  class="rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-0 backdrop:bg-black/40 w-full max-w-md"
+  class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-0 backdrop:bg-black/40 w-full max-w-md"
 >
   <form
     id={formId}
@@ -36,15 +36,15 @@ const formId = `reply-form-${instanceId}`
   >
     <div class="flex items-start justify-between mb-stack">
       <div>
-        <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">Log reply</h3>
-        <p class="text-xs text-[color:var(--color-text-muted)] mt-0.5">
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">Log reply</h3>
+        <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-0.5">
           {entityName}
         </p>
       </div>
       <button
         type="button"
         data-close-dialog
-        class="text-xs text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] transition-colors"
+        class="text-xs text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] transition-colors"
         aria-label="Close"
       >
         Close
@@ -54,7 +54,7 @@ const formId = `reply-form-${instanceId}`
     <div class="space-y-stack">
       <div>
         <label
-          class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+          class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
           for={`${instanceId}-sentiment`}
         >
           Sentiment
@@ -63,7 +63,7 @@ const formId = `reply-form-${instanceId}`
           id={`${instanceId}-sentiment`}
           name="sentiment"
           required
-          class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white text-[color:var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white text-[color:var(--ss-color-text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
         >
           <option value="interested">Interested</option>
           <option value="declined">Declined</option>
@@ -74,7 +74,7 @@ const formId = `reply-form-${instanceId}`
 
       <div>
         <label
-          class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+          class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
           for={`${instanceId}-next-action`}
         >
           Suggested next action
@@ -83,21 +83,21 @@ const formId = `reply-form-${instanceId}`
           id={`${instanceId}-next-action`}
           name="next_action"
           required
-          class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white text-[color:var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white text-[color:var(--ss-color-text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
         >
           <option value="book_meeting">Book meeting</option>
           <option value="retry_later">Retry later</option>
           <option value="mark_lost">Mark lost</option>
           <option value="continue_conversation">Continue conversation</option>
         </select>
-        <p class="text-xs text-[color:var(--color-text-muted)] mt-1">
+        <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
           No stage change happens automatically. Use the stage buttons on the entity after saving.
         </p>
       </div>
 
       <div>
         <label
-          class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+          class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
           for={`${instanceId}-notes`}
         >
           Notes
@@ -107,7 +107,7 @@ const formId = `reply-form-${instanceId}`
           name="notes"
           rows="3"
           placeholder="Paste or summarize the reply..."
-          class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
         ></textarea>
       </div>
     </div>
@@ -116,13 +116,13 @@ const formId = `reply-form-${instanceId}`
       <button
         type="button"
         data-close-dialog
-        class="text-sm bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+        class="text-sm bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)] px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
       >
         Cancel
       </button>
       <button
         type="submit"
-        class="text-sm bg-primary text-white px-4 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+        class="text-sm bg-primary text-white px-4 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
       >
         Save reply
       </button>

--- a/src/components/booking/SlotPicker.astro
+++ b/src/components/booking/SlotPicker.astro
@@ -20,10 +20,10 @@
   <!-- Loading skeleton -->
   <div
     id="sp-loading"
-    class="flex flex-col items-center justify-center py-12 text-[color:var(--color-text-secondary)]"
+    class="flex flex-col items-center justify-center py-12 text-[color:var(--ss-color-text-secondary)]"
   >
     <div
-      class="h-8 w-8 animate-spin rounded-[var(--radius-card)] border-2 border-[color:var(--color-border)] border-t-primary"
+      class="h-8 w-8 animate-spin rounded-[var(--ss-radius-card)] border-2 border-[color:var(--ss-color-border)] border-t-primary"
     >
     </div>
     <p class="mt-3 text-sm">Loading available times...</p>
@@ -31,13 +31,13 @@
 
   <!-- Error state -->
   <div id="sp-error" class="hidden py-12 text-center">
-    <p class="text-sm text-[color:var(--color-error)]" id="sp-error-msg">
+    <p class="text-sm text-[color:var(--ss-color-error)]" id="sp-error-msg">
       Something went wrong loading available times.
     </p>
     <button
       id="sp-retry-btn"
       type="button"
-      class="mt-3 rounded-[var(--radius-card)] bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+      class="mt-3 rounded-[var(--ss-radius-card)] bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
     >
       Try again
     </button>
@@ -45,10 +45,10 @@
 
   <!-- No slots state -->
   <div id="sp-empty" class="hidden py-12 text-center">
-    <p class="text-sm text-[color:var(--color-text-secondary)]">
+    <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
       No available times in the next two weeks.
     </p>
-    <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
+    <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
       Please email
       <a href="mailto:scott@smd.services" class="font-medium text-primary hover:text-primary-hover">
         scott@smd.services
@@ -60,7 +60,7 @@
   <!-- Stale banner (data older than 5 min) -->
   <div
     id="sp-stale"
-    class="mb-4 hidden rounded-[var(--radius-card)] bg-amber-50 px-4 py-2 text-sm text-[color:var(--color-attention)]"
+    class="mb-4 hidden rounded-[var(--ss-radius-card)] bg-amber-50 px-4 py-2 text-sm text-[color:var(--ss-color-attention)]"
   >
     These times may be out of date.
     <button type="button" id="sp-refresh-btn" class="ml-1 font-medium underline">Refresh</button>
@@ -69,7 +69,7 @@
   <!-- Main picker UI -->
   <div id="sp-main" class="hidden">
     <!-- Timezone label -->
-    <p class="mb-4 text-xs text-[color:var(--color-text-secondary)]" id="sp-tz-label"></p>
+    <p class="mb-4 text-xs text-[color:var(--ss-color-text-secondary)]" id="sp-tz-label"></p>
 
     <div class="flex flex-col gap-card sm:flex-row">
       <!-- Left: Date selector -->
@@ -78,7 +78,7 @@
           <button
             type="button"
             id="sp-prev"
-            class="rounded p-1 text-[color:var(--color-text-muted)] transition-colors hover:bg-[color:var(--color-border-subtle)] hover:text-[color:var(--color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed"
+            class="rounded p-1 text-[color:var(--ss-color-text-muted)] transition-colors hover:bg-[color:var(--ss-color-border-subtle)] hover:text-[color:var(--ss-color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed"
             aria-label="Previous dates"
           >
             <svg
@@ -94,11 +94,11 @@
           </button>
           <span
             id="sp-month-label"
-            class="text-sm font-semibold text-[color:var(--color-text-primary)]"></span>
+            class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]"></span>
           <button
             type="button"
             id="sp-next"
-            class="rounded p-1 text-[color:var(--color-text-muted)] transition-colors hover:bg-[color:var(--color-border-subtle)] hover:text-[color:var(--color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed"
+            class="rounded p-1 text-[color:var(--ss-color-text-muted)] transition-colors hover:bg-[color:var(--ss-color-border-subtle)] hover:text-[color:var(--ss-color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed"
             aria-label="Next dates"
           >
             <svg
@@ -120,13 +120,13 @@
       <div class="sm:w-1/2">
         <p
           id="sp-date-label"
-          class="mb-3 text-sm font-semibold text-[color:var(--color-text-primary)]"
+          class="mb-3 text-sm font-semibold text-[color:var(--ss-color-text-primary)]"
         >
         </p>
         <div id="sp-slots" class="grid grid-cols-2 gap-2"></div>
         <p
           id="sp-no-slots-day"
-          class="hidden py-8 text-center text-sm text-[color:var(--color-text-secondary)]"
+          class="hidden py-8 text-center text-sm text-[color:var(--ss-color-text-secondary)]"
         >
           No available times on this date.
         </p>
@@ -136,15 +136,15 @@
 
   <!-- 503 fallback panel -->
   <div id="sp-unavailable" class="hidden py-12 text-center">
-    <p class="text-sm text-[color:var(--color-text-secondary)]">
+    <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
       Online booking is temporarily unavailable.
     </p>
-    <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+    <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
       Please email us directly to schedule your call:
     </p>
     <a
       href="mailto:scott@smd.services?subject=Assessment%20Call%20Request"
-      class="mt-3 inline-block rounded-[var(--radius-card)] bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+      class="mt-3 inline-block rounded-[var(--ss-radius-card)] bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
     >
       Email scott@smd.services
     </a>
@@ -316,7 +316,7 @@
       dayAbbr.forEach(function (name) {
         const span = document.createElement('span')
         span.className =
-          'text-[10px] font-medium text-[color:var(--color-text-muted)] py-1 text-center'
+          'text-[10px] font-medium text-[color:var(--ss-color-text-muted)] py-1 text-center'
         span.textContent = name
         datesContainer.appendChild(span)
       })
@@ -347,22 +347,22 @@
         const btn = document.createElement('button')
         btn.type = 'button'
         btn.className =
-          'h-9 w-full flex items-center justify-center rounded-[var(--radius-card)] text-sm transition-colors '
+          'h-9 w-full flex items-center justify-center rounded-[var(--ss-radius-card)] text-sm transition-colors '
 
         if (isSelected) {
           btn.className += 'bg-primary text-white font-semibold'
         } else if (isToday && hasSlots) {
           btn.className +=
-            'ring-2 ring-primary text-[color:var(--color-text-primary)] font-semibold hover:bg-[color:var(--color-border-subtle)]'
+            'ring-2 ring-primary text-[color:var(--ss-color-text-primary)] font-semibold hover:bg-[color:var(--ss-color-border-subtle)]'
         } else if (isToday) {
-          btn.className += 'ring-2 ring-primary text-[color:var(--color-text-muted)]'
+          btn.className += 'ring-2 ring-primary text-[color:var(--ss-color-text-muted)]'
         } else if (hasSlots) {
           btn.className +=
-            'text-[color:var(--color-text-primary)] font-semibold hover:bg-[color:var(--color-border-subtle)]'
+            'text-[color:var(--ss-color-text-primary)] font-semibold hover:bg-[color:var(--ss-color-border-subtle)]'
         } else if (isPast) {
           btn.className += 'text-slate-200 cursor-not-allowed'
         } else {
-          btn.className += 'text-[color:var(--color-text-muted)] cursor-not-allowed'
+          btn.className += 'text-[color:var(--ss-color-text-muted)] cursor-not-allowed'
         }
 
         btn.textContent = day
@@ -440,12 +440,12 @@
         const isSelected = selectedSlot && selectedSlot.start_utc === slot.start_utc
 
         btn.className =
-          'rounded-[var(--radius-card)] border px-3 py-2 text-sm font-medium transition-colors '
+          'rounded-[var(--ss-radius-card)] border px-3 py-2 text-sm font-medium transition-colors '
         if (isSelected) {
           btn.className += 'border-primary bg-primary text-white'
         } else {
           btn.className +=
-            'border-[color:var(--color-border)] bg-white text-[color:var(--color-text-primary)] hover:border-primary hover:text-primary'
+            'border-[color:var(--ss-color-border)] bg-white text-[color:var(--ss-color-text-primary)] hover:border-primary hover:text-primary'
         }
 
         btn.textContent = slot.label

--- a/src/components/portal/ActionCard.astro
+++ b/src/components/portal/ActionCard.astro
@@ -14,11 +14,11 @@ const { pillLabel, amountCents, amountLabel, ctaLabel, ctaHref, ctaSubtext } = A
 ---
 
 <section
-  class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+  class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
   aria-label={pillLabel}
 >
   <div
-    class="flex items-center gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-primary)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
+    class="flex items-center gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
   >
     {pillLabel}
   </div>
@@ -28,7 +28,7 @@ const { pillLabel, amountCents, amountLabel, ctaLabel, ctaHref, ctaSubtext } = A
         <>
           <MoneyDisplay amountCents={amountCents} size="hero" />
           {amountLabel && (
-            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]">
               {amountLabel}
             </p>
           )}
@@ -38,14 +38,14 @@ const { pillLabel, amountCents, amountLabel, ctaLabel, ctaHref, ctaSubtext } = A
   </div>
   <a
     href={ctaHref}
-    class="flex items-center justify-between border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset"
+    class="flex items-center justify-between border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
   >
     <span>{ctaLabel}</span>
     <span aria-hidden="true" class="font-black">→</span>
   </a>
   {
     ctaSubtext && (
-      <p class="px-5 py-3 border-t-[2px] border-[color:var(--color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+      <p class="px-5 py-3 border-t-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
         {ctaSubtext}
       </p>
     )

--- a/src/components/portal/ArtifactChip.astro
+++ b/src/components/portal/ArtifactChip.astro
@@ -20,7 +20,7 @@ const { icon, label, href } = Astro.props
 
 <a
   href={href}
-  class="inline-flex items-center gap-1.5 font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] underline decoration-[color:var(--color-border)] hover:decoration-[color:var(--color-text-primary)] underline-offset-4 decoration-1 transition-colors"
+  class="inline-flex items-center gap-1.5 font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] underline decoration-[color:var(--ss-color-border)] hover:decoration-[color:var(--ss-color-text-primary)] underline-offset-4 decoration-1 transition-colors"
 >
   {icon && <span class="material-symbols-outlined text-[14px]">{icon}</span>}
   <span>{label}</span>

--- a/src/components/portal/ConsultantBlock.astro
+++ b/src/components/portal/ConsultantBlock.astro
@@ -119,11 +119,11 @@ const silhouetteSvg = (classes: string) => `
 {
   variant === 'default' && (
     <section
-      class={`bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-5 sm:p-card ${klass}`}
+      class={`bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-5 sm:p-card ${klass}`}
       aria-label="Your consultant"
     >
       <div class="flex items-start gap-stack">
-        <div class="w-16 h-20 shrink-0 rounded-[var(--radius-card)] bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden">
+        <div class="w-16 h-20 shrink-0 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-background)] border border-[color:var(--ss-color-border)] overflow-hidden">
           {photoUrl ? (
             <img
               alt={`${name}, consultant`}
@@ -133,36 +133,36 @@ const silhouetteSvg = (classes: string) => `
             />
           ) : (
             <Fragment
-              set:html={silhouetteSvg('w-full h-full text-[color:var(--color-text-muted)]')}
+              set:html={silhouetteSvg('w-full h-full text-[color:var(--ss-color-text-muted)]')}
             />
           )}
         </div>
         <div class="flex-1 min-w-0">
-          <p class="text-heading text-[color:var(--color-text-primary)]">{name}</p>
+          <p class="text-heading text-[color:var(--ss-color-text-primary)]">{name}</p>
           {role && (
-            <p class="mt-0.5 font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]">
+            <p class="mt-0.5 font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-muted)]">
               {role}
             </p>
           )}
           {touchpointText && (
-            <p class="mt-row font-mono text-caption tabular-nums text-[color:var(--color-text-primary)]">
+            <p class="mt-row font-mono text-caption tabular-nums text-[color:var(--ss-color-text-primary)]">
               Next check-in · {touchpointText}
             </p>
           )}
         </div>
       </div>
       {smsHref && telHref && (
-        <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
+        <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border)]">
           <a
             href={smsHref}
-            class="consultant-sms-mobile inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+            class="consultant-sms-mobile inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
           >
             <span class="material-symbols-outlined text-[18px]">sms</span>
             Text {firstName}
           </a>
           <a
             href={telHref}
-            class="consultant-tel-desktop hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+            class="consultant-tel-desktop hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
           >
             <span class="material-symbols-outlined text-[18px]">call</span>
             {phoneDisplay}
@@ -170,10 +170,10 @@ const silhouetteSvg = (classes: string) => `
         </div>
       )}
       {!smsHref && mailtoHref && (
-        <div class="mt-4 pt-4 border-t border-[color:var(--color-border)]">
+        <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border)]">
           <a
             href={mailtoHref}
-            class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+            class="inline-flex items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
           >
             <span class="material-symbols-outlined text-[18px]">mail</span>
             Email {firstName}
@@ -187,20 +187,20 @@ const silhouetteSvg = (classes: string) => `
 {
   variant === 'trade-card' && (
     <section
-      class={`border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-surface)] ${klass}`}
+      class={`border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-surface)] ${klass}`}
       aria-label="Your team"
     >
       {/* Header bar — ink bg / cream text. "Your team" left, touchpoint ref right (burnt-orange when set). */}
-      <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-4 md:px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+      <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-4 md:px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
         <span>Your team</span>
-        <span class={touchpointText ? 'text-[color:var(--color-primary)]' : 'opacity-80'}>
+        <span class={touchpointText ? 'text-[color:var(--ss-color-primary)]' : 'opacity-80'}>
           {touchpointText ? `Next · ${touchpointText}` : 'On call'}
         </span>
       </div>
 
       {/* Body — square photo flush + name/role/note. */}
       <div class="flex items-stretch">
-        <div class="w-[100px] md:w-[110px] aspect-square shrink-0 border-r-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] overflow-hidden">
+        <div class="w-[100px] md:w-[110px] aspect-square shrink-0 border-r-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] overflow-hidden">
           {photoUrl ? (
             <img
               alt={`${name}, your team contact`}
@@ -210,16 +210,16 @@ const silhouetteSvg = (classes: string) => `
             />
           ) : (
             <Fragment
-              set:html={silhouetteSvg('w-full h-full text-[color:var(--color-background)]')}
+              set:html={silhouetteSvg('w-full h-full text-[color:var(--ss-color-background)]')}
             />
           )}
         </div>
         <div class="flex-1 min-w-0 px-4 md:px-5 py-3 md:py-4 flex flex-col gap-1">
-          <h3 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)] m-0 leading-none">
+          <h3 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] m-0 leading-none">
             {name}
           </h3>
           {role && (
-            <p class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] m-0">
+            <p class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-secondary)] m-0">
               {role}
             </p>
           )}
@@ -228,33 +228,33 @@ const silhouetteSvg = (classes: string) => `
 
       {/* Footer — channel-verb eyebrow + affordance value. */}
       {smsHref && telHref && (
-        <div class="flex items-center justify-between gap-3 border-t-[2px] border-[color:var(--color-text-primary)] px-4 md:px-5 py-3 md:py-4">
-          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+        <div class="flex items-center justify-between gap-3 border-t-[2px] border-[color:var(--ss-color-text-primary)] px-4 md:px-5 py-3 md:py-4">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
             <span class="sm:hidden">Text</span>
             <span class="hidden sm:inline">Call</span>
           </span>
           <a
             href={smsHref}
-            class="sm:hidden inline-flex items-center gap-2 font-['Archivo'] text-lg font-black text-[color:var(--color-text-primary)] tabular-nums tracking-[-0.01em] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            class="sm:hidden inline-flex items-center gap-2 font-['Archivo'] text-lg font-black text-[color:var(--ss-color-text-primary)] tabular-nums tracking-[-0.01em] hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
           >
             {phoneDisplay}
           </a>
           <a
             href={telHref}
-            class="hidden sm:inline-flex items-center gap-2 font-['Archivo'] text-lg md:text-xl font-black text-[color:var(--color-text-primary)] tabular-nums tracking-[-0.01em] hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            class="hidden sm:inline-flex items-center gap-2 font-['Archivo'] text-lg md:text-xl font-black text-[color:var(--ss-color-text-primary)] tabular-nums tracking-[-0.01em] hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
           >
             {phoneDisplay}
           </a>
         </div>
       )}
       {!smsHref && mailtoHref && (
-        <div class="flex items-center justify-between gap-3 border-t-[2px] border-[color:var(--color-text-primary)] px-4 md:px-5 py-3 md:py-4">
-          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+        <div class="flex items-center justify-between gap-3 border-t-[2px] border-[color:var(--ss-color-text-primary)] px-4 md:px-5 py-3 md:py-4">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
             Email
           </span>
           <a
             href={mailtoHref}
-            class="inline-flex items-center gap-2 font-['Archivo'] text-base md:text-lg font-black text-[color:var(--color-text-primary)] tracking-[-0.01em] truncate hover:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            class="inline-flex items-center gap-2 font-['Archivo'] text-base md:text-lg font-black text-[color:var(--ss-color-text-primary)] tracking-[-0.01em] truncate hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
           >
             {email}
           </a>

--- a/src/components/portal/Documents.astro
+++ b/src/components/portal/Documents.astro
@@ -58,11 +58,11 @@ const totalCount = groups.reduce((sum, g) => sum + g.items.length, 0)
 <PortalTabs pathname="/portal/documents" />
 
 <main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
-  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Documents</h1>
+  <h1 class="text-display text-[color:var(--ss-color-text-primary)] mb-section">Documents</h1>
 
   {
     totalCount === 0 ? (
-      <p class="text-caption text-[color:var(--color-text-muted)]">
+      <p class="text-caption text-[color:var(--ss-color-text-muted)]">
         Nothing on file yet. Documents will appear here as the engagement produces them.
       </p>
     ) : (
@@ -72,7 +72,7 @@ const totalCount = groups.reduce((sum, g) => sum + g.items.length, 0)
             <section aria-labelledby={`group-${group.label.toLowerCase().replace(/\s+/g, '-')}`}>
               <h2
                 id={`group-${group.label.toLowerCase().replace(/\s+/g, '-')}`}
-                class="mb-stack pb-row border-b border-[color:var(--color-border)] font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-primary)]"
+                class="mb-stack pb-row border-b border-[color:var(--ss-color-border)] font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-primary)]"
               >
                 {group.label}
               </h2>

--- a/src/components/portal/EngagementProgress.astro
+++ b/src/components/portal/EngagementProgress.astro
@@ -88,15 +88,15 @@ const { client, engagement, timeline, consultant } = Astro.props
 <PortalTabs pathname="/portal/engagement" />
 
 <main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
-  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Engagement</h1>
+  <h1 class="text-display text-[color:var(--ss-color-text-primary)] mb-section">Engagement</h1>
 
   <!-- Summary panel -->
   <section
-    class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-section"
+    class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-section"
     aria-labelledby="summary-heading"
   >
     <div
-      class="flex items-center justify-between gap-stack pb-stack border-b border-[color:var(--color-border-subtle)] font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)] tabular-nums"
+      class="flex items-center justify-between gap-stack pb-stack border-b border-[color:var(--ss-color-border-subtle)] font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-muted)] tabular-nums"
     >
       <span>REF {engagement.reference}</span>
       <StatusPill tone={coerceTone(engagement.statusTone)} label={engagement.statusLabel} />
@@ -105,29 +105,33 @@ const { client, engagement, timeline, consultant } = Astro.props
     <div class="pt-card grid grid-cols-1 md:grid-cols-3 gap-stack md:gap-section">
       <div>
         <p
-          class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]"
+          class="font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-muted)]"
         >
           Scope
         </p>
-        <p class="mt-row text-body text-[color:var(--color-text-primary)]">{engagement.scope}</p>
+        <p class="mt-row text-body text-[color:var(--ss-color-text-primary)]">{engagement.scope}</p>
       </div>
       <div>
         <p
-          class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]"
+          class="font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-muted)]"
         >
           Opened
         </p>
-        <p class="mt-row font-mono text-body tabular-nums text-[color:var(--color-text-primary)]">
+        <p
+          class="mt-row font-mono text-body tabular-nums text-[color:var(--ss-color-text-primary)]"
+        >
           {engagement.openedOn}
         </p>
       </div>
       <div>
         <p
-          class="font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-muted)]"
+          class="font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-muted)]"
         >
           Estimated completion
         </p>
-        <p class="mt-row font-mono text-body tabular-nums text-[color:var(--color-text-primary)]">
+        <p
+          class="mt-row font-mono text-body tabular-nums text-[color:var(--ss-color-text-primary)]"
+        >
           {engagement.estimatedCompletion}
         </p>
       </div>
@@ -138,19 +142,19 @@ const { client, engagement, timeline, consultant } = Astro.props
   <section class="mb-section" aria-labelledby="log-heading">
     <h2
       id="log-heading"
-      class="mb-stack pb-row border-b border-[color:var(--color-border)] font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold text-[color:var(--color-text-primary)]"
+      class="mb-stack pb-row border-b border-[color:var(--ss-color-border)] font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold text-[color:var(--ss-color-text-primary)]"
     >
       Activity log
     </h2>
     {
       timeline.length === 0 ? (
-        <p class="text-caption text-[color:var(--color-text-muted)]">
+        <p class="text-caption text-[color:var(--ss-color-text-muted)]">
           The work begins at the first scheduled check-in.
         </p>
       ) : (
         <ol class="flex flex-col gap-stack" role="list">
           {timeline.map((entry) => (
-            <li class="pt-stack border-t border-[color:var(--color-border-subtle)] first:border-t-0 first:pt-0">
+            <li class="pt-stack border-t border-[color:var(--ss-color-border-subtle)] first:border-t-0 first:pt-0">
               <TimelineEntry
                 date={entry.date}
                 actor={entry.actor}

--- a/src/components/portal/InvoiceDetail.astro
+++ b/src/components/portal/InvoiceDetail.astro
@@ -117,7 +117,7 @@ const pathname = `/portal/invoices/${invoice.id}`
   <a
     href="/portal/invoices"
     aria-label="All invoices"
-    class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-label uppercase font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-[var(--radius-card)]"
+    class="inline-flex items-center gap-1 min-h-11 px-2 -mx-2 mb-4 text-label uppercase font-semibold text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded-[var(--ss-radius-card)]"
   >
     <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
     All invoices
@@ -131,21 +131,21 @@ const pathname = `/portal/invoices/${invoice.id}`
       <!-- Hero: eyebrow + title + subtitle + status line -->
       <div>
         <div class="flex items-center gap-row">
-          <p class="text-label uppercase text-[color:var(--color-text-secondary)]">
+          <p class="text-label uppercase text-[color:var(--ss-color-text-secondary)]">
             {invoice.type.charAt(0).toUpperCase() + invoice.type.slice(1)} invoice
           </p>
           <StatusPill tone={pillTone} label={invoice.pillLabel} size="base" />
         </div>
 
         <h1
-          class="mt-3 font-display font-bold text-display tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+          class="mt-3 font-display font-bold text-display tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
           {invoice.title}
         </h1>
 
         {
           invoice.periodSubtitle && (
-            <p class="mt-3 text-body-lg text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 text-body-lg text-[color:var(--ss-color-text-secondary)]">
               {invoice.periodSubtitle}
             </p>
           )
@@ -153,7 +153,7 @@ const pathname = `/portal/invoices/${invoice.id}`
 
         {
           !isPaid && invoice.dueCaption && (
-            <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-muted)]">
+            <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-muted)]">
               <span class="material-symbols-outlined text-[18px]" aria-hidden="true">
                 calendar_today
               </span>
@@ -164,7 +164,7 @@ const pathname = `/portal/invoices/${invoice.id}`
 
         {
           isPaid && invoice.paidShortDate && (
-            <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--color-complete)]">
+            <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-complete)]">
               <span class="material-symbols-outlined text-[18px]" aria-hidden="true">
                 check_circle
               </span>
@@ -179,21 +179,23 @@ const pathname = `/portal/invoices/${invoice.id}`
         {
           isErrorState && (
             <div
-              class="mb-card rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
+              class="mb-card rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)]/30 bg-[color:var(--ss-color-attention)]/5 p-stack"
               role="status"
             >
               <div class="flex items-start gap-row">
                 <span
-                  class="material-symbols-outlined text-[20px] text-[color:var(--color-attention)] mt-0.5"
+                  class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-attention)] mt-0.5"
                   aria-hidden="true"
                 >
                   error
                 </span>
                 <div class="min-w-0">
-                  <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                  <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                     {errorTitle}
                   </p>
-                  <p class="mt-1 text-body text-[color:var(--color-text-secondary)]">{errorBody}</p>
+                  <p class="mt-1 text-body text-[color:var(--ss-color-text-secondary)]">
+                    {errorBody}
+                  </p>
                 </div>
               </div>
             </div>
@@ -201,11 +203,11 @@ const pathname = `/portal/invoices/${invoice.id}`
         }
 
         <div
-          class="relative overflow-hidden rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-card"
+          class="relative overflow-hidden rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-surface)] p-card"
         >
           <!-- Accent bar -->
           <div
-            class={`absolute left-0 top-0 h-full w-1 ${isPaid ? 'bg-[color:var(--color-complete)]' : 'bg-[color:var(--color-primary)]'}`}
+            class={`absolute left-0 top-0 h-full w-1 ${isPaid ? 'bg-[color:var(--ss-color-complete)]' : 'bg-[color:var(--ss-color-primary)]'}`}
             aria-hidden="true"
           >
           </div>
@@ -215,12 +217,12 @@ const pathname = `/portal/invoices/${invoice.id}`
           {
             isPaid ? (
               invoice.paidShortDate && (
-                <p class="mt-2 text-caption font-medium text-[color:var(--color-complete)]">
+                <p class="mt-2 text-caption font-medium text-[color:var(--ss-color-complete)]">
                   Paid {invoice.paidShortDate}. Receipt attached.
                 </p>
               )
             ) : (
-              <p class="mt-1 text-label uppercase text-[color:var(--color-text-muted)]">
+              <p class="mt-1 text-label uppercase text-[color:var(--ss-color-text-muted)]">
                 Remaining balance
               </p>
             )
@@ -233,11 +235,11 @@ const pathname = `/portal/invoices/${invoice.id}`
                   <>
                     <a
                       href={invoice.stripeUrl}
-                      class="inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                      class="inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--ss-radius-button)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
                     >
                       {ctaLabel}
                     </a>
-                    <div class="mt-3 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-muted)]">
+                    <div class="mt-3 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-muted)]">
                       <span class="material-symbols-outlined text-[16px]" aria-hidden="true">
                         lock
                       </span>
@@ -245,7 +247,7 @@ const pathname = `/portal/invoices/${invoice.id}`
                     </div>
                   </>
                 ) : (
-                  <p class="text-body text-[color:var(--color-text-secondary)]">
+                  <p class="text-body text-[color:var(--ss-color-text-secondary)]">
                     Payment link pending — we will send it shortly.
                   </p>
                 )}
@@ -259,12 +261,12 @@ const pathname = `/portal/invoices/${invoice.id}`
                 {consultantContactHref ? (
                   <a
                     href={consultantContactHref}
-                    class="inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                    class="inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--ss-radius-button)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
                   >
                     Contact the team
                   </a>
                 ) : (
-                  <p class="text-body text-[color:var(--color-text-secondary)]">
+                  <p class="text-body text-[color:var(--ss-color-text-secondary)]">
                     Reach us for a new payment link using the contacts in the header.
                   </p>
                 )}
@@ -278,18 +280,18 @@ const pathname = `/portal/invoices/${invoice.id}`
       {
         lineItems.length > 0 && (
           <div>
-            <h2 class="font-display font-semibold text-title text-[color:var(--color-text-primary)]">
+            <h2 class="font-display font-semibold text-title text-[color:var(--ss-color-text-primary)]">
               What's included
             </h2>
             <ul class="mt-stack flex flex-col" aria-label="Invoice line items">
               {lineItems.map((li) => (
-                <li class="flex justify-between items-baseline gap-card py-5 border-b border-[color:var(--color-border)]/60">
+                <li class="flex justify-between items-baseline gap-card py-5 border-b border-[color:var(--ss-color-border)]/60">
                   <div class="min-w-0">
-                    <span class="text-body text-[color:var(--color-text-secondary)]">
+                    <span class="text-body text-[color:var(--ss-color-text-secondary)]">
                       {li.label}
                     </span>
                     {li.caption && (
-                      <p class="mt-0.5 text-caption text-[color:var(--color-text-muted)]">
+                      <p class="mt-0.5 text-caption text-[color:var(--ss-color-text-muted)]">
                         {li.caption}
                       </p>
                     )}
@@ -299,7 +301,7 @@ const pathname = `/portal/invoices/${invoice.id}`
               ))}
             </ul>
             <div class="mt-card pt-5 flex justify-between items-baseline">
-              <span class="font-display font-semibold text-title text-[color:var(--color-text-primary)]">
+              <span class="font-display font-semibold text-title text-[color:var(--ss-color-text-primary)]">
                 Total
               </span>
               <MoneyDisplay amountCents={invoice.totalCents} size="h2" />
@@ -310,22 +312,22 @@ const pathname = `/portal/invoices/${invoice.id}`
 
       <!-- ── Payment details ── -->
       <div>
-        <h2 class="font-display font-semibold text-title text-[color:var(--color-text-primary)]">
+        <h2 class="font-display font-semibold text-title text-[color:var(--ss-color-text-primary)]">
           Payment details
         </h2>
         <ul class="mt-stack grid grid-cols-1 sm:grid-cols-2 gap-card">
           {
             invoice.dueShortDate && !isPaid && (
-              <li class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card">
+              <li class="flex items-start gap-row rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-surface)] p-card">
                 <span
-                  class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+                  class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
                   style="font-variation-settings: 'FILL' 1;"
                   aria-hidden="true"
                 >
                   event
                 </span>
                 <div class="min-w-0">
-                  <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                  <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                     Due {invoice.dueShortDate}
                   </p>
                 </div>
@@ -334,16 +336,16 @@ const pathname = `/portal/invoices/${invoice.id}`
           }
           {
             isPaid && invoice.paidShortDate && (
-              <li class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card">
+              <li class="flex items-start gap-row rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-surface)] p-card">
                 <span
-                  class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)]"
+                  class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-complete)]"
                   style="font-variation-settings: 'FILL' 1;"
                   aria-hidden="true"
                 >
                   check_circle
                 </span>
                 <div class="min-w-0">
-                  <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                  <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                     Paid {invoice.paidShortDate}
                   </p>
                 </div>
@@ -351,39 +353,39 @@ const pathname = `/portal/invoices/${invoice.id}`
             )
           }
           <li
-            class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card"
+            class="flex items-start gap-row rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-surface)] p-card"
           >
             <span
-              class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+              class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
               style="font-variation-settings: 'FILL' 1;"
               aria-hidden="true"
             >
               lock
             </span>
             <div class="min-w-0">
-              <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+              <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                 Secure payment via Stripe
               </p>
-              <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+              <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
                 End-to-end encrypted processing.
               </p>
             </div>
           </li>
           <li
-            class="flex items-start gap-row rounded-[var(--radius-card)] bg-[color:var(--color-surface)] p-card"
+            class="flex items-start gap-row rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-surface)] p-card"
           >
             <span
-              class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+              class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
               style="font-variation-settings: 'FILL' 1;"
               aria-hidden="true"
             >
               credit_card
             </span>
             <div class="min-w-0">
-              <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+              <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                 Card or bank transfer
               </p>
-              <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+              <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
                 Multiple payment methods accepted.
               </p>
             </div>
@@ -414,21 +416,23 @@ const pathname = `/portal/invoices/${invoice.id}`
       {
         isErrorState && (
           <div
-            class="rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
+            class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)]/30 bg-[color:var(--ss-color-attention)]/5 p-stack"
             role="status"
           >
             <div class="flex items-start gap-row">
               <span
-                class="material-symbols-outlined text-[20px] text-[color:var(--color-attention)] mt-0.5"
+                class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-attention)] mt-0.5"
                 aria-hidden="true"
               >
                 error
               </span>
               <div class="min-w-0">
-                <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                   {errorTitle}
                 </p>
-                <p class="mt-1 text-body text-[color:var(--color-text-secondary)]">{errorBody}</p>
+                <p class="mt-1 text-body text-[color:var(--ss-color-text-secondary)]">
+                  {errorBody}
+                </p>
               </div>
             </div>
           </div>
@@ -439,28 +443,28 @@ const pathname = `/portal/invoices/${invoice.id}`
       {
         isPaid ? (
           <section
-            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-section"
             aria-label="Invoice paid"
           >
-            <p class="text-label uppercase text-[color:var(--color-complete)]">Paid</p>
+            <p class="text-label uppercase text-[color:var(--ss-color-complete)]">Paid</p>
             <div class="mt-3">
               <MoneyDisplay amountCents={invoice.amountCents} size="display" />
             </div>
             {invoice.paidShortDate && (
-              <p class="mt-4 text-caption font-medium text-[color:var(--color-complete)]">
+              <p class="mt-4 text-caption font-medium text-[color:var(--ss-color-complete)]">
                 Paid {invoice.paidShortDate}. Receipt attached.
               </p>
             )}
           </section>
         ) : isLinkExpired ? (
           <section
-            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-section"
             aria-label="Link expired"
           >
-            <p class="text-label uppercase text-[color:var(--color-attention)]">Link expired</p>
+            <p class="text-label uppercase text-[color:var(--ss-color-attention)]">Link expired</p>
             <div class="mt-3">
               <MoneyDisplay amountCents={invoice.amountCents} size="display" />
-              <p class="mt-2 text-label uppercase text-[color:var(--color-text-muted)]">
+              <p class="mt-2 text-label uppercase text-[color:var(--ss-color-text-muted)]">
                 Remaining balance
               </p>
             </div>
@@ -468,12 +472,12 @@ const pathname = `/portal/invoices/${invoice.id}`
               {consultantContactHref ? (
                 <a
                   href={consultantContactHref}
-                  class="inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                  class="inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--ss-radius-button)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
                 >
                   Contact consultant
                 </a>
               ) : (
-                <p class="text-body text-[color:var(--color-text-secondary)]">
+                <p class="text-body text-[color:var(--ss-color-text-secondary)]">
                   Contact your consultant for a new payment link.
                 </p>
               )}
@@ -481,27 +485,27 @@ const pathname = `/portal/invoices/${invoice.id}`
           </section>
         ) : invoice.isPayable && invoice.stripeUrl ? (
           <section
-            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-section"
             aria-label={ctaLabel}
           >
-            <p class="text-label uppercase text-[color:var(--color-text-muted)]">
+            <p class="text-label uppercase text-[color:var(--ss-color-text-muted)]">
               Remaining balance
             </p>
             <div class="mt-1">
               <MoneyDisplay amountCents={invoice.amountCents} size="display" />
             </div>
             {invoice.dueCaption && (
-              <p class="mt-2 text-caption font-medium text-[color:var(--color-text-muted)]">
+              <p class="mt-2 text-caption font-medium text-[color:var(--ss-color-text-muted)]">
                 Due {invoice.dueCaption}.
               </p>
             )}
             <a
               href={invoice.stripeUrl}
-              class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+              class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-[var(--ss-radius-button)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
             >
               {ctaLabel}
             </a>
-            <div class="mt-4 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-muted)]">
+            <div class="mt-4 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-muted)]">
               <span class="material-symbols-outlined text-[16px]" aria-hidden="true">
                 lock
               </span>
@@ -510,16 +514,16 @@ const pathname = `/portal/invoices/${invoice.id}`
           </section>
         ) : (
           <section
-            class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-section"
+            class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-section"
             aria-label="Payment link pending"
           >
-            <p class="text-label uppercase text-[color:var(--color-text-muted)]">
+            <p class="text-label uppercase text-[color:var(--ss-color-text-muted)]">
               Remaining balance
             </p>
             <div class="mt-3">
               <MoneyDisplay amountCents={invoice.amountCents} size="display" />
             </div>
-            <p class="mt-4 text-body text-[color:var(--color-text-secondary)]">
+            <p class="mt-4 text-body text-[color:var(--ss-color-text-secondary)]">
               Payment link pending — we will send it shortly.
             </p>
           </section>

--- a/src/components/portal/InvoicesList.astro
+++ b/src/components/portal/InvoicesList.astro
@@ -39,11 +39,11 @@ const { client, invoices } = Astro.props
 <PortalTabs pathname="/portal/invoices" />
 
 <main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
-  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Invoices</h1>
+  <h1 class="text-display text-[color:var(--ss-color-text-primary)] mb-section">Invoices</h1>
 
   {
     invoices.length === 0 ? (
-      <p class="text-caption text-[color:var(--color-text-muted)]">No invoices yet.</p>
+      <p class="text-caption text-[color:var(--ss-color-text-muted)]">No invoices yet.</p>
     ) : (
       <ul class="space-y-row" role="list">
         {invoices.map((invoice) => (

--- a/src/components/portal/MoneyDisplay.astro
+++ b/src/components/portal/MoneyDisplay.astro
@@ -39,10 +39,10 @@ const formatted = new Intl.NumberFormat('en-US', {
 // (see --text-*--font-weight in global.css). Legacy sizes keep their
 // original Modern Institutional treatment.
 const PLAINSPOKEN_SIZE_CLASS: Record<'hero' | 'total' | 'kpi' | 'row', string> = {
-  hero: 'text-hero-price text-[color:var(--color-text-primary)]',
-  total: 'text-section-h text-[color:var(--color-text-primary)]',
-  kpi: 'text-kpi text-[color:var(--color-text-primary)]',
-  row: 'text-price-row text-[color:var(--color-text-primary)]',
+  hero: 'text-hero-price text-[color:var(--ss-color-text-primary)]',
+  total: 'text-section-h text-[color:var(--ss-color-text-primary)]',
+  kpi: 'text-kpi text-[color:var(--ss-color-text-primary)]',
+  row: 'text-price-row text-[color:var(--ss-color-text-primary)]',
 }
 
 const isPlainspoken = size === 'hero' || size === 'total' || size === 'kpi' || size === 'row'
@@ -50,12 +50,12 @@ const isPlainspoken = size === 'hero' || size === 'total' || size === 'kpi' || s
 const sizeClass = isPlainspoken
   ? PLAINSPOKEN_SIZE_CLASS[size as 'hero' | 'total' | 'kpi' | 'row']
   : size === 'display'
-    ? 'font-display text-money font-medium text-[color:var(--color-text-primary)]'
+    ? 'font-display text-money font-medium text-[color:var(--ss-color-text-primary)]'
     : size === 'h2'
-      ? 'font-display text-title font-medium text-[color:var(--color-text-primary)]'
+      ? 'font-display text-title font-medium text-[color:var(--ss-color-text-primary)]'
       : emphasize
-        ? 'font-body text-body font-semibold text-[color:var(--color-text-primary)]'
-        : 'font-body text-body font-medium text-[color:var(--color-text-primary)]'
+        ? 'font-body text-body font-semibold text-[color:var(--ss-color-text-primary)]'
+        : 'font-body text-body font-medium text-[color:var(--ss-color-text-primary)]'
 ---
 
 <span class={`tabular-nums ${sizeClass} ${klass}`}>{formatted}</span>

--- a/src/components/portal/PortalHeader.astro
+++ b/src/components/portal/PortalHeader.astro
@@ -37,16 +37,16 @@ const telHref = phoneDigits ? `tel:${phoneDigits}` : null
 const mailtoHref = consultantEmail ? `mailto:${consultantEmail}` : null
 
 const iconClasses =
-  'inline-flex items-center justify-center w-11 h-11 rounded-[var(--radius-button)] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2'
+  'inline-flex items-center justify-center w-11 h-11 rounded-[var(--ss-radius-button)] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2'
 ---
 
 <header
   role="banner"
-  class="sticky top-0 z-50 h-14 md:h-16 w-full bg-[color:var(--color-background)] border-b-[3px] border-[color:var(--color-text-primary)]"
+  class="sticky top-0 z-50 h-14 md:h-16 w-full bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="max-w-5xl mx-auto h-full px-4 md:px-6 flex items-center justify-between gap-stack">
     <p
-      class="font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.18em] text-[color:var(--color-text-primary)] truncate"
+      class="font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-primary)] truncate"
     >
       {clientName}
     </p>

--- a/src/components/portal/PortalHomeDashboard.astro
+++ b/src/components/portal/PortalHomeDashboard.astro
@@ -73,21 +73,21 @@ const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
       /* ------------------------------------------------------------------ */
       <div class="flex flex-col gap-card">
         <section
-          class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 p-card sm:p-section"
+          class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)]/30 p-card sm:p-section"
           aria-live="polite"
         >
           <div class="flex items-start gap-row">
             <span
-              class="material-symbols-outlined text-[24px] text-[color:var(--color-attention)] mt-0.5"
+              class="material-symbols-outlined text-[24px] text-[color:var(--ss-color-attention)] mt-0.5"
               aria-hidden="true"
             >
               error
             </span>
             <div class="min-w-0">
-              <h1 class="text-title text-[color:var(--color-text-primary)]">
+              <h1 class="text-title text-[color:var(--ss-color-text-primary)]">
                 Something went wrong loading your portal.
               </h1>
-              <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
+              <p class="mt-2 text-body text-[color:var(--ss-color-text-secondary)]">
                 {consultantFirst
                   ? `Give it a moment and try again. If it keeps happening, ${consultantFirst} can help.`
                   : 'Give it a moment and try again.'}
@@ -95,7 +95,7 @@ const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
               <div class="mt-5 flex flex-wrap gap-row">
                 <a
                   href="/portal"
-                  class="inline-flex items-center justify-center min-h-[44px] px-5 py-2.5 rounded-[var(--radius-button)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                  class="inline-flex items-center justify-center min-h-[44px] px-5 py-2.5 rounded-[var(--ss-radius-button)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
                 >
                   Retry
                 </a>
@@ -122,7 +122,7 @@ const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
         {/* Visually hidden H1 gives screen readers a page landmark.
             Sighted users see "Engagement in flight." / "Welcome." as the
             page-level context before the action content. */}
-        <h1 class="text-title text-[color:var(--color-text-primary)] mb-section">
+        <h1 class="text-title text-[color:var(--ss-color-text-primary)] mb-section">
           {contextHeadline}
         </h1>
 
@@ -146,26 +146,28 @@ const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
               />
             ) : touchpointText ? (
               <section
-                class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card sm:p-section"
+                class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card sm:p-section"
                 aria-label="Next check-in"
               >
-                <p class="text-label uppercase text-[color:var(--color-primary)]">Next check-in</p>
-                <p class="mt-3 text-display text-[color:var(--color-text-primary)]">
+                <p class="text-label uppercase text-[color:var(--ss-color-primary)]">
+                  Next check-in
+                </p>
+                <p class="mt-3 text-display text-[color:var(--ss-color-text-primary)]">
                   {touchpointText}
                 </p>
                 {consultantFirst && (
-                  <p class="mt-2 text-caption text-[color:var(--color-text-muted)]">
+                  <p class="mt-2 text-caption text-[color:var(--ss-color-text-muted)]">
                     with {consultantFirst}
                   </p>
                 )}
               </section>
             ) : (
               <section
-                class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card sm:p-section"
+                class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card sm:p-section"
                 aria-label="Engagement status"
               >
-                <p class="text-label uppercase text-[color:var(--color-primary)]">In flight</p>
-                <p class="mt-3 text-body text-[color:var(--color-text-secondary)]">
+                <p class="text-label uppercase text-[color:var(--ss-color-primary)]">In flight</p>
+                <p class="mt-3 text-body text-[color:var(--ss-color-text-secondary)]">
                   Nothing needs your attention right now.
                 </p>
               </section>
@@ -185,10 +187,10 @@ const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
 
           {/* Main column: Recent activity timeline. */}
           <section
-            class="flex-1 min-w-0 md:order-1 mt-section md:mt-0 pt-section md:pt-0 border-t md:border-t-0 border-[color:var(--color-border)]"
+            class="flex-1 min-w-0 md:order-1 mt-section md:mt-0 pt-section md:pt-0 border-t md:border-t-0 border-[color:var(--ss-color-border)]"
             aria-labelledby="timeline-heading"
           >
-            <h2 id="timeline-heading" class="text-title text-[color:var(--color-text-primary)]">
+            <h2 id="timeline-heading" class="text-title text-[color:var(--ss-color-text-primary)]">
               Recent activity
             </h2>
             {timelineEntries.length > 0 ? (
@@ -204,7 +206,7 @@ const contextHeadline = consultant ? 'Engagement in flight.' : 'Welcome.'
                 ))}
               </div>
             ) : (
-              <p class="mt-stack text-body text-[color:var(--color-text-secondary)]">
+              <p class="mt-stack text-body text-[color:var(--ss-color-text-secondary)]">
                 Nothing here yet. First entry lands after your next touchpoint.
               </p>
             )}

--- a/src/components/portal/PortalListItem.astro
+++ b/src/components/portal/PortalListItem.astro
@@ -9,7 +9,7 @@
  *                        per row). Default for back-compat.
  *   chrome='ticket'    — Plainspoken bill-of-lading row. Flat, borderless
  *                        at the row level — consumer wraps rows in an
- *                        outer `border-[3px] border-[color:var(--color-text-primary)]`
+ *                        outer `border-[3px] border-[color:var(--ss-color-text-primary)]`
  *                        container (the rows' `border-b-[2px]` dividers
  *                        do the stitching). Plainspoken vocabulary: №
  *                        cell (status) or file-ext thumb (document), Archivo
@@ -78,24 +78,24 @@ const chrome: Chrome = props.chrome ?? 'card'
 
 // Card-chrome wrapper (existing rendering, unchanged).
 const cardShell = [
-  'block bg-[color:var(--color-surface)]',
-  'rounded-[var(--radius-card)] border border-[color:var(--color-border)]',
+  'block bg-[color:var(--ss-color-surface)]',
+  'rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]',
   'p-card',
   'transition-colors',
-  'hover:border-[color:var(--color-text-muted)]',
+  'hover:border-[color:var(--ss-color-text-muted)]',
   'focus-visible:outline-none',
-  'focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2',
+  'focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2',
 ].join(' ')
 
 // Ticket-chrome wrapper — borderless row with bottom stitch. Consumer
 // provides outer 3px ink border.
 const ticketShell = [
-  'group block bg-[color:var(--color-surface)]',
-  'border-b-[2px] border-[color:var(--color-text-primary)] last:border-b-0',
+  'group block bg-[color:var(--ss-color-surface)]',
+  'border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0',
   'transition-colors',
-  'hover:bg-[color:var(--color-border-subtle)]',
+  'hover:bg-[color:var(--ss-color-border-subtle)]',
   'focus-visible:outline-none',
-  'focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset',
+  'focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset',
 ].join(' ')
 ---
 
@@ -106,26 +106,26 @@ const ticketShell = [
         <div class="flex-1 min-w-0 flex flex-col gap-row">
           <div class="flex items-center gap-row flex-wrap">
             <StatusPill tone={props.tone} label={props.toneLabel} />
-            <span class="text-heading text-[color:var(--color-text-primary)] truncate">
+            <span class="text-heading text-[color:var(--ss-color-text-primary)] truncate">
               {props.title}
             </span>
           </div>
           <div class="flex items-baseline gap-row flex-wrap">
             <MoneyDisplay amountCents={props.amountCents} size="h2" />
             {props.metaCaption && (
-              <span class="text-caption text-[color:var(--color-text-muted)]">
+              <span class="text-caption text-[color:var(--ss-color-text-muted)]">
                 {props.metaCaption}
               </span>
             )}
             {props.trailingCaption && (
-              <span class="text-caption text-[color:var(--color-attention)]">
+              <span class="text-caption text-[color:var(--ss-color-attention)]">
                 {props.trailingCaption}
               </span>
             )}
           </div>
         </div>
         <span
-          class="material-symbols-outlined text-[color:var(--color-text-muted)] flex-shrink-0"
+          class="material-symbols-outlined text-[color:var(--ss-color-text-muted)] flex-shrink-0"
           aria-hidden="true"
         >
           chevron_right
@@ -144,21 +144,23 @@ const ticketShell = [
     >
       <div class="flex items-center gap-stack min-h-[44px]">
         <span
-          class="flex-shrink-0 w-10 h-10 rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] flex items-center justify-center text-[color:var(--color-text-secondary)]"
+          class="flex-shrink-0 w-10 h-10 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-border-subtle)] flex items-center justify-center text-[color:var(--ss-color-text-secondary)]"
           aria-hidden="true"
         >
           <span class="material-symbols-outlined">{props.icon}</span>
         </span>
         <div class="flex-1 min-w-0 flex flex-col gap-row">
-          <span class="text-heading text-[color:var(--color-text-primary)] truncate">
+          <span class="text-heading text-[color:var(--ss-color-text-primary)] truncate">
             {props.title}
           </span>
           {props.eyebrow && (
-            <span class="text-label uppercase text-[color:var(--color-meta)]">{props.eyebrow}</span>
+            <span class="text-label uppercase text-[color:var(--ss-color-meta)]">
+              {props.eyebrow}
+            </span>
           )}
         </div>
         <span
-          class="material-symbols-outlined text-[color:var(--color-text-muted)] flex-shrink-0"
+          class="material-symbols-outlined text-[color:var(--ss-color-text-muted)] flex-shrink-0"
           aria-hidden="true"
         >
           {props.trailingIcon}
@@ -174,42 +176,42 @@ const ticketShell = [
     <a href={props.href} class={ticketShell}>
       <div class="md:grid md:grid-cols-[56px_1fr_auto_auto_48px] md:items-stretch">
         {/* № cell */}
-        <div class="flex md:border-r-[2px] md:border-[color:var(--color-text-primary)] bg-[color:var(--color-text-primary)] text-[color:var(--color-primary)] items-center justify-center md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell">
+        <div class="flex md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)] items-center justify-center md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell">
           {props.serial ? `№${props.serial}` : '№ —'}
         </div>
 
         {/* Main */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2">
           <div class="flex items-center gap-3 flex-wrap">
-            <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] m-0 truncate">
+            <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0 truncate">
               {props.title}
             </h3>
             <StatusPill tone={props.tone} label={props.toneLabel} />
           </div>
           {props.subCaption && (
-            <p class="text-sm text-[color:var(--color-text-secondary)] m-0 line-clamp-2">
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] m-0 line-clamp-2">
               {props.subCaption}
             </p>
           )}
         </div>
 
         {/* Price */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col items-start md:items-end justify-center gap-1">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col items-start md:items-end justify-center gap-1">
           <MoneyDisplay amountCents={props.amountCents} size="row" />
-          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
             {props.metaCaption ?? 'Amount'}
           </span>
         </div>
 
         {/* Date */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
           {props.metaLabel && (
-            <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
               {props.metaLabel}
             </span>
           )}
           {props.trailingCaption && (
-            <span class="font-mono text-sm text-[color:var(--color-text-primary)]">
+            <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
               {props.trailingCaption}
             </span>
           )}
@@ -218,7 +220,7 @@ const ticketShell = [
         {/* Arrow */}
         <div
           aria-hidden="true"
-          class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-2xl text-[color:var(--color-primary)] transition-transform group-hover:translate-x-0.5"
+          class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-2xl text-[color:var(--ss-color-primary)] transition-transform group-hover:translate-x-0.5"
         >
           →
         </div>
@@ -237,44 +239,44 @@ const ticketShell = [
     >
       <div class="md:grid md:grid-cols-[88px_1fr_140px_180px_auto_48px] md:items-stretch">
         {/* Thumb */}
-        <div class="flex items-center justify-center md:border-r-[2px] md:border-[color:var(--color-text-primary)] bg-[color:var(--color-border-subtle)] md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell text-[color:var(--color-text-primary)]">
+        <div class="flex items-center justify-center md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-border-subtle)] md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell text-[color:var(--ss-color-text-primary)]">
           {props.fileExt ?? props.icon.slice(0, 3).toUpperCase()}
         </div>
 
         {/* Main */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2">
-          <h4 class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] m-0 truncate">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2">
+          <h4 class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0 truncate">
             {props.title}
           </h4>
           {props.eyebrow && (
-            <p class="text-sm text-[color:var(--color-text-secondary)] m-0 line-clamp-2">
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] m-0 line-clamp-2">
               {props.eyebrow}
             </p>
           )}
         </div>
 
         {/* Kind */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
-          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
             Kind
           </span>
-          <span class="font-mono text-sm text-[color:var(--color-text-primary)]">
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
             {props.kind ?? '—'}
           </span>
         </div>
 
         {/* Meta */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
-          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1">
+          <span class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
             Shared
           </span>
-          <span class="font-mono text-sm text-[color:var(--color-text-primary)]">
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
             {props.eyebrow ?? '—'}
           </span>
         </div>
 
         {/* Stamp */}
-        <div class="md:border-r-[2px] md:border-[color:var(--color-text-primary)] px-5 py-3 md:py-5 flex items-center justify-start md:justify-center">
+        <div class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex items-center justify-start md:justify-center">
           {props.tone && props.toneLabel ? (
             <StatusPill tone={props.tone} label={props.toneLabel} />
           ) : null}
@@ -283,7 +285,7 @@ const ticketShell = [
         {/* Arrow */}
         <div
           aria-hidden="true"
-          class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-xl text-[color:var(--color-primary)] transition-transform group-hover:translate-x-0.5"
+          class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-xl text-[color:var(--ss-color-primary)] transition-transform group-hover:translate-x-0.5"
         >
           ↗
         </div>

--- a/src/components/portal/PortalPageHead.astro
+++ b/src/components/portal/PortalPageHead.astro
@@ -45,16 +45,16 @@ const {
 const showCrumb = !!(crumbHref && crumbLabel)
 ---
 
-<header class={`border-b-[3px] border-[color:var(--color-text-primary)] py-6 md:py-10 ${klass}`}>
+<header class={`border-b-[3px] border-[color:var(--ss-color-text-primary)] py-6 md:py-10 ${klass}`}>
   {
     showCrumb && (
       <a
         href={crumbHref as string}
-        class="inline-flex items-center gap-2 min-h-11 -mx-1 px-1 font-['Archivo_Narrow'] text-xs md:text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+        class="inline-flex items-center gap-2 min-h-11 -mx-1 px-1 font-['Archivo_Narrow'] text-xs md:text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
       >
         <span
           aria-hidden="true"
-          class="font-['Archivo'] font-black text-[color:var(--color-primary)]"
+          class="font-['Archivo'] font-black text-[color:var(--ss-color-primary)]"
         >
           ←
         </span>
@@ -72,20 +72,20 @@ const showCrumb = !!(crumbHref && crumbLabel)
     <div class="min-w-0 flex-1">
       {
         tag && (
-          <span class="inline-block mb-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-3 py-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold whitespace-nowrap">
+          <span class="inline-block mb-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-3 py-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold whitespace-nowrap">
             {tag}
           </span>
         )
       }
       <h1
-        class="font-['Archivo'] text-hero-mobile md:text-hero uppercase text-[color:var(--color-text-primary)] m-0"
+        class="font-['Archivo'] text-hero-mobile md:text-hero uppercase text-[color:var(--ss-color-text-primary)] m-0"
       >
         {h1}
       </h1>
     </div>
     {
       meta && (
-        <div class="font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)] whitespace-pre md:text-right leading-[1.9]">
+        <div class="font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)] whitespace-pre md:text-right leading-[1.9]">
           {meta}
         </div>
       )

--- a/src/components/portal/PortalTabs.astro
+++ b/src/components/portal/PortalTabs.astro
@@ -77,7 +77,7 @@ function isActive(tab: TabDef, path: string): boolean {
 <!-- Desktop: horizontal burnt-orange-active tabs below the header. -->
 <nav
   aria-label="Portal sections"
-  class="hidden md:block sticky top-16 z-40 bg-[color:var(--color-background)] border-b-[3px] border-[color:var(--color-text-primary)]"
+  class="hidden md:block sticky top-16 z-40 bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="max-w-5xl mx-auto">
     <ul class="flex items-stretch" role="list">
@@ -85,12 +85,12 @@ function isActive(tab: TabDef, path: string): boolean {
         tabs.map((tab, i) => {
           const active = isActive(tab, pathname)
           const base =
-            "inline-flex items-baseline gap-2 px-5 py-3 min-h-[44px] font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+            "inline-flex items-baseline gap-2 px-5 py-3 min-h-[44px] font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
           const state = active
-            ? 'bg-[color:var(--color-primary)] text-[color:var(--color-background)]'
-            : 'bg-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-border-subtle)]'
+            ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
+            : 'bg-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)]'
           const isLast = i === tabs.length - 1
-          const divider = isLast ? '' : 'border-r-[2px] border-[color:var(--color-text-primary)]'
+          const divider = isLast ? '' : 'border-r-[2px] border-[color:var(--ss-color-text-primary)]'
           return (
             <li class={divider}>
               <a
@@ -100,7 +100,7 @@ function isActive(tab: TabDef, path: string): boolean {
               >
                 <span
                   aria-hidden="true"
-                  class={`font-mono text-xs tracking-[0.06em] ${active ? 'text-[color:var(--color-background)]' : 'text-[color:var(--color-primary)]'}`}
+                  class={`font-mono text-xs tracking-[0.06em] ${active ? 'text-[color:var(--ss-color-background)]' : 'text-[color:var(--ss-color-primary)]'}`}
                 >
                   § {tab.anchor}
                 </span>
@@ -117,17 +117,20 @@ function isActive(tab: TabDef, path: string): boolean {
 <!-- Mobile: fixed bottom bar, 3px ink top border, burnt-orange active tile. -->
 <nav
   aria-label="Portal sections"
-  class="md:hidden fixed bottom-0 inset-x-0 z-40 bg-[color:var(--color-background)] border-t-[3px] border-[color:var(--color-text-primary)] pb-[env(safe-area-inset-bottom)]"
+  class="md:hidden fixed bottom-0 inset-x-0 z-40 bg-[color:var(--ss-color-background)] border-t-[3px] border-[color:var(--ss-color-text-primary)] pb-[env(safe-area-inset-bottom)]"
 >
-  <ul class="grid grid-cols-4 divide-x-[2px] divide-[color:var(--color-text-primary)]" role="list">
+  <ul
+    class="grid grid-cols-4 divide-x-[2px] divide-[color:var(--ss-color-text-primary)]"
+    role="list"
+  >
     {
       tabs.map((tab) => {
         const active = isActive(tab, pathname)
         const base =
-          "flex flex-col items-center justify-center gap-0.5 py-2 min-h-[64px] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset"
+          "flex flex-col items-center justify-center gap-0.5 py-2 min-h-[64px] font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
         const state = active
-          ? 'bg-[color:var(--color-primary)] text-[color:var(--color-background)]'
-          : 'bg-transparent text-[color:var(--color-text-primary)] active:bg-[color:var(--color-border-subtle)]'
+          ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
+          : 'bg-transparent text-[color:var(--ss-color-text-primary)] active:bg-[color:var(--ss-color-border-subtle)]'
         return (
           <li>
             <a
@@ -137,7 +140,7 @@ function isActive(tab: TabDef, path: string): boolean {
             >
               <span
                 aria-hidden="true"
-                class={`font-mono text-[11px] leading-none tracking-[0.06em] ${active ? 'text-[color:var(--color-background)]' : 'text-[color:var(--color-primary)]'}`}
+                class={`font-mono text-[11px] leading-none tracking-[0.06em] ${active ? 'text-[color:var(--ss-color-background)]' : 'text-[color:var(--ss-color-primary)]'}`}
               >
                 § {tab.anchor}
               </span>

--- a/src/components/portal/QuoteDetail.astro
+++ b/src/components/portal/QuoteDetail.astro
@@ -86,7 +86,7 @@ const showSignButton = isSent
   <form method="POST" action="/api/auth/logout">
     <button
       type="submit"
-      class="text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] transition-colors"
+      class="text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] transition-colors"
     >
       Sign out
     </button>
@@ -100,7 +100,7 @@ const showSignButton = isSent
   <a
     href="/portal/quotes"
     aria-label="All proposals"
-    class="inline-flex items-center gap-2 min-h-11 -mx-2 px-2 mb-8 text-caption font-medium text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded-[var(--radius-card)] transition-colors"
+    class="inline-flex items-center gap-2 min-h-11 -mx-2 px-2 mb-8 text-caption font-medium text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded-[var(--ss-radius-card)] transition-colors"
   >
     <span class="material-symbols-outlined text-[18px]" aria-hidden="true">arrow_back</span>
     All proposals
@@ -112,13 +112,13 @@ const showSignButton = isSent
       <!-- Hero -->
       <div class="mb-section">
         <div class="flex items-center gap-row flex-wrap">
-          <p class="text-label uppercase text-[color:var(--color-meta)]">Proposal</p>
+          <p class="text-label uppercase text-[color:var(--ss-color-meta)]">Proposal</p>
           <StatusPill tone={statusTone} label={statusLabel} size="base" />
         </div>
-        <h1 class="mt-3 text-display text-[color:var(--color-text-primary)]">
+        <h1 class="mt-3 text-display text-[color:var(--ss-color-text-primary)]">
           {quote.engagementTitle}
         </h1>
-        <p class="mt-stack text-body-lg text-[color:var(--color-text-secondary)] max-w-xl">
+        <p class="mt-stack text-body-lg text-[color:var(--ss-color-text-secondary)] max-w-xl">
           {quote.engagementSubtitle}
         </p>
       </div>
@@ -126,16 +126,16 @@ const showSignButton = isSent
       <!-- Superseded banner (above action card on mobile, always visible) -->
       {
         isSuperseded && supersedingQuoteId && (
-          <div class="mb-section rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack">
-            <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
+          <div class="mb-section rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)]/30 bg-[color:var(--ss-color-attention)]/5 p-stack">
+            <p class="text-caption font-semibold text-[color:var(--ss-color-text-primary)]">
               A newer version is available.
             </p>
-            <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+            <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
               This proposal has been replaced by a newer version.
             </p>
             <a
               href={`/portal/quotes/${supersedingQuoteId}`}
-              class="mt-3 inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+              class="mt-3 inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
             >
               Go to the latest proposal
               <span class="material-symbols-outlined text-[16px]">arrow_forward</span>
@@ -147,16 +147,16 @@ const showSignButton = isSent
       <!-- Mobile action card (hidden on desktop — right rail handles it) -->
       <div class="lg:hidden mb-section">
         <div
-          class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card flex flex-col gap-stack"
+          class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card flex flex-col gap-stack"
         >
           {
             showPricingAction && (
               <div class="flex flex-col gap-row">
-                <p class="text-label uppercase text-[color:var(--color-text-secondary)]">
+                <p class="text-label uppercase text-[color:var(--ss-color-text-secondary)]">
                   Total engagement
                 </p>
                 <MoneyDisplay amountCents={quote.totalCents} size="display" />
-                <p class="text-caption text-[color:var(--color-text-secondary)]">
+                <p class="text-caption text-[color:var(--ss-color-text-secondary)]">
                   {quote.paymentSplitText}
                 </p>
               </div>
@@ -165,19 +165,19 @@ const showSignButton = isSent
 
           {
             isSigned ? (
-              <div class="flex items-start gap-row rounded-[var(--radius-card)] border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/10 p-stack">
+              <div class="flex items-start gap-row rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)]/30 bg-[color:var(--ss-color-complete)]/10 p-stack">
                 <span
-                  class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)] mt-0.5"
+                  class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-complete)] mt-0.5"
                   style="font-variation-settings: 'FILL' 1"
                 >
                   check_circle
                 </span>
                 <div class="min-w-0">
-                  <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
+                  <p class="text-caption font-semibold text-[color:var(--ss-color-text-primary)]">
                     Signed.
                   </p>
                   {nextStepText && (
-                    <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+                    <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
                       {nextStepText}
                     </p>
                   )}
@@ -185,24 +185,24 @@ const showSignButton = isSent
               </div>
             ) : isSuperseded ? (
               !supersedingQuoteId ? (
-                <p class="text-caption text-[color:var(--color-text-secondary)]">
+                <p class="text-caption text-[color:var(--ss-color-text-secondary)]">
                   This proposal has been replaced by a newer version.
                 </p>
               ) : null
             ) : isDeclined ? (
-              <p class="text-caption text-[color:var(--color-text-secondary)]">
+              <p class="text-caption text-[color:var(--ss-color-text-secondary)]">
                 This proposal was declined. Reach out to {consultant.firstName} if you'd like to
                 discuss next steps.
               </p>
             ) : isExpired ? (
-              <p class="text-caption text-[color:var(--color-text-secondary)]">
+              <p class="text-caption text-[color:var(--ss-color-text-secondary)]">
                 This proposal has expired. Contact {consultant.firstName} to request a revised
                 proposal.
               </p>
             ) : showSignButton ? (
               <a
                 href={signHref}
-                class="inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--radius-card)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                class="inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
               >
                 Review and sign
               </a>
@@ -213,7 +213,7 @@ const showSignButton = isSent
             pdfHref && (
               <a
                 href={pdfHref}
-                class="inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)] transition-colors"
+                class="inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)] transition-colors"
               >
                 View the full PDF
                 <span class="material-symbols-outlined text-[16px]">arrow_forward</span>
@@ -228,23 +228,25 @@ const showSignButton = isSent
         <!-- What you'll get -->
         {
           quote.deliverables.length > 0 && (
-            <section class="border-t border-[color:var(--color-border)] pt-section">
-              <h2 class="text-title text-[color:var(--color-text-primary)] mb-card">
+            <section class="border-t border-[color:var(--ss-color-border)] pt-section">
+              <h2 class="text-title text-[color:var(--ss-color-text-primary)] mb-card">
                 What you'll get
               </h2>
               <ul class="space-y-card">
                 {quote.deliverables.map((d) => (
                   <li class="flex items-start gap-stack">
                     <span
-                      class="material-symbols-outlined text-[color:var(--color-complete)] mt-0.5"
+                      class="material-symbols-outlined text-[color:var(--ss-color-complete)] mt-0.5"
                       style="font-variation-settings: 'FILL' 1"
                     >
                       check_circle
                     </span>
                     <div class="min-w-0">
-                      <h3 class="text-heading text-[color:var(--color-text-primary)]">{d.title}</h3>
+                      <h3 class="text-heading text-[color:var(--ss-color-text-primary)]">
+                        {d.title}
+                      </h3>
                       {d.body && (
-                        <p class="mt-1 text-body text-[color:var(--color-text-secondary)]">
+                        <p class="mt-1 text-body text-[color:var(--ss-color-text-secondary)]">
                           {d.body}
                         </p>
                       )}
@@ -259,17 +261,17 @@ const showSignButton = isSent
         <!-- How we'll work -->
         {
           quote.schedule.length > 0 && (
-            <section class="border-t border-[color:var(--color-border)] pt-section">
-              <h2 class="text-title text-[color:var(--color-text-primary)] mb-card">
+            <section class="border-t border-[color:var(--ss-color-border)] pt-section">
+              <h2 class="text-title text-[color:var(--ss-color-text-primary)] mb-card">
                 How we'll work
               </h2>
               <div class="space-y-stack">
                 {quote.schedule.map((row) => (
                   <div class="flex items-baseline gap-card">
-                    <span class="w-[96px] shrink-0 text-label uppercase text-[color:var(--color-text-secondary)]">
+                    <span class="w-[96px] shrink-0 text-label uppercase text-[color:var(--ss-color-text-secondary)]">
                       {row.label}
                     </span>
-                    <p class="flex-1 text-body text-[color:var(--color-text-secondary)]">
+                    <p class="flex-1 text-body text-[color:var(--ss-color-text-secondary)]">
                       {row.body}
                     </p>
                   </div>
@@ -282,14 +284,14 @@ const showSignButton = isSent
         <!-- Terms (isSent only — active proposal where pricing is still a decision) -->
         {
           isSent && (
-            <section class="border-t border-[color:var(--color-border)] pt-section">
-              <h2 class="text-title text-[color:var(--color-text-primary)] mb-card">Terms</h2>
-              <div class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card space-y-row">
-                <p class="text-body text-[color:var(--color-text-primary)]">
+            <section class="border-t border-[color:var(--ss-color-border)] pt-section">
+              <h2 class="text-title text-[color:var(--ss-color-text-primary)] mb-card">Terms</h2>
+              <div class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-row">
+                <p class="text-body text-[color:var(--ss-color-text-primary)]">
                   <span class="font-semibold">Total:</span>{' '}
                   <MoneyDisplay amountCents={quote.totalCents} size="body" emphasize />
                 </p>
-                <p class="text-body text-[color:var(--color-text-secondary)]">
+                <p class="text-body text-[color:var(--ss-color-text-secondary)]">
                   {quote.paymentSplitText}
                 </p>
               </div>
@@ -298,7 +300,7 @@ const showSignButton = isSent
         }
 
         <!-- Consultant block (mobile — desktop handled in right rail) -->
-        <section class="lg:hidden border-t border-[color:var(--color-border)] pt-section">
+        <section class="lg:hidden border-t border-[color:var(--ss-color-border)] pt-section">
           <ConsultantBlock
             name={consultant.name}
             photoUrl={consultant.photoUrl}
@@ -307,7 +309,7 @@ const showSignButton = isSent
           />
           {
             consultantFirstName && (
-              <p class="mt-stack text-caption text-[color:var(--color-text-muted)]">
+              <p class="mt-stack text-caption text-[color:var(--ss-color-text-muted)]">
                 Questions? Reach us using the contacts in the header.
               </p>
             )
@@ -317,17 +319,17 @@ const showSignButton = isSent
         <!-- Contact link for terminal states (declined / expired) — mobile -->
         {
           (isDeclined || isExpired) && consultantPhone && (
-            <div class="lg:hidden border-t border-[color:var(--color-border)] pt-section">
+            <div class="lg:hidden border-t border-[color:var(--ss-color-border)] pt-section">
               <a
                 href={`sms:${consultant.phone!.replace(/[^+\d]/g, '')}`}
-                class="inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                class="inline-flex sm:hidden items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
               >
                 <span class="material-symbols-outlined text-[18px]">sms</span>
                 Text the team
               </a>
               <a
                 href={`tel:${consultant.phone!.replace(/[^+\d]/g, '')}`}
-                class="hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                class="hidden sm:inline-flex items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
               >
                 <span class="material-symbols-outlined text-[18px]">call</span>
                 Contact {consultantFirstName}
@@ -343,13 +345,13 @@ const showSignButton = isSent
       <div class="sticky top-8 space-y-card">
         <!-- Action / status card -->
         <div
-          class="bg-[color:var(--color-surface)] rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+          class="bg-[color:var(--ss-color-surface)] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
         >
           {
             showPricingAction ? (
               <div>
                 <MoneyDisplay amountCents={quote.totalCents} size="display" />
-                <p class="mt-2 text-body text-[color:var(--color-text-secondary)]">
+                <p class="mt-2 text-body text-[color:var(--ss-color-text-secondary)]">
                   {quote.paymentSplitText}
                 </p>
               </div>
@@ -359,19 +361,19 @@ const showSignButton = isSent
           {
             isSigned ? (
               <div class={showPricingAction ? 'mt-card' : ''}>
-                <div class="flex items-start gap-row rounded-[var(--radius-card)] border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/10 p-stack">
+                <div class="flex items-start gap-row rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)]/30 bg-[color:var(--ss-color-complete)]/10 p-stack">
                   <span
-                    class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)] mt-0.5"
+                    class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-complete)] mt-0.5"
                     style="font-variation-settings: 'FILL' 1"
                   >
                     check_circle
                   </span>
                   <div class="min-w-0">
-                    <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
+                    <p class="text-caption font-semibold text-[color:var(--ss-color-text-primary)]">
                       Signed.
                     </p>
                     {nextStepText && (
-                      <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+                      <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
                         {nextStepText}
                       </p>
                     )}
@@ -379,14 +381,14 @@ const showSignButton = isSent
                 </div>
               </div>
             ) : isSuperseded ? (
-              <div class="rounded-[var(--radius-card)] border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack">
-                <p class="text-caption font-semibold text-[color:var(--color-text-primary)]">
+              <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)]/30 bg-[color:var(--ss-color-attention)]/5 p-stack">
+                <p class="text-caption font-semibold text-[color:var(--ss-color-text-primary)]">
                   A revised version is available.
                 </p>
                 {supersedingQuoteId && (
                   <a
                     href={`/portal/quotes/${supersedingQuoteId}`}
-                    class="mt-3 inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                    class="mt-3 inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
                   >
                     Go to the latest proposal
                     <span class="material-symbols-outlined text-[16px]">arrow_forward</span>
@@ -395,13 +397,13 @@ const showSignButton = isSent
               </div>
             ) : isDeclined ? (
               <div>
-                <p class="text-caption text-[color:var(--color-text-secondary)]">
+                <p class="text-caption text-[color:var(--ss-color-text-secondary)]">
                   This proposal was declined.
                 </p>
                 {consultant.phone && (
                   <a
                     href={`tel:${consultant.phone.replace(/[^+\d]/g, '')}`}
-                    class="mt-stack inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                    class="mt-stack inline-flex items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
                   >
                     <span class="material-symbols-outlined text-[18px]">call</span>
                     Contact {consultantFirstName}
@@ -410,13 +412,13 @@ const showSignButton = isSent
               </div>
             ) : isExpired ? (
               <div>
-                <p class="text-caption text-[color:var(--color-text-secondary)]">
+                <p class="text-caption text-[color:var(--ss-color-text-secondary)]">
                   This proposal has expired.
                 </p>
                 {consultant.phone && (
                   <a
                     href={`tel:${consultant.phone.replace(/[^+\d]/g, '')}`}
-                    class="mt-stack inline-flex items-center gap-2 text-sm font-medium text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                    class="mt-stack inline-flex items-center gap-2 text-sm font-medium text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
                   >
                     <span class="material-symbols-outlined text-[18px]">call</span>
                     Contact {consultantFirstName}
@@ -426,7 +428,7 @@ const showSignButton = isSent
             ) : showSignButton ? (
               <a
                 href={signHref}
-                class="mt-card inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--radius-card)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                class="mt-card inline-flex w-full items-center justify-center min-h-[44px] px-6 py-3 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white text-body font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
               >
                 Review and sign
               </a>
@@ -437,7 +439,7 @@ const showSignButton = isSent
             pdfHref && (
               <a
                 href={pdfHref}
-                class="mt-stack inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)] transition-colors"
+                class="mt-stack inline-flex items-center gap-1.5 text-caption font-semibold text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)] transition-colors"
               >
                 View the full PDF
                 <span class="material-symbols-outlined text-[16px]">arrow_forward</span>
@@ -455,7 +457,7 @@ const showSignButton = isSent
         />
         {
           consultantFirstName && (
-            <p class="text-caption text-[color:var(--color-text-muted)] px-1">
+            <p class="text-caption text-[color:var(--ss-color-text-muted)] px-1">
               Questions? Reach us using the contacts in the header.
             </p>
           )

--- a/src/components/portal/QuoteList.astro
+++ b/src/components/portal/QuoteList.astro
@@ -37,11 +37,11 @@ const { client, quotes } = Astro.props
 <PortalTabs pathname="/portal/quotes" />
 
 <main id="main" role="main" class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-24 md:pb-10">
-  <h1 class="text-display text-[color:var(--color-text-primary)] mb-section">Proposals</h1>
+  <h1 class="text-display text-[color:var(--ss-color-text-primary)] mb-section">Proposals</h1>
 
   {
     quotes.length === 0 ? (
-      <p class="text-caption text-[color:var(--color-text-muted)]">No proposals yet.</p>
+      <p class="text-caption text-[color:var(--ss-color-text-muted)]">No proposals yet.</p>
     ) : (
       <ul class="space-y-row" role="list">
         {quotes.map((quote) => (

--- a/src/components/portal/StatusPill.astro
+++ b/src/components/portal/StatusPill.astro
@@ -35,7 +35,7 @@ const toneClass = TONE_CLASS[tone]
 ---
 
 <span
-  class={`inline-flex items-center font-mono uppercase tracking-[var(--text-label--letter-spacing)] font-semibold rounded-[var(--radius-badge)] whitespace-nowrap ${sizeClass} ${toneClass} ${klass}`}
+  class={`inline-flex items-center font-mono uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold rounded-[var(--ss-radius-badge)] whitespace-nowrap ${sizeClass} ${toneClass} ${klass}`}
 >
   {label}
 </span>

--- a/src/components/portal/TimelineEntry.astro
+++ b/src/components/portal/TimelineEntry.astro
@@ -43,18 +43,18 @@ const {
 <div class="flex flex-col gap-row">
   <div class="flex items-baseline gap-stack">
     <span
-      class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold tabular-nums text-[color:var(--color-primary)]"
+      class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold tabular-nums text-[color:var(--ss-color-primary)]"
       >{date}</span
     >
     {
       actor && (
-        <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-primary)]">
+        <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-primary)]">
           · {actor}
         </span>
       )
     }
   </div>
-  <p class="text-body text-[color:var(--color-text-primary)] leading-[1.55]">{body}</p>
+  <p class="text-body text-[color:var(--ss-color-text-primary)] leading-[1.55]">{body}</p>
   {
     artifactLabel && artifactHref && (
       <div class="mt-row">

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -60,22 +60,22 @@ const navItems = [
     <title>{title}</title>
   </head>
   <body
-    class="min-h-screen bg-[color:var(--color-background)] text-[color:var(--color-text-primary)]"
+    class="min-h-screen bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)]"
   >
     <SkipToMain />
     <header
       role="banner"
-      class="sticky top-0 z-50 h-14 md:h-16 bg-[color:var(--color-background)] border-b-[3px] border-[color:var(--color-text-primary)]"
+      class="sticky top-0 z-50 h-14 md:h-16 bg-[color:var(--ss-color-background)] border-b-[3px] border-[color:var(--ss-color-text-primary)]"
     >
       <div class={`${maxWidth} mx-auto h-full px-4 md:px-6 flex items-center justify-between`}>
         <div class="flex items-center gap-3">
           <a
             href="/admin"
-            class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 transition-colors"
+            class="font-['Archivo'] text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
             >SMD Services</a
           >
           <span
-            class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] border border-[color:var(--color-text-primary)] px-2 py-0.5 text-[color:var(--color-text-primary)]"
+            class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] border border-[color:var(--ss-color-text-primary)] px-2 py-0.5 text-[color:var(--ss-color-text-primary)]"
             >Admin</span
           >
         </div>
@@ -91,10 +91,10 @@ const navItems = [
                     href={item.href}
                     aria-current={active ? 'page' : undefined}
                     class:list={[
-                      "inline-flex items-center min-h-11 px-2 -mx-2 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2",
+                      "inline-flex items-center min-h-11 px-2 -mx-2 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2",
                       active
-                        ? 'text-[color:var(--color-primary)] border-b-2 border-[color:var(--color-primary)]'
-                        : 'text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)]',
+                        ? 'text-[color:var(--ss-color-primary)] border-b-2 border-[color:var(--ss-color-primary)]'
+                        : 'text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)]',
                     ]}
                   >
                     {item.label}
@@ -103,12 +103,12 @@ const navItems = [
               })
             }
           </nav>
-          <span class="text-sm text-[color:var(--color-text-muted)]" aria-hidden="true">|</span>
-          <span class="text-sm text-[color:var(--color-text-secondary)]">{session.email}</span>
+          <span class="text-sm text-[color:var(--ss-color-text-muted)]" aria-hidden="true">|</span>
+          <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{session.email}</span>
           <form method="POST" action="/api/auth/logout">
             <button
               type="submit"
-              class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+              class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
             >
               Sign out
             </button>
@@ -119,12 +119,12 @@ const navItems = [
         <details class="relative md:hidden">
           <summary
             aria-label="Open menu"
-            class="list-none w-11 h-11 flex items-center justify-center rounded-[var(--radius-card)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border-subtle)] active:bg-[color:var(--color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 cursor-pointer"
+            class="list-none w-11 h-11 flex items-center justify-center rounded-[var(--ss-radius-card)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border-subtle)] active:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 cursor-pointer"
           >
             <span class="material-symbols-outlined" aria-hidden="true">menu</span>
           </summary>
           <div
-            class="absolute right-0 top-12 w-64 bg-[color:var(--color-background)] border-[3px] border-[color:var(--color-text-primary)] p-2 z-50"
+            class="absolute right-0 top-12 w-64 bg-[color:var(--ss-color-background)] border-[3px] border-[color:var(--ss-color-text-primary)] p-2 z-50"
           >
             <nav aria-label="Primary" class="flex flex-col">
               {
@@ -135,10 +135,10 @@ const navItems = [
                       href={item.href}
                       aria-current={active ? 'page' : undefined}
                       class:list={[
-                        'block px-3 py-2.5 text-sm rounded hover:bg-[color:var(--color-border-subtle)] active:bg-[color:var(--color-border-subtle)]',
+                        'block px-3 py-2.5 text-sm rounded hover:bg-[color:var(--ss-color-border-subtle)] active:bg-[color:var(--ss-color-border-subtle)]',
                         active
-                          ? 'text-[color:var(--color-primary)] font-medium'
-                          : 'text-[color:var(--color-text-primary)]',
+                          ? 'text-[color:var(--ss-color-primary)] font-medium'
+                          : 'text-[color:var(--ss-color-text-primary)]',
                       ]}
                     >
                       {item.label}
@@ -147,14 +147,14 @@ const navItems = [
                 })
               }
             </nav>
-            <hr class="my-2 border-[color:var(--color-border)]" />
-            <p class="px-3 py-1.5 text-xs text-[color:var(--color-text-secondary)] break-all">
+            <hr class="my-2 border-[color:var(--ss-color-border)]" />
+            <p class="px-3 py-1.5 text-xs text-[color:var(--ss-color-text-secondary)] break-all">
               {session.email}
             </p>
             <form method="POST" action="/api/auth/logout">
               <button
                 type="submit"
-                class="w-full text-left px-3 py-2.5 text-sm text-[color:var(--color-text-primary)] rounded hover:bg-[color:var(--color-border-subtle)] active:bg-[color:var(--color-border-subtle)]"
+                class="w-full text-left px-3 py-2.5 text-sm text-[color:var(--ss-color-text-primary)] rounded hover:bg-[color:var(--ss-color-border-subtle)] active:bg-[color:var(--ss-color-border-subtle)]"
               >
                 Sign out
               </button>
@@ -168,12 +168,12 @@ const navItems = [
       {
         breadcrumbs.length > 0 && (
           <nav aria-label="Breadcrumb" class="mb-4">
-            <ol class="flex flex-wrap items-center gap-1 text-sm text-[color:var(--color-text-secondary)]">
+            <ol class="flex flex-wrap items-center gap-1 text-sm text-[color:var(--ss-color-text-secondary)]">
               {breadcrumbs.map((crumb, i) => (
                 <>
                   {i > 0 && (
                     <li aria-hidden="true" class="flex items-center">
-                      <span class="material-symbols-outlined text-base text-[color:var(--color-text-muted)]">
+                      <span class="material-symbols-outlined text-base text-[color:var(--ss-color-text-muted)]">
                         chevron_right
                       </span>
                     </li>
@@ -182,14 +182,14 @@ const navItems = [
                     {crumb.href ? (
                       <a
                         href={crumb.href}
-                        class="hover:text-[color:var(--color-primary)] active:text-[color:var(--color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+                        class="hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
                       >
                         {crumb.label}
                       </a>
                     ) : (
                       <span
                         aria-current="page"
-                        class="text-[color:var(--color-text-primary)] font-medium"
+                        class="text-[color:var(--ss-color-text-primary)] font-medium"
                       >
                         {crumb.label}
                       </span>

--- a/src/lib/db/lost-reasons.ts
+++ b/src/lib/db/lost-reasons.ts
@@ -110,9 +110,9 @@ export function lostReasonChipClass(code: string | null | undefined): string {
     case 'wrong-contact':
       return 'bg-purple-100 text-purple-700'
     case 'other':
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
     default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 

--- a/src/lib/portal/status.ts
+++ b/src/lib/portal/status.ts
@@ -3,7 +3,7 @@
  *
  * Source of truth for status rendering on all portal surfaces. Admin uses
  * src/lib/ui/status-badge.ts (raw Tailwind hex-family classes); portal uses
- * this module (semantic var(--color-*) tokens). They remain separate by
+ * this module (semantic var(--ss-color-*) tokens). They remain separate by
  * design — the portal is the drift surface and stays tone-based.
  *
  * Contract (UI-PATTERNS.md R7):
@@ -268,14 +268,14 @@ export function resolveMilestoneStampLabel(status: string): StampLabel {
  * internal states (draft, superseded) that rarely surface to the client.
  */
 export const TONE_CLASS: Record<Tone, string> = {
-  info: 'bg-[color:var(--color-primary)] text-white',
-  success: 'bg-[color:var(--color-complete)] text-white',
-  danger: 'bg-[color:var(--color-error)] text-white',
-  warning: 'bg-[color:var(--color-attention)] text-white',
-  neutral: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+  info: 'bg-[color:var(--ss-color-primary)] text-white',
+  success: 'bg-[color:var(--ss-color-complete)] text-white',
+  danger: 'bg-[color:var(--ss-color-error)] text-white',
+  warning: 'bg-[color:var(--ss-color-attention)] text-white',
+  neutral: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
   // Plainspoken bill-of-lading register: box-outlined stamp with ink text,
   // transparent background. Visually distinguishes archived/expired states
   // from the filled "attention-needed" tones above.
   outline:
-    'bg-transparent text-[color:var(--color-text-primary)] border-2 border-[color:var(--color-text-primary)]',
+    'bg-transparent text-[color:var(--ss-color-text-primary)] border-2 border-[color:var(--ss-color-text-primary)]',
 }

--- a/src/lib/ui/admin-action-button.ts
+++ b/src/lib/ui/admin-action-button.ts
@@ -21,14 +21,15 @@
 export type AdminActionVariant = 'primary' | 'destructive' | 'ghost'
 
 const STRUCTURE =
-  'inline-flex items-center text-xs px-3 py-1.5 rounded-[var(--radius-card)] transition-colors cursor-pointer select-none'
+  'inline-flex items-center text-xs px-3 py-1.5 rounded-[var(--ss-radius-card)] transition-colors cursor-pointer select-none'
 
 const TONE: Record<AdminActionVariant, string> = {
-  primary: 'bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)]',
+  primary:
+    'bg-[color:var(--ss-color-primary)] text-white hover:bg-[color:var(--ss-color-primary-hover)]',
   destructive:
-    'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-red-50 hover:text-[color:var(--color-error)]',
+    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-red-50 hover:text-[color:var(--ss-color-error)]',
   ghost:
-    'bg-white border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]',
+    'bg-white border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)]',
 }
 
 export function adminActionButtonClass(variant: AdminActionVariant): string {

--- a/src/lib/ui/pipeline-badge.ts
+++ b/src/lib/ui/pipeline-badge.ts
@@ -23,7 +23,8 @@ const TONE: Record<string, string> = {
   website_intake: 'bg-teal-100 text-teal-700',
 }
 
-const FALLBACK = 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+const FALLBACK =
+  'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
 
 export function pipelineBadgeClass(pipeline: string): string {
   return `${STRUCTURE} ${TONE[pipeline] ?? FALLBACK}`

--- a/src/lib/ui/status-badge.ts
+++ b/src/lib/ui/status-badge.ts
@@ -13,37 +13,37 @@
  */
 
 const STRUCTURE =
-  'inline-flex items-center px-2 py-1 rounded-[var(--radius-badge)] ' +
-  'font-mono text-label uppercase tracking-[var(--text-label--letter-spacing)] font-semibold whitespace-nowrap'
+  'inline-flex items-center px-2 py-1 rounded-[var(--ss-radius-badge)] ' +
+  'font-mono text-label uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold whitespace-nowrap'
 
 const TONE: Record<string, string> = {
   // Engagement lifecycle
-  scheduled: 'bg-[color:var(--color-primary)] text-white',
-  active: 'bg-[color:var(--color-complete)] text-white',
-  completed: 'bg-[color:var(--color-complete)] text-white',
-  handoff: 'bg-[color:var(--color-primary)] text-white',
-  safety_net: 'bg-[color:var(--color-attention)] text-white',
-  cancelled: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+  scheduled: 'bg-[color:var(--ss-color-primary)] text-white',
+  active: 'bg-[color:var(--ss-color-complete)] text-white',
+  completed: 'bg-[color:var(--ss-color-complete)] text-white',
+  handoff: 'bg-[color:var(--ss-color-primary)] text-white',
+  safety_net: 'bg-[color:var(--ss-color-attention)] text-white',
+  cancelled: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
 
   // Lead lifecycle
-  disqualified: 'bg-[color:var(--color-error)] text-white',
-  converted: 'bg-[color:var(--color-complete)] text-white',
+  disqualified: 'bg-[color:var(--ss-color-error)] text-white',
+  converted: 'bg-[color:var(--ss-color-complete)] text-white',
 
   // Quote lifecycle
-  draft: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
-  sent: 'bg-[color:var(--color-primary)] text-white',
-  accepted: 'bg-[color:var(--color-complete)] text-white',
-  declined: 'bg-[color:var(--color-error)] text-white',
-  expired: 'bg-[color:var(--color-attention)] text-white',
-  superseded: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+  draft: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
+  sent: 'bg-[color:var(--ss-color-primary)] text-white',
+  accepted: 'bg-[color:var(--ss-color-complete)] text-white',
+  declined: 'bg-[color:var(--ss-color-error)] text-white',
+  expired: 'bg-[color:var(--ss-color-attention)] text-white',
+  superseded: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
 
   // Invoice lifecycle
-  paid: 'bg-[color:var(--color-complete)] text-white',
-  overdue: 'bg-[color:var(--color-error)] text-white',
-  void: 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]',
+  paid: 'bg-[color:var(--ss-color-complete)] text-white',
+  overdue: 'bg-[color:var(--ss-color-error)] text-white',
+  void: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
 }
 
-const FALLBACK = 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
+const FALLBACK = 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'
 
 export function statusBadgeClass(status: string): string {
   return `${STRUCTURE} ${TONE[status] ?? FALLBACK}`

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -18,8 +18,8 @@ import Footer from '../components/Footer.astro'
 <Base title="Page Not Found | SMD Services">
   <Nav />
   <main id="main" role="main" class="mx-auto max-w-4xl px-4 py-16 text-center">
-    <h1 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Page not found</h1>
-    <p class="mt-4 text-lg text-[color:var(--color-text-secondary)]">
+    <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)]">Page not found</h1>
+    <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
       The page you're looking for doesn't exist.
     </p>
     <a href="/" class="mt-8 inline-block text-sm font-medium text-primary hover:text-primary/80">

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -188,27 +188,27 @@ function complianceBarWidth(pct: number): string {
   title="Analytics — SMD Services"
   breadcrumbs={[{ label: 'Dashboard', href: '/admin' }, { label: 'Analytics' }]}
 >
-  <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)] mb-6">Analytics</h2>
+  <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)] mb-6">Analytics</h2>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-card">
     {/* ── Pipeline Funnel ──────────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Pipeline Funnel
       </h3>
       {
         totalClients === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No clients yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No clients yet.</p>
         ) : (
           <div class="space-y-row">
             {pipelineStages.map((stage) => (
               <div class="flex items-center gap-row">
-                <span class="text-sm text-[color:var(--color-text-secondary)] w-24 shrink-0">
+                <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-24 shrink-0">
                   {stage.label}
                 </span>
-                <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-6 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-6 overflow-hidden">
                   <div
                     class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
                     style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
@@ -221,11 +221,13 @@ function complianceBarWidth(pct: number): string {
                   </div>
                 </div>
                 {pipeline[stage.key] === 0 && (
-                  <span class="text-xs text-[color:var(--color-text-muted)] w-6 text-right">0</span>
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)] w-6 text-right">
+                    0
+                  </span>
                 )}
               </div>
             ))}
-            <p class="text-xs text-[color:var(--color-text-muted)] mt-2 pt-2 border-t border-[color:var(--color-border-subtle)]">
+            <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-2 pt-2 border-t border-[color:var(--ss-color-border-subtle)]">
               Total clients: {totalClients.toLocaleString()}
             </p>
           </div>
@@ -235,56 +237,58 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Engagement Health ────────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Engagement Health
       </h3>
       {
         health.total_engagements === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
             No completed engagements yet.
           </p>
         ) : (
           <div class="space-y-stack">
             <div class="grid grid-cols-2 gap-stack">
               <div>
-                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+                <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                   {health.avg_days_to_completion.toLocaleString()}
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">
                   Avg days to completion
                 </p>
               </div>
               <div>
-                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+                <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                   {health.total_engagements.toLocaleString()}
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">
                   Completed engagements
                 </p>
               </div>
               <div>
-                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+                <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                   {health.avg_parking_lot_items.toLocaleString()}
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">
                   Avg parking lot items
                 </p>
               </div>
               <div>
-                <p class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+                <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                   {health.on_time_pct}%
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">On-time completion</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                  On-time completion
+                </p>
               </div>
             </div>
             <div>
-              <div class="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)] mb-1">
+              <div class="flex items-center justify-between text-xs text-[color:var(--ss-color-text-secondary)] mb-1">
                 <span>On-time rate</span>
                 <span>{health.on_time_pct}%</span>
               </div>
-              <div class="bg-[color:var(--color-border-subtle)] rounded-full h-3 overflow-hidden">
+              <div class="bg-[color:var(--ss-color-border-subtle)] rounded-full h-3 overflow-hidden">
                 <div
                   class="h-full rounded-full bg-emerald-500"
                   style={`width: ${complianceBarWidth(health.on_time_pct)}`}
@@ -298,45 +302,45 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Revenue Summary ─────────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Revenue Summary
       </h3>
       {
         revenue.total_revenue === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No invoices yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No invoices yet.</p>
         ) : (
           <div class="space-y-stack">
             <div class="grid grid-cols-3 gap-stack">
               <div>
-                <p class="text-lg font-bold text-[color:var(--color-text-primary)]">
+                <p class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">
                   {formatCurrency(revenue.total_invoiced)}
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">Total invoiced</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total invoiced</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-green-700">{formatCurrency(revenue.total_paid)}</p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">Total paid</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total paid</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-amber-700">{formatCurrency(outstanding)}</p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">Outstanding</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Outstanding</p>
               </div>
             </div>
 
             {revenue.by_month.length > 0 && (
               <div>
-                <h4 class="text-sm font-medium text-[color:var(--color-text-primary)] mb-2">
+                <h4 class="text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-2">
                   Monthly Revenue
                 </h4>
                 <div class="space-y-2">
                   {revenue.by_month.map((m) => (
                     <div class="flex items-center gap-row">
-                      <span class="text-xs text-[color:var(--color-text-secondary)] w-20 shrink-0">
+                      <span class="text-xs text-[color:var(--ss-color-text-secondary)] w-20 shrink-0">
                         {formatMonthLabel(m.month)}
                       </span>
-                      <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-5 overflow-hidden">
+                      <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
                         <div
                           class="h-full rounded-full bg-green-500 flex items-center justify-end pr-2"
                           style={`width: ${revenueBarWidth(m.amount)}`}
@@ -356,16 +360,16 @@ function complianceBarWidth(pct: number): string {
 
             {revenue.by_vertical.length > 0 && (
               <div>
-                <h4 class="text-sm font-medium text-[color:var(--color-text-primary)] mb-2">
+                <h4 class="text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-2">
                   Revenue by Vertical
                 </h4>
                 <div class="space-y-1">
                   {revenue.by_vertical.map((v) => (
                     <div class="flex items-center justify-between text-sm">
-                      <span class="text-[color:var(--color-text-secondary)]">
+                      <span class="text-[color:var(--ss-color-text-secondary)]">
                         {getVerticalLabel(v.vertical)}
                       </span>
-                      <span class="font-medium text-[color:var(--color-text-primary)]">
+                      <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                         {formatCurrency(v.amount)}
                       </span>
                     </div>
@@ -380,53 +384,53 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Follow-up Compliance ────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Follow-up Compliance
       </h3>
       {
         compliance.total === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No follow-ups yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No follow-ups yet.</p>
         ) : (
           <div class="space-y-stack">
             <div class="text-center">
-              <p class="text-4xl font-bold text-[color:var(--color-text-primary)]">
+              <p class="text-4xl font-bold text-[color:var(--ss-color-text-primary)]">
                 {compliance.compliance_pct}%
               </p>
-              <p class="text-sm text-[color:var(--color-text-secondary)]">Compliance rate</p>
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Compliance rate</p>
             </div>
             <div class="grid grid-cols-3 gap-stack text-center">
               <div>
                 <p class="text-lg font-bold text-green-700">
                   {compliance.completed_on_time.toLocaleString()}
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">On time</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">On time</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-amber-700">
                   {compliance.completed_late.toLocaleString()}
                 </p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">Late</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Late</p>
               </div>
               <div>
                 <p class="text-lg font-bold text-red-700">{compliance.missed.toLocaleString()}</p>
-                <p class="text-xs text-[color:var(--color-text-secondary)]">Missed</p>
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Missed</p>
               </div>
             </div>
             <div>
-              <div class="flex items-center justify-between text-xs text-[color:var(--color-text-secondary)] mb-1">
+              <div class="flex items-center justify-between text-xs text-[color:var(--ss-color-text-secondary)] mb-1">
                 <span>Compliance</span>
                 <span>{compliance.compliance_pct}%</span>
               </div>
-              <div class="bg-[color:var(--color-border-subtle)] rounded-full h-3 overflow-hidden">
+              <div class="bg-[color:var(--ss-color-border-subtle)] rounded-full h-3 overflow-hidden">
                 <div
                   class="h-full rounded-full bg-green-500"
                   style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
                 />
               </div>
             </div>
-            <p class="text-xs text-[color:var(--color-text-muted)] pt-2 border-t border-[color:var(--color-border-subtle)]">
+            <p class="text-xs text-[color:var(--ss-color-text-muted)] pt-2 border-t border-[color:var(--ss-color-border-subtle)]">
               Total follow-ups: {compliance.total.toLocaleString()}
             </p>
           </div>
@@ -436,21 +440,21 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Quote Accuracy ──────────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card md:col-span-2"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card md:col-span-2"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Quote Accuracy
       </h3>
       {
         quoteAccuracy.length === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
             No completed engagements yet.
           </p>
         ) : (
           <div class="overflow-x-auto">
             <table class="w-full text-sm">
               <thead>
-                <tr class="text-left text-xs text-[color:var(--color-text-secondary)] border-b border-[color:var(--color-border)]">
+                <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
                   <th class="pb-2 font-medium">Client</th>
                   <th class="pb-2 font-medium text-right">Estimated</th>
                   <th class="pb-2 font-medium text-right">Actual</th>
@@ -458,7 +462,7 @@ function complianceBarWidth(pct: number): string {
                   <th class="pb-2 font-medium text-right">Accuracy</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-[color:var(--color-border-subtle)]">
+              <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
                 {quoteAccuracy.map((row) => {
                   const variance = row.actual_hours - row.estimated_hours
                   const varianceStr =
@@ -467,14 +471,16 @@ function complianceBarWidth(pct: number): string {
                       : `${variance.toLocaleString()}h`
                   return (
                     <tr>
-                      <td class="py-2 text-[color:var(--color-text-primary)]">{row.client_name}</td>
-                      <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
+                      <td class="py-2 text-[color:var(--ss-color-text-primary)]">
+                        {row.client_name}
+                      </td>
+                      <td class="py-2 text-right text-[color:var(--ss-color-text-secondary)]">
                         {row.estimated_hours.toLocaleString()}h
                       </td>
-                      <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
+                      <td class="py-2 text-right text-[color:var(--ss-color-text-secondary)]">
                         {row.actual_hours.toLocaleString()}h
                       </td>
-                      <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
+                      <td class="py-2 text-right text-[color:var(--ss-color-text-secondary)]">
                         {varianceStr}
                       </td>
                       <td class="py-2 text-right">
@@ -489,16 +495,16 @@ function complianceBarWidth(pct: number): string {
                 })}
               </tbody>
               <tfoot>
-                <tr class="border-t border-[color:var(--color-border)] font-medium">
-                  <td class="py-2 text-[color:var(--color-text-primary)]">Average</td>
-                  <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
+                <tr class="border-t border-[color:var(--ss-color-border)] font-medium">
+                  <td class="py-2 text-[color:var(--ss-color-text-primary)]">Average</td>
+                  <td class="py-2 text-right text-[color:var(--ss-color-text-secondary)]">
                     {Math.round(
                       quoteAccuracy.reduce((s, r) => s + r.estimated_hours, 0) /
                         quoteAccuracy.length
                     ).toLocaleString()}
                     h
                   </td>
-                  <td class="py-2 text-right text-[color:var(--color-text-secondary)]">
+                  <td class="py-2 text-right text-[color:var(--ss-color-text-secondary)]">
                     {Math.round(
                       quoteAccuracy.reduce((s, r) => s + r.actual_hours, 0) / quoteAccuracy.length
                     ).toLocaleString()}
@@ -522,28 +528,30 @@ function complianceBarWidth(pct: number): string {
   </div>
 
   {/* ── Site Traffic ─────────────────────────────────────── */}
-  <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mt-10 mb-4">
+  <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mt-10 mb-4">
     Site Traffic
   </h3>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-card">
     {/* ── Top pages (7d) ────────────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">Top Pages</h3>
-      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">Last 7 days, by page views</p>
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
+        Top Pages
+      </h3>
+      <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-4">Last 7 days, by page views</p>
       {
         topPaths.length === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No page views yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No page views yet.</p>
         ) : (
           <div class="space-y-2">
             {topPaths.map((row) => (
               <div class="flex items-center gap-row">
-                <span class="text-sm text-[color:var(--color-text-secondary)] w-36 shrink-0 truncate font-mono">
+                <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-36 shrink-0 truncate font-mono">
                   {row.path}
                 </span>
-                <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-5 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
                   <div
                     class="h-full rounded-full bg-blue-500 flex items-center justify-end pr-2"
                     style={`width: ${pathBarWidth(row.views)}`}
@@ -564,21 +572,25 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Top CTAs (7d) ─────────────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">Top CTAs</h3>
-      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">Last 7 days, by click count</p>
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
+        Top CTAs
+      </h3>
+      <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-4">
+        Last 7 days, by click count
+      </p>
       {
         topCtas.length === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No CTA clicks yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No CTA clicks yet.</p>
         ) : (
           <div class="space-y-2">
             {topCtas.map((row) => (
               <div class="flex items-center gap-row">
-                <span class="text-sm text-[color:var(--color-text-secondary)] w-36 shrink-0 truncate font-mono">
+                <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-36 shrink-0 truncate font-mono">
                   {row.cta}
                 </span>
-                <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-5 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
                   <div
                     class="h-full rounded-full bg-amber-500 flex items-center justify-end pr-2"
                     style={`width: ${ctaBarWidth(row.clicks)}`}
@@ -599,17 +611,17 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Conversion funnel (7d) ────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card md:col-span-2"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card md:col-span-2"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
         Conversion Funnel
       </h3>
-      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">
+      <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-4">
         Distinct sessions per step, last 7 days
       </p>
       {
         funnelTop === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No funnel data yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No funnel data yet.</p>
         ) : (
           <div class="space-y-row">
             {funnelSteps.map((step, idx) => {
@@ -617,10 +629,10 @@ function complianceBarWidth(pct: number): string {
               const drop = idx === 0 ? '—' : dropOff(count, funnel[funnelSteps[idx - 1].key])
               return (
                 <div class="flex items-center gap-row">
-                  <span class="text-sm text-[color:var(--color-text-secondary)] w-44 shrink-0">
+                  <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-44 shrink-0">
                     {step.label}
                   </span>
-                  <div class="flex-1 bg-[color:var(--color-border-subtle)] rounded-full h-6 overflow-hidden">
+                  <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-6 overflow-hidden">
                     <div
                       class="h-full rounded-full bg-emerald-500 flex items-center justify-end pr-2"
                       style={`width: ${funnelBarWidth(count)}`}
@@ -630,7 +642,7 @@ function complianceBarWidth(pct: number): string {
                       )}
                     </div>
                   </div>
-                  <span class="text-xs text-[color:var(--color-text-muted)] w-14 text-right">
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)] w-14 text-right">
                     {drop}
                   </span>
                 </div>
@@ -643,17 +655,17 @@ function complianceBarWidth(pct: number): string {
 
     {/* ── Daily uniques (30d) ───────────────────────────── */}
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card md:col-span-2"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card md:col-span-2"
     >
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
         Daily Uniques
       </h3>
-      <p class="text-xs text-[color:var(--color-text-muted)] mb-4">
+      <p class="text-xs text-[color:var(--ss-color-text-muted)] mb-4">
         Distinct sessions per day, last 30 days
       </p>
       {
         maxDailyUniques === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">No session data yet.</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">No session data yet.</p>
         ) : (
           <div>
             <svg
@@ -675,7 +687,7 @@ function complianceBarWidth(pct: number): string {
                 )
               })}
             </svg>
-            <div class="mt-2 flex justify-between text-xs text-[color:var(--color-text-muted)]">
+            <div class="mt-2 flex justify-between text-xs text-[color:var(--ss-color-text-muted)]">
               <span>{formatShortDate(dailyUniques[0].day)}</span>
               <span>{formatShortDate(dailyUniques[dailyUniques.length - 1].day)}</span>
             </div>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -54,7 +54,7 @@ function formatDate(d: string | null): string {
 function msBadgeClass(s: string): string {
   switch (s) {
     case 'pending':
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
     case 'in_progress':
       return 'bg-blue-100 text-blue-700'
     case 'completed':
@@ -62,14 +62,14 @@ function msBadgeClass(s: string): string {
     case 'skipped':
       return 'bg-red-100 text-red-600'
     default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 
 function invoiceBadgeClass(s: string): string {
   switch (s) {
     case 'draft':
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
     case 'sent':
       return 'bg-blue-100 text-blue-700'
     case 'paid':
@@ -77,9 +77,9 @@ function invoiceBadgeClass(s: string): string {
     case 'overdue':
       return 'bg-red-100 text-red-600'
     case 'void':
-      return 'bg-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'
     default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 
@@ -94,7 +94,7 @@ function contextTypeBadgeClass(t: string): string {
     case 'feedback':
       return 'bg-purple-100 text-purple-700'
     default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 
@@ -151,12 +151,12 @@ function fileSize(bytes: number): string {
 
     <!-- Header -->
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
       <div class="flex items-start justify-between">
         <div>
           <div class="flex items-center gap-row mb-2">
-            <h1 class="text-2xl font-semibold text-[color:var(--color-text-primary)]">
+            <h1 class="text-2xl font-semibold text-[color:var(--ss-color-text-primary)]">
               {entity?.name ?? 'Unknown Entity'}
             </h1>
             <span class={statusBadgeClass(engagement.status)}>
@@ -164,7 +164,7 @@ function fileSize(bytes: number): string {
             </span>
           </div>
           <div
-            class="flex flex-wrap gap-x-card gap-y-1 text-sm text-[color:var(--color-text-secondary)]"
+            class="flex flex-wrap gap-x-card gap-y-1 text-sm text-[color:var(--ss-color-text-secondary)]"
           >
             <span>Start: {formatDate(engagement.start_date)}</span>
             <span>Est. End: {formatDate(engagement.estimated_end)}</span>
@@ -184,7 +184,7 @@ function fileSize(bytes: number): string {
                     class={`text-xs px-3 py-1.5 rounded font-medium border transition-colors ${
                       ns === 'cancelled'
                         ? 'border-red-300 text-red-700 hover:bg-red-50'
-                        : 'border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]'
+                        : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)]'
                     }`}
                   >
                     {ns === 'active'
@@ -209,17 +209,17 @@ function fileSize(bytes: number): string {
       {/* Quote summary */}
       {
         quote && (
-          <div class="mt-4 pt-4 border-t border-[color:var(--color-border-subtle)]">
+          <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)]">
             <div class="flex flex-wrap gap-x-card gap-y-1 text-sm">
-              <span class="text-[color:var(--color-text-secondary)]">
+              <span class="text-[color:var(--ss-color-text-secondary)]">
                 Quote:{' '}
-                <span class="font-medium text-[color:var(--color-text-primary)]">
+                <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                   ${quote.total_price.toLocaleString()}
                 </span>
               </span>
-              <span class="text-[color:var(--color-text-secondary)]">
+              <span class="text-[color:var(--ss-color-text-secondary)]">
                 Hours:{' '}
-                <span class="font-medium text-[color:var(--color-text-primary)]">
+                <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                   {quote.total_hours}h est
                 </span>
                 {engagement.actual_hours > 0 && (
@@ -227,9 +227,9 @@ function fileSize(bytes: number): string {
                 )}
               </span>
               {quote.deposit_pct != null && (
-                <span class="text-[color:var(--color-text-secondary)]">
+                <span class="text-[color:var(--ss-color-text-secondary)]">
                   Deposit:{' '}
-                  <span class="font-medium text-[color:var(--color-text-primary)]">
+                  <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                     {(quote.deposit_pct * 100).toFixed(0)}%
                   </span>
                 </span>
@@ -237,13 +237,13 @@ function fileSize(bytes: number): string {
             </div>
             {depositInvoice && (
               <div class="mt-2 text-sm">
-                <span class="text-[color:var(--color-text-secondary)]">Deposit Invoice:</span>{' '}
+                <span class="text-[color:var(--ss-color-text-secondary)]">Deposit Invoice:</span>{' '}
                 <span
                   class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(depositInvoice.status)}`}
                 >
                   {depositInvoice.status}
                 </span>
-                <span class="ml-2 text-[color:var(--color-text-secondary)]">
+                <span class="ml-2 text-[color:var(--ss-color-text-secondary)]">
                   ${depositInvoice.amount.toLocaleString()}
                 </span>
               </div>
@@ -254,8 +254,8 @@ function fileSize(bytes: number): string {
 
       {
         engagement.scope_summary && (
-          <div class="mt-4 pt-4 border-t border-[color:var(--color-border-subtle)]">
-            <p class="text-sm text-[color:var(--color-text-secondary)] whitespace-pre-wrap">
+          <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)]">
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] whitespace-pre-wrap">
               {engagement.scope_summary}
             </p>
           </div>
@@ -265,9 +265,11 @@ function fileSize(bytes: number): string {
 
     <!-- Edit Details -->
     <details
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
     >
-      <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+      <summary
+        class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]"
+      >
         Edit Details
       </summary>
       <div class="px-6 pb-6">
@@ -275,7 +277,7 @@ function fileSize(bytes: number): string {
           <div>
             <label
               for="scope_summary"
-              class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+              class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
             >
               Scope Summary
             </label>
@@ -283,7 +285,7 @@ function fileSize(bytes: number): string {
               id="scope_summary"
               name="scope_summary"
               rows="3"
-              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+              class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               >{engagement.scope_summary ?? ''}</textarea
             >
           </div>
@@ -291,7 +293,7 @@ function fileSize(bytes: number): string {
             <div>
               <label
                 for="start_date"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Start Date
               </label>
@@ -300,13 +302,13 @@ function fileSize(bytes: number): string {
                 id="start_date"
                 name="start_date"
                 value={engagement.start_date?.split('T')[0] ?? ''}
-                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
             <div>
               <label
                 for="estimated_end"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Estimated End
               </label>
@@ -315,7 +317,7 @@ function fileSize(bytes: number): string {
                 id="estimated_end"
                 name="estimated_end"
                 value={engagement.estimated_end?.split('T')[0] ?? ''}
-                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
           </div>
@@ -323,7 +325,7 @@ function fileSize(bytes: number): string {
             <div>
               <label
                 for="estimated_hours"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Estimated Hours
               </label>
@@ -333,13 +335,13 @@ function fileSize(bytes: number): string {
                 name="estimated_hours"
                 step="0.5"
                 value={engagement.estimated_hours ?? ''}
-                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
             <div>
               <label
                 for="actual_hours"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Actual Hours
               </label>
@@ -349,7 +351,7 @@ function fileSize(bytes: number): string {
                 name="actual_hours"
                 step="0.5"
                 value={engagement.actual_hours ?? ''}
-                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
           </div>
@@ -366,14 +368,16 @@ function fileSize(bytes: number): string {
     </details>
 
     <!-- Milestones -->
-    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
-      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
-        <h2 class="font-medium text-[color:var(--color-text-primary)]">Milestones</h2>
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
+    >
+      <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Milestones</h2>
       </div>
-      <div class="divide-y divide-[color:var(--color-border-subtle)]">
+      <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
         {
           milestones.length === 0 && (
-            <div class="px-6 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
+            <div class="px-6 py-8 text-center text-sm text-[color:var(--ss-color-text-muted)]">
               No milestones yet.
             </div>
           )
@@ -389,7 +393,7 @@ function fileSize(bytes: number): string {
                     <span class={`text-xs px-2 py-0.5 rounded ${msBadgeClass(ms.status)}`}>
                       {ms.status}
                     </span>
-                    <span class="text-sm font-medium text-[color:var(--color-text-primary)] truncate">
+                    <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)] truncate">
                       {ms.name}
                     </span>
                     {ms.payment_trigger ? (
@@ -399,12 +403,12 @@ function fileSize(bytes: number): string {
                     ) : null}
                   </div>
                   {ms.description && (
-                    <p class="text-xs text-[color:var(--color-text-secondary)] mt-1 truncate">
+                    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1 truncate">
                       {ms.description}
                     </p>
                   )}
                   {ms.due_date && (
-                    <span class="text-xs text-[color:var(--color-text-muted)] mt-1 block">
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)] mt-1 block">
                       Due: {formatDate(ms.due_date)}
                     </span>
                   )}
@@ -422,7 +426,7 @@ function fileSize(bytes: number): string {
                       class={`text-xs px-2 py-1 rounded border transition-colors ${
                         ms.payment_trigger
                           ? 'border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100'
-                          : 'border-[color:var(--color-border)] text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border)]'
+                          : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-secondary)] hover:border-[color:var(--ss-color-border)]'
                       }`}
                     >
                       $
@@ -444,7 +448,7 @@ function fileSize(bytes: number): string {
                             ? 'border-green-300 text-green-700 hover:bg-green-50'
                             : ns === 'in_progress'
                               ? 'border-blue-300 text-blue-700 hover:bg-blue-50'
-                              : 'border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)]'
+                              : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)]'
                         }`}
                       >
                         {ns === 'in_progress'
@@ -482,9 +486,9 @@ function fileSize(bytes: number): string {
       </div>
 
       {/* Add milestone form */}
-      <details class="border-t border-[color:var(--color-border-subtle)]">
+      <details class="border-t border-[color:var(--ss-color-border-subtle)]">
         <summary
-          class="px-6 py-3 cursor-pointer text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+          class="px-6 py-3 cursor-pointer text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
         >
           + Add Milestone
         </summary>
@@ -498,7 +502,7 @@ function fileSize(bytes: number): string {
               <div>
                 <label
                   for="ms_name"
-                  class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+                  class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
                 >
                   Name *
                 </label>
@@ -507,13 +511,13 @@ function fileSize(bytes: number): string {
                   id="ms_name"
                   name="name"
                   required
-                  class="w-full border border-[color:var(--color-border)] rounded px-3 py-1.5 text-sm"
+                  class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
                 />
               </div>
               <div>
                 <label
                   for="ms_due"
-                  class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+                  class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
                 >
                   Due Date
                 </label>
@@ -521,14 +525,14 @@ function fileSize(bytes: number): string {
                   type="date"
                   id="ms_due"
                   name="due_date"
-                  class="w-full border border-[color:var(--color-border)] rounded px-3 py-1.5 text-sm"
+                  class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
                 />
               </div>
             </div>
             <div>
               <label
                 for="ms_desc"
-                class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+                class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
               >
                 Description
               </label>
@@ -536,12 +540,12 @@ function fileSize(bytes: number): string {
                 type="text"
                 id="ms_desc"
                 name="description"
-                class="w-full border border-[color:var(--color-border)] rounded px-3 py-1.5 text-sm"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
               />
             </div>
             <div class="flex items-center gap-stack">
               <label
-                class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]"
+                class="flex items-center gap-2 text-sm text-[color:var(--ss-color-text-secondary)]"
               >
                 <input type="checkbox" name="payment_trigger" value="1" />
                 Payment trigger
@@ -560,10 +564,12 @@ function fileSize(bytes: number): string {
     </div>
 
     <!-- Consultant photo -->
-    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
-      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
-        <h2 class="font-medium text-[color:var(--color-text-primary)]">Consultant Photo</h2>
-        <p class="text-xs text-[color:var(--color-text-secondary)] mt-1">
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
+    >
+      <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Consultant Photo</h2>
+        <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
           Shown on every portal surface for this engagement. Square, 400×400 recommended. We'll crop
           to a circle and encode as WebP in your browser before upload. JPEG/PNG/WebP up to 5 MB.
         </p>
@@ -571,7 +577,7 @@ function fileSize(bytes: number): string {
       <div class="px-6 py-5">
         <div class="flex items-start gap-5">
           <div
-            class="w-20 h-20 shrink-0 rounded-full bg-[color:var(--color-background)] border border-[color:var(--color-border)] overflow-hidden"
+            class="w-20 h-20 shrink-0 rounded-full bg-[color:var(--ss-color-background)] border border-[color:var(--ss-color-border)] overflow-hidden"
           >
             {
               engagement.consultant_photo_url ? (
@@ -585,7 +591,7 @@ function fileSize(bytes: number): string {
                 <svg
                   id="consultant-photo-placeholder"
                   viewBox="0 0 80 80"
-                  class="w-full h-full text-[color:var(--color-text-muted)]"
+                  class="w-full h-full text-[color:var(--ss-color-text-muted)]"
                   aria-hidden="true"
                 >
                   <rect width="80" height="80" fill="currentColor" fill-opacity="0.12" />
@@ -604,7 +610,8 @@ function fileSize(bytes: number): string {
               id="photo-preview"
               width="160"
               height="160"
-              class="hidden rounded-full border border-[color:var(--color-border)] mb-3"></canvas>
+              class="hidden rounded-full border border-[color:var(--ss-color-border)] mb-3"
+            ></canvas>
             <div id="photo-controls" class="flex flex-wrap items-center gap-2">
               <input
                 type="file"
@@ -615,7 +622,7 @@ function fileSize(bytes: number): string {
               <button
                 type="button"
                 id="photo-choose"
-                class="text-xs px-3 py-1.5 rounded border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)] transition-colors"
+                class="text-xs px-3 py-1.5 rounded border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
               >
                 Choose Photo
               </button>
@@ -629,7 +636,7 @@ function fileSize(bytes: number): string {
               <button
                 type="button"
                 id="photo-cancel"
-                class="hidden text-xs px-3 py-1.5 rounded border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)] transition-colors"
+                class="hidden text-xs px-3 py-1.5 rounded border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
               >
                 Cancel
               </button>
@@ -645,21 +652,26 @@ function fileSize(bytes: number): string {
                 )
               }
             </div>
-            <p id="photo-status" class="mt-2 text-xs text-[color:var(--color-text-secondary)]"></p>
+            <p id="photo-status" class="mt-2 text-xs text-[color:var(--ss-color-text-secondary)]">
+            </p>
           </div>
         </div>
       </div>
     </div>
 
     <!-- Deliverables -->
-    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
-      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
-        <h2 class="font-medium text-[color:var(--color-text-primary)]">Deliverables</h2>
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
+    >
+      <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Deliverables</h2>
       </div>
       <div class="px-6 py-4">
         {
           documents.length === 0 && (
-            <p class="text-sm text-[color:var(--color-text-muted)] mb-4">No files uploaded yet.</p>
+            <p class="text-sm text-[color:var(--ss-color-text-muted)] mb-4">
+              No files uploaded yet.
+            </p>
           )
         }
         {
@@ -675,7 +687,7 @@ function fileSize(bytes: number): string {
                     >
                       {name}
                     </a>
-                    <span class="text-xs text-[color:var(--color-text-muted)] flex-shrink-0 ml-4">
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)] flex-shrink-0 ml-4">
                       {fileSize(doc.size)} &middot; {formatDate(doc.uploaded.toISOString())}
                     </span>
                   </li>
@@ -686,20 +698,23 @@ function fileSize(bytes: number): string {
         }
         <div
           id="upload-area"
-          class="border-2 border-dashed border-[color:var(--color-border)] rounded-[var(--radius-card)] p-card text-center"
+          class="border-2 border-dashed border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] p-card text-center"
         >
-          <p class="text-sm text-[color:var(--color-text-secondary)] mb-2">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-2">
             Drag files here or click to upload
           </p>
           <input type="file" id="file-input" class="hidden" multiple />
           <button
             type="button"
             id="upload-btn"
-            class="text-xs px-3 py-1.5 rounded border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)] transition-colors"
+            class="text-xs px-3 py-1.5 rounded border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
           >
             Choose Files
           </button>
-          <div id="upload-status" class="text-xs text-[color:var(--color-text-muted)] mt-2 hidden">
+          <div
+            id="upload-status"
+            class="text-xs text-[color:var(--ss-color-text-muted)] mt-2 hidden"
+          >
           </div>
         </div>
       </div>
@@ -708,21 +723,23 @@ function fileSize(bytes: number): string {
     <!-- Invoices -->
     {
       invoices.length > 0 && (
-        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
-          <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
-            <h2 class="font-medium text-[color:var(--color-text-primary)]">Invoices</h2>
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]">
+          <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+            <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Invoices</h2>
           </div>
-          <div class="divide-y divide-[color:var(--color-border-subtle)]">
+          <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
             {invoices.map((inv) => (
               <div class="px-6 py-3 flex items-center justify-between text-sm">
                 <div class="flex items-center gap-row">
                   <span class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(inv.status)}`}>
                     {inv.status}
                   </span>
-                  <span class="text-[color:var(--color-text-primary)] capitalize">{inv.type}</span>
+                  <span class="text-[color:var(--ss-color-text-primary)] capitalize">
+                    {inv.type}
+                  </span>
                 </div>
-                <div class="flex items-center gap-stack text-[color:var(--color-text-secondary)]">
-                  <span class="font-medium text-[color:var(--color-text-primary)]">
+                <div class="flex items-center gap-stack text-[color:var(--ss-color-text-secondary)]">
+                  <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                     ${inv.amount.toLocaleString()}
                   </span>
                   {inv.due_date && <span>Due: {formatDate(inv.due_date)}</span>}
@@ -736,34 +753,36 @@ function fileSize(bytes: number): string {
     }
 
     <!-- Context Timeline -->
-    <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]">
-      <div class="px-6 py-4 border-b border-[color:var(--color-border-subtle)]">
-        <h2 class="font-medium text-[color:var(--color-text-primary)]">Timeline</h2>
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
+    >
+      <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+        <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Timeline</h2>
       </div>
       {
         contextEntries.length === 0 && (
-          <div class="px-6 py-8 text-center text-sm text-[color:var(--color-text-muted)]">
+          <div class="px-6 py-8 text-center text-sm text-[color:var(--ss-color-text-muted)]">
             No context entries for this engagement.
           </div>
         )
       }
       {
         contextEntries.length > 0 && (
-          <div class="divide-y divide-[color:var(--color-border-subtle)]">
+          <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
             {contextEntries.map((entry) => (
               <div class="px-6 py-3">
                 <div class="flex items-center gap-2 mb-1">
                   <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadgeClass(entry.type)}`}>
                     {entry.type.replace(/_/g, ' ')}
                   </span>
-                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                     {formatDate(entry.created_at)}
                   </span>
-                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                     via {entry.source}
                   </span>
                 </div>
-                <p class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap">
+                <p class="text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap">
                   {entry.content}
                 </p>
               </div>
@@ -845,7 +864,7 @@ function fileSize(bytes: number): string {
       photoStatus.textContent = msg
       photoStatus.className = isError
         ? 'mt-2 text-xs text-red-600'
-        : 'mt-2 text-xs text-[color:var(--color-text-secondary)]'
+        : 'mt-2 text-xs text-[color:var(--ss-color-text-secondary)]'
     }
 
     async function cropToSquareWebp(file) {

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -193,7 +193,7 @@ function contextTypeBadge(type: string): string {
   const map: Record<string, string> = {
     signal: 'bg-amber-100 text-amber-700',
     enrichment: 'bg-cyan-100 text-cyan-700',
-    note: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
+    note: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
     transcript: 'bg-purple-100 text-purple-700',
     extraction: 'bg-indigo-100 text-indigo-700',
     outreach_draft: 'bg-blue-100 text-blue-700',
@@ -201,11 +201,13 @@ function contextTypeBadge(type: string): string {
     follow_up_result: 'bg-teal-100 text-teal-700',
     feedback: 'bg-emerald-100 text-emerald-700',
     parking_lot: 'bg-orange-100 text-orange-700',
-    stage_change: 'bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)]',
+    stage_change:
+      'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)]',
     intake: 'bg-pink-100 text-pink-700',
   }
   return (
-    map[type] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+    map[type] ??
+    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   )
 }
 
@@ -218,10 +220,11 @@ function stageBadgeClass(stage: string): string {
     engaged: 'bg-green-100 text-green-700',
     delivered: 'bg-emerald-100 text-emerald-700',
     ongoing: 'bg-teal-100 text-teal-700',
-    lost: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
+    lost: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
   }
   return (
-    map[stage] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+    map[stage] ??
+    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   )
 }
 
@@ -334,20 +337,21 @@ function renderSimpleMarkdown(md: string): string {
   html = html.replace(
     /^## (.+)$/gm,
     (_m, t) =>
-      `<h4 class="font-semibold text-sm text-[color:var(--color-text-primary)] mt-4 mb-1">${t}</h4>`
+      `<h4 class="font-semibold text-sm text-[color:var(--ss-color-text-primary)] mt-4 mb-1">${t}</h4>`
   )
   // Bold
   html = html.replace(/\*\*(.+?)\*\*/g, (_m, t) => `<strong>${t}</strong>`)
   // Unordered list items
   html = html.replace(
     /^- (.+)$/gm,
-    (_m, t) => `<li class="ml-4 list-disc text-sm text-[color:var(--color-text-primary)]">${t}</li>`
+    (_m, t) =>
+      `<li class="ml-4 list-disc text-sm text-[color:var(--ss-color-text-primary)]">${t}</li>`
   )
   // Numbered list items
   html = html.replace(
     /^\d+\. (.+)$/gm,
     (_m, t) =>
-      `<li class="ml-4 list-decimal text-sm text-[color:var(--color-text-primary)]">${t}</li>`
+      `<li class="ml-4 list-decimal text-sm text-[color:var(--ss-color-text-primary)]">${t}</li>`
   )
   // Wrap consecutive <li> in <ul>/<ol>
   html = html.replace(
@@ -361,7 +365,7 @@ function renderSimpleMarkdown(md: string): string {
   // Paragraphs: non-empty lines that aren't already wrapped
   html = html.replace(
     /^(?!<[hulo])(.+)$/gm,
-    (_m, t) => `<p class="text-sm text-[color:var(--color-text-primary)] mb-2">${t}</p>`
+    (_m, t) => `<p class="text-sm text-[color:var(--ss-color-text-primary)] mb-2">${t}</p>`
   )
   // Clean up empty paragraphs
   html = html.replace(
@@ -375,13 +379,13 @@ function renderSimpleMarkdown(md: string): string {
 function sentimentColor(trend: string): string {
   if (trend === 'improving') return 'text-green-700 bg-green-50'
   if (trend === 'declining') return 'text-red-700 bg-red-50'
-  return 'text-[color:var(--color-text-secondary)] bg-[color:var(--color-background)]'
+  return 'text-[color:var(--ss-color-text-secondary)] bg-[color:var(--ss-color-background)]'
 }
 
 function confidenceColor(confidence: string): string {
   if (confidence === 'high') return 'bg-rose-100 text-rose-700'
   if (confidence === 'medium') return 'bg-amber-100 text-amber-700'
-  return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+  return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
 }
 ---
 
@@ -401,7 +405,7 @@ function confidenceColor(confidence: string): string {
   }
   <a
     href={`/admin/entities?stage=${entity.stage}`}
-    class="inline-flex items-center gap-1 text-xs text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] mb-3"
+    class="inline-flex items-center gap-1 text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] mb-3"
   >
     <span aria-hidden="true">←</span>
     <span>
@@ -410,28 +414,28 @@ function confidenceColor(confidence: string): string {
   </a>
   {
     promoted && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {entity.name} promoted to prospect.
       </div>
     )
   }
   {
     noteAdded && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Note added to {entity.name}.
       </div>
     )
   }
   {
     replyLogged && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Reply logged on {entity.name}.
       </div>
     )
   }
   {
     stageUpdated && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {entity.name} moved to{' '}
         {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}.
       </div>
@@ -439,7 +443,7 @@ function confidenceColor(confidence: string): string {
   }
   {
     dossierGenerated && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Re-enriched {entity.name}. Refreshed reviews, synthesis, news, and outreach draft — see
         timeline below.
       </div>
@@ -447,7 +451,7 @@ function confidenceColor(confidence: string): string {
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {decodeURIComponent(error)}
       </div>
     )
@@ -455,12 +459,12 @@ function confidenceColor(confidence: string): string {
 
   {/* Entity Summary */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between gap-stack">
       <div>
         <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
             {entity.name}
           </h2>
           <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
@@ -486,7 +490,7 @@ function confidenceColor(confidence: string): string {
                       ? 'bg-amber-100 text-amber-700'
                       : entity.tier === 'cool'
                         ? 'bg-blue-100 text-blue-700'
-                        : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+                        : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
                 }`}
               >
                 {entity.tier}
@@ -496,13 +500,13 @@ function confidenceColor(confidence: string): string {
         </div>
 
         <div
-          class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)] mb-2 flex-wrap"
+          class="flex items-center gap-stack text-sm text-[color:var(--ss-color-text-secondary)] mb-2 flex-wrap"
         >
           {entity.vertical && <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>}
           {entity.area && <span>{entity.area}</span>}
         </div>
 
-        <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)]">
+        <div class="flex items-center gap-row text-xs text-[color:var(--ss-color-text-muted)]">
           {
             entity.source_pipeline && (
               <span class={pipelineBadgeClass(entity.source_pipeline)}>
@@ -641,16 +645,16 @@ function confidenceColor(confidence: string): string {
                 <form
                   method="POST"
                   action={t.action ?? `/api/admin/entities/${entity.id}/stage`}
-                  class="absolute right-0 mt-1 z-10 w-72 bg-white border border-[color:var(--color-border)] rounded-[var(--radius-card)] shadow-lg p-3 space-y-2"
+                  class="absolute right-0 mt-1 z-10 w-72 bg-white border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] shadow-lg p-3 space-y-2"
                 >
                   <input type="hidden" name="stage" value="lost" />
                   <input type="hidden" name="reason" value={`${t.label} by admin.`} />
-                  <label class="block text-xs font-medium text-[color:var(--color-text-secondary)]">
+                  <label class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
                     Lost reason
                     <select
                       name="lost_reason"
                       required
-                      class="mt-1 block w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+                      class="mt-1 block w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1.5 bg-white text-[color:var(--ss-color-text-primary)]"
                     >
                       <option value="" disabled selected>
                         Select a reason…
@@ -660,12 +664,12 @@ function confidenceColor(confidence: string): string {
                       ))}
                     </select>
                   </label>
-                  <label class="block text-xs font-medium text-[color:var(--color-text-secondary)]">
+                  <label class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
                     Detail (optional)
                     <textarea
                       name="lost_detail"
                       rows="2"
-                      class="mt-1 block w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1.5 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                      class="mt-1 block w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1.5 resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
                     />
                   </label>
                   <div class="flex justify-end gap-2">
@@ -704,7 +708,7 @@ function confidenceColor(confidence: string): string {
               </button>
               {lastEnrichmentAt && (
                 <span
-                  class="text-xs text-[color:var(--color-text-muted)]"
+                  class="text-xs text-[color:var(--ss-color-text-muted)]"
                   title={`Last enriched ${formatDate(lastEnrichmentAt)}`}
                 >
                   Last enriched {relativeTime(lastEnrichmentAt)}
@@ -735,11 +739,11 @@ function confidenceColor(confidence: string): string {
               class="flex items-center gap-2"
             >
               {supersedeCandidates.length > 0 && (
-                <label class="text-xs text-[color:var(--color-text-secondary)] flex items-center gap-1">
+                <label class="text-xs text-[color:var(--ss-color-text-secondary)] flex items-center gap-1">
                   <span class="sr-only">Supersede prior quote</span>
                   <select
                     name="parent_quote_id"
-                    class="text-xs border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-2 py-1 bg-white"
+                    class="text-xs border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1 bg-white"
                     title="Optional: link to a prior quote this one supersedes"
                   >
                     <option value="">No supersede link</option>
@@ -773,13 +777,13 @@ function confidenceColor(confidence: string): string {
     entity.stage === 'prospect' && (
       <dialog
         id="send-booking-link-dialog"
-        class="rounded-[var(--radius-card)] p-0 max-w-md w-full backdrop:bg-black/30"
+        class="rounded-[var(--ss-radius-card)] p-0 max-w-md w-full backdrop:bg-black/30"
       >
         <form method="dialog" id="send-booking-link-form" class="p-card">
-          <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
             Send booking link
           </h3>
-          <p class="text-xs text-[color:var(--color-text-secondary)] mb-4">
+          <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-4">
             Creates a meeting row and signs a booking URL for this prospect. Link expires in 14
             days.
           </p>
@@ -787,7 +791,7 @@ function confidenceColor(confidence: string): string {
           <div class="mb-3">
             <label
               for="sbl-meeting-type"
-              class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+              class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
             >
               Meeting type (optional)
             </label>
@@ -797,21 +801,21 @@ function confidenceColor(confidence: string): string {
               name="meeting_type"
               maxlength="100"
               placeholder="e.g. discovery, assessment"
-              class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
             />
           </div>
 
           <div class="mb-4">
             <label
               for="sbl-duration"
-              class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+              class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
             >
               Duration
             </label>
             <select
               id="sbl-duration"
               name="duration_minutes"
-              class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
             >
               <option value="30" selected>
                 30 minutes
@@ -823,21 +827,21 @@ function confidenceColor(confidence: string): string {
 
           <div
             id="sbl-error"
-            class="hidden mb-3 rounded-[var(--radius-card)] bg-red-50 border border-red-200 text-red-800 text-xs px-3 py-2"
+            class="hidden mb-3 rounded-[var(--ss-radius-card)] bg-red-50 border border-red-200 text-red-800 text-xs px-3 py-2"
           />
 
           <div class="flex items-center justify-end gap-2">
             <button
               type="button"
               id="sbl-cancel"
-              class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)] transition-colors"
+              class="text-xs px-3 py-1.5 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border)] transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               id="sbl-submit"
-              class="text-xs px-3 py-1.5 rounded-[var(--radius-card)] bg-[color:var(--color-primary)] text-white hover:bg-[color:var(--color-primary-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class="text-xs px-3 py-1.5 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)] text-white hover:bg-[color:var(--ss-color-primary-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Send link
             </button>
@@ -855,7 +859,7 @@ function confidenceColor(confidence: string): string {
       handles the clearing logic. */
   }
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack mb-6"
   >
     <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-row">
       <input type="hidden" name="type" value="note" />
@@ -863,7 +867,7 @@ function confidenceColor(confidence: string): string {
         name="content"
         placeholder="Add a note..."
         rows="4"
-        class="flex-1 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        class="flex-1 text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
       ></textarea>
       <div class="flex flex-col gap-2 self-end">
         <button type="submit" class={adminActionButtonClass('ghost')}>Add Note</button>
@@ -875,9 +879,9 @@ function confidenceColor(confidence: string): string {
   {/* Context Timeline */}
   <div class="mb-6">
     <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
         Context Timeline
-        <span class="text-sm font-normal text-[color:var(--color-text-muted)]"
+        <span class="text-sm font-normal text-[color:var(--ss-color-text-muted)]"
           >({contextEntries.length})</span
         >
       </h3>
@@ -887,7 +891,7 @@ function confidenceColor(confidence: string): string {
     <div class="flex gap-1 mb-4 flex-wrap">
       <a
         href={`/admin/entities/${entity.id}`}
-        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)]'}`}
+        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border)]'}`}
       >
         All ({contextEntries.length})
       </a>
@@ -906,8 +910,8 @@ function confidenceColor(confidence: string): string {
     {/* Timeline entries */}
     {
       filteredEntries.length === 0 ? (
-        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-stack">
-          <p class="text-[color:var(--color-text-secondary)] text-sm">No context entries yet.</p>
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack">
+          <p class="text-[color:var(--ss-color-text-secondary)] text-sm">No context entries yet.</p>
         </div>
       ) : (
         <div class="space-y-row">
@@ -928,10 +932,10 @@ function confidenceColor(confidence: string): string {
             return (
               <details
                 open={openByDefault}
-                class={`group bg-white rounded-[var(--radius-card)] border px-4 py-3 ${
+                class={`group bg-white rounded-[var(--ss-radius-card)] border px-4 py-3 ${
                   isReplyLog
-                    ? 'border-l-4 border-l-teal-500 border-[color:var(--color-border)]'
-                    : 'border-[color:var(--color-border)]'
+                    ? 'border-l-4 border-l-teal-500 border-[color:var(--ss-color-border)]'
+                    : 'border-[color:var(--ss-color-border)]'
                 }`}
               >
                 <summary class="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex-wrap">
@@ -944,22 +948,24 @@ function confidenceColor(confidence: string): string {
                       {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
                     </span>
                   )}
-                  <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
-                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                    {entry.source}
+                  </span>
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                     {formatDateTime(entry.created_at)}
                   </span>
                   {replySentiment && (
-                    <span class="text-xs px-1.5 py-0.5 rounded bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] capitalize">
+                    <span class="text-xs px-1.5 py-0.5 rounded bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] capitalize">
                       {replySentiment.replace(/_/g, ' ')}
                     </span>
                   )}
                   {replyNextAction && (
-                    <span class="text-xs text-[color:var(--color-text-secondary)]">
+                    <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
                       Next: <span class="capitalize">{replyNextAction.replace(/_/g, ' ')}</span>
                     </span>
                   )}
                   <svg
-                    class="ml-auto h-3.5 w-3.5 shrink-0 text-[color:var(--color-text-muted)] transition-transform group-open:rotate-180"
+                    class="ml-auto h-3.5 w-3.5 shrink-0 text-[color:var(--ss-color-text-muted)] transition-transform group-open:rotate-180"
                     viewBox="0 0 20 20"
                     fill="currentColor"
                     aria-hidden="true"
@@ -977,7 +983,7 @@ function confidenceColor(confidence: string): string {
                   {problems && problems.length > 0 && (
                     <div class="flex gap-1 mb-1.5 flex-wrap">
                       {problems.map((p: string) => (
-                        <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded">
+                        <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
                           {p.replace(/_/g, ' ')}
                         </span>
                       ))}
@@ -985,7 +991,7 @@ function confidenceColor(confidence: string): string {
                   )}
 
                   <div
-                    class={`text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap${isLong ? ' js-truncated' : ''}`}
+                    class={`text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap${isLong ? ' js-truncated' : ''}`}
                     data-long={isLong ? 'true' : 'false'}
                   >
                     {entry.content}
@@ -993,7 +999,7 @@ function confidenceColor(confidence: string): string {
                   {isLong && (
                     <button
                       type="button"
-                      class="js-toggle-long text-xs mt-2 text-[color:var(--color-primary)] hover:underline cursor-pointer"
+                      class="js-toggle-long text-xs mt-2 text-[color:var(--ss-color-primary)] hover:underline cursor-pointer"
                     >
                       Show more
                     </button>
@@ -1010,14 +1016,14 @@ function confidenceColor(confidence: string): string {
   {/* Dossier Summary */}
   {
     hasDossier && (
-      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6">
+      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
         <div class="flex items-baseline justify-between gap-2 mb-4 flex-wrap">
-          <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
             Dossier Summary
           </h3>
           {dossierBrief && (
             <span
-              class="text-xs text-[color:var(--color-text-muted)]"
+              class="text-xs text-[color:var(--ss-color-text-muted)]"
               title={`Generated ${formatDate(dossierBrief.created_at)}`}
             >
               Generated {relativeTime(dossierBrief.created_at)}
@@ -1028,48 +1034,56 @@ function confidenceColor(confidence: string): string {
         {/* Zone 1: Quick Stats */}
         <div class="grid grid-cols-2 md:grid-cols-4 gap-stack mb-5">
           {reviewMeta?.unified_rating != null && (
-            <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
-              <div class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+            <div class="bg-[color:var(--ss-color-background)] rounded-[var(--ss-radius-card)] p-row">
+              <div class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                 {reviewMeta.unified_rating.toFixed(1)}
-                <span class="text-sm font-normal text-[color:var(--color-text-muted)]"> / 5</span>
+                <span class="text-sm font-normal text-[color:var(--ss-color-text-muted)]">
+                  {' '}
+                  / 5
+                </span>
               </div>
-              <div class="text-xs text-[color:var(--color-text-secondary)]">
+              <div class="text-xs text-[color:var(--ss-color-text-secondary)]">
                 {reviewMeta.total_reviews_across_platforms ?? 0} reviews
               </div>
             </div>
           )}
           {reviewMeta?.sentiment_trend && reviewMeta.sentiment_trend !== 'insufficient_data' && (
-            <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
+            <div class="bg-[color:var(--ss-color-background)] rounded-[var(--ss-radius-card)] p-row">
               <div
                 class={`text-sm font-semibold px-2 py-0.5 rounded inline-block ${sentimentColor(reviewMeta.sentiment_trend)}`}
               >
                 {reviewMeta.sentiment_trend}
               </div>
-              <div class="text-xs text-[color:var(--color-text-secondary)] mt-1">
+              <div class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
                 Sentiment trend
               </div>
             </div>
           )}
           {websiteMeta?.digital_maturity?.score != null && (
-            <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
-              <div class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+            <div class="bg-[color:var(--ss-color-background)] rounded-[var(--ss-radius-card)] p-row">
+              <div class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                 {websiteMeta.digital_maturity.score}
-                <span class="text-sm font-normal text-[color:var(--color-text-muted)]"> / 10</span>
+                <span class="text-sm font-normal text-[color:var(--ss-color-text-muted)]">
+                  {' '}
+                  / 10
+                </span>
               </div>
-              <div class="text-xs text-[color:var(--color-text-secondary)]">Digital maturity</div>
+              <div class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                Digital maturity
+              </div>
             </div>
           )}
           {competitorMeta?.entity_rank_by_rating != null &&
             competitorMeta?.total_competitors != null && (
-              <div class="bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-row">
-                <div class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+              <div class="bg-[color:var(--ss-color-background)] rounded-[var(--ss-radius-card)] p-row">
+                <div class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
                   #{competitorMeta.entity_rank_by_rating}
-                  <span class="text-sm font-normal text-[color:var(--color-text-muted)]">
+                  <span class="text-sm font-normal text-[color:var(--ss-color-text-muted)]">
                     {' '}
                     of {competitorMeta.total_competitors}
                   </span>
                 </div>
-                <div class="text-xs text-[color:var(--color-text-secondary)]">Local ranking</div>
+                <div class="text-xs text-[color:var(--ss-color-text-secondary)]">Local ranking</div>
               </div>
             )}
         </div>
@@ -1077,7 +1091,7 @@ function confidenceColor(confidence: string): string {
         {/* Zone 2: Identified Problems */}
         {reviewMeta?.operational_problems && reviewMeta.operational_problems.length > 0 && (
           <div class="mb-5">
-            <div class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide mb-2">
+            <div class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] uppercase tracking-wide mb-2">
               Identified Problems
             </div>
             <div class="flex flex-wrap gap-2">
@@ -1097,9 +1111,9 @@ function confidenceColor(confidence: string): string {
         {/* Zone 3: Intelligence Brief — open by default. The brief is the core
             of the dossier; collapsing it hid the highest-value research and
             forced the operator to click before reading anything substantive. */}
-        <div class="border-t border-[color:var(--color-border-subtle)] pt-4 mb-4">
+        <div class="border-t border-[color:var(--ss-color-border-subtle)] pt-4 mb-4">
           <details open>
-            <summary class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide mb-3 cursor-pointer">
+            <summary class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] uppercase tracking-wide mb-3 cursor-pointer">
               Intelligence Brief
             </summary>
             <div
@@ -1111,26 +1125,26 @@ function confidenceColor(confidence: string): string {
 
         {/* Zone 4: Outreach Draft */}
         {outreachEntry && (
-          <div class="border-t border-[color:var(--color-border-subtle)] pt-4">
+          <div class="border-t border-[color:var(--ss-color-border-subtle)] pt-4">
             <div class="flex items-center justify-between mb-2">
-              <div class="text-xs font-medium text-[color:var(--color-text-secondary)] uppercase tracking-wide">
+              <div class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] uppercase tracking-wide">
                 Outreach Draft
                 {!outreachFromDossier && (
-                  <span class="normal-case font-normal text-[color:var(--color-text-muted)] ml-2">
+                  <span class="normal-case font-normal text-[color:var(--ss-color-text-muted)] ml-2">
                     Pre-dossier draft
                   </span>
                 )}
               </div>
               <button
                 id="copy-outreach-btn"
-                class="text-xs px-2 py-1 rounded bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-border)] transition-colors"
+                class="text-xs px-2 py-1 rounded bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border)] transition-colors"
               >
                 Copy
               </button>
             </div>
             <pre
               id="outreach-content"
-              class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap bg-[color:var(--color-background)] rounded-[var(--radius-card)] p-stack border border-[color:var(--color-border-subtle)]"
+              class="text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap bg-[color:var(--ss-color-background)] rounded-[var(--ss-radius-card)] p-stack border border-[color:var(--ss-color-border-subtle)]"
             >
               {outreachEntry.content}
             </pre>
@@ -1144,26 +1158,26 @@ function confidenceColor(confidence: string): string {
   {
     contacts.length > 0 && (
       <details
-        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4"
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
         open
       >
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Contacts ({contacts.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
           {contacts.map((c) => (
             <div class="py-2 flex items-center justify-between">
               <div>
-                <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+                <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
                   {c.name}
                 </span>
                 {c.role && (
-                  <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded ml-2">
+                  <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded ml-2">
                     {c.role}
                   </span>
                 )}
               </div>
-              <div class="text-xs text-[color:var(--color-text-muted)] flex gap-row">
+              <div class="text-xs text-[color:var(--ss-color-text-muted)] flex gap-row">
                 {c.email && <span>{c.email}</span>}
                 {c.phone && <span>{c.phone}</span>}
               </div>
@@ -1177,31 +1191,31 @@ function confidenceColor(confidence: string): string {
   {
     meetings.length > 0 && (
       <details
-        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4"
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
         open
       >
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Meetings ({meetings.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
           {meetings.map((m) => (
             <a
               href={`/admin/entities/${entity.id}/meetings/${m.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-[color:var(--color-background)] -mx-2 px-2 rounded transition-colors"
+              class="py-2 flex items-center gap-2 hover:bg-[color:var(--ss-color-background)] -mx-2 px-2 rounded transition-colors"
             >
               <span class={statusBadgeClass(m.status)}>{m.status}</span>
               {m.meeting_type && (
-                <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-1.5 py-0.5 rounded">
+                <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
                   {m.meeting_type}
                 </span>
               )}
               {m.scheduled_at && (
-                <span class="text-sm text-[color:var(--color-text-primary)]">
+                <span class="text-sm text-[color:var(--ss-color-text-primary)]">
                   {formatDate(m.scheduled_at)}
                 </span>
               )}
               {m.duration_minutes && (
-                <span class="text-xs text-[color:var(--color-text-muted)]">
+                <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                   {m.duration_minutes} min
                 </span>
               )}
@@ -1214,24 +1228,24 @@ function confidenceColor(confidence: string): string {
 
   {
     engagements.length > 0 && (
-      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+      <details class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Engagements ({engagements.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
           {engagements.map((e) => (
             <a
               href={`/admin/engagements/${e.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-[color:var(--color-background)] -mx-2 px-2 rounded transition-colors"
+              class="py-2 flex items-center gap-2 hover:bg-[color:var(--ss-color-background)] -mx-2 px-2 rounded transition-colors"
             >
               <span class={statusBadgeClass(e.status)}>{e.status}</span>
               {e.start_date && (
-                <span class="text-sm text-[color:var(--color-text-primary)]">
+                <span class="text-sm text-[color:var(--ss-color-text-primary)]">
                   {formatDate(e.start_date)}
                 </span>
               )}
               {e.estimated_hours && (
-                <span class="text-xs text-[color:var(--color-text-muted)]">
+                <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                   {e.actual_hours}/{e.estimated_hours} hrs
                 </span>
               )}
@@ -1244,22 +1258,24 @@ function confidenceColor(confidence: string): string {
 
   {
     quotes.length > 0 && (
-      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+      <details class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Quotes ({quotes.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
           {quotes.map((q) => (
             <a
               href={`/admin/entities/${entity.id}/quotes/${q.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-[color:var(--color-background)] -mx-2 px-2 rounded transition-colors"
+              class="py-2 flex items-center gap-2 hover:bg-[color:var(--ss-color-background)] -mx-2 px-2 rounded transition-colors"
             >
               <span class={statusBadgeClass(q.status)}>{q.status}</span>
-              <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+              <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
                 ${q.total_price.toLocaleString()}
               </span>
-              <span class="text-xs text-[color:var(--color-text-muted)]">{q.total_hours} hrs</span>
-              <span class="text-xs text-[color:var(--color-text-muted)]">v{q.version}</span>
+              <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                {q.total_hours} hrs
+              </span>
+              <span class="text-xs text-[color:var(--ss-color-text-muted)]">v{q.version}</span>
             </a>
           ))}
         </div>
@@ -1269,21 +1285,21 @@ function confidenceColor(confidence: string): string {
 
   {
     invoices.length > 0 && (
-      <details class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--color-text-primary)]">
+      <details class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
+        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Invoices ({invoices.length})
         </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
           {invoices.map((inv) => (
             <div class="py-2 flex items-center justify-between">
               <div class="flex items-center gap-2">
                 <span class={statusBadgeClass(inv.status)}>{inv.status}</span>
-                <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+                <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
                   ${inv.amount.toLocaleString()}
                 </span>
-                <span class="text-xs text-[color:var(--color-text-muted)]">{inv.type}</span>
+                <span class="text-xs text-[color:var(--ss-color-text-muted)]">{inv.type}</span>
                 {inv.due_date && (
-                  <span class="text-xs text-[color:var(--color-text-muted)]">
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                     Due {formatDate(inv.due_date)}
                   </span>
                 )}

--- a/src/pages/admin/entities/[id]/meetings/[meetingId].astro
+++ b/src/pages/admin/entities/[id]/meetings/[meetingId].astro
@@ -104,10 +104,11 @@ function stageBadgeClass(stage: string): string {
     engaged: 'bg-green-100 text-green-700',
     delivered: 'bg-emerald-100 text-emerald-700',
     ongoing: 'bg-teal-100 text-teal-700',
-    lost: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
+    lost: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
   }
   return (
-    map[stage] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+    map[stage] ??
+    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   )
 }
 
@@ -116,10 +117,11 @@ function tierBadgeClass(tier: string): string {
     hot: 'bg-red-100 text-red-700',
     warm: 'bg-amber-100 text-amber-700',
     cool: 'bg-blue-100 text-blue-700',
-    cold: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
+    cold: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
   }
   return (
-    map[tier] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+    map[tier] ??
+    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   )
 }
 
@@ -127,7 +129,7 @@ function contextTypeBadge(type: string): string {
   const map: Record<string, string> = {
     signal: 'bg-amber-100 text-amber-700',
     enrichment: 'bg-cyan-100 text-cyan-700',
-    note: 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]',
+    note: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
     transcript: 'bg-purple-100 text-purple-700',
     extraction: 'bg-indigo-100 text-indigo-700',
     outreach_draft: 'bg-blue-100 text-blue-700',
@@ -135,12 +137,14 @@ function contextTypeBadge(type: string): string {
     follow_up_result: 'bg-teal-100 text-teal-700',
     feedback: 'bg-emerald-100 text-emerald-700',
     parking_lot: 'bg-orange-100 text-orange-700',
-    stage_change: 'bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)]',
+    stage_change:
+      'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)]',
     intake: 'bg-pink-100 text-pink-700',
     scorecard: 'bg-violet-100 text-violet-700',
   }
   return (
-    map[type] ?? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+    map[type] ??
+    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   )
 }
 
@@ -186,21 +190,21 @@ const isMeetingTerminal =
 >
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {decodeURIComponent(error)}
       </div>
     )
   }
   {
     saved && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Changes saved.
       </div>
     )
   }
   {
     completed && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Meeting completed. Pick a next action from the entity page.
       </div>
     )
@@ -208,12 +212,12 @@ const isMeetingTerminal =
 
   {/* Entity + Meeting Info */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between gap-stack mb-4">
       <div>
         <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
             {entity.name}
           </h2>
           <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
@@ -228,7 +232,7 @@ const isMeetingTerminal =
           }
           {
             meeting.meeting_type && (
-              <span class="text-xs px-2 py-0.5 rounded bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]">
+              <span class="text-xs px-2 py-0.5 rounded bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]">
                 {meeting.meeting_type}
               </span>
             )
@@ -236,13 +240,13 @@ const isMeetingTerminal =
         </div>
 
         <div
-          class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)] flex-wrap"
+          class="flex items-center gap-stack text-sm text-[color:var(--ss-color-text-secondary)] flex-wrap"
         >
           {
             entity.pain_score != null && (
               <span>
                 Pain:{' '}
-                <strong class="text-[color:var(--color-text-primary)]">
+                <strong class="text-[color:var(--ss-color-text-primary)]">
                   {entity.pain_score}/10
                 </strong>
               </span>
@@ -262,15 +266,17 @@ const isMeetingTerminal =
       schedule && (
         <div class="grid grid-cols-1 md:grid-cols-2 gap-stack text-sm">
           <div>
-            <span class="text-[color:var(--color-text-secondary)]">Scheduled:</span>
-            <span class="ml-1 text-[color:var(--color-text-primary)] font-medium">
+            <span class="text-[color:var(--ss-color-text-secondary)]">Scheduled:</span>
+            <span class="ml-1 text-[color:var(--ss-color-text-primary)] font-medium">
               {formatDateTime(schedule.slot_start_utc)}
             </span>
-            <span class="text-[color:var(--color-text-muted)] ml-1">({schedule.timezone})</span>
+            <span class="text-[color:var(--ss-color-text-muted)] ml-1">({schedule.timezone})</span>
           </div>
           <div>
-            <span class="text-[color:var(--color-text-secondary)]">Contact:</span>
-            <span class="ml-1 text-[color:var(--color-text-primary)]">{schedule.guest_name}</span>
+            <span class="text-[color:var(--ss-color-text-secondary)]">Contact:</span>
+            <span class="ml-1 text-[color:var(--ss-color-text-primary)]">
+              {schedule.guest_name}
+            </span>
             <a href={`mailto:${schedule.guest_email}`} class="ml-1 text-blue-600 hover:underline">
               {schedule.guest_email}
             </a>
@@ -281,7 +287,7 @@ const isMeetingTerminal =
                 href={schedule.google_meet_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-blue-700 transition-colors"
+                class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-blue-700 transition-colors"
               >
                 Join Video Call
               </a>
@@ -304,7 +310,7 @@ const isMeetingTerminal =
     }
     {
       !schedule && meeting.scheduled_at && (
-        <div class="text-sm text-[color:var(--color-text-secondary)]">
+        <div class="text-sm text-[color:var(--ss-color-text-secondary)]">
           Scheduled: {formatDateTime(meeting.scheduled_at)}
         </div>
       )
@@ -313,16 +319,16 @@ const isMeetingTerminal =
 
   {/* Live Notes */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">Live Notes</h3>
-      <span id="save-status" class="text-xs text-[color:var(--color-text-muted)]">Saved</span>
+      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">Live Notes</h3>
+      <span id="save-status" class="text-xs text-[color:var(--ss-color-text-muted)]">Saved</span>
     </div>
     <textarea
       id="live-notes"
       rows="10"
-      class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
+      class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary font-mono"
       placeholder="Take notes during the call...">{liveNotesValue}</textarea
     >
   </div>
@@ -330,18 +336,18 @@ const isMeetingTerminal =
   {/* Complete Meeting Form (collapsible) */}
   {
     !isMeetingTerminal && (
-      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] mb-6">
+      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-6">
         <button
           type="button"
           id="toggle-complete"
-          class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-[color:var(--color-background)] transition-colors"
+          class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-[color:var(--ss-color-background)] transition-colors"
         >
-          <h3 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
             Complete Meeting
           </h3>
           <svg
             id="toggle-icon"
-            class="w-5 h-5 text-[color:var(--color-text-muted)] transition-transform"
+            class="w-5 h-5 text-[color:var(--ss-color-text-muted)] transition-transform"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -357,7 +363,7 @@ const isMeetingTerminal =
 
         <div
           id="complete-form"
-          class="hidden px-6 pb-6 border-t border-[color:var(--color-border-subtle)]"
+          class="hidden px-6 pb-6 border-t border-[color:var(--ss-color-border-subtle)]"
         >
           <form
             method="POST"
@@ -368,7 +374,7 @@ const isMeetingTerminal =
             <div>
               <label
                 for="completion-notes"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Outcome Notes
               </label>
@@ -376,7 +382,7 @@ const isMeetingTerminal =
                 name="completion_notes"
                 id="completion-notes"
                 rows="5"
-                class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
                 placeholder="What came out of this meeting? Decisions, next steps, anything worth remembering."
               />
             </div>
@@ -385,7 +391,7 @@ const isMeetingTerminal =
             <div>
               <label
                 for="duration_minutes"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Duration (minutes)
               </label>
@@ -396,7 +402,7 @@ const isMeetingTerminal =
                 min="1"
                 max="300"
                 placeholder="30"
-                class="w-32 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                class="w-32 text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
               />
             </div>
 
@@ -404,20 +410,20 @@ const isMeetingTerminal =
             <div>
               <label
                 for="next_stage"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Next stage for {entity.name}
               </label>
               <select
                 name="next_stage"
                 id="next_stage"
-                class="w-full md:w-96 text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                class="w-full md:w-96 text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
               >
                 {NEXT_STAGE_OPTIONS.map((opt) => (
                   <option value={opt.value}>{opt.label}</option>
                 ))}
               </select>
-              <p class="mt-1 text-xs text-[color:var(--color-text-muted)]">
+              <p class="mt-1 text-xs text-[color:var(--ss-color-text-muted)]">
                 Drafting a proposal is a separate action on the entity page — completing a meeting
                 never creates a quote by itself.
               </p>
@@ -427,7 +433,7 @@ const isMeetingTerminal =
             <div class="flex items-center gap-row pt-2">
               <button
                 type="submit"
-                class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-[var(--radius-card)] hover:bg-green-700 transition-colors font-medium"
+                class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-[var(--ss-radius-card)] hover:bg-green-700 transition-colors font-medium"
               >
                 Complete Meeting
               </button>
@@ -440,35 +446,35 @@ const isMeetingTerminal =
 
   {/* Entity Context Timeline */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
   >
-    <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+    <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
       Entity Context Timeline
-      <span class="text-sm font-normal text-[color:var(--color-text-muted)] ml-1"
+      <span class="text-sm font-normal text-[color:var(--ss-color-text-muted)] ml-1"
         >({contextEntries.length} entries)</span
       >
     </h3>
 
     {
       timelineEntries.length === 0 && (
-        <p class="text-sm text-[color:var(--color-text-muted)]">No context entries yet.</p>
+        <p class="text-sm text-[color:var(--ss-color-text-muted)]">No context entries yet.</p>
       )
     }
 
     <div class="space-y-row">
       {
         timelineEntries.map((entry) => (
-          <div class="border border-[color:var(--color-border-subtle)] rounded-[var(--radius-card)] p-row">
+          <div class="border border-[color:var(--ss-color-border-subtle)] rounded-[var(--ss-radius-card)] p-row">
             <div class="flex items-center gap-2 mb-1">
               <span class={`text-xs px-1.5 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
                 {entry.type.replace(/_/g, ' ')}
               </span>
-              <span class="text-xs text-[color:var(--color-text-muted)]">{entry.source}</span>
-              <span class="text-xs text-[color:var(--color-text-muted)] ml-auto">
+              <span class="text-xs text-[color:var(--ss-color-text-muted)]">{entry.source}</span>
+              <span class="text-xs text-[color:var(--ss-color-text-muted)] ml-auto">
                 {formatDate(entry.created_at)}
               </span>
             </div>
-            <div class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap break-words">
+            <div class="text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap break-words">
               {entry.content.length > 500 ? entry.content.slice(0, 500) + '...' : entry.content}
             </div>
           </div>

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -105,14 +105,14 @@ function formatCurrency(amount: number): string {
 >
   {
     saved && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Quote saved.
       </div>
     )
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {error === 'invalid_transition'
           ? 'Invalid status transition.'
           : error === 'no_sow'
@@ -131,7 +131,7 @@ function formatCurrency(amount: number): string {
   {/* Stale PDF warning (OQ-006) */}
   {
     isSowStale && (
-      <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         The quote has been modified since the last SOW PDF was generated. Re-generate the PDF before
         sending.
       </div>
@@ -140,19 +140,21 @@ function formatCurrency(amount: number): string {
 
   {/* Header */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between gap-stack">
       <div>
         <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
             {entity.name}
           </h2>
           <span class={statusBadgeClass(status)}>
             {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
           </span>
         </div>
-        <div class="flex items-center gap-stack text-sm text-[color:var(--color-text-secondary)]">
+        <div
+          class="flex items-center gap-stack text-sm text-[color:var(--ss-color-text-secondary)]"
+        >
           <span>Created {formatDate(quote.created_at)}</span>
           {
             expiresAt && (
@@ -170,10 +172,10 @@ function formatCurrency(amount: number): string {
 
   {/* Line Item Editor */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-center justify-between mb-4">
-      <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)]">Line Items</h3>
+      <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">Line Items</h3>
       <div id="line-item-warning" class="hidden text-sm text-amber-600 font-medium">
         Consider keeping scope focused — 3+ line items may indicate too broad an engagement (OQ-005)
       </div>
@@ -182,19 +184,20 @@ function formatCurrency(amount: number): string {
     <div id="line-items-container">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b border-[color:var(--color-border)]">
-            <th class="text-left py-2 px-2 text-[color:var(--color-text-secondary)] font-medium w-8"
+          <tr class="border-b border-[color:var(--ss-color-border)]">
+            <th
+              class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-8"
               >#</th
             >
             <th
-              class="text-left py-2 px-2 text-[color:var(--color-text-secondary)] font-medium w-48"
+              class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-48"
               >Problem</th
             >
-            <th class="text-left py-2 px-2 text-[color:var(--color-text-secondary)] font-medium"
+            <th class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium"
               >Description</th
             >
             <th
-              class="text-right py-2 px-2 text-[color:var(--color-text-secondary)] font-medium w-24"
+              class="text-right py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-24"
               >Est. Hours</th
             >
             {isDraft && <th class="py-2 px-2 w-10" />}
@@ -204,47 +207,49 @@ function formatCurrency(amount: number): string {
           {
             lineItems.map((item, index) => (
               <tr
-                class="border-b border-[color:var(--color-border-subtle)] line-item-row"
+                class="border-b border-[color:var(--ss-color-border-subtle)] line-item-row"
                 data-index={index}
               >
-                <td class="py-2 px-2 text-[color:var(--color-text-muted)] row-number">
+                <td class="py-2 px-2 text-[color:var(--ss-color-text-muted)] row-number">
                   {index + 1}
                 </td>
                 <td class="py-2 px-2">
                   {isDraft ? (
                     <input
                       type="text"
-                      class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-problem"
+                      class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-problem"
                       value={item.problem}
                       placeholder="e.g., Scheduling chaos"
                     />
                   ) : (
-                    <span class="text-[color:var(--color-text-primary)]">{item.problem}</span>
+                    <span class="text-[color:var(--ss-color-text-primary)]">{item.problem}</span>
                   )}
                 </td>
                 <td class="py-2 px-2">
                   {isDraft ? (
                     <input
                       type="text"
-                      class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-description"
+                      class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-description"
                       value={item.description}
                       placeholder="What we'll deliver"
                     />
                   ) : (
-                    <span class="text-[color:var(--color-text-primary)]">{item.description}</span>
+                    <span class="text-[color:var(--ss-color-text-primary)]">
+                      {item.description}
+                    </span>
                   )}
                 </td>
                 <td class="py-2 px-2 text-right">
                   {isDraft ? (
                     <input
                       type="number"
-                      class="w-20 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm text-right item-hours"
+                      class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours"
                       value={item.estimated_hours}
                       min="0.5"
                       step="0.5"
                     />
                   ) : (
-                    <span class="text-[color:var(--color-text-primary)]">
+                    <span class="text-[color:var(--ss-color-text-primary)]">
                       {item.estimated_hours}
                     </span>
                   )}
@@ -253,7 +258,7 @@ function formatCurrency(amount: number): string {
                   <td class="py-2 px-2 text-center">
                     <button
                       type="button"
-                      class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-item-btn"
+                      class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-item-btn"
                       title="Remove"
                     >
                       &times;
@@ -280,15 +285,15 @@ function formatCurrency(amount: number): string {
     </div>
 
     {/* Totals */}
-    <div class="mt-4 pt-4 border-t border-[color:var(--color-border)] flex justify-end">
+    <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border)] flex justify-end">
       <div class="text-right space-y-1">
-        <div class="text-sm text-[color:var(--color-text-secondary)]">
+        <div class="text-sm text-[color:var(--ss-color-text-secondary)]">
           Total hours: <span
             id="total-hours"
-            class="font-medium text-[color:var(--color-text-primary)]">{quote.total_hours}</span
+            class="font-medium text-[color:var(--ss-color-text-primary)]">{quote.total_hours}</span
           >
         </div>
-        <div class="text-lg font-semibold text-[color:var(--color-text-primary)]">
+        <div class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
           Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
         </div>
       </div>
@@ -297,22 +302,22 @@ function formatCurrency(amount: number): string {
 
   {/* Payment Structure */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
-    <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-4">
+    <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
       Payment Structure
     </h3>
 
     <div class="space-y-row">
       <div class="flex items-center gap-stack">
-        <label class="text-sm text-[color:var(--color-text-secondary)] w-36"
+        <label class="text-sm text-[color:var(--ss-color-text-secondary)] w-36"
           >Deposit percentage:</label
         >
         {
           isDraft ? (
             <select
               id="deposit-pct-select"
-              class="border border-[color:var(--color-border)] rounded px-2 py-1 text-sm"
+              class="border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
             >
               <option value="0.5" selected={depositPct === 0.5}>
                 50%
@@ -322,7 +327,7 @@ function formatCurrency(amount: number): string {
               </option>
             </select>
           ) : (
-            <span class="text-sm text-[color:var(--color-text-primary)]">
+            <span class="text-sm text-[color:var(--ss-color-text-primary)]">
               {Math.round(depositPct * 100)}%
             </span>
           )
@@ -338,10 +343,10 @@ function formatCurrency(amount: number): string {
         )
       }
 
-      <div class="text-sm text-[color:var(--color-text-secondary)] space-y-1">
+      <div class="text-sm text-[color:var(--ss-color-text-secondary)] space-y-1">
         <div class="flex justify-between max-w-xs">
           <span>Deposit:</span>
-          <span id="deposit-amount" class="font-medium text-[color:var(--color-text-primary)]">
+          <span id="deposit-amount" class="font-medium text-[color:var(--ss-color-text-primary)]">
             {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
           </span>
         </div>
@@ -350,13 +355,13 @@ function formatCurrency(amount: number): string {
             <>
               <div class="flex justify-between max-w-xs">
                 <span>Mid-engagement milestone:</span>
-                <span class="font-medium text-[color:var(--color-text-primary)]">
+                <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                   {formatCurrency(quote.total_price * 0.3)}
                 </span>
               </div>
               <div class="flex justify-between max-w-xs">
                 <span>Completion:</span>
-                <span class="font-medium text-[color:var(--color-text-primary)]">
+                <span class="font-medium text-[color:var(--ss-color-text-primary)]">
                   {formatCurrency(quote.total_price * 0.3)}
                 </span>
               </div>
@@ -366,7 +371,7 @@ function formatCurrency(amount: number): string {
               <span>Completion:</span>
               <span
                 id="completion-amount"
-                class="font-medium text-[color:var(--color-text-primary)]"
+                class="font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 {formatCurrency(quote.total_price * (1 - depositPct))}
               </span>
@@ -379,10 +384,10 @@ function formatCurrency(amount: number): string {
 
   {/* Authored client-facing content (#377) */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between mb-1">
-      <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)]">
+      <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
         Client-facing content
       </h3>
       {
@@ -397,7 +402,7 @@ function formatCurrency(amount: number): string {
         )
       }
     </div>
-    <p class="text-sm text-[color:var(--color-text-secondary)] mb-5">
+    <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-5">
       Authored per engagement. Renders on the client proposal page and SOW PDF. Quotes cannot be
       sent until the schedule and deliverables are populated.
     </p>
@@ -405,7 +410,7 @@ function formatCurrency(amount: number): string {
     {/* Schedule */}
     <div class="mb-6">
       <div class="flex items-center justify-between mb-2">
-        <label class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+        <label class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
           How we'll work (schedule)
         </label>
         {
@@ -420,13 +425,13 @@ function formatCurrency(amount: number): string {
           )
         }
       </div>
-      <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
+      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
         One row per phase. The label sits in the left gutter (e.g. "Discovery", "Build").
       </p>
       <div id="schedule-rows" data-empty-text="No schedule rows authored yet.">
         {
           schedule.length === 0 ? (
-            <div class="text-sm text-[color:var(--color-text-secondary)] italic py-2 schedule-empty-state">
+            <div class="text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 schedule-empty-state">
               No schedule rows authored yet.
             </div>
           ) : (
@@ -436,19 +441,19 @@ function formatCurrency(amount: number): string {
                   <>
                     <input
                       type="text"
-                      class="w-32 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-label"
+                      class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label"
                       value={row.label}
                       placeholder="Label"
                     />
                     <input
                       type="text"
-                      class="flex-1 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-body"
+                      class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body"
                       value={row.body}
                       placeholder="What happens in this phase"
                     />
                     <button
                       type="button"
-                      class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2"
+                      class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2"
                       title="Remove"
                     >
                       &times;
@@ -456,10 +461,10 @@ function formatCurrency(amount: number): string {
                   </>
                 ) : (
                   <>
-                    <span class="w-32 text-sm font-medium text-[color:var(--color-text-secondary)]">
+                    <span class="w-32 text-sm font-medium text-[color:var(--ss-color-text-secondary)]">
                       {row.label}
                     </span>
-                    <span class="flex-1 text-sm text-[color:var(--color-text-primary)]">
+                    <span class="flex-1 text-sm text-[color:var(--ss-color-text-primary)]">
                       {row.body}
                     </span>
                   </>
@@ -474,7 +479,7 @@ function formatCurrency(amount: number): string {
     {/* Deliverables */}
     <div class="mb-6">
       <div class="flex items-center justify-between mb-2">
-        <label class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+        <label class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
           What you'll get (deliverables)
         </label>
         {
@@ -489,13 +494,13 @@ function formatCurrency(amount: number): string {
           )
         }
       </div>
-      <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
+      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
         Authored deliverables replace the line-item-derived list on the proposal page.
       </p>
       <div id="deliverable-rows" data-empty-text="No deliverables authored yet.">
         {
           deliverables.length === 0 ? (
-            <div class="text-sm text-[color:var(--color-text-secondary)] italic py-2 deliverable-empty-state">
+            <div class="text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 deliverable-empty-state">
               No deliverables authored yet.
             </div>
           ) : (
@@ -506,12 +511,12 @@ function formatCurrency(amount: number): string {
                     <div class="flex-1 space-y-1">
                       <input
                         type="text"
-                        class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-title"
+                        class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title"
                         value={row.title}
                         placeholder="Title"
                       />
                       <textarea
-                        class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-body"
+                        class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body"
                         rows="2"
                         placeholder="Description"
                       >
@@ -520,7 +525,7 @@ function formatCurrency(amount: number): string {
                     </div>
                     <button
                       type="button"
-                      class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2"
+                      class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2"
                       title="Remove"
                     >
                       &times;
@@ -528,10 +533,10 @@ function formatCurrency(amount: number): string {
                   </div>
                 ) : (
                   <div>
-                    <p class="text-sm font-semibold text-[color:var(--color-text-primary)]">
+                    <p class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
                       {row.title}
                     </p>
-                    <p class="text-sm text-[color:var(--color-text-secondary)]">{row.body}</p>
+                    <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{row.body}</p>
                   </div>
                 )}
               </div>
@@ -544,28 +549,28 @@ function formatCurrency(amount: number): string {
     {/* Engagement overview (SOW PDF) */}
     <div class="mb-6">
       <label
-        class="block text-sm font-semibold text-[color:var(--color-text-primary)] mb-1"
+        class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
         for="engagement-overview-input"
       >
         Engagement overview (SOW PDF)
       </label>
-      <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
+      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
         Renders on the SOW PDF "Engagement overview" page. Required before generating the SOW PDF.
       </p>
       {
         isDraft ? (
           <textarea
             id="engagement-overview-input"
-            class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
             rows="3"
             placeholder="What this engagement is about, in one or two sentences."
           >
             {engagementOverview}
           </textarea>
         ) : (
-          <p class="text-sm text-[color:var(--color-text-primary)] whitespace-pre-wrap">
+          <p class="text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap">
             {engagementOverview || (
-              <span class="italic text-[color:var(--color-text-muted)]">Not authored.</span>
+              <span class="italic text-[color:var(--ss-color-text-muted)]">Not authored.</span>
             )}
           </p>
         )
@@ -577,12 +582,12 @@ function formatCurrency(amount: number): string {
       isThreeMilestone && (
         <div class="mb-2">
           <label
-            class="block text-sm font-semibold text-[color:var(--color-text-primary)] mb-1"
+            class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
             for="milestone-label-input"
           >
             Mid-engagement milestone label
           </label>
-          <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
+          <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
             Per-engagement label for the 30% mid-engagement milestone (e.g. "First-pass review",
             "Pilot rollout"). Optional; the SOW renders neutral wording when empty.
           </p>
@@ -590,14 +595,14 @@ function formatCurrency(amount: number): string {
             <input
               id="milestone-label-input"
               type="text"
-              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+              class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               value={milestoneLabel}
               placeholder="Optional label for the mid-engagement milestone"
             />
           ) : (
-            <p class="text-sm text-[color:var(--color-text-primary)]">
+            <p class="text-sm text-[color:var(--ss-color-text-primary)]">
               {milestoneLabel || (
-                <span class="italic text-[color:var(--color-text-muted)]">Not authored.</span>
+                <span class="italic text-[color:var(--ss-color-text-muted)]">Not authored.</span>
               )}
             </p>
           )}
@@ -609,9 +614,11 @@ function formatCurrency(amount: number): string {
   {/* SOW PDF Status */}
   {
     hasSow && (
-      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card mb-6">
-        <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-2">SOW PDF</h3>
-        <div class="text-sm text-[color:var(--color-text-secondary)] space-y-1">
+      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
+        <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
+          SOW PDF
+        </h3>
+        <div class="text-sm text-[color:var(--ss-color-text-secondary)] space-y-1">
           <div>
             Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
           </div>
@@ -625,9 +632,9 @@ function formatCurrency(amount: number): string {
 
   {/* Actions */}
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
   >
-    <h3 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-4">Actions</h3>
+    <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">Actions</h3>
     <div class="flex flex-wrap gap-row">
       {/* Save Draft */}
       {
@@ -702,7 +709,7 @@ function formatCurrency(amount: number): string {
           <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
             <select
               name="signer_contact_id"
-              class="px-3 py-2 border border-[color:var(--color-border)] rounded text-sm bg-white"
+              class="px-3 py-2 border border-[color:var(--ss-color-border)] rounded text-sm bg-white"
               required
             >
               {contacts
@@ -730,7 +737,7 @@ function formatCurrency(amount: number): string {
             <input type="hidden" name="action" value="decline" />
             <button
               type="submit"
-              class="px-4 py-2 bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] rounded hover:bg-[color:var(--color-border)] transition-colors text-sm font-medium"
+              class="px-4 py-2 bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] rounded hover:bg-[color:var(--ss-color-border)] transition-colors text-sm font-medium"
             >
               Decline
             </button>
@@ -745,7 +752,7 @@ function formatCurrency(amount: number): string {
             <input type="hidden" name="action" value="expire" />
             <button
               type="submit"
-              class="px-4 py-2 bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] rounded hover:bg-[color:var(--color-border)] transition-colors text-sm font-medium"
+              class="px-4 py-2 bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] rounded hover:bg-[color:var(--ss-color-border)] transition-colors text-sm font-medium"
             >
               Mark Expired
             </button>
@@ -756,7 +763,7 @@ function formatCurrency(amount: number): string {
 
     {
       isTerminal && (
-        <p class="mt-3 text-sm text-[color:var(--color-text-secondary)]">
+        <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
           This quote is in a terminal state ({status}) and cannot be modified.
         </p>
       )
@@ -870,7 +877,7 @@ function formatCurrency(amount: number): string {
         if (rows.length === 0) {
           const div = document.createElement('div')
           div.className =
-            'text-sm text-[color:var(--color-text-secondary)] italic py-2 ' +
+            'text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 ' +
             (isDeliverable ? 'deliverable-empty-state' : 'schedule-empty-state')
           div.textContent = container.getAttribute('data-empty-text') ?? ''
           container.appendChild(div)
@@ -924,9 +931,9 @@ function formatCurrency(amount: number): string {
         const div = document.createElement('div')
         div.className = 'flex gap-2 mb-2 schedule-row'
         div.innerHTML = `
-          <input type="text" class="w-32 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
-          <input type="text" class="flex-1 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
-          <button type="button" class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
+          <input type="text" class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
+          <input type="text" class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
+          <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
         `
         scheduleRowsContainer.appendChild(div)
       }
@@ -939,10 +946,10 @@ function formatCurrency(amount: number): string {
         div.innerHTML = `
           <div class="flex gap-2">
             <div class="flex-1 space-y-1">
-              <input type="text" class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
-              <textarea class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
+              <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
+              <textarea class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
             </div>
-            <button type="button" class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
+            <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
           </div>
         `
         deliverableRowsContainer.appendChild(div)
@@ -987,21 +994,21 @@ function formatCurrency(amount: number): string {
       function addRow() {
         const index = body.querySelectorAll('.line-item-row').length
         const tr = document.createElement('tr')
-        tr.className = 'border-b border-[color:var(--color-border-subtle)] line-item-row'
+        tr.className = 'border-b border-[color:var(--ss-color-border-subtle)] line-item-row'
         tr.setAttribute('data-index', String(index))
         tr.innerHTML = `
-            <td class="py-2 px-2 text-[color:var(--color-text-muted)] row-number">${index + 1}</td>
+            <td class="py-2 px-2 text-[color:var(--ss-color-text-muted)] row-number">${index + 1}</td>
             <td class="py-2 px-2">
-              <input type="text" class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
+              <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
             </td>
             <td class="py-2 px-2">
-              <input type="text" class="w-full border border-[color:var(--color-border)] rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
+              <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
             </td>
             <td class="py-2 px-2 text-right">
-              <input type="number" class="w-20 border border-[color:var(--color-border)] rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
+              <input type="number" class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
             </td>
             <td class="py-2 px-2 text-center">
-              <button type="button" class="text-[color:var(--color-text-muted)] hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
+              <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
             </td>
           `
         body.appendChild(tr)

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -266,7 +266,7 @@ function meetingSubstateBadgeClass(s: MeetingSubstate): string {
       return 'bg-blue-100 text-blue-700'
     case 'awaiting-booking':
     default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 
@@ -279,7 +279,7 @@ function tierBadgeClass(tier: string | null): string {
     case 'cool':
       return 'bg-blue-100 text-blue-700'
     case 'cold':
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
     default:
       return ''
   }
@@ -302,9 +302,9 @@ function stageBadgeClass(stage: string): string {
     case 'ongoing':
       return 'border-teal-500 text-teal-600'
     case 'lost':
-      return 'border-slate-400 text-[color:var(--color-text-secondary)]'
+      return 'border-slate-400 text-[color:var(--ss-color-text-secondary)]'
     default:
-      return 'border-[color:var(--color-border)] text-[color:var(--color-text-secondary)]'
+      return 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 
@@ -363,26 +363,26 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
 >
   {
     dismissed && (
-      <div class="bg-[color:var(--color-background)] border border-[color:var(--color-border)] text-[color:var(--color-text-secondary)] text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-[color:var(--ss-color-background)] border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {dismissedName ? `${dismissedName} dismissed.` : 'Entity dismissed.'}
       </div>
     )
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {error}
       </div>
     )
   }
 
   <div class="flex items-center justify-between mb-6">
-    <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Entities</h2>
+    <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">Entities</h2>
     <form method="GET" class="flex items-center gap-2">
       <input type="hidden" name="stage" value={filterStage} />
       <select
         name="pipeline"
-        class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+        class="text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-1.5 bg-white text-[color:var(--ss-color-text-primary)]"
         onchange="this.form.submit()"
       >
         <option value="">All pipelines</option>
@@ -398,7 +398,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
   </div>
 
   {/* Stage tabs */}
-  <div class="flex gap-1 mb-6 border-b border-[color:var(--color-border)] overflow-x-auto">
+  <div class="flex gap-1 mb-6 border-b border-[color:var(--ss-color-border)] overflow-x-auto">
     {
       ENTITY_STAGES.map((s) => (
         <a
@@ -406,7 +406,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
           class={`px-3 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
             filterStage === s.value
               ? stageBadgeClass(s.value) + ' border-current'
-              : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
+              : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
           }`}
         >
           {s.label}
@@ -414,8 +414,8 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             <span
               class={`ml-1 text-xs px-1.5 py-0.5 rounded-full ${
                 filterStage === s.value
-                  ? 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-primary)]'
-                  : 'bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)]'
+                  ? 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-primary)]'
+                  : 'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)]'
               }`}
             >
               {stageCounts[s.value]}
@@ -429,13 +429,13 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
   {/* Entity list */}
   {
     displayEntities.length === 0 ? (
-      <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
+      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
         {filterPipeline ? (
-          <p class="text-[color:var(--color-text-secondary)] text-sm">
+          <p class="text-[color:var(--ss-color-text-secondary)] text-sm">
             No <strong>{filterStage}</strong> entities match the selected pipeline.{' '}
             <a
               href={`/admin/entities?stage=${filterStage}`}
-              class="text-[color:var(--color-primary)] hover:underline"
+              class="text-[color:var(--ss-color-primary)] hover:underline"
             >
               Clear filter
             </a>
@@ -443,10 +443,10 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
           </p>
         ) : (
           <>
-            <p class="text-[color:var(--color-text-primary)] text-sm font-medium mb-1">
+            <p class="text-[color:var(--ss-color-text-primary)] text-sm font-medium mb-1">
               {EMPTY_STATE_COPY[filterStage].headline}
             </p>
-            <p class="text-[color:var(--color-text-secondary)] text-sm">
+            <p class="text-[color:var(--ss-color-text-secondary)] text-sm">
               {EMPTY_STATE_COPY[filterStage].hint}
             </p>
           </>
@@ -455,30 +455,30 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
     ) : (
       <div
         id="entity-list"
-        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)]"
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
         data-bulk-enabled={bulkEnabled ? 'true' : 'false'}
       >
         {bulkEnabled && (
-          <div class="px-6 py-3 border-b border-[color:var(--color-border-subtle)] flex items-center gap-3 bg-[color:var(--color-background)]">
-            <label class="inline-flex items-center gap-2 text-xs text-[color:var(--color-text-secondary)] cursor-pointer select-none">
+          <div class="px-6 py-3 border-b border-[color:var(--ss-color-border-subtle)] flex items-center gap-3 bg-[color:var(--ss-color-background)]">
+            <label class="inline-flex items-center gap-2 text-xs text-[color:var(--ss-color-text-secondary)] cursor-pointer select-none">
               <input
                 type="checkbox"
                 id="bulk-select-all"
-                class="w-4 h-4 rounded border-[color:var(--color-border)] cursor-pointer"
+                class="w-4 h-4 rounded border-[color:var(--ss-color-border)] cursor-pointer"
                 aria-label="Select all on page"
               />
               Select all on page
             </label>
             <span
               id="bulk-count-inline"
-              class="text-xs text-[color:var(--color-text-muted)]"
+              class="text-xs text-[color:var(--ss-color-text-muted)]"
               aria-live="polite"
             >
               {displayEntities.length} {displayEntities.length === 1 ? 'entity' : 'entities'}
             </span>
           </div>
         )}
-        <div class="divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
           {displayEntities.map((e: Entity) => {
             const meta = signalMetadata.get(e.id)
             const problems = (meta?.top_problems ?? [])
@@ -532,7 +532,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             const quoteAge = relativeTime(quoteTimestamp)
             return (
               <div
-                class="group relative px-6 py-4 flex items-start gap-3 hover:bg-[color:var(--color-background)] transition-colors"
+                class="group relative px-6 py-4 flex items-start gap-3 hover:bg-[color:var(--ss-color-background)] transition-colors"
                 data-entity-row
                 data-entity-id={e.id}
               >
@@ -540,7 +540,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                   <div class="relative z-10 pt-0.5">
                     <input
                       type="checkbox"
-                      class="bulk-select-row w-4 h-4 rounded border-[color:var(--color-border)] cursor-pointer"
+                      class="bulk-select-row w-4 h-4 rounded border-[color:var(--ss-color-border)] cursor-pointer"
                       data-entity-id={e.id}
                       data-entity-name={e.name}
                       aria-label={`Select ${e.name}`}
@@ -552,14 +552,14 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                     relative z-10 so they remain independently clickable. */}
                 <a
                   href={`/admin/entities/${e.id}`}
-                  class="absolute inset-0 z-0 rounded-[var(--radius-card)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-primary)]"
+                  class="absolute inset-0 z-0 rounded-[var(--ss-radius-card)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)]"
                   aria-label={`Open ${e.name}`}
                   tabindex="0"
                 />
                 <div class="flex items-start justify-between gap-stack flex-1 min-w-0">
                   <div class="min-w-0 flex-1">
                     <div class="flex items-center gap-2 mb-1 flex-wrap">
-                      <span class="text-sm font-medium text-[color:var(--color-text-primary)] group-hover:text-primary transition-colors">
+                      <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)] group-hover:text-primary transition-colors">
                         {e.name}
                       </span>
                       {activeQuote && (
@@ -569,7 +569,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                             {activeQuote.version > 1 ? ` v${activeQuote.version}` : ''}
                           </span>
                           {quoteAge && (
-                            <span class="text-xs text-[color:var(--color-text-muted)]">
+                            <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                               {quoteAge}
                             </span>
                           )}
@@ -615,7 +615,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                     {isSignal && problems.length > 0 && (
                       <div class="flex flex-wrap items-center gap-1 mb-1.5">
                         {problems.map((p) => (
-                          <span class="text-xs px-2 py-0.5 rounded-full bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] border border-[color:var(--color-border-subtle)]">
+                          <span class="text-xs px-2 py-0.5 rounded-full bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)] border border-[color:var(--ss-color-border-subtle)]">
                             {p.label}
                           </span>
                         ))}
@@ -623,13 +623,13 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                     )}
 
                     {isSignal && outreachAngle && (
-                      <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2 italic">
+                      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-1 line-clamp-2 italic">
                         {outreachAngle}
                       </p>
                     )}
 
                     {!isSignal && e.summary && (
-                      <p class="text-xs text-[color:var(--color-text-secondary)] mb-1 line-clamp-2">
+                      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-1 line-clamp-2">
                         {e.summary}
                       </p>
                     )}
@@ -650,7 +650,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                       </p>
                     )}
 
-                    <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)] mt-1 flex-wrap">
+                    <div class="flex items-center gap-row text-xs text-[color:var(--ss-color-text-muted)] mt-1 flex-wrap">
                       {isSignal && lastActivity ? (
                         <span>Last activity {formatDate(lastActivity)}</span>
                       ) : isSignal ? (
@@ -688,7 +688,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           href={website.href}
                           target="_blank"
                           rel="noreferrer noopener"
-                          class="relative z-10 inline-flex items-center gap-1 text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] transition-colors"
+                          class="relative z-10 inline-flex items-center gap-1 text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] transition-colors"
                           title={website.label}
                         >
                           <svg
@@ -712,7 +712,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                       {isSignal && e.phone && (
                         <a
                           href={`tel:${e.phone}`}
-                          class="relative z-10 text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-primary)] transition-colors"
+                          class="relative z-10 text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] transition-colors"
                         >
                           {e.phone}
                         </a>
@@ -732,7 +732,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                             <form method="POST" action={`/api/admin/entities/${e.id}/promote`}>
                               <button
                                 type="submit"
-                                class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                                class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
                               >
                                 Promote
                               </button>
@@ -740,7 +740,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                             <form method="POST" action={`/api/admin/entities/${e.id}/dismiss`}>
                               <button
                                 type="submit"
-                                class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                                class="text-xs bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)] px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
                               >
                                 Dismiss
                               </button>
@@ -753,7 +753,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           >
                             <button
                               type="submit"
-                              class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                              class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
                               title="Create a draft quote from the most recent completed meeting's notes"
                             >
                               Draft proposal
@@ -764,7 +764,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                             {rowOutreachMailto && (
                               <a
                                 href={rowOutreachMailto}
-                                class="text-xs border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+                                class="text-xs border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-background)] transition-colors"
                                 title={`Open mail to ${rowContactEmail} with the draft pre-filled`}
                               >
                                 Send outreach
@@ -774,7 +774,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                               <button
                                 type="button"
                                 data-open-reply-dialog={e.id}
-                                class="text-xs border border-[color:var(--color-border)] text-[color:var(--color-text-primary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+                                class="text-xs border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-background)] transition-colors"
                               >
                                 Log reply
                               </button>
@@ -808,7 +808,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
         {/* Sticky bulk action bar — hidden until a row is selected */}
         <div
           id="bulk-bar"
-          class="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 hidden bg-[color:var(--color-text-primary)] text-white rounded-[var(--radius-card)] shadow-lg px-4 py-3 items-center gap-3 max-w-[calc(100%-2rem)]"
+          class="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 hidden bg-[color:var(--ss-color-text-primary)] text-white rounded-[var(--ss-radius-card)] shadow-lg px-4 py-3 items-center gap-3 max-w-[calc(100%-2rem)]"
           role="region"
           aria-label="Bulk actions"
         >
@@ -819,21 +819,21 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
           <button
             type="button"
             id="bulk-outreach"
-            class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1.5 rounded-[var(--radius-card)] transition-colors"
+            class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1.5 rounded-[var(--ss-radius-card)] transition-colors"
           >
             Send outreach
           </button>
           <button
             type="button"
             id="bulk-export"
-            class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1.5 rounded-[var(--radius-card)] transition-colors"
+            class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1.5 rounded-[var(--ss-radius-card)] transition-colors"
           >
             Export CSV
           </button>
           <button
             type="button"
             id="bulk-dismiss"
-            class="text-xs bg-red-500/80 hover:bg-red-500 px-3 py-1.5 rounded-[var(--radius-card)] transition-colors"
+            class="text-xs bg-red-500/80 hover:bg-red-500 px-3 py-1.5 rounded-[var(--ss-radius-card)] transition-colors"
           >
             Dismiss
           </button>
@@ -855,26 +855,26 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
           aria-modal="true"
           aria-labelledby="bulk-dismiss-title"
         >
-          <div class="bg-white rounded-[var(--radius-card)] shadow-lg max-w-md w-full p-6">
+          <div class="bg-white rounded-[var(--ss-radius-card)] shadow-lg max-w-md w-full p-6">
             <h3
               id="bulk-dismiss-title"
-              class="text-base font-semibold text-[color:var(--color-text-primary)] mb-1"
+              class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
             >
               Dismiss <span id="bulk-dismiss-count">0</span> entities?
             </h3>
-            <p class="text-sm text-[color:var(--color-text-secondary)] mb-4">
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-4">
               Each entity transitions to <strong>lost</strong>. A structured reason is recorded per
               entity. This can be undone individually from the Lost tab.
             </p>
             <label
               for="bulk-dismiss-reason"
-              class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+              class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
             >
               Reason (required)
             </label>
             <select
               id="bulk-dismiss-reason"
-              class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white text-[color:var(--color-text-primary)] mb-3"
+              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white text-[color:var(--ss-color-text-primary)] mb-3"
             >
               {LOST_REASONS.map((r) => (
                 <option value={r.value}>{r.label}</option>
@@ -882,14 +882,14 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             </select>
             <label
               for="bulk-dismiss-detail"
-              class="block text-xs font-medium text-[color:var(--color-text-secondary)] mb-1"
+              class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
             >
               Optional detail
             </label>
             <textarea
               id="bulk-dismiss-detail"
               rows="2"
-              class="w-full text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-2 bg-white text-[color:var(--color-text-primary)] mb-4 resize-none"
+              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white text-[color:var(--ss-color-text-primary)] mb-4 resize-none"
               placeholder="Optional context saved with the reason"
             />
             <div id="bulk-dismiss-error" class="text-xs text-red-600 mb-3 hidden" role="alert" />
@@ -897,14 +897,14 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
               <button
                 type="button"
                 id="bulk-dismiss-cancel"
-                class="text-sm px-3 py-1.5 rounded-[var(--radius-card)] text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-background)] transition-colors"
+                class="text-sm px-3 py-1.5 rounded-[var(--ss-radius-card)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
               >
                 Cancel
               </button>
               <button
                 type="button"
                 id="bulk-dismiss-confirm"
-                class="text-sm px-3 py-1.5 rounded-[var(--radius-card)] bg-red-600 text-white hover:bg-red-700 transition-colors"
+                class="text-sm px-3 py-1.5 rounded-[var(--ss-radius-card)] bg-red-600 text-white hover:bg-red-700 transition-colors"
               >
                 Dismiss entities
               </button>

--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -93,21 +93,21 @@ const success = Astro.url.searchParams.get('saved')
 >
   {
     success && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--radius-card)] mb-4">
+      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Follow-up updated successfully.
       </div>
     )
   }
 
   <div class="flex items-center justify-between mb-6">
-    <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Follow-ups</h2>
+    <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">Follow-ups</h2>
 
     {/* Type filter */}
     <form method="GET" class="flex items-center gap-2">
       <input type="hidden" name="tab" value={activeTab} />
       <select
         name="type"
-        class="text-sm border border-[color:var(--color-border)] rounded-[var(--radius-card)] px-3 py-1.5 bg-white text-[color:var(--color-text-primary)]"
+        class="text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-1.5 bg-white text-[color:var(--ss-color-text-primary)]"
         onchange="this.form.submit()"
       >
         <option value="">All types</option>
@@ -123,13 +123,13 @@ const success = Astro.url.searchParams.get('saved')
   </div>
 
   {/* Tabs */}
-  <div class="flex gap-1 mb-6 border-b border-[color:var(--color-border)]">
+  <div class="flex gap-1 mb-6 border-b border-[color:var(--ss-color-border)]">
     <a
       href={`/admin/follow-ups?tab=upcoming${filterType ? `&type=${filterType}` : ''}`}
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'upcoming'
           ? 'border-primary text-primary'
-          : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
+          : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
       }`}
     >
       Upcoming ({upcoming.length})
@@ -139,7 +139,7 @@ const success = Astro.url.searchParams.get('saved')
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'overdue'
           ? 'border-red-500 text-red-600'
-          : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
+          : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
       }`}
     >
       Overdue ({overdue.length})
@@ -149,7 +149,7 @@ const success = Astro.url.searchParams.get('saved')
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'completed'
           ? 'border-green-500 text-green-600'
-          : 'border-transparent text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
+          : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
       }`}
     >
       Completed ({completed.length})
@@ -163,8 +163,8 @@ const success = Astro.url.searchParams.get('saved')
         activeTab === 'overdue' ? overdue : activeTab === 'completed' ? completed : upcoming
       if (items.length === 0) {
         return (
-          <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
-            <p class="text-[color:var(--color-text-secondary)] text-sm">
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <p class="text-[color:var(--ss-color-text-secondary)] text-sm">
               {activeTab === 'upcoming' && 'No upcoming follow-ups.'}
               {activeTab === 'overdue' && 'No overdue follow-ups.'}
               {activeTab === 'completed' && 'No completed follow-ups.'}
@@ -173,29 +173,29 @@ const success = Astro.url.searchParams.get('saved')
         )
       }
       return (
-        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] divide-y divide-[color:var(--ss-color-border-subtle)]">
           {items.map((f: FollowUp) => (
             <div class="px-6 py-4">
               <div class="flex items-start justify-between gap-stack">
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2 mb-1">
                     <span
-                      class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-[color:var(--color-text-primary)]' : 'italic text-[color:var(--color-text-muted)]'}`}
+                      class={`text-sm font-medium ${f.entity_id && clientMap[f.entity_id] ? 'text-[color:var(--ss-color-text-primary)]' : 'italic text-[color:var(--ss-color-text-muted)]'}`}
                     >
                       {f.entity_id ? (clientMap[f.entity_id] ?? 'Missing entity') : 'Unlinked'}
                     </span>
-                    <span class="text-xs bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)] px-2 py-0.5 rounded">
+                    <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-2 py-0.5 rounded">
                       {getTypeLabel(f.type)}
                     </span>
                   </div>
-                  <div class="flex items-center gap-row text-xs text-[color:var(--color-text-muted)]">
+                  <div class="flex items-center gap-row text-xs text-[color:var(--ss-color-text-muted)]">
                     <span>{formatDate(f.scheduled_for)}</span>
                     {f.status === 'scheduled' && (
                       <span
                         class={
                           daysUntil(f.scheduled_for) < 0
                             ? 'text-red-500 font-medium'
-                            : 'text-[color:var(--color-text-secondary)]'
+                            : 'text-[color:var(--ss-color-text-secondary)]'
                         }
                       >
                         {daysLabel(f.scheduled_for)}
@@ -211,7 +211,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="send_email" />
                       <button
                         type="submit"
-                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+                        class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
                       >
                         Send Email
                       </button>
@@ -220,7 +220,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="complete" />
                       <button
                         type="submit"
-                        class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-green-100 transition-colors"
+                        class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-green-100 transition-colors"
                       >
                         Mark Complete
                       </button>
@@ -229,7 +229,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="skip" />
                       <button
                         type="submit"
-                        class="text-xs bg-[color:var(--color-background)] text-[color:var(--color-text-secondary)] px-3 py-1.5 rounded-[var(--radius-card)] hover:bg-[color:var(--color-border-subtle)] transition-colors"
+                        class="text-xs bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)] px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
                       >
                         Skip
                       </button>

--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -256,9 +256,9 @@ function tierClass(tier: string | null): string {
     case 'cool':
       return 'bg-blue-100 text-blue-700'
     case 'cold':
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
     default:
-      return 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-secondary)]'
+      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
 
@@ -292,24 +292,24 @@ const runDisabledReason = !runWorkerUrl
   ]}
 >
   <div class="mb-6">
-    <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">
+    <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
       {PIPELINE_LABELS[type]}
     </h2>
-    <p class="text-sm text-[color:var(--color-text-secondary)] mt-1">
+    <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
       {PIPELINE_DESCRIPTIONS[type]}
     </p>
   </div>
 
   {
     saved && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-green-800">Configuration saved.</p>
       </div>
     )
   }
   {
     ran && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-green-800">
           Run complete. {ranSignals} signal{ranSignals === '1' ? '' : 's'} written.
         </p>
@@ -318,7 +318,7 @@ const runDisabledReason = !runWorkerUrl
   }
   {
     errorParam && (
-      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-red-800">
           {errorParam === 'run_not_configured'
             ? `Run-now is not configured. Set ${type.toUpperCase()}_WORKER_URL and LEAD_INGEST_API_KEY on this Pages project.`
@@ -329,7 +329,7 @@ const runDisabledReason = !runWorkerUrl
   }
   {
     configRow.parseError.length > 0 && (
-      <div class="mb-6 p-stack bg-yellow-50 border border-yellow-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-yellow-50 border border-yellow-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-yellow-800 font-medium mb-1">
           Stored configuration failed validation. Showing defaults.
         </p>
@@ -344,7 +344,7 @@ const runDisabledReason = !runWorkerUrl
 
   <section aria-labelledby="liveness" class="mb-8">
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
       <div class="flex items-center justify-between gap-4 flex-wrap">
         <div class="flex items-center gap-row">
@@ -352,18 +352,18 @@ const runDisabledReason = !runWorkerUrl
             class={`w-3 h-3 rounded-full ${configRow.enabled ? 'bg-green-500' : 'bg-slate-300'}`}
           >
           </div>
-          <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+          <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
             {configRow.enabled ? 'Enabled' : 'Disabled'}
           </span>
-          <span class="text-xs text-[color:var(--color-text-muted)]">·</span>
-          <span class="text-sm text-[color:var(--color-text-secondary)]">
+          <span class="text-xs text-[color:var(--ss-color-text-muted)]">·</span>
+          <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
             Last run: {formatRelative(configRow.last_run_at)}
           </span>
           {
             configRow.last_run_signals_count !== null && (
               <>
-                <span class="text-xs text-[color:var(--color-text-muted)]">·</span>
-                <span class="text-sm text-[color:var(--color-text-secondary)]">
+                <span class="text-xs text-[color:var(--ss-color-text-muted)]">·</span>
+                <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
                   {configRow.last_run_signals_count} signal
                   {configRow.last_run_signals_count === 1 ? '' : 's'}
                 </span>
@@ -373,7 +373,7 @@ const runDisabledReason = !runWorkerUrl
           {
             configRow.last_run_error && (
               <>
-                <span class="text-xs text-[color:var(--color-text-muted)]">·</span>
+                <span class="text-xs text-[color:var(--ss-color-text-muted)]">·</span>
                 <span class="text-sm text-red-600">Error: {configRow.last_run_error}</span>
               </>
             )
@@ -384,7 +384,7 @@ const runDisabledReason = !runWorkerUrl
           <button
             type="submit"
             disabled={!runConfigured}
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-[var(--radius-card)] hover:bg-primary/90 disabled:bg-slate-300 disabled:cursor-not-allowed transition-colors"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-[var(--ss-radius-card)] hover:bg-primary/90 disabled:bg-slate-300 disabled:cursor-not-allowed transition-colors"
             title={runConfigured ? 'Invoke worker now' : runDisabledReason}
           >
             <span class="material-symbols-outlined text-base">play_arrow</span>
@@ -394,7 +394,7 @@ const runDisabledReason = !runWorkerUrl
       </div>
       {
         !runConfigured && (
-          <p class="mt-2 text-xs text-[color:var(--color-text-secondary)]">
+          <p class="mt-2 text-xs text-[color:var(--ss-color-text-secondary)]">
             Run-now disabled: <code class="font-mono">{runDisabledReason}</code>
           </p>
         )
@@ -405,13 +405,13 @@ const runDisabledReason = !runWorkerUrl
   <section aria-labelledby="config-form" class="mb-8">
     <h3
       id="config-form"
-      class="text-base font-semibold text-[color:var(--color-text-primary)] mb-3"
+      class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3"
     >
       Configuration
     </h3>
     <form
       method="POST"
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card space-y-stack"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card space-y-stack"
     >
       <input type="hidden" name="action" value="save_config" />
 
@@ -421,9 +421,9 @@ const runDisabledReason = !runWorkerUrl
           id="enabled"
           name="enabled"
           checked={configRow.enabled}
-          class="w-4 h-4 rounded border-[color:var(--color-border)]"
+          class="w-4 h-4 rounded border-[color:var(--ss-color-border)]"
         />
-        <label for="enabled" class="text-sm font-medium text-[color:var(--color-text-primary)]">
+        <label for="enabled" class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
           Enabled — when unchecked, worker returns early and writes no signals
         </label>
       </div>
@@ -431,9 +431,9 @@ const runDisabledReason = !runWorkerUrl
       <div>
         <label
           for="target_verticals"
-          class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+          class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
         >
-          Target verticals <span class="text-xs text-[color:var(--color-text-secondary)]"
+          Target verticals <span class="text-xs text-[color:var(--ss-color-text-secondary)]"
             >(one per line)</span
           >
         </label>
@@ -441,10 +441,10 @@ const runDisabledReason = !runWorkerUrl
           id="target_verticals"
           name="target_verticals"
           rows="6"
-          class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
+          class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
           set:html={(configRow.config as NewBusinessConfig).target_verticals.join('\n')}
         />
-        <p class="text-xs text-[color:var(--color-text-secondary)] mt-1">
+        <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
           Free-text. Suggestions: {VERTICALS.map((v) => v.replace(/_/g, ' ')).join(', ')}.
         </p>
       </div>
@@ -453,7 +453,7 @@ const runDisabledReason = !runWorkerUrl
         <div>
           <label
             for="revenue_min_usd"
-            class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+            class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
           >
             Revenue min (USD)
           </label>
@@ -464,13 +464,13 @@ const runDisabledReason = !runWorkerUrl
             value={(configRow.config as NewBusinessConfig).revenue_range.min_usd}
             min="0"
             step="50000"
-            class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
           />
         </div>
         <div>
           <label
             for="revenue_max_usd"
-            class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+            class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
           >
             Revenue max (USD)
           </label>
@@ -481,7 +481,7 @@ const runDisabledReason = !runWorkerUrl
             value={(configRow.config as NewBusinessConfig).revenue_range.max_usd}
             min="0"
             step="50000"
-            class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
           />
         </div>
       </div>
@@ -489,9 +489,9 @@ const runDisabledReason = !runWorkerUrl
       <div>
         <label
           for="geos"
-          class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+          class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
         >
-          Geographies <span class="text-xs text-[color:var(--color-text-secondary)]"
+          Geographies <span class="text-xs text-[color:var(--ss-color-text-secondary)]"
             >(one per line)</span
           >
         </label>
@@ -499,7 +499,7 @@ const runDisabledReason = !runWorkerUrl
           id="geos"
           name="geos"
           rows="2"
-          class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
+          class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
           set:html={(configRow.config as NewBusinessConfig).geos.join('\n')}
         />
       </div>
@@ -507,7 +507,7 @@ const runDisabledReason = !runWorkerUrl
       {
         type === 'new_business' && (
           <div>
-            <label class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-2">
+            <label class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-2">
               Data sources
             </label>
             <div class="space-y-1">
@@ -517,13 +517,13 @@ const runDisabledReason = !runWorkerUrl
                     type="checkbox"
                     name={`soda_${s.city}`}
                     checked={s.enabled}
-                    class="w-4 h-4 rounded border-[color:var(--color-border)]"
+                    class="w-4 h-4 rounded border-[color:var(--ss-color-border)]"
                   />
                   <span class="font-mono text-xs">{s.city.replace(/_/g, ' ')}</span>
                 </label>
               ))}
             </div>
-            <p class="text-xs text-[color:var(--color-text-secondary)] mt-1">
+            <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
               Per-city toggles. Unchecking skips that feed entirely on the next run.
             </p>
           </div>
@@ -535,16 +535,18 @@ const runDisabledReason = !runWorkerUrl
           <div>
             <label
               for="search_queries"
-              class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+              class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
             >
               Search queries{' '}
-              <span class="text-xs text-[color:var(--color-text-secondary)]">(one per line)</span>
+              <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                (one per line)
+              </span>
             </label>
             <textarea
               id="search_queries"
               name="search_queries"
               rows="8"
-              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
+              class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
               set:html={jm.search_queries.join('\n')}
             />
           </div>
@@ -557,24 +559,26 @@ const runDisabledReason = !runWorkerUrl
             <div>
               <label
                 for="discovery_queries"
-                class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+                class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
               >
                 Discovery queries{' '}
-                <span class="text-xs text-[color:var(--color-text-secondary)]">(one per line)</span>
+                <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                  (one per line)
+                </span>
               </label>
               <textarea
                 id="discovery_queries"
                 name="discovery_queries"
                 rows="10"
-                class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
                 set:html={rm.discovery_queries.join('\n')}
               />
             </div>
             <div>
-              <label class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1">
+              <label class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1">
                 Search area
               </label>
-              <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
+              <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
                 Google Places biases results near this point. Defaults are Phoenix downtown
                 (33.4484, -112.074) with a 50km radius — covers Scottsdale, Tempe, Mesa, Chandler,
                 Glendale.
@@ -583,7 +587,7 @@ const runDisabledReason = !runWorkerUrl
                 <div>
                   <label
                     for="geo_lat"
-                    class="text-xs text-[color:var(--color-text-secondary)] block mb-1"
+                    class="text-xs text-[color:var(--ss-color-text-secondary)] block mb-1"
                   >
                     Latitude
                   </label>
@@ -593,13 +597,13 @@ const runDisabledReason = !runWorkerUrl
                     name="geo_lat"
                     value={rm.geo_center.lat}
                     step="0.0001"
-                    class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                    class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
                   />
                 </div>
                 <div>
                   <label
                     for="geo_lon"
-                    class="text-xs text-[color:var(--color-text-secondary)] block mb-1"
+                    class="text-xs text-[color:var(--ss-color-text-secondary)] block mb-1"
                   >
                     Longitude
                   </label>
@@ -609,13 +613,13 @@ const runDisabledReason = !runWorkerUrl
                     name="geo_lon"
                     value={rm.geo_center.lon}
                     step="0.0001"
-                    class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                    class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
                   />
                 </div>
                 <div>
                   <label
                     for="geo_radius_km"
-                    class="text-xs text-[color:var(--color-text-secondary)] block mb-1"
+                    class="text-xs text-[color:var(--ss-color-text-secondary)] block mb-1"
                   >
                     Radius (km, 1–500)
                   </label>
@@ -626,7 +630,7 @@ const runDisabledReason = !runWorkerUrl
                     value={rm.geo_radius_km}
                     min="1"
                     max="500"
-                    class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm"
+                    class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
                   />
                 </div>
               </div>
@@ -647,16 +651,18 @@ const runDisabledReason = !runWorkerUrl
           <div>
             <label
               for="search_queries"
-              class="text-sm font-medium text-[color:var(--color-text-primary)] block mb-1"
+              class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1"
             >
               Search queries{' '}
-              <span class="text-xs text-[color:var(--color-text-secondary)]">(one per line)</span>
+              <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                (one per line)
+              </span>
             </label>
             <textarea
               id="search_queries"
               name="search_queries"
               rows="5"
-              class="w-full border border-[color:var(--color-border)] rounded px-3 py-2 text-sm font-mono"
+              class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
               set:html={sl.search_queries.join('\n')}
             />
           </div>
@@ -666,7 +672,7 @@ const runDisabledReason = !runWorkerUrl
       <div>
         <button
           type="submit"
-          class="px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+          class="px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
         >
           Save configuration
         </button>
@@ -675,29 +681,29 @@ const runDisabledReason = !runWorkerUrl
   </section>
 
   <section aria-labelledby="volume" class="mb-8">
-    <h3 id="volume" class="text-base font-semibold text-[color:var(--color-text-primary)] mb-3">
+    <h3 id="volume" class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
       Signal volume (30 days)
     </h3>
     <div
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
       {
         daysWithData.length === 0 ? (
-          <p class="text-sm text-[color:var(--color-text-secondary)]">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
             No signals in the last 30 days.
           </p>
         ) : (
           <ul class="space-y-1">
             {daysWithData.map((d) => (
               <li class="flex items-center gap-3 text-sm">
-                <span class="text-xs text-[color:var(--color-text-secondary)] font-mono w-20">
+                <span class="text-xs text-[color:var(--ss-color-text-secondary)] font-mono w-20">
                   {d.day}
                 </span>
                 <span
                   class="h-3 bg-primary/20 rounded-sm"
                   style={`width: ${(d.count / maxDayCount) * 100}%; min-width: 2px;`}
                 />
-                <span class="text-xs text-[color:var(--color-text-primary)] font-medium">
+                <span class="text-xs text-[color:var(--ss-color-text-primary)] font-medium">
                   {d.count}
                 </span>
               </li>
@@ -709,31 +715,31 @@ const runDisabledReason = !runWorkerUrl
   </section>
 
   <section aria-labelledby="signals">
-    <h3 id="signals" class="text-base font-semibold text-[color:var(--color-text-primary)] mb-3">
+    <h3 id="signals" class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
       Last {signalRows.length} signals
     </h3>
     {
       signalRows.length === 0 ? (
-        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card">
-          <p class="text-sm text-[color:var(--color-text-secondary)]">
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
             No signals yet for this pipeline.
           </p>
         </div>
       ) : (
-        <div class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] divide-y divide-[color:var(--color-border-subtle)]">
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] divide-y divide-[color:var(--ss-color-border-subtle)]">
           {signalRows.map((s) => (
             <details class="group">
-              <summary class="px-6 py-3 flex items-start justify-between gap-3 cursor-pointer hover:bg-[color:var(--color-background)] list-none">
+              <summary class="px-6 py-3 flex items-start justify-between gap-3 cursor-pointer hover:bg-[color:var(--ss-color-background)] list-none">
                 <div class="min-w-0 flex-1">
                   <div class="flex items-center gap-2 flex-wrap">
                     <a
                       href={`/admin/entities/${s.id}`}
-                      class="text-sm font-medium text-[color:var(--color-text-primary)] hover:text-primary truncate"
+                      class="text-sm font-medium text-[color:var(--ss-color-text-primary)] hover:text-primary truncate"
                     >
                       {s.name}
                     </a>
                     {s.pain_score !== null && (
-                      <span class="text-xs text-[color:var(--color-text-secondary)]">
+                      <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
                         Pain: {s.pain_score}/10
                       </span>
                     )}
@@ -743,30 +749,30 @@ const runDisabledReason = !runWorkerUrl
                       </span>
                     )}
                     {s.vertical && s.vertical !== 'unknown' && (
-                      <span class="text-xs text-[color:var(--color-text-secondary)] capitalize">
+                      <span class="text-xs text-[color:var(--ss-color-text-secondary)] capitalize">
                         {s.vertical.replace(/_/g, ' ')}
                       </span>
                     )}
                     {s.area && (
-                      <span class="text-xs text-[color:var(--color-text-muted)]">{s.area}</span>
+                      <span class="text-xs text-[color:var(--ss-color-text-muted)]">{s.area}</span>
                     )}
                   </div>
                   {s.context_content && (
-                    <p class="text-xs text-[color:var(--color-text-secondary)] mt-1 line-clamp-2">
+                    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1 line-clamp-2">
                       {s.context_content}
                     </p>
                   )}
                 </div>
-                <div class="flex items-center gap-2 shrink-0 text-xs text-[color:var(--color-text-muted)]">
+                <div class="flex items-center gap-2 shrink-0 text-xs text-[color:var(--ss-color-text-muted)]">
                   <span>{formatDate(s.created_at)}</span>
                   <span class="material-symbols-outlined text-sm group-open:rotate-90 transition-transform">
                     chevron_right
                   </span>
                 </div>
               </summary>
-              <div class="px-6 pb-4 pt-1 bg-[color:var(--color-background)]/50">
+              <div class="px-6 pb-4 pt-1 bg-[color:var(--ss-color-background)]/50">
                 {s.context_source_ref && (
-                  <p class="text-xs text-[color:var(--color-text-secondary)] mb-2">
+                  <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
                     Source ref: <code class="font-mono">{s.context_source_ref}</code>
                   </p>
                 )}
@@ -775,7 +781,7 @@ const runDisabledReason = !runWorkerUrl
                     {prettyJson(s.context_metadata)}
                   </pre>
                 ) : (
-                  <p class="text-xs text-[color:var(--color-text-secondary)] italic">
+                  <p class="text-xs text-[color:var(--ss-color-text-secondary)] italic">
                     No metadata recorded.
                   </p>
                 )}

--- a/src/pages/admin/generators/index.astro
+++ b/src/pages/admin/generators/index.astro
@@ -159,10 +159,10 @@ function vlabel(v: string): string {
 >
   <div class="flex items-start justify-between mb-6 gap-4 flex-wrap">
     <div>
-      <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)]">Generators</h2>
-      <p class="text-sm text-[color:var(--color-text-secondary)] mt-1">
+      <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">Generators</h2>
+      <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
         Lead generation pipelines. Each pipeline writes entities at stage <code
-          class="text-xs bg-[color:var(--color-border-subtle)] px-1 rounded">signal</code
+          class="text-xs bg-[color:var(--ss-color-border-subtle)] px-1 rounded">signal</code
         >.
       </p>
     </div>
@@ -181,7 +181,7 @@ function vlabel(v: string): string {
         return (
           <a
             href={`/admin/generators/${pipeline.id}`}
-            class="block bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card hover:border-[color:var(--color-border)] hover:shadow-sm transition-all"
+            class="block bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card hover:border-[color:var(--ss-color-border)] hover:shadow-sm transition-all"
           >
             <div class="flex items-start justify-between mb-3 gap-2">
               <div class="min-w-0">
@@ -190,38 +190,40 @@ function vlabel(v: string): string {
                     class={`w-2 h-2 rounded-full shrink-0 ${enabled ? 'bg-green-500' : 'bg-slate-300'}`}
                     title={enabled ? 'Enabled' : 'Disabled'}
                   />
-                  <h3 class="text-base font-semibold text-[color:var(--color-text-primary)] truncate">
+                  <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] truncate">
                     {PIPELINE_LABELS[pipeline.id]}
                   </h3>
                 </div>
-                <p class="text-xs text-[color:var(--color-text-secondary)] mt-0.5">
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-0.5">
                   {pipeline.description}
                 </p>
               </div>
-              <span class="text-xs text-[color:var(--color-text-muted)] whitespace-nowrap">
+              <span class="text-xs text-[color:var(--ss-color-text-muted)] whitespace-nowrap">
                 {lastRun(pipeline.id)}
               </span>
             </div>
 
             <dl class="grid grid-cols-2 gap-row text-sm">
               <div>
-                <dt class="text-xs text-[color:var(--color-text-secondary)]">Total signals</dt>
-                <dd class="text-[color:var(--color-text-primary)] font-medium">
+                <dt class="text-xs text-[color:var(--ss-color-text-secondary)]">Total signals</dt>
+                <dd class="text-[color:var(--ss-color-text-primary)] font-medium">
                   {m.total_signals}
                 </dd>
               </div>
               <div>
-                <dt class="text-xs text-[color:var(--color-text-secondary)]">Last 7 days</dt>
-                <dd class="text-[color:var(--color-text-primary)] font-medium">{m.last_7d}</dd>
+                <dt class="text-xs text-[color:var(--ss-color-text-secondary)]">Last 7 days</dt>
+                <dd class="text-[color:var(--ss-color-text-primary)] font-medium">{m.last_7d}</dd>
               </div>
 
               {painPct >= 50 && avgPain !== null && (
                 <div>
-                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                  <dt class="text-xs text-[color:var(--ss-color-text-secondary)]">
                     Avg pain{' '}
-                    <span class="text-[color:var(--color-text-muted)]">({painPct}% coverage)</span>
+                    <span class="text-[color:var(--ss-color-text-muted)]">
+                      ({painPct}% coverage)
+                    </span>
                   </dt>
-                  <dd class="text-[color:var(--color-text-primary)] font-medium">
+                  <dd class="text-[color:var(--ss-color-text-primary)] font-medium">
                     {avgPain.toFixed(1)}/10
                   </dd>
                 </div>
@@ -229,13 +231,13 @@ function vlabel(v: string): string {
 
               {verticalPct >= 50 && m.top_vertical && (
                 <div>
-                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                  <dt class="text-xs text-[color:var(--ss-color-text-secondary)]">
                     Top vertical{' '}
-                    <span class="text-[color:var(--color-text-muted)]">
+                    <span class="text-[color:var(--ss-color-text-muted)]">
                       ({verticalPct}% coverage)
                     </span>
                   </dt>
-                  <dd class="text-[color:var(--color-text-primary)] font-medium capitalize">
+                  <dd class="text-[color:var(--ss-color-text-primary)] font-medium capitalize">
                     {vlabel(m.top_vertical)}
                   </dd>
                 </div>
@@ -243,11 +245,13 @@ function vlabel(v: string): string {
 
               {empPct >= 50 && (
                 <div>
-                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                  <dt class="text-xs text-[color:var(--ss-color-text-secondary)]">
                     Employee count{' '}
-                    <span class="text-[color:var(--color-text-muted)]">({empPct}% coverage)</span>
+                    <span class="text-[color:var(--ss-color-text-muted)]">
+                      ({empPct}% coverage)
+                    </span>
                   </dt>
-                  <dd class="text-[color:var(--color-text-primary)] font-medium">
+                  <dd class="text-[color:var(--ss-color-text-primary)] font-medium">
                     {m.has_employee_count} enriched
                   </dd>
                 </div>
@@ -255,11 +259,13 @@ function vlabel(v: string): string {
 
               {areaPct >= 50 && (
                 <div>
-                  <dt class="text-xs text-[color:var(--color-text-secondary)]">
+                  <dt class="text-xs text-[color:var(--ss-color-text-secondary)]">
                     Area{' '}
-                    <span class="text-[color:var(--color-text-muted)]">({areaPct}% coverage)</span>
+                    <span class="text-[color:var(--ss-color-text-muted)]">
+                      ({areaPct}% coverage)
+                    </span>
                   </dt>
-                  <dd class="text-[color:var(--color-text-primary)] font-medium">
+                  <dd class="text-[color:var(--ss-color-text-primary)] font-medium">
                     {m.has_area} tagged
                   </dd>
                 </div>
@@ -267,7 +273,7 @@ function vlabel(v: string): string {
             </dl>
 
             {m.total_signals === 0 && (
-              <p class="text-xs text-[color:var(--color-text-secondary)] mt-3 italic">
+              <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-3 italic">
                 No signals yet.
               </p>
             )}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -145,50 +145,52 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
   <div class="space-y-card">
     <!-- Card 1: Today's Work -->
     <section
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h2 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h2 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Today's Work
       </h2>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-stack">
         <a
           href="/admin/entities?stage=signal"
-          class="flex items-center gap-row p-row rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+          class="flex items-center gap-row p-row rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-background)] transition-colors"
         >
           <div
             class:list={[
               'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
               signalCount > 0
                 ? 'bg-amber-100 text-amber-700'
-                : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-muted)]',
+                : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-muted)]',
             ]}
           >
             {signalCount}
           </div>
           <div>
-            <div class="text-sm font-medium text-[color:var(--color-text-primary)]">
+            <div class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Signals to triage
             </div>
-            <div class="text-xs text-[color:var(--color-text-secondary)]">Promote or dismiss</div>
+            <div class="text-xs text-[color:var(--ss-color-text-secondary)]">
+              Promote or dismiss
+            </div>
           </div>
         </a>
 
-        <div class="flex items-center gap-row p-row rounded-[var(--radius-card)]">
+        <div class="flex items-center gap-row p-row rounded-[var(--ss-radius-card)]">
           <div
             class:list={[
               'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
               todayAssessments.length > 0
                 ? 'bg-indigo-100 text-indigo-700'
-                : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-muted)]',
+                : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-muted)]',
             ]}
           >
             {todayAssessments.length}
           </div>
           <div>
-            <div class="text-sm font-medium text-[color:var(--color-text-primary)]">
+            <div class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Assessments today
             </div>
-            <div class="text-xs text-[color:var(--color-text-secondary)]">
+            <div class="text-xs text-[color:var(--ss-color-text-secondary)]">
               {
                 todayAssessments.length > 0
                   ? todayAssessments
@@ -210,23 +212,23 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
         <a
           href="/admin/follow-ups?filter=overdue"
-          class="flex items-center gap-row p-row rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+          class="flex items-center gap-row p-row rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-background)] transition-colors"
         >
           <div
             class:list={[
               'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
               overdueCount > 0
                 ? 'bg-red-100 text-red-700'
-                : 'bg-[color:var(--color-border-subtle)] text-[color:var(--color-text-muted)]',
+                : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-muted)]',
             ]}
           >
             {overdueCount}
           </div>
           <div>
-            <div class="text-sm font-medium text-[color:var(--color-text-primary)]">
+            <div class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Overdue follow-ups
             </div>
-            <div class="text-xs text-[color:var(--color-text-secondary)]">
+            <div class="text-xs text-[color:var(--ss-color-text-secondary)]">
               {overdueCount > 0 ? 'Needs attention' : 'All clear'}
             </div>
           </div>
@@ -236,13 +238,13 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
     <!-- Card 2: Pipeline State -->
     <section
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-base font-semibold text-[color:var(--color-text-primary)]">Pipeline</h2>
+        <h2 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">Pipeline</h2>
         <a
           href="/admin/entities"
-          class="text-xs text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+          class="text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
           >{totalPipeline} total</a
         >
       </div>
@@ -250,7 +252,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
       <!-- Funnel bar -->
       {
         totalPipeline > 0 && (
-          <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-[color:var(--color-border-subtle)]">
+          <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-[color:var(--ss-color-border-subtle)]">
             {pipelineStages.map((s) =>
               s.count > 0 ? (
                 <div
@@ -276,19 +278,19 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           pipelineStages.map((s) => (
             <a
               href={`/admin/entities?stage=${s.stage}`}
-              class="text-center p-2 rounded-[var(--radius-card)] hover:bg-[color:var(--color-background)] transition-colors"
+              class="text-center p-2 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-background)] transition-colors"
             >
               <div
                 class:list={[
                   'text-2xl font-bold',
                   s.count > 0
-                    ? 'text-[color:var(--color-text-primary)]'
-                    : 'text-[color:var(--color-text-muted)]',
+                    ? 'text-[color:var(--ss-color-text-primary)]'
+                    : 'text-[color:var(--ss-color-text-muted)]',
                 ]}
               >
                 {s.count}
               </div>
-              <div class="text-xs text-[color:var(--color-text-secondary)]">{s.label}</div>
+              <div class="text-xs text-[color:var(--ss-color-text-secondary)]">{s.label}</div>
             </a>
           ))
         }
@@ -296,10 +298,10 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
       {
         pipeline.lost > 0 && (
-          <div class="mt-3 pt-3 border-t border-[color:var(--color-border-subtle)] text-center">
+          <div class="mt-3 pt-3 border-t border-[color:var(--ss-color-border-subtle)] text-center">
             <a
               href="/admin/entities?stage=lost"
-              class="text-xs text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-secondary)]"
+              class="text-xs text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-secondary)]"
             >
               {pipeline.lost} lost
             </a>
@@ -311,50 +313,52 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
     <div class="grid grid-cols-1 md:grid-cols-2 gap-card">
       <!-- Card 3: Revenue -->
       <section
-        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
       >
-        <h2 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">Revenue</h2>
+        <h2 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
+          Revenue
+        </h2>
         <div class="space-y-row">
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Invoiced</span>
-            <span class="text-lg font-semibold text-[color:var(--color-text-primary)]">
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Invoiced</span>
+            <span class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
               ${revenue.total_invoiced.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Paid</span>
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Paid</span>
             <span class="text-lg font-semibold text-green-600">
               ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Outstanding</span>
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Outstanding</span>
             <span
               class:list={[
                 'text-lg font-semibold',
-                outstandingTotal > 0 ? 'text-amber-600' : 'text-[color:var(--color-text-muted)]',
+                outstandingTotal > 0 ? 'text-amber-600' : 'text-[color:var(--ss-color-text-muted)]',
               ]}
             >
               ${outstandingTotal.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
 
-          <div class="pt-3 border-t border-[color:var(--color-border-subtle)]">
+          <div class="pt-3 border-t border-[color:var(--ss-color-border-subtle)]">
             <div class="flex justify-between items-baseline">
-              <span class="text-sm text-[color:var(--color-text-secondary)]"
+              <span class="text-sm text-[color:var(--ss-color-text-secondary)]"
                 >Active engagements</span
               >
-              <span class="text-sm font-medium text-[color:var(--color-text-primary)]"
+              <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >{activeEngagements.length}</span
               >
             </div>
             {
               health.avg_days_to_completion > 0 && (
                 <div class="flex justify-between items-baseline mt-1">
-                  <span class="text-sm text-[color:var(--color-text-secondary)]">
+                  <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
                     Avg completion
                   </span>
-                  <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+                  <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
                     {health.avg_days_to_completion} days
                   </span>
                 </div>
@@ -366,21 +370,21 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
       <!-- Card 4: Follow-up Health -->
       <section
-        class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
       >
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-base font-semibold text-[color:var(--color-text-primary)]">
+          <h2 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
             Follow-up Health
           </h2>
           <a
             href="/admin/follow-ups"
-            class="text-xs text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+            class="text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
             >View all</a
           >
         </div>
         <div class="space-y-row">
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">On-time rate</span>
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">On-time rate</span>
             <span
               class:list={[
                 'text-lg font-semibold',
@@ -395,40 +399,42 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Sent on time</span>
-            <span class="text-sm font-medium text-[color:var(--color-text-primary)]"
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Sent on time</span>
+            <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >{compliance.completed_on_time}</span
             >
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Sent late</span>
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Sent late</span>
             <span
               class:list={[
                 'text-sm font-medium',
                 compliance.completed_late > 0
                   ? 'text-amber-600'
-                  : 'text-[color:var(--color-text-primary)]',
+                  : 'text-[color:var(--ss-color-text-primary)]',
               ]}
             >
               {compliance.completed_late}
             </span>
           </div>
           <div class="flex justify-between items-baseline">
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Missed</span>
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Missed</span>
             <span
               class:list={[
                 'text-sm font-medium',
-                compliance.missed > 0 ? 'text-red-600' : 'text-[color:var(--color-text-primary)]',
+                compliance.missed > 0
+                  ? 'text-red-600'
+                  : 'text-[color:var(--ss-color-text-primary)]',
               ]}
             >
               {compliance.missed}
             </span>
           </div>
 
-          <div class="pt-3 border-t border-[color:var(--color-border-subtle)]">
+          <div class="pt-3 border-t border-[color:var(--ss-color-border-subtle)]">
             <div class="flex justify-between items-baseline">
-              <span class="text-sm text-[color:var(--color-text-secondary)]">Upcoming</span>
-              <span class="text-sm font-medium text-[color:var(--color-text-primary)]"
+              <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Upcoming</span>
+              <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >{upcomingFollowUps.length} scheduled</span
               >
             </div>
@@ -439,12 +445,12 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
 
     <!-- Card 5: Automations -->
     <section
-      class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
     >
-      <h2 class="text-base font-semibold text-[color:var(--color-text-primary)] mb-4">
+      <h2 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
         Automations
       </h2>
-      <div class="divide-y divide-[color:var(--color-border-subtle)]">
+      <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
         <!-- Google Calendar -->
         <div class="flex items-center justify-between py-2">
           <div class="flex items-center gap-2">
@@ -459,14 +465,14 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               ]}
             >
             </div>
-            <span class="text-sm text-[color:var(--color-text-secondary)]">Google Calendar</span>
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Google Calendar</span>
           </div>
           <span
             class:list={[
               'text-xs',
               calStatus === 'error' || calStatus === 'revoked'
                 ? 'text-red-600'
-                : 'text-[color:var(--color-text-muted)]',
+                : 'text-[color:var(--ss-color-text-muted)]',
             ]}
           >
             {
@@ -506,13 +512,13 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               <div class="flex items-center justify-between py-2">
                 <div class="flex items-center gap-2">
                   <div class:list={['w-2 h-2 rounded-full', p.color]} />
-                  <span class="text-sm text-[color:var(--color-text-secondary)]">{p.label}</span>
+                  <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{p.label}</span>
                 </div>
-                <span class="text-xs text-[color:var(--color-text-muted)]">{p.ago}</span>
+                <span class="text-xs text-[color:var(--ss-color-text-muted)]">{p.ago}</span>
               </div>
             ))
           ) : (
-            <div class="py-2 text-xs text-[color:var(--color-text-muted)]">
+            <div class="py-2 text-xs text-[color:var(--ss-color-text-muted)]">
               No pipeline data yet
             </div>
           )

--- a/src/pages/admin/settings/google-connect.astro
+++ b/src/pages/admin/settings/google-connect.astro
@@ -51,13 +51,13 @@ const errorMessages: Record<string, string> = {
     { label: 'Google Calendar' },
   ]}
 >
-  <h2 class="text-xl font-semibold text-[color:var(--color-text-primary)] mb-6">
+  <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)] mb-6">
     Google Calendar Integration
   </h2>
 
   {
     successParam === 'connected' && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-green-800">Google Calendar connected successfully.</p>
       </div>
     )
@@ -65,7 +65,7 @@ const errorMessages: Record<string, string> = {
 
   {
     successParam === 'disconnected' && (
-      <div class="mb-6 p-stack bg-blue-50 border border-blue-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-blue-50 border border-blue-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-blue-800">Google Calendar disconnected.</p>
       </div>
     )
@@ -73,7 +73,7 @@ const errorMessages: Record<string, string> = {
 
   {
     errorParam && (
-      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--radius-card)]">
+      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--ss-radius-card)]">
         <p class="text-sm text-red-800">
           {errorMessages[errorParam] ?? `Something went wrong (${errorParam}). Please try again.`}
         </p>
@@ -82,41 +82,41 @@ const errorMessages: Record<string, string> = {
   }
 
   <div
-    class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-card"
+    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
   >
     {
       isConnected ? (
         <div>
           <div class="flex items-center gap-row mb-4">
             <div class="w-3 h-3 rounded-full bg-green-500" />
-            <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+            <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Connected
             </span>
           </div>
           <dl class="grid grid-cols-1 gap-row text-sm mb-6">
             <div>
-              <dt class="text-[color:var(--color-text-secondary)]">Account</dt>
-              <dd class="text-[color:var(--color-text-primary)] font-medium">
+              <dt class="text-[color:var(--ss-color-text-secondary)]">Account</dt>
+              <dd class="text-[color:var(--ss-color-text-primary)] font-medium">
                 {integration.account_email}
               </dd>
             </div>
             <div>
-              <dt class="text-[color:var(--color-text-secondary)]">Calendar</dt>
-              <dd class="text-[color:var(--color-text-primary)]">{integration.calendar_id}</dd>
+              <dt class="text-[color:var(--ss-color-text-secondary)]">Calendar</dt>
+              <dd class="text-[color:var(--ss-color-text-primary)]">{integration.calendar_id}</dd>
             </div>
             <div>
-              <dt class="text-[color:var(--color-text-secondary)]">Status</dt>
-              <dd class="text-[color:var(--color-text-primary)]">{integration.status}</dd>
+              <dt class="text-[color:var(--ss-color-text-secondary)]">Status</dt>
+              <dd class="text-[color:var(--ss-color-text-primary)]">{integration.status}</dd>
             </div>
             <div>
-              <dt class="text-[color:var(--color-text-secondary)]">Connected</dt>
-              <dd class="text-[color:var(--color-text-primary)]">
+              <dt class="text-[color:var(--ss-color-text-secondary)]">Connected</dt>
+              <dd class="text-[color:var(--ss-color-text-primary)]">
                 {new Date(integration.created_at).toLocaleDateString()}
               </dd>
             </div>
             {integration.last_error && (
               <div>
-                <dt class="text-[color:var(--color-text-secondary)]">Last error</dt>
+                <dt class="text-[color:var(--ss-color-text-secondary)]">Last error</dt>
                 <dd class="text-red-600">{integration.last_error}</dd>
               </div>
             )}
@@ -125,7 +125,7 @@ const errorMessages: Record<string, string> = {
             <input type="hidden" name="action" value="disconnect" />
             <button
               type="submit"
-              class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-[var(--radius-card)] hover:bg-red-100 transition-colors"
+              class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-[var(--ss-radius-card)] hover:bg-red-100 transition-colors"
               onclick="return confirm('Disconnect Google Calendar? Existing booked events will not be affected.')"
             >
               Disconnect
@@ -136,17 +136,17 @@ const errorMessages: Record<string, string> = {
         <div>
           <div class="flex items-center gap-row mb-4">
             <div class="w-3 h-3 rounded-full bg-slate-300" />
-            <span class="text-sm font-medium text-[color:var(--color-text-primary)]">
+            <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Not connected
             </span>
           </div>
-          <p class="text-sm text-[color:var(--color-text-secondary)] mb-6">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-6">
             Connect your Google Calendar to automatically create events when assessments are booked
             and check availability in real time.
           </p>
           <a
             href="/api/auth/google/connect"
-            class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--radius-card)] hover:bg-primary/90 transition-colors"
+            class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
           >
             Connect Google Calendar
           </a>

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -17,12 +17,12 @@ import CtaButton from '../components/CtaButton.astro'
     <section class="relative overflow-hidden px-6 pb-32 pt-24">
       <div class="mx-auto max-w-4xl text-center">
         <h1
-          class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-[color:var(--color-text-primary)] md:text-7xl"
+          class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-[color:var(--ss-color-text-primary)] md:text-7xl"
         >
           AI and Automation for Growing Businesses.
         </h1>
         <p
-          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--color-text-secondary)]"
+          class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           Some of what you're hearing about AI is useful. A lot of it is noise. We help you sort it
           out and build what fits how your business actually works.
@@ -34,25 +34,25 @@ import CtaButton from '../components/CtaButton.astro'
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-4xl">
         <h2
-          class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl"
+          class="mb-12 text-center text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl"
         >
           What Working With Us Looks Like
         </h2>
-        <div class="space-y-10 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+        <div class="space-y-10 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
-            <span class="font-semibold text-[color:var(--color-text-primary)]"
+            <span class="font-semibold text-[color:var(--ss-color-text-primary)]"
               >A conversation first.</span
             > We walk through what you're trying to do and where things are getting stuck. Then we figure
             out together whether AI is the right answer or whether something simpler would serve you better.
           </p>
           <p>
-            <span class="font-semibold text-[color:var(--color-text-primary)]"
+            <span class="font-semibold text-[color:var(--ss-color-text-primary)]"
               >The right tool, not the loudest one.</span
             > Dozens of AI tools are marketed at businesses your size every month. We help you tell which
             ones actually fit your work and which are solving someone else's problem.
           </p>
           <p>
-            <span class="font-semibold text-[color:var(--color-text-primary)]"
+            <span class="font-semibold text-[color:var(--ss-color-text-primary)]"
               >Built for how your team already works.</span
             >
             If we build something custom, whether it's an AI assistant, a script that cleans up a recurring
@@ -60,7 +60,7 @@ import CtaButton from '../components/CtaButton.astro'
             of asking them to change.
           </p>
           <p>
-            <span class="font-semibold text-[color:var(--color-text-primary)]"
+            <span class="font-semibold text-[color:var(--ss-color-text-primary)]"
               >Training your team to use it.</span
             > A tool nobody uses is worse than no tool at all. We make sure your team can actually run
             what we build after we're gone.
@@ -69,12 +69,12 @@ import CtaButton from '../components/CtaButton.astro'
       </div>
     </section>
 
-    <section class="bg-[color:var(--color-background)] px-6 py-24">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-3xl text-center">
-        <h2 class="mb-8 text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl">
+        <h2 class="mb-8 text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
           Is AI Actually the Right Answer?
         </h2>
-        <p class="text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+        <p class="text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           Sometimes yes. Other times the answer is a simple script, a better process, or just
           getting two of your tools to talk to each other. And sometimes the answer is not yet.
           That's the conversation. If you walk out of it thinking AI isn't where you should spend
@@ -86,18 +86,18 @@ import CtaButton from '../components/CtaButton.astro'
     <section class="bg-white px-6 py-24">
       <div class="mx-auto max-w-4xl">
         <h2
-          class="mb-4 text-center text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl"
+          class="mb-4 text-center text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl"
         >
           What We Won't Do
         </h2>
         <p
-          class="mx-auto mb-12 max-w-2xl text-center text-lg leading-relaxed text-[color:var(--color-text-secondary)]"
+          class="mx-auto mb-12 max-w-2xl text-center text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           A few lines we hold because they matter more than a sale.
         </p>
-        <div class="space-y-10 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+        <div class="space-y-10 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <div>
-            <h3 class="mb-3 text-xl font-semibold text-[color:var(--color-text-primary)]">
+            <h3 class="mb-3 text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
               We won't automate judgment.
             </h3>
             <p>
@@ -107,7 +107,7 @@ import CtaButton from '../components/CtaButton.astro'
             </p>
           </div>
           <div>
-            <h3 class="mb-3 text-xl font-semibold text-[color:var(--color-text-primary)]">
+            <h3 class="mb-3 text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
               We won't replace people.
             </h3>
             <p>
@@ -118,7 +118,7 @@ import CtaButton from '../components/CtaButton.astro'
             </p>
           </div>
           <div>
-            <h3 class="mb-3 text-xl font-semibold text-[color:var(--color-text-primary)]">
+            <h3 class="mb-3 text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
               We won't hand over a dashboard and call it strategy.
             </h3>
             <p>
@@ -131,12 +131,12 @@ import CtaButton from '../components/CtaButton.astro'
       </div>
     </section>
 
-    <section class="bg-[color:var(--color-background)] px-6 py-24">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-3xl text-center">
-        <h2 class="mb-8 text-3xl font-bold text-[color:var(--color-text-primary)] sm:text-4xl">
+        <h2 class="mb-8 text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
           When AI is part of the answer, Claude is our default.
         </h2>
-        <div class="space-y-6 text-lg leading-relaxed text-[color:var(--color-text-secondary)]">
+        <div class="space-y-6 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
             Not every engagement calls for AI. When one does, Claude is what we reach for because
             it's the best fit for most of the work we do.

--- a/src/pages/auth/login.astro
+++ b/src/pages/auth/login.astro
@@ -35,14 +35,14 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
     />
     <title>Sign In — SMD Services</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <header
       role="banner"
-      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--color-border)]"
+      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--ss-color-border)]"
     >
       <div class="max-w-md mx-auto h-full flex items-center justify-center px-4">
-        <span class="text-lg font-bold tracking-tight text-[color:var(--color-text-primary)]"
+        <span class="text-lg font-bold tracking-tight text-[color:var(--ss-color-text-primary)]"
           >SMD Services</span
         >
       </div>
@@ -55,17 +55,19 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
     >
       <div class="w-full max-w-sm">
         <div class="text-center mb-8">
-          <p class="text-sm text-[color:var(--color-text-secondary)]">Admin sign-in</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Admin sign-in</p>
         </div>
 
         <div
-          class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-6"
+          class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-6"
         >
-          <h2 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-6">Sign in</h2>
+          <h2 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-6">
+            Sign in
+          </h2>
 
           {
             errorMessage && (
-              <div class="mb-4 px-3 py-2 bg-[color:var(--color-error)]/5 border border-[color:var(--color-error)]/30 rounded text-sm text-[color:var(--color-error)]">
+              <div class="mb-4 px-3 py-2 bg-[color:var(--ss-color-error)]/5 border border-[color:var(--ss-color-error)]/30 rounded text-sm text-[color:var(--ss-color-error)]">
                 {errorMessage}
               </div>
             )
@@ -75,7 +77,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
             <div>
               <label
                 for="email"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Email
               </label>
@@ -85,7 +87,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
                 type="email"
                 required
                 autocomplete="email"
-                class="w-full px-3 py-2 border border-[color:var(--color-border)] rounded-[var(--radius-card)] text-sm
+                class="w-full px-3 py-2 border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
                 placeholder="you@smd.services"
@@ -95,7 +97,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
             <div>
               <label
                 for="password"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Password
               </label>
@@ -105,7 +107,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
                 type="password"
                 required
                 autocomplete="current-password"
-                class="w-full px-3 py-2 border border-[color:var(--color-border)] rounded-[var(--radius-card)] text-sm
+                class="w-full px-3 py-2 border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
                 placeholder="Enter your password"
@@ -114,7 +116,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
 
             <button
               type="submit"
-              class="w-full bg-primary text-white py-2 px-4 rounded-[var(--radius-card)] text-sm font-medium
+              class="w-full bg-primary text-white py-2 px-4 rounded-[var(--ss-radius-card)] text-sm font-medium
                    hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
                    focus:ring-primary focus:ring-offset-2"
             >

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -46,14 +46,14 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
     />
     <title>Sign In — SMD Services Portal</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <header
       role="banner"
-      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--color-border)]"
+      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--ss-color-border)]"
     >
       <div class="max-w-md mx-auto h-full flex items-center justify-center px-4">
-        <span class="text-lg font-bold tracking-tight text-[color:var(--color-text-primary)]"
+        <span class="text-lg font-bold tracking-tight text-[color:var(--ss-color-text-primary)]"
           >SMD Services</span
         >
       </div>
@@ -66,14 +66,16 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
     >
       <div class="w-full max-w-sm">
         <div class="text-center mb-8">
-          <p class="text-sm text-[color:var(--color-text-secondary)]">Client portal sign-in</p>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Client portal sign-in</p>
         </div>
 
         <div
-          class="bg-white rounded-[var(--radius-card)] border border-[color:var(--color-border)] p-6"
+          class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-6"
         >
-          <h2 class="text-lg font-semibold text-[color:var(--color-text-primary)] mb-2">Sign in</h2>
-          <p class="text-sm text-[color:var(--color-text-secondary)] mb-6">
+          <h2 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
+            Sign in
+          </h2>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-6">
             Enter your email and we'll send you a link to sign in.
           </p>
 
@@ -83,8 +85,8 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
                 class:list={[
                   'mb-4 px-3 py-2 border rounded text-sm',
                   message.type === 'success'
-                    ? 'bg-[color:var(--color-complete)]/5 border-[color:var(--color-complete)]/30 text-[color:var(--color-complete)]'
-                    : 'bg-[color:var(--color-error)]/5 border-[color:var(--color-error)]/30 text-[color:var(--color-error)]',
+                    ? 'bg-[color:var(--ss-color-complete)]/5 border-[color:var(--ss-color-complete)]/30 text-[color:var(--ss-color-complete)]'
+                    : 'bg-[color:var(--ss-color-error)]/5 border-[color:var(--ss-color-error)]/30 text-[color:var(--ss-color-error)]',
                 ]}
               >
                 {message.text}
@@ -96,7 +98,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
             <div>
               <label
                 for="email"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)] mb-1"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
               >
                 Email
               </label>
@@ -107,7 +109,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
                 required
                 autocomplete="email"
                 value={prefillEmail}
-                class="w-full px-3 py-2 border border-[color:var(--color-border)] rounded-[var(--radius-card)] text-sm
+                class="w-full px-3 py-2 border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] text-sm
                      focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary
                      placeholder-slate-400"
                 placeholder="your@email.com"
@@ -116,7 +118,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
 
             <button
               type="submit"
-              class="w-full bg-primary text-white py-2 px-4 rounded-[var(--radius-card)] text-sm font-medium
+              class="w-full bg-primary text-white py-2 px-4 rounded-[var(--ss-radius-card)] text-sm font-medium
                    hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2
                    focus:ring-primary focus:ring-offset-2"
             >

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -63,15 +63,15 @@ if (prefillToken) {
   <Nav />
   <main id="main" role="main">
     <!-- Hero -->
-    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">
         <div class="text-center">
           <h1
-            class="text-3xl font-bold tracking-tight text-[color:var(--color-text-primary)] sm:text-4xl"
+            class="text-3xl font-bold tracking-tight text-[color:var(--ss-color-text-primary)] sm:text-4xl"
           >
             Let's Talk About Your Business
           </h1>
-          <p class="mx-auto mt-4 max-w-2xl text-xl text-[color:var(--color-text-secondary)]">
+          <p class="mx-auto mt-4 max-w-2xl text-xl text-[color:var(--ss-color-text-secondary)]">
             Pick a time that works. We'll ask how things run, where you're trying to go, and what
             the best path forward looks like.
           </p>
@@ -81,7 +81,7 @@ if (prefillToken) {
         <div class="mx-auto mt-10 max-w-3xl">
           {
             prefillTokenError && (
-              <div class="mb-6 rounded-[var(--radius-card)] bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+              <div class="mb-6 rounded-[var(--ss-radius-card)] bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
                 {prefillTokenError === 'expired'
                   ? 'This booking link has expired. You can still pick a time below — we will just take a few extra details.'
                   : 'This booking link is not valid. You can still pick a time below — we will just take a few extra details.'}
@@ -89,18 +89,18 @@ if (prefillToken) {
             )
           }
           <!-- Step 1: Pick a time -->
-          <div class="rounded-[var(--radius-card)] bg-white p-card sm:p-section">
-            <h2 class="mb-1 text-lg font-bold text-[color:var(--color-text-primary)]">
+          <div class="rounded-[var(--ss-radius-card)] bg-white p-card sm:p-section">
+            <h2 class="mb-1 text-lg font-bold text-[color:var(--ss-color-text-primary)]">
               Pick a time
             </h2>
-            <p class="mb-6 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mb-6 text-sm text-[color:var(--ss-color-text-secondary)]">
               Choose a date and time that works for you.
             </p>
             <SlotPicker />
           </div>
 
           <!-- Standalone intake escape hatch -->
-          <p class="mt-4 text-center text-sm text-[color:var(--color-text-secondary)]">
+          <p class="mt-4 text-center text-sm text-[color:var(--ss-color-text-secondary)]">
             Not ready to pick a time?
             <a href="/get-started" class="font-medium text-primary underline hover:text-primary/80"
               >Tell us about your business</a
@@ -110,20 +110,20 @@ if (prefillToken) {
           <!-- Step 2: Intake form (appears after slot selection) -->
           <div
             id="intake-section"
-            class="mt-6 rounded-[var(--radius-card)] bg-white p-card transition-opacity duration-300 sm:p-section"
+            class="mt-6 rounded-[var(--ss-radius-card)] bg-white p-card transition-opacity duration-300 sm:p-section"
             style="display: none;"
           >
-            <h2 class="text-lg font-bold text-[color:var(--color-text-primary)]">
+            <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">
               Tell us about your business
             </h2>
-            <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
               The more we know, the more useful the conversation will be.
             </p>
 
             <!-- Selected slot summary -->
             <div
               id="selected-slot-banner"
-              class="mt-4 flex items-center gap-2 rounded-[var(--radius-card)] bg-primary/5 px-4 py-2.5"
+              class="mt-4 flex items-center gap-2 rounded-[var(--ss-radius-card)] bg-primary/5 px-4 py-2.5"
             >
               <svg
                 class="h-5 w-5 flex-shrink-0 text-primary"
@@ -172,7 +172,7 @@ if (prefillToken) {
                 <div>
                   <label
                     for="bf-name"
-                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                   >
                     Full name <span class="text-red-500">*</span>
                   </label>
@@ -184,14 +184,14 @@ if (prefillToken) {
                     maxlength="200"
                     autocomplete="name"
                     value={prefillContactName ?? ''}
-                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="e.g. Maria Garcia"
                   />
                 </div>
                 <div>
                   <label
                     for="bf-email"
-                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                   >
                     Work email <span class="text-red-500">*</span>
                   </label>
@@ -203,7 +203,7 @@ if (prefillToken) {
                     maxlength="254"
                     autocomplete="email"
                     value={prefillEmail ?? ''}
-                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="maria@example.com"
                   />
                 </div>
@@ -214,7 +214,7 @@ if (prefillToken) {
                 <div>
                   <label
                     for="bf-business"
-                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                   >
                     Business name <span class="text-red-500">*</span>
                   </label>
@@ -225,14 +225,14 @@ if (prefillToken) {
                     required
                     maxlength="200"
                     value={prefillBusinessName ?? ''}
-                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="e.g. Phoenix Plumbing Co."
                   />
                 </div>
                 <div>
                   <label
                     for="bf-phone"
-                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                   >
                     Phone <span class="text-red-500">*</span>
                   </label>
@@ -243,7 +243,7 @@ if (prefillToken) {
                     required
                     maxlength="30"
                     autocomplete="tel"
-                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="(602) 555-0123"
                   />
                 </div>
@@ -254,14 +254,14 @@ if (prefillToken) {
                 <div>
                   <label
                     for="bf-vertical"
-                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                   >
                     What kind of business?
                   </label>
                   <select
                     id="bf-vertical"
                     name="vertical"
-                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   >
                     <option value="">Select one</option>
                     {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
@@ -270,21 +270,21 @@ if (prefillToken) {
                     type="text"
                     id="bf-vertical-other"
                     name="vertical_other"
-                    class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     placeholder="Describe your business type"
                   />
                 </div>
                 <div>
                   <label
                     for="bf-employees"
-                    class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                   >
                     Employee count
                   </label>
                   <select
                     id="bf-employees"
                     name="employee_count"
-                    class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   >
                     <option value="">Select one</option>
                     <option value="1-5">1 - 5</option>
@@ -300,14 +300,14 @@ if (prefillToken) {
               <div class="sm:w-1/2">
                 <label
                   for="bf-years"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   Years in business
                 </label>
                 <select
                   id="bf-years"
                   name="years_in_business"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   <option value="<1">Less than 1 year</option>
@@ -322,13 +322,13 @@ if (prefillToken) {
               <div>
                 <label
                   for="bf-challenge"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   What's the single biggest operational challenge right now? <span
                     class="text-red-500">*</span
                   >
                 </label>
-                <p class="mt-0.5 text-xs text-[color:var(--color-text-muted)]">
+                <p class="mt-0.5 text-xs text-[color:var(--ss-color-text-muted)]">
                   What would make the biggest difference in how your business runs day to day?
                 </p>
                 <textarea
@@ -337,7 +337,7 @@ if (prefillToken) {
                   required
                   rows="3"
                   maxlength="2000"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="e.g. I want to stop being the bottleneck for every decision..."
                 ></textarea>
               </div>
@@ -346,14 +346,14 @@ if (prefillToken) {
               <div>
                 <label
                   for="bf-how-heard"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   How did you hear about us?
                 </label>
                 <select
                   id="bf-how-heard"
                   name="how_heard"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   <option value="Google Search">Google Search</option>
@@ -368,7 +368,7 @@ if (prefillToken) {
                   type="text"
                   id="bf-how-heard-other"
                   name="how_heard_other"
-                  class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="Tell us more"
                 />
               </div>
@@ -379,12 +379,12 @@ if (prefillToken) {
               <!-- Banners -->
               <div
                 id="bf-error"
-                class="hidden rounded-[var(--radius-card)] bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]"
+                class="hidden rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]"
               >
               </div>
               <div
                 id="bf-slot-taken"
-                class="hidden rounded-[var(--radius-card)] bg-amber-50 px-4 py-3 text-sm text-[color:var(--color-attention)]"
+                class="hidden rounded-[var(--ss-radius-card)] bg-amber-50 px-4 py-3 text-sm text-[color:var(--ss-color-attention)]"
               >
                 That time was just taken. Please choose another time above.
               </div>
@@ -395,7 +395,7 @@ if (prefillToken) {
                 type="submit"
                 disabled
                 data-ev="book-submit"
-                class="w-full rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+                class="w-full rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Book Your Call
               </button>
@@ -405,14 +405,14 @@ if (prefillToken) {
           <!-- Confirmation panel (replaces the form on success) -->
           <div
             id="confirmation-panel"
-            class="mt-6 hidden rounded-[var(--radius-card)] bg-white p-card sm:p-section"
+            class="mt-6 hidden rounded-[var(--ss-radius-card)] bg-white p-card sm:p-section"
           >
             <div class="text-center">
               <div
-                class="mx-auto flex h-14 w-14 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10"
+                class="mx-auto flex h-14 w-14 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-complete)]/10"
               >
                 <svg
-                  class="h-7 w-7 text-[color:var(--color-complete)]"
+                  class="h-7 w-7 text-[color:var(--ss-color-complete)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="2"
@@ -422,14 +422,14 @@ if (prefillToken) {
                   ></path>
                 </svg>
               </div>
-              <h2 class="mt-4 text-xl font-bold text-[color:var(--color-text-primary)]">
+              <h2 class="mt-4 text-xl font-bold text-[color:var(--ss-color-text-primary)]">
                 You're all set
               </h2>
-              <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+              <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
                 We'll see you at your scheduled time. Check your email for a confirmation with the
                 meeting link.
               </p>
-              <p class="mt-3 text-sm text-[color:var(--color-text-secondary)]">
+              <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
                 <a
                   href="/get-started?booked=1"
                   class="font-medium text-primary underline hover:text-primary/80"
@@ -439,11 +439,11 @@ if (prefillToken) {
             </div>
 
             <div
-              class="mt-6 space-y-row rounded-[var(--radius-card)] bg-[color:var(--color-background)] p-stack"
+              class="mt-6 space-y-row rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-background)] p-stack"
             >
               <div class="flex items-start gap-row">
                 <svg
-                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--color-text-muted)]"
+                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--ss-color-text-muted)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
@@ -457,11 +457,11 @@ if (prefillToken) {
                 </svg>
                 <span
                   id="conf-slot"
-                  class="text-sm font-medium text-[color:var(--color-text-primary)]"></span>
+                  class="text-sm font-medium text-[color:var(--ss-color-text-primary)]"></span>
               </div>
               <div id="conf-meet-row" class="hidden flex items-start gap-row">
                 <svg
-                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--color-text-muted)]"
+                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--ss-color-text-muted)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
@@ -485,7 +485,7 @@ if (prefillToken) {
               </div>
               <div id="conf-manage-row" class="hidden flex items-start gap-row">
                 <svg
-                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--color-text-muted)]"
+                  class="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--ss-color-text-muted)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke-width="1.5"
@@ -515,18 +515,18 @@ if (prefillToken) {
           <!-- 503 email fallback panel -->
           <div
             id="email-fallback-panel"
-            class="mt-6 hidden rounded-[var(--radius-card)] bg-white p-card text-center sm:p-section"
+            class="mt-6 hidden rounded-[var(--ss-radius-card)] bg-white p-card text-center sm:p-section"
           >
-            <p class="text-sm text-[color:var(--color-text-secondary)]">
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
               Online booking is temporarily unavailable.
             </p>
-            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
               Please email us directly to schedule your call.
             </p>
             <a
               id="fallback-mailto"
               href="mailto:scott@smd.services?subject=Assessment%20Call%20Request"
-              class="mt-4 inline-block rounded-[var(--radius-card)] bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+              class="mt-4 inline-block rounded-[var(--ss-radius-card)] bg-primary px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
             >
               Email scott@smd.services
             </a>
@@ -538,48 +538,48 @@ if (prefillToken) {
     <!-- What to Expect -->
     <section class="bg-white px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">
-        <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)]">
+        <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--ss-color-text-primary)]">
           What Happens on the Call
         </h2>
         <div class="mx-auto grid max-w-3xl gap-section sm:grid-cols-3">
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-card)] bg-primary text-lg font-bold text-white"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--ss-radius-card)] bg-primary text-lg font-bold text-white"
             >
               1
             </div>
-            <h3 class="mt-4 font-bold text-[color:var(--color-text-primary)]">
+            <h3 class="mt-4 font-bold text-[color:var(--ss-color-text-primary)]">
               You walk us through your day
             </h3>
-            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
               How do customers find you? How do jobs get scheduled? What happens when something goes
               wrong? We're just trying to understand how things really work day to day.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] text-lg font-bold text-[color:var(--color-text-primary)]"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-border-subtle)] text-lg font-bold text-[color:var(--ss-color-text-primary)]"
             >
               2
             </div>
-            <h3 class="mt-4 font-bold text-[color:var(--color-text-primary)]">
+            <h3 class="mt-4 font-bold text-[color:var(--ss-color-text-primary)]">
               We figure out what matters most
             </h3>
-            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
               Together we identify what would make the biggest difference for where you're trying to
               go, and why those things matter most right now.
             </p>
           </div>
           <div class="text-center">
             <div
-              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)] text-lg font-bold text-[color:var(--color-text-primary)]"
+              class="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-border-subtle)] text-lg font-bold text-[color:var(--ss-color-text-primary)]"
             >
               3
             </div>
-            <h3 class="mt-4 font-bold text-[color:var(--color-text-primary)]">
+            <h3 class="mt-4 font-bold text-[color:var(--ss-color-text-primary)]">
               You decide if you want help
             </h3>
-            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
               If it makes sense to work together, we'll send you a proposal with the scope, price,
               and timeline. If not, you still walked away with a useful conversation.
             </p>
@@ -589,46 +589,46 @@ if (prefillToken) {
     </section>
 
     <!-- FAQ -->
-    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-5xl">
-        <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--color-text-primary)]">
+        <h2 class="mb-12 text-center text-3xl font-bold text-[color:var(--ss-color-text-primary)]">
           Common Questions
         </h2>
         <dl class="mx-auto max-w-2xl space-y-section">
           <div>
-            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+            <dt class="font-semibold text-[color:var(--ss-color-text-primary)]">
               Does the call cost anything?
             </dt>
-            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
+            <dd class="mt-2 text-[color:var(--ss-color-text-secondary)]">
               No. If it makes sense to work together, we'll send a proposal after the call. If not,
               you still got a useful conversation about your business. Either way it costs you
               nothing but time.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+            <dt class="font-semibold text-[color:var(--ss-color-text-primary)]">
               Do I need to prepare anything?
             </dt>
-            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
+            <dd class="mt-2 text-[color:var(--ss-color-text-secondary)]">
               Just be ready to talk honestly about how things work. We'll ask questions. The less
               polished, the better. The real version of how things run is what helps us figure out
               the right path forward.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+            <dt class="font-semibold text-[color:var(--ss-color-text-primary)]">
               What happens after the call?
             </dt>
-            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
+            <dd class="mt-2 text-[color:var(--ss-color-text-secondary)]">
               If it makes sense to work together, you get a proposal. Fixed price, clear scope, no
               surprises. If not, we'll tell you that too. No pressure either way.
             </dd>
           </div>
           <div>
-            <dt class="font-semibold text-[color:var(--color-text-primary)]">
+            <dt class="font-semibold text-[color:var(--ss-color-text-primary)]">
               What size business is this for?
             </dt>
-            <dd class="mt-2 text-[color:var(--color-text-secondary)]">
+            <dd class="mt-2 text-[color:var(--ss-color-text-secondary)]">
               Phoenix-area businesses with roughly 5 to 50 employees. Big enough that the owner
               can't do everything themselves anymore, small enough that hiring a full-time
               operations person doesn't make sense yet.
@@ -924,7 +924,7 @@ if (prefillToken) {
         // Hide picker + form, show confirmation
         const pickerCard = document.querySelector('[data-component="slot-picker"]')
         if (pickerCard) {
-          const card = pickerCard.closest('.rounded-[var(--radius-card)]')
+          const card = pickerCard.closest('.rounded-[var(--ss-radius-card)]')
           if (card) card.style.display = 'none'
         }
         intakeSection.style.display = 'none'
@@ -968,7 +968,7 @@ if (prefillToken) {
         mailtoEl.textContent = 'Email ' + fallbackEmail
 
         // Hide picker + form, show fallback
-        const pickerEl = picker.closest('.rounded-[var(--radius-card)]')
+        const pickerEl = picker.closest('.rounded-[var(--ss-radius-card)]')
         if (pickerEl) pickerEl.style.display = 'none'
         intakeSection.style.display = 'none'
         emailFallback.classList.remove('hidden')

--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -12,15 +12,15 @@ import Footer from '../../../components/Footer.astro'
 >
   <Nav />
   <main id="main" role="main">
-    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Loading state -->
         <div id="loading" class="text-center">
           <div
-            class="mx-auto h-8 w-8 animate-spin rounded-[var(--radius-card)] border-4 border-[color:var(--color-border)] border-t-primary"
+            class="mx-auto h-8 w-8 animate-spin rounded-[var(--ss-radius-card)] border-4 border-[color:var(--ss-color-border)] border-t-primary"
           >
           </div>
-          <p class="mt-4 text-sm text-[color:var(--color-text-secondary)]">
+          <p class="mt-4 text-sm text-[color:var(--ss-color-text-secondary)]">
             Loading your booking...
           </p>
         </div>
@@ -28,10 +28,10 @@ import Footer from '../../../components/Footer.astro'
         <!-- Error state -->
         <div id="error-state" class="hidden text-center">
           <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-error)]/10"
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-error)]/10"
           >
             <svg
-              class="h-8 w-8 text-[color:var(--color-error)]"
+              class="h-8 w-8 text-[color:var(--ss-color-error)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -44,17 +44,17 @@ import Footer from '../../../components/Footer.astro'
             </svg>
           </div>
           <h1
-            class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]"
+            class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]"
             id="error-title"
           >
             Something went wrong
           </h1>
-          <p class="mt-3 text-[color:var(--color-text-secondary)]" id="error-message">
+          <p class="mt-3 text-[color:var(--ss-color-text-secondary)]" id="error-message">
             Please try again or contact us directly.
           </p>
           <a
             href="/book"
-            class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
+            class="mt-6 inline-block rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
           >
             Book a new time
           </a>
@@ -63,10 +63,10 @@ import Footer from '../../../components/Footer.astro'
         <!-- Cancelled state -->
         <div id="cancelled-state" class="hidden text-center">
           <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-border-subtle)]"
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-border-subtle)]"
           >
             <svg
-              class="h-8 w-8 text-[color:var(--color-text-muted)]"
+              class="h-8 w-8 text-[color:var(--ss-color-text-muted)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -75,15 +75,15 @@ import Footer from '../../../components/Footer.astro'
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path>
             </svg>
           </div>
-          <h1 class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]">
+          <h1 class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
             This booking was cancelled
           </h1>
-          <p class="mt-3 text-[color:var(--color-text-secondary)]">
+          <p class="mt-3 text-[color:var(--ss-color-text-secondary)]">
             Whenever you're ready, you can book a new time.
           </p>
           <a
             href="/book"
-            class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
+            class="mt-6 inline-block rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
           >
             Book a new time
           </a>
@@ -93,10 +93,10 @@ import Footer from '../../../components/Footer.astro'
         <div id="booking-details" class="hidden">
           <div class="text-center">
             <div
-              class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-primary)]/10"
+              class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)]/10"
             >
               <svg
-                class="h-8 w-8 text-[color:var(--color-primary)]"
+                class="h-8 w-8 text-[color:var(--ss-color-primary)]"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke-width="2"
@@ -109,44 +109,45 @@ import Footer from '../../../components/Footer.astro'
                 ></path>
               </svg>
             </div>
-            <h1 class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]">
+            <h1 class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
               Your Booking
             </h1>
-            <p class="mt-1 text-sm text-[color:var(--color-text-secondary)]" id="meeting-label"></p>
+            <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]" id="meeting-label">
+            </p>
           </div>
 
-          <div class="mt-8 rounded-[var(--radius-card)] bg-white p-card">
+          <div class="mt-8 rounded-[var(--ss-radius-card)] bg-white p-card">
             <div class="space-y-stack">
               <div>
                 <p
-                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]"
+                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)]"
                 >
                   When
                 </p>
                 <p
-                  class="mt-1 text-lg font-semibold text-[color:var(--color-text-primary)]"
+                  class="mt-1 text-lg font-semibold text-[color:var(--ss-color-text-primary)]"
                   id="slot-label"
                 >
                 </p>
               </div>
               <div>
                 <p
-                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]"
+                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)]"
                 >
                   Guest
                 </p>
-                <p class="mt-1 text-[color:var(--color-text-primary)]" id="guest-name"></p>
+                <p class="mt-1 text-[color:var(--ss-color-text-primary)]" id="guest-name"></p>
               </div>
               <div id="meet-link-container" class="hidden">
                 <p
-                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--color-text-muted)]"
+                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)]"
                 >
                   Video call
                 </p>
                 <a
                   id="meet-link"
                   href=""
-                  class="mt-1 inline-block text-sm text-[color:var(--color-primary)] hover:text-blue-800"
+                  class="mt-1 inline-block text-sm text-[color:var(--ss-color-primary)] hover:text-blue-800"
                   target="_blank"
                   rel="noopener"></a>
               </div>
@@ -155,13 +156,13 @@ import Footer from '../../../components/Footer.astro'
             <div class="mt-8 flex flex-col gap-row sm:flex-row">
               <button
                 id="reschedule-btn"
-                class="flex-1 rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-background)]"
+                class="flex-1 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--ss-color-text-primary)] transition-colors hover:bg-[color:var(--ss-color-background)]"
               >
                 Reschedule
               </button>
               <button
                 id="cancel-btn"
-                class="flex-1 rounded-[var(--radius-card)] border border-[color:var(--color-error)]/30 bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--color-error)] transition-colors hover:bg-[color:var(--color-error)]/5"
+                class="flex-1 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--ss-color-error)] transition-colors hover:bg-[color:var(--ss-color-error)]/5"
               >
                 Cancel Booking
               </button>
@@ -172,20 +173,20 @@ import Footer from '../../../components/Footer.astro'
         <!-- Reschedule panel -->
         <div id="reschedule-panel" class="hidden">
           <div class="text-center">
-            <h2 class="text-2xl font-bold text-[color:var(--color-text-primary)]">
+            <h2 class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
               Pick a new time
             </h2>
-            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
               Choose an available slot below.
             </p>
           </div>
 
           <div id="slots-loading" class="mt-8 text-center">
             <div
-              class="mx-auto h-6 w-6 animate-spin rounded-[var(--radius-card)] border-4 border-[color:var(--color-border)] border-t-primary"
+              class="mx-auto h-6 w-6 animate-spin rounded-[var(--ss-radius-card)] border-4 border-[color:var(--ss-color-border)] border-t-primary"
             >
             </div>
-            <p class="mt-3 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
               Loading available times...
             </p>
           </div>
@@ -193,7 +194,7 @@ import Footer from '../../../components/Footer.astro'
           <div id="slots-container" class="mt-8 hidden space-y-card"></div>
 
           <div id="slots-empty" class="mt-8 hidden text-center">
-            <p class="text-[color:var(--color-text-secondary)]">
+            <p class="text-[color:var(--ss-color-text-secondary)]">
               No available times found. Please check back later or contact us.
             </p>
           </div>
@@ -201,7 +202,7 @@ import Footer from '../../../components/Footer.astro'
           <div class="mt-6 text-center">
             <button
               id="back-to-details-btn"
-              class="text-sm text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+              class="text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
             >
               Back to booking details
             </button>
@@ -213,34 +214,34 @@ import Footer from '../../../components/Footer.astro'
           id="cancel-dialog"
           class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50 p-stack"
         >
-          <div class="w-full max-w-md rounded-[var(--radius-card)] bg-white p-card">
-            <h3 class="text-lg font-bold text-[color:var(--color-text-primary)]">
+          <div class="w-full max-w-md rounded-[var(--ss-radius-card)] bg-white p-card">
+            <h3 class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">
               Cancel your booking?
             </h3>
-            <p class="mt-2 text-sm text-[color:var(--color-text-secondary)]">
+            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
               This will cancel your assessment call. You can always book a new time later.
             </p>
             <div class="mt-4">
               <label
                 for="cancel-reason"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >Reason (optional)</label
               >
               <textarea
                 id="cancel-reason"
                 rows="2"
-                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:ring-1 focus:ring-primary"
                 placeholder="Let us know why you're cancelling..."></textarea>
             </div>
             <div class="mt-6 flex gap-row">
               <button
                 id="cancel-dialog-dismiss"
-                class="flex-1 rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-background)]"
+                class="flex-1 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)]"
                 >Keep Booking</button
               >
               <button
                 id="cancel-dialog-confirm"
-                class="flex-1 rounded-[var(--radius-card)] bg-red-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-red-700"
+                class="flex-1 rounded-[var(--ss-radius-card)] bg-red-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-red-700"
                 >Yes, Cancel</button
               >
             </div>
@@ -250,10 +251,10 @@ import Footer from '../../../components/Footer.astro'
         <!-- Success state -->
         <div id="success-state" class="hidden text-center">
           <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10"
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-complete)]/10"
           >
             <svg
-              class="h-8 w-8 text-[color:var(--color-complete)]"
+              class="h-8 w-8 text-[color:var(--ss-color-complete)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -263,11 +264,11 @@ import Footer from '../../../components/Footer.astro'
             </svg>
           </div>
           <h1
-            class="mt-6 text-2xl font-bold text-[color:var(--color-text-primary)]"
+            class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]"
             id="success-title"
           >
           </h1>
-          <p class="mt-3 text-[color:var(--color-text-secondary)]" id="success-message"></p>
+          <p class="mt-3 text-[color:var(--ss-color-text-secondary)]" id="success-message"></p>
         </div>
       </div>
     </section>
@@ -411,7 +412,7 @@ import Footer from '../../../components/Footer.astro'
               day: 'numeric',
             })
             const h = document.createElement('h3')
-            h.className = 'text-sm font-semibold text-[color:var(--color-text-primary)]'
+            h.className = 'text-sm font-semibold text-[color:var(--ss-color-text-primary)]'
             h.textContent = lbl
             div.appendChild(h)
             const g = document.createElement('div')
@@ -419,7 +420,7 @@ import Footer from '../../../components/Footer.astro'
             day.slots.forEach(function (slot) {
               const b = document.createElement('button')
               b.className =
-                'rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary'
+                'rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary'
               b.textContent = slot.label
               b.dataset.startUtc = slot.start_utc
               b.addEventListener('click', function () {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,8 +8,8 @@ import Footer from '../components/Footer.astro'
   <Nav />
   <main id="main" role="main" class="px-6 py-20">
     <div class="mx-auto max-w-xl">
-      <h1 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Get in Touch</h1>
-      <p class="mt-2 text-lg text-[color:var(--color-text-secondary)]">
+      <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)]">Get in Touch</h1>
+      <p class="mt-2 text-lg text-[color:var(--ss-color-text-secondary)]">
         Have a question or want to talk about your business? Send us a message.
       </p>
 
@@ -19,7 +19,7 @@ import Footer from '../components/Footer.astro'
         <div>
           <label
             for="name"
-            class="mb-1 block text-sm font-medium text-[color:var(--color-text-primary)]"
+            class="mb-1 block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
             >Name</label
           >
           <input
@@ -29,7 +29,7 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="200"
             autocomplete="name"
-            class="w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="Your name"
           />
         </div>
@@ -37,7 +37,7 @@ import Footer from '../components/Footer.astro'
         <div>
           <label
             for="email"
-            class="mb-1 block text-sm font-medium text-[color:var(--color-text-primary)]"
+            class="mb-1 block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
             >Email</label
           >
           <input
@@ -47,7 +47,7 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="254"
             autocomplete="email"
-            class="w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="you@example.com"
           />
         </div>
@@ -55,7 +55,7 @@ import Footer from '../components/Footer.astro'
         <div>
           <label
             for="message"
-            class="mb-1 block text-sm font-medium text-[color:var(--color-text-primary)]"
+            class="mb-1 block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
             >Message</label
           >
           <textarea
@@ -64,7 +64,7 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="5000"
             rows="6"
-            class="w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-3 py-2 text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             placeholder="What's on your mind?"></textarea>
         </div>
 
@@ -77,7 +77,7 @@ import Footer from '../components/Footer.astro'
         <button
           type="submit"
           data-ev="contact-submit"
-          class="rounded-[var(--radius-card)] bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-80"
+          class="rounded-[var(--ss-radius-card)] bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-80"
         >
           Send Message
         </button>
@@ -114,21 +114,21 @@ import Footer from '../components/Footer.astro'
 
           if (res.ok) {
             status.innerHTML =
-              '<div class="rounded-[var(--radius-card)] border border-[color:var(--color-complete)]/30 bg-[color:var(--color-complete)]/5 px-4 py-3 text-sm text-[color:var(--color-complete)]">Message sent. We\'ll get back to you soon.</div>'
+              '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)]/30 bg-[color:var(--ss-color-complete)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-complete)]">Message sent. We\'ll get back to you soon.</div>'
             form.reset()
             form.style.display = 'none'
           } else {
             const body = await res.json()
             if (res.status === 400 && body.fields) {
               const msgs = Object.values(body.fields).join('. ')
-              status.innerHTML = `<div class="rounded-[var(--radius-card)] border border-[color:var(--color-error)]/30 bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]">${msgs}</div>`
+              status.innerHTML = `<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]">${msgs}</div>`
             } else {
               throw new Error(body.error || 'Request failed')
             }
           }
         } catch {
           status.innerHTML =
-            '<div class="rounded-[var(--radius-card)] border border-[color:var(--color-error)]/30 bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]">Something went wrong. Please email <a href="mailto:team@smd.services" class="underline">team@smd.services</a> directly.</div>'
+            '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]">Something went wrong. Please email <a href="mailto:team@smd.services" class="underline">team@smd.services</a> directly.</div>'
         } finally {
           button.disabled = false
           button.textContent = 'Send Message'

--- a/src/pages/design-preview/portal-documents.astro
+++ b/src/pages/design-preview/portal-documents.astro
@@ -28,7 +28,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] Documents</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <Documents {...fixtureData} />
   </body>
 </html>

--- a/src/pages/design-preview/portal-engagement.astro
+++ b/src/pages/design-preview/portal-engagement.astro
@@ -28,7 +28,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] EngagementProgress</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <EngagementProgress {...fixtureData} />
   </body>
 </html>

--- a/src/pages/design-preview/portal-home.astro
+++ b/src/pages/design-preview/portal-home.astro
@@ -28,7 +28,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] PortalHomeDashboard</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <PortalHomeDashboard {...fixtureData} />
   </body>
 </html>

--- a/src/pages/design-preview/portal-invoices-detail.astro
+++ b/src/pages/design-preview/portal-invoices-detail.astro
@@ -28,7 +28,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] InvoiceDetail</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <InvoiceDetail {...fixtureData} />
   </body>
 </html>

--- a/src/pages/design-preview/portal-invoices-list.astro
+++ b/src/pages/design-preview/portal-invoices-list.astro
@@ -28,7 +28,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] InvoicesList</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <InvoicesList {...fixtureData} />
   </body>
 </html>

--- a/src/pages/design-preview/portal-quotes-detail.astro
+++ b/src/pages/design-preview/portal-quotes-detail.astro
@@ -27,7 +27,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] QuoteDetail</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <QuoteDetail {...fixtureData} />
   </body>
 </html>

--- a/src/pages/design-preview/portal-quotes-list.astro
+++ b/src/pages/design-preview/portal-quotes-list.astro
@@ -27,7 +27,7 @@ if (!import.meta.env.DEV) {
     />
     <title>[preview] QuoteList</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <QuoteList {...fixtureData} />
   </body>
 </html>

--- a/src/pages/dev/portal-components.astro
+++ b/src/pages/dev/portal-components.astro
@@ -35,7 +35,7 @@ if (import.meta.env.PROD) {
     />
     <title>Portal component gallery — dev</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <PortalHeader
       clientName="Delgado Plumbing"
       consultantPhone="+14805550100"
@@ -43,13 +43,15 @@ if (import.meta.env.PROD) {
       consultantFirstName="Scott"
     >
       <form method="POST" action="/api/auth/logout">
-        <button type="submit" class="text-sm text-[color:var(--color-text-muted)]">Sign out</button>
+        <button type="submit" class="text-sm text-[color:var(--ss-color-text-muted)]"
+          >Sign out</button
+        >
       </form>
     </PortalHeader>
 
     <main class="max-w-3xl mx-auto px-4 sm:px-6 py-10 space-y-10">
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           ActionCard — invoice
         </h2>
         <ActionCard
@@ -63,7 +65,7 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           ConsultantBlock
         </h2>
         <ConsultantBlock
@@ -76,9 +78,9 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">Timeline</h2>
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">Timeline</h2>
         <div
-          class="space-y-6 bg-[color:var(--color-surface)] border border-[color:var(--color-border)] rounded-lg p-6"
+          class="space-y-6 bg-[color:var(--ss-color-surface)] border border-[color:var(--ss-color-border)] rounded-lg p-6"
         >
           <TimelineEntry
             date="Apr 9"
@@ -96,7 +98,9 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">ArtifactChip</h2>
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
+          ArtifactChip
+        </h2>
         <div class="flex gap-3">
           <ArtifactChip icon="description" label="scope_of_work.pdf" href="#" />
           <ArtifactChip icon="receipt_long" label="invoice_1023.pdf" href="#" />
@@ -104,9 +108,11 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">MoneyDisplay</h2>
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
+          MoneyDisplay
+        </h2>
         <div
-          class="bg-[color:var(--color-surface)] border border-[color:var(--color-border)] rounded-lg p-6 space-y-4"
+          class="bg-[color:var(--ss-color-surface)] border border-[color:var(--ss-color-border)] rounded-lg p-6 space-y-4"
         >
           <div><MoneyDisplay amountCents={425000} size="display" /></div>
           <div><MoneyDisplay amountCents={425000} size="h2" /></div>
@@ -115,11 +121,11 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           StatusPill — all tones
         </h2>
         <div
-          class="bg-[color:var(--color-surface)] border border-[color:var(--color-border)] rounded-lg p-6 flex flex-wrap gap-3"
+          class="bg-[color:var(--ss-color-surface)] border border-[color:var(--ss-color-border)] rounded-lg p-6 flex flex-wrap gap-3"
         >
           <StatusPill tone="info" label="Pending Review" />
           <StatusPill tone="success" label="Paid" />
@@ -131,7 +137,7 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalListItem — status variant (proposals)
         </h2>
         <div class="space-y-row">
@@ -167,7 +173,7 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalListItem — status variant (invoices)
         </h2>
         <div class="space-y-row">
@@ -203,7 +209,7 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalListItem — document variant
         </h2>
         <div class="space-y-row">
@@ -234,25 +240,25 @@ if (import.meta.env.PROD) {
         </div>
       </section>
 
-      <hr class="border-[color:var(--color-text-primary)] border-t-[3px] my-12" />
+      <hr class="border-[color:var(--ss-color-text-primary)] border-t-[3px] my-12" />
 
       <section class="space-y-4">
         <p
-          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]"
+          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]"
         >
           Plainspoken additions — PR A
         </p>
-        <p class="text-sm text-[color:var(--color-text-secondary)]">
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
           Everything below renders the new Plainspoken variants. Page consumers stay on `card` /
           `default` until PR B flips them, so live portal routes still show the legacy chrome.
         </p>
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalPageHead
         </h2>
-        <div class="border-[3px] border-[color:var(--color-text-primary)] px-5 md:px-8">
+        <div class="border-[3px] border-[color:var(--ss-color-text-primary)] px-5 md:px-8">
           <PortalPageHead
             crumbHref="#"
             crumbLabel="Home"
@@ -261,7 +267,7 @@ if (import.meta.env.PROD) {
             meta={'4 total\n1 open · 3 closed'}
           />
         </div>
-        <div class="mt-4 border-[3px] border-[color:var(--color-text-primary)] px-5 md:px-8">
+        <div class="mt-4 border-[3px] border-[color:var(--ss-color-text-primary)] px-5 md:px-8">
           <PortalPageHead
             crumbHref="#"
             crumbLabel="All proposals · № 03"
@@ -273,34 +279,34 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           MoneyDisplay — Plainspoken sizes
         </h2>
-        <div class="border-[3px] border-[color:var(--color-text-primary)] p-6 space-y-5">
+        <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 space-y-5">
           <div class="flex items-baseline gap-6">
             <span
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] w-16"
               >hero</span
             >
             <MoneyDisplay amountCents={525000} size="hero" />
           </div>
           <div class="flex items-baseline gap-6">
             <span
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] w-16"
               >kpi</span
             >
             <MoneyDisplay amountCents={262500} size="kpi" />
           </div>
           <div class="flex items-baseline gap-6">
             <span
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] w-16"
               >total</span
             >
             <MoneyDisplay amountCents={525000} size="total" />
           </div>
           <div class="flex items-baseline gap-6">
             <span
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] w-16"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] w-16"
               >row</span
             >
             <MoneyDisplay amountCents={262500} size="row" />
@@ -309,10 +315,12 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           StatusPill — outline tone (new)
         </h2>
-        <div class="border-[3px] border-[color:var(--color-text-primary)] p-6 flex flex-wrap gap-3">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 flex flex-wrap gap-3"
+        >
           <StatusPill tone="outline" label="ARCHIVED" />
           <StatusPill tone="outline" label="EXPIRED" />
           <StatusPill tone="outline" label="COMPLETED" size="base" />
@@ -320,10 +328,10 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalListItem — ticket chrome · status (proposals)
         </h2>
-        <div class="border-[3px] border-[color:var(--color-text-primary)]">
+        <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
           <PortalListItem
             chrome="ticket"
             variant="status"
@@ -370,10 +378,10 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalListItem — ticket chrome · status (invoices)
         </h2>
-        <div class="border-[3px] border-[color:var(--color-text-primary)]">
+        <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
           <PortalListItem
             chrome="ticket"
             variant="status"
@@ -406,10 +414,10 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           PortalListItem — ticket chrome · document
         </h2>
-        <div class="border-[3px] border-[color:var(--color-text-primary)]">
+        <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
           <PortalListItem
             chrome="ticket"
             variant="document"
@@ -453,13 +461,13 @@ if (import.meta.env.PROD) {
       </section>
 
       <section>
-        <h2 class="text-lg font-bold text-[color:var(--color-text-primary)] mb-4">
+        <h2 class="text-lg font-bold text-[color:var(--ss-color-text-primary)] mb-4">
           ConsultantBlock — trade-card variant · data-state matrix
         </h2>
         <div class="grid gap-6 md:grid-cols-2">
           <div>
             <p
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] mb-2"
             >
               A. phone + photo
             </p>
@@ -474,7 +482,7 @@ if (import.meta.env.PROD) {
           </div>
           <div>
             <p
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] mb-2"
             >
               B. phone + no photo
             </p>
@@ -489,7 +497,7 @@ if (import.meta.env.PROD) {
           </div>
           <div>
             <p
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] mb-2"
             >
               C. no phone + email
             </p>
@@ -505,7 +513,7 @@ if (import.meta.env.PROD) {
           </div>
           <div>
             <p
-              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)] mb-2"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] mb-2"
             >
               D. neither — contact row hidden
             </p>

--- a/src/pages/dev/portal-states.astro
+++ b/src/pages/dev/portal-states.astro
@@ -50,25 +50,27 @@ const dashboardStates = [
       rel="stylesheet"
     />
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <main class="max-w-3xl mx-auto px-4 sm:px-6 py-10 space-y-10">
       <header>
-        <p class="text-[12px] font-bold tracking-[0.1em] uppercase text-[color:var(--color-meta)]">
+        <p
+          class="text-[12px] font-bold tracking-[0.1em] uppercase text-[color:var(--ss-color-meta)]"
+        >
           Dev harness
         </p>
         <h1
-          class="mt-3 font-['Archivo'] font-extrabold text-[32px] leading-[36px] tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+          class="mt-3 font-['Archivo'] font-extrabold text-[32px] leading-[36px] tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
         >
           Portal error and edge states
         </h1>
-        <p class="mt-3 text-[15px] leading-[22px] text-[color:var(--color-text-secondary)]">
+        <p class="mt-3 text-[15px] leading-[22px] text-[color:var(--ss-color-text-secondary)]">
           Replace <code>:id</code> with a real invoice or quote ID from your local D1.
         </p>
       </header>
 
       <section>
         <h2
-          class="font-['Archivo'] font-bold text-[20px] leading-[26px] text-[color:var(--color-text-primary)] mb-4"
+          class="font-['Archivo'] font-bold text-[20px] leading-[26px] text-[color:var(--ss-color-text-primary)] mb-4"
         >
           Dashboard
         </h2>
@@ -78,7 +80,7 @@ const dashboardStates = [
               <li>
                 <a
                   href={s.path}
-                  class="text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)] text-sm"
+                  class="text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)] text-sm"
                 >
                   {s.label} — <code>{s.path}</code>
                 </a>
@@ -90,15 +92,17 @@ const dashboardStates = [
 
       <section>
         <h2
-          class="font-['Archivo'] font-bold text-[20px] leading-[26px] text-[color:var(--color-text-primary)] mb-4"
+          class="font-['Archivo'] font-bold text-[20px] leading-[26px] text-[color:var(--ss-color-text-primary)] mb-4"
         >
           Invoice
         </h2>
         <ul class="space-y-2">
           {
             invoiceStates.map((s) => (
-              <li class="text-sm text-[color:var(--color-text-secondary)]">
-                <span class="font-semibold text-[color:var(--color-text-primary)]">{s.label}</span>
+              <li class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                <span class="font-semibold text-[color:var(--ss-color-text-primary)]">
+                  {s.label}
+                </span>
                 {s.query && <code class="ml-2">/portal/invoices/:id{s.query}</code>}
               </li>
             ))
@@ -108,15 +112,17 @@ const dashboardStates = [
 
       <section>
         <h2
-          class="font-['Archivo'] font-bold text-[20px] leading-[26px] text-[color:var(--color-text-primary)] mb-4"
+          class="font-['Archivo'] font-bold text-[20px] leading-[26px] text-[color:var(--ss-color-text-primary)] mb-4"
         >
           Proposal
         </h2>
         <ul class="space-y-2">
           {
             proposalStates.map((s) => (
-              <li class="text-sm text-[color:var(--color-text-secondary)]">
-                <span class="font-semibold text-[color:var(--color-text-primary)]">{s.label}</span>
+              <li class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                <span class="font-semibold text-[color:var(--ss-color-text-primary)]">
+                  {s.label}
+                </span>
                 {s.query && <code class="ml-2">/portal/quotes/:id{s.query}</code>}
               </li>
             ))

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -21,16 +21,16 @@ const isPostBooking = Astro.url.searchParams.has('booked')
 >
   <Nav />
   <main id="main" role="main">
-    <section class="bg-[color:var(--color-background)] px-6 py-16 sm:py-24">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-16 sm:py-24">
       <div class="mx-auto max-w-2xl">
         <!-- Hero -->
         <div class="text-center">
           {
             isPostBooking ? (
               <Fragment>
-                <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10">
+                <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-complete)]/10">
                   <svg
-                    class="h-8 w-8 text-[color:var(--color-complete)]"
+                    class="h-8 w-8 text-[color:var(--ss-color-complete)]"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke-width="2"
@@ -43,20 +43,20 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                     />
                   </svg>
                 </div>
-                <h1 class="mt-6 text-3xl font-bold tracking-tight text-[color:var(--color-text-primary)] sm:text-4xl">
+                <h1 class="mt-6 text-3xl font-bold tracking-tight text-[color:var(--ss-color-text-primary)] sm:text-4xl">
                   You're All Set
                 </h1>
-                <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--color-text-secondary)]">
+                <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--ss-color-text-secondary)]">
                   We'll see you on the call. In the meantime, a few quick questions to help us
                   prepare so we can make the most of our time together.
                 </p>
               </Fragment>
             ) : (
               <Fragment>
-                <h1 class="text-3xl font-bold tracking-tight text-[color:var(--color-text-primary)] sm:text-4xl">
+                <h1 class="text-3xl font-bold tracking-tight text-[color:var(--ss-color-text-primary)] sm:text-4xl">
                   Tell Us About Your Business
                 </h1>
-                <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--color-text-secondary)]">
+                <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--ss-color-text-secondary)]">
                   Not ready to schedule a call? No problem. Share a few details about your business
                   and what you're working on. We'll review it and reach out to start the
                   conversation on your terms.
@@ -69,7 +69,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
         <!-- Intake form -->
         <div
           id="intake-form-container"
-          class="mt-10 rounded-[var(--radius-card)] bg-white p-6 sm:p-8"
+          class="mt-10 rounded-[var(--ss-radius-card)] bg-white p-6 sm:p-8"
         >
           <form id="intake-form" class="space-y-5" novalidate>
             <!-- Honeypot -->
@@ -82,7 +82,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
               <div>
                 <label
                   for="gs-name"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   Full name <span class="text-red-500">*</span>
                 </label>
@@ -93,14 +93,14 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                   required
                   maxlength="200"
                   autocomplete="name"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="e.g. Maria Garcia"
                 />
               </div>
               <div>
                 <label
                   for="gs-email"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   Work email <span class="text-red-500">*</span>
                 </label>
@@ -111,7 +111,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                   required
                   maxlength="254"
                   autocomplete="email"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="maria@example.com"
                 />
               </div>
@@ -121,7 +121,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <div>
               <label
                 for="gs-business"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 Business name <span class="text-red-500">*</span>
               </label>
@@ -131,7 +131,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                 name="business_name"
                 required
                 maxlength="200"
-                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder="e.g. Phoenix Plumbing Co."
               />
             </div>
@@ -141,14 +141,14 @@ const isPostBooking = Astro.url.searchParams.has('booked')
               <div>
                 <label
                   for="gs-vertical"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   What kind of business?
                 </label>
                 <select
                   id="gs-vertical"
                   name="vertical"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
@@ -157,21 +157,21 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                   type="text"
                   id="gs-vertical-other"
                   name="vertical_other"
-                  class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   placeholder="Describe your business type"
                 />
               </div>
               <div>
                 <label
                   for="gs-employees"
-                  class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >
                   Employee count
                 </label>
                 <select
                   id="gs-employees"
                   name="employee_count"
-                  class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 >
                   <option value="">Select one</option>
                   <option value="1-5">1 - 5</option>
@@ -187,14 +187,14 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <div class="sm:w-1/2">
               <label
                 for="gs-years"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 Years in business
               </label>
               <select
                 id="gs-years"
                 name="years_in_business"
-                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               >
                 <option value="">Select one</option>
                 <option value="<1">Less than 1 year</option>
@@ -209,12 +209,12 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <div>
               <label
                 for="gs-challenge"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 What's the single biggest operational challenge right now?
                 <span class="text-red-500">*</span>
               </label>
-              <p class="mt-0.5 text-xs text-[color:var(--color-text-muted)]">
+              <p class="mt-0.5 text-xs text-[color:var(--ss-color-text-muted)]">
                 What would make the biggest difference in how your business runs day to day?
               </p>
               <textarea
@@ -223,7 +223,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                 required
                 rows="3"
                 maxlength="2000"
-                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder="e.g. I want to stop being the bottleneck for every decision..."
               ></textarea>
             </div>
@@ -232,14 +232,14 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <div>
               <label
                 for="gs-how-heard"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 How did you hear about us?
               </label>
               <select
                 id="gs-how-heard"
                 name="how_heard"
-                class="mt-1 w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               >
                 <option value="">Select one</option>
                 <option value="Google Search">Google Search</option>
@@ -254,7 +254,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
                 type="text"
                 id="gs-how-heard-other"
                 name="how_heard_other"
-                class="mt-2 hidden w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white px-3 py-2 text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 placeholder="Tell us more"
               />
             </div>
@@ -265,7 +265,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <!-- Error banner -->
             <div
               id="gs-error"
-              class="hidden rounded-[var(--radius-card)] bg-[color:var(--color-error)]/5 px-4 py-3 text-sm text-[color:var(--color-error)]"
+              class="hidden rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]"
             >
             </div>
 
@@ -273,7 +273,7 @@ const isPostBooking = Astro.url.searchParams.has('booked')
             <button
               id="gs-submit"
               type="submit"
-              class="w-full rounded-[var(--radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
+              class="w-full rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
             >
               Send
             </button>
@@ -283,10 +283,10 @@ const isPostBooking = Astro.url.searchParams.has('booked')
         <!-- Success state (replaces form on submit) -->
         <div id="success-panel" class="mt-10 hidden text-center">
           <div
-            class="mx-auto flex h-14 w-14 items-center justify-center rounded-[var(--radius-card)] bg-[color:var(--color-complete)]/10"
+            class="mx-auto flex h-14 w-14 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-complete)]/10"
           >
             <svg
-              class="h-7 w-7 text-[color:var(--color-complete)]"
+              class="h-7 w-7 text-[color:var(--ss-color-complete)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke-width="2"
@@ -295,20 +295,20 @@ const isPostBooking = Astro.url.searchParams.has('booked')
               <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
             </svg>
           </div>
-          <h2 class="mt-4 text-xl font-bold text-[color:var(--color-text-primary)]">
+          <h2 class="mt-4 text-xl font-bold text-[color:var(--ss-color-text-primary)]">
             Thanks for sharing
           </h2>
           {
             isPostBooking ? (
-              <p class="mt-2 text-base text-[color:var(--color-text-secondary)]">
+              <p class="mt-2 text-base text-[color:var(--ss-color-text-secondary)]">
                 We'll review this before your call so we can make the most of our time together.
               </p>
             ) : (
               <Fragment>
-                <p class="mt-2 text-base text-[color:var(--color-text-secondary)]">
+                <p class="mt-2 text-base text-[color:var(--ss-color-text-secondary)]">
                   We'll review this and be in touch to start the conversation.
                 </p>
-                <p class="mt-6 text-sm text-[color:var(--color-text-secondary)]">
+                <p class="mt-6 text-sm text-[color:var(--ss-color-text-secondary)]">
                   Ready to schedule a call?
                   <a href="/book" class="font-medium text-primary hover:text-primary/80 underline">
                     Book a time here

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,18 +30,18 @@ import Footer from '../components/Footer.astro'
     <CaseStudies />
 
     <!-- Scorecard CTA -->
-    <section class="bg-[color:var(--color-background)] px-6 py-20">
+    <section class="bg-[color:var(--ss-color-background)] px-6 py-20">
       <div class="mx-auto max-w-5xl text-center">
-        <h2 class="text-2xl font-bold text-[color:var(--color-text-primary)] sm:text-3xl">
+        <h2 class="text-2xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-3xl">
           Not sure where to start?
         </h2>
-        <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--color-text-secondary)]">
+        <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--ss-color-text-secondary)]">
           Take our quick operations scorecard and see where your business stands across 6 key areas.
           Takes about 3 minutes.
         </p>
         <a
           href="/scorecard"
-          class="mt-8 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+          class="mt-8 inline-block rounded-[var(--ss-radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
           data-ev="home-scorecard-cta"
         >
           Take the Scorecard

--- a/src/pages/patterns.astro
+++ b/src/pages/patterns.astro
@@ -39,8 +39,8 @@ if (!enabled) {
   <Nav />
   <main id="main" role="main" class="px-6 py-20">
     <div class="mx-auto max-w-3xl">
-      <h1 class="text-3xl font-bold text-[color:var(--color-text-primary)]">Patterns</h1>
-      <p class="mt-2 text-lg text-[color:var(--color-text-secondary)]">
+      <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)]">Patterns</h1>
+      <p class="mt-2 text-lg text-[color:var(--ss-color-text-secondary)]">
         What we're seeing across the businesses we've worked with.
       </p>
 
@@ -52,9 +52,9 @@ if (!enabled) {
       }
 
       <div
-        class="mt-10 rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-8 text-center"
+        class="mt-10 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white p-8 text-center"
       >
-        <p class="text-base text-[color:var(--color-text-secondary)]">
+        <p class="text-base text-[color:var(--ss-color-text-secondary)]">
           Patterns will appear here once we've worked with enough businesses to share them without
           identifying any one of them.
         </p>

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -141,13 +141,13 @@ function kindFor(doc: DocumentEntry): string {
     />
     <title>Documents — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader clientName={clientName}>
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
         >
           Sign out
         </button>
@@ -167,24 +167,24 @@ function kindFor(doc: DocumentEntry): string {
 
       {
         documents.length === 0 ? (
-          <div class="mt-10 border-[3px] border-[color:var(--color-text-primary)] p-8 md:p-12 text-center">
-            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]">
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
               No documents yet
             </p>
-            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
               Documents will appear here as your engagement progresses.
             </p>
           </div>
         ) : (
           <>
-            <p class="mt-8 mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--color-text-secondary)]">
+            <p class="mt-8 mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
               {documents.length} document{documents.length !== 1 ? 's' : ''}
             </p>
-            <div class="border-[3px] border-[color:var(--color-text-primary)]">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
               {engagement && (
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-4 md:px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-4 md:px-5 py-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                   <span>Engagement № {engagement.id.slice(0, 2).toUpperCase()}</span>
-                  <span class="text-[color:var(--color-primary)]">
+                  <span class="text-[color:var(--ss-color-primary)]">
                     {documents.length} doc{documents.length !== 1 ? 's' : ''}
                   </span>
                 </div>

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -90,7 +90,7 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
     />
     <title>Progress — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader
       clientName={clientName}
@@ -102,7 +102,7 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
           type="submit"
           aria-label="Sign out"
           title="Sign out"
-          class="inline-flex items-center justify-center w-9 h-9 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 transition-colors"
+          class="inline-flex items-center justify-center w-9 h-9 text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
         >
           <span class="material-symbols-outlined text-[20px]">logout</span>
         </button>
@@ -131,11 +131,11 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
 
       {
         !engagement ? (
-          <div class="mt-10 border-[3px] border-[color:var(--color-text-primary)] p-8 md:p-12 text-center">
-            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]">
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
               No active engagement
             </p>
-            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
               Progress appears here once your engagement begins.
             </p>
           </div>
@@ -143,14 +143,14 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
           <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
             <div class="flex flex-col gap-8 min-w-0">
               {/* § 01 Overview */}
-              <section class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                   <span>Overview</span>
-                  <span class="text-[color:var(--color-primary)]">§ 01</span>
+                  <span class="text-[color:var(--ss-color-primary)]">§ 01</span>
                 </div>
                 <div class="px-5 md:px-7 py-6">
                   {engagement.scope_summary && (
-                    <p class="text-[color:var(--color-text-secondary)] leading-[1.55]">
+                    <p class="text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
                       {engagement.scope_summary}
                     </p>
                   )}
@@ -158,31 +158,31 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
                     class:list={[
                       'grid grid-cols-1 md:grid-cols-3',
                       engagement.scope_summary
-                        ? 'mt-6 pt-6 border-t-[2px] border-[color:var(--color-text-primary)]'
+                        ? 'mt-6 pt-6 border-t-[2px] border-[color:var(--ss-color-text-primary)]'
                         : '',
                     ]}
                   >
-                    <div class="py-3 md:py-0 md:pr-6 md:border-r-[2px] md:border-[color:var(--color-text-primary)]">
-                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]">
+                    <div class="py-3 md:py-0 md:pr-6 md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)]">
+                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
                         Started
                       </p>
-                      <p class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+                      <p class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
                         {formatDate(engagement.start_date)}
                       </p>
                     </div>
-                    <div class="py-3 md:py-0 md:px-6 md:border-r-[2px] md:border-[color:var(--color-text-primary)] border-t-[2px] md:border-t-0 border-[color:var(--color-text-primary)]">
-                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]">
+                    <div class="py-3 md:py-0 md:px-6 md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] border-t-[2px] md:border-t-0 border-[color:var(--ss-color-text-primary)]">
+                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
                         Estimated completion
                       </p>
-                      <p class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+                      <p class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
                         {formatDate(engagement.estimated_end)}
                       </p>
                     </div>
-                    <div class="py-3 md:py-0 md:pl-6 border-t-[2px] md:border-t-0 border-[color:var(--color-text-primary)]">
-                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]">
+                    <div class="py-3 md:py-0 md:pl-6 border-t-[2px] md:border-t-0 border-[color:var(--ss-color-text-primary)]">
+                      <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
                         Current state
                       </p>
-                      <p class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-primary)]">
+                      <p class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-primary)]">
                         {currentMilestoneLabel}
                       </p>
                     </div>
@@ -191,33 +191,33 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
               </section>
 
               {/* § 02 Milestones */}
-              <section class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                   <span>Milestones</span>
-                  <span class="text-[color:var(--color-primary)]">§ 02</span>
+                  <span class="text-[color:var(--ss-color-primary)]">§ 02</span>
                 </div>
 
                 {milestones.length === 0 ? (
                   <div class="px-5 md:px-7 py-6">
-                    <p class="text-[color:var(--color-text-secondary)]">
+                    <p class="text-[color:var(--ss-color-text-secondary)]">
                       Milestones appear here as your engagement progresses.
                     </p>
                   </div>
                 ) : (
-                  <ol class="divide-y-[2px] divide-[color:var(--color-text-primary)]">
+                  <ol class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]">
                     {milestones.map((m, idx) => {
                       const isDone = m.status === 'completed'
                       const isNow = m.status === 'in_progress'
                       const markerClass = isDone
-                        ? 'bg-[color:var(--color-text-primary)] text-[color:var(--color-primary)]'
+                        ? 'bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)]'
                         : isNow
-                          ? 'bg-[color:var(--color-primary)] text-[color:var(--color-background)]'
-                          : 'bg-[color:var(--color-background)] text-[color:var(--color-text-primary)]'
+                          ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
+                          : 'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)]'
                       return (
                         <li class="grid grid-cols-[72px_1fr] md:grid-cols-[88px_1fr_auto] items-stretch">
                           <div
                             class:list={[
-                              'flex items-center justify-center font-["Archivo"] font-black text-2xl md:text-3xl tracking-[-0.02em] border-r-[2px] border-[color:var(--color-text-primary)]',
+                              'flex items-center justify-center font-["Archivo"] font-black text-2xl md:text-3xl tracking-[-0.02em] border-r-[2px] border-[color:var(--ss-color-text-primary)]',
                               markerClass,
                             ]}
                             aria-hidden="true"
@@ -225,15 +225,15 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
                             {String(idx + 1).padStart(2, '0')}
                           </div>
                           <div class="px-5 py-5 min-w-0">
-                            <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] m-0 leading-tight">
+                            <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0 leading-tight">
                               {m.name}
                             </h3>
                             {m.description && (
-                              <p class="mt-2 text-[color:var(--color-text-secondary)] leading-[1.55]">
+                              <p class="mt-2 text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
                                 {m.description}
                               </p>
                             )}
-                            <p class="mt-3 font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]">
+                            <p class="mt-3 font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
                               {isDone && m.completed_at
                                 ? `Completed ${formatDate(m.completed_at)}`
                                 : m.due_date

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -294,7 +294,7 @@ const touchpointText: string | null = (() => {
     />
     <title>Portal — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader
       clientName={client.name}
@@ -306,7 +306,7 @@ const touchpointText: string | null = (() => {
           type="submit"
           aria-label="Sign out"
           title="Sign out"
-          class="inline-flex items-center justify-center w-9 h-9 rounded-full text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-primary)]/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 transition-colors"
+          class="inline-flex items-center justify-center w-9 h-9 rounded-full text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-primary)]/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
         >
           <span class="material-symbols-outlined text-[20px]">logout</span>
         </button>
@@ -325,23 +325,23 @@ const touchpointText: string | null = (() => {
       {
         dashboardError ? (
           <section
-            class="mt-10 border-[3px] border-[color:var(--color-error)] bg-[color:var(--color-background)] p-6 md:p-8"
+            class="mt-10 border-[3px] border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-background)] p-6 md:p-8"
             aria-live="polite"
           >
-            <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-error)]">
+            <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-error)]">
               Something broke
             </p>
-            <h2 class="mt-2 font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]">
+            <h2 class="mt-2 font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
               We couldn't load your portal.
             </h2>
-            <p class="mt-3 text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 text-[color:var(--ss-color-text-secondary)]">
               Give it a moment and try again. If it keeps happening, reach the team using the
               contacts in the header.
             </p>
             <div class="mt-5">
               <a
                 href="/portal"
-                class="inline-flex items-center min-h-11 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] px-5 py-2.5 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                class="inline-flex items-center min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] px-5 py-2.5 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
               >
                 Retry
               </a>
@@ -365,26 +365,26 @@ const touchpointText: string | null = (() => {
           {
             pendingInvoice && invoicePillLabel ? (
               <section
-                class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+                class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
                 aria-label="Pending invoice"
               >
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                   <span>{invoicePillLabel}</span>
-                  <span class="text-[color:var(--color-primary)]">
+                  <span class="text-[color:var(--ss-color-primary)]">
                     № {pendingInvoice.id.slice(0, 2).toUpperCase()}
                   </span>
                 </div>
                 <div class="px-5 py-5">
                   <MoneyDisplay amountCents={invoiceAmountCents ?? 0} size="hero" />
                   {invoiceCaption && (
-                    <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--color-text-secondary)]">
+                    <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]">
                       {invoiceCaption}
                     </p>
                   )}
                 </div>
                 <a
                   href={`/portal/invoices/${pendingInvoice.id}`}
-                  class="flex items-center justify-between border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset"
+                  class="flex items-center justify-between border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
                 >
                   <span>Pay invoice</span>
                   <span aria-hidden="true" class="font-black">
@@ -394,30 +394,30 @@ const touchpointText: string | null = (() => {
               </section>
             ) : touchpointText ? (
               <section
-                class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] px-5 py-6"
+                class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-5 py-6"
                 aria-label="Next check-in"
               >
-                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
                   Next check-in
                 </p>
-                <p class="mt-3 font-['Archivo'] text-3xl md:text-[2.5rem] font-black uppercase tracking-[-0.02em] leading-none text-[color:var(--color-text-primary)]">
+                <p class="mt-3 font-['Archivo'] text-3xl md:text-[2.5rem] font-black uppercase tracking-[-0.02em] leading-none text-[color:var(--ss-color-text-primary)]">
                   {touchpointText}
                 </p>
                 {consultantFirst && (
-                  <p class="mt-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+                  <p class="mt-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
                     with {consultantFirst}
                   </p>
                 )}
               </section>
             ) : (
               <section
-                class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] px-5 py-6"
+                class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-5 py-6"
                 aria-label="Engagement status"
               >
-                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
                   In flight
                 </p>
-                <p class="mt-3 text-[color:var(--color-text-secondary)]">
+                <p class="mt-3 text-[color:var(--ss-color-text-secondary)]">
                   Nothing needs your attention right now.
                 </p>
               </section>
@@ -441,19 +441,19 @@ const touchpointText: string | null = (() => {
 
         <section class="flex-1 min-w-0 md:order-1 mt-10 md:mt-0">
           <p
-            class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]"
+            class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]"
           >
             Recent activity
           </p>
           <h2
-            class="mt-2 font-['Archivo'] text-3xl md:text-4xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]"
+            class="mt-2 font-['Archivo'] text-3xl md:text-4xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
           >
             Log
           </h2>
 
           {
             timelineEntries.length > 0 ? (
-              <div class="mt-6 border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] p-5 md:p-7 space-y-6">
+              <div class="mt-6 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-5 md:p-7 space-y-6">
                 {timelineEntries.map((entry) => (
                   <TimelineEntry
                     date={entry.date}
@@ -465,8 +465,8 @@ const touchpointText: string | null = (() => {
                 ))}
               </div>
             ) : (
-              <div class="mt-6 border-[3px] border-[color:var(--color-text-primary)] p-6 md:p-8">
-                <p class="text-[color:var(--color-text-secondary)]">
+              <div class="mt-6 border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
+                <p class="text-[color:var(--ss-color-text-secondary)]">
                   Nothing here yet. First entry lands after your next touchpoint.
                 </p>
               </div>

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -205,7 +205,7 @@ const consultantFirstName: string | null = consultantName
     />
     <title>Invoice — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader
       clientName={client.name}
@@ -215,7 +215,7 @@ const consultantFirstName: string | null = consultantName
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-secondary)] transition-colors"
+          class="text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-secondary)] transition-colors"
         >
           Sign out
         </button>
@@ -246,14 +246,14 @@ const consultantFirstName: string | null = consultantName
           <div>
             {
               periodSubtitle && (
-                <p class="text-body-lg text-[color:var(--color-text-secondary)]">
+                <p class="text-body-lg text-[color:var(--ss-color-text-secondary)]">
                   {periodSubtitle}
                 </p>
               )
             }
             {
               !isPaid && dueCaption && (
-                <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-muted)]">
+                <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-muted)]">
                   <span class="material-symbols-outlined text-[18px]" aria-hidden="true">
                     calendar_today
                   </span>
@@ -263,7 +263,7 @@ const consultantFirstName: string | null = consultantName
             }
             {
               isPaid && paidShortDate && (
-                <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--color-complete)]">
+                <p class="mt-4 inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-complete)]">
                   <span class="material-symbols-outlined text-[18px]" aria-hidden="true">
                     check_circle
                   </span>
@@ -279,22 +279,22 @@ const consultantFirstName: string | null = consultantName
             {
               isErrorState && (
                 <div
-                  class="mb-card rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
+                  class="mb-card rounded-lg border border-[color:var(--ss-color-attention)]/30 bg-[color:var(--ss-color-attention)]/5 p-stack"
                   role="status"
                 >
                   <div class="flex items-start gap-row">
-                    <span class="material-symbols-outlined text-[20px] text-[color:var(--color-attention)] mt-0.5">
+                    <span class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-attention)] mt-0.5">
                       error
                     </span>
                     <div class="min-w-0">
-                      <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                      <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                         {isDeclined
                           ? 'Payment declined'
                           : isCardExpired
                             ? 'Card expired'
                             : 'Link expired'}
                       </p>
-                      <p class="mt-1 text-body text-[color:var(--color-text-secondary)]">
+                      <p class="mt-1 text-body text-[color:var(--ss-color-text-secondary)]">
                         {surface.next}
                       </p>
                     </div>
@@ -303,17 +303,17 @@ const consultantFirstName: string | null = consultantName
               )
             }
             <div
-              class="relative overflow-hidden rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-card"
+              class="relative overflow-hidden rounded-lg border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-surface)] p-card"
             >
               <div
-                class="absolute left-0 top-0 h-full w-1 bg-[color:var(--color-primary)]"
+                class="absolute left-0 top-0 h-full w-1 bg-[color:var(--ss-color-primary)]"
                 aria-hidden="true"
               >
               </div>
               <MoneyDisplay amountCents={amountCents} size="display" />
               {
                 !isPaid && (
-                  <p class="mt-1 text-label uppercase text-[color:var(--color-text-muted)]">
+                  <p class="mt-1 text-label uppercase text-[color:var(--ss-color-text-muted)]">
                     Remaining balance
                   </p>
                 )
@@ -325,7 +325,7 @@ const consultantFirstName: string | null = consultantName
                     <>
                       <a
                         href={stripeUrl!}
-                        class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                        class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
                       >
                         {isDeclined
                           ? 'Try again'
@@ -333,7 +333,7 @@ const consultantFirstName: string | null = consultantName
                             ? 'Update payment method'
                             : 'Pay invoice'}
                       </a>
-                      <div class="mt-3 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-muted)]">
+                      <div class="mt-3 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-muted)]">
                         <span class="material-symbols-outlined text-[16px]" aria-hidden="true">
                           lock
                         </span>
@@ -341,7 +341,7 @@ const consultantFirstName: string | null = consultantName
                       </div>
                     </>
                   ) : (
-                    <div class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-surface-muted)] text-[color:var(--color-text-secondary)] font-semibold">
+                    <div class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--ss-color-surface-muted)] text-[color:var(--ss-color-text-secondary)] font-semibold">
                       Payment link pending
                     </div>
                   ))
@@ -352,15 +352,15 @@ const consultantFirstName: string | null = consultantName
           <!-- What's included -->
           <div>
             <h2
-              class="font-['Archivo'] font-bold text-title text-[color:var(--color-text-primary)]"
+              class="font-['Archivo'] font-bold text-title text-[color:var(--ss-color-text-primary)]"
             >
               What's included
             </h2>
             <ul class="mt-stack flex flex-col">
               {
                 lineItems.map((li) => (
-                  <li class="flex justify-between items-baseline gap-card py-5 border-b border-[color:var(--color-border)]/60">
-                    <span class="text-body text-[color:var(--color-text-secondary)] max-w-[480px]">
+                  <li class="flex justify-between items-baseline gap-card py-5 border-b border-[color:var(--ss-color-border)]/60">
+                    <span class="text-body text-[color:var(--ss-color-text-secondary)] max-w-[480px]">
                       {li.description}
                     </span>
                     <MoneyDisplay amountCents={li.amount_cents} size="body" emphasize />
@@ -370,7 +370,7 @@ const consultantFirstName: string | null = consultantName
             </ul>
             <div class="mt-card pt-5 flex justify-between items-baseline">
               <span
-                class="font-['Archivo'] font-bold text-title text-[color:var(--color-text-primary)]"
+                class="font-['Archivo'] font-bold text-title text-[color:var(--ss-color-text-primary)]"
                 >Total</span
               >
               <MoneyDisplay amountCents={totalCents} size="h2" />
@@ -380,22 +380,22 @@ const consultantFirstName: string | null = consultantName
           <!-- Payment details -->
           <div>
             <h2
-              class="font-['Archivo'] font-bold text-title text-[color:var(--color-text-primary)]"
+              class="font-['Archivo'] font-bold text-title text-[color:var(--ss-color-text-primary)]"
             >
               Payment details
             </h2>
             <ul class="mt-stack grid grid-cols-1 sm:grid-cols-2 gap-card">
               {
                 dueShortDate && !isPaid && (
-                  <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card">
+                  <li class="flex items-start gap-row rounded-lg bg-[color:var(--ss-color-surface)] p-card">
                     <span
-                      class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+                      class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
                       style="font-variation-settings: 'FILL' 1;"
                     >
                       event
                     </span>
                     <div class="min-w-0">
-                      <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                      <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                         Due {dueShortDate}
                       </p>
                     </div>
@@ -404,15 +404,15 @@ const consultantFirstName: string | null = consultantName
               }
               {
                 isPaid && paidShortDate && (
-                  <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card">
+                  <li class="flex items-start gap-row rounded-lg bg-[color:var(--ss-color-surface)] p-card">
                     <span
-                      class="material-symbols-outlined text-[20px] text-[color:var(--color-complete)]"
+                      class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-complete)]"
                       style="font-variation-settings: 'FILL' 1;"
                     >
                       check_circle
                     </span>
                     <div class="min-w-0">
-                      <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                      <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                         Paid {paidShortDate}
                       </p>
                     </div>
@@ -420,52 +420,52 @@ const consultantFirstName: string | null = consultantName
                 )
               }
               <li
-                class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card"
+                class="flex items-start gap-row rounded-lg bg-[color:var(--ss-color-surface)] p-card"
               >
                 <span
-                  class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+                  class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
                   style="font-variation-settings: 'FILL' 1;"
                 >
                   check_circle
                 </span>
                 <div class="min-w-0">
-                  <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                  <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                     Secure payment via Stripe
                   </p>
-                  <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+                  <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
                     End-to-end encrypted processing.
                   </p>
                 </div>
               </li>
               <li
-                class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card"
+                class="flex items-start gap-row rounded-lg bg-[color:var(--ss-color-surface)] p-card"
               >
                 <span
-                  class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+                  class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
                   style="font-variation-settings: 'FILL' 1;"
                 >
                   check_circle
                 </span>
                 <div class="min-w-0">
-                  <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                  <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                     Card or bank transfer
                   </p>
-                  <p class="mt-1 text-caption text-[color:var(--color-text-secondary)]">
+                  <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)]">
                     Multiple payment methods accepted.
                   </p>
                 </div>
               </li>
               {
                 depositNote && (
-                  <li class="flex items-start gap-row rounded-lg bg-[color:var(--color-surface)] p-card sm:col-span-2">
+                  <li class="flex items-start gap-row rounded-lg bg-[color:var(--ss-color-surface)] p-card sm:col-span-2">
                     <span
-                      class="material-symbols-outlined text-[20px] text-[color:var(--color-primary)]"
+                      class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-primary)]"
                       style="font-variation-settings: 'FILL' 1;"
                     >
                       history
                     </span>
                     <div class="min-w-0">
-                      <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                      <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                         {depositNote}
                       </p>
                     </div>
@@ -495,7 +495,7 @@ const consultantFirstName: string | null = consultantName
           <!-- Mobile-only back link -->
           <a
             href="/portal"
-            class="md:hidden inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]"
+            class="md:hidden inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
           >
             <span class="material-symbols-outlined text-[18px]">arrow_back</span>
             Engagement dashboard
@@ -506,27 +506,29 @@ const consultantFirstName: string | null = consultantName
         <aside class="hidden md:flex md:flex-col gap-card md:sticky md:top-8">
           {
             isPaid ? (
-              <div class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section">
-                <p class="text-label uppercase text-[color:var(--color-complete)]">Paid</p>
+              <div class="bg-[color:var(--ss-color-surface)] rounded-lg border border-[color:var(--ss-color-border)] p-section">
+                <p class="text-label uppercase text-[color:var(--ss-color-complete)]">Paid</p>
                 <div class="mt-3">
                   <MoneyDisplay amountCents={amountCents} size="display" />
                 </div>
                 {paidShortDate && (
-                  <p class="mt-4 text-caption font-medium text-[color:var(--color-complete)]">
+                  <p class="mt-4 text-caption font-medium text-[color:var(--ss-color-complete)]">
                     Paid {paidShortDate}.
                   </p>
                 )}
               </div>
             ) : isLinkExpired ? (
-              <div class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section">
-                <p class="text-label uppercase text-[color:var(--color-attention)]">Link expired</p>
+              <div class="bg-[color:var(--ss-color-surface)] rounded-lg border border-[color:var(--ss-color-border)] p-section">
+                <p class="text-label uppercase text-[color:var(--ss-color-attention)]">
+                  Link expired
+                </p>
                 <div class="mt-3">
                   <MoneyDisplay amountCents={amountCents} size="display" />
-                  <p class="mt-2 text-label uppercase text-[color:var(--color-text-muted)]">
+                  <p class="mt-2 text-label uppercase text-[color:var(--ss-color-text-muted)]">
                     Remaining balance
                   </p>
                 </div>
-                <p class="mt-6 text-body text-[color:var(--color-text-secondary)]">
+                <p class="mt-6 text-body text-[color:var(--ss-color-text-secondary)]">
                   {surface.next}
                 </p>
               </div>
@@ -534,18 +536,18 @@ const consultantFirstName: string | null = consultantName
               <>
                 {isErrorState && (
                   <div
-                    class="rounded-lg border border-[color:var(--color-attention)]/30 bg-[color:var(--color-attention)]/5 p-stack"
+                    class="rounded-lg border border-[color:var(--ss-color-attention)]/30 bg-[color:var(--ss-color-attention)]/5 p-stack"
                     role="status"
                   >
                     <div class="flex items-start gap-row">
-                      <span class="material-symbols-outlined text-[20px] text-[color:var(--color-attention)] mt-0.5">
+                      <span class="material-symbols-outlined text-[20px] text-[color:var(--ss-color-attention)] mt-0.5">
                         error
                       </span>
                       <div class="min-w-0">
-                        <p class="text-body font-semibold text-[color:var(--color-text-primary)]">
+                        <p class="text-body font-semibold text-[color:var(--ss-color-text-primary)]">
                           {isDeclined ? 'Payment declined' : 'Card expired'}
                         </p>
-                        <p class="mt-1 text-body text-[color:var(--color-text-secondary)]">
+                        <p class="mt-1 text-body text-[color:var(--ss-color-text-secondary)]">
                           {surface.next}
                         </p>
                       </div>
@@ -554,12 +556,12 @@ const consultantFirstName: string | null = consultantName
                 )}
                 {isPayable ? (
                   <section
-                    class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section"
+                    class="bg-[color:var(--ss-color-surface)] rounded-lg border border-[color:var(--ss-color-border)] p-section"
                     aria-label={
                       isDeclined ? 'Try again' : isCardExpired ? 'Update payment method' : pillLabel
                     }
                   >
-                    <p class="text-label uppercase text-[color:var(--color-text-muted)]">
+                    <p class="text-label uppercase text-[color:var(--ss-color-text-muted)]">
                       Remaining balance
                     </p>
                     <div class="mt-1">
@@ -567,7 +569,7 @@ const consultantFirstName: string | null = consultantName
                     </div>
                     <a
                       href={stripeUrl!}
-                      class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2"
+                      class="mt-6 inline-flex w-full items-center justify-center gap-2 min-h-[52px] px-6 py-4 rounded-lg bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] text-white font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
                     >
                       {isDeclined
                         ? 'Try again'
@@ -575,7 +577,7 @@ const consultantFirstName: string | null = consultantName
                           ? 'Update payment method'
                           : 'Pay invoice'}
                     </a>
-                    <div class="mt-4 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-muted)]">
+                    <div class="mt-4 flex items-center justify-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-muted)]">
                       <span class="material-symbols-outlined text-[16px]" aria-hidden="true">
                         lock
                       </span>
@@ -584,15 +586,15 @@ const consultantFirstName: string | null = consultantName
                   </section>
                 ) : (
                   <section
-                    class="bg-[color:var(--color-surface)] rounded-lg border border-[color:var(--color-border)] p-section"
+                    class="bg-[color:var(--ss-color-surface)] rounded-lg border border-[color:var(--ss-color-border)] p-section"
                     aria-label="Payment link pending"
                   >
-                    <p class="text-label uppercase text-[color:var(--color-text-muted)]">
+                    <p class="text-label uppercase text-[color:var(--ss-color-text-muted)]">
                       Payment link pending
                     </p>
                     <div class="mt-3">
                       <MoneyDisplay amountCents={amountCents} size="display" />
-                      <p class="mt-2 text-label uppercase text-[color:var(--color-text-muted)]">
+                      <p class="mt-2 text-label uppercase text-[color:var(--ss-color-text-muted)]">
                         Remaining balance
                       </p>
                     </div>
@@ -618,7 +620,7 @@ const consultantFirstName: string | null = consultantName
 
           <a
             href="/portal"
-            class="inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)] px-2"
+            class="inline-flex items-center gap-2 text-label uppercase font-semibold text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] px-2"
           >
             <span class="material-symbols-outlined text-[18px]">arrow_back</span>
             Engagement dashboard

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -81,13 +81,13 @@ const totalCents = invoices.reduce((sum, i) => sum + Math.round(i.amount * 100),
     />
     <title>Invoices — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader clientName={clientName}>
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
         >
           Sign out
         </button>
@@ -107,31 +107,31 @@ const totalCents = invoices.reduce((sum, i) => sum + Math.round(i.amount * 100),
 
       {
         invoices.length === 0 ? (
-          <div class="mt-10 border-[3px] border-[color:var(--color-text-primary)] p-8 md:p-12 text-center">
-            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]">
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
               No invoices yet
             </p>
-            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
               Invoices appear here once created for your engagement.
             </p>
           </div>
         ) : (
           <>
             {/* KPI trio */}
-            <div class="mt-8 grid grid-cols-1 md:grid-cols-3 border-[3px] border-[color:var(--color-text-primary)]">
-              <div class="p-6 md:p-7 md:border-r-[2px] md:border-[color:var(--color-text-primary)] border-b-[2px] md:border-b-0 border-[color:var(--color-text-primary)] md:last:border-b-0">
-                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]">
+            <div class="mt-8 grid grid-cols-1 md:grid-cols-3 border-[3px] border-[color:var(--ss-color-text-primary)]">
+              <div class="p-6 md:p-7 md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] border-b-[2px] md:border-b-0 border-[color:var(--ss-color-text-primary)] md:last:border-b-0">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
                   Paid to date
                 </p>
                 <div class="mt-3">
                   <MoneyDisplay amountCents={paidCents} size="kpi" />
                 </div>
               </div>
-              <div class="bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] p-6 md:p-7 md:border-r-[2px] md:border-[color:var(--color-text-primary)] border-b-[2px] md:border-b-0 border-[color:var(--color-text-primary)]">
-                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]">
+              <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] p-6 md:p-7 md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] border-b-[2px] md:border-b-0 border-[color:var(--ss-color-text-primary)]">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
                   Balance due
                 </p>
-                <div class="mt-3 font-['Archivo'] text-kpi tabular-nums text-[color:var(--color-background)]">
+                <div class="mt-3 font-['Archivo'] text-kpi tabular-nums text-[color:var(--ss-color-background)]">
                   {new Intl.NumberFormat('en-US', {
                     style: 'currency',
                     currency: 'USD',
@@ -140,7 +140,7 @@ const totalCents = invoices.reduce((sum, i) => sum + Math.round(i.amount * 100),
                 </div>
               </div>
               <div class="p-6 md:p-7">
-                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]">
                   Engagement total
                 </p>
                 <div class="mt-3">
@@ -150,10 +150,10 @@ const totalCents = invoices.reduce((sum, i) => sum + Math.round(i.amount * 100),
             </div>
 
             {/* Ledger */}
-            <p class="mt-10 mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--color-text-secondary)]">
+            <p class="mt-10 mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
               {invoices.length} invoice{invoices.length !== 1 ? 's' : ''}
             </p>
-            <div class="border-[3px] border-[color:var(--color-text-primary)]">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
               {invoices.map((inv: Invoice, idx: number) => (
                 <PortalListItem
                   chrome="ticket"

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -162,7 +162,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
     />
     <title>Proposal — Portal — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader
       clientName={client.name}
@@ -172,7 +172,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] transition-colors"
+          class="text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] transition-colors"
         >
           Sign out
         </button>
@@ -199,55 +199,55 @@ const consultantPhone = engagement?.consultant_phone ?? null
           <!-- Mobile summary card (hidden on lg+ — right rail takes over there) -->
           <div class="lg:hidden mb-8">
             <div
-              class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
             >
               <div
-                class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
+                class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
               >
                 <span>Engagement total</span>
-                <span class="text-[color:var(--color-primary)]">
+                <span class="text-[color:var(--ss-color-primary)]">
                   № {quote.id.slice(0, 2).toUpperCase()}
                 </span>
               </div>
               <div class="px-5 py-5">
                 <MoneyDisplay amountCents={totalCents} size="hero" />
                 <p
-                  class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--color-text-secondary)]"
+                  class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
                 >
                   Fixed · USD
                 </p>
-                <p class="mt-4 text-sm text-[color:var(--color-text-secondary)]">
+                <p class="mt-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                   {paymentSplitText}
                 </p>
               </div>
 
               {
                 isSigned ? (
-                  <div class="border-t-[2px] border-[color:var(--color-text-primary)] bg-[color:var(--color-border-subtle)] px-5 py-4 flex items-center justify-between gap-3">
-                    <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-complete)] flex items-center gap-2">
+                  <div class="border-t-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-border-subtle)] px-5 py-4 flex items-center justify-between gap-3">
+                    <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-complete)] flex items-center gap-2">
                       <span
                         aria-hidden="true"
-                        class="inline-flex items-center justify-center w-5 h-5 bg-[color:var(--color-complete)] text-[color:var(--color-background)] font-['Archivo'] font-black text-xs"
+                        class="inline-flex items-center justify-center w-5 h-5 bg-[color:var(--ss-color-complete)] text-[color:var(--ss-color-background)] font-['Archivo'] font-black text-xs"
                       >
                         ✓
                       </span>
                       Signed
                     </span>
                     {quote.accepted_at && (
-                      <span class="font-mono text-xs text-[color:var(--color-text-secondary)] tracking-[0.04em]">
+                      <span class="font-mono text-xs text-[color:var(--ss-color-text-secondary)] tracking-[0.04em]">
                         {formatShortDate(quote.accepted_at)}
                       </span>
                     )}
                   </div>
                 ) : isSuperseded ? (
-                  <div class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4">
-                    <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]">
+                  <div class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4">
+                    <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
                       A revised version is available
                     </p>
                     {supersedingQuoteId && (
                       <a
                         href={`/portal/quotes/${supersedingQuoteId}`}
-                        class="mt-3 inline-flex items-center gap-2 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                        class="mt-3 inline-flex items-center gap-2 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
                       >
                         Go to the latest proposal
                         <span aria-hidden="true" class="font-['Archivo'] font-black">
@@ -257,19 +257,19 @@ const consultantPhone = engagement?.consultant_phone ?? null
                     )}
                   </div>
                 ) : isDeclined ? (
-                  <p class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4 text-sm text-[color:var(--color-text-secondary)]">
+                  <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                     This proposal was declined.{surface.next ? ` ${surface.next}` : ''}
                   </p>
                 ) : isExpired ? (
                   surface.next ? (
-                    <p class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4 text-sm text-[color:var(--color-text-secondary)]">
+                    <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                       {surface.next}
                     </p>
                   ) : null
                 ) : hasActiveSignature ? (
                   <a
                     href="#sign-surface"
-                    class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] flex items-center justify-between gap-3 px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset"
+                    class="border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] flex items-center justify-between gap-3 px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
                   >
                     <span>Review and sign</span>
                     <span aria-hidden="true" class="font-black">
@@ -277,7 +277,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
                     </span>
                   </a>
                 ) : (
-                  <p class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4 text-sm text-[color:var(--color-text-secondary)]">
+                  <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                     Your proposal is being prepared. You'll get an email when it's ready to sign.
                   </p>
                 )
@@ -288,12 +288,12 @@ const consultantPhone = engagement?.consultant_phone ?? null
               pdfHref && (
                 <a
                   href={pdfHref}
-                  class="mt-4 flex items-center justify-between border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] hover:bg-[color:var(--color-border-subtle)] px-5 py-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] transition-colors"
+                  class="mt-4 flex items-center justify-between border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-border-subtle)] px-5 py-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)] transition-colors"
                 >
                   <span>View the full PDF</span>
                   <span
                     aria-hidden="true"
-                    class="font-['Archivo'] font-black text-[color:var(--color-primary)]"
+                    class="font-['Archivo'] font-black text-[color:var(--ss-color-primary)]"
                   >
                     ↓
                   </span>
@@ -307,31 +307,33 @@ const consultantPhone = engagement?.consultant_phone ?? null
             <!-- § 01 What you'll get — rendered only when deliverables are authored. -->
             {
               deliverables.length > 0 && (
-                <section class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]">
-                  <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                  <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                     <span>What you'll get</span>
-                    <span class="text-[color:var(--color-primary)]">§ 01</span>
+                    <span class="text-[color:var(--ss-color-primary)]">§ 01</span>
                   </div>
                   <ol class="px-5 md:px-7 py-2">
                     {deliverables.map((d, i) => (
                       <li
                         class:list={[
                           'grid grid-cols-[48px_1fr] gap-4 py-5',
-                          i !== 0 ? 'border-t-[2px] border-[color:var(--color-text-primary)]' : '',
+                          i !== 0
+                            ? 'border-t-[2px] border-[color:var(--ss-color-text-primary)]'
+                            : '',
                         ]}
                       >
                         <span
                           aria-hidden="true"
-                          class="font-['Archivo'] text-2xl font-black text-[color:var(--color-primary)] tracking-[-0.02em] leading-none"
+                          class="font-['Archivo'] text-2xl font-black text-[color:var(--ss-color-primary)] tracking-[-0.02em] leading-none"
                         >
                           {String(i + 1).padStart(2, '0')}.
                         </span>
                         <div class="min-w-0">
-                          <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--color-text-primary)] m-0 leading-tight">
+                          <h3 class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0 leading-tight">
                             {d.title}
                           </h3>
                           {d.body && (
-                            <p class="mt-2 text-[color:var(--color-text-secondary)] leading-[1.55]">
+                            <p class="mt-2 text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
                               {d.body}
                             </p>
                           )}
@@ -346,23 +348,25 @@ const consultantPhone = engagement?.consultant_phone ?? null
             <!-- § 02 How we'll work (only when authored — never synthesized; #377) -->
             {
               schedule.length > 0 && (
-                <section class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]">
-                  <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                  <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                     <span>How we'll work</span>
-                    <span class="text-[color:var(--color-primary)]">§ 02</span>
+                    <span class="text-[color:var(--ss-color-primary)]">§ 02</span>
                   </div>
                   <div class="px-5 md:px-7 py-2">
                     {schedule.map((row, i) => (
                       <div
                         class:list={[
                           'grid grid-cols-1 md:grid-cols-[140px_1fr] gap-3 md:gap-6 py-5',
-                          i !== 0 ? 'border-t-[2px] border-[color:var(--color-text-primary)]' : '',
+                          i !== 0
+                            ? 'border-t-[2px] border-[color:var(--ss-color-text-primary)]'
+                            : '',
                         ]}
                       >
-                        <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]">
+                        <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
                           {row.label}
                         </span>
-                        <p class="text-[color:var(--color-text-secondary)] leading-[1.55] m-0">
+                        <p class="text-[color:var(--ss-color-text-secondary)] leading-[1.55] m-0">
                           {row.body}
                         </p>
                       </div>
@@ -374,20 +378,20 @@ const consultantPhone = engagement?.consultant_phone ?? null
 
             <!-- § 03 Terms -->
             <section
-              class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
             >
               <div
-                class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
+                class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
               >
                 <span>Terms</span>
-                <span class="text-[color:var(--color-primary)]">§ 03</span>
+                <span class="text-[color:var(--ss-color-primary)]">§ 03</span>
               </div>
               <div class="grid grid-cols-1 md:grid-cols-2">
                 <div
-                  class="px-5 py-5 md:border-r-[2px] md:border-[color:var(--color-text-primary)] border-b-[2px] md:border-b-0 border-[color:var(--color-text-primary)]"
+                  class="px-5 py-5 md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] border-b-[2px] md:border-b-0 border-[color:var(--ss-color-text-primary)]"
                 >
                   <p
-                    class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]"
+                    class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]"
                   >
                     Total
                   </p>
@@ -397,11 +401,11 @@ const consultantPhone = engagement?.consultant_phone ?? null
                 </div>
                 <div class="px-5 py-5">
                   <p
-                    class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-text-secondary)]"
+                    class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]"
                   >
                     Payment schedule
                   </p>
-                  <p class="mt-3 text-[color:var(--color-text-primary)] leading-[1.55]">
+                  <p class="mt-3 text-[color:var(--ss-color-text-primary)] leading-[1.55]">
                     {paymentSplitText}
                   </p>
                 </div>
@@ -412,17 +416,17 @@ const consultantPhone = engagement?.consultant_phone ?? null
             {
               hasActiveSignature && (
                 <section id="sign-surface" class="mt-8">
-                  <div class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]">
-                    <div class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  <div class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                    <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
                       <span>Review and sign</span>
-                      <span class="text-[color:var(--color-primary)]">§ 04</span>
+                      <span class="text-[color:var(--ss-color-primary)]">§ 04</span>
                     </div>
                     <div class="px-5 py-5">
-                      <p class="text-[color:var(--color-text-secondary)] mb-5">
+                      <p class="text-[color:var(--ss-color-text-secondary)] mb-5">
                         The full Statement of Work is below. Sign when you're ready.
                       </p>
                       <div
-                        class="border-[2px] border-[color:var(--color-text-primary)] overflow-hidden bg-[color:var(--color-surface)]"
+                        class="border-[2px] border-[color:var(--ss-color-text-primary)] overflow-hidden bg-[color:var(--ss-color-surface)]"
                         style="min-height: 600px;"
                       >
                         <iframe
@@ -442,7 +446,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
             <!-- Consultant block (mobile — above footer; desktop hides here, shown in rail) -->
             {
               consultantName && (
-                <section class="lg:hidden mt-10 pt-10 border-t-[3px] border-[color:var(--color-text-primary)]">
+                <section class="lg:hidden mt-10 pt-10 border-t-[3px] border-[color:var(--ss-color-text-primary)]">
                   <ConsultantBlock
                     variant="trade-card"
                     name={consultantName}
@@ -452,7 +456,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
                     nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
                     phone={engagement?.consultant_phone ?? null}
                   />
-                  <p class="mt-stack text-caption text-[color:var(--color-text-muted)]">
+                  <p class="mt-stack text-caption text-[color:var(--ss-color-text-muted)]">
                     Questions? Reach us using the contacts in the header.
                   </p>
                 </section>
@@ -466,55 +470,55 @@ const consultantPhone = engagement?.consultant_phone ?? null
           <div class="sticky top-40 space-y-6">
             <!-- Sign card — Plainspoken ticket chrome -->
             <div
-              class="border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)]"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
             >
               <div
-                class="flex items-center justify-between gap-3 bg-[color:var(--color-text-primary)] text-[color:var(--color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
+                class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
               >
                 <span>Engagement total</span>
-                <span class="text-[color:var(--color-primary)]"
+                <span class="text-[color:var(--ss-color-primary)]"
                   >№ {quote.id.slice(0, 2).toUpperCase()}</span
                 >
               </div>
               <div class="px-5 py-5">
                 <MoneyDisplay amountCents={totalCents} size="hero" />
                 <p
-                  class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--color-text-secondary)]"
+                  class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
                 >
                   Fixed · USD
                 </p>
-                <p class="mt-4 text-sm text-[color:var(--color-text-secondary)]">
+                <p class="mt-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                   {paymentSplitText}
                 </p>
               </div>
 
               {
                 isSigned ? (
-                  <div class="border-t-[2px] border-[color:var(--color-text-primary)] bg-[color:var(--color-border-subtle)] px-5 py-4 flex items-center justify-between gap-3">
-                    <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-complete)] flex items-center gap-2">
+                  <div class="border-t-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-border-subtle)] px-5 py-4 flex items-center justify-between gap-3">
+                    <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-complete)] flex items-center gap-2">
                       <span
                         aria-hidden="true"
-                        class="inline-flex items-center justify-center w-5 h-5 bg-[color:var(--color-complete)] text-[color:var(--color-background)] font-['Archivo'] font-black text-xs"
+                        class="inline-flex items-center justify-center w-5 h-5 bg-[color:var(--ss-color-complete)] text-[color:var(--ss-color-background)] font-['Archivo'] font-black text-xs"
                       >
                         ✓
                       </span>
                       Signed
                     </span>
                     {quote.accepted_at && (
-                      <span class="font-mono text-xs text-[color:var(--color-text-secondary)] tracking-[0.04em]">
+                      <span class="font-mono text-xs text-[color:var(--ss-color-text-secondary)] tracking-[0.04em]">
                         {formatShortDate(quote.accepted_at)}
                       </span>
                     )}
                   </div>
                 ) : isSuperseded ? (
-                  <div class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4">
-                    <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--color-primary)]">
+                  <div class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4">
+                    <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
                       A revised version is available
                     </p>
                     {supersedingQuoteId && (
                       <a
                         href={`/portal/quotes/${supersedingQuoteId}`}
-                        class="mt-3 inline-flex items-center gap-2 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--color-primary)] hover:text-[color:var(--color-primary-hover)]"
+                        class="mt-3 inline-flex items-center gap-2 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
                       >
                         Go to the latest proposal
                         <span aria-hidden="true" class="font-['Archivo'] font-black">
@@ -525,14 +529,14 @@ const consultantPhone = engagement?.consultant_phone ?? null
                   </div>
                 ) : isDeclined || isExpired ? (
                   surface.next ? (
-                    <p class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4 text-sm text-[color:var(--color-text-secondary)]">
+                    <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                       {surface.next}
                     </p>
                   ) : null
                 ) : hasActiveSignature ? (
                   <a
                     href="#sign-surface"
-                    class="border-t-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-primary)] hover:bg-[color:var(--color-primary-hover)] flex items-center justify-between gap-3 px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-inset"
+                    class="border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] flex items-center justify-between gap-3 px-5 py-4 font-['Archivo'] text-sm font-bold uppercase tracking-[0.08em] text-[color:var(--ss-color-background)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
                   >
                     <span>Review and sign</span>
                     <span aria-hidden="true" class="font-black">
@@ -540,7 +544,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
                     </span>
                   </a>
                 ) : (
-                  <p class="border-t-[2px] border-[color:var(--color-text-primary)] px-5 py-4 text-sm text-[color:var(--color-text-secondary)]">
+                  <p class="border-t-[2px] border-[color:var(--ss-color-text-primary)] px-5 py-4 text-sm text-[color:var(--ss-color-text-secondary)]">
                     Your proposal is being prepared. You'll get an email when it's ready.
                   </p>
                 )
@@ -551,12 +555,12 @@ const consultantPhone = engagement?.consultant_phone ?? null
               pdfHref && (
                 <a
                   href={pdfHref}
-                  class="flex items-center justify-between border-[3px] border-[color:var(--color-text-primary)] bg-[color:var(--color-background)] hover:bg-[color:var(--color-border-subtle)] px-5 py-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--color-text-primary)] transition-colors"
+                  class="flex items-center justify-between border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-border-subtle)] px-5 py-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)] transition-colors"
                 >
                   <span>View the full PDF</span>
                   <span
                     aria-hidden="true"
-                    class="font-['Archivo'] font-black text-[color:var(--color-primary)]"
+                    class="font-['Archivo'] font-black text-[color:var(--ss-color-primary)]"
                   >
                     ↓
                   </span>
@@ -577,7 +581,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
                     nextTouchpointLabel={engagement?.next_touchpoint_label ?? null}
                     phone={engagement?.consultant_phone ?? null}
                   />
-                  <p class="text-caption text-[color:var(--color-text-muted)] px-1">
+                  <p class="text-caption text-[color:var(--ss-color-text-muted)] px-1">
                     Questions? Reach us using the contacts in the header.
                   </p>
                 </>

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -76,13 +76,13 @@ const eyebrowText = eyebrowParts.join(' · ').toUpperCase()
     />
     <title>Proposals — {BRAND_NAME}</title>
   </head>
-  <body class="min-h-screen bg-[color:var(--color-background)]">
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
     <PortalHeader clientName={client.name}>
       <form method="POST" action="/api/auth/logout">
         <button
           type="submit"
-          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text-primary)] active:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
         >
           Sign out
         </button>
@@ -102,20 +102,20 @@ const eyebrowText = eyebrowParts.join(' · ').toUpperCase()
 
       {
         quotes.length === 0 ? (
-          <div class="mt-10 border-[3px] border-[color:var(--color-text-primary)] p-8 md:p-12 text-center">
-            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--color-text-primary)]">
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
               No proposals yet
             </p>
-            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--color-text-secondary)]">
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
               Proposals will appear here once they are ready for review.
             </p>
           </div>
         ) : (
           <>
-            <p class="mt-8 mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--color-text-secondary)]">
+            <p class="mt-8 mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
               {eyebrowText}
             </p>
-            <div class="border-[3px] border-[color:var(--color-text-primary)]">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
               {quotes.map((quote: Quote) => (
                 <PortalListItem
                   chrome="ticket"

--- a/src/pages/scorecard.astro
+++ b/src/pages/scorecard.astro
@@ -69,7 +69,7 @@ for (const [i, q] of QUESTIONS.entries()) {
 
   <!-- Progress bar (hidden on landing and results) -->
   <div id="progress-wrapper" class="fixed left-0 top-14 md:top-16 z-50 hidden w-full">
-    <div id="progress-bar" class="h-1.5 w-full bg-[color:var(--color-border)]">
+    <div id="progress-bar" class="h-1.5 w-full bg-[color:var(--ss-color-border)]">
       <div
         id="progress-fill"
         class="h-1.5 bg-primary transition-all duration-300"
@@ -78,9 +78,9 @@ for (const [i, q] of QUESTIONS.entries()) {
       </div>
     </div>
     <div class="mx-auto flex max-w-2xl items-center justify-between px-6 pt-2">
-      <p id="progress-text" class="text-sm font-medium text-[color:var(--color-text-secondary)]">
+      <p id="progress-text" class="text-sm font-medium text-[color:var(--ss-color-text-secondary)]">
       </p>
-      <p id="progress-pct" class="text-sm text-[color:var(--color-text-muted)]"></p>
+      <p id="progress-pct" class="text-sm text-[color:var(--ss-color-text-muted)]"></p>
     </div>
   </div>
 
@@ -92,53 +92,58 @@ for (const [i, q] of QUESTIONS.entries()) {
       <!-- Hero -->
       <div class="px-6 py-20 text-center sm:py-28">
         <h1
-          class="mx-auto max-w-3xl text-4xl font-extrabold text-[color:var(--color-text-primary)] sm:text-5xl"
+          class="mx-auto max-w-3xl text-4xl font-extrabold text-[color:var(--ss-color-text-primary)] sm:text-5xl"
         >
           See where your operations stand
         </h1>
-        <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--color-text-secondary)]">
+        <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--ss-color-text-secondary)]">
           Answer a few questions about how your business runs. Get an instant, personalized report
           showing where you're strong and where there's room to grow.
         </p>
         <button
           data-action="start"
           data-ev="scorecard-start-primary"
-          class="mt-8 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
+          class="mt-8 inline-block rounded-[var(--ss-radius-card)] bg-primary px-8 py-3 text-lg font-semibold text-white transition-opacity hover:opacity-80"
         >
           Start your scorecard
         </button>
 
         <!-- Trust signals -->
         <div class="mt-8 flex flex-wrap items-center justify-center gap-8">
-          <div class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
-            <span class="material-symbols-outlined text-[color:var(--color-text-muted)]"
+          <div class="flex items-center gap-2 text-sm text-[color:var(--ss-color-text-secondary)]">
+            <span class="material-symbols-outlined text-[color:var(--ss-color-text-muted)]"
               >schedule</span
             >
             Takes about 3 minutes
           </div>
-          <div class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
-            <span class="material-symbols-outlined text-[color:var(--color-text-muted)]">block</span
+          <div class="flex items-center gap-2 text-sm text-[color:var(--ss-color-text-secondary)]">
+            <span class="material-symbols-outlined text-[color:var(--ss-color-text-muted)]"
+              >block</span
             >
             No sales pitch
           </div>
-          <div class="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
-            <span class="material-symbols-outlined text-[color:var(--color-text-muted)]">bolt</span>
+          <div class="flex items-center gap-2 text-sm text-[color:var(--ss-color-text-secondary)]">
+            <span class="material-symbols-outlined text-[color:var(--ss-color-text-muted)]"
+              >bolt</span
+            >
             Instant results
           </div>
         </div>
       </div>
 
       <!-- Dimensions preview -->
-      <div class="bg-[color:var(--color-background)] px-6 py-16">
-        <h2 class="text-center text-2xl font-bold text-[color:var(--color-text-primary)]">
+      <div class="bg-[color:var(--ss-color-background)] px-6 py-16">
+        <h2 class="text-center text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
           What we look at
         </h2>
         <div class="mx-auto mt-10 grid max-w-4xl grid-cols-2 gap-6 sm:grid-cols-3">
           {
             DIMENSIONS.map((dim) => (
-              <div class="rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-6">
+              <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white p-6">
                 <span class="material-symbols-outlined text-3xl text-primary">{dim.icon}</span>
-                <p class="mt-3 font-semibold text-[color:var(--color-text-primary)]">{dim.label}</p>
+                <p class="mt-3 font-semibold text-[color:var(--ss-color-text-primary)]">
+                  {dim.label}
+                </p>
               </div>
             ))
           }
@@ -147,11 +152,13 @@ for (const [i, q] of QUESTIONS.entries()) {
 
       <!-- Secondary CTA -->
       <div class="px-6 py-16 text-center">
-        <p class="text-xl text-[color:var(--color-text-primary)]">Ready to see where you stand?</p>
+        <p class="text-xl text-[color:var(--ss-color-text-primary)]">
+          Ready to see where you stand?
+        </p>
         <button
           data-action="start"
           data-ev="scorecard-start-secondary"
-          class="mt-6 inline-block rounded-[var(--radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+          class="mt-6 inline-block rounded-[var(--ss-radius-card)] bg-primary px-8 py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
         >
           Start your scorecard
         </button>
@@ -167,18 +174,18 @@ for (const [i, q] of QUESTIONS.entries()) {
           steps.map((step) => (
             <div data-step={step.num} class="hidden">
               {step.sectionHeader && (
-                <p class="text-sm font-medium uppercase tracking-wide text-[color:var(--color-text-secondary)]">
+                <p class="text-sm font-medium uppercase tracking-wide text-[color:var(--ss-color-text-secondary)]">
                   {step.sectionHeader}
                 </p>
               )}
-              <p class="mt-4 text-xl font-semibold leading-relaxed text-[color:var(--color-text-primary)] sm:text-2xl">
+              <p class="mt-4 text-xl font-semibold leading-relaxed text-[color:var(--ss-color-text-primary)] sm:text-2xl">
                 {step.text}
               </p>
               <div class="mt-8 space-y-3">
                 {step.options.map((opt) => (
                   <button
                     data-answer={opt.value}
-                    class="block w-full cursor-pointer rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-5 py-4 text-left text-base leading-relaxed text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-background)]"
+                    class="block w-full cursor-pointer rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-5 py-4 text-left text-base leading-relaxed text-[color:var(--ss-color-text-primary)] transition-colors hover:bg-[color:var(--ss-color-background)]"
                   >
                     {opt.text}
                   </button>
@@ -186,7 +193,7 @@ for (const [i, q] of QUESTIONS.entries()) {
                 {step.type === 'scored' && (
                   <button
                     data-answer="-1"
-                    class="block w-full cursor-pointer rounded-[var(--radius-card)] border border-dashed border-[color:var(--color-border)] px-5 py-3 text-left text-sm text-[color:var(--color-text-muted)] transition-colors hover:bg-[color:var(--color-background)]"
+                    class="block w-full cursor-pointer rounded-[var(--ss-radius-card)] border border-dashed border-[color:var(--ss-color-border)] px-5 py-3 text-left text-sm text-[color:var(--ss-color-text-muted)] transition-colors hover:bg-[color:var(--ss-color-background)]"
                   >
                     Doesn't apply to my business
                   </button>
@@ -201,17 +208,17 @@ for (const [i, q] of QUESTIONS.entries()) {
     <!-- Quiz navigation (back/next) -->
     <div
       id="quiz-nav"
-      class="fixed bottom-0 left-0 hidden w-full border-t border-[color:var(--color-border-subtle)] bg-white px-6 py-4"
+      class="fixed bottom-0 left-0 hidden w-full border-t border-[color:var(--ss-color-border-subtle)] bg-white px-6 py-4"
     >
       <div class="mx-auto flex max-w-2xl items-center justify-between">
         <button
           id="btn-back"
-          class="text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+          class="text-[color:var(--ss-color-text-secondary)] transition-colors hover:text-[color:var(--ss-color-text-primary)]"
           >Back</button
         >
         <button
           id="btn-next"
-          class="rounded-[var(--radius-card)] bg-primary px-6 py-2.5 font-medium text-white opacity-50 pointer-events-none transition-opacity"
+          class="rounded-[var(--ss-radius-card)] bg-primary px-6 py-2.5 font-medium text-white opacity-50 pointer-events-none transition-opacity"
         >
           Next
         </button>
@@ -224,22 +231,22 @@ for (const [i, q] of QUESTIONS.entries()) {
     <section id="email-gate" class="hidden">
       <div class="flex min-h-[80vh] flex-col items-center justify-center px-6 py-16">
         <span class="material-symbols-outlined text-5xl text-green-500">check_circle</span>
-        <h2 class="mt-4 text-2xl font-bold text-[color:var(--color-text-primary)] sm:text-3xl">
+        <h2 class="mt-4 text-2xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-3xl">
           Your report is ready
         </h2>
-        <p class="mt-2 text-base text-[color:var(--color-text-secondary)]">
+        <p class="mt-2 text-base text-[color:var(--ss-color-text-secondary)]">
           Where should we send the full breakdown?
         </p>
 
         <form
           id="gate-form"
-          class="mx-auto mt-8 w-full max-w-md rounded-[var(--radius-card)] border border-[color:var(--color-border)] bg-white p-6 sm:p-8"
+          class="mx-auto mt-8 w-full max-w-md rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white p-6 sm:p-8"
         >
           <div class="space-y-4">
             <div>
               <label
                 for="first_name"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 First name <span class="text-red-500">*</span>
               </label>
@@ -248,13 +255,13 @@ for (const [i, q] of QUESTIONS.entries()) {
                 name="first_name"
                 id="first_name"
                 required
-                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-4 py-2.5 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:ring-primary"
               />
             </div>
             <div>
               <label
                 for="email"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 Email <span class="text-red-500">*</span>
               </label>
@@ -263,13 +270,13 @@ for (const [i, q] of QUESTIONS.entries()) {
                 name="email"
                 id="email"
                 required
-                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-4 py-2.5 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:ring-primary"
               />
             </div>
             <div>
               <label
                 for="business_name"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
               >
                 Business name <span class="text-red-500">*</span>
               </label>
@@ -278,22 +285,22 @@ for (const [i, q] of QUESTIONS.entries()) {
                 name="business_name"
                 id="business_name"
                 required
-                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-4 py-2.5 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:ring-primary"
               />
             </div>
             <div>
               <label
                 for="phone"
-                class="block text-sm font-medium text-[color:var(--color-text-primary)]"
+                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
                 >Phone</label
               >
               <input
                 type="tel"
                 name="phone"
                 id="phone"
-                class="mt-1 block w-full rounded-[var(--radius-card)] border border-[color:var(--color-border)] px-4 py-2.5 text-[color:var(--color-text-primary)] focus:border-primary focus:ring-primary"
+                class="mt-1 block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-4 py-2.5 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:ring-primary"
               />
-              <p class="mt-1 text-sm text-[color:var(--color-text-muted)]">
+              <p class="mt-1 text-sm text-[color:var(--ss-color-text-muted)]">
                 In case you'd rather talk through your results
               </p>
             </div>
@@ -302,15 +309,15 @@ for (const [i, q] of QUESTIONS.entries()) {
               <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
             </div>
           </div>
-          <p id="gate-error" class="mt-4 hidden text-sm text-[color:var(--color-error)]"></p>
+          <p id="gate-error" class="mt-4 hidden text-sm text-[color:var(--ss-color-error)]"></p>
           <button
             type="submit"
-            class="mt-6 w-full rounded-[var(--radius-card)] bg-primary py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
+            class="mt-6 w-full rounded-[var(--ss-radius-card)] bg-primary py-3 text-base font-semibold text-white transition-opacity hover:opacity-80"
           >
             See my results
           </button>
         </form>
-        <p class="mt-4 text-sm text-[color:var(--color-text-muted)]">
+        <p class="mt-4 text-sm text-[color:var(--ss-color-text-muted)]">
           We'll send your detailed PDF report to this email. No spam, ever.
         </p>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,151 +1,149 @@
 @import '@venturecrane/tokens/ss.css';
 @import 'tailwindcss';
 
-@theme {
-  /* ------------------------------------------------------------------
-   * SMD Services — Plainspoken Sign Shop identity
-   * Migrated from Desert Functional on 2026-04-23.
-   * Paint-job, not brochure. 1950s commercial signage register.
-   * Full token documentation: .design/DESIGN.md
-   * ------------------------------------------------------------------ */
+/*
+ * SMD Services — Plainspoken Sign Shop identity
+ * Migrated from Desert Functional on 2026-04-23.
+ * Paint-job, not brochure. 1950s commercial signage register.
+ * Full token documentation: .design/DESIGN.md
+ *
+ * Stream C5 PR B (2026-04-25): values now sourced from
+ * @venturecrane/tokens/ss.css. The @theme inline block below maps
+ * Tailwind v4's expected namespaces (--color-*, --font-*, --text-*,
+ * --spacing-*, --radius-*) onto the package's --ss-* tokens so utility
+ * classes (bg-primary, text-display, font-body, p-section, rounded-card,
+ * etc.) continue to generate from the same single source of truth.
+ *
+ * Direct var() references in source files were codemodded to use
+ * --ss-* prefixed names — see PR description.
+ */
 
+@theme inline {
   /* ---------- Color roles ---------- */
-  --color-background: #f5f0e3; /* cream paper */
-  --color-surface: #f5f0e3; /* flat paper — cards defined by rules, not fill */
-  --color-surface-inverse: #1a1512; /* ink */
-  --color-border: rgba(26, 21, 18, 0.16);
-  --color-border-subtle: rgba(26, 21, 18, 0.08);
+  --color-background: var(--ss-color-background);
+  --color-surface: var(--ss-color-surface);
+  --color-surface-inverse: var(--ss-color-surface-inverse);
+  --color-border: var(--ss-color-border);
+  --color-border-subtle: var(--ss-color-border-subtle);
 
-  --color-text-primary: #1a1512;
-  --color-text-secondary: #4a423c;
-  --color-text-muted: #8a7f73;
+  --color-text-primary: var(--ss-color-text-primary);
+  --color-text-secondary: var(--ss-color-text-secondary);
+  --color-text-muted: var(--ss-color-text-muted);
 
-  --color-meta: #4a423c;
+  --color-meta: var(--ss-color-meta);
 
-  --color-primary: #c5501e; /* burnt orange */
-  --color-primary-hover: #a84318;
-  --color-action: #c5501e;
-  --color-attention: #c5501e;
-  --color-complete: #4a6b3e; /* olive — complement to burnt, not in prototype palette */
-  --color-error: #a02a2a;
+  --color-primary: var(--ss-color-primary);
+  --color-primary-hover: var(--ss-color-primary-hover);
+  --color-action: var(--ss-color-action);
+  --color-attention: var(--ss-color-attention);
+  --color-complete: var(--ss-color-complete);
+  --color-error: var(--ss-color-error);
 
   /* ---------- Typography families ---------- */
-  --font-display: 'Archivo', system-ui, sans-serif;
-  --font-body: 'Archivo', system-ui, sans-serif;
-  --font-accent-label: 'Archivo Narrow', 'Archivo', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-display: var(--ss-font-display);
+  --font-body: var(--ss-font-body);
+  --font-accent-label: var(--ss-font-accent-label);
+  --font-mono: var(--ss-font-mono);
 
-  /* ---------- Typography scale ---------- */
-  --text-display: 3rem; /* 48px */
-  --text-display--line-height: 3.375rem; /* 54px */
-  --text-display--font-weight: 500;
-  --text-display--letter-spacing: -0.01em;
-
-  --text-title: 1.75rem; /* 28px */
-  --text-title--line-height: 2.125rem; /* 34px */
-  --text-title--font-weight: 500;
-  --text-title--letter-spacing: -0.005em;
-
-  --text-heading: 1.125rem; /* 18px */
-  --text-heading--line-height: 1.5rem; /* 24px */
-  --text-heading--font-weight: 600;
-
-  --text-body-lg: 1.0625rem; /* 17px */
-  --text-body-lg--line-height: 1.625rem; /* 26px */
-  --text-body-lg--font-weight: 400;
-
-  --text-body: 1rem; /* 16px */
-  --text-body--line-height: 1.55rem;
-  --text-body--font-weight: 400;
-
-  --text-caption: 0.875rem; /* 14px */
-  --text-caption--line-height: 1.25rem; /* 20px */
-  --text-caption--font-weight: 500;
-
-  --text-label: 0.75rem; /* 12px */
-  --text-label--line-height: 1rem;
-  --text-label--font-weight: 500;
-  --text-label--letter-spacing: 0.08em;
-
-  --text-money: 2.75rem; /* 44px */
-  --text-money--line-height: 3rem;
-  --text-money--font-weight: 500;
-
-  /* ---------- Plainspoken display scale ----------
-   * Named tokens for the Plainspoken Sign Shop visual register. Each token
-   * ships with the Tailwind v4 sibling quartet (line-height, font-weight,
-   * letter-spacing) so utilities bake the full type style and consumers
-   * never reach for `text-[Npx] leading-[N] tracking-[N]` ad-hoc. Respects
-   * UI-PATTERNS R5 (typography scale only via named tokens).
-   *
-   * Line-heights target 0.92 × font-size on H1 sizes (Plainspoken mocks).
+  /* ---------- Typography scale ----------
+   * Tailwind v4 sibling quartet per token: size, line-height, font-weight,
+   * letter-spacing. The package emits flat --ss-text-{prop}-{name} keys;
+   * Tailwind v4 expects the sibling syntax --text-{name}--{prop}.
    */
+  --text-display: var(--ss-text-size-display);
+  --text-display--line-height: var(--ss-text-line-height-display);
+  --text-display--font-weight: var(--ss-text-weight-display);
+  --text-display--letter-spacing: var(--ss-text-letter-spacing-display);
 
-  /* Portal H1 — desktop */
-  --text-hero: 4.5rem; /* 72px */
-  --text-hero--line-height: 4.14rem; /* 0.92 × 72 */
-  --text-hero--font-weight: 900;
-  --text-hero--letter-spacing: -0.03em;
+  --text-title: var(--ss-text-size-title);
+  --text-title--line-height: var(--ss-text-line-height-title);
+  --text-title--font-weight: var(--ss-text-weight-title);
+  --text-title--letter-spacing: var(--ss-text-letter-spacing-title);
 
-  /* Portal H1 — mobile (used with md:text-hero) */
-  --text-hero-mobile: 2.75rem; /* 44px */
-  --text-hero-mobile--line-height: 2.53rem; /* 0.92 × 44 */
-  --text-hero-mobile--font-weight: 900;
-  --text-hero-mobile--letter-spacing: -0.03em;
+  --text-heading: var(--ss-text-size-heading);
+  --text-heading--line-height: var(--ss-text-line-height-heading);
+  --text-heading--font-weight: var(--ss-text-weight-heading);
 
-  /* Summary-card total price */
-  --text-hero-price: 4rem; /* 64px */
-  --text-hero-price--line-height: 3.68rem; /* 0.92 × 64 */
-  --text-hero-price--font-weight: 900;
-  --text-hero-price--letter-spacing: -0.04em;
+  --text-body-lg: var(--ss-text-size-body-lg);
+  --text-body-lg--line-height: var(--ss-text-line-height-body-lg);
+  --text-body-lg--font-weight: var(--ss-text-weight-body-lg);
 
-  /* KPI row big numbers */
-  --text-kpi: 2.75rem; /* 44px */
-  --text-kpi--line-height: 2.75rem;
-  --text-kpi--font-weight: 900;
-  --text-kpi--letter-spacing: -0.03em;
+  --text-body: var(--ss-text-size-body);
+  --text-body--line-height: var(--ss-text-line-height-body);
+  --text-body--font-weight: var(--ss-text-weight-body);
 
-  /* § block headings on detail pages */
-  --text-section-h: 2.25rem; /* 36px */
-  --text-section-h--line-height: 2.25rem;
-  --text-section-h--font-weight: 900;
-  --text-section-h--letter-spacing: -0.02em;
+  --text-caption: var(--ss-text-size-caption);
+  --text-caption--line-height: var(--ss-text-line-height-caption);
+  --text-caption--font-weight: var(--ss-text-weight-caption);
 
-  /* Row-level money (list rows, ledger amounts) */
-  --text-price-row: 1.75rem; /* 28px */
-  --text-price-row--line-height: 1.75rem;
-  --text-price-row--font-weight: 900;
-  --text-price-row--letter-spacing: -0.02em;
+  --text-label: var(--ss-text-size-label);
+  --text-label--line-height: var(--ss-text-line-height-label);
+  --text-label--font-weight: var(--ss-text-weight-label);
+  --text-label--letter-spacing: var(--ss-text-letter-spacing-label);
 
-  /* № / § cell glyph in ticket rows */
-  --text-num-cell: 1.375rem; /* 22px */
-  --text-num-cell--line-height: 1.375rem;
-  --text-num-cell--font-weight: 900;
-  --text-num-cell--letter-spacing: -0.01em;
+  --text-money: var(--ss-text-size-money);
+  --text-money--line-height: var(--ss-text-line-height-money);
+  --text-money--font-weight: var(--ss-text-weight-money);
+
+  /* Plainspoken display scale — Portal H1, hero price, KPI, etc. */
+  --text-hero: var(--ss-text-size-hero);
+  --text-hero--line-height: var(--ss-text-line-height-hero);
+  --text-hero--font-weight: var(--ss-text-weight-hero);
+  --text-hero--letter-spacing: var(--ss-text-letter-spacing-hero);
+
+  --text-hero-mobile: var(--ss-text-size-hero-mobile);
+  --text-hero-mobile--line-height: var(--ss-text-line-height-hero-mobile);
+  --text-hero-mobile--font-weight: var(--ss-text-weight-hero-mobile);
+  --text-hero-mobile--letter-spacing: var(--ss-text-letter-spacing-hero-mobile);
+
+  --text-hero-price: var(--ss-text-size-hero-price);
+  --text-hero-price--line-height: var(--ss-text-line-height-hero-price);
+  --text-hero-price--font-weight: var(--ss-text-weight-hero-price);
+  --text-hero-price--letter-spacing: var(--ss-text-letter-spacing-hero-price);
+
+  --text-kpi: var(--ss-text-size-kpi);
+  --text-kpi--line-height: var(--ss-text-line-height-kpi);
+  --text-kpi--font-weight: var(--ss-text-weight-kpi);
+  --text-kpi--letter-spacing: var(--ss-text-letter-spacing-kpi);
+
+  --text-section-h: var(--ss-text-size-section-h);
+  --text-section-h--line-height: var(--ss-text-line-height-section-h);
+  --text-section-h--font-weight: var(--ss-text-weight-section-h);
+  --text-section-h--letter-spacing: var(--ss-text-letter-spacing-section-h);
+
+  --text-price-row: var(--ss-text-size-price-row);
+  --text-price-row--line-height: var(--ss-text-line-height-price-row);
+  --text-price-row--font-weight: var(--ss-text-weight-price-row);
+  --text-price-row--letter-spacing: var(--ss-text-letter-spacing-price-row);
+
+  --text-num-cell: var(--ss-text-size-num-cell);
+  --text-num-cell--line-height: var(--ss-text-line-height-num-cell);
+  --text-num-cell--font-weight: var(--ss-text-weight-num-cell);
+  --text-num-cell--letter-spacing: var(--ss-text-letter-spacing-num-cell);
 
   /* ---------- Spacing rhythm ---------- */
-  --spacing-section: 3rem;
-  --spacing-card: 2rem;
-  --spacing-stack: 1rem;
-  --spacing-row: 0.75rem;
+  --spacing-section: var(--ss-space-section);
+  --spacing-card: var(--ss-space-card);
+  --spacing-stack: var(--ss-space-stack);
+  --spacing-row: var(--ss-space-row);
 
   /* ---------- Shape — flat institutional ---------- */
-  --radius-card: 0;
-  --radius-button: 0;
-  --radius-badge: 0;
+  --radius-card: var(--ss-radius-card);
+  --radius-button: var(--ss-radius-button);
+  --radius-badge: var(--ss-radius-badge);
 }
 
 @layer base {
   body {
-    background-color: var(--color-background);
-    color: var(--color-text-primary);
-    font-family: var(--font-body);
+    background-color: var(--ss-color-background);
+    color: var(--ss-color-text-primary);
+    font-family: var(--ss-font-body);
     -webkit-font-smoothing: antialiased;
   }
   h1,
   h2,
   h3 {
-    font-family: var(--font-display);
+    font-family: var(--ss-font-display);
   }
 }
 

--- a/tests/portal-list-consistency.test.ts
+++ b/tests/portal-list-consistency.test.ts
@@ -36,7 +36,7 @@ describe('portal list pages: unified scaffolding (R7 registry)', () => {
         // Ticket chrome replaces the previous soft-card space-y-row stack.
         // The ink-bordered wrapper is the structural contract: rows stitch
         // together with their own 2px dividers inside.
-        expect(source()).toMatch(/border-\[3px\] border-\[color:var\(--color-text-primary\)\]/)
+        expect(source()).toMatch(/border-\[3px\] border-\[color:var\(--ss-color-text-primary\)\]/)
       })
 
       it('imports PortalListItem primitive', () => {


### PR DESCRIPTION
## Summary

Stream C5 PR B of the SS design-system migration. PR A ([#568](https://github.com/venturecrane/ss-console/pull/568)) imported `@venturecrane/tokens/ss.css` additively; this PR rewires SS so every visual value is sourced from that package. Single source of truth: the package.

## Path taken: Path B (`@theme inline` aliases)

Path A as originally specified — codemod source `var()` refs **and** delete the unprefixed `@theme {}` block — is not viable under Tailwind v4. Tailwind v4 generates utility classes from a fixed namespace set (`--color-*`, `--font-*`, `--text-*`, `--spacing-*`, `--radius-*`); custom prefixes like `--ss-color-*` do **not** generate utilities. Removing the unprefixed `@theme` block would silently break ~hundreds of utility class usages (`bg-primary`, `text-display`, `font-body`, `p-section`, `rounded-card`, etc.) — verified against [Tailwind v4 theme variable namespace docs](https://tailwindcss.com/docs/theme).

Path B keeps the unprefixed Tailwind-namespace keys in `src/styles/global.css` but converts the block to `@theme inline {}` where every value is a `var()` reference into the package's `--ss-*` tokens. End state: package is the single source of truth for every value; **no hex literals remain in SS source CSS**; Tailwind utilities continue to generate normally.

Beyond vanilla Path B, this PR also runs the codemod step from Path A on source files: every `var(--color-X)`, `var(--font-X)`, `var(--text-X*)`, `var(--spacing-X)`, `var(--radius-X)` reference in `.astro`/`.tsx`/`.ts`/`.css` sources is rewritten to `var(--ss-*)`. **Source files now exclusively use prefixed tokens.**

## Smoke test #9

| | |
|---|---|
| Pre-codemod  | 1634 unprefixed `var()` references in `src/` |
| Post-codemod | **0** unprefixed `var()` references in `src/` |

The runbook's strict smoke test
```sh
grep -rE 'var\(--(color|font|text|radius|spacing)-' ~/dev/ss-console/src
```
returns 0 matches. The `@theme inline {}` block in `global.css` contains `--color-*` / `--font-*` / `--text-*` / `--spacing-*` / `--radius-*` LHS definitions but those are not `var()` references and don't match the smoke test pattern.

## Codemod mapping

```
var(--color-X)                -> var(--ss-color-X)
var(--font-X)                 -> var(--ss-font-X)
var(--radius-X)               -> var(--ss-radius-X)
var(--spacing-X)              -> var(--ss-space-X)               (name change)
var(--text-X)                 -> var(--ss-text-size-X)           (size token)
var(--text-X--line-height)    -> var(--ss-text-line-height-X)
var(--text-X--font-weight)    -> var(--ss-text-weight-X)
var(--text-X--letter-spacing) -> var(--ss-text-letter-spacing-X)
```

The package emits flat `--ss-text-{prop}-{name}` keys (one per Tailwind v4 sibling property); the inline `@theme` had used the v4 sibling-syntax form `--text-X--{prop}`. The codemod normalizes references to the package's flat naming. The `@theme inline {}` aliases re-expose the sibling-syntax form so utility classes (`text-display` etc.) continue to generate the full sibling quartet (size + line-height + font-weight + letter-spacing).

## Token gap flagged for Captain follow-up

`src/pages/portal/invoices/[id].astro:344` references `var(--color-surface-muted)`, which is **not defined** in either the inline `@theme` block (pre-PR) or the package's `ss.css`. This is a pre-existing latent bug — the var resolves to no value, so the `bg-[color:var(--ss-color-surface-muted)]` falls back to no fill. The codemod renamed it mechanically to `var(--ss-color-surface-muted)`; behavior is unchanged (still undefined). **Follow-up:** either add `color-surface-muted` to `packages/tokens/src/ventures/ss.json` or fix the single call site to use `color-surface`. Did not change unilaterally — out of scope for this PR.

## Files changed (78)

- `src/styles/global.css` — `@theme {}` block converted to `@theme inline {}` with every value sourced from `--ss-*`. `@layer base` block also rewritten to use `--ss-*` directly.
- 76 source files codemodded (.astro / .ts in `src/components/`, `src/pages/`, `src/layouts/`, `src/lib/`).
- 1 test regex literal updated (`tests/portal-list-consistency.test.ts`) — the test asserts on a literal Tailwind class string that needed the new token name.

## Verification

- [x] `npm run build` — exits 0; bundled CSS shows utilities resolving through `@theme inline` aliases to `--ss-*` tokens. Spot checks:
  - `.bg-primary { background-color: var(--ss-color-primary) }`
  - `.text-display { font-size: var(--ss-text-size-display); line-height: var(--tw-leading, var(--ss-text-line-height-display)); ... }`
  - `.font-body { font-family: var(--ss-font-body) }`
  - `.p-section { padding: var(--ss-space-section) }`
  - `.rounded-card { border-radius: var(--ss-radius-card) }`
- [x] `npm run typecheck` — 0 errors, 0 warnings (pre-existing hints only)
- [x] `npm run lint` — 0 errors, 6 pre-existing warnings (no new warnings)
- [x] `npm run format` — clean (prettier reformatted 29 files post-codemod)
- [x] `npm test` — 1592 passed, 1 test regex literal updated for the new token name, 2 pre-existing skips
- [x] `ui-drift-audit` — 404 raw Tailwind color classes (under 410 threshold). Hex/rgb still 0.
- [x] **Smoke test #9** — `grep -rE 'var\\(--(color|font|text|radius|spacing)-' src/` returns 0.

## Test plan

- [x] Build green
- [x] Typecheck green
- [x] Lint green
- [x] Tests green (1592/1592)
- [x] Prettier format check green
- [x] UI drift audit under thresholds
- [x] Smoke test #9 returns 0
- [x] Tailwind v4 utility classes verified to resolve via `@theme inline` (spot-checked in bundled CSS)
- [ ] CI green on PR
- [ ] Captain eyeballs the deploy preview — visual diff expected to be byte-identical (every value flows through the same hex literals via the alias chain)

## Screenshots

Skipped — PR A's description noted Playwright baselines were pending. No visual diff is structurally expected: every utility class and `var()` reference now resolves through the `@theme inline` aliases to the same hex values that the inline `@theme` block previously defined directly. (Stream A's authoring rule 2 mandates `ss.json` map 1:1 to legacy inline values, so the alias chain produces identical output.)

Captain reviews live deploy preview as the visual gate before merge.

## Hard constraints respected

- Did not modify `packages/tokens` in crane-console.
- Did not skip hooks (`--no-verify`) or force-push.
- Worked inside `.worktrees/c5-prb` to avoid the long-running `astro dev` in the main checkout.
- Did not commit the codemod script (one-shot in `/tmp`).