### PR TITLE
fix(booking): review findings 1-6 — dual-write meetings, pre-seed integrity, rollback

### DIFF
--- a/migrations/0027_harden_magic_links_context_and_milestones.sql
+++ b/migrations/0027_harden_magic_links_context_and_milestones.sql
@@ -1,0 +1,129 @@
+-- Migration 0027: Harden magic_links, context, and milestones
+--
+-- Fixes three integrity gaps left by earlier incremental migrations:
+--
+--   1. magic_links stored only email, so auth resolution was ambiguous once
+--      the same email existed in multiple orgs. Rebuild with org_id + user_id
+--      and intentionally invalidate old links. Magic links expire after 15
+--      minutes, so preserving legacy rows is not worth carrying ambiguous auth.
+--
+--   2. context lost its FK to entities in 0026. Rebuild it with the FK
+--      restored. If orphan context rows exist, the INSERT should fail loudly
+--      rather than silently preserve corrupted data.
+--
+--   3. milestones.org_id was bolted on via ALTER TABLE with a sentinel
+--      default and no FK/index. Rebuild the table with a real org FK and
+--      tenant-aware indexes.
+
+-- ============================================================================
+-- 1. magic_links - bind tokens to a specific user
+-- ============================================================================
+
+CREATE TABLE magic_links_new (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  user_id         TEXT NOT NULL REFERENCES users(id),
+  email           TEXT NOT NULL,
+  token           TEXT NOT NULL UNIQUE,
+  expires_at      TEXT NOT NULL,
+  used_at         TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+DROP TABLE magic_links;
+ALTER TABLE magic_links_new RENAME TO magic_links;
+
+CREATE INDEX idx_magic_links_org_email ON magic_links(org_id, email);
+CREATE INDEX idx_magic_links_expires ON magic_links(expires_at);
+CREATE INDEX idx_magic_links_user_expires ON magic_links(user_id, expires_at);
+
+-- ============================================================================
+-- 2. context - restore entity FK
+-- ============================================================================
+
+CREATE TABLE context_new (
+  id              TEXT PRIMARY KEY,
+  entity_id       TEXT NOT NULL REFERENCES entities(id),
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+
+  type            TEXT NOT NULL CHECK (type IN (
+    'signal',
+    'enrichment',
+    'note',
+    'transcript',
+    'extraction',
+    'outreach_draft',
+    'engagement_log',
+    'follow_up_result',
+    'feedback',
+    'parking_lot',
+    'stage_change',
+    'intake',
+    'scorecard',
+    'alert'
+  )),
+
+  content         TEXT NOT NULL,
+  source          TEXT NOT NULL,
+  source_ref      TEXT,
+  content_size    INTEGER,
+  metadata        TEXT,
+  engagement_id   TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO context_new SELECT * FROM context;
+
+DROP TABLE context;
+ALTER TABLE context_new RENAME TO context;
+
+CREATE INDEX idx_context_entity ON context(entity_id, created_at);
+CREATE INDEX idx_context_entity_type ON context(entity_id, type);
+CREATE INDEX idx_context_org_type ON context(org_id, type, created_at DESC);
+CREATE INDEX idx_context_engagement ON context(engagement_id)
+  WHERE engagement_id IS NOT NULL;
+
+-- ============================================================================
+-- 3. milestones - rebuild with real org FK + indexes
+-- ============================================================================
+
+CREATE TABLE milestones_new (
+  id              TEXT PRIMARY KEY,
+  engagement_id   TEXT NOT NULL REFERENCES engagements(id),
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  name            TEXT NOT NULL,
+  description     TEXT,
+  due_date        TEXT,
+  completed_at    TEXT,
+  status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+                    'pending', 'in_progress', 'completed', 'skipped'
+                  )),
+  payment_trigger INTEGER DEFAULT 0,
+  sort_order      INTEGER DEFAULT 0,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO milestones_new (
+  id, engagement_id, org_id, name, description, due_date,
+  completed_at, status, payment_trigger, sort_order, created_at
+)
+SELECT
+  m.id,
+  m.engagement_id,
+  COALESCE(NULLIF(m.org_id, ''), e.org_id),
+  m.name,
+  m.description,
+  m.due_date,
+  m.completed_at,
+  m.status,
+  m.payment_trigger,
+  m.sort_order,
+  m.created_at
+FROM milestones m
+JOIN engagements e ON e.id = m.engagement_id;
+
+DROP TABLE milestones;
+ALTER TABLE milestones_new RENAME TO milestones;
+
+CREATE INDEX idx_milestones_org_engagement_order ON milestones(org_id, engagement_id, sort_order);
+CREATE INDEX idx_milestones_org_status ON milestones(org_id, status);

--- a/src/lib/auth/magic-link.ts
+++ b/src/lib/auth/magic-link.ts
@@ -2,27 +2,42 @@
  * Magic link authentication for client portal access.
  *
  * Magic links are single-use, time-limited tokens sent via email.
- * They provide passwordless authentication for client users.
  *
  * Token lifecycle:
- *   1. createMagicLink() — generates crypto-random token, stores in D1 with 15min expiry
- *   2. verifyMagicLink() — validates token, marks as used, returns email
+ *   1. createMagicLink() - generates a crypto-random token and stores it in D1
+ *   2. verifyMagicLink() - atomically consumes the token and returns the bound user
  *
- * Security constraints (OQ-007):
+ * Security constraints:
  *   - Tokens expire after 15 minutes
- *   - Tokens are single-use (used_at set on verification)
+ *   - Tokens are single-use under concurrent requests
+ *   - Tokens are bound to a specific org_id + user_id, not just an email
  *   - Tokens are 64-character hex strings (32 bytes of entropy)
  */
 
-export const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000 // 15 minutes
+export const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000
 
 export interface MagicLinkRow {
   id: string
+  org_id: string
+  user_id: string
   email: string
   token: string
   expires_at: string
   used_at: string | null
   created_at: string
+}
+
+export interface MagicLinkSubject {
+  orgId: string
+  userId: string
+  email: string
+}
+
+export interface ConsumedMagicLink {
+  id: string
+  orgId: string
+  userId: string
+  email: string
 }
 
 /**
@@ -37,36 +52,49 @@ function generateToken(): string {
 }
 
 /**
- * Create a new magic link for the given email address.
- *
- * Stores the token in the magic_links table with a 15-minute expiry.
- * Returns the raw token (to be embedded in the magic link URL).
+ * Create a new magic link for the given user identity.
  */
-export async function createMagicLink(db: D1Database, email: string): Promise<string> {
+export async function createMagicLink(db: D1Database, subject: MagicLinkSubject): Promise<string> {
   const token = generateToken()
   const id = crypto.randomUUID()
   const expiresAt = new Date(Date.now() + MAGIC_LINK_EXPIRY_MS).toISOString()
 
   await db
     .prepare(
-      `INSERT INTO magic_links (id, email, token, expires_at)
-       VALUES (?, ?, ?, ?)`
+      `INSERT INTO magic_links (id, org_id, user_id, email, token, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
     )
-    .bind(id, email.toLowerCase().trim(), token, expiresAt)
+    .bind(id, subject.orgId, subject.userId, subject.email.toLowerCase().trim(), token, expiresAt)
     .run()
 
   return token
 }
 
 /**
- * Verify a magic link token.
+ * Atomically consume a magic link token.
  *
- * Checks that the token exists, has not expired, and has not been used.
- * On success, marks the token as used and returns the associated email.
- * On failure, returns null.
+ * Returns the bound user identity if the token existed, was unconsumed, and
+ * had not expired. Otherwise returns null.
  */
-export async function verifyMagicLink(db: D1Database, token: string): Promise<string | null> {
-  // Look up the token
+export async function verifyMagicLink(
+  db: D1Database,
+  token: string
+): Promise<ConsumedMagicLink | null> {
+  const now = new Date().toISOString()
+
+  const result = await db
+    .prepare(
+      `UPDATE magic_links
+       SET used_at = ?
+       WHERE token = ? AND used_at IS NULL AND expires_at > ?`
+    )
+    .bind(now, token, now)
+    .run()
+
+  if (!result.meta.changed_db || (result.meta.changes ?? 0) === 0) {
+    return null
+  }
+
   const row = await db
     .prepare(`SELECT * FROM magic_links WHERE token = ? LIMIT 1`)
     .bind(token)
@@ -76,21 +104,10 @@ export async function verifyMagicLink(db: D1Database, token: string): Promise<st
     return null
   }
 
-  // Check if already used
-  if (row.used_at !== null) {
-    return null
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    userId: row.user_id,
+    email: row.email,
   }
-
-  // Check if expired
-  if (new Date(row.expires_at) <= new Date()) {
-    return null
-  }
-
-  // Mark as used (single-use enforcement)
-  await db
-    .prepare(`UPDATE magic_links SET used_at = datetime('now') WHERE id = ?`)
-    .bind(row.id)
-    .run()
-
-  return row.email
 }

--- a/src/lib/booking/intake-core.ts
+++ b/src/lib/booking/intake-core.ts
@@ -8,8 +8,8 @@
 
 import { findOrCreateEntity, getEntity } from '../db/entities'
 import { createContact } from '../db/contacts'
-import { createAssessment, updateAssessment, getAssessment } from '../db/assessments'
-import { createMeeting } from '../db/meetings'
+import { updateAssessment, getAssessment } from '../db/assessments'
+import { createMeetingWithLegacyAssessment, ensureMeetingForAssessment } from '../db/meetings'
 import { appendContext } from '../db/context'
 
 export interface IntakeInput {
@@ -31,6 +31,7 @@ export interface IntakeInput {
 export interface PreSeededIntake {
   entityId: string
   assessmentId: string
+  meetingType?: string | null
   /**
    * When the admin identified a primary contact at send-link time, pass the
    * id here so we can reuse it rather than creating a duplicate contact when
@@ -56,6 +57,18 @@ export interface IntakeResult {
   meetingId: string | null
   /** Whether the entity was freshly created (vs. found by slug dedup). */
   entityCreated: boolean
+  /** Whether this intake created a new contact row. */
+  contactCreated: boolean
+  /** Context row id for compensating rollback on booking failures. */
+  contextId: string | null
+  /** Whether this intake created a new legacy assessment row. */
+  assessmentCreated: boolean
+  /** Whether this intake created a new canonical meeting row. */
+  meetingCreated: boolean
+  /** Previous legacy assessment scheduled_at before any booking mutation. */
+  previousAssessmentScheduledAt: string | null
+  /** Previous canonical meeting scheduled_at before any booking mutation. */
+  previousMeetingScheduledAt: string | null
   /** Formatted intake lines for use in admin notification emails. */
   intakeLines: string[]
 }
@@ -114,6 +127,7 @@ export async function processIntakeSubmission(
   //    otherwise fall back to email-based dedup and creation so we never
   //    drop the guest's real contact details on the floor.
   let contactId: string
+  let contactCreated = false
   const existingContact = await db
     .prepare('SELECT id FROM contacts WHERE org_id = ? AND email = ? LIMIT 1')
     .bind(orgId, input.email)
@@ -130,12 +144,14 @@ export async function processIntakeSubmission(
       email: input.email,
     })
     contactId = contact.id
+    contactCreated = true
   } else {
     const contact = await createContact(db, orgId, entityId, {
       name: input.name,
       email: input.email,
     })
     contactId = contact.id
+    contactCreated = true
   }
 
   // 3. Meeting + legacy assessment row.
@@ -151,6 +167,10 @@ export async function processIntakeSubmission(
   //    lands (follow-up issue #503).
   let meetingId: string | null = null
   let assessmentId: string | null = null
+  let assessmentCreated = false
+  let meetingCreated = false
+  let previousAssessmentScheduledAt: string | null = null
+  let previousMeetingScheduledAt: string | null = null
   if (preSeeded?.assessmentId && scheduledAt) {
     const existing = await getAssessment(db, orgId, preSeeded.assessmentId)
     if (!existing) {
@@ -158,25 +178,31 @@ export async function processIntakeSubmission(
         `Pre-seeded assessment not found: ${preSeeded.assessmentId}. The booking link may be stale.`
       )
     }
+    if (existing.entity_id !== entityId) {
+      throw new Error(
+        `Pre-seeded assessment ${preSeeded.assessmentId} does not belong to entity ${entityId}.`
+      )
+    }
+    previousAssessmentScheduledAt = existing.scheduled_at
     await updateAssessment(db, orgId, preSeeded.assessmentId, { scheduled_at: scheduledAt })
     assessmentId = preSeeded.assessmentId
-    // meetingId stays null for the pre-seeded path — legacy FK resolves via assessmentId.
+    const ensured = await ensureMeetingForAssessment(db, orgId, entityId, {
+      assessmentId: preSeeded.assessmentId,
+      scheduled_at: scheduledAt,
+      meeting_type: preSeeded.meetingType,
+    })
+    meetingId = ensured.meeting.id
+    meetingCreated = ensured.created
+    previousMeetingScheduledAt = ensured.previousScheduledAt
   } else if (scheduledAt) {
-    const meeting = await createMeeting(db, orgId, entityId, {
+    const meeting = await createMeetingWithLegacyAssessment(db, orgId, entityId, {
       scheduled_at: scheduledAt,
       meeting_type: 'assessment',
     })
     meetingId = meeting.id
     assessmentId = meeting.id
-
-    // Seed legacy row with the same primary key for FK compatibility.
-    await db
-      .prepare(
-        `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
-         VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
-      )
-      .bind(meeting.id, orgId, entityId, scheduledAt)
-      .run()
+    assessmentCreated = true
+    meetingCreated = true
   }
 
   // 4. Append intake context
@@ -188,8 +214,9 @@ export async function processIntakeSubmission(
     intakeLines.push(`What they're trying to accomplish: ${input.biggestChallenge}`)
   if (input.howHeard) intakeLines.push(`How they found us: ${input.howHeard}`)
 
+  let contextId: string | null = null
   if (intakeLines.length > 0) {
-    await appendContext(db, orgId, {
+    const contextEntry = await appendContext(db, orgId, {
       entity_id: entityId,
       type: 'intake',
       content: intakeLines.join('\n'),
@@ -204,6 +231,7 @@ export async function processIntakeSubmission(
         how_heard: input.howHeard,
       },
     })
+    contextId = contextEntry.id
   }
 
   return {
@@ -212,6 +240,12 @@ export async function processIntakeSubmission(
     assessmentId,
     meetingId,
     entityCreated,
+    contactCreated,
+    contextId,
+    assessmentCreated,
+    meetingCreated,
+    previousAssessmentScheduledAt,
+    previousMeetingScheduledAt,
     intakeLines,
   }
 }

--- a/src/lib/booking/rollback.ts
+++ b/src/lib/booking/rollback.ts
@@ -1,0 +1,78 @@
+import { recomputeDeterministicCache } from '../entities/recompute.js'
+
+export interface RollbackFailedBookingInput {
+  orgId: string
+  holdId: string
+  scheduleId: string
+  meetingScheduleId: string
+  assessmentId: string
+  meetingId: string
+  preserveBookingRows: boolean
+  previousAssessmentScheduledAt: string | null
+  previousMeetingScheduledAt: string | null
+  entityId?: string
+  entityCreated?: boolean
+  contactId?: string
+  contactCreated?: boolean
+  contextId?: string | null
+}
+
+/**
+ * Compensating rollback for failed booking reserves.
+ *
+ * A booking is only "real" after Google sync succeeds. If any later phase
+ * fails, remove or restore every artifact created during intake so the CRM
+ * does not drift into a false partially-booked state.
+ */
+export async function rollbackFailedBooking(
+  db: D1Database,
+  input: RollbackFailedBookingInput
+): Promise<void> {
+  await db.prepare('DELETE FROM meeting_schedule WHERE id = ?').bind(input.meetingScheduleId).run()
+  await db.prepare('DELETE FROM assessment_schedule WHERE id = ?').bind(input.scheduleId).run()
+
+  if (input.preserveBookingRows) {
+    await db
+      .prepare('UPDATE meetings SET scheduled_at = ? WHERE id = ? AND org_id = ?')
+      .bind(input.previousMeetingScheduledAt, input.meetingId, input.orgId)
+      .run()
+    await db
+      .prepare('UPDATE assessments SET scheduled_at = ? WHERE id = ? AND org_id = ?')
+      .bind(input.previousAssessmentScheduledAt, input.assessmentId, input.orgId)
+      .run()
+  } else {
+    await db
+      .prepare('DELETE FROM meetings WHERE id = ? AND org_id = ?')
+      .bind(input.meetingId, input.orgId)
+      .run()
+    await db
+      .prepare('DELETE FROM assessments WHERE id = ? AND org_id = ?')
+      .bind(input.assessmentId, input.orgId)
+      .run()
+  }
+
+  if (input.contextId) {
+    await db
+      .prepare('DELETE FROM context WHERE id = ? AND org_id = ?')
+      .bind(input.contextId, input.orgId)
+      .run()
+  }
+
+  if (input.contactCreated && input.contactId) {
+    await db
+      .prepare('DELETE FROM contacts WHERE id = ? AND org_id = ?')
+      .bind(input.contactId, input.orgId)
+      .run()
+  }
+
+  if (input.entityCreated && input.entityId) {
+    await db
+      .prepare('DELETE FROM entities WHERE id = ? AND org_id = ?')
+      .bind(input.entityId, input.orgId)
+      .run()
+  } else if (input.contextId && input.entityId) {
+    await recomputeDeterministicCache(db, input.orgId, input.entityId)
+  }
+
+  await db.prepare('DELETE FROM booking_holds WHERE id = ?').bind(input.holdId).run()
+}

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -61,6 +61,18 @@ export interface CreateMeetingData {
   meeting_type?: string | null
 }
 
+export interface EnsureMeetingForAssessmentData {
+  assessmentId: string
+  scheduled_at?: string | null
+  meeting_type?: string | null
+}
+
+export interface EnsureMeetingForAssessmentResult {
+  meeting: Meeting
+  created: boolean
+  previousScheduledAt: string | null
+}
+
 export interface UpdateMeetingData {
   scheduled_at?: string | null
   completed_at?: string | null
@@ -179,6 +191,146 @@ export async function createMeeting(
     throw new Error('Failed to retrieve created meeting')
   }
   return meeting
+}
+
+/**
+ * Create the canonical meeting row and the legacy assessment mirror row using
+ * the same primary key during the monitoring window.
+ */
+export async function createMeetingWithLegacyAssessment(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  data: CreateMeetingData
+): Promise<Meeting> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  try {
+    await db.batch([
+      db
+        .prepare(
+          `INSERT INTO meetings (
+            id, org_id, entity_id, meeting_type, scheduled_at, status, created_at
+          ) VALUES (?, ?, ?, ?, ?, 'scheduled', ?)`
+        )
+        .bind(id, orgId, entityId, data.meeting_type ?? null, data.scheduled_at ?? null, now),
+      db
+        .prepare(
+          `INSERT INTO assessments (
+            id, org_id, entity_id, scheduled_at, status, created_at
+          ) VALUES (?, ?, ?, ?, 'scheduled', ?)`
+        )
+        .bind(id, orgId, entityId, data.scheduled_at ?? null, now),
+    ])
+  } catch (error) {
+    await db.batch([
+      db.prepare('DELETE FROM meetings WHERE id = ? AND org_id = ?').bind(id, orgId),
+      db.prepare('DELETE FROM assessments WHERE id = ? AND org_id = ?').bind(id, orgId),
+    ])
+    throw error
+  }
+
+  const meeting = await getMeeting(db, orgId, id)
+  if (!meeting) {
+    throw new Error('Failed to retrieve created meeting')
+  }
+  return meeting
+}
+
+/**
+ * Ensure a canonical meeting row exists for a legacy assessment id, then keep
+ * its scheduled_at / meeting_type aligned with the booking flow.
+ */
+export async function ensureMeetingForAssessment(
+  db: D1Database,
+  orgId: string,
+  entityId: string,
+  data: EnsureMeetingForAssessmentData
+): Promise<EnsureMeetingForAssessmentResult> {
+  const existing = await getMeeting(db, orgId, data.assessmentId)
+  if (existing) {
+    const updated = await updateMeeting(db, orgId, data.assessmentId, {
+      scheduled_at: data.scheduled_at,
+      ...(data.meeting_type !== undefined ? { meeting_type: data.meeting_type } : {}),
+    })
+    if (!updated) {
+      throw new Error('Failed to update meeting for legacy assessment')
+    }
+    return {
+      meeting: updated,
+      created: false,
+      previousScheduledAt: existing.scheduled_at,
+    }
+  }
+
+  const assessment = await db
+    .prepare(
+      `SELECT entity_id, scheduled_at, status, created_at
+       FROM assessments
+       WHERE id = ? AND org_id = ?`
+    )
+    .bind(data.assessmentId, orgId)
+    .first<{
+      entity_id: string
+      scheduled_at: string | null
+      status: string
+      created_at: string
+    }>()
+
+  if (!assessment) {
+    throw new Error(`Assessment not found: ${data.assessmentId}`)
+  }
+
+  if (assessment.entity_id !== entityId) {
+    throw new Error(`Assessment ${data.assessmentId} does not belong to entity ${entityId}`)
+  }
+
+  try {
+    await db
+      .prepare(
+        `INSERT INTO meetings (
+          id, org_id, entity_id, meeting_type, scheduled_at, status, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        data.assessmentId,
+        orgId,
+        entityId,
+        data.meeting_type ?? 'assessment',
+        data.scheduled_at ?? assessment.scheduled_at,
+        assessment.status,
+        assessment.created_at
+      )
+      .run()
+  } catch (error) {
+    const raced = await getMeeting(db, orgId, data.assessmentId)
+    if (!raced) throw error
+
+    const updated = await updateMeeting(db, orgId, data.assessmentId, {
+      scheduled_at: data.scheduled_at,
+      ...(data.meeting_type !== undefined ? { meeting_type: data.meeting_type } : {}),
+    })
+    if (!updated) {
+      throw new Error('Failed to update raced meeting for legacy assessment')
+    }
+    return {
+      meeting: updated,
+      created: false,
+      previousScheduledAt: raced.scheduled_at,
+    }
+  }
+
+  const meeting = await getMeeting(db, orgId, data.assessmentId)
+  if (!meeting) {
+    throw new Error('Failed to retrieve meeting for legacy assessment')
+  }
+
+  return {
+    meeting,
+    created: true,
+    previousScheduledAt: null,
+  }
 }
 
 /**

--- a/src/lib/sow/service.ts
+++ b/src/lib/sow/service.ts
@@ -409,12 +409,14 @@ export async function finalizeCompletedSOWSignature(args: {
   const milestoneStmts = lineItems.map((item, i) =>
     db
       .prepare(
-        `INSERT INTO milestones (id, engagement_id, name, description, status, payment_trigger, sort_order, created_at)
-         VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`
+        `INSERT INTO milestones (
+           id, engagement_id, org_id, name, description, status, payment_trigger, sort_order, created_at
+         ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?)`
       )
       .bind(
         milestoneIds[i],
         engagementId,
+        request.org_id,
         item.problem,
         item.description,
         i === lineItems.length - 1 ? 1 : 0,

--- a/src/pages/api/admin/entities/[id]/send-booking-link.ts
+++ b/src/pages/api/admin/entities/[id]/send-booking-link.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
 import { getEntity, transitionStage } from '../../../../../lib/db/entities'
-import { createAssessment } from '../../../../../lib/db/assessments'
+import { createMeetingWithLegacyAssessment } from '../../../../../lib/db/meetings'
 import { listContacts } from '../../../../../lib/db/contacts'
 import { appendContext } from '../../../../../lib/db/context'
 import {
@@ -18,13 +18,13 @@ import { env } from 'cloudflare:workers'
  * that actually matches its label (#467).
  *
  * Flow:
- *   1. Create an assessment row in `scheduled` status with no `scheduled_at`
- *      yet — the schedule sidecar row is added by `/api/booking/reserve` when
- *      the prospect actually picks a slot.
- *   2. Transition the entity `prospect → assessing` (stage rename to
- *      `meetings` is tracked separately in #466 and will be adopted then).
+ *   1. Create a canonical meeting row in `scheduled` status with no
+ *      `scheduled_at` yet, and seed the legacy assessment mirror row with the
+ *      same primary key during the monitoring window.
+ *   2. Transition the entity `prospect → meetings`.
  *   3. Sign a booking-link token that carries the entity_id, contact_id,
- *      assessment_id, and admin-chosen duration. TTL defaults to 14 days.
+ *      assessment_id, meeting_type, and admin-chosen duration. TTL defaults
+ *      to 14 days.
  *   4. Append a context entry noting the link was sent, with a copyable
  *      outreach template and mailto URL.
  *   5. Return JSON with the signed URL and outreach template so the admin
@@ -85,17 +85,18 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     const contactEmail = primaryContact?.email ?? null
     const contactName = primaryContact?.name ?? null
 
-    // --- 1. Create the assessment row in scheduled status -------------------
+    // --- 1. Create the meeting row and the legacy assessment mirror ---------
     //
     // scheduled_at stays null until the prospect picks a slot via the public
-    // booking flow. The create helper sets status = 'scheduled' by default.
-    const assessment = await createAssessment(env.DB, session.orgId, entityId, {
+    // booking flow.
+    const meeting = await createMeetingWithLegacyAssessment(env.DB, session.orgId, entityId, {
       scheduled_at: null,
+      meeting_type: meetingType,
     })
 
-    // --- 2. Transition entity stage prospect → assessing --------------------
+    // --- 2. Transition entity stage prospect → meetings ---------------------
     //
-    // We do this AFTER creating the assessment row so the acceptance-criteria
+    // We do this AFTER creating the meeting row so the acceptance-criteria
     // invariant (stage transitions only after the meeting row exists) holds
     // even if the caller retries. If the stage transition fails we leave the
     // orphan `scheduled` assessment in place — it is harmless and a subsequent
@@ -122,7 +123,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
       token = await signBookingLink({
         entity_id: entityId,
         contact_id: primaryContact?.id ?? null,
-        assessment_id: assessment.id,
+        assessment_id: meeting.id,
         duration_minutes: duration,
         meeting_type: meetingType,
       })
@@ -159,7 +160,8 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
       source: 'send_booking_link',
       metadata: {
         trigger: 'send_booking_link',
-        assessment_id: assessment.id,
+        assessment_id: meeting.id,
+        meeting_id: meeting.id,
         duration_minutes: duration,
         meeting_type: meetingType,
         token_ttl_days: DEFAULT_BOOKING_LINK_TTL_DAYS,
@@ -175,7 +177,8 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 
     return jsonResponse(200, {
       ok: true,
-      assessment_id: assessment.id,
+      assessment_id: meeting.id,
+      meeting_id: meeting.id,
       booking_url: bookingUrl,
       token_ttl_days: DEFAULT_BOOKING_LINK_TTL_DAYS,
       contact_email: contactEmail,

--- a/src/pages/api/admin/resend-invitation.ts
+++ b/src/pages/api/admin/resend-invitation.ts
@@ -94,7 +94,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
 
     // Create magic link
-    const token = await createMagicLink(env.DB, targetEmail)
+    const token = await createMagicLink(env.DB, {
+      orgId: user.org_id,
+      userId: user.id,
+      email: targetEmail,
+    })
 
     // Build verification URL from the canonical PORTAL_BASE_URL.
     // Never derive from request host — see issue #173.

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { verifyPassword } from '../../../lib/auth/password'
 import { createSession, buildSessionCookie } from '../../../lib/auth/session'
+import { ORG_ID } from '../../../lib/constants'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import { env } from 'cloudflare:workers'
 
@@ -48,9 +49,12 @@ export const POST: APIRoute = async ({ request, redirect }) => {
       return redirect('/auth/login?error=missing', 302)
     }
 
-    // Look up user by email
-    const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ? AND role = 'admin'`)
-      .bind(email.toLowerCase().trim())
+    // Look up the admin within the current app org. Email is not globally
+    // unique across organizations.
+    const user = await env.DB.prepare(
+      `SELECT * FROM users WHERE org_id = ? AND email = ? AND role = 'admin'`
+    )
+      .bind(ORG_ID, email.toLowerCase().trim())
       .first<UserRow>()
 
     if (!user || !user.password_hash) {

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro'
 import { createMagicLink } from '../../../lib/auth/magic-link'
+import { ORG_ID } from '../../../lib/constants'
 import { requirePortalBaseUrl } from '../../../lib/config/app-url'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildMagicLinkUrl, magicLinkEmailHtml } from '../../../lib/email/templates'
@@ -44,9 +45,12 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     }
 
     const normalizedEmail = email.toLowerCase().trim()
-    // Look up client user by email
-    const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ? AND role = 'client'`)
-      .bind(normalizedEmail)
+    // Look up the client user in the current app org. Email is not globally
+    // unique across organizations.
+    const user = await env.DB.prepare(
+      `SELECT * FROM users WHERE org_id = ? AND email = ? AND role = 'client'`
+    )
+      .bind(ORG_ID, normalizedEmail)
       .first<UserRow>()
 
     if (!user) {
@@ -56,7 +60,11 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     }
 
     // Create magic link token
-    const token = await createMagicLink(env.DB, normalizedEmail)
+    const token = await createMagicLink(env.DB, {
+      orgId: user.org_id,
+      userId: user.id,
+      email: normalizedEmail,
+    })
 
     // Build the verification URL from the canonical PORTAL_BASE_URL.
     // Never derive from request host — see issue #173.

--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../lib/booking/tokens'
 import { buildIcs, icsToBase64 } from '../../../lib/booking/ics'
 import { processIntakeSubmission, type PreSeededIntake } from '../../../lib/booking/intake-core'
+import { rollbackFailedBooking } from '../../../lib/booking/rollback'
 import { createScheduleStatement, updateScheduleGoogleSync } from '../../../lib/booking/schedule'
 import { verifyBookingLink } from '../../../lib/booking/signed-link'
 import {
@@ -36,9 +37,9 @@ const NOTIFY_EMAIL = 'team@smd.services'
  *
  * Atomic 3-phase booking flow:
  *   1. Preflight  — Turnstile, rate limit, input validation
- *   2. DB commit  — Intake (entity + contact + assessment) + schedule + hold + token
+ *   2. DB commit  — Intake + schedule sidecars + hold + token
  *   3. Google sync — Create calendar event; compensating rollback on failure
- *   4. Post-commit — Send confirmation email with ICS
+ *   4. Post-commit — Promote stage, send confirmation email with ICS
  *
  * Google event creation failure = booking failure. No silent fallback.
  */
@@ -137,6 +138,7 @@ export const POST: APIRoute = async ({ request }) => {
       preSeeded = {
         entityId: verify.payload.entity_id,
         assessmentId: verify.payload.assessment_id,
+        meetingType: verify.payload.meeting_type,
         contactId: verify.payload.contact_id,
       }
     } else {
@@ -195,6 +197,12 @@ export const POST: APIRoute = async ({ request }) => {
   let meetingScheduleId: string
   let manageToken: string
   let intakeLines: string[]
+  let entityCreated = false
+  let contactCreated = false
+  let contactId: string | undefined
+  let contextId: string | null = null
+  let previousAssessmentScheduledAt: string | null = null
+  let previousMeetingScheduledAt: string | null = null
 
   try {
     // 2b. Process intake (entity + contact + assessment)
@@ -223,7 +231,13 @@ export const POST: APIRoute = async ({ request }) => {
     assessmentId = intakeResult.assessmentId!
     meetingId = intakeResult.meetingId!
     entityId = intakeResult.entityId
+    entityCreated = intakeResult.entityCreated
+    contactCreated = intakeResult.contactCreated
+    contactId = intakeResult.contactId
+    contextId = intakeResult.contextId
     intakeLines = intakeResult.intakeLines
+    previousAssessmentScheduledAt = intakeResult.previousAssessmentScheduledAt
+    previousMeetingScheduledAt = intakeResult.previousMeetingScheduledAt
 
     // 2c. Generate manage token + hash
     manageToken = generateManageToken()
@@ -270,19 +284,6 @@ export const POST: APIRoute = async ({ request }) => {
       })
     meetingScheduleId = newMeetingScheduleId
     await meetingScheduleStmt.run()
-
-    // 2e. Promote entity stage to 'meetings' (only if currently 'prospect')
-    try {
-      await transitionStage(
-        env.DB,
-        ORG_ID,
-        entityId,
-        'meetings',
-        'Booking reserve: meeting scheduled'
-      )
-    } catch {
-      // Stage transition may fail if entity is already past prospect — that's fine
-    }
   } catch (err) {
     // DB commit failed — release hold and return error
     console.error('[api/booking/reserve] DB commit failed:', err)
@@ -294,13 +295,9 @@ export const POST: APIRoute = async ({ request }) => {
   // Phase 3: Google Calendar sync
   // -----------------------------------------------------------------------
   const calendarId = integration.calendar_id || BOOKING_CONFIG.consultant.calendar_id
-  let googleEventId: string | null = null
-  let googleEventLink: string | null = null
   let googleMeetUrl: string | null = null
 
   try {
-    const slotLabel = formatSlotLabelLong(slotStartUtc, BOOKING_CONFIG.consultant.timezone)
-
     const meetUrl = BOOKING_CONFIG.meeting_url
     const eventResult = await createGoogleCalendarEvent(accessToken, calendarId, {
       summary: `Assessment: ${businessName} (${name})`,
@@ -311,8 +308,6 @@ export const POST: APIRoute = async ({ request }) => {
       assessmentId,
     })
 
-    googleEventId = eventResult.eventId
-    googleEventLink = eventResult.htmlLink
     googleMeetUrl = meetUrl
 
     // Update both schedules with Google sync data. See the dual-write rationale
@@ -327,23 +322,41 @@ export const POST: APIRoute = async ({ request }) => {
       googleEventLink: eventResult.htmlLink,
       googleMeetUrl: meetUrl,
     })
+
+    // Promote the entity only after Google sync succeeds so a failed booking
+    // never leaves the CRM in a false "meeting scheduled" state.
+    try {
+      await transitionStage(
+        env.DB,
+        ORG_ID,
+        entityId,
+        'meetings',
+        'Booking reserve: meeting scheduled'
+      )
+    } catch {
+      // Entity may already be past prospect. Do not fail the booking.
+    }
   } catch (err) {
     // Google sync failed — compensating rollback
     console.error('[api/booking/reserve] Google Calendar event creation failed:', err)
 
     try {
-      // Delete both schedule sidecars, meeting + assessment, and the hold.
-      // Order matters — sidecars first so FK constraints don't block the drop.
-      await env.DB.batch([
-        env.DB.prepare('DELETE FROM meeting_schedule WHERE id = ?').bind(meetingScheduleId),
-        env.DB.prepare('DELETE FROM assessment_schedule WHERE id = ?').bind(scheduleId),
-        env.DB.prepare('DELETE FROM meetings WHERE id = ? AND org_id = ?').bind(meetingId, ORG_ID),
-        env.DB.prepare('DELETE FROM assessments WHERE id = ? AND org_id = ?').bind(
-          assessmentId,
-          ORG_ID
-        ),
-        env.DB.prepare('DELETE FROM booking_holds WHERE id = ?').bind(holdResult.id!),
-      ])
+      await rollbackFailedBooking(env.DB, {
+        orgId: ORG_ID,
+        holdId: holdResult.id!,
+        scheduleId,
+        meetingScheduleId,
+        assessmentId,
+        meetingId,
+        preserveBookingRows: Boolean(preSeeded),
+        previousAssessmentScheduledAt,
+        previousMeetingScheduledAt,
+        entityId,
+        entityCreated,
+        contactId,
+        contactCreated,
+        contextId,
+      })
     } catch (rollbackErr) {
       console.error('[api/booking/reserve] Rollback failed:', rollbackErr)
     }

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -10,7 +10,7 @@ import { env } from 'cloudflare:workers'
  *
  * When a client clicks their magic link, this page:
  *   1. Validates the token (exists, not expired, not used)
- *   2. Looks up the user by email
+ *   2. Looks up the bound user by id + org
  *   3. Creates a session (7-day expiry)
  *   4. Redirects to /portal with session cookie set
  *
@@ -23,15 +23,15 @@ if (!token) {
   return Astro.redirect('/auth/portal-login?error=invalid')
 }
 
-// Verify the magic link token
-const email = await verifyMagicLink(env.DB, token)
+// Verify and atomically consume the magic link token
+const verified = await verifyMagicLink(env.DB, token)
 
-if (!email) {
+if (!verified) {
   // Token is invalid, expired, or already used
   return Astro.redirect('/auth/portal-login?error=invalid')
 }
 
-// Look up the client user by email
+// Look up the bound client user by id + org. Email alone is not globally unique.
 interface UserRow {
   id: string
   org_id: string
@@ -41,8 +41,10 @@ interface UserRow {
   entity_id: string | null
 }
 
-const user = await env.DB.prepare(`SELECT * FROM users WHERE email = ? AND role = 'client'`)
-  .bind(email)
+const user = await env.DB.prepare(
+  `SELECT * FROM users WHERE id = ? AND org_id = ? AND role = 'client'`
+)
+  .bind(verified.userId, verified.orgId)
   .first<UserRow>()
 
 if (!user) {

--- a/tests/admin/send-booking-link.test.ts
+++ b/tests/admin/send-booking-link.test.ts
@@ -3,12 +3,12 @@
  *
  * Verifies the acceptance criteria end-to-end:
  *   - Button behavior matches the label: the endpoint creates a scheduled
- *     assessment row and signs a booking URL. It does NOT perform a bare
- *     stage transition.
+ *     meeting row plus its legacy assessment mirror and signs a booking URL.
+ *     It does NOT perform a bare stage transition.
  *   - Signed URL has a TTL (14 days default).
  *   - Meeting row is created in status `scheduled` at click time, with
  *     `scheduled_at` null (prospect hasn't picked a slot yet).
- *   - Stage transitions to `assessing` only after the meeting row exists.
+ *   - Stage transitions to `meetings` only after the meeting row exists.
  *   - Auth: non-admin sessions are rejected.
  */
 
@@ -123,6 +123,7 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
     const body = (await response.json()) as {
       ok: boolean
       assessment_id: string
+      meeting_id: string
       booking_url: string
       token_ttl_days: number
       contact_email: string
@@ -131,6 +132,7 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
     }
     expect(body.ok).toBe(true)
     expect(body.assessment_id).toMatch(/^[0-9a-f-]+$/)
+    expect(body.meeting_id).toBe(body.assessment_id)
     expect(body.token_ttl_days).toBe(DEFAULT_BOOKING_LINK_TTL_DAYS)
     expect(body.contact_email).toBe('maria@phoenixplumbing.example')
     expect(body.booking_url).toMatch(/^https:\/\/smd\.services\/book\?t=/)
@@ -138,7 +140,7 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
     expect(body.outreach_template).toContain('Maria')
     expect(body.mailto_url).toMatch(/^mailto:/)
 
-    // --- AC: meeting row created in scheduled status, no slot yet -----------
+    // --- AC: legacy assessment row exists in scheduled status, no slot yet --
     const assessment = await db
       .prepare('SELECT * FROM assessments WHERE id = ?')
       .bind(body.assessment_id)
@@ -149,7 +151,30 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
     expect(assessment!.entity_id).toBe(ENTITY_ID)
     expect(assessment!.org_id).toBe(ORG_ID)
 
-    // --- AC: entity transitioned to `assessing` ----------------------------
+    // --- AC: canonical meeting row exists too, using the same id -----------
+    const meeting = await db
+      .prepare(
+        `SELECT id, status, scheduled_at, entity_id, org_id, meeting_type
+         FROM meetings WHERE id = ?`
+      )
+      .bind(body.meeting_id)
+      .first<{
+        id: string
+        status: string
+        scheduled_at: string | null
+        entity_id: string
+        org_id: string
+        meeting_type: string | null
+      }>()
+    expect(meeting).not.toBeNull()
+    expect(meeting!.id).toBe(body.assessment_id)
+    expect(meeting!.status).toBe('scheduled')
+    expect(meeting!.scheduled_at).toBeNull()
+    expect(meeting!.entity_id).toBe(ENTITY_ID)
+    expect(meeting!.org_id).toBe(ORG_ID)
+    expect(meeting!.meeting_type).toBe('discovery')
+
+    // --- AC: entity transitioned to `meetings` -----------------------------
     const entity = await db
       .prepare('SELECT stage FROM entities WHERE id = ?')
       .bind(ENTITY_ID)

--- a/tests/booking/intake-core-preseeded.test.ts
+++ b/tests/booking/intake-core-preseeded.test.ts
@@ -4,6 +4,7 @@
  * When the booking came from an admin-issued signed link, the intake must:
  *   - Anchor to the pre-existing entity (no slug dedup / fan-out to a new row)
  *   - Reuse the pre-created `scheduled` assessment (no duplicate row)
+ *   - Ensure a canonical meeting row exists for that assessment id
  *   - Still capture the guest's email/name as a contact if they differ
  */
 
@@ -64,7 +65,7 @@ describe('processIntakeSubmission — pre-seeded admin booking link flow (#467)'
       .run()
   })
 
-  it('updates the pre-created assessment with the chosen slot instead of creating a new one', async () => {
+  it('updates the pre-created assessment and backfills the canonical meeting row', async () => {
     const slot = '2026-05-01T17:00:00.000Z'
 
     const result = await processIntakeSubmission(
@@ -80,13 +81,20 @@ describe('processIntakeSubmission — pre-seeded admin booking link flow (#467)'
       {
         entityId: ENTITY_ID,
         assessmentId: ASSESSMENT_ID,
+        meetingType: 'discovery',
         contactId: CONTACT_ID,
       }
     )
 
     expect(result.entityId).toBe(ENTITY_ID)
     expect(result.assessmentId).toBe(ASSESSMENT_ID)
+    expect(result.meetingId).toBe(ASSESSMENT_ID)
     expect(result.entityCreated).toBe(false)
+    expect(result.contactCreated).toBe(false)
+    expect(result.assessmentCreated).toBe(false)
+    expect(result.meetingCreated).toBe(true)
+    expect(result.previousAssessmentScheduledAt).toBeNull()
+    expect(result.previousMeetingScheduledAt).toBeNull()
 
     // Only one assessment row for this entity
     const assessments = await db
@@ -96,6 +104,15 @@ describe('processIntakeSubmission — pre-seeded admin booking link flow (#467)'
     expect(assessments.results).toHaveLength(1)
     expect(assessments.results[0].id).toBe(ASSESSMENT_ID)
     expect(assessments.results[0].scheduled_at).toBe(slot)
+
+    const meeting = await db
+      .prepare(`SELECT id, scheduled_at, meeting_type FROM meetings WHERE id = ? AND entity_id = ?`)
+      .bind(ASSESSMENT_ID, ENTITY_ID)
+      .first<{ id: string; scheduled_at: string; meeting_type: string | null }>()
+    expect(meeting).not.toBeNull()
+    expect(meeting!.id).toBe(ASSESSMENT_ID)
+    expect(meeting!.scheduled_at).toBe(slot)
+    expect(meeting!.meeting_type).toBe('discovery')
   })
 
   it('anchors to the pre-seeded entity even when the guest types a different business name', async () => {

--- a/tests/booking/rollback.test.ts
+++ b/tests/booking/rollback.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../../src/lib/db/entities'
+import { createContact } from '../../src/lib/db/contacts'
+import { appendContext } from '../../src/lib/db/context'
+import { createMeetingWithLegacyAssessment } from '../../src/lib/db/meetings'
+import { createScheduleStatement } from '../../src/lib/booking/schedule'
+import { createMeetingScheduleStatement } from '../../src/lib/booking/meeting-schedule'
+import { acquireHold } from '../../src/lib/booking/holds'
+import { rollbackFailedBooking } from '../../src/lib/booking/rollback'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-rollback'
+
+describe('rollbackFailedBooking', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Rollback Org', 'rollback-org')
+      .run()
+  })
+
+  it('removes all intake artifacts for a failed standalone booking', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Rollback Plumbing',
+      stage: 'prospect',
+    })
+    const contact = await createContact(db, ORG_ID, entity.id, {
+      name: 'Jamie Owner',
+      email: 'jamie@example.com',
+    })
+    const context = await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'intake',
+      content: 'What they are trying to accomplish: stabilize bookings',
+      source: 'website_booking',
+      metadata: { biggest_challenge: 'stabilize bookings' },
+    })
+
+    const meeting = await createMeetingWithLegacyAssessment(db, ORG_ID, entity.id, {
+      scheduled_at: '2026-05-01T17:00:00.000Z',
+      meeting_type: 'assessment',
+    })
+
+    const { statement: scheduleStmt, id: scheduleId } = createScheduleStatement(db, {
+      assessmentId: meeting.id,
+      orgId: ORG_ID,
+      slotStartUtc: '2026-05-01T17:00:00.000Z',
+      slotEndUtc: '2026-05-01T17:30:00.000Z',
+      durationMinutes: 30,
+      timezone: 'America/Phoenix',
+      guestName: 'Jamie Owner',
+      guestEmail: 'jamie@example.com',
+      manageTokenHash: 'hash-1',
+      manageTokenExpiresAt: '2026-05-03T17:30:00.000Z',
+    })
+    await scheduleStmt.run()
+
+    const { statement: meetingScheduleStmt, id: meetingScheduleId } =
+      createMeetingScheduleStatement(db, {
+        meetingId: meeting.id,
+        orgId: ORG_ID,
+        slotStartUtc: '2026-05-01T17:00:00.000Z',
+        slotEndUtc: '2026-05-01T17:30:00.000Z',
+        durationMinutes: 30,
+        timezone: 'America/Phoenix',
+        guestName: 'Jamie Owner',
+        guestEmail: 'jamie@example.com',
+        manageTokenHash: 'hash-2',
+        manageTokenExpiresAt: '2026-05-03T17:30:00.000Z',
+      })
+    await meetingScheduleStmt.run()
+
+    const hold = await acquireHold(db, ORG_ID, '2026-05-01T17:00:00.000Z', 'jamie@example.com')
+    expect(hold.acquired).toBe(true)
+
+    await rollbackFailedBooking(db, {
+      orgId: ORG_ID,
+      holdId: hold.id!,
+      scheduleId,
+      meetingScheduleId,
+      assessmentId: meeting.id,
+      meetingId: meeting.id,
+      preserveBookingRows: false,
+      previousAssessmentScheduledAt: null,
+      previousMeetingScheduledAt: null,
+      entityId: entity.id,
+      entityCreated: true,
+      contactId: contact.id,
+      contactCreated: true,
+      contextId: context.id,
+    })
+
+    const counts = await Promise.all([
+      db
+        .prepare(`SELECT COUNT(*) as c FROM entities WHERE id = ?`)
+        .bind(entity.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM contacts WHERE id = ?`)
+        .bind(contact.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM context WHERE id = ?`)
+        .bind(context.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM assessments WHERE id = ?`)
+        .bind(meeting.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM meetings WHERE id = ?`)
+        .bind(meeting.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM assessment_schedule WHERE id = ?`)
+        .bind(scheduleId)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM meeting_schedule WHERE id = ?`)
+        .bind(meetingScheduleId)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM booking_holds WHERE id = ?`)
+        .bind(hold.id!)
+        .first<{ c: number }>(),
+    ])
+
+    for (const row of counts) {
+      expect(row?.c).toBe(0)
+    }
+  })
+
+  it('preserves pre-seeded booking rows and restores scheduled_at on sync failure', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Existing Prospect',
+      stage: 'meetings',
+    })
+    await createContact(db, ORG_ID, entity.id, {
+      name: 'Dana Owner',
+      email: 'dana@example.com',
+    })
+    const createdContact = await createContact(db, ORG_ID, entity.id, {
+      name: 'Dana Backup',
+      email: 'backup@example.com',
+    })
+    const context = await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'intake',
+      content: 'Vertical: home services',
+      source: 'admin_booking_link',
+      metadata: { vertical: 'home_services' },
+    })
+
+    const meeting = await createMeetingWithLegacyAssessment(db, ORG_ID, entity.id, {
+      scheduled_at: null,
+      meeting_type: 'discovery',
+    })
+
+    await db
+      .prepare('UPDATE assessments SET scheduled_at = ? WHERE id = ?')
+      .bind('2026-05-01T17:00:00.000Z', meeting.id)
+      .run()
+    await db
+      .prepare('UPDATE meetings SET scheduled_at = ? WHERE id = ?')
+      .bind('2026-05-01T17:00:00.000Z', meeting.id)
+      .run()
+
+    const { statement: scheduleStmt, id: scheduleId } = createScheduleStatement(db, {
+      assessmentId: meeting.id,
+      orgId: ORG_ID,
+      slotStartUtc: '2026-05-01T17:00:00.000Z',
+      slotEndUtc: '2026-05-01T17:30:00.000Z',
+      durationMinutes: 30,
+      timezone: 'America/Phoenix',
+      guestName: 'Dana Owner',
+      guestEmail: 'dana@example.com',
+      manageTokenHash: 'hash-3',
+      manageTokenExpiresAt: '2026-05-03T17:30:00.000Z',
+    })
+    await scheduleStmt.run()
+
+    const { statement: meetingScheduleStmt, id: meetingScheduleId } =
+      createMeetingScheduleStatement(db, {
+        meetingId: meeting.id,
+        orgId: ORG_ID,
+        slotStartUtc: '2026-05-01T17:00:00.000Z',
+        slotEndUtc: '2026-05-01T17:30:00.000Z',
+        durationMinutes: 30,
+        timezone: 'America/Phoenix',
+        guestName: 'Dana Owner',
+        guestEmail: 'dana@example.com',
+        manageTokenHash: 'hash-4',
+        manageTokenExpiresAt: '2026-05-03T17:30:00.000Z',
+      })
+    await meetingScheduleStmt.run()
+
+    const hold = await acquireHold(db, ORG_ID, '2026-05-01T17:00:00.000Z', 'dana@example.com')
+    expect(hold.acquired).toBe(true)
+
+    await rollbackFailedBooking(db, {
+      orgId: ORG_ID,
+      holdId: hold.id!,
+      scheduleId,
+      meetingScheduleId,
+      assessmentId: meeting.id,
+      meetingId: meeting.id,
+      preserveBookingRows: true,
+      previousAssessmentScheduledAt: null,
+      previousMeetingScheduledAt: null,
+      entityId: entity.id,
+      entityCreated: false,
+      contactId: createdContact.id,
+      contactCreated: true,
+      contextId: context.id,
+    })
+
+    const restoredAssessment = await db
+      .prepare('SELECT scheduled_at FROM assessments WHERE id = ?')
+      .bind(meeting.id)
+      .first<{ scheduled_at: string | null }>()
+    const restoredMeeting = await db
+      .prepare('SELECT scheduled_at FROM meetings WHERE id = ?')
+      .bind(meeting.id)
+      .first<{ scheduled_at: string | null }>()
+
+    expect(restoredAssessment?.scheduled_at).toBeNull()
+    expect(restoredMeeting?.scheduled_at).toBeNull()
+
+    const counts = await Promise.all([
+      db
+        .prepare(`SELECT COUNT(*) as c FROM contacts WHERE id = ?`)
+        .bind(createdContact.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM contacts WHERE email = ?`)
+        .bind('dana@example.com')
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM context WHERE id = ?`)
+        .bind(context.id)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM assessment_schedule WHERE id = ?`)
+        .bind(scheduleId)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM meeting_schedule WHERE id = ?`)
+        .bind(meetingScheduleId)
+        .first<{ c: number }>(),
+      db
+        .prepare(`SELECT COUNT(*) as c FROM booking_holds WHERE id = ?`)
+        .bind(hold.id!)
+        .first<{ c: number }>(),
+    ])
+
+    expect(counts[0]?.c).toBe(0)
+    expect(counts[1]?.c).toBe(1)
+    expect(counts[2]?.c).toBe(0)
+    expect(counts[3]?.c).toBe(0)
+    expect(counts[4]?.c).toBe(0)
+    expect(counts[5]?.c).toBe(0)
+  })
+})

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -1,424 +1,168 @@
-import { describe, it, expect } from 'vitest'
-import { existsSync, readFileSync } from 'fs'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
 import { resolve } from 'path'
