### PR TITLE
chore: sync .claude/commands/ from crane-console launcher

### DIFF
--- a/.claude/commands/auth-setup.md
+++ b/.claude/commands/auth-setup.md
@@ -1,0 +1,163 @@
+# /auth-setup - Set up Clerk + Playwright auth bootstrap for a venture
+
+Wires up `@clerk/testing/playwright` so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes **without manual login**.
+
+Solves the recurring pain: "agent gets hung up needing manual login to test."
+
+## When to use
+
+- Run **inside a venture console repo** that uses Clerk (`dc`, `dfg`, `ke`, `sc`)
+- After verifying the venture's Clerk integration is working in dev (`npm run dev` reaches a protected page)
+- One-time setup per venture; re-run only to update the template
+
+## Prerequisites (Manual)
+
+Before running this command, the Captain must have completed:
+
+1. Created a Clerk **test user** in the venture's Clerk Dashboard
+   - Email: `agent-test+clerk_test@venturecrane.com` (the `+clerk_test` is required — Clerk recognizes it as a test identity)
+   - Password: anything strong, stored in Bitwarden
+   - Roles/permissions: same as a typical authenticated user
+2. Confirmed the venture's Infisical secrets include working `CLERK_SECRET_KEY` and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (or `PUBLIC_CLERK_PUBLISHABLE_KEY` for Astro)
+3. (If running against deployed CI) added the same env vars to GitHub Actions secrets
+
+## Execution
+
+### Step 1: Detect Context
+
+1. Confirm cwd is a venture console repo. Walk up to the `.git` root and read `package.json`. If the repo is not in `{dc,dfg,ke,sc}-console`, stop and explain.
+2. Detect framework from `package.json`:
+   - `@clerk/nextjs` → Next.js
+   - `@clerk/astro` → Astro
+3. Detect existing Playwright config: `playwright.config.{ts,js}`. If absent, stop — this skill does not bootstrap Playwright itself.
+4. Read the canonical runbook for reference:
+   ```bash
+   cat ~/dev/crane-console/docs/runbooks/clerk-playwright-auth-setup.md
+   ```
+
+### Step 2: Add Infisical secret
+
+Add `E2E_CLERK_USER_EMAIL` if not present:
+
+```bash
+infisical secrets set --path=/{venture} E2E_CLERK_USER_EMAIL=agent-test+clerk_test@venturecrane.com
+```
+
+Verify the venture's existing Clerk keys are present:
+
+```bash
+infisical secrets list --path=/{venture} | grep -E "CLERK_(SECRET_KEY|PUBLISHABLE_KEY)"
+```
+
+If `CLERK_SECRET_KEY` is missing, stop — the test instance must be configured first.
+
+### Step 3: Install dev deps
+
+```bash
+npm install -D @clerk/testing
+```
+
+(`@playwright/test` should already be installed; verify with `npm list @playwright/test`.)
+
+### Step 4: Copy template files
+
+From `~/dev/crane-console/templates/clerk-playwright-auth/`:
+
+```bash
+TEMPLATE=~/dev/crane-console/templates/clerk-playwright-auth
+
+mkdir -p playwright
+cp "$TEMPLATE/auth.setup.ts" playwright/auth.setup.ts
+```
+
+For Astro projects (`sc`), edit `playwright/auth.setup.ts` and verify env-var names match `PUBLIC_CLERK_PUBLISHABLE_KEY` (Clerk's testing pkg reads from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` by default — Astro repos may need to copy the value).
+
+### Step 5: Update playwright.config.ts
+
+Read the existing `playwright.config.ts` and merge the `projects` block from `templates/clerk-playwright-auth/playwright.config.snippet.ts`:
+
+- Add a `setup-clerk` project that runs `auth.setup.ts`
+- Make authenticated browser projects depend on `setup-clerk` and load `storageState: 'playwright/.clerk/user.json'`
+- Leave any existing public/unauthenticated projects unchanged
+
+Use the Edit tool. Show the diff before applying.
+
+### Step 6: .gitignore
+
+Ensure `playwright/.clerk/` is gitignored (the captured `user.json` is a session secret):
+
+```bash
+grep -q "playwright/.clerk" .gitignore || echo "playwright/.clerk/" >> .gitignore
+```
+
+### Step 7: .env.example
+
+Append from the template:
+
+```bash
+cat ~/dev/crane-console/templates/clerk-playwright-auth/.env.example.snippet >> .env.example
+```
+
+### Step 8: Verify
+
+```bash
+npx playwright test --project=setup-clerk
+```
+
+Expected output: two tests pass (`global clerk setup`, `authenticate and save state`). A `playwright/.clerk/user.json` is created.
+
+If the second test fails with `E2E_CLERK_USER_EMAIL not set`, re-run `crane vc {venture}` (or whatever launches with secrets) so Infisical injects the env.
+
+If the second test fails with a redirect to `/sign-in`, the test user wasn't found in Clerk Dashboard — re-check Step 1 of Prerequisites.
+
+### Step 9: Smoke test the authenticated flow
+
+Add a minimal smoke test that hits a protected page:
+
+```ts
+// e2e/smoke.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('authenticated user reaches protected route', async ({ page }) => {
+  await page.goto('/')
+  // Adjust the URL/selector to a real protected page in this venture
+  await expect(page).not.toHaveURL(/sign-in/)
+})
+```
+
+Run with `npx playwright test --project=chromium-authed` (or whatever the authed project is named). Expect green.
+
+### Step 10: Commit
+
+```bash
+git checkout -b chore/clerk-playwright-auth-bootstrap
+git add playwright/auth.setup.ts playwright.config.ts .gitignore .env.example package.json package-lock.json
+git commit -m "$(cat <<'EOF'
+chore: clerk + playwright auth bootstrap
+
+Solves recurring pain where E2E runs (and agents driving Playwright)
+hit the Clerk login wall and require manual sign-in. Uses
+@clerk/testing/playwright to issue a server-side sign-in token
+(bypasses password/OTP/2FA), captures storageState once, and reuses
+it across workers.
+
+Runbook: ~/dev/crane-console/docs/runbooks/clerk-playwright-auth-setup.md
+EOF
+)"
+git push -u origin chore/clerk-playwright-auth-bootstrap
+gh pr create --title "chore: clerk + playwright auth bootstrap" --body "..."
+```
+
+## What NOT to do
+
+- Don't commit `playwright/.clerk/user.json` — it's a session secret
+- Don't use the production `sk_live_*` Clerk key in CI — testing tokens only work on dev instances
+- Don't reuse a real (human) user as the test identity — use the `+clerk_test` pattern
+- Don't add this to `ss-console` (workers only, no UI auth) or `crane-console` (backend, no UI auth)
+
+## Related
+
+- Runbook: `docs/runbooks/clerk-playwright-auth-setup.md`
+- Template: `templates/clerk-playwright-auth/`
+- Memory: `reference_browser_automation_tools.md`
+- Tooling catalog: `docs/instructions/tooling.md`

--- a/.claude/commands/auto-build.md
+++ b/.claude/commands/auto-build.md
@@ -1,0 +1,104 @@
+# /auto-build - Vetted plan-and-execute workflow
+
+This skill orchestrates a fixed six-step workflow the Captain runs by hand for non-trivial implementation tasks: enter plan mode → build a plan → run `/critique` → exit plan mode for approval → execute autonomously under Auto Mode. It is a thin coordination layer over harness primitives and the existing `/critique` skill. It does not reinvent any of those pieces.
+
+The skill is single-shot. There is no internal "revise loop." Re-run `/auto-build` if the approval gate is rejected.
+
+## Arguments
+
+```
+/auto-build [agents]
+```
+
+- `agents` — number of critic agents `/critique` will spawn in Step 4. Default: **1** (Devil's Advocate). Pass through verbatim to `/critique`. The Captain knows the stakes at invocation; do not infer the count from plan content.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. Store as `AGENT_COUNT`.
+
+## Execution
+
+### Step 1: Verify Auto Mode is active (fail-closed)
+
+Scan the current system-reminder context for any of these known signals:
+
+- `Auto Mode Active` — current canonical string
+- `Auto-Accept Mode` — alternate string seen in some harness builds
+- `auto_mode: true` or similar structured field if/when one ships
+
+**If a match is found**, proceed to Step 2 silently.
+
+**If NO match is found**, do NOT assume Auto Mode is off — assume the detection is unreliable. Halt with:
+
+> `/auto-build` couldn't confirm Auto Mode is active. The skill needs autonomous execution after plan approval; without it, you'll be prompted on every tool call.
+>
+> Either: toggle Auto Mode on (Shift+Tab cycles modes) and re-run, OR reply `yes auto` to override and proceed anyway.
+
+Wait for the Captain's response. Only proceed to Step 2 if they re-invoke after toggling, or reply with the literal `yes auto` override.
+
+**Known fragility:** This is string-matching against harness output and will break if the harness changes its signal. Replace this step with a programmatic mode signal (env var, dedicated tool, structured field) when one ships. Until then, the synonym set + override is the best available.
+
+### Step 2: Enter plan mode
+
+Call `EnterPlanMode`. The harness requests Captain approval and provides a plan file path on entry. If the Captain rejects entry, the skill ends.
+
+### Step 3: Build the plan
+
+Follow the plan-mode discipline already documented in the system prompt:
+
+- **Phase 1 (Initial Understanding):** launch up to 3 Explore subagents in parallel to map the affected code. Use the minimum number needed (often 1).
+- **Phase 2 (Design):** launch up to 3 Plan subagents to design the approach.
+- **Phase 3 (Review):** read critical files identified by the agents; resolve any open questions with `AskUserQuestion`.
+- **Phase 4 (Final Plan):** write the plan to the plan file. Include Context, recommended approach (only the chosen one), critical file paths, reused functions/utilities, and a Verification section.
+
+Do not call `ExitPlanMode` yet. Step 5 owns the exit.
+
+### Step 4: Invoke `/critique`
+
+Call the `/critique` skill via the Skill tool, passing `AGENT_COUNT`:
+
+```
+/auto-build           → /critique 1   (default Devil's Advocate)
+/auto-build 3         → /critique 3   (Devil's Advocate + Simplifier + Pragmatist)
+/auto-build 6         → /critique 6   (full panel)
+```
+
+`/critique` reads the conversation, spawns critics in parallel, and returns a revised plan with `### Changes Made` and `### Critiques Acknowledged but Not Adopted` sections.
+
+**Apply the revised plan to the plan file.** Editing the plan file is allowed under plan-mode rules (it is the only writable file). The plan file is the source of truth the Captain will see at the approval gate, so it must reflect the post-critique state.
+
+If `/critique` reports "no plan identifiable," something went wrong in Step 3. Re-enter Step 3 — do not attempt to exit plan mode with an unwritten plan.
+
+### Step 5: Gate on Captain approval
+
+Call `ExitPlanMode`. The harness presents the revised plan to the Captain.
+
+- **Approved** → proceed to Step 6.
+- **Rejected** → the skill ends. The Captain re-runs `/auto-build` (or any other command) to start a fresh flow.
+
+We do not model a revise loop. ExitPlanMode rejection delivers Captain feedback as a new user turn, at which point the Captain's next message supersedes the in-progress skill — there is no reliable contract that `/auto-build` regains control with prior context intact. Re-running is cheap; pretending the loop works is dishonest.
+
+### Step 6: Execute autonomously
+
+Implement per the approved plan. Auto Mode is active (verified in Step 1), so:
+
+- No confirmation prompts on routine tool calls.
+- File edits, test runs, commits proceed without per-action approval.
+- **Destructive actions still require explicit confirmation.** Per CLAUDE.md and the Auto Mode reminder: production systems, data deletion, force-push, secret rotation, account creation, dropping schema, modifying auth, removing access controls. Auto Mode is not a license to destroy.
+- If the plan touches code in this repo, end with `npm run verify`.
+- Then commit, push, and open a PR per `pr-workflow.md`.
+
+End-of-session summary: one or two sentences (per `/own-it` rule 5).
+
+## Anti-patterns
+
+The skill must explicitly forbid these. The Captain has flagged each one in feedback memory; do not regress:
+
+1. **No deferral revisions.** When `/critique` raises an issue, fix it in the plan — do not file a follow-up ticket and call the plan done. (Per `feedback_critique_deferrals.md`, `feedback_kill_dont_file.md`.)
+2. **No "I'll figure it out during execution."** If a step is unclear after critique, revise the plan in Step 4; do not punt to runtime.
+3. **No degradation to ask-mode in Step 6.** Routine questions are yours to decide (per `/own-it` rule 1). Only stop for guardrails-gated actions (`crane_doc('global', 'guardrails.md')`).
+4. **No theater.** Plan is one scrollable screen. End-of-session summary is two sentences. No ceremonial status updates mid-step.
+
+## Notes
+
+- **Composability:** `/auto-build` ends at "PR opened, CI green, ready to merge." It does not invoke `/ship`. If the Captain wants ship-too, they invoke `/ship` after.
+- **Critique depth:** Single round per `/critique`'s own design. The Captain can re-invoke `/critique` manually if they want another round before approval.
+- **Trigger ownership:** Captain-invoked, not harness-suggested. The description field reflects this. Do not lower the bar by self-suggesting `/auto-build` in conversational responses; let the Captain decide.

--- a/.claude/commands/calendar-sync.md
+++ b/.claude/commands/calendar-sync.md
@@ -42,7 +42,7 @@ For each venture/day entry from session history:
    - Create a new Google Calendar event with actual venture and times
    - Create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
 
-**IMPORTANT: Never modify, replace, or delete planned events.** Planned events are the work schedule set by `/work-plan`. They stay on the calendar regardless of what actually happened. The calendar shows both planned blocks and actual session blocks side by side.
+**IMPORTANT: Never modify, replace, or delete planned events.** Planned events are the work schedule recorded via `crane_schedule`. They stay on the calendar regardless of what actually happened. The calendar shows both planned blocks and actual session blocks side by side.
 
 ### Step 3: Display Summary
 
@@ -64,8 +64,8 @@ Synced: 2 days, Already synced: 1 day
 
 After sync, Google Calendar should show:
 
-- **Past days**: Both planned blocks (from /work-plan) AND actual session blocks (from D1)
-- **Future days**: Planned blocks only (from /work-plan)
+- **Past days**: Both planned blocks (from `crane_schedule`) AND actual session blocks (from D1)
+- **Future days**: Planned blocks only (from `crane_schedule`)
 - Planned and actual events coexist — they are not mutually exclusive
 
 ## Timezone

--- a/.claude/commands/design-brief.md
+++ b/.claude/commands/design-brief.md
@@ -1,5 +1,14 @@
 # /design-brief - Multi-Agent Design Brief Generator
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "design-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before launching any design-round agent (Brand Strategist, Interaction Designer, Design Technologist, Target User), load the cross-venture pattern + component catalog. Pass the loaded content into `docs/design/context.md` so each round-agent works against the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system.patterns.index.md')`
+> - `crane_doc('global', 'design-system.components.index.md')`
+>
+> The four roles below are voices, not pattern catalogs. Concrete pattern + component decisions in their output should map back to the loaded catalog (or extend it with a clear rationale). Then load the venture's `design-spec.md` for venture-specific palette and tone.
+
 This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
 
 The design brief answers "how should this look and feel?" - downstream of the PRD ("what to build and why?"). It requires a PRD to exist before running.
@@ -10,7 +19,10 @@ Works in any venture console that has `docs/pm/prd.md`.
 
 ```
 /design-brief [rounds]
+/design-brief --extract-identity <path-to-frontend-design-output>
 ```
+
+**Default mode (with optional `rounds` argument):**
 
 - `rounds` - number of design rounds (default: **1**). Each additional round adds cross-pollination where agents read and respond to each other's work.
   - **1 round**: Independent analysis + synthesis. Fast. Good for greenfield projects or early design exploration.
@@ -20,6 +32,12 @@ Works in any venture console that has `docs/pm/prd.md`.
 Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value. There is no upper bound - if someone wants 5 rounds, run 5 rounds.
 
 Store as `TOTAL_ROUNDS`.
+
+**Identity-extraction mode (`--extract-identity`):**
+
+Ingests output from Anthropic's `frontend-design` plugin (HTML/CSS/component code produced by an identity exploration run) and extracts concrete tokens into the venture's `.design/DESIGN.md`. See [workflows/extract-identity.md](workflows/extract-identity.md).
+
+This mode skips the 4-agent brief process entirely. It parses visual output → token spec → file. Use when you've just run `/frontend-design` and need to codify the chosen aesthetic direction before running `/nav-spec`, `/ux-brief`, and `/product-design` downstream.
 
 ## Execution
 

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -1,0 +1,140 @@
+# /heartbeat - Keep Session Alive
+
+Send a heartbeat to prevent your session from timing out.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Updates the `last_heartbeat_at` timestamp
+3. Prevents 45-minute session timeout
+4. Shows when next heartbeat is recommended
+
+## When to Use
+
+- Working on long tasks (>30 minutes)
+- Want to keep session active while reading/researching
+- Need to maintain "active" status visibility
+
+**Not needed if:** You're actively using `/sos`, `/update`, or `/eos` - those all refresh heartbeat automatically.
+
+## Usage
+
+```bash
+/heartbeat
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Send Heartbeat
+
+```bash
+# Build request body
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  '{
+    session_id: $session_id
+  }')
+
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/heartbeat" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Heartbeat failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 3. Display Results
+
+```bash
+LAST_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.last_heartbeat_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "💓 Heartbeat sent"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Last heartbeat: $LAST_HEARTBEAT"
+echo "Next heartbeat in: ~$MINUTES minutes"
+echo ""
+echo "Your session will stay active for 45 minutes from this heartbeat."
+```
+
+## Notes
+
+- Automatic heartbeats: `/sos`, `/update`, `/eos` all refresh heartbeat
+- Manual heartbeat needed when working >30 minutes without those commands
+- Recommended interval: every 10-15 minutes during long tasks
+- Sessions become "abandoned" after 45 minutes without heartbeat (next `/sos` creates new session)
+- Requires active session and CRANE_CONTEXT_KEY
+- Safe to call frequently (idempotent)

--- a/.claude/commands/nav-spec.md
+++ b/.claude/commands/nav-spec.md
@@ -1,50 +1,119 @@
----
-name: nav-spec
-description: Author or revise `.stitch/NAVIGATION.md` — the per-venture three-layer navigation specification (IA + patterns + chrome) that eliminates drift across Stitch-generated screens and live code.
----
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-# /nav-spec - Navigation Specification
+> **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
 
-Invokes the `nav-spec` skill (`~/.agents/skills/nav-spec/`). Produces or revises `.stitch/NAVIGATION.md`.
+# /nav-spec - Nav Spec Authority (v3)
 
-## Usage
+You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every generated screen and shipped surface.
+
+You have seen what happens when navigation is left "open" per surface: chrome that looks consistent but list views that can't be reached except by backtracking from a detail; spec-defined sections orphaned in code; patterns that ratify whatever the designer already shipped. Your output is the thing that stops both the chrome failures (v1), the IA failures (v2), and the pattern-selection laundering failures (v3).
+
+## What changed in v3
+
+v2 added an IA layer and a pattern catalog. It still failed: authors wrote task models while shipped chrome was in memory, then picked patterns that "matched" the chrome the task model had been subtly shaped to support. ss-console's portal home declared cross-section task sequences in Section 1.4.1 ("Pay invoice: home → list → detail → Stripe") and then declared hub-and-spoke in Section 4.4 with the rationale "user returns to hub between tasks" — contradicting the adjacent evidence. No reviewer, no validator rule caught the contradiction.
+
+v3 adds two structural enforcements:
+
+1. **Citation-anchored pattern disqualifiers (R25).** [references/pattern-disqualifiers.md](references/pattern-disqualifiers.md) enumerates disqualifier conditions per catalog pattern, each cited to NN/g / Material 3 / Apple HIG (or tagged `HEURISTIC: UNTESTED`). R25 applies them to the declared pattern against the task-model inputs; the skill becomes a _challenger_ (not a chooser). Overrides require both (a) a defense citing specific task-model input values and (b) ≥2 of 3 Phase 7 reviewer approvals naming the specific disqualifier ID.
+2. **Authoring-direction lint (R26).** Sections 1–4 of `NAVIGATION.md` must not cite `src/components/**` or `*.astro` paths. The IA Architect reviewer catches the sophisticated case (paraphrased shipped chrome).
+
+Additional v3 tightenings:
+
+- Task table requires new columns: `evidence_source` (non-UI artifact) and `return_locus` (task terminus).
+- `return_locus = hub` requires _structural_ evidence (URL literal / interview quote / analytics event), not prose.
+- "Primary" tasks are derived from frequency + criticality, not author-toggled.
+- Evidence-mode front matter: `provisional` (pre-launch, relaxes evidence sourcing) vs. `validated` (production, requires real artifacts). R25 is structural in both modes.
+- Time-bounded provisional-override artifacts: `.design/provisional-override-<date>.md` requires named `deferred_validation.event` and `date ≤90 days`. Expired overrides re-fire R25.
+
+## Core responsibilities
+
+1. **Spec authoring** (`/nav-spec`) — produce `.design/NAVIGATION.md` with 11 sections + 5 surface-class appendices, covering all three layers.
+2. **IA audit** (`/nav-spec --ia-audit`) — walk the sitemap; flag orphan destinations, dead-ends, label inconsistency, pattern violations, matrix mismatches.
+3. **Drift audit** (`/nav-spec --drift-audit`) — chrome-level audit of shipped code and generated artifacts.
+4. **Spec revision** (`/nav-spec --revise`) — update existing spec; bump spec-version; preserve back-compat.
+5. **Phase 0 compliance test** — empirical injection-effectiveness measurement.
+6. **Validation** (`validate.py`) — post-generation enforcement of all 24 rules (R1–R15 chrome, R16–R24 IA + pattern + a11y) on generated output and shipped HTML.
+
+## The three layers
 
 ```
-/nav-spec                        # Author (first time) or check status (if spec exists)
-/nav-spec --revise [flags]       # Update existing spec
-/nav-spec --drift-audit          # Run chrome drift audit only
-/nav-spec --ia-audit             # Run IA audit (orphans, dead-ends, pattern violations)
-/nav-spec --phase-0              # Re-run Phase 0 injection compliance test
-/nav-spec --classify-help        # Show classification decision rubric (5 tags)
+┌─────────────────────────────────────────────────────────────────┐
+│ Layer 1 — Information Architecture                              │
+│   Task model → Sitemap → Reachability matrix                    │
+│   Entry/exit catalogue → State machine                          │
+│   Cross-surface context → URL contract → Content taxonomy       │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 2 — Patterns                                              │
+│   Named patterns from NN/g + Material + HIG                     │
+│   Per {surface × archetype}: which pattern, why, what variants  │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 3 — Chrome                                                │
+│   Header, back, breadcrumbs, footer, skip-link                  │
+│   States, tap targets, mobile↔desktop transforms                │
+│   Per-surface a11y                                              │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
-### Revise flags
+Cross-cutting: search strategy, recovery paths, IA-level a11y, analytics hooks.
 
-```
---add-surface-class <class>      # Add a new auth-model surface class
---add-archetype <archetype>      # Add a new screen archetype
---align-to-code <path>           # Align spec to shipped code at path (resolves code-spec mismatch)
-```
+## Anchoring principle
 
-## Behavior
+The skill **does not invent patterns**. Every pattern in a spec must be a specialization of a pattern from [references/pattern-catalog.md](references/pattern-catalog.md), which catalogs:
 
-1. Resolves this venture's Stitch project ID via `crane_ventures` (fails fast if `stitchProjectId` is null).
-2. Routes to the appropriate workflow based on presence of `.stitch/NAVIGATION.md` and supplied flags:
-   - Absent + no flags → `workflows/author.md`
-   - Present + `--revise` → `workflows/revise.md`
-   - Present + no flags → status summary + suggest next action
-   - `--drift-audit` → `workflows/drift-audit.md`
-   - `--ia-audit` → `workflows/ia-audit.md`
-   - `--phase-0` → `workflows/phase-0-compliance-test.md`
-3. Produces artifacts:
-   - `.stitch/NAVIGATION.md` (primary output)
-   - `.stitch/drift-audit-<YYYY-MM-DD>.md` (drift audit runs)
-   - IA audit report (ia-audit runs)
-   - Phase 0 compliance report copied to the skill's `examples/` folder for reuse
+- **NN/g navigation patterns** — hub-and-spoke, nested-doll, sequential, pyramid, faceted, tag
+- **Material Design 3 navigation components** — top app bar, bottom nav, navigation rail, drawer, tabs, segmented button (with destination-count rules)
+- **Apple HIG patterns** — tab bar, split view, navigation stack, modal
+- **Industry composite patterns** — master-detail, index+preview, modal-on-list, persistent-context workspace, progressive disclosure, command palette
 
-## Classification (v3)
+Reviewing the spec against [references/ia-principles.md](references/ia-principles.md) (Dan Brown's 8 principles of IA) is a required Phase 7 deliverable.
 
-v3 requires 5 classification tags per screen generation:
+## Workflows
+
+| User intent                                     | Workflow                                                           | Primary output                                |
+| ----------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
+| "Create NAVIGATION.md for this venture"         | [author.md](workflows/author.md)                                   | `.design/NAVIGATION.md`                       |
+| "Audit IA holes (orphans, dead-ends, taxonomy)" | [ia-audit.md](workflows/ia-audit.md)                               | `examples/ia-audit-report.md`                 |
+| "Audit chrome drift"                            | [drift-audit.md](workflows/drift-audit.md)                         | In-memory drift report                        |
+| "Update existing NAVIGATION.md"                 | [revise.md](workflows/revise.md)                                   | `.design/NAVIGATION.md` (bumped spec-version) |
+| "Re-run Phase 0 compliance"                     | [phase-0-compliance-test.md](workflows/phase-0-compliance-test.md) | `examples/phase-0-compliance-report.md`       |
+| "Validate a generated screen"                   | [validate.md](workflows/validate.md)                               | Violation report                              |
+
+## Fail-fast preconditions
+
+Before any workflow except the audits:
+
+1. Resolve the venture code for the current repo via `crane_ventures`. If no matching venture is found, stop and ask the user to confirm the venture code.
+2. Check for `.design/DESIGN.md`. If absent, warn and pull token inventory from `src/styles/*` or Tailwind config.
+3. Check for `.design/NAVIGATION.md`. If present, route to `revise.md`. If absent, route to `author.md`.
+
+## Surface-class taxonomy (authoritative)
+
+Surface classes are modeled by **auth model**, not by subdomain.
+
+| Class                 | Auth                          | Examples (ss-console)                        |
+| --------------------- | ----------------------------- | -------------------------------------------- |
+| `public`              | None                          | Marketing home, scorecard, blog, contact     |
+| `auth-gate`           | Sign-in form (no session yet) | `/auth/login`, `/auth/portal-login`          |
+| `token-auth`          | Signed URL token              | `/portal/proposals/[token]`, `/invoice/[id]` |
+| `session-auth-client` | Cookie session, role=client   | `/portal/*`                                  |
+| `session-auth-admin`  | Cookie session, role=admin    | `/admin/*`                                   |
+
+The subdomain is a secondary attribute. A public page on `portal.*` is still `public` chrome-wise.
+
+## Archetype taxonomy (authoritative)
+
+Ten archetypes: `dashboard`, `list`, `detail`, `form`, `wizard`, `empty`, `error`, `modal`, `drawer`, `transient`.
+
+Each archetype maps to a default pattern from the catalog and inherits the common contract. Full table in [references/archetype-catalog.md](references/archetype-catalog.md).
+
+## Classification (deterministic, required, 5 tags)
+
+Every generation (via `product-design`) targeting a specific screen must carry **five** explicit classification tags:
 
 ```
 surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
@@ -54,12 +123,88 @@ task=<short-name from venture's task model>
 pattern=<name from pattern-catalog.md>
 ```
 
-`task=` and `pattern=` are required because chrome alone never determines a pattern. Run `/nav-spec --classify-help` for the decision rubric.
+The pipeline fails fast if any tag is missing or unrecognized. Natural-language inference is explicitly disabled.
 
-## Integration
+The two new tags (`task=`, `pattern=`) are required because chrome alone never determines a pattern — the same chrome can implement different patterns. Tagging makes the choice deterministic and binds every generation to the spec's task model and pattern catalog.
 
-The `stitch-design` and `stitch-ux-brief` skills consume `.stitch/NAVIGATION.md` via graceful-degradation guards. When the spec is present, nav contracts are injected into Stitch prompts and the validator runs post-generation. When absent, both skills fall back to legacy behavior with zero behavior change. v3 rules (R25, R26) soft-skip when their inputs are missing, so v1/v2 specs remain compatible.
+Manual lookup aid: [references/classification-rubric.md](references/classification-rubric.md).
 
-## Execution
+## Injection mechanism
 
-Run the `nav-spec` skill. Start with its `SKILL.md` for phase orientation. The skill's fail-fast preconditions cover project-ID resolution, DESIGN.md check, and NAVIGATION.md presence.
+At prompt-enhancement time, the generator reads `.design/NAVIGATION.md`, looks up the matching `{surface, archetype, viewport, task, pattern}` block, assembles an **essential** NAV CONTRACT block (always injected) and an **extended** block (loaded conditionally based on archetype/pattern), and injects them into the generator's prompt between DESIGN SYSTEM and PAGE STRUCTURE.
+
+Token budget: ≤500 essential, ≤800 essential+extended combined. Canonical format: [references/injection-snippet-template.md](references/injection-snippet-template.md).
+
+Post-generation, `validate.py` parses the returned HTML and runs all 24 rules. Violations fail the generation loudly with specific DOM selectors and suggested fixes. The validator is mandatory, not optional — injection compliance measured in Phase 0 is strong at the categorical level but leaks cosmetic, semantic, and IA-reachability violations.
+
+## Validator coverage (R1–R26)
+
+| #       | Category                | Rule                                                                    | Layer       | Added in |
+| ------- | ----------------------- | ----------------------------------------------------------------------- | ----------- | -------- |
+| R1      | Chrome                  | Header sticky, not fixed                                                | Chrome      | v1       |
+| R2      | Chrome                  | Header bg solid (no blur, no opacity)                                   | Chrome      | v1       |
+| R3      | Chrome                  | No icon before client name                                              | Chrome      | v1       |
+| R4      | Chrome                  | Back not wrapped in breadcrumb nav                                      | Chrome      | v1       |
+| R5      | Chrome                  | Back href is canonical URL                                              | Chrome      | v1       |
+| R6      | Chrome                  | No global nav tabs in header                                            | Chrome      | v1       |
+| R7      | Chrome                  | No sticky-bottom outside dialog                                         | Chrome      | v1       |
+| R8      | Chrome                  | No footer on auth surfaces                                              | Chrome      | v1       |
+| R9      | Chrome                  | No real-face photo placeholders                                         | Chrome      | v1       |
+| R10     | Chrome                  | No marketing CTAs on auth                                               | Chrome      | v1       |
+| R11     | Chrome                  | Header height matches viewport                                          | Chrome      | v1       |
+| R14     | A11y                    | Landmarks present                                                       | A11y        | v1       |
+| R15     | A11y                    | Skip-to-main link wired correctly                                       | A11y        | v1       |
+| R16     | IA                      | Reachability — dashboards link to sibling lists                         | IA          | v2       |
+| R17     | Pattern                 | Pattern conformance — surface implements declared pattern               | Pattern     | v2       |
+| R18     | IA                      | No dead ends                                                            | IA          | v2       |
+| R19     | IA                      | Token-auth handles cold arrival                                         | IA          | v2       |
+| R20     | IA                      | Content taxonomy adherence                                              | IA          | v2       |
+| R21     | IA                      | State machine completeness                                              | IA          | v2       |
+| R22     | A11y                    | Heading hierarchy                                                       | A11y        | v2       |
+| R23     | IA                      | Search affordance present when declared                                 | IA          | v2       |
+| R24     | Pattern                 | Cross-surface context preserved                                         | Pattern     | v2       |
+| **R25** | **Pattern Fitness**     | **Citation-anchored disqualifiers for declared pattern vs. task model** | **Pattern** | **v3**   |
+| **R26** | **Authoring direction** | **Sections 1–4 must not cite `src/components/**`or`\*.astro`\*\*        | **Meta**    | **v3**   |
+
+Severity tiers: **structural** always fails; **semantic** retries once; **cosmetic** warns but passes (configurable per venture).
+
+R25 runs in a spec-only mode via `python3 validate.py --check-pattern-fitness --spec .design/NAVIGATION.md` (no HTML file required). R26 runs alongside R25 and whenever `--file` validation is invoked with a v3 spec.
+
+## References
+
+- [pattern-catalog.md](references/pattern-catalog.md) — NN/g + Material + HIG + composite patterns
+- [pattern-disqualifiers.md](references/pattern-disqualifiers.md) — **v3** citation-anchored disqualifier conditions (powers R25)
+- [ia-principles.md](references/ia-principles.md) — Dan Brown's 8 principles
+- [task-model-template.md](references/task-model-template.md) — task elicitation and structure (v3: evidence_source + return_locus)
+- [reachability-matrix-template.md](references/reachability-matrix-template.md) — central IA artifact
+- [state-machine-template.md](references/state-machine-template.md) — auth/data/task states
+- [content-taxonomy-template.md](references/content-taxonomy-template.md) — labels, verbs, statuses
+- [archetype-catalog.md](references/archetype-catalog.md) — 10 archetypes × default patterns
+- [chrome-component-contracts.md](references/chrome-component-contracts.md) — DOM + Tailwind
+- [classification-rubric.md](references/classification-rubric.md) — 5-tag decision rules
+- [injection-snippet-template.md](references/injection-snippet-template.md) — NAV CONTRACT block (essential + extended)
+- [anti-patterns.md](references/anti-patterns.md) — chrome anti-patterns 1–15 + IA anti-patterns 16–24
+
+## Examples
+
+- [examples/NAVIGATION.md](examples/NAVIGATION.md) — gold-standard v3 spec (migrated from ss-console v2)
+- [examples/ia-audit-report.md](examples/ia-audit-report.md) — IA audit format
+- [examples/drift-audit-report.md](examples/drift-audit-report.md) — chrome drift audit format
+- [examples/phase-0-compliance-report.md](examples/phase-0-compliance-report.md) — empirical compliance measurement
+- [examples/pattern-disqualifier-tests/](examples/pattern-disqualifier-tests/) — v3 synthetic regression tests (admin-heavy-switching, mandatory-wizard, deep-content-library)
+- [examples/v3-regression-test.md](examples/v3-regression-test.md) — expected outputs for the v3 regression suite
+
+## Best practices
+
+- **Author in direction: tasks → golden paths → IA → pattern → spec → COMPARE to code.** Sections 1–4 must be authorable as if shipped code did not exist. Phase 5 (chrome contracts) is the first authorized read of shipped components. R26 enforces this at the lint level; the IA Architect reviewer catches paraphrased shipped-chrome claims in §1–4.
+- **Anchor every pattern.** Every pattern in a spec is a specialization of a catalog entry. Every disqualifier in [pattern-disqualifiers.md](references/pattern-disqualifiers.md) cites NN/g / Material 3 / HIG, or carries a `HEURISTIC: UNTESTED` tag. Never invent.
+- **Skill is a challenger, not a chooser.** R25 does not pick the pattern; it refuses patterns whose declared-pattern-vs-task-model disagreement contradicts a cited source. Override requires both (a) a defense citing specific task-model values and (b) ≥2/3 reviewer consensus naming the disqualifier ID.
+- **"Primary" is structural, not declarative.** A task is primary iff `frequency ∈ {high, medium}` OR `criticality = blocking`. The author cannot dodge R25 disqualifiers by relabeling tasks.
+- **`return_locus = hub` requires structural evidence.** Literal URL in a file or SOW, interview quote, or analytics event. Prose intent is insufficient.
+- **Provisional mode relaxes evidence, not R25.** Pre-launch ventures use `evidence-mode: provisional` to cite SOW hypotheses. R25 remains structural. Dismissal requires a time-bounded `.design/provisional-override-<date>.md` with a named validation event and date ≤90 days.
+- **Five surface classes, not three or four.** v1 forgot `auth-gate`; v2+ include it explicitly.
+- **The reachability matrix is validator-checkable.** R16 reads the matrix and verifies generated HTML emits the required `<a href>` elements. The matrix is not decorative — it is the contract.
+- **The validator is the enforcement layer.** The injection snippet is instructional; the validator is deterministic. When in conflict, trust the validator.
+- **Spec-version bumps reflect breaking changes.** Additive (new archetype, new pattern, new anti-pattern) lands without bump. Structural (taxonomy redefinition, rule inversion, new required section) bumps.
+- **A11y is woven, not bolted.** It lives in chrome (per-surface) AND IA (cross-surface heading hierarchy, landmark consistency). The Implementation reviewer covers per-surface; the IA architect reviewer covers cross-surface.
+- **Backwards compatibility.** v1 specs validate against R1–R15 only. v2 specs (task/pattern tags, reachability matrix) add R16–R24. v3 specs (evidence-mode, return_locus column, decision log) add R25 and R26. Soft-skip warnings are emitted on stderr when a rule's inputs are missing; the pipeline never fails unexpectedly on a v1 or v2 spec due to a v3 rule.

--- a/.claude/commands/product-design.md
+++ b/.claude/commands/product-design.md
@@ -1,0 +1,108 @@
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue.
+
+> **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
+
+# /product-design — Product UI realization
+
+You produce Astro/React components in a venture's own repo. You consume the harness inputs (nav-spec + DESIGN.md + UX brief + existing component source) and emit components that satisfy them — validated by the venture's build command and `validate.py`, reviewed by the Captain.
+
+**Package manager detection.** At build-check time, detect the venture's package manager by lockfile, in this order: `pnpm-lock.yaml` → `pnpm build`, `yarn.lock` → `yarn build`, `package-lock.json` (or absent) → `npm run build`. Preview commands follow the same mapping (`npm run dev` etc.). Don't hardcode.
+
+You are not a design tool. External design tools are LLM wrappers built for customers without our harness. We have nav-spec v3.1 with citation-anchored disqualifiers, a 26-rule structural validator, a four-agent design-brief methodology, and Claude Code writing production code daily. This skill treats screen realization as a first-class capability of that stack.
+
+## What you produce
+
+**Components, not pages.** You write component files (e.g., `src/components/portal/QuoteDetail.astro`). Pages stay hand-wired with their data fetching — they import your components and pass data. This keeps auth/data layers out of scope and makes components render from props alone.
+
+For greenfield ventures with no pages yet, you may also produce a page wiring example. In mature ventures (the common case), stick to components.
+
+## Arguments
+
+```
+/product-design [--surface <name>] [--set <surface-set>] [--revise <path>]
+```
+
+- `--surface <name>` — generate a single surface (e.g., `portal-quotes-detail`). Surface names must match the classification in the venture's NAVIGATION.md.
+- `--set <surface-set>` — generate or revise a batch (e.g., `portal` covers every client-portal surface declared in NAVIGATION.md §1 task model). **Revise-aware:** for each surface, if a component file already exists at the target path, the skill loads it as prior-version context before generating (same as `--revise` for a single file). This makes `--set` the right tool for both greenfield batch generation AND identity-reset sweeps across shipped surfaces.
+- `--revise <path>` — revise an existing component file with a new request. Reads the existing file, treats it as prior context, generates a new version.
+- No args — ask the user which surface or set to generate; route accordingly.
+
+## Pre-flight (fail fast)
+
+Before any generation:
+
+1. **Identify venture.** Match the current repo against `crane_ventures`. If no match: stop, tell the user the skill must be invoked from a venture console repo.
+2. **NAVIGATION.md exists and is v3+.** Read `.design/NAVIGATION.md` from the venture repo. Check `spec-version` frontmatter. If absent or `< 3`: stop, suggest `/nav-spec` first.
+3. **UX brief covers the requested surface.** Look for `.design/<target>-ux-brief.md` where the surface class matches. Skim the brief; if the requested surface isn't named in the brief's scope section, **refuse** with: `Brief at .design/<target>-ux-brief.md does not cover <surface>. Run /ux-brief to extend it, or pick a covered surface.` This is the negative-case behavior — it's the point.
+4. **DESIGN.md or @theme tokens discoverable.** Read `.design/DESIGN.md` if present, or extract the `@theme` block from `src/styles/global.css` (Tailwind v4). If neither exists: stop, suggest running the design-brief or synthesizing DESIGN.md first.
+5. **Adapter known.** Determine the adapter from the venture's stack:
+   - Astro + Tailwind v4 → `adapters/astro-component.md`
+   - Next.js + Tailwind v4 → `adapters/nextjs-page.md` (Phase 2; not in v1)
+   - Unknown → stop, tell the user the adapter for their stack doesn't exist yet.
+
+If any pre-flight fails, stop before calling the generation workflow. Do not invent context.
+
+## Workflows
+
+| User intent                                         | Workflow                                                                                                                               |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| "Design/build one surface"                          | [workflows/generate-single-surface.md](workflows/generate-single-surface.md)                                                           |
+| "Design/build the whole client portal (or any set)" | [workflows/generate-surface-set.md](workflows/generate-surface-set.md)                                                                 |
+| "Revise this component"                             | [workflows/generate-single-surface.md](workflows/generate-single-surface.md) with `--revise` — same flow, prior file loaded as context |
+
+## The iteration loop (per component)
+
+Five steps. Every generation follows this shape. Do not add steps without Captain approval.
+
+1. **Assemble prompt.** See [references/prompt-assembly.md](references/prompt-assembly.md) for exactly what goes into the prompt and in what order. Inputs: nav-spec surface-class appendix, DESIGN.md or @theme tokens, UX brief section for this surface, five-tag classification (`surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`), adapter template, **raw source of every file under the venture's `src/components/**`\*\*. No registry. No AST. Let Claude read the component source directly.
+2. **Generate code.** Use the Write tool to produce the component file at its target path in the venture repo.
+3. **Build check.** Run the venture's build command (detected from lockfile — see package-manager note above). If it fails: read the compile errors, append to the prompt, regenerate. Max one retry.
+4. **Structural validate.** If a preview route is wired for this surface, extract the rendered HTML and run `~/.agents/skills/nav-spec/validate.py --file <html> --surface <tag> --archetype <tag> --viewport <tag> --task <tag> --pattern <tag> --spec <path-to-NAVIGATION.md>`. If structural violations: append to prompt, regenerate. Max one retry. If no preview route exists for this surface yet, skip — validator runs after the Captain promotes.
+5. **Land.** The component file is in place. Report to the Captain: file path, how to preview (the venture's dev command → `/design-preview/<surface>`), and anything you iterated on. Done.
+
+**Iteration budget: 2 total** (initial + 1 retry). If the retry fails build or validator, stop. Do not polish on iteration 3. Surface the diagnostic (which check failed, why) and ask the Captain how to proceed.
+
+**No vision-critique loop in v1.** The Captain is the visual critic at gate 0. Chrome MCP screenshots, vision critique, reuse-check scripts — all deferred to Phase 2, added only if gate 0 surfaces quality problems the simple loop missed.
+
+## Preview route convention
+
+Each generated component must be previewable at `/design-preview/<surface>` in the venture's dev server. See [references/preview-route-pattern.md](references/preview-route-pattern.md) for the exact convention. Preview routes live in `src/pages/design-preview/` and are gated to `import.meta.env.DEV`, so they never serve in production. Fixture data co-located: `<surface>.fixture.json`.
+
+If a preview route for the requested surface doesn't exist yet, the skill creates it alongside the component. ~15 lines per preview route.
+
+## What you refuse
+
+- Generating a surface not covered by the current UX brief (refuse with a clear pointer to extending the brief)
+- Generating against a v<3 NAVIGATION.md (refuse with a pointer to `/nav-spec` v3)
+- Generating into a venture without DESIGN.md or discoverable @theme tokens
+- Generating a stack you don't have an adapter for
+- Modifying pages under `src/pages/` other than the preview routes (pages are hand-wired; you produce components)
+- Adding third-party runtime dependencies — you work with what's already in `package.json`
+
+## References
+
+- [prompt-assembly.md](references/prompt-assembly.md) — exact prompt structure and input ordering
+- [preview-route-pattern.md](references/preview-route-pattern.md) — how to wire a surface for preview
+- [adapters/astro-component.md](adapters/astro-component.md) — Astro + Tailwind v4 adapter template
+- **Reused, read-only:**
+  - `~/.agents/skills/nav-spec/validate.py` — structural validator
+  - `~/.agents/skills/nav-spec/references/injection-snippet-template.md` — nav-contract block template
+
+## Related skills
+
+- `design-brief` — PRD → design charter (upstream)
+- `nav-spec` — IA + patterns + chrome authority (sibling; structural authority)
+- `ux-brief` — three-reviewer surface-level UX brief (upstream)
+
+## Known limits (v1)
+
+- Astro adapter only. Next.js adapter lands in Phase 2 (KE/DC).
+- No vision-critique. Captain visually reviews via the venture's dev command.
+- No batch parallelism. Surfaces in a `--set` generate serially; whole batch must fit within one Claude Code session (Max plan billing).
+- No feedback-log. Git history is the log.
+- No cross-venture consistency analysis. Each product is itself.

--- a/.claude/commands/save-lesson.md
+++ b/.claude/commands/save-lesson.md
@@ -1,0 +1,29 @@
+# /save-lesson - Capture Session Lesson
+
+Capture a memoryable lesson or anti-pattern from the current session into the enterprise memory system. Agent drafts frontmatter and body from session context; Captain confirms before the note is written.
+
+## Usage
+
+```
+/save-lesson [optional one-line summary]
+```
+
+If a summary is omitted, the agent drafts one from recent session context.
+
+## What it does
+
+1. Infers `kind` (lesson vs anti-pattern), `scope`, and `applies_when` from session context.
+2. Drafts a 1-2 sentence body and shows it to you for confirmation.
+3. Applies the 3 memoryability tests (actionable, non-obvious, general enough to recur).
+4. Saves to VCMS with `status: draft, captain_approved: false`.
+5. Reports the saved note ID.
+
+Draft memories become injection-eligible only after Captain approval via `/memory-audit` or `crane_memory(update)`. For immediate `captain_approved: true` capture, use the "Memoryable moments?" step in `/eos`.
+
+## Examples
+
+```
+/save-lesson
+/save-lesson "parallel agents writing to the same branch collide — always use worktrees"
+/save-lesson "never run infisical secrets -o json — it dumps plaintext values into the transcript"
+```

--- a/.claude/commands/skill-deprecate.md
+++ b/.claude/commands/skill-deprecate.md
@@ -1,0 +1,29 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-deprecate
+
+Captain-gated skill sunset flow. Marks a skill as deprecated, injects a warning banner, logs it to `docs/skills/deprecated.md`, and opens a PR for review. Does not delete the skill.
+
+## Usage
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+## Execution
+
+Follow the full skill specification at `.agents/skills/skill-deprecate/SKILL.md`.
+
+Key points:
+
+- Requires explicit Captain confirmation in chat before any changes are made
+- Fails fast if the skill does not exist or is already deprecated
+- 90-day grace period: the skill stays invocable until a separate removal PR
+- Never merges automatically

--- a/.claude/commands/sos.md
+++ b/.claude/commands/sos.md
@@ -3,9 +3,8 @@
 1. Call `crane_sos` MCP tool (returns formatted briefing).
 2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
 3. Display briefing. Highlight any Resume block or P0 issues.
-4. If weekly plan stale/missing, suggest `/work-plan`.
-5. If cadence items overdue, ask: "Execute any now, or skip?"
-6. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
+4. If cadence items overdue, ask: "Execute any now, or skip?"
+5. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
 
 ## Rules
 

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,78 @@
+# /status - Show Session Status
+
+Display current session state, tasks, and git status for situational awareness.
+
+## What to Show
+
+### 1. Session Information
+
+Query crane-context for current session (if available):
+
+- Session ID
+- Session age (how long since /sos)
+- Last heartbeat time
+- Venture context
+
+If no session exists, note: "No active session. Run /sos to start."
+
+### 2. Active Tasks
+
+Use TaskList to show current task state:
+
+- Pending tasks (not started)
+- In-progress tasks (being worked on)
+- Recently completed tasks
+
+### 3. Git Status
+
+Show current repository state:
+
+- Current branch
+- Uncommitted changes (staged and unstaged)
+- Commits ahead/behind remote
+
+### 4. Context Summary
+
+- Current working directory
+- Repository name
+- Machine name (hostname)
+
+## Output Format
+
+```
+== Session Status ==
+Session: [ID or "None"]
+Age: [duration or "N/A"]
+Venture: [venture name or "Unknown"]
+
+== Tasks ==
+In Progress: [count]
+  - [task subject]
+Pending: [count]
+  - [task subject]
+Completed (recent): [count]
+
+== Git ==
+Branch: [branch name]
+Changes: [staged] staged, [unstaged] unstaged
+Remote: [ahead/behind status]
+
+== Context ==
+Repo: [repo name]
+Dir: [current directory]
+Machine: [hostname]
+```
+
+## Implementation Steps
+
+1. Check for active session by querying crane-context /session endpoint
+2. Call TaskList to get task state
+3. Run `git status --porcelain` and `git branch -vv` for git info
+4. Get hostname and current directory from environment
+5. Format and display results
+
+## Notes
+
+- This is a read-only status check - it should not modify anything
+- If crane-context is unavailable, show what information is available locally
+- Keep output concise and scannable

--- a/.claude/commands/ui-drift-audit.md
+++ b/.claude/commands/ui-drift-audit.md
@@ -1,0 +1,34 @@
+---
+name: ui-drift-audit
+description: Source-level UI drift audit. Counts visual-design anti-patterns (pills, typography, spacing, headings, primary CTAs, redundancy, token-compliance) across .astro/.tsx/.jsx files and emits a markdown matrix or JSON.
+version: 2.1.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /ui-drift-audit - Visual drift audit
+
+Run a source-level audit of the venture's UI code and produce a per-file violation matrix. Use to seed pattern-spec citations, size remediation PRs, or gate token-compliance in CI.
+
+See `.agents/skills/ui-drift-audit/SKILL.md` for the full rule mapping, output schemas, and per-venture configuration via `.ui-drift.json`.
+
+## Quick start
+
+```bash
+# Markdown report (default)
+python3 .agents/skills/ui-drift-audit/audit.py
+
+# JSON report for CI threshold gates
+python3 .agents/skills/ui-drift-audit/audit.py --format json --out audit.json
+
+# Custom status words for redundancy detection
+python3 .agents/skills/ui-drift-audit/audit.py --status-words "Pending,Approved,Draft"
+```
+
+## When to invoke
+
+- Before authoring or revising a venture's pattern spec.
+- Before sizing a Rule-class remediation PR (count > 30 → split by component family).
+- Monthly as a drift watchdog.
+- In CI on every PR — see `docs/design-system/adoption/audit-workflow.yml.template`.

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,197 @@
+# /update - Update Session Context
+
+Update your session with current branch, commit, and work metadata.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Auto-detects current git branch and commit
+3. Updates session with current work context
+4. Refreshes heartbeat (keeps session alive)
+5. Provides visibility: "Agent X is on branch Y working on issue #123"
+
+## When to Use
+
+- Started working on a new issue
+- Switched branches
+- Made significant progress (checkpoint)
+- Want to update team visibility
+
+**Tip:** Call this when you start work on an issue and after major milestones.
+
+## Usage
+
+```bash
+# Auto-detect branch/commit
+/update
+
+# With issue number
+/update 123
+
+# With custom metadata
+/update --meta '{"issue": 123, "priority": "P0"}'
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Detect Current Work Context
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+# Get current commit
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+
+# Parse arguments for issue number or metadata
+ISSUE_NUMBER=""
+META_JSON=""
+
+# If first arg is a number, it's an issue
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+  ISSUE_NUMBER="$1"
+  META_JSON=$(jq -n --argjson issue "$ISSUE_NUMBER" '{issue: $issue}')
+fi
+
+# If --meta flag provided, use that
+if [[ "$1" == "--meta" && -n "$2" ]]; then
+  META_JSON="$2"
+fi
+
+echo "## 📝 Updating Session"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Branch: $BRANCH"
+echo "Commit: $COMMIT"
+if [ -n "$ISSUE_NUMBER" ]; then
+  echo "Issue: #$ISSUE_NUMBER"
+fi
+echo ""
+```
+
+### 3. Build Update Request
+
+```bash
+# Build request body with current context
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg branch "$BRANCH" \
+  --arg commit "$COMMIT" \
+  --argjson meta "${META_JSON:-null}" \
+  '{
+    session_id: $session_id,
+    branch: $branch,
+    commit_sha: $commit
+  } + (if $meta != null then {meta: $meta} else {} end)')
+```
+
+### 4. Call Context Worker /update
+
+```bash
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/update" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Update failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 5. Display Results
+
+```bash
+UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updated_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "✅ Session updated"
+echo ""
+echo "Updated at: $UPDATED_AT"
+echo "Next heartbeat: ~$MINUTES minutes"
+echo ""
+echo "Your session context is now visible to other agents."
+```
+
+## What Gets Updated
+
+- `branch`, `commit_sha`, `last_heartbeat_at` (always)
+- `meta` (optional freeform JSON: issue, priority, tags, etc.)
+- Venture, repo, track are set at session creation (not updated)
+
+## Notes
+
+- Auto-detects git branch and commit
+- Requires active session (run `/sos` first) and CRANE_CONTEXT_KEY
+- Refreshes heartbeat (prevents timeout)
+- Safe to call frequently
+- The `meta` field is freeform JSON - use it for whatever context helps your workflow

--- a/.claude/commands/ux-brief.md
+++ b/.claude/commands/ux-brief.md
@@ -1,0 +1,347 @@
+# /ux-brief - UX Brief Authoring
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ux-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before Phase 1 intake — and certainly before drafting v1 — load the cross-venture pattern + component catalog. Concept proposals (timeline / archive / action-centric, etc.) and chrome decisions in the brief should anchor on the loaded catalog or explicitly note the divergence:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the venture's `design-spec.md` for venture-specific palette and tone. Anti-patterns the brief calls out should reconcile with Patterns 1–8 (status display by context, redundancy ban, button hierarchy, etc.) — those are enterprise-canonical and the brief should not contradict them silently.
+
+Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona). When the brief is approved, the skill stops. To realize the brief into screens, run `/product-design`.
+
+## Arguments
+
+```
+/ux-brief [target] [--rounds=3]
+```
+
+- `target` — short name of the surface being designed (e.g., `client-portal`, `signup-flow`, `admin-inbox`). Required. Used for artifact file names.
+- `rounds` — brief review rounds (default **3**). Each round spawns three parallel reviewers; output is synthesized between rounds. Fewer than 3 is not recommended.
+
+Parse the arguments. If `target` is missing, stop and ask the user what surface they want to brief.
+
+## The methodology, in one paragraph
+
+This skill exists because a UX brief handed to a downstream design tool fails in predictable ways: the objectives are pretty but unmeasurable, the tokens are described in vibes instead of hex, the concepts all collapse into card-grid variations, and the generated output comes back padded with marketing chrome. This skill fixes each of those by running the brief through a critical three-reviewer pass (one of them a named customer who talks back), forcing structural divergence in the concept brief ("timeline vs archive vs action-centric, not three visual variations of the same layout"), and hardening every decision before generation begins. The final brief is a self-contained specification that downstream tools (e.g., `/product-design`) read to realize the screens — every step has a learning embedded, and the skill is the accumulated scar tissue of running this end-to-end.
+
+## Phases
+
+1. Intake — establish target, scope, existing context
+2. Draft brief v1
+3. Three-reviewer passes with synthesis
+4. Decision checkpoints — resolve open questions surfaced by reviewers
+5. Final brief, user-approved, saved to `.design/<target>-ux-brief.md`
+
+Each phase ends with a checkpoint. The user can stop at any checkpoint. Do not skip phases.
+
+---
+
+## Phase 1 — Intake
+
+Ask the user these questions if they aren't already answered by the conversation:
+
+1. **Target surface.** What surface are we designing? (e.g., "client portal home dashboard + invoice and proposal deep-link landings").
+2. **Authentication context.** Is the user logged in? Prospect? Public-web visitor? This shapes the "no marketing chrome" framing.
+3. **Customer persona seed.** Give me a realistic archetype — named if possible. Role, revenue range, tech comfort, what they care about. If the user hasn't thought about this, offer to draft one and confirm.
+4. **Any existing brief, PRD, or prior design** to build on? Check for `docs/pm/prd.md`, `docs/design/*`, `.design/*-ux-brief.md`, or a prior version of the target.
+
+Scan the repo for context:
+
+- `CLAUDE.md` for venture positioning / tone rules
+- `src/styles/globals.css` or `**/globals.css` for design tokens (hex values, type families)
+- `tailwind.config.*` for palette and type scale
+- Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
+- `.design/DESIGN.md` if present (established design system for the venture)
+- `.design/NAVIGATION.md` if present (navigation specification). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value. When present and `spec-version >= 3`, each concept must include `task=` and `pattern=` tags per-screen (sourced from the spec's task model in §1 and pattern catalog in §4).
+
+Display an **Intake Summary** table:
+
+| Field          | Value                                         |
+| -------------- | --------------------------------------------- |
+| Target         | _e.g., `client-portal`_                       |
+| Authentication | _logged-in / prospect / public_               |
+| Persona        | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
+| Prior brief    | _path or "none"_                              |
+| Tokens source  | _path to globals.css or config_               |
+| Nav spec       | _spec-version N or "absent"_                  |
+| Venture code   | _resolved from `crane_ventures`_              |
+
+Present the table and ask: **"Does this capture the intake? Anything to correct before I draft?"**
+
+Wait for confirmation.
+
+---
+
+## Phase 2 — Draft v1
+
+Write a v1 brief to `.design/<target>-ux-brief.md` (create the directory if needed). Use this structure:
+
+```markdown
+# <Title> — UX Redesign Brief (v1)
+
+## Context
+
+<2-4 paragraphs: venture positioning, what this surface is for, why we're redesigning>
+
+## Scope
+
+<surfaces + viewports to be designed>
+
+## Visit modes
+
+<5-ish modes: action responder, status checker, etc. Be specific to this surface>
+
+## Objectives, ranked
+
+1. ... 2. ... 3. ... 4. ... 5. ...
+
+## Entry points (with email context)
+
+<each entry point, with the subject line and CTA from the email that triggers it>
+
+## Design principles
+
+<3-5 principles that constrain generation without dictating layout>
+
+## Three concepts requested (structurally distinct, not visual variations)
+
+A — <axis>
+B — <axis>
+C — <axis>
+
+## Worked example (fidelity reference)
+
+<one concept × one surface × one viewport, with inline type specs>
+
+## Above-fold specs for B and C
+
+<matching A's format>
+
+## What must be preserved
+
+<typography, palette, shape, voice>
+
+## What is open
+
+<layout, hierarchy, flow — full creative freedom>
+
+## Anti-patterns (do not produce)
+
+<bullet list of explicit no-gos>
+
+## Mobile spec
+
+<390×844, thumb zone, tap target, no hover, no horizontal scroll>
+
+## Desktop spec
+
+<1280px, right-rail placement, eye-level action>
+
+## Contact affordance spec
+
+<primary channel, fallback, SLA — operational commitment, not copy>
+
+## Copy samples (tone calibration)
+
+<5-6 lines showing the voice in concrete context>
+
+## Error states (must design)
+
+<per-surface error list — each includes named human + next step>
+
+## Activity timeline schema
+
+<if the surface has time-series data, define the event shape>
+
+## Money rule
+
+<dollar figures only, never bars or percentages, if applicable>
+
+## Photo placeholder rule
+
+<harder than "neutral placeholder" — use initials-in-circle or solid shape; never real faces>
+
+## Accessibility floor
+
+<WCAG 2.2 AA, focus rings with hex, landmarks, tap targets>
+
+## Success criteria
+
+**Primary acceptance test:** <one measurable design constraint — e.g., "on 390×844, [Pay invoice] button top edge at y ≤ 700px, no scroll">
+
+Secondary: <2-4 testable criteria>
+
+## Follow-ups (scheduled, not gaps)
+
+<real priorities scheduled after this pass, each with a target window>
+
+## Data available
+
+<data fields the design can use; ask for flag if design needs data we don't capture>
+
+## Constraints
+
+<stack, viewports, scope limits>
+
+## Approver
+
+<name — output reviewed before any iteration>
+
+## Appendix: Hard design tokens
+
+### Color
+
+<hex block — use exact values from globals.css or tailwind config>
+
+### Typography
+
+<family, weights, sizes, line-heights, tracking>
+
+### Spacing and shape
+
+<rounded, padding, rhythm, tap target, breakpoints>
+```
+
+Write the brief. Then present the draft to the user and proceed to Phase 3.
+
+---
+
+## Phase 3 — Three-reviewer passes
+
+Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via the Task tool using `subagent_type: general-purpose`. The three reviewers are:
+
+### Product manager reviewer
+
+**Role prompt preamble:**
+
+> You are a senior product manager at a [venture type] firm. You review UX briefs for client-facing surfaces. You are direct, critical, and do not validate work you find weak.
+
+**Focus:**
+
+- Are user objectives correctly framed and ranked?
+- Are lifecycle states complete? What failure states are missing (declined, paused, expired, disputed, cancelled, overdue)?
+- Are success criteria measurable? Name the primary metric.
+- Is scope bounded for a realistic first pass?
+- Does the data inventory match what the design is being asked to do?
+- Business logic edge cases: multi-contact reality, partial payments, SOW revisions, out-of-portal artifacts
+- Is "reach a human" spec'd as an affordance or left as a phrase?
+- Are empty/error states required? Accessibility floor? Approver named?
+
+### UX designer reviewer
+
+**Role prompt preamble:**
+
+> You are a senior UX designer with deep experience using AI code generators — v0, Magic Patterns, Figma Make, in-house skills like `/product-design`. You know what makes them produce generic output vs considered work.
+
+**Focus:**
+
+- Are design tokens described precisely enough? Vague tokens ("muted violet") produce inconsistent results. Require hex.
+- Is mobile-first a slogan or a constraint? Specific viewport, thumb zone, tap targets, no-hover rules.
+- Will three runs produce structurally distinct concepts, or three visual variations of the same layout? Commission structural divergence with explicit axis names.
+- Is information hierarchy clear? What dominates, what recedes?
+- Are anti-patterns named? Are placeholder instructions strong enough to prevent real-face drift?
+- Predict what a generation tool will produce as-is, including what's likely to go wrong.
+
+### Customer persona reviewer
+
+**Role prompt preamble (customize per surface):**
+
+> You are <NAME>, <AGE>. You own <BUSINESS>. <BACKGROUND: years, team, revenue>. You are not <disqualifying tech trait> but you run a real business with real software. <SPOUSE/PARTNER> handles <ROLE>. You just <TRIGGERING EVENT>. Someone handed you a document that describes people like you — how you use [target surface], what you need from it. Tell them if it sounds right. Call out patronizing language. Flag missing things they don't know about your actual life. Talk plainly. Swear if you want. Don't bullet-point at the top; talk first, then summarize.
+
+**Focus:**
+
+- Does this sound like real me, or like someone who's never talked to someone in my role?
+- What's patronizing? Soft? Over-explained?
+- What's missing about my actual life? (spouse access, SMS vs email, what I'd show my advisor)
+- What would I actually do on this surface vs what they think I'd do?
+
+**Persona discipline:**
+
+- Specific name, age, business details. "A business owner in the 30-55 age range" does not work. "Mike Delgado, 52, plumbing HVAC, 9 employees, $1.8M revenue, wife Elena does books" does.
+- Give the persona permission to push back on the brief's description of them. The most common persona finding: the brief describes the user in ways no user would recognize.
+
+### Round structure
+
+**Round 1:** Each reviewer critiques v1 from their role. Output format:
+
+```
+## Overall assessment
+[2-3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Specific changes I'd make
+<concrete rewrites with proposed wording>
+
+## What's missing
+<things the brief does not address that it needs to>
+```
+
+Persona reviewer uses a different format — see their prompt above. They talk first, then summarize in three sections: got right / got wrong / still missing.
+
+**Between rounds:** Synthesize the feedback into a delta. Apply clear fixes directly to the brief. Surface disagreements or decisions that require user input as **open questions** — these become Phase 4 checkpoints.
+
+**Round 2:** Reviewers see v2 plus a summary of what changed from v1. They critique v2 specifically — what's still weak, what new issues emerged, what v2 got wrong in addressing Round 1 feedback.
+
+**Round 3:** Final polish pass. Reviewers are asked whether v3 is ready to ship. Format tightens to:
+
+```
+## Ready to ship? (Yes / Yes with caveats / No)
+## Any remaining critical issues?
+## Any last surgical edits?
+```
+
+**IMPORTANT**: All three reviewers in a round must be launched in a single Task tool message to run in parallel.
+
+---
+
+## Phase 4 — Decision checkpoints
+
+After each round, surface any decisions the reviewers flagged that require user judgment. Common examples:
+
+- An SLA promise in copy — is it an operational commitment or just marketing?
+- A user mode that was named but doesn't get its own surface — fold it into another mode, or design for it?
+- A concept that has an internal contradiction on a specific viewport — which way does it resolve?
+
+Present decisions as a short numbered list with your recommendation and rationale. Do NOT present 10 decisions — filter to the ones that will actually change the brief.
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 5 — Final brief saved
+
+Apply the last round's fixes and the user's decisions. Save the final brief to `.design/<target>-ux-brief.md`. Present the user a summary of:
+
+- Total rounds run
+- Major things that shifted v1 → final
+- Open decisions resolved
+
+Tell the user: **"Brief is complete. Run `/product-design` to realize the screens."**
+
+---
+
+## Embedded learnings
+
+1. **Personify the customer reviewer.** A named individual with real specifics produces sharper critique than a demographic. The persona should push back on the brief's description of them — that's usually where the brief is patronizing.
+
+2. **Structural divergence must be commissioned explicitly.** "Three structurally distinct concepts — timeline-centric, archive-centric, action-centric" works. "Three concepts" collapses into variations.
+
+3. **Tokens as hex, not vibes.** "Muted violet" is three different colors to three generation runs. Always include hex values from the venture's actual stylesheet.
+
+4. **Mobile-first as constraint, not slogan.** Specify viewport (390×844), thumb zone (bottom 40%), tap target (44px), no-hover rule, no-horizontal-scroll rule.
+
+5. **Anti-patterns need an affirmative frame.** "No nav tabs, no testimonials" is weaker than "This is an authenticated portal, not a marketing page. Chrome is strictly limited to what's listed below."
+
+6. **Placeholder instructions are weak.** "Neutral portrait placeholder" is routinely ignored. Either spec a solid shape ("solid indigo circle with initials") or a clearly abstract graphic ("geometric avatar, no face").
+
+---
+
+## Conventions
+
+- **Brief filename:** `.design/<target>-ux-brief.md`
+- **Versioning:** when iterating a target that already has a brief, move the prior version to `.design/<target>-ux-brief-v1.md` before overwriting.


### PR DESCRIPTION
## Summary

Periodic sync of enterprise skill command files from crane-console. The launcher mirrors `.claude/commands/` from crane-console on every `crane <venture>` launch; ss-console has accumulated 4 modified + 10 new command files since the last sync commit.

This is the same chore pattern as #340.

**Modified (re-synced):** `calendar-sync`, `design-brief` (also includes the design-system doc-name path fix — VCMS storage flattens slashes to dots, so `design-system.patterns.index.md` resolves while `design-system/patterns/index.md` 404s), `nav-spec`, `sos`.

**New (first sync):** `auth-setup`, `auto-build`, `heartbeat`, `product-design`, `save-lesson`, `skill-deprecate`, `status`, `ui-drift-audit`, `update`, `ux-brief`.

Note that `.claude/commands/` is tracked (unlike `.agents/skills/` which is gitignored per #573).

## Test plan

- [x] `npm run format:check -- .claude/commands/` passes
- [ ] No semantic review needed; these are launcher-managed enterprise files

🤖 Generated with [Claude Code](https://claude.com/claude-code)