### PR TITLE
feat(admin): migrate engagements + analytics + home, remove pills

### DIFF
--- a/src/lib/ui/status-badge.ts
+++ b/src/lib/ui/status-badge.ts
@@ -41,6 +41,11 @@ const TONE: Record<string, string> = {
   paid: 'bg-[color:var(--ss-color-complete)] text-white',
   overdue: 'bg-[color:var(--ss-color-error)] text-white',
   void: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
+
+  // Milestone lifecycle (`completed` shared with engagement above)
+  pending: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
+  in_progress: 'bg-[color:var(--ss-color-primary)] text-white',
+  skipped: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
 }
 
 const FALLBACK = 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -340,11 +340,15 @@ function complianceBarWidth(pct: number): string {
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total invoiced</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">{formatCurrency(revenue.total_paid)}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">
+                  {formatCurrency(revenue.total_paid)}
+                </p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total paid</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-[color:var(--ss-color-attention)]">{formatCurrency(outstanding)}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-attention)]">
+                  {formatCurrency(outstanding)}
+                </p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Outstanding</p>
               </div>
             </div>
@@ -434,7 +438,9 @@ function complianceBarWidth(pct: number): string {
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Late</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-[color:var(--ss-color-error)]">{compliance.missed.toLocaleString()}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-error)]">
+                  {compliance.missed.toLocaleString()}
+                </p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Missed</p>
               </div>
             </div>

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -116,13 +116,24 @@ function formatShortDate(iso: string): string {
 }
 
 // ── Pipeline helpers ─────────────────────────────────────────────
+// Single-accent discipline (design-spec §4.6): no decorative palette per
+// stage. Burnt-orange tracks active progression; olive marks delivered;
+// brick marks lost; secondary ink for early stages.
 const pipelineStages = [
-  { key: 'prospect' as const, label: 'Prospect', color: 'bg-slate-400' },
-  { key: 'meetings' as const, label: 'Meetings', color: 'bg-blue-500' },
-  { key: 'proposing' as const, label: 'Proposing', color: 'bg-amber-500' },
-  { key: 'engaged' as const, label: 'Engaged', color: 'bg-green-500' },
-  { key: 'delivered' as const, label: 'Delivered', color: 'bg-emerald-600' },
-  { key: 'lost' as const, label: 'Lost', color: 'bg-red-500' },
+  {
+    key: 'prospect' as const,
+    label: 'Prospect',
+    color: 'bg-[color:var(--ss-color-text-secondary)]',
+  },
+  {
+    key: 'meetings' as const,
+    label: 'Meetings',
+    color: 'bg-[color:var(--ss-color-text-secondary)]',
+  },
+  { key: 'proposing' as const, label: 'Proposing', color: 'bg-[color:var(--ss-color-primary)]' },
+  { key: 'engaged' as const, label: 'Engaged', color: 'bg-[color:var(--ss-color-primary)]' },
+  { key: 'delivered' as const, label: 'Delivered', color: 'bg-[color:var(--ss-color-complete)]' },
+  { key: 'lost' as const, label: 'Lost', color: 'bg-[color:var(--ss-color-error)]' },
 ]
 
 const maxPipelineCount = Math.max(...pipelineStages.map((s) => pipeline[s.key]), 1)
@@ -135,11 +146,14 @@ function pipelineBarWidth(count: number): string {
 }
 
 // ── Quote accuracy helpers ──────────────────────────────────────
+// Render the accuracy chip flat (no fill) per Pattern 01: this is metadata
+// adjacent to the actual percentage prose, not a status pill. Use semantic
+// ink-on-cream tokens for the variance signal.
 function accuracyColor(pct: number): string {
   const variance = Math.abs(pct - 100)
-  if (variance <= 20) return 'text-green-700 bg-green-50'
-  if (variance <= 40) return 'text-amber-700 bg-amber-50'
-  return 'text-red-700 bg-red-50'
+  if (variance <= 20) return 'text-[color:var(--ss-color-complete)]'
+  if (variance <= 40) return 'text-[color:var(--ss-color-attention)]'
+  return 'text-[color:var(--ss-color-error)]'
 }
 
 const avgAccuracy =
@@ -208,9 +222,9 @@ function complianceBarWidth(pct: number): string {
                 <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-24 shrink-0">
                   {stage.label}
                 </span>
-                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-6 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-6 overflow-hidden">
                   <div
-                    class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
+                    class={`h-full ${stage.color} flex items-center justify-end pr-2`}
                     style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
                   >
                     {pipeline[stage.key] > 0 && (
@@ -288,9 +302,9 @@ function complianceBarWidth(pct: number): string {
                 <span>On-time rate</span>
                 <span>{health.on_time_pct}%</span>
               </div>
-              <div class="bg-[color:var(--ss-color-border-subtle)] rounded-full h-3 overflow-hidden">
+              <div class="bg-[color:var(--ss-color-border-subtle)] h-3 overflow-hidden">
                 <div
-                  class="h-full rounded-full bg-emerald-500"
+                  class="h-full bg-[color:var(--ss-color-complete)]"
                   style={`width: ${complianceBarWidth(health.on_time_pct)}`}
                 />
               </div>
@@ -320,11 +334,11 @@ function complianceBarWidth(pct: number): string {
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total invoiced</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-green-700">{formatCurrency(revenue.total_paid)}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-complete)]">{formatCurrency(revenue.total_paid)}</p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total paid</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-amber-700">{formatCurrency(outstanding)}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-attention)]">{formatCurrency(outstanding)}</p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Outstanding</p>
               </div>
             </div>
@@ -340,9 +354,9 @@ function complianceBarWidth(pct: number): string {
                       <span class="text-xs text-[color:var(--ss-color-text-secondary)] w-20 shrink-0">
                         {formatMonthLabel(m.month)}
                       </span>
-                      <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
+                      <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
                         <div
-                          class="h-full rounded-full bg-green-500 flex items-center justify-end pr-2"
+                          class="h-full bg-[color:var(--ss-color-complete)] flex items-center justify-end pr-2"
                           style={`width: ${revenueBarWidth(m.amount)}`}
                         >
                           {m.amount > 0 && (
@@ -402,19 +416,19 @@ function complianceBarWidth(pct: number): string {
             </div>
             <div class="grid grid-cols-3 gap-stack text-center">
               <div>
-                <p class="text-lg font-bold text-green-700">
+                <p class="text-lg font-bold text-[color:var(--ss-color-complete)]">
                   {compliance.completed_on_time.toLocaleString()}
                 </p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">On time</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-amber-700">
+                <p class="text-lg font-bold text-[color:var(--ss-color-attention)]">
                   {compliance.completed_late.toLocaleString()}
                 </p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Late</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-red-700">{compliance.missed.toLocaleString()}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-error)]">{compliance.missed.toLocaleString()}</p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Missed</p>
               </div>
             </div>
@@ -423,9 +437,9 @@ function complianceBarWidth(pct: number): string {
                 <span>Compliance</span>
                 <span>{compliance.compliance_pct}%</span>
               </div>
-              <div class="bg-[color:var(--ss-color-border-subtle)] rounded-full h-3 overflow-hidden">
+              <div class="bg-[color:var(--ss-color-border-subtle)] h-3 overflow-hidden">
                 <div
-                  class="h-full rounded-full bg-green-500"
+                  class="h-full bg-[color:var(--ss-color-complete)]"
                   style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
                 />
               </div>
@@ -551,9 +565,9 @@ function complianceBarWidth(pct: number): string {
                 <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-36 shrink-0 truncate font-mono">
                   {row.path}
                 </span>
-                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
                   <div
-                    class="h-full rounded-full bg-blue-500 flex items-center justify-end pr-2"
+                    class="h-full bg-[color:var(--ss-color-text-secondary)] flex items-center justify-end pr-2"
                     style={`width: ${pathBarWidth(row.views)}`}
                   >
                     {row.views > 0 && (
@@ -590,9 +604,9 @@ function complianceBarWidth(pct: number): string {
                 <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-36 shrink-0 truncate font-mono">
                   {row.cta}
                 </span>
-                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
                   <div
-                    class="h-full rounded-full bg-amber-500 flex items-center justify-end pr-2"
+                    class="h-full bg-[color:var(--ss-color-primary)] flex items-center justify-end pr-2"
                     style={`width: ${ctaBarWidth(row.clicks)}`}
                   >
                     {row.clicks > 0 && (
@@ -632,9 +646,9 @@ function complianceBarWidth(pct: number): string {
                   <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-44 shrink-0">
                     {step.label}
                   </span>
-                  <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-6 overflow-hidden">
+                  <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-6 overflow-hidden">
                     <div
-                      class="h-full rounded-full bg-emerald-500 flex items-center justify-end pr-2"
+                      class="h-full bg-[color:var(--ss-color-complete)] flex items-center justify-end pr-2"
                       style={`width: ${funnelBarWidth(count)}`}
                     >
                       {count > 0 && (
@@ -680,7 +694,13 @@ function complianceBarWidth(pct: number): string {
                 const y = dailyChartHeight - h
                 return (
                   <g>
-                    <rect x={x} y={y} width={dailyBarWidth} height={h} fill="#6366f1" rx={1}>
+                    <rect
+                      x={x}
+                      y={y}
+                      width={dailyBarWidth}
+                      height={h}
+                      fill="var(--ss-color-primary)"
+                    >
                       <title>{`${row.day}: ${row.uniques} unique sessions`}</title>
                     </rect>
                   </g>

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -116,9 +116,10 @@ function formatShortDate(iso: string): string {
 }
 
 // ── Pipeline helpers ─────────────────────────────────────────────
-// Single-accent discipline (design-spec §4.6): no decorative palette per
-// stage. Burnt-orange tracks active progression; olive marks delivered;
-// brick marks lost; secondary ink for early stages.
+// Olive discipline (brief §4.5): admin operational state never uses
+// --ss-color-complete (olive). Single-accent discipline (design-spec §4.6):
+// burnt-orange tracks active progression; ink marks terminal stages; brick
+// marks lost; secondary ink for early stages.
 const pipelineStages = [
   {
     key: 'prospect' as const,
@@ -132,7 +133,11 @@ const pipelineStages = [
   },
   { key: 'proposing' as const, label: 'Proposing', color: 'bg-[color:var(--ss-color-primary)]' },
   { key: 'engaged' as const, label: 'Engaged', color: 'bg-[color:var(--ss-color-primary)]' },
-  { key: 'delivered' as const, label: 'Delivered', color: 'bg-[color:var(--ss-color-complete)]' },
+  {
+    key: 'delivered' as const,
+    label: 'Delivered',
+    color: 'bg-[color:var(--ss-color-text-primary)]',
+  },
   { key: 'lost' as const, label: 'Lost', color: 'bg-[color:var(--ss-color-error)]' },
 ]
 
@@ -147,11 +152,12 @@ function pipelineBarWidth(count: number): string {
 
 // ── Quote accuracy helpers ──────────────────────────────────────
 // Render the accuracy chip flat (no fill) per Pattern 01: this is metadata
-// adjacent to the actual percentage prose, not a status pill. Use semantic
-// ink-on-cream tokens for the variance signal.
+// adjacent to the actual percentage prose, not a status pill. Olive
+// discipline (brief §4.5): on-target accuracy is operational data, not a
+// hero event — use ink, not olive.
 function accuracyColor(pct: number): string {
   const variance = Math.abs(pct - 100)
-  if (variance <= 20) return 'text-[color:var(--ss-color-complete)]'
+  if (variance <= 20) return 'text-[color:var(--ss-color-text-primary)]'
   if (variance <= 40) return 'text-[color:var(--ss-color-attention)]'
   return 'text-[color:var(--ss-color-error)]'
 }
@@ -304,7 +310,7 @@ function complianceBarWidth(pct: number): string {
               </div>
               <div class="bg-[color:var(--ss-color-border-subtle)] h-3 overflow-hidden">
                 <div
-                  class="h-full bg-[color:var(--ss-color-complete)]"
+                  class="h-full bg-[color:var(--ss-color-text-primary)]"
                   style={`width: ${complianceBarWidth(health.on_time_pct)}`}
                 />
               </div>
@@ -334,7 +340,7 @@ function complianceBarWidth(pct: number): string {
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total invoiced</p>
               </div>
               <div>
-                <p class="text-lg font-bold text-[color:var(--ss-color-complete)]">{formatCurrency(revenue.total_paid)}</p>
+                <p class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">{formatCurrency(revenue.total_paid)}</p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">Total paid</p>
               </div>
               <div>
@@ -356,7 +362,7 @@ function complianceBarWidth(pct: number): string {
                       </span>
                       <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
                         <div
-                          class="h-full bg-[color:var(--ss-color-complete)] flex items-center justify-end pr-2"
+                          class="h-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
                           style={`width: ${revenueBarWidth(m.amount)}`}
                         >
                           {m.amount > 0 && (
@@ -416,7 +422,7 @@ function complianceBarWidth(pct: number): string {
             </div>
             <div class="grid grid-cols-3 gap-stack text-center">
               <div>
-                <p class="text-lg font-bold text-[color:var(--ss-color-complete)]">
+                <p class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">
                   {compliance.completed_on_time.toLocaleString()}
                 </p>
                 <p class="text-xs text-[color:var(--ss-color-text-secondary)]">On time</p>
@@ -439,7 +445,7 @@ function complianceBarWidth(pct: number): string {
               </div>
               <div class="bg-[color:var(--ss-color-border-subtle)] h-3 overflow-hidden">
                 <div
-                  class="h-full bg-[color:var(--ss-color-complete)]"
+                  class="h-full bg-[color:var(--ss-color-text-primary)]"
                   style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
                 />
               </div>
@@ -648,7 +654,7 @@ function complianceBarWidth(pct: number): string {
                   </span>
                   <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-6 overflow-hidden">
                     <div
-                      class="h-full bg-[color:var(--ss-color-complete)] flex items-center justify-end pr-2"
+                      class="h-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
                       style={`width: ${funnelBarWidth(count)}`}
                     >
                       {count > 0 && (

--- a/src/pages/admin/analytics/index.astro
+++ b/src/pages/admin/analytics/index.astro
@@ -228,9 +228,9 @@ function complianceBarWidth(pct: number): string {
                 <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-24 shrink-0">
                   {stage.label}
                 </span>
-                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-6 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-6 overflow-hidden">
                   <div
-                    class={`h-full ${stage.color} flex items-center justify-end pr-2`}
+                    class={`h-full rounded-full ${stage.color} flex items-center justify-end pr-2`}
                     style={`width: ${pipelineBarWidth(pipeline[stage.key])}`}
                   >
                     {pipeline[stage.key] > 0 && (
@@ -308,9 +308,9 @@ function complianceBarWidth(pct: number): string {
                 <span>On-time rate</span>
                 <span>{health.on_time_pct}%</span>
               </div>
-              <div class="bg-[color:var(--ss-color-border-subtle)] h-3 overflow-hidden">
+              <div class="bg-[color:var(--ss-color-border-subtle)] rounded-full h-3 overflow-hidden">
                 <div
-                  class="h-full bg-[color:var(--ss-color-text-primary)]"
+                  class="h-full rounded-full bg-[color:var(--ss-color-text-primary)]"
                   style={`width: ${complianceBarWidth(health.on_time_pct)}`}
                 />
               </div>
@@ -360,9 +360,9 @@ function complianceBarWidth(pct: number): string {
                       <span class="text-xs text-[color:var(--ss-color-text-secondary)] w-20 shrink-0">
                         {formatMonthLabel(m.month)}
                       </span>
-                      <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
+                      <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
                         <div
-                          class="h-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
+                          class="h-full rounded-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
                           style={`width: ${revenueBarWidth(m.amount)}`}
                         >
                           {m.amount > 0 && (
@@ -443,9 +443,9 @@ function complianceBarWidth(pct: number): string {
                 <span>Compliance</span>
                 <span>{compliance.compliance_pct}%</span>
               </div>
-              <div class="bg-[color:var(--ss-color-border-subtle)] h-3 overflow-hidden">
+              <div class="bg-[color:var(--ss-color-border-subtle)] rounded-full h-3 overflow-hidden">
                 <div
-                  class="h-full bg-[color:var(--ss-color-text-primary)]"
+                  class="h-full rounded-full bg-[color:var(--ss-color-text-primary)]"
                   style={`width: ${complianceBarWidth(compliance.compliance_pct)}`}
                 />
               </div>
@@ -571,9 +571,9 @@ function complianceBarWidth(pct: number): string {
                 <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-36 shrink-0 truncate font-mono">
                   {row.path}
                 </span>
-                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
                   <div
-                    class="h-full bg-[color:var(--ss-color-text-secondary)] flex items-center justify-end pr-2"
+                    class="h-full rounded-full bg-[color:var(--ss-color-text-secondary)] flex items-center justify-end pr-2"
                     style={`width: ${pathBarWidth(row.views)}`}
                   >
                     {row.views > 0 && (
@@ -610,9 +610,9 @@ function complianceBarWidth(pct: number): string {
                 <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-36 shrink-0 truncate font-mono">
                   {row.cta}
                 </span>
-                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-5 overflow-hidden">
+                <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
                   <div
-                    class="h-full bg-[color:var(--ss-color-primary)] flex items-center justify-end pr-2"
+                    class="h-full rounded-full bg-[color:var(--ss-color-primary)] flex items-center justify-end pr-2"
                     style={`width: ${ctaBarWidth(row.clicks)}`}
                   >
                     {row.clicks > 0 && (
@@ -652,9 +652,9 @@ function complianceBarWidth(pct: number): string {
                   <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-44 shrink-0">
                     {step.label}
                   </span>
-                  <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] h-6 overflow-hidden">
+                  <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-6 overflow-hidden">
                     <div
-                      class="h-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
+                      class="h-full rounded-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
                       style={`width: ${funnelBarWidth(count)}`}
                     >
                       {count > 0 && (

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -198,9 +198,7 @@ function fileSize(bytes: number): string {
             {depositInvoice && (
               <div class="mt-2 text-sm">
                 <span class="text-[color:var(--ss-color-text-secondary)]">Deposit Invoice:</span>{' '}
-                <span class={statusBadgeClass(depositInvoice.status)}>
-                  {depositInvoice.status}
-                </span>
+                <span class={statusBadgeClass(depositInvoice.status)}>{depositInvoice.status}</span>
                 <span class="ml-2 text-[color:var(--ss-color-text-secondary)]">
                   ${depositInvoice.amount.toLocaleString()}
                 </span>
@@ -729,9 +727,7 @@ function fileSize(bytes: number): string {
             {contextEntries.map((entry) => (
               <div class="px-6 py-3">
                 <div class="flex items-center gap-2 mb-1">
-                  <span class={contextTypeEyebrowClass()}>
-                    {entry.type.replace(/_/g, ' ')}
-                  </span>
+                  <span class={contextTypeEyebrowClass()}>{entry.type.replace(/_/g, ' ')}</span>
                   <span class="text-xs text-[color:var(--ss-color-text-muted)]">
                     {formatDate(entry.created_at)}
                   </span>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -12,6 +12,13 @@ import { listContext } from '../../../lib/db/context'
 import { listDocuments } from '../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 
+// Context-entry type → flat eyebrow class. Per Pattern 01 these are
+// category labels above a record, not state — render as ink-on-cream
+// uppercase eyebrow, no fill, no rounded shape.
+function contextTypeEyebrowClass(): string {
+  return 'text-label uppercase font-mono text-[color:var(--ss-color-text-secondary)] tracking-[var(--ss-text-letter-spacing-label)]'
+}
+
 const session = Astro.locals.session!
 if (session.role !== 'admin') return Astro.redirect('/login')
 
@@ -51,53 +58,6 @@ function formatDate(d: string | null): string {
   })
 }
 
-function msBadgeClass(s: string): string {
-  switch (s) {
-    case 'pending':
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-    case 'in_progress':
-      return 'bg-blue-100 text-blue-700'
-    case 'completed':
-      return 'bg-green-100 text-green-700'
-    case 'skipped':
-      return 'bg-red-100 text-red-600'
-    default:
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  }
-}
-
-function invoiceBadgeClass(s: string): string {
-  switch (s) {
-    case 'draft':
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-    case 'sent':
-      return 'bg-blue-100 text-blue-700'
-    case 'paid':
-      return 'bg-green-100 text-green-700'
-    case 'overdue':
-      return 'bg-red-100 text-red-600'
-    case 'void':
-      return 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'
-    default:
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  }
-}
-
-function contextTypeBadgeClass(t: string): string {
-  switch (t) {
-    case 'note':
-      return 'bg-blue-100 text-blue-700'
-    case 'stage_change':
-      return 'bg-yellow-100 text-yellow-700'
-    case 'engagement_log':
-      return 'bg-green-100 text-green-700'
-    case 'feedback':
-      return 'bg-purple-100 text-purple-700'
-    default:
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  }
-}
-
 function fileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
@@ -116,28 +76,28 @@ function fileSize(bytes: number): string {
   <div class="space-y-card">
     {
       saved && (
-        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
+        <div class="border-l-4 border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
           Changes saved.
         </div>
       )
     }
     {
       milestoneAdded && (
-        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
+        <div class="border-l-4 border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
           Milestone added.
         </div>
       )
     }
     {
       milestoneDeleted && (
-        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-2 rounded text-sm">
+        <div class="border-l-4 border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
           Milestone deleted.
         </div>
       )
     }
     {
       error && (
-        <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-2 rounded text-sm">
+        <div class="border-l-4 border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
           {error === 'invalid_status'
             ? 'Invalid status transition.'
             : error === 'invalid_transition'
@@ -181,9 +141,9 @@ function fileSize(bytes: number): string {
                   <input type="hidden" name="new_status" value={ns} />
                   <button
                     type="submit"
-                    class={`text-xs px-3 py-1.5 rounded font-medium border transition-colors ${
+                    class={`text-xs px-3 py-1.5 font-medium border transition-colors ${
                       ns === 'cancelled'
-                        ? 'border-red-300 text-red-700 hover:bg-red-50'
+                        ? 'border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)]'
                         : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)]'
                     }`}
                   >
@@ -238,9 +198,7 @@ function fileSize(bytes: number): string {
             {depositInvoice && (
               <div class="mt-2 text-sm">
                 <span class="text-[color:var(--ss-color-text-secondary)]">Deposit Invoice:</span>{' '}
-                <span
-                  class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(depositInvoice.status)}`}
-                >
+                <span class={statusBadgeClass(depositInvoice.status)}>
                   {depositInvoice.status}
                 </span>
                 <span class="ml-2 text-[color:var(--ss-color-text-secondary)]">
@@ -358,7 +316,7 @@ function fileSize(bytes: number): string {
           <div class="flex justify-end">
             <button
               type="submit"
-              class="bg-slate-900 text-white text-sm px-4 py-2 rounded hover:bg-slate-800 transition-colors"
+              class="bg-[color:var(--ss-color-primary)] text-white text-sm px-4 py-2 hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
             >
               Save Changes
             </button>
@@ -390,14 +348,15 @@ function fileSize(bytes: number): string {
               <div class="px-6 py-4 flex items-center justify-between gap-stack">
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2">
-                    <span class={`text-xs px-2 py-0.5 rounded ${msBadgeClass(ms.status)}`}>
-                      {ms.status}
-                    </span>
+                    <span class={statusBadgeClass(ms.status)}>{ms.status}</span>
                     <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)] truncate">
                       {ms.name}
                     </span>
                     {ms.payment_trigger ? (
-                      <span class="text-xs px-1.5 py-0.5 rounded bg-amber-100 text-amber-700">
+                      <span
+                        title="Payment trigger"
+                        class="inline-flex items-center px-1.5 py-0.5 bg-[color:var(--ss-color-attention)] text-white text-label uppercase font-mono tracking-[var(--ss-text-letter-spacing-label)]"
+                      >
                         $
                       </span>
                     ) : null}
@@ -423,10 +382,10 @@ function fileSize(bytes: number): string {
                       title={
                         ms.payment_trigger ? 'Remove payment trigger' : 'Set as payment trigger'
                       }
-                      class={`text-xs px-2 py-1 rounded border transition-colors ${
+                      class={`text-xs px-2 py-1 border transition-colors ${
                         ms.payment_trigger
-                          ? 'border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100'
-                          : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-secondary)] hover:border-[color:var(--ss-color-border)]'
+                          ? 'border-[color:var(--ss-color-attention)] text-[color:var(--ss-color-attention)] hover:bg-[color:var(--ss-color-background)]'
+                          : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-secondary)]'
                       }`}
                     >
                       $
@@ -443,11 +402,11 @@ function fileSize(bytes: number): string {
                       <input type="hidden" name="new_status" value={ns} />
                       <button
                         type="submit"
-                        class={`text-xs px-2.5 py-1 rounded border transition-colors ${
+                        class={`text-xs px-2.5 py-1 border transition-colors ${
                           ns === 'completed'
-                            ? 'border-green-300 text-green-700 hover:bg-green-50'
+                            ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)] hover:bg-[color:var(--ss-color-background)]'
                             : ns === 'in_progress'
-                              ? 'border-blue-300 text-blue-700 hover:bg-blue-50'
+                              ? 'border-[color:var(--ss-color-primary)] text-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-background)]'
                               : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)]'
                         }`}
                       >
@@ -471,7 +430,7 @@ function fileSize(bytes: number): string {
                       <input type="hidden" name="milestone_id" value={ms.id} />
                       <button
                         type="submit"
-                        class="text-xs px-2 py-1 rounded border border-red-200 text-red-500 hover:bg-red-50 transition-colors"
+                        class="text-xs px-2 py-1 border border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)] transition-colors"
                         onclick="return confirm('Delete this milestone?')"
                       >
                         Del
@@ -553,7 +512,7 @@ function fileSize(bytes: number): string {
               <input type="hidden" name="sort_order" value={String(milestones.length)} />
               <button
                 type="submit"
-                class="ml-auto bg-slate-900 text-white text-xs px-3 py-1.5 rounded hover:bg-slate-800 transition-colors"
+                class="ml-auto bg-[color:var(--ss-color-primary)] text-white text-xs px-3 py-1.5 hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
               >
                 Add Milestone
               </button>
@@ -629,7 +588,7 @@ function fileSize(bytes: number): string {
               <button
                 type="button"
                 id="photo-upload"
-                class="hidden text-xs px-3 py-1.5 rounded bg-slate-900 text-white hover:bg-slate-800 transition-colors"
+                class="hidden text-xs px-3 py-1.5 bg-[color:var(--ss-color-primary)] text-white hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
               >
                 Upload
               </button>
@@ -645,7 +604,7 @@ function fileSize(bytes: number): string {
                   <button
                     type="button"
                     id="photo-remove"
-                    class="text-xs px-3 py-1.5 rounded border border-red-200 text-red-600 hover:bg-red-50 transition-colors"
+                    class="text-xs px-3 py-1.5 border border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)] transition-colors"
                   >
                     Remove
                   </button>
@@ -683,7 +642,7 @@ function fileSize(bytes: number): string {
                   <li class="flex items-center justify-between text-sm">
                     <a
                       href={`/api/admin/engagements/${engagementId}/deliverables/${name}`}
-                      class="text-blue-600 hover:underline truncate"
+                      class="text-[color:var(--ss-color-primary)] hover:underline truncate"
                     >
                       {name}
                     </a>
@@ -731,9 +690,7 @@ function fileSize(bytes: number): string {
             {invoices.map((inv) => (
               <div class="px-6 py-3 flex items-center justify-between text-sm">
                 <div class="flex items-center gap-row">
-                  <span class={`text-xs px-2 py-0.5 rounded ${invoiceBadgeClass(inv.status)}`}>
-                    {inv.status}
-                  </span>
+                  <span class={statusBadgeClass(inv.status)}>{inv.status}</span>
                   <span class="text-[color:var(--ss-color-text-primary)] capitalize">
                     {inv.type}
                   </span>
@@ -772,7 +729,7 @@ function fileSize(bytes: number): string {
             {contextEntries.map((entry) => (
               <div class="px-6 py-3">
                 <div class="flex items-center gap-2 mb-1">
-                  <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadgeClass(entry.type)}`}>
+                  <span class={contextTypeEyebrowClass()}>
                     {entry.type.replace(/_/g, ' ')}
                   </span>
                   <span class="text-xs text-[color:var(--ss-color-text-muted)]">
@@ -804,14 +761,14 @@ function fileSize(bytes: number): string {
 
     uploadArea.addEventListener('dragover', (e) => {
       e.preventDefault()
-      uploadArea.classList.add('border-blue-400', 'bg-blue-50')
+      uploadArea.classList.add('drag-active')
     })
     uploadArea.addEventListener('dragleave', () => {
-      uploadArea.classList.remove('border-blue-400', 'bg-blue-50')
+      uploadArea.classList.remove('drag-active')
     })
     uploadArea.addEventListener('drop', (e) => {
       e.preventDefault()
-      uploadArea.classList.remove('border-blue-400', 'bg-blue-50')
+      uploadArea.classList.remove('drag-active')
       uploadFiles(e.dataTransfer.files)
     })
 
@@ -863,7 +820,7 @@ function fileSize(bytes: number): string {
       if (!photoStatus) return
       photoStatus.textContent = msg
       photoStatus.className = isError
-        ? 'mt-2 text-xs text-red-600'
+        ? 'mt-2 text-xs text-[color:var(--ss-color-error)]'
         : 'mt-2 text-xs text-[color:var(--ss-color-text-secondary)]'
     }
 
@@ -984,4 +941,13 @@ function fileSize(bytes: number): string {
       })
     }
   </script>
+
+  <style>
+    /* Drag-target feedback for the deliverables uploader. Toggled in JS via
+       the `.drag-active` class so the visual state stays in tokens. */
+    .drag-active {
+      border-color: var(--ss-color-primary);
+      background-color: var(--ss-color-background);
+    }
+  </style>
 </AdminLayout>

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -404,7 +404,7 @@ function fileSize(bytes: number): string {
                         type="submit"
                         class={`text-xs px-2.5 py-1 border transition-colors ${
                           ns === 'completed'
-                            ? 'border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)] hover:bg-[color:var(--ss-color-background)]'
+                            ? 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)]'
                             : ns === 'in_progress'
                               ? 'border-[color:var(--ss-color-primary)] text-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-background)]'
                               : 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)]'

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -469,7 +469,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           <div class="flex items-center gap-2">
             <div
               class:list={[
-                'w-2 h-2',
+                'w-2 h-2 rounded-full',
                 calStatus === 'active'
                   ? 'bg-[color:var(--ss-color-text-primary)]'
                   : calStatus === 'error' || calStatus === 'revoked'
@@ -524,7 +524,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
             pipelineRows.map((p) => (
               <div class="flex items-center justify-between py-2">
                 <div class="flex items-center gap-2">
-                  <div class:list={['w-2 h-2', p.color]} />
+                  <div class:list={['w-2 h-2 rounded-full', p.color]} />
                   <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{p.label}</span>
                 </div>
                 <span class="text-xs text-[color:var(--ss-color-text-muted)]">{p.ago}</span>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -79,14 +79,23 @@ const overdueCount = overdueFollowUps.length
 const signalCount = signals.length
 
 // Pipeline
+// Single-accent discipline (design-spec §4.6): pipeline progression rendered
+// through ink hierarchy + the burnt-orange accent + olive completion. No
+// per-stage decorative palette.
 const pipelineStages = [
-  { label: 'Signals', count: signalCount, stage: 'signal', color: 'amber' },
-  { label: 'Prospects', count: pipeline.prospect, stage: 'prospect', color: 'blue' },
-  { label: 'Meetings', count: pipeline.meetings, stage: 'meetings', color: 'indigo' },
-  { label: 'Proposing', count: pipeline.proposing, stage: 'proposing', color: 'purple' },
-  { label: 'Engaged', count: pipeline.engaged, stage: 'engaged', color: 'green' },
-  { label: 'Delivered', count: pipeline.delivered, stage: 'delivered', color: 'teal' },
-]
+  { label: 'Signals', count: signalCount, stage: 'signal', tone: 'meta' },
+  { label: 'Prospects', count: pipeline.prospect, stage: 'prospect', tone: 'meta' },
+  { label: 'Meetings', count: pipeline.meetings, stage: 'meetings', tone: 'primary' },
+  { label: 'Proposing', count: pipeline.proposing, stage: 'proposing', tone: 'primary' },
+  { label: 'Engaged', count: pipeline.engaged, stage: 'engaged', tone: 'complete' },
+  { label: 'Delivered', count: pipeline.delivered, stage: 'delivered', tone: 'complete' },
+] as const
+
+const STAGE_FILL: Record<(typeof pipelineStages)[number]['tone'], string> = {
+  meta: 'bg-[color:var(--ss-color-text-secondary)]',
+  primary: 'bg-[color:var(--ss-color-primary)]',
+  complete: 'bg-[color:var(--ss-color-complete)]',
+}
 const totalPipeline = pipelineStages.reduce((sum, s) => sum + s.count, 0)
 
 // Engagements
@@ -136,7 +145,11 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
   }
   const h = hoursAgo(r.last_signal)
   const color =
-    h < thresholds.warn ? 'bg-green-500' : h < thresholds.critical ? 'bg-amber-400' : 'bg-red-500'
+    h < thresholds.warn
+      ? 'bg-[color:var(--ss-color-complete)]'
+      : h < thresholds.critical
+        ? 'bg-[color:var(--ss-color-attention)]'
+        : 'bg-[color:var(--ss-color-error)]'
   return { id: r.source_pipeline, label: thresholds.label, ago: relativeTime(r.last_signal), color }
 })
 ---
@@ -157,9 +170,9 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
         >
           <div
             class:list={[
-              'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+              'w-10 h-10 rounded-[var(--ss-radius-card)] flex items-center justify-center text-sm font-semibold',
               signalCount > 0
-                ? 'bg-amber-100 text-amber-700'
+                ? 'bg-[color:var(--ss-color-attention)] text-white'
                 : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-muted)]',
             ]}
           >
@@ -178,9 +191,9 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
         <div class="flex items-center gap-row p-row rounded-[var(--ss-radius-card)]">
           <div
             class:list={[
-              'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+              'w-10 h-10 rounded-[var(--ss-radius-card)] flex items-center justify-center text-sm font-semibold',
               todayAssessments.length > 0
-                ? 'bg-indigo-100 text-indigo-700'
+                ? 'bg-[color:var(--ss-color-primary)] text-white'
                 : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-muted)]',
             ]}
           >
@@ -216,9 +229,9 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
         >
           <div
             class:list={[
-              'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold',
+              'w-10 h-10 rounded-[var(--ss-radius-card)] flex items-center justify-center text-sm font-semibold',
               overdueCount > 0
-                ? 'bg-red-100 text-red-700'
+                ? 'bg-[color:var(--ss-color-error)] text-white'
                 : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-muted)]',
             ]}
           >
@@ -252,18 +265,11 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
       <!-- Funnel bar -->
       {
         totalPipeline > 0 && (
-          <div class="flex h-3 rounded-full overflow-hidden mb-4 bg-[color:var(--ss-color-border-subtle)]">
+          <div class="flex h-3 overflow-hidden mb-4 bg-[color:var(--ss-color-border-subtle)]">
             {pipelineStages.map((s) =>
               s.count > 0 ? (
                 <div
-                  class:list={[
-                    s.color === 'amber' && 'bg-amber-400',
-                    s.color === 'blue' && 'bg-blue-400',
-                    s.color === 'indigo' && 'bg-indigo-400',
-                    s.color === 'purple' && 'bg-purple-400',
-                    s.color === 'green' && 'bg-green-400',
-                    s.color === 'teal' && 'bg-teal-400',
-                  ]}
+                  class={STAGE_FILL[s.tone]}
                   style={`width: ${(s.count / totalPipeline) * 100}%`}
                   title={`${s.label}: ${s.count}`}
                 />
@@ -327,7 +333,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           </div>
           <div class="flex justify-between items-baseline">
             <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Paid</span>
-            <span class="text-lg font-semibold text-green-600">
+            <span class="text-lg font-semibold text-[color:var(--ss-color-complete)]">
               ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
@@ -336,7 +342,9 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
             <span
               class:list={[
                 'text-lg font-semibold',
-                outstandingTotal > 0 ? 'text-amber-600' : 'text-[color:var(--ss-color-text-muted)]',
+                outstandingTotal > 0
+                  ? 'text-[color:var(--ss-color-attention)]'
+                  : 'text-[color:var(--ss-color-text-muted)]',
               ]}
             >
               ${outstandingTotal.toLocaleString('en-US', { minimumFractionDigits: 0 })}
@@ -389,10 +397,10 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               class:list={[
                 'text-lg font-semibold',
                 compliance.compliance_pct >= 80
-                  ? 'text-green-600'
+                  ? 'text-[color:var(--ss-color-complete)]'
                   : compliance.compliance_pct >= 50
-                    ? 'text-amber-600'
-                    : 'text-red-600',
+                    ? 'text-[color:var(--ss-color-attention)]'
+                    : 'text-[color:var(--ss-color-error)]',
               ]}
             >
               {compliance.compliance_pct}%
@@ -410,7 +418,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               class:list={[
                 'text-sm font-medium',
                 compliance.completed_late > 0
-                  ? 'text-amber-600'
+                  ? 'text-[color:var(--ss-color-attention)]'
                   : 'text-[color:var(--ss-color-text-primary)]',
               ]}
             >
@@ -423,7 +431,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               class:list={[
                 'text-sm font-medium',
                 compliance.missed > 0
-                  ? 'text-red-600'
+                  ? 'text-[color:var(--ss-color-error)]'
                   : 'text-[color:var(--ss-color-text-primary)]',
               ]}
             >
@@ -456,12 +464,12 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           <div class="flex items-center gap-2">
             <div
               class:list={[
-                'w-2 h-2 rounded-full',
+                'w-2 h-2',
                 calStatus === 'active'
-                  ? 'bg-green-500'
+                  ? 'bg-[color:var(--ss-color-complete)]'
                   : calStatus === 'error' || calStatus === 'revoked'
-                    ? 'bg-red-500'
-                    : 'bg-slate-300',
+                    ? 'bg-[color:var(--ss-color-error)]'
+                    : 'bg-[color:var(--ss-color-border)]',
               ]}
             >
             </div>
@@ -471,7 +479,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
             class:list={[
               'text-xs',
               calStatus === 'error' || calStatus === 'revoked'
-                ? 'text-red-600'
+                ? 'text-[color:var(--ss-color-error)]'
                 : 'text-[color:var(--ss-color-text-muted)]',
             ]}
           >
@@ -492,12 +500,12 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           (syncErrors > 0 || syncStuck > 0) && (
             <div class="py-2 pl-4">
               {syncErrors > 0 && (
-                <p class="text-xs text-red-600">
+                <p class="text-xs text-[color:var(--ss-color-error)]">
                   {syncErrors} booking{syncErrors === 1 ? '' : 's'} failed to sync
                 </p>
               )}
               {syncStuck > 0 && (
-                <p class="text-xs text-amber-600">
+                <p class="text-xs text-[color:var(--ss-color-attention)]">
                   {syncStuck} booking{syncStuck === 1 ? '' : 's'} stuck pending
                 </p>
               )}
@@ -511,7 +519,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
             pipelineRows.map((p) => (
               <div class="flex items-center justify-between py-2">
                 <div class="flex items-center gap-2">
-                  <div class:list={['w-2 h-2 rounded-full', p.color]} />
+                  <div class:list={['w-2 h-2', p.color]} />
                   <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{p.label}</span>
                 </div>
                 <span class="text-xs text-[color:var(--ss-color-text-muted)]">{p.ago}</span>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -79,22 +79,26 @@ const overdueCount = overdueFollowUps.length
 const signalCount = signals.length
 
 // Pipeline
-// Single-accent discipline (design-spec §4.6): pipeline progression rendered
-// through ink hierarchy + the burnt-orange accent + olive completion. No
-// per-stage decorative palette.
+// Olive discipline (brief §4.5): admin operational state never uses
+// --ss-color-complete (olive). Olive is reserved for four client-facing
+// hero events on the portal (engagement complete, quote signed, deposit
+// paid, completion invoice paid) and never appears on this dashboard.
+// Single-accent discipline (design-spec §4.6): active stages take the
+// accent; terminal stages take ink; inactive early stages take secondary
+// ink.
 const pipelineStages = [
   { label: 'Signals', count: signalCount, stage: 'signal', tone: 'meta' },
   { label: 'Prospects', count: pipeline.prospect, stage: 'prospect', tone: 'meta' },
   { label: 'Meetings', count: pipeline.meetings, stage: 'meetings', tone: 'primary' },
   { label: 'Proposing', count: pipeline.proposing, stage: 'proposing', tone: 'primary' },
-  { label: 'Engaged', count: pipeline.engaged, stage: 'engaged', tone: 'complete' },
-  { label: 'Delivered', count: pipeline.delivered, stage: 'delivered', tone: 'complete' },
+  { label: 'Engaged', count: pipeline.engaged, stage: 'engaged', tone: 'ink' },
+  { label: 'Delivered', count: pipeline.delivered, stage: 'delivered', tone: 'ink' },
 ] as const
 
 const STAGE_FILL: Record<(typeof pipelineStages)[number]['tone'], string> = {
   meta: 'bg-[color:var(--ss-color-text-secondary)]',
   primary: 'bg-[color:var(--ss-color-primary)]',
-  complete: 'bg-[color:var(--ss-color-complete)]',
+  ink: 'bg-[color:var(--ss-color-text-primary)]',
 }
 const totalPipeline = pipelineStages.reduce((sum, s) => sum + s.count, 0)
 
@@ -144,9 +148,10 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
     label: r.source_pipeline.replace(/_/g, ' '),
   }
   const h = hoursAgo(r.last_signal)
+  // Operational freshness — fresh = ink (not olive, per brief §4.5).
   const color =
     h < thresholds.warn
-      ? 'bg-[color:var(--ss-color-complete)]'
+      ? 'bg-[color:var(--ss-color-text-primary)]'
       : h < thresholds.critical
         ? 'bg-[color:var(--ss-color-attention)]'
         : 'bg-[color:var(--ss-color-error)]'
@@ -333,7 +338,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
           </div>
           <div class="flex justify-between items-baseline">
             <span class="text-sm text-[color:var(--ss-color-text-secondary)]">Paid</span>
-            <span class="text-lg font-semibold text-[color:var(--ss-color-complete)]">
+            <span class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
               ${revenue.total_paid.toLocaleString('en-US', { minimumFractionDigits: 0 })}
             </span>
           </div>
@@ -397,7 +402,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               class:list={[
                 'text-lg font-semibold',
                 compliance.compliance_pct >= 80
-                  ? 'text-[color:var(--ss-color-complete)]'
+                  ? 'text-[color:var(--ss-color-text-primary)]'
                   : compliance.compliance_pct >= 50
                     ? 'text-[color:var(--ss-color-attention)]'
                     : 'text-[color:var(--ss-color-error)]',
@@ -466,7 +471,7 @@ const pipelineRows = (pipelineFreshness?.results ?? []).map((r) => {
               class:list={[
                 'w-2 h-2',
                 calStatus === 'active'
-                  ? 'bg-[color:var(--ss-color-complete)]'
+                  ? 'bg-[color:var(--ss-color-text-primary)]'
                   : calStatus === 'error' || calStatus === 'revoked'
                     ? 'bg-[color:var(--ss-color-error)]'
                     : 'bg-[color:var(--ss-color-border)]',

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -264,20 +264,25 @@ describe('analytics: dashboard page', () => {
   })
 
   it('color-codes quote accuracy within 20%, 20-40%, and >40%', () => {
+    // Updated for Plainspoken Sign Shop migration: token-mapped utilities
+    // replace raw Tailwind palette. On-target uses ink (Pattern 01: metadata,
+    // not status pill); off-target uses attention; way-off uses error.
     const code = source()
-    expect(code).toContain('text-green-700')
-    expect(code).toContain('text-amber-700')
-    expect(code).toContain('text-red-700')
+    expect(code).toContain('text-[color:var(--ss-color-text-primary)]') // on-target
+    expect(code).toContain('text-[color:var(--ss-color-attention)]') // off-target
+    expect(code).toContain('text-[color:var(--ss-color-error)]') // way-off
   })
 
   it('color-codes pipeline stages', () => {
+    // Updated for Plainspoken migration: pipeline stages now use the
+    // burnt-orange-tracks-active-progression / ink-marks-terminal-stages
+    // pattern (single-accent discipline). Stage taxonomy renamed to
+    // prospect/meetings/proposing/engaged/delivered/lost.
     const code = source()
-    expect(code).toContain('bg-slate-400') // prospect
-    expect(code).toContain('bg-blue-500') // assessed
-    expect(code).toContain('bg-amber-500') // quoted
-    expect(code).toContain('bg-green-500') // active
-    expect(code).toContain('bg-emerald-600') // completed
-    expect(code).toContain('bg-red-500') // dead
+    expect(code).toContain('bg-[color:var(--ss-color-text-secondary)]') // prospect/meetings (top-of-funnel, neutral)
+    expect(code).toContain('bg-[color:var(--ss-color-primary)]') // proposing/engaged (active, burnt orange)
+    expect(code).toContain('bg-[color:var(--ss-color-text-primary)]') // delivered (ink terminal)
+    expect(code).toContain('bg-[color:var(--ss-color-error)]') // lost (brick terminal)
   })
 })
 


### PR DESCRIPTION
## Summary

Cluster B of the admin token migration. Closes part of #576. Migrates three admin surfaces from raw Tailwind palette classes + tinted pill-shaped status badges to `--ss-*` tokens and Pattern 01 flat institutional shapes per `docs/style/UI-PATTERNS.md` and `docs/design/brief.md` §4.

Three commits on this branch:

- `375cd36` — initial token migration + Pattern 7 helper consolidation.
- `e0de5f3` — olive-discipline fix (admin operational state moved from `--ss-color-complete` to `--ss-color-text-primary`; olive reserved for confirmation-event banners and the four `--ss-color-complete` use cases enumerated in `brief.md` §4.5).
- `56ac0f4` — `rounded-full` restored on status dots + bar tracks/fills. §4.9's "all radii are 0" rule enumerates buttons / cards / badges / chips / modals. Status dots and data-viz bars are not enumerated and Material 3 / Polaris / Atlassian all ship them with soft ends — the convention is what reads as "status indicator" or "meter" rather than "completion checkmark" or "selection chip". KPI count tiles stay flat (those ARE chip-like).

### Per-file

- `src/pages/admin/index.astro` — home dashboard: **28 → 0 raw TW, 4 → 0 pills**. KPI count blocks on Today's Work converted from `rounded-full bg-{amber,indigo,red}-100` circles to flat token blocks (attention / primary / error). Pipeline funnel uses single-accent discipline (text-secondary / primary / ink — terminal stages take ink, not olive). Status dots restored to `rounded-full` per Material 3 / Polaris convention.
- `src/pages/admin/analytics/index.astro` — analytics: **23 → 0 raw TW, 6 → 0 pills**. Pipeline / revenue / compliance bar tracks + fills converted to ink + primary + error tokens (no olive on operational charts). Bar `rounded-full` retained. `accuracyColor()` returns flat ink-on-cream prose colors. Daily-uniques SVG migrated from raw `#6366f1` to `var(--ss-color-primary)`.
- `src/pages/admin/engagements/[id].astro` — engagement detail: **67 → 0 raw TW, 0 → 0 pills**. Three local badge helpers (`msBadgeClass` / `invoiceBadgeClass` / `contextTypeBadgeClass`) removed in favor of `statusBadgeClass()` (Pattern 7: shared primitive). Banners moved from green-50/red-50 to flat ink-on-cream with a left-border accent (Saved / Milestone added / Milestone deleted KEEP olive — they are confirmation events, not steady operational state). Mark Complete milestone-transition button uses neutral border + ink text (see Olive call-out below). Drag-target feedback re-housed in a scoped `.drag-active` rule.
- `src/lib/ui/status-badge.ts` — extended TONE map with milestone lifecycle (`pending`, `in_progress`, `skipped`). `completed` already shared with engagement.

### Pattern 1 (status display by context)

Every former status pill is now either a `statusBadgeClass()` rectangular tag (mono caps, 2px radius via `--ss-radius-badge`, single-accent token tones) or a flat eyebrow / prose treatment when the value is a category (e.g. context-entry types in the engagement timeline), not a state.

### Olive call-out — Mark Complete milestone button is intentionally NOT olive

`engagements/[id].astro` Mark Complete button uses `border-[--ss-color-border] text-[--ss-color-text-primary]` rather than olive. Per `brief.md` §4.5 the four hero events that earn olive are: engagement complete, quote signed, deposit paid, completion-invoice paid. A milestone is a *recurring sub-step* within an engagement (multiple per engagement), so milestone completion is routine progress, not a hero event. Hero "engagement complete" is reflected on the portal, not on this admin button. Mirrors PR #579's neutral Mark Complete in `/admin/follow-ups`.

### Shape call-out — round dots + rounded bars are intentional

Status dots and bar tracks/fills retain `rounded-full`. §4.9's hard-rule list is "buttons / cards / badges / chips / modals" — explicit and not exhaustive of UI primitives. Material 3, Polaris, and Atlassian all ship status dots round (Pattern 01 single-item dashboard treatment) and progress/meter bars with soft ends (semantically "measurement display"). A 2-pixel ink square dot reads as a checkbox tick, not a status indicator. KPI count tiles in Today's Work ARE chip-like and stay flat.

## Test plan

- [x] `npm run typecheck` — 323 files, 0 errors, 0 warnings (all three commits)
- [x] `npm run lint -- src/pages/admin/ src/lib/ui/status-badge.ts` — 0 errors (pre-existing warnings outside touched files only)
- [x] `ui-drift-audit` on the three files: `pills=0`, `raw_tailwind_color_classes=0`
- [ ] Visual sanity pass on `/admin`, `/admin/analytics`, `/admin/engagements/<id>` (Captain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)