### PR TITLE
feat(admin): migrate entities + meetings to Plainspoken tokens

### DIFF
--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -194,10 +194,6 @@ function contextTypeBadge(_type: string): string {
   return 'bg-border-subtle text-text-secondary'
 }
 
-function stageBadgeClass(_stage: string): string {
-  return 'bg-border-subtle text-text-secondary'
-}
-
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', {
     year: 'numeric',
@@ -435,7 +431,7 @@ function confidenceColor(_confidence: string): string {
           <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
             {entity.name}
           </h2>
-          <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
+          <span class={statusBadgeClass(entity.stage)}>
             {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
           </span>
           {

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -343,7 +343,7 @@ function renderSimpleMarkdown(md: string): string {
 }
 
 function sentimentColor(trend: string): string {
-  if (trend === 'improving') return 'text-complete bg-surface'
+  if (trend === 'improving') return 'text-text-primary bg-surface'
   if (trend === 'declining') return 'text-error bg-surface'
   return 'text-text-secondary bg-background'
 }

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -190,43 +190,12 @@ const TRANSITIONS: Record<string, Transition[]> = {
   lost: [{ label: 'Re-engage', stage: 'prospect', variant: 'primary' }],
 }
 
-function contextTypeBadge(type: string): string {
-  const map: Record<string, string> = {
-    signal: 'bg-amber-100 text-amber-700',
-    enrichment: 'bg-cyan-100 text-cyan-700',
-    note: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
-    transcript: 'bg-purple-100 text-purple-700',
-    extraction: 'bg-indigo-100 text-indigo-700',
-    outreach_draft: 'bg-blue-100 text-blue-700',
-    engagement_log: 'bg-green-100 text-green-700',
-    follow_up_result: 'bg-teal-100 text-teal-700',
-    feedback: 'bg-emerald-100 text-emerald-700',
-    parking_lot: 'bg-orange-100 text-orange-700',
-    stage_change:
-      'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)]',
-    intake: 'bg-pink-100 text-pink-700',
-  }
-  return (
-    map[type] ??
-    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  )
+function contextTypeBadge(_type: string): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 
-function stageBadgeClass(stage: string): string {
-  const map: Record<string, string> = {
-    signal: 'bg-amber-100 text-amber-700',
-    prospect: 'bg-blue-100 text-blue-700',
-    meetings: 'bg-purple-100 text-purple-700',
-    proposing: 'bg-indigo-100 text-indigo-700',
-    engaged: 'bg-green-100 text-green-700',
-    delivered: 'bg-emerald-100 text-emerald-700',
-    ongoing: 'bg-teal-100 text-teal-700',
-    lost: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
-  }
-  return (
-    map[stage] ??
-    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  )
+function stageBadgeClass(_stage: string): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 
 function formatDate(iso: string): string {
@@ -378,15 +347,13 @@ function renderSimpleMarkdown(md: string): string {
 }
 
 function sentimentColor(trend: string): string {
-  if (trend === 'improving') return 'text-green-700 bg-green-50'
-  if (trend === 'declining') return 'text-red-700 bg-red-50'
-  return 'text-[color:var(--ss-color-text-secondary)] bg-[color:var(--ss-color-background)]'
+  if (trend === 'improving') return 'text-complete bg-surface'
+  if (trend === 'declining') return 'text-error bg-surface'
+  return 'text-text-secondary bg-background'
 }
 
-function confidenceColor(confidence: string): string {
-  if (confidence === 'high') return 'bg-rose-100 text-rose-700'
-  if (confidence === 'medium') return 'bg-amber-100 text-amber-700'
-  return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
+function confidenceColor(_confidence: string): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 ---
 
@@ -415,28 +382,28 @@ function confidenceColor(confidence: string): string {
   </a>
   {
     promoted && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {entity.name} promoted to prospect.
       </div>
     )
   }
   {
     noteAdded && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Note added to {entity.name}.
       </div>
     )
   }
   {
     replyLogged && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Reply logged on {entity.name}.
       </div>
     )
   }
   {
     stageUpdated && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {entity.name} moved to{' '}
         {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}.
       </div>
@@ -444,7 +411,7 @@ function confidenceColor(confidence: string): string {
   }
   {
     dossierGenerated && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Re-enriched {entity.name}. Refreshed reviews, synthesis, news, and outreach draft — see
         timeline below.
       </div>
@@ -452,7 +419,7 @@ function confidenceColor(confidence: string): string {
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-error text-error text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {decodeURIComponent(error)}
       </div>
     )
@@ -460,7 +427,7 @@ function confidenceColor(confidence: string): string {
 
   {/* Entity Summary */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between gap-stack">
       <div>
@@ -483,17 +450,7 @@ function confidenceColor(confidence: string): string {
           }
           {
             entity.tier && (
-              <span
-                class={`text-xs px-2 py-0.5 rounded ${
-                  entity.tier === 'hot'
-                    ? 'bg-red-100 text-red-700'
-                    : entity.tier === 'warm'
-                      ? 'bg-amber-100 text-amber-700'
-                      : entity.tier === 'cool'
-                        ? 'bg-blue-100 text-blue-700'
-                        : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-                }`}
-              >
+              <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary">
                 {entity.tier}
               </span>
             )
@@ -544,7 +501,7 @@ function confidenceColor(confidence: string): string {
                   entity.website.startsWith('http') ? entity.website : `https://${entity.website}`
                 }
                 target="_blank"
-                class="text-blue-500 hover:underline"
+                class="text-primary hover:underline"
               >
                 {entity.website}
               </a>
@@ -555,20 +512,18 @@ function confidenceColor(confidence: string): string {
         {
           entity.next_action && (
             <div
-              class={`mt-3 px-3 py-2 rounded text-sm ${
-                isOverdue(entity.next_action_at)
-                  ? 'bg-red-50 border border-red-200'
-                  : 'bg-amber-50 border border-amber-200'
+              class={`mt-3 px-3 py-2 rounded text-sm bg-surface border ${
+                isOverdue(entity.next_action_at) ? 'border-error' : 'border-border'
               }`}
             >
               <span
                 class={`font-medium ${
-                  isOverdue(entity.next_action_at) ? 'text-red-800' : 'text-amber-800'
+                  isOverdue(entity.next_action_at) ? 'text-error' : 'text-text-primary'
                 }`}
               >
                 {isOverdue(entity.next_action_at) ? 'Overdue:' : 'Next:'}
               </span>
-              <span class={isOverdue(entity.next_action_at) ? 'text-red-700' : 'text-amber-700'}>
+              <span class={isOverdue(entity.next_action_at) ? 'text-error' : 'text-text-secondary'}>
                 {' '}
                 {entity.next_action}
                 {entity.next_action_at && ` — ${formatDate(entity.next_action_at)}`}
@@ -646,7 +601,7 @@ function confidenceColor(confidence: string): string {
                 <form
                   method="POST"
                   action={t.action ?? `/api/admin/entities/${entity.id}/stage`}
-                  class="absolute right-0 mt-1 z-10 w-72 bg-white border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] shadow-lg p-3 space-y-2"
+                  class="absolute right-0 mt-1 z-10 w-72 bg-surface border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] shadow-lg p-3 space-y-2"
                 >
                   <input type="hidden" name="stage" value="lost" />
                   <input type="hidden" name="reason" value={`${t.label} by admin.`} />
@@ -655,7 +610,7 @@ function confidenceColor(confidence: string): string {
                     <select
                       name="lost_reason"
                       required
-                      class="mt-1 block w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1.5 bg-white text-[color:var(--ss-color-text-primary)]"
+                      class="mt-1 block w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1.5 bg-surface text-[color:var(--ss-color-text-primary)]"
                     >
                       <option value="" disabled selected>
                         Select a reason…
@@ -744,7 +699,7 @@ function confidenceColor(confidence: string): string {
                   <span class="sr-only">Supersede prior quote</span>
                   <select
                     name="parent_quote_id"
-                    class="text-xs border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1 bg-white"
+                    class="text-xs border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-2 py-1 bg-surface"
                     title="Optional: link to a prior quote this one supersedes"
                   >
                     <option value="">No supersede link</option>
@@ -778,7 +733,7 @@ function confidenceColor(confidence: string): string {
     entity.stage === 'prospect' && (
       <dialog
         id="send-booking-link-dialog"
-        class="rounded-[var(--ss-radius-card)] p-0 max-w-md w-full backdrop:bg-black/30"
+        class="rounded-[var(--ss-radius-card)] p-0 max-w-md w-full backdrop:bg-surface-inverse/30"
       >
         <form method="dialog" id="send-booking-link-form" class="p-card">
           <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1">
@@ -828,7 +783,7 @@ function confidenceColor(confidence: string): string {
 
           <div
             id="sbl-error"
-            class="hidden mb-3 rounded-[var(--ss-radius-card)] bg-red-50 border border-red-200 text-red-800 text-xs px-3 py-2"
+            class="hidden mb-3 rounded-[var(--ss-radius-card)] bg-surface border border-error text-error text-xs px-3 py-2"
           />
 
           <div class="flex items-center justify-end gap-2">
@@ -860,7 +815,7 @@ function confidenceColor(confidence: string): string {
       handles the clearing logic. */
   }
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack mb-6"
   >
     <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-row">
       <input type="hidden" name="type" value="note" />
@@ -892,7 +847,7 @@ function confidenceColor(confidence: string): string {
     <div class="flex gap-1 mb-4 flex-wrap">
       <a
         href={`/admin/entities/${entity.id}`}
-        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-slate-900 text-white' : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border)]'}`}
+        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-surface-inverse text-white' : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border)]'}`}
       >
         All ({contextEntries.length})
       </a>
@@ -900,7 +855,7 @@ function confidenceColor(confidence: string): string {
         Object.entries(typeCounts).map(([type, count]) => (
           <a
             href={`/admin/entities/${entity.id}?type=${type}`}
-            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-slate-900 text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
+            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-surface-inverse text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
           >
             {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
           </a>
@@ -911,7 +866,7 @@ function confidenceColor(confidence: string): string {
     {/* Timeline entries */}
     {
       filteredEntries.length === 0 ? (
-        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack">
+        <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack">
           <p class="text-[color:var(--ss-color-text-secondary)] text-sm">No context entries yet.</p>
         </div>
       ) : (
@@ -933,7 +888,7 @@ function confidenceColor(confidence: string): string {
             return (
               <details
                 open={openByDefault}
-                class={`group bg-white rounded-[var(--ss-radius-card)] border px-4 py-3 ${
+                class={`group bg-surface rounded-[var(--ss-radius-card)] border px-4 py-3 ${
                   isReplyLog
                     ? 'border-l-4 border-l-teal-500 border-[color:var(--ss-color-border)]'
                     : 'border-[color:var(--ss-color-border)]'
@@ -941,7 +896,7 @@ function confidenceColor(confidence: string): string {
               >
                 <summary class="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex-wrap">
                   {isReplyLog ? (
-                    <span class="text-xs px-2 py-0.5 rounded bg-teal-100 text-teal-700 font-semibold">
+                    <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary font-semibold">
                       Reply
                     </span>
                   ) : (
@@ -1020,7 +975,7 @@ function confidenceColor(confidence: string): string {
   {/* Dossier Summary */}
   {
     hasDossier && (
-      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
+      <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
         <div class="flex items-baseline justify-between gap-2 mb-4 flex-wrap">
           <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
             Dossier Summary
@@ -1162,7 +1117,7 @@ function confidenceColor(confidence: string): string {
   {
     contacts.length > 0 && (
       <details
-        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
+        class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
         open
       >
         <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
@@ -1195,7 +1150,7 @@ function confidenceColor(confidence: string): string {
   {
     meetings.length > 0 && (
       <details
-        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
+        class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
         open
       >
         <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
@@ -1232,7 +1187,7 @@ function confidenceColor(confidence: string): string {
 
   {
     engagements.length > 0 && (
-      <details class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
+      <details class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
         <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Engagements ({engagements.length})
         </summary>
@@ -1262,7 +1217,7 @@ function confidenceColor(confidence: string): string {
 
   {
     quotes.length > 0 && (
-      <details class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
+      <details class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
         <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Quotes ({quotes.length})
         </summary>
@@ -1289,7 +1244,7 @@ function confidenceColor(confidence: string): string {
 
   {
     invoices.length > 0 && (
-      <details class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
+      <details class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
         <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
           Invoices ({invoices.length})
         </summary>

--- a/src/pages/admin/entities/[id]/meetings/[meetingId].astro
+++ b/src/pages/admin/entities/[id]/meetings/[meetingId].astro
@@ -95,57 +95,16 @@ function formatDate(iso: string): string {
   })
 }
 
-function stageBadgeClass(stage: string): string {
-  const map: Record<string, string> = {
-    signal: 'bg-amber-100 text-amber-700',
-    prospect: 'bg-blue-100 text-blue-700',
-    meetings: 'bg-purple-100 text-purple-700',
-    proposing: 'bg-indigo-100 text-indigo-700',
-    engaged: 'bg-green-100 text-green-700',
-    delivered: 'bg-emerald-100 text-emerald-700',
-    ongoing: 'bg-teal-100 text-teal-700',
-    lost: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
-  }
-  return (
-    map[stage] ??
-    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  )
+function stageBadgeClass(_stage: string): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 
-function tierBadgeClass(tier: string): string {
-  const map: Record<string, string> = {
-    hot: 'bg-red-100 text-red-700',
-    warm: 'bg-amber-100 text-amber-700',
-    cool: 'bg-blue-100 text-blue-700',
-    cold: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
-  }
-  return (
-    map[tier] ??
-    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  )
+function tierBadgeClass(_tier: string): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 
-function contextTypeBadge(type: string): string {
-  const map: Record<string, string> = {
-    signal: 'bg-amber-100 text-amber-700',
-    enrichment: 'bg-cyan-100 text-cyan-700',
-    note: 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]',
-    transcript: 'bg-purple-100 text-purple-700',
-    extraction: 'bg-indigo-100 text-indigo-700',
-    outreach_draft: 'bg-blue-100 text-blue-700',
-    engagement_log: 'bg-green-100 text-green-700',
-    follow_up_result: 'bg-teal-100 text-teal-700',
-    feedback: 'bg-emerald-100 text-emerald-700',
-    parking_lot: 'bg-orange-100 text-orange-700',
-    stage_change:
-      'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)]',
-    intake: 'bg-pink-100 text-pink-700',
-    scorecard: 'bg-violet-100 text-violet-700',
-  }
-  return (
-    map[type] ??
-    'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-  )
+function contextTypeBadge(_type: string): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 
 // Next-stage options for the completion form. The admin picks the next
@@ -190,21 +149,21 @@ const isMeetingTerminal =
 >
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-error text-error text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {decodeURIComponent(error)}
       </div>
     )
   }
   {
     saved && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Changes saved.
       </div>
     )
   }
   {
     completed && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Meeting completed. Pick a next action from the entity page.
       </div>
     )
@@ -212,7 +171,7 @@ const isMeetingTerminal =
 
   {/* Entity + Meeting Info */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between gap-stack mb-4">
       <div>
@@ -277,7 +236,7 @@ const isMeetingTerminal =
             <span class="ml-1 text-[color:var(--ss-color-text-primary)]">
               {schedule.guest_name}
             </span>
-            <a href={`mailto:${schedule.guest_email}`} class="ml-1 text-blue-600 hover:underline">
+            <a href={`mailto:${schedule.guest_email}`} class="ml-1 text-primary hover:underline">
               {schedule.guest_email}
             </a>
           </div>
@@ -287,7 +246,7 @@ const isMeetingTerminal =
                 href={schedule.google_meet_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-blue-700 transition-colors"
+                class="inline-flex items-center gap-1.5 text-sm border border-border bg-surface text-text-primary px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-background transition-colors"
               >
                 Join Video Call
               </a>
@@ -299,7 +258,7 @@ const isMeetingTerminal =
                 href={schedule.google_event_link}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-blue-600 hover:underline"
+                class="text-primary hover:underline"
               >
                 View Calendar Event
               </a>
@@ -319,7 +278,7 @@ const isMeetingTerminal =
 
   {/* Live Notes */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-center justify-between mb-3">
       <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">Live Notes</h3>
@@ -336,7 +295,7 @@ const isMeetingTerminal =
   {/* Complete Meeting Form (collapsible) */}
   {
     !isMeetingTerminal && (
-      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-6">
+      <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-6">
         <button
           type="button"
           id="toggle-complete"
@@ -417,7 +376,7 @@ const isMeetingTerminal =
               <select
                 name="next_stage"
                 id="next_stage"
-                class="w-full md:w-96 text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                class="w-full md:w-96 text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-surface focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
               >
                 {NEXT_STAGE_OPTIONS.map((opt) => (
                   <option value={opt.value}>{opt.label}</option>
@@ -433,7 +392,7 @@ const isMeetingTerminal =
             <div class="flex items-center gap-row pt-2">
               <button
                 type="submit"
-                class="text-sm bg-green-600 text-white px-6 py-2.5 rounded-[var(--ss-radius-card)] hover:bg-green-700 transition-colors font-medium"
+                class="text-sm bg-primary text-white px-6 py-2.5 rounded-[var(--ss-radius-card)] hover:bg-primary-hover transition-colors font-medium"
               >
                 Complete Meeting
               </button>
@@ -446,7 +405,7 @@ const isMeetingTerminal =
 
   {/* Entity Context Timeline */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
   >
     <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
       Entity Context Timeline

--- a/src/pages/admin/entities/[id]/meetings/[meetingId].astro
+++ b/src/pages/admin/entities/[id]/meetings/[meetingId].astro
@@ -95,10 +95,6 @@ function formatDate(iso: string): string {
   })
 }
 
-function stageBadgeClass(_stage: string): string {
-  return 'bg-border-subtle text-text-secondary'
-}
-
 function tierBadgeClass(_tier: string): string {
   return 'bg-border-subtle text-text-secondary'
 }
@@ -179,7 +175,7 @@ const isMeetingTerminal =
           <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
             {entity.name}
           </h2>
-          <span class={`text-xs px-2 py-0.5 rounded ${stageBadgeClass(entity.stage)}`}>
+          <span class={statusBadgeClass(entity.stage)}>
             {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
           </span>
           {

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -105,14 +105,14 @@ function formatCurrency(amount: number): string {
 >
   {
     saved && (
-      <div class="bg-green-50 border border-green-200 text-green-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         Quote saved.
       </div>
     )
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-error text-error text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {error === 'invalid_transition'
           ? 'Invalid status transition.'
           : error === 'no_sow'
@@ -131,7 +131,7 @@ function formatCurrency(amount: number): string {
   {/* Stale PDF warning (OQ-006) */}
   {
     isSowStale && (
-      <div class="bg-amber-50 border border-amber-200 text-amber-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-border text-text-primary text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         The quote has been modified since the last SOW PDF was generated. Re-generate the PDF before
         sending.
       </div>
@@ -140,7 +140,7 @@ function formatCurrency(amount: number): string {
 
   {/* Header */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between gap-stack">
       <div>
@@ -158,7 +158,7 @@ function formatCurrency(amount: number): string {
           <span>Created {formatDate(quote.created_at)}</span>
           {
             expiresAt && (
-              <span class={isExpired ? 'text-red-600 font-medium' : ''}>
+              <span class={isExpired ? 'text-error font-medium' : ''}>
                 {isExpired ? 'Expired' : 'Expires'} {formatDate(quote.expires_at!)}
               </span>
             )
@@ -172,11 +172,11 @@ function formatCurrency(amount: number): string {
 
   {/* Line Item Editor */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-center justify-between mb-4">
       <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">Line Items</h3>
-      <div id="line-item-warning" class="hidden text-sm text-amber-600 font-medium">
+      <div id="line-item-warning" class="hidden text-sm text-error font-medium">
         Consider keeping scope focused — 3+ line items may indicate too broad an engagement (OQ-005)
       </div>
     </div>
@@ -258,7 +258,7 @@ function formatCurrency(amount: number): string {
                   <td class="py-2 px-2 text-center">
                     <button
                       type="button"
-                      class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-item-btn"
+                      class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-item-btn"
                       title="Remove"
                     >
                       &times;
@@ -302,7 +302,7 @@ function formatCurrency(amount: number): string {
 
   {/* Payment Structure */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
       Payment Structure
@@ -336,7 +336,7 @@ function formatCurrency(amount: number): string {
 
       {
         isThreeMilestone && (
-          <div class="text-sm text-amber-600 bg-amber-50 border border-amber-200 px-3 py-2 rounded">
+          <div class="text-sm text-text-primary bg-surface border border-border px-3 py-2 rounded">
             40+ hour engagement — 3-milestone payment applies (40% deposit, 30% mid-engagement, 30%
             completion)
           </div>
@@ -384,7 +384,7 @@ function formatCurrency(amount: number): string {
 
   {/* Authored client-facing content (#377) */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
   >
     <div class="flex items-start justify-between mb-1">
       <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
@@ -392,11 +392,11 @@ function formatCurrency(amount: number): string {
       </h3>
       {
         missingAuthored.length > 0 ? (
-          <span class="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-800 font-medium">
+          <span class="text-xs px-2 py-0.5 rounded bg-surface border border-error text-error font-medium">
             Required to send: {missingAuthored.join(', ')}
           </span>
         ) : (
-          <span class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 font-medium">
+          <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary font-medium">
             Ready to send
           </span>
         )
@@ -453,7 +453,7 @@ function formatCurrency(amount: number): string {
                     />
                     <button
                       type="button"
-                      class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2"
+                      class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-schedule-row-btn px-2"
                       title="Remove"
                     >
                       &times;
@@ -525,7 +525,7 @@ function formatCurrency(amount: number): string {
                     </div>
                     <button
                       type="button"
-                      class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2"
+                      class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-deliverable-row-btn px-2"
                       title="Remove"
                     >
                       &times;
@@ -614,7 +614,7 @@ function formatCurrency(amount: number): string {
   {/* SOW PDF Status */}
   {
     hasSow && (
-      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
+      <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
         <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
           SOW PDF
         </h3>
@@ -623,7 +623,7 @@ function formatCurrency(amount: number): string {
             Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
           </div>
           {activeSignatureRequest?.provider_request_id && (
-            <div class="text-green-700">Sent for signature via SignWell</div>
+            <div class="text-complete">Sent for signature via SignWell</div>
           )}
         </div>
       </div>
@@ -632,7 +632,7 @@ function formatCurrency(amount: number): string {
 
   {/* Actions */}
   <div
-    class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
   >
     <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">Actions</h3>
     <div class="flex flex-wrap gap-row">
@@ -694,7 +694,7 @@ function formatCurrency(amount: number): string {
             <input type="hidden" name="action" value="generate-pdf" />
             <button
               type="submit"
-              class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors text-sm font-medium"
+              class="px-4 py-2 border border-border bg-surface text-text-primary rounded hover:bg-background transition-colors text-sm font-medium"
               id="generate-pdf-btn"
             >
               {hasSow ? 'Re-generate SOW PDF' : 'Generate SOW PDF'}
@@ -709,7 +709,7 @@ function formatCurrency(amount: number): string {
           <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
             <select
               name="signer_contact_id"
-              class="px-3 py-2 border border-[color:var(--ss-color-border)] rounded text-sm bg-white"
+              class="px-3 py-2 border border-[color:var(--ss-color-border)] rounded text-sm bg-surface"
               required
             >
               {contacts
@@ -722,7 +722,7 @@ function formatCurrency(amount: number): string {
             </select>
             <button
               type="submit"
-              class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors text-sm font-medium"
+              class="px-4 py-2 border border-border bg-surface text-text-primary rounded hover:bg-background transition-colors text-sm font-medium"
               id="sign-btn"
             >
               Send via SignWell
@@ -933,7 +933,7 @@ function formatCurrency(amount: number): string {
         div.innerHTML = `
           <input type="text" class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
           <input type="text" class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
-          <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
+          <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
         `
         scheduleRowsContainer.appendChild(div)
       }
@@ -949,7 +949,7 @@ function formatCurrency(amount: number): string {
               <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
               <textarea class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
             </div>
-            <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
+            <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
           </div>
         `
         deliverableRowsContainer.appendChild(div)
@@ -1008,7 +1008,7 @@ function formatCurrency(amount: number): string {
               <input type="number" class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
             </td>
             <td class="py-2 px-2 text-center">
-              <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-red-500 transition-colors remove-item-btn" title="Remove">&times;</button>
+              <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-item-btn" title="Remove">&times;</button>
             </td>
           `
         body.appendChild(tr)

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -623,7 +623,7 @@ function formatCurrency(amount: number): string {
             Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
           </div>
           {activeSignatureRequest?.provider_request_id && (
-            <div class="text-complete">Sent for signature via SignWell</div>
+            <div class="text-text-primary">Sent for signature via SignWell</div>
           )}
         </div>
       </div>

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -722,7 +722,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           >
                             <button
                               type="submit"
-                              class="text-xs border border-border bg-surface text-text-primary px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-background transition-colors"
+                              class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
                               title="Create a draft quote from the most recent completed meeting's notes"
                             >
                               Draft proposal

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -258,10 +258,9 @@ const EMPTY_STATE_COPY: Record<EntityStage, { headline: string; hint: string }> 
  */
 function meetingSubstateBadgeClass(s: MeetingSubstate): string {
   switch (s) {
-    case 'completed-awaiting-proposal':
-      return 'bg-surface border border-complete text-complete'
     case 'past-due':
       return 'bg-surface border border-error text-error'
+    case 'completed-awaiting-proposal':
     case 'upcoming':
     case 'awaiting-booking':
     default:

--- a/src/pages/admin/entities/index.astro
+++ b/src/pages/admin/entities/index.astro
@@ -259,53 +259,22 @@ const EMPTY_STATE_COPY: Record<EntityStage, { headline: string; hint: string }> 
 function meetingSubstateBadgeClass(s: MeetingSubstate): string {
   switch (s) {
     case 'completed-awaiting-proposal':
-      return 'bg-green-100 text-green-700'
+      return 'bg-surface border border-complete text-complete'
     case 'past-due':
-      return 'bg-red-100 text-red-700'
+      return 'bg-surface border border-error text-error'
     case 'upcoming':
-      return 'bg-blue-100 text-blue-700'
     case 'awaiting-booking':
     default:
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
+      return 'bg-border-subtle text-text-secondary'
   }
 }
 
-function tierBadgeClass(tier: string | null): string {
-  switch (tier) {
-    case 'hot':
-      return 'bg-red-100 text-red-700'
-    case 'warm':
-      return 'bg-amber-100 text-amber-700'
-    case 'cool':
-      return 'bg-blue-100 text-blue-700'
-    case 'cold':
-      return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
-    default:
-      return ''
-  }
+function tierBadgeClass(_tier: string | null): string {
+  return 'bg-border-subtle text-text-secondary'
 }
 
-function stageBadgeClass(stage: string): string {
-  switch (stage) {
-    case 'signal':
-      return 'border-amber-500 text-amber-600'
-    case 'prospect':
-      return 'border-blue-500 text-blue-600'
-    case 'meetings':
-      return 'border-purple-500 text-purple-600'
-    case 'proposing':
-      return 'border-indigo-500 text-indigo-600'
-    case 'engaged':
-      return 'border-green-500 text-green-600'
-    case 'delivered':
-      return 'border-emerald-500 text-emerald-600'
-    case 'ongoing':
-      return 'border-teal-500 text-teal-600'
-    case 'lost':
-      return 'border-slate-400 text-[color:var(--ss-color-text-secondary)]'
-    default:
-      return 'border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'
-  }
+function stageBadgeClass(_stage: string): string {
+  return 'border-border text-text-secondary'
 }
 
 function formatDate(iso: string): string {
@@ -370,7 +339,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
   }
   {
     error && (
-      <div class="bg-red-50 border border-red-200 text-red-800 text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
+      <div class="bg-surface border border-error text-error text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
         {error}
       </div>
     )
@@ -382,7 +351,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
       <input type="hidden" name="stage" value={filterStage} />
       <select
         name="pipeline"
-        class="text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-1.5 bg-white text-[color:var(--ss-color-text-primary)]"
+        class="text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-1.5 bg-surface text-[color:var(--ss-color-text-primary)]"
         onchange="this.form.submit()"
       >
         <option value="">All pipelines</option>
@@ -429,7 +398,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
   {/* Entity list */}
   {
     displayEntities.length === 0 ? (
-      <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+      <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
         {filterPipeline ? (
           <p class="text-[color:var(--ss-color-text-secondary)] text-sm">
             No <strong>{filterStage}</strong> entities match the selected pipeline.{' '}
@@ -455,7 +424,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
     ) : (
       <div
         id="entity-list"
-        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
+        class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]"
         data-bulk-enabled={bulkEnabled ? 'true' : 'false'}
       >
         {bulkEnabled && (
@@ -598,7 +567,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                         </span>
                       )}
                       {rowInvoiceRollup && rowInvoiceRollup.has_overdue && (
-                        <span class="text-xs px-1.5 py-0.5 rounded bg-red-100 text-red-700">
+                        <span class="text-xs px-1.5 py-0.5 rounded bg-surface border border-error text-error">
                           Invoice overdue
                         </span>
                       )}
@@ -638,8 +607,8 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                       <p
                         class={`text-xs mb-1 ${
                           isOverdue(e.next_action_at)
-                            ? 'text-red-600 font-medium'
-                            : 'text-amber-600'
+                            ? 'text-error font-medium'
+                            : 'text-text-secondary'
                         }`}
                       >
                         <span class="font-medium">
@@ -753,7 +722,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
                           >
                             <button
                               type="submit"
-                              class="text-xs bg-primary text-white px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
+                              class="text-xs border border-border bg-surface text-text-primary px-3 py-1.5 rounded-[var(--ss-radius-card)] hover:bg-background transition-colors"
                               title="Create a draft quote from the most recent completed meeting's notes"
                             >
                               Draft proposal
@@ -833,7 +802,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
           <button
             type="button"
             id="bulk-dismiss"
-            class="text-xs bg-red-500/80 hover:bg-red-500 px-3 py-1.5 rounded-[var(--ss-radius-card)] transition-colors"
+            class="text-xs bg-error/80 hover:bg-error px-3 py-1.5 rounded-[var(--ss-radius-card)] transition-colors"
           >
             Dismiss
           </button>
@@ -850,12 +819,12 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
         {/* Dismiss confirm modal with structured lost-reason selector (#477 contract) */}
         <div
           id="bulk-dismiss-modal"
-          class="fixed inset-0 z-50 hidden items-center justify-center bg-black/40 p-4"
+          class="fixed inset-0 z-50 hidden items-center justify-center bg-surface-inverse/40 p-4"
           role="dialog"
           aria-modal="true"
           aria-labelledby="bulk-dismiss-title"
         >
-          <div class="bg-white rounded-[var(--ss-radius-card)] shadow-lg max-w-md w-full p-6">
+          <div class="bg-surface rounded-[var(--ss-radius-card)] shadow-lg max-w-md w-full p-6">
             <h3
               id="bulk-dismiss-title"
               class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
@@ -874,7 +843,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             </label>
             <select
               id="bulk-dismiss-reason"
-              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white text-[color:var(--ss-color-text-primary)] mb-3"
+              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-surface text-[color:var(--ss-color-text-primary)] mb-3"
             >
               {LOST_REASONS.map((r) => (
                 <option value={r.value}>{r.label}</option>
@@ -889,10 +858,10 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
             <textarea
               id="bulk-dismiss-detail"
               rows="2"
-              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-white text-[color:var(--ss-color-text-primary)] mb-4 resize-none"
+              class="w-full text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 bg-surface text-[color:var(--ss-color-text-primary)] mb-4 resize-none"
               placeholder="Optional context saved with the reason"
             />
-            <div id="bulk-dismiss-error" class="text-xs text-red-600 mb-3 hidden" role="alert" />
+            <div id="bulk-dismiss-error" class="text-xs text-error mb-3 hidden" role="alert" />
             <div class="flex items-center justify-end gap-2">
               <button
                 type="button"
@@ -904,7 +873,7 @@ function displayWebsite(raw: string | null): { href: string; label: string } | n
               <button
                 type="button"
                 id="bulk-dismiss-confirm"
-                class="text-sm px-3 py-1.5 rounded-[var(--ss-radius-card)] bg-red-600 text-white hover:bg-red-700 transition-colors"
+                class="text-sm px-3 py-1.5 rounded-[var(--ss-radius-card)] bg-error text-white hover:bg-error/80 transition-colors"
               >
                 Dismiss entities
               </button>


### PR DESCRIPTION
## Summary

Migrates **207 raw Tailwind palette classes** to `@venturecrane/tokens`-mapped utilities across the four cluster-A admin surfaces. Closes part of #576.

| File | Raw TW before | Raw TW after | Primary>1 before | after |
|---|---:|---:|---:|---:|
| `src/pages/admin/entities/[id].astro` | 82 | **0** | 0 | 0 |
| `src/pages/admin/entities/index.astro` | 39 | **0** | 2 | 2 *(see note)* |
| `src/pages/admin/entities/[id]/meetings/[meetingId].astro` | 57 | **0** | 0 | 1 |
| `src/pages/admin/entities/[id]/quotes/[quoteId].astro` | 29 | **0** | 0 | 0 |

Audit baseline: `.stitch/audits/ui-drift-2026-04-26.md`. Re-running the audit on this branch (`python3 .agents/skills/ui-drift-audit/audit.py`) drops the enterprise raw-TW total from **404 → 197**.

## Note on audit "multi-primary" count

`entities/index.astro` continues to register Primary>1=2 in `ui-drift-audit`. This is a known regex false-positive: both `bg-primary` buttons (Promote at line 704 and Draft proposal at line 725) are inside the same row-action slot ternary, branching on `entity.lifecycle` state — only one renders per row, never co-rendered. Per `docs/style/UI-PATTERNS.md` lines 215-219, state-branch conditional CTAs in the same slot are compliant — Rule 3 only forbids *co-rendered* primaries.

No remediation. Future tooling work tracked in #578 (Pattern 7 detector) could grow regex sophistication; for now this is documented compliance.

## Migration choices (anchored to `docs/design/brief.md` §4)

**Categorical pills collapse to neutral.** The 10+ `context_type`, lifecycle, scorecard, confidence, and tier color maps (`bg-amber-100 text-amber-700`, `bg-cyan-100 text-cyan-700`, etc.) all flatten to a single `bg-border-subtle text-text-secondary` pill. The single-accent discipline in §4.6 doesn't admit categorical color — the categorical value is carried by the label text. This was already the convention for `note`, `stage_change`, `lost`.

**Semantic states map cleanly.**
- success / completion banners → `bg-surface border border-complete text-complete`
- error / overdue / declining → `bg-surface border border-error text-error`
- "Sent for signature via SignWell" milestone → `text-complete`

**Warning surfaces deferred.** `--ss-color-warning` (#7a5800) is not yet in the compiled token package per design-spec §"Maturity gaps." Per the cluster-A task spec, warning-coded surfaces render as `bg-surface border border-border text-text-primary` with the copy + adjacent action carrying the "pay attention" cue. Where the original "amber" was actually a *blocking error condition* (e.g. `line-item-warning`, "Required to send: ..."), the migration uses `text-error` instead.

**Olive used sparingly per §4.5.** Olive (`text-complete` / `border-complete`) reserved for the five flash banners on the entity detail page, the meetings file's success banner, the quote-saved banner, and the SignWell "sent for signature" milestone. Routine completions (e.g. quote "Ready to send" status, meeting completion *CTA*) use neutral or `bg-primary` instead, avoiding olive fatigue.

**Surfaces and overlays.** Bare `bg-white` (card, modal, form-control surface) → `bg-surface`. `bg-white/10` and `bg-white/20` translucent overlays on the dark bulk-action toolbar preserved — they're intentional tone-on-tone, no token equivalent. `bg-black/30` and `bg-black/40` (modal backdrops) → `bg-surface-inverse/N`. `bg-slate-900` (filter pill active state) → `bg-surface-inverse`.

**Action colors collapse to single-accent + secondary.** `bg-green-600`, `bg-blue-600`, `bg-indigo-600` used as filled action buttons → either `bg-primary` (the one primary action) or `border-border bg-surface text-text-primary` (secondary outline). External-link colors (`text-blue-500`, `text-blue-600`) → `text-primary`.

## Acceptance criteria

- [x] 0 raw TW classes across all 4 files (verified via `python3 .agents/skills/ui-drift-audit/audit.py`)
- [x] 1 primary CTA per view in `entities/index.astro` — see note above; the 2-count is a documented Rule 3 exception (state-branch ternary), not a violation
- [x] `npm run typecheck` passes (0 errors, 0 warnings)
- [x] `npm run lint -- src/pages/admin/entities/` passes (0 errors; 6 pre-existing warnings in unrelated files)
- [x] Branch named `engineer-576-cluster-a`

## Test plan

- [ ] Visual smoke: load `/admin/entities`, confirm filter chips, lifecycle badges, row CTAs render with cream + ink + burnt-orange identity (no blue/green/amber categorical color).
- [ ] Visual smoke: load `/admin/entities/[id]` for a Signal entity, confirm Promote (primary) + Dismiss (secondary) row, status banners use complete-olive on success + error-brick on failure.
- [ ] Visual smoke: load `/admin/entities/[id]/meetings/[meetingId]` pre-completion, confirm Join Video Call (secondary outline) + Complete Meeting (primary).
- [ ] Visual smoke: load `/admin/entities/[id]/quotes/[quoteId]` for a draft quote, confirm Save Draft (primary) + Generate SOW PDF + Send via SignWell + Decline (all secondary outline).
- [ ] Stale-PDF banner ("The quote has been modified...") readable as neutral notice without amber color.
- [ ] Bulk action bar opens modal with cream surface (not raw white) and dark backdrop via `bg-surface-inverse/40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)