-
-describe('magic-link: token module', () => {
-  it('magic-link.ts exists', () => {
-    expect(existsSync(resolve('src/lib/auth/magic-link.ts'))).toBe(true)
-  })
-
-  it('exports createMagicLink and verifyMagicLink', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('export async function createMagicLink')
-    expect(source).toContain('export async function verifyMagicLink')
-  })
-
-  it('tokens expire after 15 minutes', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    // 15 * 60 * 1000 = 900000ms
-    expect(source).toContain('15 * 60 * 1000')
-  })
-
-  it('uses cryptographically random token generation', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('crypto.getRandomValues')
-  })
-
-  it('generates 32-byte (64-char hex) tokens for sufficient entropy', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('Uint8Array(32)')
-  })
-
-  it('enforces single-use tokens by setting used_at', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('used_at')
-    expect(source).toContain("UPDATE magic_links SET used_at = datetime('now')")
-  })
-
-  it('checks token expiration before verification', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('expires_at')
-    expect(source).toContain('new Date(row.expires_at)')
-  })
-
-  it('rejects already-used tokens', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('row.used_at !== null')
-  })
-
-  it('stores tokens in magic_links table', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('INSERT INTO magic_links')
-  })
-
-  it('normalizes email to lowercase on creation', () => {
-    const source = readFileSync(resolve('src/lib/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('email.toLowerCase().trim()')
-  })
-
-  it('is re-exported from auth index module', () => {
-    const source = readFileSync(resolve('src/lib/auth/index.ts'), 'utf-8')
-    expect(source).toContain('createMagicLink')
-    expect(source).toContain('verifyMagicLink')
-    expect(source).toContain('MAGIC_LINK_EXPIRY_MS')
-  })
-})
-
-describe('magic-link: email module', () => {
-  it('resend.ts email client exists', () => {
-    expect(existsSync(resolve('src/lib/email/resend.ts'))).toBe(true)
-  })
-
-  it('templates.ts exists', () => {
-    expect(existsSync(resolve('src/lib/email/templates.ts'))).toBe(true)
-  })
-
-  it('email index module exists', () => {
-    expect(existsSync(resolve('src/lib/email/index.ts'))).toBe(true)
-  })
-
-  it('uses Resend API endpoint', () => {
-    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
-    expect(source).toContain('https://api.resend.com/emails')
-  })
-
-  it('sends from team@smd.services', () => {
-    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
-    expect(source).toContain('team@smd.services')
-  })
-
-  it('logs emails in dev mode when API key is missing', () => {
-    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
-    expect(source).toContain('!apiKey')
-    expect(source).toContain('console.log')
-  })
-
-  it('sends Authorization Bearer header', () => {
-    const source = readFileSync(resolve('src/lib/email/resend.ts'), 'utf-8')
-    expect(source).toContain('Authorization')
-    expect(source).toContain('Bearer')
-  })
-
-  it('magic link email template is branded', () => {
-    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
-    expect(source).toContain('BRAND_NAME')
-    expect(source).toContain('Client Portal')
-  })
-
-  it('magic link email includes 15-minute expiry notice', () => {
-    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
-    expect(source).toContain('15 minutes')
-  })
-
-  it('portal invitation template mentions proposal', () => {
-    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
-    expect(source).toContain('proposal')
-  })
-
-  it('templates export buildMagicLinkUrl helper', () => {
-    const source = readFileSync(resolve('src/lib/email/templates.ts'), 'utf-8')
-    expect(source).toContain('export function buildMagicLinkUrl')
-    expect(source).toContain('/auth/verify')
-  })
-})
-
-describe('magic-link: portal login page', () => {
-  it('portal-login.astro exists', () => {
-    expect(existsSync(resolve('src/pages/auth/portal-login.astro'))).toBe(true)
-  })
-
-  it('form posts to /api/auth/magic-link', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('method="POST"')
-    expect(source).toContain('action="/api/auth/magic-link"')
-  })
-
-  it('includes email input only (no password)', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('name="email"')
-    expect(source).toContain('type="email"')
-    expect(source).not.toContain('type="password"')
-  })
-
-  it('is branded with SMD Services and identifies as the client portal sign-in', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('SMD Services')
-    expect(source).toContain('Client portal sign-in')
-  })
-
-  it('is not indexed by search engines', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('noindex')
-  })
-
-  it('displays success message when magic link is sent', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('sent')
-    expect(source).toContain('Check your email')
-  })
-
-  it('displays error messages for expired and invalid links', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('expired')
-    expect(source).toContain('invalid')
-  })
-})
-
-describe('magic-link: verify page', () => {
-  it('verify.astro exists', () => {
-    expect(existsSync(resolve('src/pages/auth/verify.astro'))).toBe(true)
-  })
-
-  it('reads token from query params', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain("searchParams.get('token')")
-  })
-
-  it('calls verifyMagicLink to validate token', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain('verifyMagicLink')
-  })
-
-  it('creates a session on successful verification', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain('createSession')
-    expect(source).toContain('buildSessionCookie')
-  })
-
-  it('redirects to portal base URL on success', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain('getPortalBaseUrl')
-  })
-
-  it('redirects to portal-login on invalid token', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain('/auth/portal-login?error=invalid')
-  })
-
-  it('looks up client user by email', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain("role = 'client'")
-  })
-
-  it('updates last_login_at on successful verify', () => {
-    const source = readFileSync(resolve('src/pages/auth/verify.astro'), 'utf-8')
-    expect(source).toContain('last_login_at')
-  })
-})
-
-describe('magic-link: API endpoint', () => {
-  it('magic-link API endpoint exists', () => {
-    expect(existsSync(resolve('src/pages/api/auth/magic-link.ts'))).toBe(true)
-  })
-
-  it('handles POST requests', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('export const POST')
-  })
-
-  it('creates magic link and sends email', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('createMagicLink')
-    expect(source).toContain('sendEmail')
-  })
-
-  it('prevents email enumeration by always showing success', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    // Should redirect to sent status even when user not found
-    expect(source).toContain('enumeration')
-    expect(source).toContain('status=sent')
-  })
-
-  it('normalizes email input', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('toLowerCase().trim()')
-  })
-
-  it('only sends to client-role users', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain("role = 'client'")
-  })
-})
-
-describe('magic-link: portal page', () => {
-  it('portal index page exists', () => {
-    expect(existsSync(resolve('src/pages/portal/index.astro'))).toBe(true)
-  })
-
-  it('portal page uses session data', () => {
-    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
-    expect(source).toContain('Astro.locals.session')
-  })
-
-  it('portal page includes logout form', () => {
-    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
-    expect(source).toContain('/api/auth/logout')
-  })
-
-  it('portal page is not indexed by search engines', () => {
-    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
-    expect(source).toContain('noindex')
-  })
-
-  it('portal page is branded via BRAND_NAME', () => {
-    const source = readFileSync(resolve('src/pages/portal/index.astro'), 'utf-8')
-    expect(source).toContain('BRAND_NAME')
-    expect(source).toContain('Portal')
-  })
-})
-
-describe('magic-link: admin resend invitation', () => {
-  it('resend-invitation endpoint exists', () => {
-    expect(existsSync(resolve('src/pages/api/admin/resend-invitation.ts'))).toBe(true)
-  })
-
-  it('handles POST requests', () => {
-    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
-    expect(source).toContain('export const POST')
-  })
-
-  it('verifies admin session', () => {
-    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
-    expect(source).toContain("role !== 'admin'")
-    expect(source).toContain('Unauthorized')
-  })
-
-  it('creates magic link and sends email', () => {
-    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
-    expect(source).toContain('createMagicLink')
-    expect(source).toContain('sendEmail')
-  })
-
-  it('supports email correction for bounced emails (OQ-010)', () => {
-    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
-    // Should update email if a new one is provided
-    expect(source).toContain('UPDATE users SET email')
-    expect(source).toContain('newEmail')
-  })
-
-  it('only targets client-role users', () => {
-    const source = readFileSync(resolve('src/pages/api/admin/resend-invitation.ts'), 'utf-8')
-    expect(source).toContain("role = 'client'")
-  })
-})
-
-describe('magic-link: middleware updates', () => {
-  it('middleware protects /portal routes', () => {
-    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(source).toContain("pathname.startsWith('/portal')")
-  })
-
-  it('middleware protects /api/admin routes', () => {
-    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(source).toContain("pathname.startsWith('/api/admin')")
-  })
-
-  it('middleware redirects unauthenticated portal users to portal-login', () => {
-    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(source).toContain("redirect('/auth/portal-login')")
-  })
-
-  it('middleware returns 401 JSON for unauthenticated admin API requests', () => {
-    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(source).toContain('status: 401')
-  })
-
-  it('middleware enforces role-based access control', () => {
-    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(source).toContain("'admin'")
-    expect(source).toContain("'client'")
-    expect(source).toContain('requiredRole')
-  })
-
-  it('middleware returns 403 for wrong role on admin API routes', () => {
-    const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
-    expect(source).toContain('status: 403')
-    expect(source).toContain('Forbidden')
-  })
-})
-
-describe('magic-link: env types', () => {
-  it('CfEnv includes RESEND_API_KEY', () => {
-    const source = readFileSync(resolve('src/env.d.ts'), 'utf-8')
-    expect(source).toContain('RESEND_API_KEY')
-  })
-})
-
-describe('magic-link: wrangler config', () => {
-  it('wrangler.toml documents RESEND_API_KEY secret', () => {
-    const source = readFileSync(resolve('wrangler.toml'), 'utf-8')
-    expect(source).toContain('RESEND_API_KEY')
-  })
-})
-
-describe('magic-link: logout', () => {
-  it('logout redirects client users to portal-login', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/logout.ts'), 'utf-8')
-    expect(source).toContain('/auth/portal-login')
-  })
-
-  it('logout checks role to determine redirect', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/logout.ts'), 'utf-8')
-    expect(source).toContain("role === 'client'")
-  })
-})
-
-describe('magic-link: D1 schema', () => {
-  it('magic_links table exists in migration', () => {
-    const sql = readFileSync(resolve('migrations/0001_create_tables.sql'), 'utf-8')
-    expect(sql).toContain('CREATE TABLE magic_links')
-  })
-
-  it('magic_links table has required columns', () => {
-    const sql = readFileSync(resolve('migrations/0001_create_tables.sql'), 'utf-8')
-    expect(sql).toContain('email')
-    expect(sql).toContain('token')
-    expect(sql).toContain('expires_at')
-    expect(sql).toContain('used_at')
-  })
-
-  it('magic_links table has token uniqueness constraint', () => {
-    const sql = readFileSync(resolve('migrations/0001_create_tables.sql'), 'utf-8')
-    expect(sql).toContain('token')
-    expect(sql).toContain('UNIQUE')
-  })
-
-  it('magic_links indexes exist', () => {
-    const sql = readFileSync(resolve('migrations/0002_create_indexes.sql'), 'utf-8')
-    expect(sql).toContain('idx_magic_links_email')
-    expect(sql).toContain('idx_magic_links_expires')
-  })
-})
-
-describe('magic-link: rate limiting', () => {
-  it('magic-link endpoint imports rateLimitByIp', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('rateLimitByIp')
-    expect(source).toContain('rate-limit')
-  })
-
-  it('magic-link endpoint rate limit uses auth-magic bucket', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('auth-magic')
-  })
-
-  it('magic-link endpoint redirects to rate_limited error on block', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    expect(source).toContain('rate_limited')
-  })
-
-  it('portal-login page has rate_limited error message', () => {
-    const source = readFileSync(resolve('src/pages/auth/portal-login.astro'), 'utf-8')
-    expect(source).toContain('rate_limited')
-    expect(source).toContain('Too many requests')
-  })
-
-  it('rate limit check occurs before DB lookup (enumeration guard)', () => {
-    const source = readFileSync(resolve('src/pages/api/auth/magic-link.ts'), 'utf-8')
-    const rateLimitIdx = source.indexOf('rateLimitByIp')
-    const dbLookupIdx = source.indexOf('SELECT * FROM users')
-    expect(rateLimitIdx).toBeGreaterThan(-1)
-    expect(dbLookupIdx).toBeGreaterThan(-1)
-    expect(rateLimitIdx).toBeLessThan(dbLookupIdx)
+import type { D1Database } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+
+import { createMagicLink, verifyMagicLink } from '../src/lib/auth/magic-link'
+import { POST } from '../src/pages/api/auth/magic-link'
+import { ORG_ID } from '../src/lib/constants'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const PRIMARY_USER_ID = 'user-primary'
+const SECONDARY_ORG_ID = 'org-secondary'
+const SECONDARY_USER_ID = 'user-secondary'
+
+describe('magic links', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare('INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'SMD Services', 'smd-services')
+      .run()
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(SECONDARY_ORG_ID, 'Secondary Org', 'secondary-org')
+      .run()
+
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role)
+         VALUES (?, ?, ?, ?, 'client')`
+      )
+      .bind(PRIMARY_USER_ID, ORG_ID, 'client@example.com', 'Primary Client')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role)
+         VALUES (?, ?, ?, ?, 'client')`
+      )
+      .bind(SECONDARY_USER_ID, SECONDARY_ORG_ID, 'client@example.com', 'Secondary Client')
+      .run()
+
+    Object.assign(testEnv, {
+      DB: db,
+      APP_BASE_URL: 'https://smd.services',
+      PORTAL_BASE_URL: 'https://portal.smd.services',
+    })
+  })
+
+  afterEach(() => {
+    for (const key of Object.keys(testEnv)) {
+      delete (testEnv as unknown as Record<string, unknown>)[key]
+    }
+  })
+
+  it('stores org_id and user_id, consumes once, and returns the bound subject', async () => {
+    const token = await createMagicLink(db, {
+      orgId: ORG_ID,
+      userId: PRIMARY_USER_ID,
+      email: 'Client@Example.com',
+    })
+
+    const stored = await db
+      .prepare(
+        `SELECT org_id, user_id, email, used_at
+         FROM magic_links
+         WHERE token = ?`
+      )
+      .bind(token)
+      .first<{
+        org_id: string
+        user_id: string
+        email: string
+        used_at: string | null
+      }>()
+
+    expect(stored).not.toBeNull()
+    expect(stored!.org_id).toBe(ORG_ID)
+    expect(stored!.user_id).toBe(PRIMARY_USER_ID)
+    expect(stored!.email).toBe('client@example.com')
+    expect(stored!.used_at).toBeNull()
+
+    const consumed = await verifyMagicLink(db, token)
+    expect(consumed).toEqual({
+      id: expect.any(String),
+      orgId: ORG_ID,
+      userId: PRIMARY_USER_ID,
+      email: 'client@example.com',
+    })
+
+    const secondAttempt = await verifyMagicLink(db, token)
+    expect(secondAttempt).toBeNull()
+  })
+
+  it('allows only one winner under concurrent verification', async () => {
+    const token = await createMagicLink(db, {
+      orgId: ORG_ID,
+      userId: PRIMARY_USER_ID,
+      email: 'client@example.com',
+    })
+
+    const [a, b] = await Promise.all([verifyMagicLink(db, token), verifyMagicLink(db, token)])
+    const winners = [a, b].filter(Boolean)
+
+    expect(winners).toHaveLength(1)
+    expect(winners[0]).toMatchObject({
+      orgId: ORG_ID,
+      userId: PRIMARY_USER_ID,
+      email: 'client@example.com',
+    })
+  })
+
+  it('rejects expired tokens', async () => {
+    const token = await createMagicLink(db, {
+      orgId: ORG_ID,
+      userId: PRIMARY_USER_ID,
+      email: 'client@example.com',
+    })
+
+    await db
+      .prepare(`UPDATE magic_links SET expires_at = datetime('now', '-1 minute') WHERE token = ?`)
+      .bind(token)
+      .run()
+
+    const consumed = await verifyMagicLink(db, token)
+    expect(consumed).toBeNull()
+  })
+
+  it('magic-link POST scopes the lookup to the current app org', async () => {
+    const request = new Request('https://smd.services/api/auth/magic-link', {
+      method: 'POST',
+      body: new URLSearchParams({ email: 'client@example.com' }),
+    })
+
+    const redirect = (location: string, status: number) =>
+      new Response(null, {
+        status,
+        headers: { Location: location },
+      })
+
+    const response = await POST({
+      request,
+      redirect,
+    } as unknown as Parameters<typeof POST>[0])
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe('/auth/portal-login?status=sent')
+
+    const rows = await db
+      .prepare(`SELECT org_id, user_id FROM magic_links ORDER BY created_at ASC`)
+      .all<{ org_id: string; user_id: string }>()
+
+    expect(rows.results).toHaveLength(1)
+    expect(rows.results[0]).toEqual({
+      org_id: ORG_ID,
+      user_id: PRIMARY_USER_ID,
+    })
   })
 })

