### PR TITLE
feat(admin): migrate generators + follow-ups + settings, remove pills

### DIFF
--- a/src/pages/admin/follow-ups/index.astro
+++ b/src/pages/admin/follow-ups/index.astro
@@ -93,7 +93,7 @@ const success = Astro.url.searchParams.get('saved')
 >
   {
     success && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-[color:var(--ss-color-complete)]/10 border border-[color:var(--ss-color-complete)]/30 text-[color:var(--ss-color-complete)] text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Follow-up updated successfully.
       </div>
     )
@@ -138,7 +138,7 @@ const success = Astro.url.searchParams.get('saved')
       href={`/admin/follow-ups?tab=overdue${filterType ? `&type=${filterType}` : ''}`}
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'overdue'
-          ? 'border-red-500 text-red-600'
+          ? 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)]'
           : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
       }`}
     >
@@ -148,7 +148,7 @@ const success = Astro.url.searchParams.get('saved')
       href={`/admin/follow-ups?tab=completed${filterType ? `&type=${filterType}` : ''}`}
       class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         activeTab === 'completed'
-          ? 'border-green-500 text-green-600'
+          ? 'border-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-text-primary)]'
           : 'border-transparent text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]'
       }`}
     >
@@ -194,7 +194,7 @@ const success = Astro.url.searchParams.get('saved')
                       <span
                         class={
                           daysUntil(f.scheduled_for) < 0
-                            ? 'text-red-500 font-medium'
+                            ? 'text-[color:var(--ss-color-error)] font-medium'
                             : 'text-[color:var(--ss-color-text-secondary)]'
                         }
                       >
@@ -220,7 +220,7 @@ const success = Astro.url.searchParams.get('saved')
                       <input type="hidden" name="action" value="complete" />
                       <button
                         type="submit"
-                        class="text-xs bg-green-50 text-green-700 px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-green-100 transition-colors"
+                        class="text-xs bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] border border-[color:var(--ss-color-border)] px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-border-subtle)] transition-colors"
                       >
                         Mark Complete
                       </button>

--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -375,7 +375,9 @@ const runDisabledReason = !runWorkerUrl
             configRow.last_run_error && (
               <>
                 <span class="text-xs text-[color:var(--ss-color-text-muted)]">·</span>
-                <span class="text-sm text-[color:var(--ss-color-error)]">Error: {configRow.last_run_error}</span>
+                <span class="text-sm text-[color:var(--ss-color-error)]">
+                  Error: {configRow.last_run_error}
+                </span>
               </>
             )
           }

--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -250,11 +250,11 @@ function prettyJson(raw: string | null): string {
 function tierClass(tier: string | null): string {
   switch (tier) {
     case 'hot':
-      return 'bg-red-100 text-red-700'
+      return 'bg-[color:var(--ss-color-error)]/10 text-[color:var(--ss-color-error)]'
     case 'warm':
-      return 'bg-amber-100 text-amber-700'
+      return 'bg-[color:var(--ss-color-warning)]/10 text-[color:var(--ss-color-warning)]'
     case 'cool':
-      return 'bg-blue-100 text-blue-700'
+      return 'bg-[color:var(--ss-color-action)]/10 text-[color:var(--ss-color-action)]'
     case 'cold':
       return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
     default:
@@ -302,15 +302,15 @@ const runDisabledReason = !runWorkerUrl
 
   {
     saved && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-green-800">Configuration saved.</p>
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-complete)]/10 border border-[color:var(--ss-color-complete)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-complete)]">Configuration saved.</p>
       </div>
     )
   }
   {
     ran && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-green-800">
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-complete)]/10 border border-[color:var(--ss-color-complete)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-complete)]">
           Run complete. {ranSignals} signal{ranSignals === '1' ? '' : 's'} written.
         </p>
       </div>
@@ -318,8 +318,8 @@ const runDisabledReason = !runWorkerUrl
   }
   {
     errorParam && (
-      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-red-800">
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-error)]/10 border border-[color:var(--ss-color-error)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-error)]">
           {errorParam === 'run_not_configured'
             ? `Run-now is not configured. Set ${type.toUpperCase()}_WORKER_URL and LEAD_INGEST_API_KEY on this Pages project.`
             : errorParam}
