### PR TITLE
chore(workers/review-mining): raise weekly cap from 50 to 200 with budget guard

### DIFF
--- a/workers/review-mining/src/alert.ts
+++ b/workers/review-mining/src/alert.ts
@@ -5,6 +5,8 @@
 export interface RunSummary {
   queries: number
   discovered: number
+  /** Number of businesses sent to Outscraper after applying the per-run cap. */
+  reviewChecksAttempted: number
   withReviews: number
   newBusinesses: number
   qualified: number
@@ -12,6 +14,10 @@ export interface RunSummary {
   written: number
   errors: number
   errorDetails: string[]
+  /** Estimated Outscraper spend for the run (USD). */
+  outscraperSpendUsd: number
+  /** True if the run stopped early because the per-run budget was exceeded. */
+  budgetGuardTripped: boolean
 }
 
 export async function sendFailureAlert(summary: RunSummary, resendApiKey: string): Promise<void> {
@@ -20,11 +26,14 @@ export async function sendFailureAlert(summary: RunSummary, resendApiKey: string
     ``,
     `Discovery queries: ${summary.queries}`,
     `Businesses discovered: ${summary.discovered}`,
+    `Review checks attempted: ${summary.reviewChecksAttempted}`,
     `With recent reviews: ${summary.withReviews}`,
     `New (not deduped): ${summary.newBusinesses}`,
     `Qualified (pain >= 7): ${summary.qualified}`,
     `Below threshold: ${summary.belowThreshold}`,
     `Written to D1: ${summary.written}`,
+    `Outscraper spend (est.): $${summary.outscraperSpendUsd.toFixed(2)}`,
+    `Budget guard tripped: ${summary.budgetGuardTripped ? 'YES' : 'no'}`,
     `Errors: ${summary.errors}`,
     ``,
     `Error details:`,

--- a/workers/review-mining/src/index.test.ts
+++ b/workers/review-mining/src/index.test.ts
@@ -335,3 +335,69 @@ describe('review-mining scheduled handler', () => {
     ).resolves.toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Tests: per-run cap + Outscraper budget guard (issue #592)
+// ---------------------------------------------------------------------------
+
+describe('review-mining cap and budget guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
+    vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
+    vi.mocked(fetchReviews).mockResolvedValue([])
+    vi.mocked(findOrCreateEntity).mockResolvedValue({
+      entity: { id: 'entity-001', name: 'Desert HVAC' },
+    } as never)
+    vi.mocked(appendContext).mockResolvedValue(undefined as never)
+  })
+
+  it('respects MAX_REVIEW_CHECKS env override (caps at 5 of 12 discovered)', async () => {
+    const businesses = Array.from({ length: 12 }, (_, i) =>
+      makeDiscoveredBusiness({ place_id: `p-${i}` })
+    )
+    vi.mocked(discoverBusinesses).mockResolvedValue(businesses)
+    const res = await worker.fetch(
+      makeRequest('Bearer sk-test-ingest-key'),
+      makeEnv({ MAX_REVIEW_CHECKS: '5' }),
+      makeCtx()
+    )
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.discovered).toBe(12)
+    expect(body.reviewChecksAttempted).toBe(5)
+    // 5 places x $0.003 = $0.015
+    expect(body.outscraperSpendUsd).toBeCloseTo(0.015, 5)
+    expect(body.budgetGuardTripped).toBe(false)
+  })
+
+  it('stops early when the Outscraper budget guard would be exceeded', async () => {
+    // 30 discovered, batch size 10, $0.003 each. Budget $0.04 allows
+    // at most 1 batch ($0.030); the 2nd batch would push to $0.060 > $0.040.
+    const businesses = Array.from({ length: 30 }, (_, i) =>
+      makeDiscoveredBusiness({ place_id: `p-${i}` })
+    )
+    vi.mocked(discoverBusinesses).mockResolvedValue(businesses)
+    const res = await worker.fetch(
+      makeRequest('Bearer sk-test-ingest-key'),
+      makeEnv({ OUTSCRAPER_BUDGET_USD_PER_RUN: '0.04' }),
+      makeCtx()
+    )
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.budgetGuardTripped).toBe(true)
+    expect(body.reviewChecksAttempted).toBe(10)
+    expect(body.outscraperSpendUsd).toBeCloseTo(0.03, 5)
+  })
+
+  it('uses the 200 default when MAX_REVIEW_CHECKS is unset', async () => {
+    const businesses = Array.from({ length: 250 }, (_, i) =>
+      makeDiscoveredBusiness({ place_id: `p-${i}` })
+    )
+    vi.mocked(discoverBusinesses).mockResolvedValue(businesses)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.discovered).toBe(250)
+    expect(body.reviewChecksAttempted).toBe(200)
+    expect(body.outscraperSpendUsd).toBeCloseTo(0.6, 5)
+    expect(body.budgetGuardTripped).toBe(false)
+  })
+})

--- a/workers/review-mining/src/index.ts
+++ b/workers/review-mining/src/index.ts
@@ -24,6 +24,28 @@ import type { DiscoveredBusiness } from './outscraper.js'
 
 const PAIN_THRESHOLD = 7
 
