### PR TITLE
feat(email): Resend integration + outreach_events telemetry

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -20,6 +20,7 @@ PORTAL_BASE_URL="http://localhost:4321"
 # These are documented for reference. Actual values must come from the
 # team vault — never commit real keys.
 RESEND_API_KEY=""
+RESEND_WEBHOOK_SECRET=""
 ANTHROPIC_API_KEY=""
 SIGNWELL_API_KEY=""
 SIGNWELL_WEBHOOK_SECRET=""

--- a/migrations/0028_create_outreach_events.sql
+++ b/migrations/0028_create_outreach_events.sql
@@ -1,0 +1,92 @@
+-- Outreach attribution telemetry. Captures per-message lifecycle events
+-- (sent / open / click / bounce / reply) so we can answer the most basic
+-- ROI question for lead-gen: which signals turn into engagements, and at
+-- what funnel-stage drop-off rate.
+--
+-- Without this table, every outreach decision is guesswork. See
+-- docs/strategy/lead-gen-strategy-2026-04-25.md and issue #587.
+--
+-- Append-only. One row per provider event. Do NOT mutate rows after insert.
+-- Funnel math is computed by aggregating over (entity_id, message_id, event_type).
+--
+-- Field semantics
+-- ---------------
+-- entity_id         FK to entities.id. The originating signal that the message
+--                   was sent for. Threaded through the send path so every
+--                   downstream event (open, click, bounce, reply) links back
+--                   to a specific entity in the lead-gen pipeline.
+--
+-- event_type        Lifecycle event, taken from the Resend webhook payload's
+--                   `type` field, mapped to a stable internal vocabulary so
+--                   the schema does not lock to one provider.
+--                   - sent     — Resend `email.sent` (handed to upstream MTA)
+--                   - open     — Resend `email.opened` (tracking pixel hit)
+--                   - click    — Resend `email.clicked` (tracked link clicked)
+--                   - bounce   — Resend `email.bounced`
+--                   - reply    — synthesized when an inbound message arrives
+--                                that we attribute to a sent message_id.
+--                                (Reply parsing is issue #590 — schema is
+--                                ready for it; events insert as the parser
+--                                lands.)
+--
+-- channel           'email' for now. Reserved for SMS, LinkedIn, etc., once
+--                   those send paths exist.
+--
+-- message_id        Provider-issued unique identifier. For Resend, this is
+--                   the `id` returned by POST /emails (UUID). Webhook events
+--                   carry this in `data.email_id`. Used to join sent → opens
+--                   → clicks → replies for the same message.
+--
+-- provider_event_id Resend webhook envelope `id` (Svix message id). Stored
+--                   so we can dedupe retries — Svix retries deliver the same
+--                   id, and we never want to double-count an open.
+--
+-- payload           Raw JSON body of the provider event. Kept verbose so
+--                   future analytics (e.g. reading user-agent or geo from
+--                   open events) does not require a schema migration.
+--                   May be NULL for synthetic 'sent' rows recorded by the
+--                   send wrapper before the webhook lands.
+--
+-- created_at        Wall-clock time the row was inserted, not the provider
+--                   event time. Provider event time (when distinct) lives
+--                   inside `payload`. We index on created_at because that
+--                   is what backfill, dedupe, and monitoring queries use.
+--
+-- Indexes
+-- -------
+-- (entity_id, created_at DESC)         — entity timeline ("show me everything
+--                                        that happened for this prospect").
+-- (message_id, event_type)             — per-message rollup ("did this email
+--                                        bounce? was it opened?").
+-- (provider_event_id) UNIQUE           — webhook idempotency. INSERT OR IGNORE
+--                                        on the webhook handler is the dedupe
+--                                        primitive.
+
+CREATE TABLE outreach_events (
+  id                 TEXT PRIMARY KEY,
+  org_id             TEXT NOT NULL REFERENCES organizations(id),
+  entity_id          TEXT REFERENCES entities(id),
+
+  event_type         TEXT NOT NULL CHECK (event_type IN (
+    'sent', 'open', 'click', 'bounce', 'reply'
+  )),
+  channel            TEXT NOT NULL DEFAULT 'email' CHECK (channel IN (
+    'email'
+  )),
+
+  message_id         TEXT,
+  provider_event_id  TEXT,
+  payload            TEXT,
+
+  created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_outreach_events_entity
+  ON outreach_events(entity_id, created_at DESC);
+
+CREATE INDEX idx_outreach_events_message
+  ON outreach_events(message_id, event_type);
+
+CREATE UNIQUE INDEX idx_outreach_events_provider_event
+  ON outreach_events(provider_event_id)
+  WHERE provider_event_id IS NOT NULL;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -59,6 +59,13 @@ declare namespace Cloudflare {
     /** Cloudflare Turnstile site key for the /book booking widget. Public. */
     PUBLIC_TURNSTILE_SITE_KEY?: string
     RESEND_API_KEY?: string
+    /**
+     * Resend webhook signing secret (`whsec_…` from the Resend dashboard
+     * webhook detail page). Used to verify Svix-signed webhook deliveries
+     * for the outreach attribution path. See
+     * src/pages/api/webhooks/resend.ts and issue #587.
+     */
+    RESEND_WEBHOOK_SECRET?: string
     ANTHROPIC_API_KEY?: string
     SIGNWELL_API_KEY?: string
     SIGNWELL_WEBHOOK_SECRET?: string

--- a/src/lib/db/outreach-events.test.ts
+++ b/src/lib/db/outreach-events.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for outreach_events DAL.
+ *
+ * Uses the @venturecrane/crane-test-harness D1 polyfill so we exercise
+ * the real schema (migrations applied) rather than mock the SQL surface.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import type { D1Database } from '@cloudflare/workers-types'
+import path from 'node:path'
+import { recordEvent, findSentByMessageId, listEventsByEntity } from './outreach-events'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../../../migrations')
+
+const ORG_ID = 'org-test-outreach'
+const ENTITY_ID = 'ent-test-outreach'
+
+async function seed(db: D1Database) {
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Test Org', 'test-org', datetime('now'), datetime('now'))`
+    )
+    .bind(ORG_ID)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+       VALUES (?, ?, 'Test Biz', 'test-biz', 'signal', datetime('now'), datetime('now'), datetime('now'))`
+    )
+    .bind(ENTITY_ID, ORG_ID)
+    .run()
+}
+
+describe('outreach-events DAL', () => {
+  let db: D1Database
+
+  beforeAll(() => {
+    const files = discoverNumericMigrations(migrationsDir)
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    db = createTestD1()
+    const files = discoverNumericMigrations(migrationsDir)
+    await runMigrations(db, { files })
+    await seed(db)
+  })
+
+  it('inserts a sent event with entity attribution and JSON-serializes the payload', async () => {
+    const result = await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-1',
+      payload: { to: 'a@b.com', subject: 'hi' },
+    })
+    expect(result.inserted).toBe(true)
+    expect(result.id).toBeDefined()
+
+    const row = await db
+      .prepare('SELECT * FROM outreach_events WHERE id = ?')
+      .bind(result.id)
+      .first<{
+        org_id: string
+        entity_id: string
+        event_type: string
+        channel: string
+        message_id: string
+        provider_event_id: string | null
+        payload: string
+      }>()
+    expect(row).not.toBeNull()
+    expect(row!.event_type).toBe('sent')
+    expect(row!.entity_id).toBe(ENTITY_ID)
+    expect(row!.message_id).toBe('rs-msg-1')
+    expect(row!.provider_event_id).toBeNull()
+    expect(row!.channel).toBe('email')
+    expect(JSON.parse(row!.payload)).toEqual({ to: 'a@b.com', subject: 'hi' })
+  })
+
+  it('dedupes on provider_event_id', async () => {
+    const first = await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'open',
+      message_id: 'rs-msg-2',
+      provider_event_id: 'svix-msg-abc',
+    })
+    expect(first.inserted).toBe(true)
+
+    const second = await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'open',
+      message_id: 'rs-msg-2',
+      provider_event_id: 'svix-msg-abc',
+    })
+    expect(second.inserted).toBe(false)
+    expect(second.id).toBe(first.id)
+
+    const count = await db
+      .prepare('SELECT COUNT(*) AS n FROM outreach_events WHERE provider_event_id = ?')
+      .bind('svix-msg-abc')
+      .first<{ n: number }>()
+    expect(count!.n).toBe(1)
+  })
+
+  it('allows multiple synthetic sent rows when provider_event_id is null', async () => {
+    // Both rows should insert — the unique partial index excludes NULLs.
+    const a = await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-x',
+      provider_event_id: null,
+    })
+    const b = await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-y',
+      provider_event_id: null,
+    })
+    expect(a.inserted).toBe(true)
+    expect(b.inserted).toBe(true)
+    expect(a.id).not.toBe(b.id)
+  })
+
+  it('findSentByMessageId returns the original sent row', async () => {
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-find',
+      provider_event_id: null,
+    })
+    // Add an open event for the same message — findSentByMessageId should
+    // still return the sent row, not the open.
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'open',
+      message_id: 'rs-msg-find',
+      provider_event_id: 'svix-find-1',
+    })
+
+    const sent = await findSentByMessageId(db, 'rs-msg-find')
+    expect(sent).not.toBeNull()
+    expect(sent!.event_type).toBe('sent')
+    expect(sent!.entity_id).toBe(ENTITY_ID)
+  })
+
+  it('findSentByMessageId returns null when the message_id is unknown', async () => {
+    const sent = await findSentByMessageId(db, 'never-existed')
+    expect(sent).toBeNull()
+  })
+
+  it('listEventsByEntity returns events newest-first', async () => {
+    // Force ordering by inserting with explicit small delays via separate
+    // calls — created_at default uses datetime('now') which is per-second
+    // resolution, so we sort by created_at DESC then by insertion order is
+    // not guaranteed. Instead, verify that all entries appear.
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'msg-list-1',
+    })
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'open',
+      message_id: 'msg-list-1',
+      provider_event_id: 'svix-list-1',
+    })
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'click',
+      message_id: 'msg-list-1',
+      provider_event_id: 'svix-list-2',
+    })
+
+    const events = await listEventsByEntity(db, ENTITY_ID)
+    expect(events.length).toBe(3)
+    const types = events.map((e) => e.event_type).sort()
+    expect(types).toEqual(['click', 'open', 'sent'])
+  })
+
+  it('listEventsByEntity returns an empty array for an entity with no events', async () => {
+    const events = await listEventsByEntity(db, 'no-such-entity')
+    expect(events).toEqual([])
+  })
+})

--- a/src/lib/db/outreach-events.ts
+++ b/src/lib/db/outreach-events.ts
@@ -1,0 +1,152 @@
+/**
+ * Outreach events data access layer.
+ *
+ * INVARIANT: append-only. Once a row is inserted it is never updated or
+ * deleted. The funnel math (sent → open → click → reply) is derived from
+ * these rows, not stored on them. Mutating a row would corrupt historical
+ * attribution.
+ *
+ * Idempotency: webhook handlers call `recordEvent` with a non-null
+ * `provider_event_id`. The unique partial index on `provider_event_id`
+ * lets us use INSERT OR IGNORE so Svix retries (which deliver the same
+ * provider event id) collapse to a single row.
+ *
+ * See migrations/0028_create_outreach_events.sql for column semantics.
+ */
+
+export type OutreachEventType = 'sent' | 'open' | 'click' | 'bounce' | 'reply'
+
+export type OutreachChannel = 'email'
+
+export interface OutreachEvent {
+  id: string
+  org_id: string
+  entity_id: string | null
+  event_type: OutreachEventType
+  channel: OutreachChannel
+  message_id: string | null
+  provider_event_id: string | null
+  payload: string | null
+  created_at: string
+}
+
+export interface RecordEventInput {
+  org_id: string
+  entity_id?: string | null
+  event_type: OutreachEventType
+  channel?: OutreachChannel
+  message_id?: string | null
+  provider_event_id?: string | null
+  payload?: unknown
+}
+
+export interface RecordEventResult {
+  /**
+   * The id of the row in the database. When the event was deduped
+   * (provider_event_id already existed), this is the id of the existing
+   * row, not a new one.
+   */
+  id: string
+  /**
+   * True when a new row was written. False when the event was deduped
+   * against an existing provider_event_id.
+   */
+  inserted: boolean
+}
+
+/**
+ * Insert an outreach-event row, deduping on provider_event_id when present.
+ *
+ * The dedupe path is the primary entry point from the Resend webhook —
+ * Svix delivers the same envelope id on retry and we must not double-count.
+ * Synthetic 'sent' rows from the send wrapper omit `provider_event_id` and
+ * always insert.
+ */
+export async function recordEvent(
+  db: D1Database,
+  input: RecordEventInput
+): Promise<RecordEventResult> {
+  // Dedupe path: if we already have a row for this provider_event_id,
+  // return that id without inserting.
+  if (input.provider_event_id) {
+    const existing = await db
+      .prepare('SELECT id FROM outreach_events WHERE provider_event_id = ? LIMIT 1')
+      .bind(input.provider_event_id)
+      .first<{ id: string }>()
+
+    if (existing) {
+      return { id: existing.id, inserted: false }
+    }
+  }
+
+  const id = crypto.randomUUID()
+  const payloadJson =
+    input.payload === undefined || input.payload === null
+      ? null
+      : typeof input.payload === 'string'
+        ? input.payload
+        : JSON.stringify(input.payload)
+
+  await db
+    .prepare(
+      `INSERT INTO outreach_events (
+        id, org_id, entity_id, event_type, channel, message_id,
+        provider_event_id, payload
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      input.org_id,
+      input.entity_id ?? null,
+      input.event_type,
+      input.channel ?? 'email',
+      input.message_id ?? null,
+      input.provider_event_id ?? null,
+      payloadJson
+    )
+    .run()
+
+  return { id, inserted: true }
+}
+
+/**
+ * Look up the most recent 'sent' event for a given message_id. Used by the
+ * webhook handler to recover the originating entity_id from a downstream
+ * event (open / click / bounce / reply) — Resend echoes the message id in
+ * `data.email_id` but does not echo our entity_id, so we re-resolve it from
+ * the original send row.
+ */
+export async function findSentByMessageId(
+  db: D1Database,
+  messageId: string
+): Promise<OutreachEvent | null> {
+  const row = await db
+    .prepare(
+      `SELECT * FROM outreach_events
+       WHERE message_id = ? AND event_type = 'sent'
+       ORDER BY created_at ASC
+       LIMIT 1`
+    )
+    .bind(messageId)
+    .first<OutreachEvent>()
+  return row ?? null
+}
+
+/**
+ * Return all events for an entity, newest first. Used by the admin entity
+ * detail page to render a per-prospect outreach timeline.
+ */
+export async function listEventsByEntity(
+  db: D1Database,
+  entityId: string
+): Promise<OutreachEvent[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM outreach_events
+       WHERE entity_id = ?
+       ORDER BY created_at DESC`
+    )
+    .bind(entityId)
+    .all<OutreachEvent>()
+  return result.results ?? []
+}

--- a/src/lib/email/resend.test.ts
+++ b/src/lib/email/resend.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the outreach send wrapper. Exercises the dev-mode branch
+ * (no RESEND_API_KEY) to avoid network calls — the wrapper still records
+ * the synthetic 'sent' row in that mode so dev/test flows produce
+ * realistic telemetry.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import type { D1Database } from '@cloudflare/workers-types'
+import path from 'node:path'
+import { sendOutreachEmail } from './resend'
+import { findSentByMessageId, listEventsByEntity } from '../db/outreach-events'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../../../migrations')
+
+const ORG_ID = 'org-outreach-send'
+const ENTITY_ID = 'ent-outreach-send'
+
+describe('sendOutreachEmail', () => {
+  let db: D1Database
+
+  beforeAll(() => {
+    const files = discoverNumericMigrations(migrationsDir)
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    db = createTestD1()
+    const files = discoverNumericMigrations(migrationsDir)
+    await runMigrations(db, { files })
+
+    await db
+      .prepare(
+        `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+         VALUES (?, 'Test Org', 'test-org', datetime('now'), datetime('now'))`
+      )
+      .bind(ORG_ID)
+      .run()
+
+    await db
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+         VALUES (?, ?, 'Biz', 'biz', 'signal', datetime('now'), datetime('now'), datetime('now'))`
+      )
+      .bind(ENTITY_ID, ORG_ID)
+      .run()
+  })
+
+  it('records a sent event with entity attribution in dev mode (no api key)', async () => {
+    const result = await sendOutreachEmail(
+      undefined, // dev mode
+      {
+        to: 'prospect@example.com',
+        subject: 'Hello',
+        html: '<p>Hi</p>',
+      },
+      { db, orgId: ORG_ID, entityId: ENTITY_ID }
+    )
+    expect(result.success).toBe(true)
+    expect(result.id).toBe('dev-mode')
+    expect(result.outreach_event_id).toBeDefined()
+
+    const sent = await findSentByMessageId(db, 'dev-mode')
+    expect(sent).not.toBeNull()
+    expect(sent!.entity_id).toBe(ENTITY_ID)
+    expect(sent!.org_id).toBe(ORG_ID)
+    expect(sent!.event_type).toBe('sent')
+  })
+
+  it('still records when entityId is omitted (org-scoped)', async () => {
+    const result = await sendOutreachEmail(
+      undefined,
+      { to: 't@e.com', subject: 's', html: 'h' },
+      { db, orgId: ORG_ID }
+    )
+    expect(result.success).toBe(true)
+    expect(result.outreach_event_id).toBeDefined()
+  })
+
+  it('attributes multiple sends to the same entity timeline', async () => {
+    await sendOutreachEmail(
+      undefined,
+      { to: 'a@e.com', subject: 'A', html: 'a' },
+      { db, orgId: ORG_ID, entityId: ENTITY_ID }
+    )
+    await sendOutreachEmail(
+      undefined,
+      { to: 'a@e.com', subject: 'B', html: 'b' },
+      { db, orgId: ORG_ID, entityId: ENTITY_ID }
+    )
+
+    const events = await listEventsByEntity(db, ENTITY_ID)
+    expect(events.length).toBe(2)
+    expect(events.every((e) => e.event_type === 'sent')).toBe(true)
+  })
+})

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,13 +1,33 @@
 /**
- * Resend email client for transactional emails.
+ * Resend email client for transactional and outreach emails.
  *
  * Sends emails via the Resend API (https://resend.com/docs/api-reference).
  * In dev/test environments (no RESEND_API_KEY), logs emails to console instead.
  *
  * Sender name is sourced from BRAND_NAME (../config/brand.ts).
+ *
+ * ## Outreach attribution (issue #587)
+ *
+ * `sendOutreachEmail` is a thin wrapper around the same fetch path that:
+ *   1. Threads `entity_id` from the caller through to a 'sent' row in
+ *      `outreach_events`, so every downstream event (open/click/bounce/
+ *      reply) can be re-attributed to the originating signal by the
+ *      webhook handler. See src/pages/api/webhooks/resend.ts.
+ *   2. Records the synthetic 'sent' row immediately after Resend returns
+ *      success — we do not wait for the `email.sent` webhook because the
+ *      send-time attribution data (entity_id, org_id) is only known here.
+ *   3. Relies on Resend's native open/click tracking — Resend rewrites
+ *      links and injects a pixel server-side when tracking is enabled on
+ *      the project. We do NOT inject our own pixel; double tracking would
+ *      double-count opens. See https://resend.com/docs/dashboard/emails/tracking.
+ *
+ * The base `sendEmail` API is unchanged so existing callers (transactional
+ * emails — booking, magic link, invoices, payment confirmations) keep
+ * working without entity attribution.
  */
 
 import { BRAND_NAME } from '../config/brand'
