### PR TITLE
feat(lifecycle): originating_signal attribution on engagements (#589)

### DIFF
--- a/migrations/0028_originating_signal_attribution.sql
+++ b/migrations/0028_originating_signal_attribution.sql
@@ -1,0 +1,47 @@
+-- Originating-signal attribution on lifecycle artifacts (#589).
+--
+-- Why: signals (rows in `context` with type='signal') are the leading indicator
+-- of which lead-gen pipeline produced revenue. Without an FK from the
+-- downstream artifact (meeting / quote / engagement) back to the originating
+-- signal, ROI per pipeline is unknowable — we can see signal volume per
+-- pipeline and revenue per engagement, but the join in between requires
+-- attribution that only the admin can author.
+--
+-- Strategy: nullable FK on each lifecycle artifact, defaulting to the most
+-- recent qualified signal for the entity at creation time. Admin UI lets the
+-- operator pick a different signal or unset attribution entirely. NULL is
+-- valid — pre-migration rows stay NULL, and artifacts created against an
+-- entity with no signals (e.g. inbound referrals) also stay NULL.
+--
+-- Strictly additive. No backfill (pre-existing rows keep NULL — attribution
+-- prior to this migration is unrecoverable). No drops. Safe to roll back by
+-- ignoring the new columns; downstream code treats NULL as "unknown".
+--
+-- Choice of FK target: `context.id`. Signals are stored as context entries
+-- with type='signal', not as their own table (the `lead_signals` table from
+-- migration 0007 was superseded by the entity/context architecture in 0008).
+-- See `src/lib/db/context.ts` for the append-only contract.
+
+-- ============================================================================
+-- meetings.originating_signal_id
+-- ============================================================================
+ALTER TABLE meetings ADD COLUMN originating_signal_id TEXT REFERENCES context(id);
+CREATE INDEX IF NOT EXISTS idx_meetings_originating_signal
+  ON meetings(originating_signal_id)
+  WHERE originating_signal_id IS NOT NULL;
+
+-- ============================================================================
+-- quotes.originating_signal_id
+-- ============================================================================
+ALTER TABLE quotes ADD COLUMN originating_signal_id TEXT REFERENCES context(id);
+CREATE INDEX IF NOT EXISTS idx_quotes_originating_signal
+  ON quotes(originating_signal_id)
+  WHERE originating_signal_id IS NOT NULL;
+
+-- ============================================================================
+-- engagements.originating_signal_id
+-- ============================================================================
+ALTER TABLE engagements ADD COLUMN originating_signal_id TEXT REFERENCES context(id);
+CREATE INDEX IF NOT EXISTS idx_engagements_originating_signal
+  ON engagements(originating_signal_id)
+  WHERE originating_signal_id IS NOT NULL;

--- a/src/lib/db/engagements.ts
+++ b/src/lib/db/engagements.ts
@@ -7,6 +7,7 @@
 
 import { scheduleEngagementCadence } from '../follow-ups/scheduler'
 import { transitionStage } from './entities'
+import { getDefaultOriginatingSignalId } from './signal-attribution'
 
 export interface Engagement {
   id: string
@@ -28,6 +29,13 @@ export interface Engagement {
   consultant_phone: string | null
   next_touchpoint_at: string | null
   next_touchpoint_label: string | null
+  /**
+   * Context-row id (type='signal') that this engagement is attributed to (#589).
+   * NULL when the entity had no signals at engagement creation time, or when
+   * the admin explicitly cleared the attribution. Powers the per-pipeline ROI
+   * roll-up via `getEngagementsBySourcePipeline` in `signal-attribution.ts`.
+   */
+  originating_signal_id: string | null
   created_at: string
   updated_at: string
 }
@@ -75,6 +83,17 @@ export interface CreateEngagementData {
   start_date?: string | null
   estimated_end?: string | null
   estimated_hours?: number | null
+  /**
+   * Originating signal attribution (#589). Three states:
+   * - `undefined` (omitted): caller defers to the default — most-recent signal
+   *   for the entity, or NULL if the entity has none.
+   * - `string`: caller has an explicit signal id (e.g. admin override). Stored
+   *   as-is. The caller is responsible for validating the id belongs to this
+   *   entity/org.
+   * - `null`: caller explicitly wants the engagement unattributed (e.g.
+   *   inbound referral with no signal on file). Default-resolution is skipped.
+   */
+  originating_signal_id?: string | null
 }
 
 export interface UpdateEngagementData {
@@ -92,6 +111,13 @@ export interface UpdateEngagementData {
   consultant_phone?: string | null
   next_touchpoint_at?: string | null
   next_touchpoint_label?: string | null
+  /**
+   * Edit attribution post-creation (#589). Pass `null` to clear, a string
+   * to set, or omit to leave unchanged. The caller validates the id belongs
+   * to this entity/org before calling — see `getSignalById` in
+   * `signal-attribution.ts`.
+   */
+  originating_signal_id?: string | null
 }
 
 /**
@@ -187,10 +213,19 @@ export async function createEngagement(
   const id = crypto.randomUUID()
   const now = new Date().toISOString()
 
+  // Resolve originating-signal attribution (#589). `undefined` means "use
+  // the default" — most-recent signal context-row for the entity, or NULL
+  // if the entity has none. Explicit `null` skips defaulting (admin chose
+  // to leave the engagement unattributed).
+  const originatingSignalId =
+    data.originating_signal_id === undefined
+      ? await getDefaultOriginatingSignalId(db, orgId, data.entity_id)
+      : data.originating_signal_id
+
   await db
     .prepare(
-      `INSERT INTO engagements (id, org_id, entity_id, quote_id, scope_summary, start_date, estimated_end, status, estimated_hours, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?, ?)`
+      `INSERT INTO engagements (id, org_id, entity_id, quote_id, scope_summary, start_date, estimated_end, status, estimated_hours, originating_signal_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?, ?, ?)`
     )
     .bind(
       id,
@@ -201,6 +236,7 @@ export async function createEngagement(
       data.start_date ?? null,
       data.estimated_end ?? null,
       data.estimated_hours ?? null,
+      originatingSignalId,
       now,
       now
     )
@@ -298,6 +334,11 @@ export async function updateEngagement(
   if (data.next_touchpoint_label !== undefined) {
     fields.push('next_touchpoint_label = ?')
     params.push(data.next_touchpoint_label)
+  }
+
+  if (data.originating_signal_id !== undefined) {
+    fields.push('originating_signal_id = ?')
+    params.push(data.originating_signal_id)
   }
 
   if (fields.length === 0) {

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -15,6 +15,8 @@
  * Primary keys use crypto.randomUUID().
  */
 
+import { getDefaultOriginatingSignalId } from './signal-attribution'
+
 export interface Meeting {
   id: string
   org_id: string
@@ -30,6 +32,12 @@ export interface Meeting {
   /** Free-form completion notes written by the admin when the meeting is completed. */
   completion_notes: string | null
   status: MeetingStatus
+  /**
+   * Originating signal attribution (#589). Context-row id (type='signal')
+   * that this meeting is attributed to, or NULL if the meeting was booked
+   * without a triggering signal (inbound, manual entry, pre-migration row).
+   */
+  originating_signal_id: string | null
   created_at: string
 }
 
@@ -59,6 +67,12 @@ export const VALID_TRANSITIONS: Record<MeetingStatus, MeetingStatus[]> = {
 export interface CreateMeetingData {
   scheduled_at?: string | null
   meeting_type?: string | null
+  /**
+   * Originating signal attribution (#589). Same three-state contract used
+   * across the lifecycle: undefined → default to most-recent signal for the
+   * entity, string → explicit override, null → leave unattributed.
+   */
+  originating_signal_id?: string | null
 }
 
 export interface EnsureMeetingForAssessmentData {
@@ -82,6 +96,8 @@ export interface UpdateMeetingData {
   live_notes?: string | null
   completion_notes?: string | null
   meeting_type?: string | null
+  /** See CreateMeetingData. `null` clears, string sets, omit leaves unchanged. */
+  originating_signal_id?: string | null
 }
 
 /**
@@ -178,12 +194,27 @@ export async function createMeeting(
   const id = crypto.randomUUID()
   const now = new Date().toISOString()
 
+  // Resolve originating-signal attribution (#589). See createEngagement /
+  // createQuote for the same three-state default contract.
+  const originatingSignalId =
+    data.originating_signal_id === undefined
+      ? await getDefaultOriginatingSignalId(db, orgId, entityId)
+      : data.originating_signal_id
+
   await db
     .prepare(
-      `INSERT INTO meetings (id, org_id, entity_id, meeting_type, scheduled_at, status, created_at)
-     VALUES (?, ?, ?, ?, ?, 'scheduled', ?)`
+      `INSERT INTO meetings (id, org_id, entity_id, meeting_type, scheduled_at, status, originating_signal_id, created_at)
+     VALUES (?, ?, ?, ?, ?, 'scheduled', ?, ?)`
     )
-    .bind(id, orgId, entityId, data.meeting_type ?? null, data.scheduled_at ?? null, now)
+    .bind(
+      id,
+      orgId,
+      entityId,
+      data.meeting_type ?? null,
+      data.scheduled_at ?? null,
+      originatingSignalId,
+      now
+    )
     .run()
 
   const meeting = await getMeeting(db, orgId, id)
@@ -206,15 +237,31 @@ export async function createMeetingWithLegacyAssessment(
   const id = crypto.randomUUID()
   const now = new Date().toISOString()
 
+  // Resolve originating-signal attribution (#589). The legacy `assessments`
+  // table is read-only after the meetings backfill so we don't dual-write
+  // attribution there — attribution lives on `meetings` only.
+  const originatingSignalId =
+    data.originating_signal_id === undefined
+      ? await getDefaultOriginatingSignalId(db, orgId, entityId)
+      : data.originating_signal_id
+
   try {
     await db.batch([
       db
         .prepare(
           `INSERT INTO meetings (
-            id, org_id, entity_id, meeting_type, scheduled_at, status, created_at
-          ) VALUES (?, ?, ?, ?, ?, 'scheduled', ?)`
+            id, org_id, entity_id, meeting_type, scheduled_at, status, originating_signal_id, created_at
+          ) VALUES (?, ?, ?, ?, ?, 'scheduled', ?, ?)`
         )
-        .bind(id, orgId, entityId, data.meeting_type ?? null, data.scheduled_at ?? null, now),
+        .bind(
+          id,
+          orgId,
+          entityId,
+          data.meeting_type ?? null,
+          data.scheduled_at ?? null,
+          originatingSignalId,
+          now
+        ),
       db
         .prepare(
           `INSERT INTO assessments (
@@ -286,12 +333,16 @@ export async function ensureMeetingForAssessment(
     throw new Error(`Assessment ${data.assessmentId} does not belong to entity ${entityId}`)
   }
 
+  // Resolve originating-signal attribution (#589). The legacy assessment row
+  // doesn't have a signal FK so we always default-resolve from context.
+  const originatingSignalId = await getDefaultOriginatingSignalId(db, orgId, entityId)
+
   try {
     await db
       .prepare(
         `INSERT INTO meetings (
-          id, org_id, entity_id, meeting_type, scheduled_at, status, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+          id, org_id, entity_id, meeting_type, scheduled_at, status, originating_signal_id, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         data.assessmentId,
@@ -300,6 +351,7 @@ export async function ensureMeetingForAssessment(
         data.meeting_type ?? 'assessment',
         data.scheduled_at ?? assessment.scheduled_at,
         assessment.status,
+        originatingSignalId,
         assessment.created_at
       )
       .run()
@@ -388,6 +440,11 @@ export async function updateMeeting(
   if (data.meeting_type !== undefined) {
     fields.push('meeting_type = ?')
     params.push(data.meeting_type)
+  }
+
+  if (data.originating_signal_id !== undefined) {
+    fields.push('originating_signal_id = ?')
+    params.push(data.originating_signal_id)
   }
 
   if (fields.length === 0) {

--- a/src/lib/db/quotes.ts
+++ b/src/lib/db/quotes.ts
@@ -12,6 +12,7 @@
  */
 
 import { isQuoteAcceptanceReady } from '../sow/store'
+import { getDefaultOriginatingSignalId } from './signal-attribution'
 
 export interface Quote {
   id: string
@@ -49,6 +50,12 @@ export interface Quote {
   deliverables: string | null // JSON array of DeliverableRow
   engagement_overview: string | null
   milestone_label: string | null
+  /**
+   * Originating-signal attribution (#589). NULL until set; see
+   * `signal-attribution.ts`. Set by default at quote creation to the most
+   * recent signal on the entity.
+   */
+  originating_signal_id: string | null
   created_at: string
   updated_at: string
 }
@@ -137,6 +144,13 @@ export interface CreateQuoteData {
    * `superseded` — createQuote does not mutate the parent record.
    */
   parentQuoteId?: string | null
+  /**
+   * Originating signal attribution (#589). Same three-state contract as
+   * `CreateEngagementData.originating_signal_id`: undefined → default,
+   * string → explicit, null → skip default. Validation of the id belonging
+   * to the entity/org is the caller's responsibility.
+   */
+  originatingSignalId?: string | null
 }
 
 export interface UpdateQuoteData {
@@ -147,6 +161,12 @@ export interface UpdateQuoteData {
   deliverables?: DeliverableRow[] | null
   engagementOverview?: string | null
   milestoneLabel?: string | null
+  /**
+   * Edit attribution post-creation (#589). `null` clears, string sets, omit
+   * leaves unchanged. Recalculation of totals/version below is unaffected;
+   * attribution is metadata, not part of the quote's pricing identity.
+   */
+  originatingSignalId?: string | null
 }
 
 /**
@@ -323,10 +343,18 @@ export async function createQuote(
   // assessment primary key) unless the caller passes an explicit meetingId.
   const meetingIdValue = data.meetingId ?? data.assessmentId
 
+  // Resolve originating-signal attribution (#589). Same three-state contract
+  // as createEngagement — undefined defaults to most-recent, null is an
+  // explicit skip, string is an explicit override.
+  const originatingSignalId =
+    data.originatingSignalId === undefined
+      ? await getDefaultOriginatingSignalId(db, orgId, data.entityId)
+      : data.originatingSignalId
+
   await db
     .prepare(
-      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, meeting_id, version, parent_quote_id, line_items, total_hours, rate, total_price, deposit_pct, deposit_amount, status, schedule, deliverables, engagement_overview, milestone_label, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO quotes (id, org_id, entity_id, assessment_id, meeting_id, version, parent_quote_id, line_items, total_hours, rate, total_price, deposit_pct, deposit_amount, status, schedule, deliverables, engagement_overview, milestone_label, originating_signal_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?, ?)`
     )
     .bind(
       id,
@@ -346,6 +374,7 @@ export async function createQuote(
       deliverablesJson,
       engagementOverview,
       milestoneLabel,
+      originatingSignalId,
       now,
       now
     )
@@ -421,6 +450,11 @@ export async function updateQuote(
     fields.push('milestone_label = ?')
     const trimmed = data.milestoneLabel?.trim() ?? null
     params.push(trimmed && trimmed.length > 0 ? trimmed : null)
+  }
+
+  if (data.originatingSignalId !== undefined) {
+    fields.push('originating_signal_id = ?')
+    params.push(data.originatingSignalId)
   }
 
   // Recalculate totals if line items or rate changed
@@ -523,6 +557,7 @@ export async function getActiveQuotesForEntities(
            line_items, total_hours, rate, total_price, deposit_pct,
            deposit_amount, status, sent_at, expires_at, accepted_at,
            schedule, deliverables, engagement_overview, milestone_label,
+           originating_signal_id,
            created_at, updated_at
     FROM (
       SELECT q.*,

--- a/src/lib/db/signal-attribution.ts
+++ b/src/lib/db/signal-attribution.ts
@@ -1,0 +1,154 @@
+/**
+ * Signal-attribution helpers for lifecycle artifacts (#589).
+ *
+ * "Originating signal" is the context-row id (type='signal') that an
+ * admin attributes a meeting/quote/engagement to. Without this link we
+ * can count signals per pipeline and revenue per engagement, but never
+ * cross the two — i.e. ROI per pipeline is unknowable.
+ *
+ * Signals are stored as `context` rows (see migration 0008 + context DAL)
+ * — not their own table — so attribution FKs point at `context.id`.
+ *
+ * All queries are parameterized and scoped by `org_id` per the P0 #399
+ * cross-tenant isolation rule. NULL `originating_signal_id` is valid and
+ * means "unattributed" (inbound referral, pre-migration row, or admin
+ * intentionally cleared the attribution).
+ */
+
+import type { ContextEntry } from './context'
+
+export interface SignalSummary {
+  /** Context row id of a signal — the value stored in `originating_signal_id`. */
+  id: string
+  /** When the signal was logged (context.created_at). */
+  created_at: string
+  /** The pipeline that produced the signal (context.source). */
+  source_pipeline: string
+  /** The signal body (context.content) — truncated by callers if needed. */
+  content: string
+}
+
+/**
+ * Return the signals on file for an entity, most recent first.
+ *
+ * "Signal" here means a context row of type='signal'. The most recent
+ * signal is the default attribution choice for new artifacts created
+ * against this entity. Empty array means the entity has no signals —
+ * artifact creation must leave `originating_signal_id` NULL.
+ *
+ * Org-scoped to enforce tenant isolation (#399).
+ */
+export async function listSignalsForEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<SignalSummary[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, created_at, source AS source_pipeline, content
+       FROM context
+       WHERE org_id = ? AND entity_id = ? AND type = 'signal'
+       ORDER BY created_at DESC`
+    )
+    .bind(orgId, entityId)
+    .all<SignalSummary>()
+  return result.results ?? []
+}
+
+/**
+ * Return the most recent qualified signal for an entity, or null if the
+ * entity has no signals. "Qualified" today means any context row of
+ * type='signal' — the ingest endpoint already enforces a closed set of
+ * pipelines (review_mining, job_monitor, new_business, social_listening).
+ * If a future qualifier (e.g. pain_score >= N) is needed it goes in this
+ * one query, not the call sites.
+ *
+ * Used as the default attribution at artifact-creation time when the
+ * caller doesn't supply an explicit `originating_signal_id`.
+ */
+export async function getDefaultOriginatingSignalId(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<string | null> {
+  const row = await db
+    .prepare(
+      `SELECT id FROM context
+       WHERE org_id = ? AND entity_id = ? AND type = 'signal'
+       ORDER BY created_at DESC
+       LIMIT 1`
+    )
+    .bind(orgId, entityId)
+    .first<{ id: string }>()
+  return row?.id ?? null
+}
+
+/**
+ * Resolve a context-row id back to its signal record, scoped to the org.
+ * Returns null if the id doesn't exist, isn't a signal, or belongs to a
+ * different org. Callers should reject mismatches before persisting an
+ * attribution choice — D1 would silently store a dangling FK otherwise
+ * (D1's FK enforcement is on by default but the column is nullable, and
+ * we want the "wrong org" path to be a clean validation error rather
+ * than an opaque constraint failure).
+ */
+export async function getSignalById(
+  db: D1Database,
+  orgId: string,
+  signalId: string
+): Promise<ContextEntry | null> {
+  const row = await db
+    .prepare(`SELECT * FROM context WHERE id = ? AND org_id = ? AND type = 'signal'`)
+    .bind(signalId, orgId)
+    .first<ContextEntry>()
+  return row ?? null
+}
+
+export interface SignalPipelineRevenueRow {
+  /** Pipeline value from context.source (review_mining / job_monitor / ...). */
+  source_pipeline: string
+  /** Engagements attributed to a signal from this pipeline. */
+  engagement_count: number
+  /** Sum of engagements.estimated_hours across the bucket (NULL hours skipped). */
+  total_estimated_hours: number
+  /** Sum of engagements.actual_hours across the bucket. */
+  total_actual_hours: number
+}
+
+/**
+ * Group engagements by the source pipeline of their originating signal.
+ * Read-only attribution roll-up powering the (forthcoming) ROI dashboard.
+ *
+ * Engagements with NULL `originating_signal_id` are excluded — they can't
+ * be attributed by definition. The dashboard surface is responsible for
+ * showing the unattributed count separately if it wants to.
+ *
+ * Pipeline names come from `context.source` rather than a hardcoded enum
+ * because the pipeline list lives in the ingest endpoint's `ALLOWED_PIPELINES`
+ * constant; binding the SQL to that enum here would couple the DAL to the
+ * API contract and force a code change every time we add a pipeline.
+ */
+export async function getEngagementsBySourcePipeline(
+  db: D1Database,
+  orgId: string
+): Promise<SignalPipelineRevenueRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT
+         c.source AS source_pipeline,
+         COUNT(e.id) AS engagement_count,
+         COALESCE(SUM(e.estimated_hours), 0) AS total_estimated_hours,
+         COALESCE(SUM(e.actual_hours), 0) AS total_actual_hours
+       FROM engagements e
+       JOIN context c
+         ON c.id = e.originating_signal_id
+        AND c.type = 'signal'
+        AND c.org_id = e.org_id
+       WHERE e.org_id = ?
+       GROUP BY c.source
+       ORDER BY engagement_count DESC, c.source ASC`
+    )
+    .bind(orgId)
+    .all<SignalPipelineRevenueRow>()
+  return result.results ?? []
+}

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -9,6 +9,7 @@ import { listMilestones, VALID_TRANSITIONS as MS_TRANSITIONS } from '../../../li
 import type { MilestoneStatus } from '../../../lib/db/milestones'
 import { listInvoices } from '../../../lib/db/invoices'
 import { listContext } from '../../../lib/db/context'
+import { listSignalsForEntity } from '../../../lib/db/signal-attribution'
 import { listDocuments } from '../../../lib/storage/r2'
 import { env } from 'cloudflare:workers'
 
@@ -35,6 +36,24 @@ const invoices = await listInvoices(env.DB, session.orgId, { engagementId })
 const contextEntries = await listContext(env.DB, engagement.entity_id, {
   engagement_id: engagementId,
 })
+
+// Signals on file for this entity, most-recent first (#589). Powers the
+// originating-signal dropdown in the Edit Details form.
+const entitySignals = await listSignalsForEntity(env.DB, session.orgId, engagement.entity_id)
+
+function truncateSignal(content: string, max = 80): string {
+  const oneLine = content.replace(/\s+/g, ' ').trim()
+  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max - 1)}…`
+}
+
+function formatSignalLabel(s: { source_pipeline: string; created_at: string; content: string }) {
+  const date = new Date(s.created_at).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  return `[${s.source_pipeline}] ${date} — ${truncateSignal(s.content)}`
+}
 
 const depositInvoice = invoices.find((i) => i.type === 'deposit')
 
@@ -310,6 +329,34 @@ function fileSize(bytes: number): string {
                 class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
               />
             </div>
+          </div>
+          <div>
+            <label
+              for="originating_signal_id"
+              class="block text-sm font-medium text-[color:var(--ss-color-text-primary)] mb-1"
+            >
+              Originating Signal
+            </label>
+            <select
+              id="originating_signal_id"
+              name="originating_signal_id"
+              class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
+            >
+              <option value="__none__" selected={!engagement.originating_signal_id}>
+                — Unattributed —
+              </option>
+              {
+                entitySignals.map((s) => (
+                  <option value={s.id} selected={engagement.originating_signal_id === s.id}>
+                    {formatSignalLabel(s)}
+                  </option>
+                ))
+              }
+            </select>
+            <p class="mt-1 text-xs text-[color:var(--ss-color-text-muted)]">
+              Pipeline signal that produced this engagement. Defaults to the most recent signal on
+              file. Used for ROI-per-pipeline reporting.
+            </p>
           </div>
           <div class="flex justify-end">
             <button

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -17,6 +17,7 @@ import type {
   DeliverableRow,
 } from '../../../../../lib/db/quotes'
 import { listContacts } from '../../../../../lib/db/contacts'
+import { listSignalsForEntity } from '../../../../../lib/db/signal-attribution'
 import { getSOWStateForQuote } from '../../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
 
@@ -38,11 +39,30 @@ const session = Astro.locals.session!
 const entityId = Astro.params.id!
 const quoteId = Astro.params.quoteId!
 
-const [entity, quote, contacts] = await Promise.all([
+const [entity, quote, contacts, entitySignals] = await Promise.all([
   getEntity(env.DB, session.orgId, entityId),
   getQuote(env.DB, session.orgId, quoteId),
   listContacts(env.DB, session.orgId, entityId),
+  listSignalsForEntity(env.DB, session.orgId, entityId),
 ])
+
+// Format helper for the originating-signal dropdown (#589). Single-line,
+// truncated, with pipeline + date + content snippet so an admin can pick the
+// right signal at a glance.
+function formatSignalLabel(s: {
+  source_pipeline: string
+  created_at: string
+  content: string
+}): string {
+  const date = new Date(s.created_at).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  const oneLine = s.content.replace(/\s+/g, ' ').trim()
+  const snippet = oneLine.length > 80 ? `${oneLine.slice(0, 79)}…` : oneLine
+  return `[${s.source_pipeline}] ${date} — ${snippet}`
+}
 
 if (!entity) return Astro.redirect('/admin/entities?error=not_found')
 if (!quote) return Astro.redirect(`/admin/entities/${entityId}?error=not_found`)
@@ -577,6 +597,46 @@ function formatCurrency(amount: number): string {
       }
     </div>
 
+    {/* Originating signal (#589) */}
+    <div class="mb-6">
+      <label
+        class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
+        for="originating-signal-input"
+      >
+        Originating signal
+      </label>
+      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
+        Pipeline signal that produced this engagement. Defaults to the most recent signal on file.
+        Used for ROI-per-pipeline reporting; never rendered to the client.
+      </p>
+      {
+        isDraft ? (
+          <select
+            id="originating-signal-input"
+            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
+          >
+            <option value="__none__" selected={!quote.originating_signal_id}>
+              — Unattributed —
+            </option>
+            {entitySignals.map((s) => (
+              <option value={s.id} selected={quote.originating_signal_id === s.id}>
+                {formatSignalLabel(s)}
+              </option>
+            ))}
+          </select>
+        ) : quote.originating_signal_id ? (
+          <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+            {(() => {
+              const s = entitySignals.find((x) => x.id === quote.originating_signal_id)
+              return s ? formatSignalLabel(s) : 'Attributed (signal no longer visible).'
+            })()}
+          </p>
+        ) : (
+          <p class="text-sm italic text-[color:var(--ss-color-text-muted)]">Unattributed.</p>
+        )
+      }
+    </div>
+
     {/* Milestone label (three-milestone only) */}
     {
       isThreeMilestone && (
@@ -676,6 +736,12 @@ function formatCurrency(amount: number): string {
               name="milestone_label"
               id="save-milestone-label"
               value={milestoneLabel}
+            />
+            <input
+              type="hidden"
+              name="originating_signal_id"
+              id="save-originating-signal-id"
+              value={quote.originating_signal_id ?? '__none__'}
             />
             <button
               type="submit"
@@ -787,12 +853,14 @@ function formatCurrency(amount: number): string {
       const saveDeliverablesInput = document.getElementById('save-deliverables')
       const saveEngagementOverviewInput = document.getElementById('save-engagement-overview')
       const saveMilestoneLabelInput = document.getElementById('save-milestone-label')
+      const saveOriginatingSignalInput = document.getElementById('save-originating-signal-id')
       const scheduleRowsContainer = document.getElementById('schedule-rows')
       const deliverableRowsContainer = document.getElementById('deliverable-rows')
       const addScheduleRowBtn = document.getElementById('add-schedule-row-btn')
       const addDeliverableRowBtn = document.getElementById('add-deliverable-row-btn')
       const engagementOverviewInput = document.getElementById('engagement-overview-input')
       const milestoneLabelInput = document.getElementById('milestone-label-input')
+      const originatingSignalInput = document.getElementById('originating-signal-input')
       const generatePdfBtn = document.getElementById('generate-pdf-btn')
       const signBtn = document.getElementById('sign-btn')
 
@@ -922,6 +990,12 @@ function formatCurrency(amount: number): string {
         }
         if (saveMilestoneLabelInput && milestoneLabelInput) {
           saveMilestoneLabelInput.value = milestoneLabelInput.value
+        }
+        if (saveOriginatingSignalInput && originatingSignalInput) {
+          // Mirror the dropdown value (#589) into the save form. The "__none__"
+          // sentinel is sent verbatim — the API endpoint translates it back to
+          // null. Real signal ids pass through unchanged.
+          saveOriginatingSignalInput.value = originatingSignalInput.value
         }
       }
 

--- a/src/pages/api/admin/engagements/[id].ts
+++ b/src/pages/api/admin/engagements/[id].ts
@@ -5,6 +5,7 @@ import {
   updateEngagementStatus,
 } from '../../../../lib/db/engagements'
 import type { EngagementStatus } from '../../../../lib/db/engagements'
+import { getSignalById } from '../../../../lib/db/signal-attribution'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -70,6 +71,25 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
     const estimatedHours = formData.get('estimated_hours')
     const actualHours = formData.get('actual_hours')
 
+    // Originating-signal attribution edit (#589). Only present when the form
+    // includes the dropdown — absence means "no change". Same sentinel rules
+    // as the create endpoint: "" / missing = no change, "__none__" = clear,
+    // "<id>" = explicit override (validated against entity/org).
+    const signalRaw = formData.get('originating_signal_id')
+    let originatingSignalId: string | null | undefined
+    if (typeof signalRaw === 'string') {
+      const v = signalRaw.trim()
+      if (v === '__none__') {
+        originatingSignalId = null
+      } else if (v !== '') {
+        const signal = await getSignalById(env.DB, session.orgId, v)
+        // Reject mismatched entity scopes silently — UI shouldn't have rendered
+        // a foreign signal in the dropdown, but guard against tampered POSTs.
+        originatingSignalId =
+          signal && signal.entity_id === existing.entity_id ? signal.id : undefined
+      }
+    }
+
     await updateEngagement(env.DB, session.orgId, engagementId, {
       scope_summary:
         scopeSummary && typeof scopeSummary === 'string' ? scopeSummary.trim() || null : undefined,
@@ -87,6 +107,7 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
         actualHours && typeof actualHours === 'string' && actualHours.trim()
           ? parseFloat(actualHours) || null
           : undefined,
+      ...(originatingSignalId !== undefined && { originating_signal_id: originatingSignalId }),
     })
 
     return redirect(`/admin/engagements/${engagementId}?saved=1`, 302)

--- a/src/pages/api/admin/engagements/index.ts
+++ b/src/pages/api/admin/engagements/index.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { createEngagement } from '../../../../lib/db/engagements'
 import { createMilestone } from '../../../../lib/db/milestones'
+import { getSignalById } from '../../../../lib/db/signal-attribution'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -53,8 +54,26 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     const scopeSummary = formData.get('scope_summary')
     const estimatedHours = formData.get('estimated_hours')
 
+    // Originating signal attribution (#589). Form may pass:
+    //   "" / missing  → defer to DAL default (most-recent signal)
+    //   "__none__"    → explicit unattributed (sentinel; admin chose blank)
+    //   "<id>"        → explicit override; we validate org/entity scoping
+    // Bad ids fall back to default rather than blocking engagement creation.
+    const signalRaw = formData.get('originating_signal_id')
+    const entityIdTrimmed = clientId.trim()
+    let originatingSignalId: string | null | undefined
+    if (typeof signalRaw === 'string') {
+      const v = signalRaw.trim()
+      if (v === '__none__') {
+        originatingSignalId = null
+      } else if (v !== '') {
+        const signal = await getSignalById(env.DB, session.orgId, v)
+        originatingSignalId = signal && signal.entity_id === entityIdTrimmed ? signal.id : undefined
+      }
+    }
+
     const engagement = await createEngagement(env.DB, session.orgId, {
-      entity_id: clientId.trim(),
+      entity_id: entityIdTrimmed,
       quote_id: quoteId.trim(),
       start_date:
         startDate && typeof startDate === 'string' && startDate.trim() ? startDate.trim() : null,
@@ -70,6 +89,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
         estimatedHours && typeof estimatedHours === 'string' && estimatedHours.trim()
           ? parseFloat(estimatedHours) || null
           : null,
+      ...(originatingSignalId !== undefined && { originating_signal_id: originatingSignalId }),
     })
 
     // Create default milestones if provided

--- a/src/pages/api/admin/quotes/[id].ts
+++ b/src/pages/api/admin/quotes/[id].ts
@@ -8,6 +8,7 @@ import {
 import type { LineItem, QuoteStatus, DeliverableRow } from '../../../../lib/db/quotes'
 import { getEntity } from '../../../../lib/db/entities'
 import { listContacts } from '../../../../lib/db/contacts'
+import { getSignalById } from '../../../../lib/db/signal-attribution'
 import type { SOWTemplateProps } from '../../../../lib/pdf/sow-template'
 import { createSOWRevisionForQuote } from '../../../../lib/sow/service'
 import { env } from 'cloudflare:workers'
@@ -285,6 +286,23 @@ export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
 
     if (typeof milestoneLabel === 'string') {
       updateData.milestoneLabel = milestoneLabel
+    }
+
+    // Originating-signal attribution edit (#589). Same sentinel rules as the
+    // engagement endpoints. Validation rejects ids belonging to a different
+    // entity or org silently — falls through to "no change" so a tampered
+    // POST can't reattribute an engagement to another tenant's signal.
+    const signalRaw = formData.get('originating_signal_id')
+    if (typeof signalRaw === 'string') {
+      const v = signalRaw.trim()
+      if (v === '__none__') {
+        updateData.originatingSignalId = null
+      } else if (v !== '') {
+        const signal = await getSignalById(env.DB, session.orgId, v)
+        if (signal && signal.entity_id === existing.entity_id) {
+          updateData.originatingSignalId = signal.id
+        }
+      }
     }
 
     await updateQuote(env.DB, session.orgId, quoteId, updateData)

--- a/tests/quotes-authored-content.test.ts
+++ b/tests/quotes-authored-content.test.ts
@@ -66,6 +66,7 @@ function makeQuote(overrides: Partial<Quote> = {}): Quote {
     deliverables: null,
     engagement_overview: null,
     milestone_label: null,
+    originating_signal_id: null,
     created_at: '2026-04-15T00:00:00.000Z',
     updated_at: '2026-04-15T00:00:00.000Z',
     ...overrides,

--- a/tests/signal-attribution.test.ts
+++ b/tests/signal-attribution.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Originating-signal attribution tests (#589).
+ *
+ * Exercises:
+ *   - DAL helpers (listSignalsForEntity, getDefaultOriginatingSignalId,
+ *     getSignalById, getEngagementsBySourcePipeline)
+ *   - createMeeting / createQuote / createEngagement default-resolution
+ *     behavior (undefined → most recent signal, null → unattributed,
+ *     explicit string → stored as-is)
+ *   - update paths persist the new column
+ *   - Roll-up query groups attributed engagements by source pipeline
+ *
+ * Uses @venturecrane/crane-test-harness so we exercise real D1 SQL,
+ * not text-greps. The lifecycle DAL is the load-bearing surface here —
+ * source-string checks would miss the actual default-resolution.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../src/lib/db/entities'
+import { appendContext } from '../src/lib/db/context'
+import { createMeeting } from '../src/lib/db/meetings'
+import { createQuote } from '../src/lib/db/quotes'
+import { createEngagement, updateEngagement } from '../src/lib/db/engagements'
+import {
+  listSignalsForEntity,
+  getDefaultOriginatingSignalId,
+  getSignalById,
+  getEngagementsBySourcePipeline,
+} from '../src/lib/db/signal-attribution'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ORG = 'org-589'
+const ORG_OTHER = 'org-589-other'
+
+interface Setup {
+  db: D1Database
+  entityA: string
+  entityB: string
+  entityC: string
+}
+
+async function bootstrap(): Promise<Setup> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?), (?, ?, ?)')
+    .bind(ORG, 'Org 589', 'org-589', ORG_OTHER, 'Org 589 Other', 'org-589-other')
+    .run()
+
+  // Three entities so we can test cross-entity isolation, defaults, and the
+  // roll-up's GROUP BY behavior simultaneously.
+  const a = await createEntity(db, ORG, { name: 'Entity A', source_pipeline: 'review_mining' })
+  const b = await createEntity(db, ORG, { name: 'Entity B', source_pipeline: 'job_monitor' })
+  const c = await createEntity(db, ORG, { name: 'Entity C', source_pipeline: 'new_business' })
+
+  return { db, entityA: a.id, entityB: b.id, entityC: c.id }
+}
+
+describe('signal attribution: DAL helpers (#589)', () => {
+  let s: Setup
+  beforeEach(async () => {
+    s = await bootstrap()
+  })
+
+  it('listSignalsForEntity returns most-recent first and excludes other entities', async () => {
+    const older = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'signal',
+      content: 'first signal',
+      source: 'review_mining',
+    })
+    // Bump created_at on the second signal so DESC ordering is unambiguous —
+    // datetime('now') resolution is per-second on D1's SQLite build.
+    await s.db
+      .prepare(`UPDATE context SET created_at = datetime('now', '-1 hour') WHERE id = ?`)
+      .bind(older.id)
+      .run()
+    const newer = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'signal',
+      content: 'second signal',
+      source: 'job_monitor',
+    })
+
+    // Noise on a different entity must not appear.
+    await appendContext(s.db, ORG, {
+      entity_id: s.entityB,
+      type: 'signal',
+      content: 'b signal',
+      source: 'review_mining',
+    })
+
+    const signals = await listSignalsForEntity(s.db, ORG, s.entityA)
+    expect(signals.map((x) => x.id)).toEqual([newer.id, older.id])
+  })
+
+  it('getDefaultOriginatingSignalId returns null when entity has no signals', async () => {
+    const id = await getDefaultOriginatingSignalId(s.db, ORG, s.entityA)
+    expect(id).toBeNull()
+  })
+
+  it('getDefaultOriginatingSignalId returns the most recent signal id', async () => {
+    const older = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'signal',
+      content: 'a',
+      source: 'review_mining',
+    })
+    await s.db
+      .prepare(`UPDATE context SET created_at = datetime('now', '-1 hour') WHERE id = ?`)
+      .bind(older.id)
+      .run()
+    const newer = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'signal',
+      content: 'b',
+      source: 'job_monitor',
+    })
+
+    const id = await getDefaultOriginatingSignalId(s.db, ORG, s.entityA)
+    expect(id).toBe(newer.id)
+  })
+
+  it('getSignalById rejects ids from a different org (#399 isolation)', async () => {
+    const sig = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'signal',
+      content: 'x',
+      source: 'review_mining',
+    })
+    expect(await getSignalById(s.db, ORG, sig.id)).not.toBeNull()
+    expect(await getSignalById(s.db, ORG_OTHER, sig.id)).toBeNull()
+  })
+
+  it('getSignalById rejects non-signal context entries', async () => {
+    const note = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'note',
+      content: 'admin note',
+      source: 'admin',
+    })
+    expect(await getSignalById(s.db, ORG, note.id)).toBeNull()
+  })
+})
+
+describe('signal attribution: createMeeting/createQuote/createEngagement (#589)', () => {
+  let s: Setup
+  beforeEach(async () => {
+    s = await bootstrap()
+  })
+
+  async function seedSignal(entityId: string, source: string): Promise<string> {
+    const sig = await appendContext(s.db, ORG, {
+      entity_id: entityId,
+      type: 'signal',
+      content: `signal from ${source}`,
+      source,
+    })
+    return sig.id
+  }
+
+  it('createMeeting defaults to most-recent signal when omitted', async () => {
+    const sigId = await seedSignal(s.entityA, 'review_mining')
+    const meeting = await createMeeting(s.db, ORG, s.entityA, {})
+    expect(meeting.originating_signal_id).toBe(sigId)
+  })
+
+  it('createMeeting honors explicit null (unattributed)', async () => {
+    await seedSignal(s.entityA, 'review_mining')
+    const meeting = await createMeeting(s.db, ORG, s.entityA, { originating_signal_id: null })
+    expect(meeting.originating_signal_id).toBeNull()
+  })
+
+  it('createMeeting stores explicit signal id', async () => {
+    const sigId = await seedSignal(s.entityA, 'review_mining')
+    // Add a newer signal to prove the explicit override wins over the default.
+    await seedSignal(s.entityA, 'job_monitor')
+    const meeting = await createMeeting(s.db, ORG, s.entityA, { originating_signal_id: sigId })
+    expect(meeting.originating_signal_id).toBe(sigId)
+  })
+
+  it('createQuote defaults to most-recent signal', async () => {
+    const sigId = await seedSignal(s.entityA, 'review_mining')
+    // A quote needs an assessment per the schema. Insert a meeting (which is
+    // backwards-compatible with assessment_id thanks to migration 0025).
+    await s.db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
+         VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+      )
+      .bind('mtg-1', ORG, s.entityA, null)
+      .run()
+    const quote = await createQuote(s.db, ORG, {
+      entityId: s.entityA,
+      assessmentId: 'mtg-1',
+      lineItems: [],
+      rate: 175,
+    })
+    expect(quote.originating_signal_id).toBe(sigId)
+  })
+
+  it('createEngagement defaults to most-recent signal', async () => {
+    const sigId = await seedSignal(s.entityA, 'review_mining')
+
+    // Build the upstream chain (assessment → quote) so the engagement FK is
+    // satisfiable. We don't care about pricing — just the attribution column.
+    await s.db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
+         VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+      )
+      .bind('mtg-eng', ORG, s.entityA, null)
+      .run()
+    const quote = await createQuote(s.db, ORG, {
+      entityId: s.entityA,
+      assessmentId: 'mtg-eng',
+      lineItems: [],
+      rate: 175,
+    })
+
+    const eng = await createEngagement(s.db, ORG, {
+      entity_id: s.entityA,
+      quote_id: quote.id,
+    })
+
+    expect(eng.originating_signal_id).toBe(sigId)
+  })
+
+  it('updateEngagement clears attribution when null is passed', async () => {
+    const sigId = await seedSignal(s.entityA, 'review_mining')
+    await s.db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
+         VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+      )
+      .bind('mtg-upd', ORG, s.entityA, null)
+      .run()
+    const quote = await createQuote(s.db, ORG, {
+      entityId: s.entityA,
+      assessmentId: 'mtg-upd',
+      lineItems: [],
+      rate: 175,
+    })
+    const eng = await createEngagement(s.db, ORG, {
+      entity_id: s.entityA,
+      quote_id: quote.id,
+    })
+    expect(eng.originating_signal_id).toBe(sigId)
+
+    const cleared = await updateEngagement(s.db, ORG, eng.id, { originating_signal_id: null })
+    expect(cleared?.originating_signal_id).toBeNull()
+  })
+})
+
+describe('signal attribution: getEngagementsBySourcePipeline roll-up (#589)', () => {
+  let s: Setup
+  beforeEach(async () => {
+    s = await bootstrap()
+  })
+
+  it('groups engagements by the source pipeline of their attributed signal', async () => {
+    // Two engagements from review_mining, one from job_monitor, one
+    // unattributed (must be excluded from the buckets).
+    const make = async (entityId: string, source: string, hours: number) => {
+      const sig = await appendContext(s.db, ORG, {
+        entity_id: entityId,
+        type: 'signal',
+        content: 'sig',
+        source,
+      })
+      const aid = `mtg-${entityId}-${source}-${hours}`
+      await s.db
+        .prepare(
+          `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
+           VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+        )
+        .bind(aid, ORG, entityId, null)
+        .run()
+      const q = await createQuote(s.db, ORG, {
+        entityId,
+        assessmentId: aid,
+        lineItems: [],
+        rate: 175,
+        originatingSignalId: sig.id,
+      })
+      await createEngagement(s.db, ORG, {
+        entity_id: entityId,
+        quote_id: q.id,
+        estimated_hours: hours,
+        originating_signal_id: sig.id,
+      })
+    }
+
+    await make(s.entityA, 'review_mining', 10)
+    await make(s.entityB, 'review_mining', 20)
+    await make(s.entityC, 'job_monitor', 5)
+
+    // Unattributed engagement — must not appear in any bucket.
+    await s.db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
+         VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+      )
+      .bind('mtg-orphan', ORG, s.entityA, null)
+      .run()
+    const qOrphan = await createQuote(s.db, ORG, {
+      entityId: s.entityA,
+      assessmentId: 'mtg-orphan',
+      lineItems: [],
+      rate: 175,
+      originatingSignalId: null,
+    })
+    await createEngagement(s.db, ORG, {
+      entity_id: s.entityA,
+      quote_id: qOrphan.id,
+      estimated_hours: 99,
+      originating_signal_id: null,
+    })
+
+    const rows = await getEngagementsBySourcePipeline(s.db, ORG)
+    const byPipeline = Object.fromEntries(rows.map((r) => [r.source_pipeline, r]))
+
+    expect(byPipeline.review_mining?.engagement_count).toBe(2)
+    expect(byPipeline.review_mining?.total_estimated_hours).toBe(30)
+    expect(byPipeline.job_monitor?.engagement_count).toBe(1)
+    expect(byPipeline.job_monitor?.total_estimated_hours).toBe(5)
+    expect(byPipeline.new_business).toBeUndefined()
+  })
+
+  it('is org-scoped — engagements from a different org never appear', async () => {
+    // Seed in ORG, query ORG_OTHER. Result must be empty.
+    const sig = await appendContext(s.db, ORG, {
+      entity_id: s.entityA,
+      type: 'signal',
+      content: 'sig',
+      source: 'review_mining',
+    })
+    await s.db
+      .prepare(
+        `INSERT INTO assessments (id, org_id, entity_id, scheduled_at, status, created_at)
+         VALUES (?, ?, ?, ?, 'scheduled', datetime('now'))`
+      )
+      .bind('mtg-iso', ORG, s.entityA, null)
+      .run()
+    const q = await createQuote(s.db, ORG, {
+      entityId: s.entityA,
+      assessmentId: 'mtg-iso',
+      lineItems: [],
+      rate: 175,
+      originatingSignalId: sig.id,
+    })
+    await createEngagement(s.db, ORG, {
+      entity_id: s.entityA,
+      quote_id: q.id,
+      originating_signal_id: sig.id,
+    })
+
+    const rows = await getEngagementsBySourcePipeline(s.db, ORG_OTHER)
+    expect(rows).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #589.

## Why

When a meeting / quote / engagement is created we need to know which signal originated it. Without this link ROI per pipeline is unknowable — we can count signals per pipeline and revenue per engagement but never join the two. Telemetry from #586 (PR #569) gave us per-pipeline run heartbeats; this PR closes the loop on the revenue side.

## What

### Migration (`0028_originating_signal_attribution.sql`)

Strictly additive. Adds nullable `originating_signal_id TEXT` FK to `meetings`, `quotes`, `engagements`, each pointing at `context.id` (signals are stored as `context` rows of `type='signal'` per the entity/context architecture in 0008 — the `lead_signals` table from 0007 has been superseded). Partial indexes only on non-NULL rows. No backfill — pre-existing rows stay NULL because their attribution is unrecoverable. No drops.

### DAL (`src/lib/db/signal-attribution.ts`)

Three helpers + a roll-up:

- `listSignalsForEntity(db, orgId, entityId)` — populates the dropdown.
- `getDefaultOriginatingSignalId(db, orgId, entityId)` — returns the most-recent signal id, or NULL.
- `getSignalById(db, orgId, signalId)` — resolves an id back to a signal, scoped to the org. Used by the API endpoints to validate admin form submissions before persisting.
- `getEngagementsBySourcePipeline(db, orgId)` — read-only roll-up that groups attributed engagements by `context.source` (pipeline), summing estimated and actual hours. Returns the AC sample query for "engagements grouped by source pipeline."

All queries are org-scoped per the P0 #399 cross-tenant isolation rule.

### Three-state contract on creation

Across `createMeeting`, `createQuote`, `createEngagement`:

- `undefined` (omitted): defaults to most-recent signal on the entity, or NULL if none.
- `string`: explicit override, stored as-is.
- `null`: explicit unattributed (e.g. inbound referral); skips defaulting.

`updateEngagement`, `updateQuote`, and `updateMeeting` accept the same column for post-creation edits — `null` clears, string sets, omit leaves unchanged.

### Admin UI

- **Engagement detail** (`/admin/engagements/[id]`): "Originating Signal" dropdown in the Edit Details form, default-selected to the current attribution. "— Unattributed —" option clears it.
- **Quote builder** (`/admin/entities/[id]/quotes/[quoteId]`): same dropdown in the content panel. Mirrors via JS into the existing hidden-field save form (same pattern as engagement_overview / milestone_label). Read-only render after the quote leaves draft.

API endpoints (`/api/admin/engagements`, `/api/admin/engagements/[id]`, `/api/admin/quotes/[id]`) accept the form field, validate the signal belongs to the entity/org via `getSignalById`, and translate the `__none__` sentinel back to NULL. Tampered/foreign signal ids fall through to "no change" silently — UI shouldn't render a foreign signal in the dropdown but we don't trust the wire.

### Sample query (powers the forthcoming dashboard)

```ts
const rows = await getEngagementsBySourcePipeline(db, orgId)
// [
//   { source_pipeline: 'review_mining', engagement_count: 2, total_estimated_hours: 30, total_actual_hours: 12 },
//   { source_pipeline: 'job_monitor',   engagement_count: 1, total_estimated_hours: 5,  total_actual_hours: 0 },
// ]
```

Engagements with NULL `originating_signal_id` are excluded by definition. The dashboard surface (follow-up) is responsible for rendering the unattributed bucket separately if useful.

## Tests

`tests/signal-attribution.test.ts` — 13 D1-backed tests via `@venturecrane/crane-test-harness`:

- DAL helpers: ordering, isolation, type filtering, org scoping
- All three creation paths default-resolve correctly
- `null` is honored (unattributed)
- Explicit string id wins over default
- `updateEngagement` clears attribution
- Roll-up groups by pipeline, excludes NULL, is org-scoped

`npm run verify` passes locally.

## Migration plan

1. Land this PR.
2. CI deploys the Worker.
3. Run `wrangler d1 migrations apply ss-console-db --remote` to apply 0028 in prod.
4. Pre-existing rows stay NULL; new artifacts default to most-recent signal.
5. (Out of scope, follow-up issue) Wire the dashboard surface to `getEngagementsBySourcePipeline`.

## Acceptance criteria

- [x] `originating_signal_id` FK added to meetings, quotes, engagements
- [x] UI in admin to set/edit the originating signal on creation (engagement Edit Details + quote builder)
- [x] Attribution defaults to most-recent qualified signal for the entity

## Test plan

- [ ] Apply migration on prod D1
- [ ] Create a new engagement via admin — verify "Originating Signal" dropdown defaults to most-recent signal
- [ ] Edit engagement, switch to a different signal, save, reload — verify persisted
- [ ] Edit engagement, set to "— Unattributed —", save — verify NULL persisted
- [ ] Same flows on the quote builder
- [ ] Run `getEngagementsBySourcePipeline` against a small live dataset and confirm counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)