+// Per-business Outscraper cost. Reviews extraction is ~$3 per 1,000 place_ids
+// queried regardless of how many reviews come back. Source:
+// docs/lead-automation/specs/outscraper-queries.md ("Outscraper Pricing").
+const OUTSCRAPER_USD_PER_PLACE = 0.003
+
+// Default cap on businesses sent to Outscraper per run. Raised from 50 to 200
+// per issue #592 to lift the artificial top-of-funnel constraint identified
+// in the 2026-04-25 lead-gen audit. At ~$0.003/business that is ~$0.60/run,
+// ~$2.40/month at the weekly cron cadence. Both this cap and PAIN_THRESHOLD
+// will move into admin config under issue #595; until then they are constants
+// here, with `MAX_REVIEW_CHECKS` and `OUTSCRAPER_BUDGET_USD_PER_RUN` env vars
+// available as escape hatches without a code deploy.
+const DEFAULT_MAX_REVIEW_CHECKS = 200
+
+// Hard ceiling on how much a single run may spend on Outscraper. The cap above
+// is the primary constraint; this is a belt-and-suspenders guard so a future
+// change to discovery queries, geo radius, or batch logic can't blow through
+// the budget unobserved. At default settings (200 places, $0.003/place) a run
+// spends ~$0.60, comfortably under the $1.00 default. Override per environment
+// via the `OUTSCRAPER_BUDGET_USD_PER_RUN` env var.
+const DEFAULT_OUTSCRAPER_BUDGET_USD_PER_RUN = 1.0
+
 export interface Env {
   DB: D1Database
   GOOGLE_PLACES_API_KEY: string
@@ -34,12 +56,30 @@ export interface Env {
   // Optional keys used by the at-ingest enrichment pipeline.
   SERPAPI_API_KEY?: string
   PROXYCURL_API_KEY?: string
+  // Optional overrides for the per-run cap and budget guard. Both are strings
+  // because Wrangler vars are strings; parsed at run start with sane fallbacks.
+  // Will be replaced by admin-config in issue #595.
+  MAX_REVIEW_CHECKS?: string
+  OUTSCRAPER_BUDGET_USD_PER_RUN?: string
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function parsePositiveFloat(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
 async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   const summary: RunSummary = {
     queries: 0,
     discovered: 0,
+    reviewChecksAttempted: 0,
     withReviews: 0,
     newBusinesses: 0,
     qualified: 0,
@@ -47,7 +87,18 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
     written: 0,
     errors: 0,
     errorDetails: [],
+    outscraperSpendUsd: 0,
+    budgetGuardTripped: false,
   }
+
+  // Resolve the per-run cap and budget guard. Env vars are escape hatches so
+  // we can tune live without a code deploy; defaults are the values that
+  // shipped with #592. Both move into admin config under #595.
+  const maxReviewChecks = parsePositiveInt(env.MAX_REVIEW_CHECKS, DEFAULT_MAX_REVIEW_CHECKS)
+  const budgetUsd = parsePositiveFloat(
+    env.OUTSCRAPER_BUDGET_USD_PER_RUN,
+    DEFAULT_OUTSCRAPER_BUDGET_USD_PER_RUN
+  )
 
   const configRow = await getGeneratorConfig(env.DB, ORG_ID, 'review_mining')
   if (!configRow.enabled) {
@@ -89,19 +140,34 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   summary.discovered = allBusinesses.length
   console.log(`Discovery: ${summary.queries} queries, ${summary.discovered} unique businesses`)
 
-  // Phase 2: Fetch reviews (one Outscraper call per business)
-  // Cap at 50 businesses per run to manage Outscraper costs (~$1/run at $2/1000 reviews)
-  const MAX_REVIEW_CHECKS = 50
+  // Phase 2: Fetch reviews (one Outscraper call per business).
+  // Cap at maxReviewChecks businesses per run AND stop early if the running
+  // estimated Outscraper spend exceeds budgetUsd. Outscraper is the only
+  // metered call in this loop — Google Places and Anthropic are accounted for
+  // outside the budget guard.
   const BATCH_SIZE = 10
-  const businessesToCheck = allBusinesses.slice(0, MAX_REVIEW_CHECKS)
+  const businessesToCheck = allBusinesses.slice(0, maxReviewChecks)
   const businessesWithReviews = []
 
   console.log(
-    `Checking reviews for ${businessesToCheck.length} of ${allBusinesses.length} businesses`
+    `Checking reviews for ${businessesToCheck.length} of ${allBusinesses.length} businesses ` +
+      `(cap=${maxReviewChecks}, budget=$${budgetUsd.toFixed(2)})`
   )
 
   for (let i = 0; i < businessesToCheck.length; i += BATCH_SIZE) {
     const batch = businessesToCheck.slice(i, i + BATCH_SIZE)
+    const projectedSpend = summary.outscraperSpendUsd + batch.length * OUTSCRAPER_USD_PER_PLACE
+    if (projectedSpend > budgetUsd) {
+      summary.budgetGuardTripped = true
+      console.warn(
+        `Outscraper budget guard: projected $${projectedSpend.toFixed(2)} would exceed ` +
+          `$${budgetUsd.toFixed(2)}. Stopping after ${summary.reviewChecksAttempted} of ` +
+          `${businessesToCheck.length} businesses.`
+      )
+      break
+    }
+    summary.reviewChecksAttempted += batch.length
+    summary.outscraperSpendUsd += batch.length * OUTSCRAPER_USD_PER_PLACE
     try {
       const results = await fetchReviews(batch, env.OUTSCRAPER_API_KEY)
       businessesWithReviews.push(...results)
@@ -211,7 +277,9 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
 
   console.log(
     `Run complete: ${summary.newBusinesses} new, ${summary.qualified} qualified (pain>=${PAIN_THRESHOLD}), ` +
-      `${summary.belowThreshold} below threshold, ${summary.written} written, ${summary.errors} errors`
+      `${summary.belowThreshold} below threshold, ${summary.written} written, ${summary.errors} errors, ` +
+      `Outscraper spend ~$${summary.outscraperSpendUsd.toFixed(2)}` +
+      (summary.budgetGuardTripped ? ' (budget guard tripped)' : '')
   )
 
   await recordGeneratorRun(env.DB, ORG_ID, 'review_mining', {


### PR DESCRIPTION
## Summary

Closes #592. Lifts the artificial 50-businesses/run cap on the review-mining worker, identified as the cheapest top-of-funnel lever in the [2026-04-25 lead-gen audit](docs/strategy/lead-gen-internal-audit-2026-04-25.md) and called out as a Phase 1A engineering punch list item in the [strategy doc](docs/strategy/lead-gen-strategy-2026-04-25.md) (issue [#592](https://github.com/venturecrane/ss-console/issues/592), "1 hour" estimate).

- Default `MAX_REVIEW_CHECKS` raised from `50` to `200` (4x).
- New soft budget guard `OUTSCRAPER_BUDGET_USD_PER_RUN` (default `$1.00`) stops the loop early if running spend would exceed the threshold. Belt-and-suspenders against a future change to discovery queries / geo radius / batch size silently blowing through cost.
- Both knobs are env vars on the worker, parsed at run start; defaults match what shipped here. Code comments cite #595 as the planned migration to admin config.
- `RunSummary` (and the failure-alert email) now include `reviewChecksAttempted`, `outscraperSpendUsd`, and `budgetGuardTripped` so we can see in telemetry when the guard fires and tune the cap.

`PAIN_THRESHOLD = 7` is **left as-is** in this PR. The issue mentioned it as part of the same "lift the cap" cluster, but tuning it (vs simply making it configurable) is the real question, and that's better dispatched under #595 — the explicit admin-config issue — once we have a few weeks of post-cap-lift telemetry to inform the threshold. The constants are now adjacent and labeled, so #595 is a small move.

## Outscraper cost projection

Outscraper reviews extraction is **\~\$3 per 1,000 place_ids queried** regardless of how many reviews come back ([source](docs/lead-automation/specs/outscraper-queries.md), "Outscraper Pricing"). Cron is weekly (Mondays 8 AM MST).

| Cap     | Per-run spend | Monthly (4 runs) |
| ------- | ------------- | ---------------- |
| 50 (current)  | \~\$0.15      | \~\$0.60         |
| **200 (this PR default)** | **\~\$0.60** | **\~\$2.40**     |
| 500 (future) | \~\$1.50     | \~\$6.00         |
| 1,000 (future) | \~\$3.00     | \~\$12.00        |

Real spend is typically lower because not every discovered business has reviews matching our 7-day cutoff (`businessesToCheck` is hit, but the `fetchReviews` path skips zero-recent-review businesses internally — and Outscraper still bills per place_id queried, so the table above is the upper bound).

The default $1.00/run budget guard caps absolute worst-case at **~\$4/month**. Captain can tune via `OUTSCRAPER_BUDGET_USD_PER_RUN` without a deploy.

These numbers slot under the \~\$20/mo Phase 1A tooling burn (Resend) referenced in the strategy doc. No change to the spend ceiling Captain set.

## Test plan

- [x] Unit tests added (`workers/review-mining/src/index.test.ts`):
  - `MAX_REVIEW_CHECKS=5` env override caps the loop at 5 of 12 discovered businesses.
  - `OUTSCRAPER_BUDGET_USD_PER_RUN=0.04` trips the guard after 1 batch (10 places, $0.030) instead of attempting the 2nd ($0.060 projected).
  - Default cap of 200 applies when no env override is set; spend logs as $0.60.
- [x] Existing review-mining tests still pass (10 prior + 3 new = 13).
- [x] `npm run verify` green locally (typecheck, workers typecheck, format, lint, build, all unit tests, all worker tests).
- [ ] After merge: watch the next Monday 15:00 UTC cron run for `outscraperSpendUsd` and `budgetGuardTripped` in logs and the failure-alert email if it fires.

## Coordination notes

Confined to `workers/review-mining/`. No collision with parallel agents on `src/lib/email/` (#587) or `src/lib/db/` + `migrations/` (#589).

🤖 Generated with [Claude Code](https://claude.com/claude-code)