+import { recordEvent } from '../db/outreach-events'
 
 const RESEND_API_URL = 'https://api.resend.com/emails'
 const SENDER = `${BRAND_NAME} <team@smd.services>`
@@ -85,4 +105,80 @@ export async function sendEmail(
 
   const data = (await response.json()) as { id: string }
   return { success: true, id: data.id }
+}
+
+// ===========================================================================
+// Outreach send path (issue #587)
+// ===========================================================================
+
+export interface OutreachSendOptions {
+  /** D1 binding used to record the synthetic 'sent' row. */
+  db: D1Database
+  /** Org id the send is attributed to. Required for tenant scoping. */
+  orgId: string
+  /**
+   * Originating entity. Threaded through so the webhook handler can
+   * re-attribute downstream events. May be null only for org-internal
+   * outreach without a specific prospect target — never null for the
+   * lead-gen send queue (#588).
+   */
+  entityId?: string | null
+}
+
+export interface OutreachSendResult extends SendResult {
+  /**
+   * Resolves to the row id in `outreach_events` for the synthetic 'sent'
+   * event when the send succeeded. Undefined when send failed or when
+   * the DB write itself failed (we still return SendResult.success=true
+   * because the email did go out — observability is best-effort).
+   */
+  outreach_event_id?: string
+}
+
+/**
+ * Send an outreach email and record a 'sent' row in `outreach_events`.
+ *
+ * The DB write is best-effort — a failure to record the event does NOT
+ * fail the send (the email already went out, and rolling that back is
+ * impossible). Failures are logged for monitoring; the missing row
+ * surfaces as a gap in funnel attribution rather than a lost email.
+ *
+ * If RESEND_API_KEY is unset, the send is logged (dev mode) and a
+ * 'sent' row is still recorded with a synthetic message_id so dev/test
+ * flows exercise the full event path.
+ */
+export async function sendOutreachEmail(
+  apiKey: string | undefined,
+  payload: EmailPayload,
+  options: OutreachSendOptions
+): Promise<OutreachSendResult> {
+  const sendResult = await sendEmail(apiKey, payload)
+  if (!sendResult.success || !sendResult.id) {
+    return sendResult
+  }
+
+  try {
+    const eventResult = await recordEvent(options.db, {
+      org_id: options.orgId,
+      entity_id: options.entityId ?? null,
+      event_type: 'sent',
+      channel: 'email',
+      message_id: sendResult.id,
+      // No provider_event_id — this is a synthetic row recorded by the
+      // send wrapper, not an inbound webhook. The eventual `email.sent`
+      // webhook from Resend will dedupe against this row by message_id
+      // semantics in the webhook handler.
+      provider_event_id: null,
+      payload: {
+        to: payload.to,
+        subject: payload.subject,
+        recorded_by: 'send-wrapper',
+      },
+    })
+    return { ...sendResult, outreach_event_id: eventResult.id }
+  } catch (err) {
+    // Best-effort: do not fail the send because the telemetry row failed.
+    console.error('[email/outreach] failed to record sent event:', err)
+    return sendResult
+  }
 }