--- a/tests/schema-hardening.test.ts
+++ b/tests/schema-hardening.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+interface TableColumn {
+  name: string
+  type: string
+  notnull: number
+  dflt_value: string | null
+}
+
+interface ForeignKeyRow {
+  table: string
+  from: string
+  to: string
+}
+
+interface IndexRow {
+  name: string
+}
+
+describe('schema hardening migration 0027', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  })
+
+  it('binds magic links to org_id and user_id', async () => {
+    const columns = await db.prepare(`PRAGMA table_info('magic_links')`).all<TableColumn>()
+    const fks = await db.prepare(`PRAGMA foreign_key_list('magic_links')`).all<ForeignKeyRow>()
+    const indexes = await db.prepare(`PRAGMA index_list('magic_links')`).all<IndexRow>()
+
+    const columnMap = new Map(columns.results.map((column) => [column.name, column]))
+    expect(columnMap.get('org_id')?.notnull).toBe(1)
+    expect(columnMap.get('user_id')?.notnull).toBe(1)
+    expect(columnMap.get('email')?.notnull).toBe(1)
+
+    expect(
+      fks.results.some(
+        (fk) => fk.table === 'organizations' && fk.from === 'org_id' && fk.to === 'id'
+      )
+    ).toBe(true)
+    expect(
+      fks.results.some((fk) => fk.table === 'users' && fk.from === 'user_id' && fk.to === 'id')
+    ).toBe(true)
+
+    const indexNames = indexes.results.map((index) => index.name)
+    expect(indexNames).toContain('idx_magic_links_org_email')
+    expect(indexNames).toContain('idx_magic_links_expires')
+    expect(indexNames).toContain('idx_magic_links_user_expires')
+  })
+
+  it('restores the context foreign key to entities', async () => {
+    const fks = await db.prepare(`PRAGMA foreign_key_list('context')`).all<ForeignKeyRow>()
+
+    expect(
+      fks.results.some((fk) => fk.table === 'entities' && fk.from === 'entity_id' && fk.to === 'id')
+    ).toBe(true)
+    expect(
+      fks.results.some(
+        (fk) => fk.table === 'organizations' && fk.from === 'org_id' && fk.to === 'id'
+      )
+    ).toBe(true)
+  })
+
+  it('hardens milestones.org_id with a real FK and no sentinel default', async () => {
+    const columns = await db.prepare(`PRAGMA table_info('milestones')`).all<TableColumn>()
+    const fks = await db.prepare(`PRAGMA foreign_key_list('milestones')`).all<ForeignKeyRow>()
+    const indexes = await db.prepare(`PRAGMA index_list('milestones')`).all<IndexRow>()
+
+    const orgColumn = columns.results.find((column) => column.name === 'org_id')
+    expect(orgColumn).toBeDefined()
+    expect(orgColumn?.notnull).toBe(1)
+    expect(orgColumn?.dflt_value).toBeNull()
+
+    expect(
+      fks.results.some(
+        (fk) => fk.table === 'organizations' && fk.from === 'org_id' && fk.to === 'id'
+      )
+    ).toBe(true)
+
+    const indexNames = indexes.results.map((index) => index.name)
+    expect(indexNames).toContain('idx_milestones_org_engagement_order')
+    expect(indexNames).toContain('idx_milestones_org_status')
+  })
+})


### PR DESCRIPTION
## Summary

Ships the prior session's review-findings 1-6 work, which was completed and marked `[done]` but never committed.

- **Dual-write booking flow:** canonical `meetings` table + legacy `assessments` table both populated, ensuring backward compatibility during the migration period
- **Pre-seeded booking link integrity:** admin-created entity invitations now populate `meetingId` on creation; no more null-meetingId records leaking into prod
- **Rollback on reserve failure:** new `src/lib/booking/rollback.ts` helper undoes partial state when `/api/booking/reserve` fails midway, leaving no orphaned rows
- **Magic-link auth hardening:** migration 0027 tightens schema constraints; new `tests/schema-hardening.test.ts` validates them

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (including new tests)
- [ ] Migration 0027 applied to staging and validated
- [ ] Manual booking-flow smoke test on staging (pre-seed + reserve + cancel)

## Origin

Implemented in session `sess_01KQ3KWKPTRCXFM5R9DRC6MQ7T` (handoff 16:02 today, status [done]). Shipped from a follow-on session after isolated verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)