@@ -329,11 +329,11 @@ const runDisabledReason = !runWorkerUrl
   }
   {
     configRow.parseError.length > 0 && (
-      <div class="mb-6 p-stack bg-yellow-50 border border-yellow-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-yellow-800 font-medium mb-1">
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-warning)]/10 border border-[color:var(--ss-color-warning)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-warning)] font-medium mb-1">
           Stored configuration failed validation. Showing defaults.
         </p>
-        <ul class="text-xs text-yellow-800 list-disc pl-4 space-y-0.5">
+        <ul class="text-xs text-[color:var(--ss-color-warning)] list-disc pl-4 space-y-0.5">
           {configRow.parseError.map((e) => (
             <li>{e}</li>
           ))}
@@ -349,7 +349,8 @@ const runDisabledReason = !runWorkerUrl
       <div class="flex items-center justify-between gap-4 flex-wrap">
         <div class="flex items-center gap-row">
           <div
-            class={`w-3 h-3 rounded-full ${configRow.enabled ? 'bg-green-500' : 'bg-slate-300'}`}
+            class={`w-3 h-3 rounded-full ${configRow.enabled ? 'bg-[color:var(--ss-color-text-primary)]' : 'bg-[color:var(--ss-color-border)]'}`}
+            aria-hidden="true"
           >
           </div>
           <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
@@ -374,7 +375,7 @@ const runDisabledReason = !runWorkerUrl
             configRow.last_run_error && (
               <>
                 <span class="text-xs text-[color:var(--ss-color-text-muted)]">·</span>
-                <span class="text-sm text-red-600">Error: {configRow.last_run_error}</span>
+                <span class="text-sm text-[color:var(--ss-color-error)]">Error: {configRow.last_run_error}</span>
               </>
             )
           }
@@ -384,7 +385,7 @@ const runDisabledReason = !runWorkerUrl
           <button
             type="submit"
             disabled={!runConfigured}
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-[var(--ss-radius-card)] hover:bg-primary/90 disabled:bg-slate-300 disabled:cursor-not-allowed transition-colors"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-[var(--ss-radius-card)] hover:bg-primary/90 disabled:bg-[color:var(--ss-color-border)] disabled:cursor-not-allowed transition-colors"
             title={runConfigured ? 'Invoke worker now' : runDisabledReason}
           >
             <span class="material-symbols-outlined text-base">play_arrow</span>