--- a/src/lib/webhooks/resend-handler.test.ts
+++ b/src/lib/webhooks/resend-handler.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the Resend webhook handler — event-type mapping, entity
+ * re-attribution from sent rows, and idempotent dedupe.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import type { D1Database } from '@cloudflare/workers-types'
+import path from 'node:path'
+import { handleResendEvent, mapResendEventType } from './resend-handler'
+import { recordEvent } from '../db/outreach-events'
+
+installWorkerdPolyfills()
+
+const migrationsDir = path.resolve(__dirname, '../../../migrations')
+
+const ORG_ID = 'org-resend-test'
+const ENTITY_ID = 'ent-resend-test'
+const FALLBACK_ORG = 'org-fallback'
+
+async function seed(db: D1Database) {
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Test Org', 'test-org', datetime('now'), datetime('now'))`
+    )
+    .bind(ORG_ID)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+       VALUES (?, 'Fallback Org', 'fallback-org', datetime('now'), datetime('now'))`
+    )
+    .bind(FALLBACK_ORG)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+       VALUES (?, ?, 'Test Biz', 'test-biz', 'signal', datetime('now'), datetime('now'), datetime('now'))`
+    )
+    .bind(ENTITY_ID, ORG_ID)
+    .run()
+}
+
+describe('mapResendEventType', () => {
+  it('maps every supported Resend event type', () => {
+    expect(mapResendEventType('email.sent')).toBe('sent')
+    expect(mapResendEventType('email.delivered')).toBe('sent')
+    expect(mapResendEventType('email.opened')).toBe('open')
+    expect(mapResendEventType('email.clicked')).toBe('click')
+    expect(mapResendEventType('email.bounced')).toBe('bounce')
+    expect(mapResendEventType('email.complained')).toBe('bounce')
+  })
+
+  it('returns null for events we do not record', () => {
+    expect(mapResendEventType('email.delivery_delayed')).toBeNull()
+    expect(mapResendEventType('contact.created')).toBeNull()
+    expect(mapResendEventType('domain.created')).toBeNull()
+    expect(mapResendEventType('unknown.thing')).toBeNull()
+  })
+})
+
+describe('handleResendEvent', () => {
+  let db: D1Database
+
+  beforeAll(() => {
+    const files = discoverNumericMigrations(migrationsDir)
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    db = createTestD1()
+    const files = discoverNumericMigrations(migrationsDir)
+    await runMigrations(db, { files })
+    await seed(db)
+  })
+
+  it('re-attributes opens to the originating entity via the sent row', async () => {
+    // Send wrapper would have written this row.
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-001',
+    })
+
+    const result = await handleResendEvent(db, {
+      providerEventId: 'svix-evt-1',
+      payload: {
+        type: 'email.opened',
+        data: { email_id: 'rs-msg-001' },
+      },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+
+    expect(result.recorded).toBe(true)
+    expect(result.eventType).toBe('open')
+    expect(result.entityId).toBe(ENTITY_ID)
+
+    const row = await db
+      .prepare(
+        `SELECT entity_id, org_id, event_type FROM outreach_events
+         WHERE provider_event_id = ?`
+      )
+      .bind('svix-evt-1')
+      .first<{ entity_id: string; org_id: string; event_type: string }>()
+    expect(row!.entity_id).toBe(ENTITY_ID)
+    expect(row!.org_id).toBe(ORG_ID)
+    expect(row!.event_type).toBe('open')
+  })
+
+  it('dedupes Svix retries on provider_event_id', async () => {
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-dedupe',
+    })
+
+    const first = await handleResendEvent(db, {
+      providerEventId: 'svix-dedupe-1',
+      payload: {
+        type: 'email.opened',
+        data: { email_id: 'rs-msg-dedupe' },
+      },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(first.recorded).toBe(true)
+
+    const retry = await handleResendEvent(db, {
+      providerEventId: 'svix-dedupe-1',
+      payload: {
+        type: 'email.opened',
+        data: { email_id: 'rs-msg-dedupe' },
+      },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(retry.recorded).toBe(false)
+    expect(retry.reason).toBe('deduped')
+
+    const count = await db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM outreach_events
+         WHERE provider_event_id = ?`
+      )
+      .bind('svix-dedupe-1')
+      .first<{ n: number }>()
+    expect(count!.n).toBe(1)
+  })
+
+  it('skips events with unmapped types', async () => {
+    const result = await handleResendEvent(db, {
+      providerEventId: 'svix-skip-1',
+      payload: { type: 'email.delivery_delayed', data: { email_id: 'rs-msg-skip' } },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(result.recorded).toBe(false)
+    expect(result.reason).toBe('unhandled_event_type')
+  })
+
+  it('skips events that lack an email_id', async () => {
+    const result = await handleResendEvent(db, {
+      providerEventId: 'svix-noid-1',
+      payload: { type: 'email.opened', data: {} },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(result.recorded).toBe(false)
+    expect(result.reason).toBe('no_message_id')
+  })
+
+  it('falls back to fallbackOrgId and null entity_id when no sent row exists', async () => {
+    const result = await handleResendEvent(db, {
+      providerEventId: 'svix-orphan-1',
+      payload: {
+        type: 'email.bounced',
+        data: { email_id: 'rs-msg-orphan' },
+      },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(result.recorded).toBe(true)
+    expect(result.eventType).toBe('bounce')
+    expect(result.entityId).toBeNull()
+
+    const row = await db
+      .prepare(
+        `SELECT entity_id, org_id FROM outreach_events
+         WHERE provider_event_id = ?`
+      )
+      .bind('svix-orphan-1')
+      .first<{ entity_id: string | null; org_id: string }>()
+    expect(row!.entity_id).toBeNull()
+    expect(row!.org_id).toBe(FALLBACK_ORG)
+  })
+
+  it('email.delivered collapses to the sent event type', async () => {
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'rs-msg-delivered',
+    })
+
+    const result = await handleResendEvent(db, {
+      providerEventId: 'svix-delivered-1',
+      payload: {
+        type: 'email.delivered',
+        data: { email_id: 'rs-msg-delivered' },
+      },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(result.recorded).toBe(true)
+    expect(result.eventType).toBe('sent')
+    expect(result.entityId).toBe(ENTITY_ID)
+  })
+
+  it('email.complained maps to bounce', async () => {
+    const result = await handleResendEvent(db, {
+      providerEventId: 'svix-comp-1',
+      payload: {
+        type: 'email.complained',
+        data: { email_id: 'rs-msg-complained' },
+      },
+      fallbackOrgId: FALLBACK_ORG,
+    })
+    expect(result.recorded).toBe(true)
+    expect(result.eventType).toBe('bounce')
+  })
+})

--- a/src/lib/webhooks/resend-handler.ts
+++ b/src/lib/webhooks/resend-handler.ts
@@ -1,0 +1,148 @@
+/**
+ * Resend webhook event handler.
+ *
+ * Maps Resend event types to internal `outreach_events` rows and resolves
+ * the originating `entity_id` from the synthetic 'sent' row recorded by
+ * the send wrapper (since Resend does not echo arbitrary metadata in
+ * webhook payloads).
+ *
+ * Refs:
+ *   https://resend.com/docs/dashboard/webhooks/event-types
+ *   https://resend.com/docs/api-reference/webhooks/introduction
+ */
+
+import { recordEvent, findSentByMessageId, type OutreachEventType } from '../db/outreach-events'
+
+/**
+ * Subset of Resend webhook payload that we depend on. Resend includes more
+ * fields (created_at, tags, etc.) but we keep our type narrow so a vendor
+ * payload reshape doesn't silently break the handler at compile time.
+ */
+export interface ResendWebhookPayload {
+  type: string
+  data?: {
+    email_id?: string
+    /** Recipient list — Resend sends this as an array of strings. */
+    to?: string[]
+    from?: string
+    subject?: string
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+/**
+ * Map Resend's event type vocabulary to our internal event_type taxonomy.
+ * Returns null for events we do not record (delivery_delayed, etc.) — they
+ * are acknowledged at the route level but produce no row.
+ *
+ * Resend event names per
+ * https://resend.com/docs/dashboard/webhooks/event-types:
+ *   email.sent           → 'sent'
+ *   email.delivered      → 'sent' (delivered to inbox; we collapse to 'sent'
+ *                                  since funnel math wants "did it leave")
+ *   email.opened         → 'open'
+ *   email.clicked        → 'click'
+ *   email.bounced        → 'bounce'
+ *   email.complained     → 'bounce' (spam complaint — same lifecycle bucket
+ *                                    for funnel math; payload preserves the
+ *                                    exact provider type for forensics)
+ *   email.delivery_delayed → null (transient, no funnel signal)
+ *   contact.* / domain.* → null (not message-scoped)
+ */
+export function mapResendEventType(resendType: string): OutreachEventType | null {
+  switch (resendType) {
+    case 'email.sent':
+    case 'email.delivered':
+      return 'sent'
+    case 'email.opened':
+      return 'open'
+    case 'email.clicked':
+      return 'click'
+    case 'email.bounced':
+    case 'email.complained':
+      return 'bounce'
+    default:
+      return null
+  }
+}
+
+export interface HandleResendEventInput {
+  /** Svix message id from `svix-id` header. Used as our dedupe key. */
+  providerEventId: string
+  /** Parsed payload from the verified webhook body. */
+  payload: ResendWebhookPayload
+  /** Fallback org id when we can't resolve from a 'sent' row. */
+  fallbackOrgId: string
+}
+
+export interface HandleResendEventResult {
+  /** True when a row was inserted; false when ignored or deduped. */
+  recorded: boolean
+  /** Reason when recorded=false. */
+  reason?: 'unhandled_event_type' | 'no_message_id' | 'deduped'
+  /** Internal event_type written when recorded=true. */
+  eventType?: OutreachEventType
+  /** Resolved entity_id, if known. */
+  entityId?: string | null
+}
+
+/**
+ * Process a single verified Resend webhook event:
+ *   1. Map provider event type → internal event_type, or short-circuit.
+ *   2. Resolve entity_id by joining message_id → original 'sent' row.
+ *   3. Insert (or dedupe via provider_event_id) into outreach_events.
+ *
+ * The 'sent' row recorded here (when type is email.sent / email.delivered)
+ * is distinct from the synthetic 'sent' row written by the send wrapper:
+ *   - send-wrapper row is written immediately after Resend returns 200,
+ *     carries entity_id, has a NULL provider_event_id.
+ *   - webhook 'sent'/'delivered' row is written when Resend's MTA reports
+ *     the email handed off, carries the Svix provider_event_id.
+ *
+ * Both are intentional — the send-wrapper row anchors entity attribution
+ * for everything downstream; the webhook row gives us the provider's
+ * authoritative timeline.
+ */
+export async function handleResendEvent(
+  db: D1Database,
+  input: HandleResendEventInput
+): Promise<HandleResendEventResult> {
+  const internalType = mapResendEventType(input.payload.type)
+  if (!internalType) {
+    return { recorded: false, reason: 'unhandled_event_type' }
+  }
+
+  const messageId = input.payload.data?.email_id ?? null
+
+  // Without a message_id we cannot link the event to anything actionable.
+  // 'sent' webhook events without an email_id would be a Resend bug, but
+  // we still ack and skip rather than insert an orphan row.
+  if (!messageId) {
+    return { recorded: false, reason: 'no_message_id' }
+  }
+
+  // Resolve attribution by joining back to the synthetic 'sent' row from
+  // the send wrapper. If no such row exists (e.g. transactional email
+  // from outside the outreach path), entity_id stays null and the row
+  // is recorded as org-scoped only.
+  const sentRow = await findSentByMessageId(db, messageId)
+  const orgId = sentRow?.org_id ?? input.fallbackOrgId
+  const entityId = sentRow?.entity_id ?? null
+
+  const result = await recordEvent(db, {
+    org_id: orgId,
+    entity_id: entityId,
+    event_type: internalType,
+    channel: 'email',
+    message_id: messageId,
+    provider_event_id: input.providerEventId,
+    payload: input.payload,
+  })
+
+  if (!result.inserted) {
+    return { recorded: false, reason: 'deduped', eventType: internalType, entityId }
+  }
+
+  return { recorded: true, eventType: internalType, entityId }
+}

--- a/src/pages/api/webhooks/resend.ts
+++ b/src/pages/api/webhooks/resend.ts
@@ -1,0 +1,256 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { handleResendEvent, type ResendWebhookPayload } from '../../../lib/webhooks/resend-handler'
+
+/**
+ * POST /api/webhooks/resend
+ *
+ * Receives webhook callbacks from Resend (https://resend.com/docs/dashboard/webhooks)
+ * for outreach lifecycle events: email.sent, email.delivered, email.opened,
+ * email.clicked, email.bounced, email.complained.
+ *
+ * This is an unauthenticated endpoint — Resend webhooks do not carry
+ * session tokens. Security is enforced via Svix signature verification
+ * using the RESEND_WEBHOOK_SECRET (the `whsec_…` value from the Resend
+ * dashboard webhook detail page).
+ *
+ * Resend uses Svix for delivery, which means three headers are sent on
+ * every request:
+ *   svix-id        — message id (also used as our idempotency key)
+ *   svix-timestamp — unix seconds, used for staleness check
+ *   svix-signature — space-delimited list of `vN,base64sig` pairs
+ *
+ * The signed content is `${svix-id}.${svix-timestamp}.${rawBody}`. The
+ * secret is base64-decoded after stripping the `whsec_` prefix; HMAC-SHA256
+ * yields the expected signature in base64. We accept the request when ANY
+ * `v1` signature in the header matches.
+ *
+ * Refs:
+ *   https://resend.com/docs/dashboard/webhooks/verify-webhooks-requests
+ *   https://docs.svix.com/receiving/verifying-payloads/how-manual
+ *
+ * Idempotency: handleResendEvent dedupes on svix-id via the unique partial
+ * index on outreach_events.provider_event_id. A retry of the same event
+ * collapses to a single row.
+ */
+
+/** Reject webhooks older than this many seconds. Matches Stripe/SignWell. */
+const MAX_WEBHOOK_AGE_SECONDS = 300
+
+/** Default org id for events that can't be re-attributed via the sent row. */
+const DEFAULT_ORG_ID = '01JQFK0000SMDSERVICES000'
+
+export const POST: APIRoute = async ({ request }) => {
+  const webhookSecret = env.RESEND_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[webhook/resend] RESEND_WEBHOOK_SECRET not configured')
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const svixId = request.headers.get('svix-id')
+  const svixTimestamp = request.headers.get('svix-timestamp')
+  const svixSignature = request.headers.get('svix-signature')
+
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return new Response(JSON.stringify({ error: 'Missing svix headers' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Read the raw body BEFORE parsing — Svix signs the exact bytes, and any
+  // round-trip through JSON.parse + JSON.stringify will mutate whitespace
+  // and break verification.
+  const rawBody = await request.text()
+
+  // --- Timestamp freshness (replay protection) ---
+  const tsSeconds = parseInt(svixTimestamp, 10)
+  if (!Number.isFinite(tsSeconds)) {
+    return new Response(JSON.stringify({ error: 'Invalid timestamp' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  if (Math.abs(nowSeconds - tsSeconds) > MAX_WEBHOOK_AGE_SECONDS) {
+    console.error(`[webhook/resend] Stale webhook: ts=${tsSeconds}, now=${nowSeconds}`)
+    return new Response(JSON.stringify({ error: 'Stale webhook' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Svix signature verification ---
+  const isValid = await verifySvixSignature(
+    svixId,
+    svixTimestamp,
+    rawBody,
+    svixSignature,
+    webhookSecret
+  )
+  if (!isValid) {
+    console.error('[webhook/resend] Invalid signature')
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Parse the now-verified body ---
+  let payload: ResendWebhookPayload
+  try {
+    payload = JSON.parse(rawBody) as ResendWebhookPayload
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  if (!payload.type) {
+    return new Response(JSON.stringify({ error: 'Missing event type' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // --- Dispatch ---
+  try {
+    const result = await handleResendEvent(env.DB, {
+      providerEventId: svixId,
+      payload,
+      fallbackOrgId: DEFAULT_ORG_ID,
+    })
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        recorded: result.recorded,
+        ...(result.reason ? { reason: result.reason } : {}),
+        ...(result.eventType ? { event_type: result.eventType } : {}),
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    console.error('[webhook/resend] handler failed:', err)
+    // 500 → Svix retries with backoff. Better than silently 200ing on a
+    // transient D1 error and losing the event.
+    return new Response(JSON.stringify({ error: 'Internal error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
+/**
+ * Verify a Svix-signed webhook payload.
+ *
+ * Algorithm (Svix manual verification):
+ *   1. Strip the `whsec_` prefix from the secret and base64-decode the rest.
+ *   2. Build signed content as `${svix-id}.${svix-timestamp}.${rawBody}`.
+ *   3. HMAC-SHA256 with the decoded key bytes; output base64.
+ *   4. Compare against any of the `v1,…` segments in the svix-signature
+ *      header (which may carry multiple signatures during key rotation).
+ *
+ * Constant-time comparison mitigates timing attacks.
+ *
+ * Ref: https://docs.svix.com/receiving/verifying-payloads/how-manual
+ */
+async function verifySvixSignature(
+  svixId: string,
+  svixTimestamp: string,
+  body: string,
+  signatureHeader: string,
+  secret: string
+): Promise<boolean> {
+  // Resend dashboard secrets carry a `whsec_` prefix. Tolerate either form
+  // so a misconfigured secret (paste of just the base64 portion) still works.
+  const secretBase64 = secret.startsWith('whsec_') ? secret.slice('whsec_'.length) : secret
+  const keyBuffer = base64ToArrayBuffer(secretBase64)
+  if (!keyBuffer) {
+    console.error('[webhook/resend] Webhook secret is not valid base64')
+    return false
+  }
+
+  const signedContent = `${svixId}.${svixTimestamp}.${body}`
+  const encoder = new TextEncoder()
+
+  let key: CryptoKey
+  try {
+    key = await crypto.subtle.importKey(
+      'raw',
+      keyBuffer,
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign']
+    )
+  } catch (err) {
+    console.error('[webhook/resend] importKey failed:', err)
+    return false
+  }
+
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(signedContent))
+  const expectedSignature = bytesToBase64(new Uint8Array(mac))
+
+  // svix-signature: `v1,sig1 v1,sig2 v2,sig3` — accept ANY v1 match.
+  const candidates = signatureHeader.split(' ')
+  for (const candidate of candidates) {
+    const [version, sig] = candidate.split(',', 2)
+    if (version !== 'v1' || !sig) continue
+    if (constantTimeEquals(expectedSignature, sig)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Constant-time string comparison. Returns false immediately on length
+ * mismatch — that is acceptable here because the expected signature is
+ * a fixed 44-character base64 of a 32-byte HMAC-SHA256 digest.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return mismatch === 0
+}
+
+/**
+ * Decode a standard base64 string to a fresh ArrayBuffer. Returns null when
+ * the input is malformed (atob throws on illegal characters).
+ *
+ * We return an ArrayBuffer (not a Uint8Array view) because crypto.subtle
+ * APIs are typed against `BufferSource` with the strict `ArrayBuffer`
+ * variant under @cloudflare/workers-types — passing a typed-array view
+ * runs afoul of `ArrayBufferLike` vs `ArrayBuffer` strictness.
+ */
+function base64ToArrayBuffer(input: string): ArrayBuffer | null {
+  try {
+    const binary = atob(input)
+    const buffer = new ArrayBuffer(binary.length)
+    const view = new Uint8Array(buffer)
+    for (let i = 0; i < binary.length; i++) {
+      view[i] = binary.charCodeAt(i)
+    }
+    return buffer
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Encode a Uint8Array to standard base64.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}

--- a/tests/resend-webhook.test.ts
+++ b/tests/resend-webhook.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Route-level tests for POST /api/webhooks/resend.
+ *
+ * Exercises the Svix signature verification + dispatch path end-to-end
+ * with a real D1 instance and the same env-injection pattern used by
+ * other API-route tests (tests/_stubs/cloudflare-workers.ts).
+ *
+ * Generates valid Svix signatures via Node's crypto so we can assert
+ * acceptance on a correctly-signed body and rejection on a wrong-secret
+ * signature, stale timestamp, or replay.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import { createHmac, randomUUID } from 'node:crypto'
+import type { D1Database } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+
+import { POST } from '../src/pages/api/webhooks/resend'
+import { recordEvent } from '../src/lib/db/outreach-events'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+// --- Test secret. Encodes the string "test-secret-bytes" as base64 raw key.
+//     Format mirrors what Resend stores: `whsec_<base64-raw-key>`.
+const RAW_SECRET_BYTES = Buffer.from('test-secret-bytes-1234567890abcd')
+const SECRET_BASE64 = RAW_SECRET_BYTES.toString('base64')
+const WEBHOOK_SECRET = `whsec_${SECRET_BASE64}`
+
+const ORG_ID = 'org-resend-route'
+const ENTITY_ID = 'ent-resend-route'
+
+function svixSign(svixId: string, svixTimestamp: string, body: string): string {
+  const signed = `${svixId}.${svixTimestamp}.${body}`
+  const sig = createHmac('sha256', RAW_SECRET_BYTES).update(signed).digest('base64')
+  return `v1,${sig}`
+}
+
+function makeRequest(opts: {
+  body: string
+  svixId?: string
+  timestamp?: string
+  signature?: string
+}): Request {
+  const svixId = opts.svixId ?? `msg_${randomUUID()}`
+  const ts = opts.timestamp ?? String(Math.floor(Date.now() / 1000))
+  const sig = opts.signature ?? svixSign(svixId, ts, opts.body)
+  return new Request('http://test.local/api/webhooks/resend', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'svix-id': svixId,
+      'svix-timestamp': ts,
+      'svix-signature': sig,
+    },
+    body: opts.body,
+  })
+}
+
+async function callRoute(req: Request) {
+  return await POST({ request: req } as Parameters<typeof POST>[0])
+}
+
+describe('POST /api/webhooks/resend', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    await db
+      .prepare(
+        `INSERT INTO organizations (id, name, slug, created_at, updated_at)
+         VALUES (?, 'Test Org', 'test-org', datetime('now'), datetime('now'))`
+      )
+      .bind(ORG_ID)
+      .run()
+
+    await db
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at, created_at, updated_at)
+         VALUES (?, ?, 'Biz', 'biz', 'signal', datetime('now'), datetime('now'), datetime('now'))`
+      )
+      .bind(ENTITY_ID, ORG_ID)
+      .run()
+
+    Object.assign(testEnv, {
+      DB: db,
+      RESEND_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    })
+  })
+
+  afterEach(() => {
+    for (const key of Object.keys(testEnv)) {
+      delete (testEnv as unknown as Record<string, unknown>)[key]
+    }
+  })
+
+  it('500s when RESEND_WEBHOOK_SECRET is unset', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).RESEND_WEBHOOK_SECRET
+    const body = JSON.stringify({ type: 'email.opened', data: { email_id: 'm1' } })
+    const res = await callRoute(makeRequest({ body }))
+    expect(res.status).toBe(500)
+  })
+
+  it('400s when svix headers are missing', async () => {
+    const req = new Request('http://test.local/api/webhooks/resend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'email.opened', data: { email_id: 'm1' } }),
+    })
+    const res = await callRoute(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('401s on bad signature', async () => {
+    const body = JSON.stringify({ type: 'email.opened', data: { email_id: 'm1' } })
+    const ts = String(Math.floor(Date.now() / 1000))
+    const req = makeRequest({
+      body,
+      timestamp: ts,
+      signature: 'v1,' + Buffer.from('not-a-real-signature').toString('base64'),
+    })
+    const res = await callRoute(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('401s on stale timestamp', async () => {
+    const body = JSON.stringify({ type: 'email.opened', data: { email_id: 'm1' } })
+    const tsOld = String(Math.floor(Date.now() / 1000) - 600) // 10 min in the past
+    const req = makeRequest({ body, timestamp: tsOld })
+    const res = await callRoute(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('400s on invalid JSON even with a valid signature', async () => {
+    const body = 'this is not json'
+    const req = makeRequest({ body })
+    const res = await callRoute(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('records an event and re-attributes to the entity via the sent row', async () => {
+    // Pre-seed the synthetic 'sent' row that the send wrapper would write.
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'msg-route-1',
+    })
+
+    const body = JSON.stringify({
+      type: 'email.opened',
+      data: { email_id: 'msg-route-1' },
+    })
+    const res = await callRoute(makeRequest({ body }))
+    expect(res.status).toBe(200)
+
+    const json = (await res.json()) as { ok: boolean; recorded: boolean }
+    expect(json.ok).toBe(true)
+    expect(json.recorded).toBe(true)
+
+    const row = await db
+      .prepare(
+        `SELECT entity_id, event_type FROM outreach_events
+         WHERE message_id = ? AND event_type = 'open'`
+      )
+      .bind('msg-route-1')
+      .first<{ entity_id: string; event_type: string }>()
+    expect(row).not.toBeNull()
+    expect(row!.entity_id).toBe(ENTITY_ID)
+  })
+
+  it('dedupes a Svix retry of the same svix-id', async () => {
+    await recordEvent(db, {
+      org_id: ORG_ID,
+      entity_id: ENTITY_ID,
+      event_type: 'sent',
+      message_id: 'msg-route-2',
+    })
+
+    const body = JSON.stringify({
+      type: 'email.opened',
+      data: { email_id: 'msg-route-2' },
+    })
+    const svixId = `msg_${randomUUID()}`
+    const ts = String(Math.floor(Date.now() / 1000))
+
+    const first = await callRoute(makeRequest({ body, svixId, timestamp: ts }))
+    expect(first.status).toBe(200)
+
+    const retry = await callRoute(makeRequest({ body, svixId, timestamp: ts }))
+    expect(retry.status).toBe(200)
+    const retryJson = (await retry.json()) as { recorded: boolean; reason?: string }
+    expect(retryJson.recorded).toBe(false)
+    expect(retryJson.reason).toBe('deduped')
+
+    const count = await db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM outreach_events
+         WHERE provider_event_id = ?`
+      )
+      .bind(svixId)
+      .first<{ n: number }>()
+    expect(count!.n).toBe(1)
+  })
+
+  it('acks unhandled event types without inserting a row', async () => {
+    const body = JSON.stringify({
+      type: 'email.delivery_delayed',
+      data: { email_id: 'msg-route-3' },
+    })
+    const res = await callRoute(makeRequest({ body }))
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { recorded: boolean; reason?: string }
+    expect(json.recorded).toBe(false)
+    expect(json.reason).toBe('unhandled_event_type')
+  })
+
+  it('accepts a signature when the secret is provided WITHOUT the whsec_ prefix', async () => {
+    // Replace env with the prefix-stripped secret. The route should still
+    // verify because we tolerate either form.
+    Object.assign(testEnv, { RESEND_WEBHOOK_SECRET: SECRET_BASE64 })
+
+    const body = JSON.stringify({
+      type: 'email.bounced',
+      data: { email_id: 'msg-route-4' },
+    })
+    const res = await callRoute(makeRequest({ body }))
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts a signature when the header carries multiple v1 candidates', async () => {
+    const body = JSON.stringify({
+      type: 'email.opened',
+      data: { email_id: 'msg-route-5' },
+    })
+    const svixId = `msg_${randomUUID()}`
+    const ts = String(Math.floor(Date.now() / 1000))
+    const validSig = svixSign(svixId, ts, body)
+    const fakeSig = 'v1,' + Buffer.from('not-a-real-signature').toString('base64')
+    const req = makeRequest({
+      body,
+      svixId,
+      timestamp: ts,
+      signature: `${fakeSig} ${validSig}`,
+    })
+    const res = await callRoute(req)
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
Closes #587.

## Summary

Lays the funnel-attribution foundation for the Phase 1A lead-gen sprint. Without per-message sent/open/click/bounce/reply telemetry, every campaign decision is guesswork — issue #587 calls this the single biggest leverage fix. See [docs/strategy/lead-gen-strategy-2026-04-25.md](https://github.com/venturecrane/ss-console/blob/main/docs/strategy/lead-gen-strategy-2026-04-25.md).

Unblocks #588 (send queue) and #590 (reply parser) — both are queued to start as soon as this lands.

## Acceptance criteria

- [x] `outreach_events` table migration (entity_id, event_type [sent/open/click/bounce/reply], timestamp, channel, message_id) — `migrations/0028_create_outreach_events.sql`
- [x] Resend client wrapper at `src/lib/email/resend.ts` — adds `sendOutreachEmail` alongside existing `sendEmail`; threads `entity_id` from caller into a synthetic `sent` row
- [x] Inbound webhook handler for Resend events at `/api/webhooks/resend` — `src/pages/api/webhooks/resend.ts` with full Svix signature verification (per [Svix manual-verification docs](https://docs.svix.com/receiving/verifying-payloads/how-manual))
- [x] Send path threads `entity_id` so events link back to the originating signal — `sendOutreachEmail` records the synthetic `sent` row immediately on Resend success; webhook handler re-attributes downstream events by joining `message_id` → original sent row
- [x] Open/click pixels embedded in outbound HTML — relies on Resend's native open/click tracking (link rewriting + server-injected pixel). We do **not** inject our own pixel; double tracking would double-count opens. See `src/lib/email/resend.ts` doc comment for the rationale.

## What's in the change

| File | Purpose |
| --- | --- |
| `migrations/0028_create_outreach_events.sql` | Append-only events table. Unique partial index on `provider_event_id` enables Svix-retry idempotency. |
| `src/lib/db/outreach-events.ts` | DAL — `recordEvent` (dedupes on provider_event_id), `findSentByMessageId` (re-attribution lookup), `listEventsByEntity` (admin timeline). |
| `src/lib/email/resend.ts` | Adds `sendOutreachEmail`. `sendEmail` is unchanged so existing callers (booking, magic-link, invoices) keep working. |
| `src/lib/webhooks/resend-handler.ts` | Maps Resend event types (`email.sent` / `email.delivered` → `sent`; `email.opened` → `open`; `email.clicked` → `click`; `email.bounced` / `email.complained` → `bounce`; everything else acked + skipped) and resolves entity attribution. |
| `src/pages/api/webhooks/resend.ts` | POST route. Svix signature verify: `whsec_`-prefix tolerant, base64-decoded HMAC-SHA256, multi-v1 candidate parse, 5-minute timestamp window, constant-time compare. Mirrors the existing Stripe / SignWell handlers. |
| `src/env.d.ts` + `.dev.vars.example` | Documents `RESEND_WEBHOOK_SECRET`. |

## Tests (29 new, all green)

- `src/lib/db/outreach-events.test.ts` — DAL: insert + JSON-serialize, dedupe on provider_event_id, NULL-tolerant unique index, sent-row lookup, listing.
- `src/lib/webhooks/resend-handler.test.ts` — event-type mapping (every supported + every ignored type), entity re-attribution via sent-row join, idempotency, fallback-org behavior, `email.delivered` → `sent` collapse, `email.complained` → `bounce`.
- `src/lib/email/resend.test.ts` — `sendOutreachEmail` records sent row in dev mode, supports omitted entityId, attributes multiple sends to one entity timeline.
- `tests/resend-webhook.test.ts` — full route-level Svix signature roundtrip with Node's `crypto.createHmac`: accepts valid signature, rejects bad signature, rejects stale timestamp, dedupes Svix retry, acks unhandled types, tolerates `whsec_`-stripped secret, accepts multi-candidate signature header during key rotation.

`npm run verify` clean: typecheck (0 errors), format (clean), lint (0 errors, 2 pre-existing warnings unrelated to this change), build, 1557 tests passing.

## Secrets to provision

The Resend webhook secret is **NOT** in `wrangler.toml` or `.dev.vars`. It must go into Cloudflare Worker secrets:

```bash
wrangler secret put RESEND_WEBHOOK_SECRET   # the whsec_... value from the Resend dashboard webhook detail page
wrangler secret put RESEND_API_KEY          # already exists in prod, no change
```

After deploy, configure the webhook endpoint in the Resend dashboard:
- URL: `https://smd.services/api/webhooks/resend`
- Events: `email.sent`, `email.delivered`, `email.opened`, `email.clicked`, `email.bounced`, `email.complained`

Tracking (open + click rewriting) must also be enabled at the Resend project level for the open/click events to fire.

## Test plan

- [x] DAL unit tests pass against a fresh D1 with the migration applied
- [x] Handler tests cover every Resend event type we map and every short-circuit reason
- [x] Route tests verify Svix signature acceptance/rejection paths end-to-end
- [x] `npm run verify` passes locally
- [ ] After merge: run `wrangler secret put RESEND_WEBHOOK_SECRET` against prod, configure the Resend dashboard endpoint, send a test event, confirm a row lands in `outreach_events`

## Coordination notes

Stayed in `src/lib/email/`, `src/lib/db/outreach-events.ts`, `src/lib/webhooks/resend-handler.ts`, `src/pages/api/webhooks/resend.ts`, and migration `0028_*`. No collisions with #589 (signal attribution) or #592 (review-mining cap, workers dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)