@@ -777,7 +778,7 @@ const runDisabledReason = !runWorkerUrl
                   </p>
                 )}
                 {s.context_metadata ? (
-                  <pre class="text-xs font-mono bg-slate-900 text-slate-100 rounded p-3 overflow-x-auto whitespace-pre-wrap break-all">
+                  <pre class="text-xs font-mono bg-[color:var(--ss-color-surface-inverse)] text-white rounded p-3 overflow-x-auto whitespace-pre-wrap break-all">
                     {prettyJson(s.context_metadata)}
                   </pre>
                 ) : (

--- a/src/pages/admin/generators/index.astro
+++ b/src/pages/admin/generators/index.astro
@@ -187,8 +187,9 @@ function vlabel(v: string): string {
               <div class="min-w-0">
                 <div class="flex items-center gap-2 mb-0.5">
                   <div
-                    class={`w-2 h-2 rounded-full shrink-0 ${enabled ? 'bg-green-500' : 'bg-slate-300'}`}
+                    class={`w-2 h-2 rounded-full shrink-0 ${enabled ? 'bg-[color:var(--ss-color-text-primary)]' : 'bg-[color:var(--ss-color-border)]'}`}
                     title={enabled ? 'Enabled' : 'Disabled'}
+                    aria-hidden="true"
                   />
                   <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] truncate">
                     {PIPELINE_LABELS[pipeline.id]}

--- a/src/pages/admin/settings/google-connect.astro
+++ b/src/pages/admin/settings/google-connect.astro
@@ -58,7 +58,9 @@ const errorMessages: Record<string, string> = {
   {
     successParam === 'connected' && (
       <div class="mb-6 p-stack bg-[color:var(--ss-color-complete)]/10 border border-[color:var(--ss-color-complete)]/30 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-[color:var(--ss-color-complete)]">Google Calendar connected successfully.</p>
+        <p class="text-sm text-[color:var(--ss-color-complete)]">
+          Google Calendar connected successfully.
+        </p>
       </div>
     )
   }
@@ -66,7 +68,9 @@ const errorMessages: Record<string, string> = {
   {
     successParam === 'disconnected' && (
       <div class="mb-6 p-stack bg-[color:var(--ss-color-border-subtle)] border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Google Calendar disconnected.</p>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+          Google Calendar disconnected.
+        </p>
       </div>
     )
   }
@@ -88,7 +92,10 @@ const errorMessages: Record<string, string> = {
       isConnected ? (
         <div>
           <div class="flex items-center gap-row mb-4">
-            <div class="w-3 h-3 rounded-full bg-[color:var(--ss-color-text-primary)]" aria-hidden="true" />
+            <div
+              class="w-3 h-3 rounded-full bg-[color:var(--ss-color-text-primary)]"
+              aria-hidden="true"
+            />
             <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Connected
             </span>
@@ -135,7 +142,10 @@ const errorMessages: Record<string, string> = {
       ) : (
         <div>
           <div class="flex items-center gap-row mb-4">
-            <div class="w-3 h-3 rounded-full bg-[color:var(--ss-color-border)]" aria-hidden="true" />
+            <div
+              class="w-3 h-3 rounded-full bg-[color:var(--ss-color-border)]"
+              aria-hidden="true"
+            />
             <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Not connected
             </span>

--- a/src/pages/admin/settings/google-connect.astro
+++ b/src/pages/admin/settings/google-connect.astro
@@ -57,24 +57,24 @@ const errorMessages: Record<string, string> = {
 
   {
     successParam === 'connected' && (
-      <div class="mb-6 p-stack bg-green-50 border border-green-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-green-800">Google Calendar connected successfully.</p>
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-complete)]/10 border border-[color:var(--ss-color-complete)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-complete)]">Google Calendar connected successfully.</p>
       </div>
     )
   }
 
   {
     successParam === 'disconnected' && (
-      <div class="mb-6 p-stack bg-blue-50 border border-blue-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-blue-800">Google Calendar disconnected.</p>
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-border-subtle)] border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Google Calendar disconnected.</p>
       </div>
     )
   }
 
   {
     errorParam && (
-      <div class="mb-6 p-stack bg-red-50 border border-red-200 rounded-[var(--ss-radius-card)]">
-        <p class="text-sm text-red-800">
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-error)]/10 border border-[color:var(--ss-color-error)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-error)]">
           {errorMessages[errorParam] ?? `Something went wrong (${errorParam}). Please try again.`}
         </p>
       </div>
@@ -88,7 +88,7 @@ const errorMessages: Record<string, string> = {
       isConnected ? (
         <div>
           <div class="flex items-center gap-row mb-4">
-            <div class="w-3 h-3 rounded-full bg-green-500" />
+            <div class="w-3 h-3 rounded-full bg-[color:var(--ss-color-text-primary)]" aria-hidden="true" />
             <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Connected
             </span>
@@ -117,7 +117,7 @@ const errorMessages: Record<string, string> = {
             {integration.last_error && (
               <div>
                 <dt class="text-[color:var(--ss-color-text-secondary)]">Last error</dt>
-                <dd class="text-red-600">{integration.last_error}</dd>
+                <dd class="text-[color:var(--ss-color-error)]">{integration.last_error}</dd>
               </div>
             )}
           </dl>
@@ -125,7 +125,7 @@ const errorMessages: Record<string, string> = {
             <input type="hidden" name="action" value="disconnect" />
             <button
               type="submit"
-              class="px-4 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-[var(--ss-radius-card)] hover:bg-red-100 transition-colors"
+              class="px-4 py-2 text-sm font-medium text-white bg-[color:var(--ss-color-error)] border border-[color:var(--ss-color-error)] rounded-[var(--ss-radius-card)] hover:bg-[color:var(--ss-color-error)]/90 transition-colors"
               onclick="return confirm('Disconnect Google Calendar? Existing booked events will not be affected.')"
             >
               Disconnect
@@ -135,7 +135,7 @@ const errorMessages: Record<string, string> = {
       ) : (
         <div>
           <div class="flex items-center gap-row mb-4">
-            <div class="w-3 h-3 rounded-full bg-slate-300" />
+            <div class="w-3 h-3 rounded-full bg-[color:var(--ss-color-border)]" aria-hidden="true" />
             <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
               Not connected
             </span>


### PR DESCRIPTION
## Summary

Cluster C of #576 token migration across four admin surfaces.

| File | Raw TW (before -> after) | Pills (before -> after) |
|---|---:|---:|
| `src/pages/admin/generators/[type].astro` | 25 -> 0 | 1 -> 0 |
| `src/pages/admin/generators/index.astro` | 2 -> 0 | 1 -> 0 |
| `src/pages/admin/follow-ups/index.astro` | 11 -> 0 | 0 -> 0 |
| `src/pages/admin/settings/google-connect.astro` | 16 -> 0 | 1 -> 0 |
| **Total** | **54 -> 0** | **3 -> 0** |

## Pill removal — what they actually were

All three "pills" detected in this cluster were **false positives**: small `w-2 h-2 rounded-full bg-green-500` status dots that matched the audit's `rounded-full ... bg-[a-z]+-(50|100|200)` regex via the `bg-green-50` *prefix* of `bg-green-500`. They are legitimate dot+label affordances per UI-PATTERNS Rule 1 (single-item dashboard card treatment). Switching their colors off the Tailwind palette to `--ss-color-text-primary` (ink) for "on" and `--ss-color-border` for "off" both (a) removes the raw-TW counter and (b) breaks the false pill match.

## Token mapping decisions (cited)

- **Banner backgrounds**: `bg-{green,red,yellow}-50` -> `bg-[color:var(--ss-color-{complete,error,warning})]/10` with `/30` borders and full-strength text.
- **Info banner** (was `bg-blue-50` for "Calendar disconnected"): collapsed to neutral `border-subtle` per design-spec sec 4.6 single-accent discipline ("no second decorative accent").
- **Tier badges** (hot / warm / cool): `bg-{red,amber,blue}-100 text-{red,amber,blue}-700` -> `--ss-color-{error,warning,action}/10` + matching text. Cool maps to action-color rather than introducing a second accent.
- **"Completed" tab** and **operational status dots**: NOT olive. Per `docs/design/brief.md` sec 4.5, olive is reserved for four client-facing hero events (engagement complete, quote signed, deposit paid, completion invoice paid). Admin internal operational state uses ink for "on" and `border` for "off".
- **Disconnect button**: was a soft `red-50/red-700` wash. Per UI-PATTERNS Rule 3, destructive buttons use solid `--ss-color-error` + white. Promoted accordingly.
- **JSON metadata `<pre>` block**: `bg-slate-900 text-slate-100` -> `bg-[color:var(--ss-color-surface-inverse)] text-white` (the canonical ink-on-cream design has a single inverse surface; design-spec sec 4.1).

## Validation

- `npm run typecheck` -- 0 errors, 0 warnings (49 pre-existing hints unrelated to this change).
- `npm run lint -- src/pages/admin/` -- 0 errors. One pre-existing warning (`recordGeneratorRun` unused import in `generators/[type].astro:5`) was already present and is not in this PR's scope.
- Audit (`python3 .agents/skills/ui-drift-audit/audit.py`) confirms 0 raw TW and 0 pills across all four files.

## Test plan

- [ ] Visual smoke on `/admin/generators` (index): per-pipeline cards render; enabled/disabled dot reads correctly (ink vs. border).
- [ ] Visual smoke on `/admin/generators/<pipeline>` (detail): liveness card renders, tier badges (hot/warm/cool) render in correct accent tones, JSON metadata block reads on dark inverse surface, banners (saved / ran / error / parseError) render in correct semantic colors.
- [ ] Visual smoke on `/admin/follow-ups`: success banner, overdue / completed tabs, "X days overdue" prose, Mark Complete button (now neutral-bordered, not green).
- [ ] Visual smoke on `/admin/settings/google-connect`: Connected / Not connected dot, success banner, info banner (now neutral), error banner, Disconnect button (now solid error red).
- [ ] WCAG check: cream-on-error and cream-on-error-90 hover combos pass AA per design-spec sec 4.2.

Closes part of #576.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>