### PR TITLE
feat(admin/prospect): send booking link action + server-side email send (#467)

### DIFF
--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -565,3 +565,83 @@ export function bookingCancelledEmailHtml(input: BookingCancelledEmailInput): st
 </body>
 </html>`
 }
+
+// ===========================================================================
+// Admin-issued booking link invitation (#467)
+// ===========================================================================
+
+export interface BookingLinkInviteEmailInput {
+  /**
+   * Display name of the recipient (primary contact). May be null when no
+   * authored name is on file — the template renders a neutral "Hi," in that
+   * case rather than fabricating a placeholder ("Hi Owner," / "Hi there,").
+   */
+  contactName: string | null
+  /**
+   * Recipient business name from the entity record. Used for subject + body
+   * context. Always present (entity.name is required).
+   */
+  businessName: string
+  /**
+   * The signed `/book?t=<token>` URL. Already absolute when APP_BASE_URL is
+   * configured; relative when the build is misconfigured. Tracking pixels
+   * and link rewriting are added by Resend server-side; we do not inject
+   * our own.
+   */
+  bookingUrl: string
+}
+
+/**
+ * HTML email sent by the admin "Send booking link" action.
+ *
+ * Voice: "we" — the SMD Services team is the speaker, never an individual
+ * consultant. CLAUDE.md / Decision #20.
+ *
+ * Forbidden: response-time promises (specific business-day reply windows),
+ * named consultants attributed as the speaker, uncontracted next-step
+ * commitments (proposals, deliverables, post-call behavior). The body is
+ * deliberately narrow — pick a time, link.
+ */
+export function bookingLinkInviteEmailHtml(input: BookingLinkInviteEmailInput): string {
+  const businessName = escapeBookingHtml(input.businessName)
+  const bookingUrl = escapeBookingHtml(input.bookingUrl)
+  const greeting = input.contactName ? `Hi ${escapeBookingHtml(input.contactName)},` : 'Hi,'
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;">
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">${greeting}</p>
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        Following up on <strong>${businessName}</strong>. When it works for you, pick a time
+        for a quick call so we can learn how things run and where you're trying to go.
+      </p>
+
+      <p style="margin:24px 0;">
+        <a href="${bookingUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 28px;border-radius:6px;">
+          Pick a time
+        </a>
+      </p>
+
+      <p style="font-size:13px;color:#64748b;margin:0 0 16px;word-break:break-all;">
+        Or paste this link into your browser:<br>
+        <a href="${bookingUrl}" style="color:#1e40af;">${bookingUrl}</a>
+      </p>
+
+      <p style="font-size:13px;color:#64748b;margin:24px 0 0;">
+        — ${BRAND_NAME}
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -777,6 +777,35 @@ function confidenceColor(_confidence: string): string {
             </select>
           </div>
 
+          {/* Send-mode toggle. Default is "send via email" so the button
+              actually does what its label says (#467). The "copy only"
+              path is preserved for cases where the admin wants to edit
+              the body in their own mail client. */}
+          <fieldset class="mb-4">
+            <legend class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1">
+              Delivery
+            </legend>
+            <label class="flex items-start gap-2 text-xs text-[color:var(--ss-color-text-primary)] mb-1.5">
+              <input type="radio" name="send_mode" value="email" checked class="mt-0.5" />
+              <span>
+                Send the email now
+                <span class="block text-[color:var(--ss-color-text-muted)]">
+                  Recorded in the outreach timeline so opens and clicks attribute back to this
+                  prospect.
+                </span>
+              </span>
+            </label>
+            <label class="flex items-start gap-2 text-xs text-[color:var(--ss-color-text-primary)]">
+              <input type="radio" name="send_mode" value="copy" class="mt-0.5" />
+              <span>
+                Copy the body and open mailto
+                <span class="block text-[color:var(--ss-color-text-muted)]">
+                  No tracking. Use when you want to edit the message in your own mail client.
+                </span>
+              </span>
+            </label>
+          </fieldset>
+
           <div
             id="sbl-error"
             class="hidden mb-3 rounded-[var(--ss-radius-card)] bg-surface border border-error text-error text-xs px-3 py-2"
@@ -1343,9 +1372,11 @@ function confidenceColor(_confidence: string): string {
         const formData = new FormData(sblForm)
         const meetingType = (formData.get('meeting_type') ?? '').toString().trim()
         const durationMinutes = (formData.get('duration_minutes') ?? '30').toString()
+        const sendMode = (formData.get('send_mode') ?? 'email').toString()
+        const wantsServerSend = sendMode === 'email'
 
         sblSubmit.disabled = true
-        sblSubmit.textContent = 'Sending...'
+        sblSubmit.textContent = wantsServerSend ? 'Sending...' : 'Preparing...'
         if (sblError) {
           sblError.classList.add('hidden')
           sblError.textContent = ''
@@ -1359,6 +1390,7 @@ function confidenceColor(_confidence: string): string {
             body: JSON.stringify({
               meeting_type: meetingType || null,
               duration_minutes: durationMinutes,
+              send_email: wantsServerSend,
             }),
           })
           const body = (await res.json().catch(() => ({}))) as {
@@ -1366,6 +1398,8 @@ function confidenceColor(_confidence: string): string {
             booking_url?: string
             outreach_template?: string
             mailto_url?: string
+            email_status?: string
+            send_error?: string | null
             error?: string
             message?: string
           }
@@ -1373,7 +1407,35 @@ function confidenceColor(_confidence: string): string {
             throw new Error(body.message ?? body.error ?? `HTTP ${res.status}`)
           }
 
-          // Copy outreach template to clipboard (best-effort)
+          // When the server-side send failed, surface the error and offer
+          // the copy-paste/mailto fallback rather than silently transitioning
+          // — the admin needs to know the prospect did NOT receive the link.
+          if (body.email_status === 'send_failed') {
+            if (sblError) {
+              sblError.textContent =
+                'Email send failed. The booking link is on your clipboard — paste it into mailto or your own mail client.'
+              sblError.classList.remove('hidden')
+            }
+            if (body.outreach_template) {
+              try {
+                await navigator.clipboard.writeText(body.outreach_template)
+              } catch (copyErr) {
+                console.warn('[send-booking-link] clipboard write failed:', copyErr)
+              }
+            }
+            if (body.mailto_url) {
+              window.open(body.mailto_url, '_blank')
+            }
+            // The stage transition still happened on the server, so reload
+            // — but mark the URL so the entity detail can surface a banner
+            // that the send did not complete.
+            window.location.href = `${window.location.pathname}?stage_updated=1&send=failed`
+            return
+          }
+
+          // Copy-paste / mailto path (or no-recipient fallback) — clipboard
+          // + mailto are the deliverable. We still copy on the email path
+          // so the admin has a backup if their mail provider drops it.
           if (body.outreach_template) {
             try {
               await navigator.clipboard.writeText(body.outreach_template)
@@ -1382,10 +1444,13 @@ function confidenceColor(_confidence: string): string {
             }
           }
 
-          // Open mailto in a new window so it doesn't navigate away from the
-          // admin page. If mailto isn't handled by the browser, this is a
-          // no-op — the clipboard already holds the template text.
-          if (body.mailto_url) {
+          // Only open mailto when the server did NOT send. If the email
+          // already went out via Resend, popping a mailto would lead the
+          // admin to send it twice.
+          const skippedServerSend =
+            body.email_status === 'skipped_by_caller' ||
+            body.email_status === 'skipped_no_recipient'
+          if (skippedServerSend && body.mailto_url) {
             window.open(body.mailto_url, '_blank')
           }
 
@@ -1393,7 +1458,8 @@ function confidenceColor(_confidence: string): string {
 
           // Reload so the context timeline shows the new outreach_draft entry
           // and the stage badge reflects the transition.
-          window.location.href = `${window.location.pathname}?stage_updated=1`
+          const sentParam = body.email_status === 'sent' ? '&send=sent' : ''
+          window.location.href = `${window.location.pathname}?stage_updated=1${sentParam}`
         } catch (err) {
           console.error('[send-booking-link] error:', err)
           if (sblError) {

--- a/src/pages/api/admin/entities/[id]/send-booking-link.ts
+++ b/src/pages/api/admin/entities/[id]/send-booking-link.ts
@@ -9,6 +9,8 @@ import {
 } from '../../../../../lib/booking/signed-link'
 import { BOOKING_CONFIG } from '../../../../../lib/booking/config'
 import { requireAppBaseUrl } from '../../../../../lib/config/app-url'
+import { sendOutreachEmail } from '../../../../../lib/email/resend'
+import { bookingLinkInviteEmailHtml } from '../../../../../lib/email/templates'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -25,13 +27,20 @@ import { env } from 'cloudflare:workers'
  *   3. Sign a booking-link token that carries the entity_id, contact_id,
  *      assessment_id, meeting_type, and admin-chosen duration. TTL defaults
  *      to 14 days.
- *   4. Append a context entry noting the link was sent, with a copyable
- *      outreach template and mailto URL.
- *   5. Return JSON with the signed URL and outreach template so the admin
- *      UI can copy-to-clipboard and open the mail client.
+ *   4. Send the booking-link email server-side via `sendOutreachEmail` so
+ *      the send is recorded in `outreach_events` (entity-attributed) and
+ *      Resend's tracking pixel + link rewrites attribute downstream
+ *      open/click/bounce/reply events back to this entity (#587 path).
+ *      Skipped when the entity has no contact email — the admin still gets
+ *      a copy-paste template + mailto fallback.
+ *   5. Append a context entry noting the link was sent, with the same
+ *      outreach template the admin gets back in the response.
+ *   6. Return JSON with the signed URL, send status, and outreach template
+ *      so the admin UI can copy-to-clipboard or open mailto when the
+ *      server-side send was skipped.
  *
- * Response is JSON (not a redirect) because the admin UI drives the copy
- * and mailto steps client-side.
+ * Response is JSON (not a redirect) because the admin UI reflects send
+ * status inline rather than navigating away.
  */
 export const POST: APIRoute = async ({ params, request, locals }) => {
   const session = locals.session
@@ -62,6 +71,11 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   const meetingTypeRaw = typeof bodyData.meeting_type === 'string' ? bodyData.meeting_type : null
   const meetingType =
     meetingTypeRaw && meetingTypeRaw.trim().length > 0 ? meetingTypeRaw.trim().slice(0, 100) : null
+  // `send_email` defaults true: the goal of #467 is for clicking the button
+  // to actually send the link. The flag exists so the admin can opt into the
+  // legacy copy-paste / mailto path (e.g. they want to edit the body in
+  // their own mail client) without us inventing a separate endpoint.
+  const sendEmailFlag = parseBoolean(bodyData.send_email, true)
 
   try {
     // --- Load entity --------------------------------------------------------
@@ -146,13 +160,67 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     }
     const bookingUrl = `${appBaseUrl}/book?t=${encodeURIComponent(token)}`
 
-    // --- 4. Append context entry with the outreach template ----------------
+    // --- 4. Build outreach template + email body ---------------------------
     const outreachTemplate = buildOutreachTemplate({
       contactName,
       businessName: entity.name,
       bookingUrl,
     })
+    const subject = buildSubject(entity.name)
 
+    // --- 5. Send the email server-side (if requested + recipient exists) ---
+    //
+    // The send goes through `sendOutreachEmail` so the synthetic 'sent' row
+    // in `outreach_events` is attributed to this entity. Downstream Resend
+    // webhooks (open/click/bounce/reply) re-resolve the entity_id from that
+    // row by message_id. Failures in the DB write do not fail the send —
+    // the email is unrecoverable once Resend accepts it. See #587.
+    let emailStatus: 'sent' | 'skipped_no_recipient' | 'skipped_by_caller' | 'send_failed'
+    let messageId: string | null = null
+    let outreachEventId: string | null = null
+    let sendError: string | null = null
+
+    if (!sendEmailFlag) {
+      emailStatus = 'skipped_by_caller'
+    } else if (!contactEmail) {
+      emailStatus = 'skipped_no_recipient'
+    } else {
+      const html = bookingLinkInviteEmailHtml({
+        contactName,
+        businessName: entity.name,
+        bookingUrl,
+      })
+      try {
+        const sendResult = await sendOutreachEmail(
+          env.RESEND_API_KEY,
+          { to: contactEmail, subject, html },
+          { db: env.DB, orgId: session.orgId, entityId }
+        )
+        if (sendResult.success) {
+          emailStatus = 'sent'
+          messageId = sendResult.id ?? null
+          outreachEventId = sendResult.outreach_event_id ?? null
+        } else {
+          emailStatus = 'send_failed'
+          sendError = sendResult.error ?? 'unknown_send_error'
+          console.error(
+            '[api/admin/entities/send-booking-link] email send failed:',
+            sendResult.error
+          )
+        }
+      } catch (err) {
+        emailStatus = 'send_failed'
+        sendError = err instanceof Error ? err.message : 'send_threw'
+        console.error('[api/admin/entities/send-booking-link] email send threw:', err)
+      }
+    }
+
+    // --- 6. Append context entry with the outreach template ----------------
+    //
+    // The metadata captures send status so the entity timeline can render
+    // "Sent to maria@example.com" vs. "Drafted; admin to send manually" vs.
+    // "Send failed" — an admin scanning the timeline never has to guess
+    // whether the prospect actually received the link.
     await appendContext(env.DB, session.orgId, {
       entity_id: entityId,
       type: 'outreach_draft',
@@ -165,13 +233,18 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
         duration_minutes: duration,
         meeting_type: meetingType,
         token_ttl_days: DEFAULT_BOOKING_LINK_TTL_DAYS,
+        email_status: emailStatus,
+        recipient_email: contactEmail,
+        message_id: messageId,
+        outreach_event_id: outreachEventId,
+        send_error: sendError,
       },
     })
 
-    // --- 5. Return JSON for the client -------------------------------------
+    // --- 7. Return JSON for the client -------------------------------------
     const mailtoUrl = buildMailtoUrl({
       to: contactEmail,
-      subject: `Let's set up a call — ${entity.name}`,
+      subject,
       body: outreachTemplate,
     })
 
@@ -184,6 +257,10 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
       contact_email: contactEmail,
       outreach_template: outreachTemplate,
       mailto_url: mailtoUrl,
+      email_status: emailStatus,
+      message_id: messageId,
+      outreach_event_id: outreachEventId,
+      send_error: sendError,
     })
   } catch (err) {
     console.error('[api/admin/entities/send-booking-link] Error:', err)
@@ -212,10 +289,34 @@ function parseDuration(raw: unknown): number {
   return ALLOWED_DURATIONS.includes(num) ? num : def
 }
 
+function parseBoolean(raw: unknown, defaultValue: boolean): boolean {
+  if (raw === undefined || raw === null) return defaultValue
+  if (typeof raw === 'boolean') return raw
+  if (typeof raw === 'number') return raw !== 0
+  if (typeof raw === 'string') {
+    const v = raw.trim().toLowerCase()
+    if (v === 'true' || v === '1' || v === 'yes' || v === 'on') return true
+    if (v === 'false' || v === '0' || v === 'no' || v === 'off' || v === '') return false
+  }
+  return defaultValue
+}
+
+function buildSubject(businessName: string): string {
+  return `Quick call about ${businessName}`
+}
+
 /**
- * Outreach template text. Kept deliberately free of specific timeframes,
- * scope language, or business promises (CLAUDE.md "no fabricated client
- * content" rule). The admin is expected to edit before sending.
+ * Plain-text outreach body. Used both as the synced clipboard payload (when
+ * the admin chooses copy-paste rather than server-side send) and as the
+ * stored context entry.
+ *
+ * Voice: "we" only. No consultant names. No response-time promises. No
+ * uncontracted next-step language. CLAUDE.md "no fabricated client content"
+ * rule, Pattern A.
+ *
+ * The signature is the brand name, never an individual — even if a future
+ * field stores a consultant name, surfacing it here would imply ownership
+ * of a single-person reply that we have not contracted to provide.
  */
 function buildOutreachTemplate(params: {
   contactName: string | null
@@ -226,13 +327,11 @@ function buildOutreachTemplate(params: {
   const lines = [
     greeting,
     '',
-    `Following up on ${params.businessName}. When you have time, pick a slot that works for a quick intro call:`,
+    `Following up on ${params.businessName}. When it works for you, pick a time for a quick call so we can learn how things run and where you're trying to go.`,
     '',
     params.bookingUrl,
     '',
-    'Looking forward to talking.',
-    '',
-    'Scott',
+    '— SMD Services',
   ]
   return lines.join('\n')
 }

--- a/tests/admin/send-booking-link.test.ts
+++ b/tests/admin/send-booking-link.test.ts
@@ -111,10 +111,14 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
   })
 
   it('creates a scheduled assessment, transitions stage, and returns a signed URL', async () => {
+    // No RESEND_API_KEY in this test → sendOutreachEmail takes the dev-mode
+    // path that still records a synthetic 'sent' row. Email-status assertions
+    // still verify the attribution wiring. send_email: false is used here so
+    // this baseline test stays focused on the create/sign/transition path.
     const ctx = buildContext({
       session: adminSession,
       entityId: ENTITY_ID,
-      body: { duration_minutes: 30, meeting_type: 'discovery' },
+      body: { duration_minutes: 30, meeting_type: 'discovery', send_email: false },
     })
 
     const response = await POST(ctx as unknown as Parameters<typeof POST>[0])
@@ -129,6 +133,7 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
       contact_email: string
       outreach_template: string
       mailto_url: string
+      email_status: string
     }
     expect(body.ok).toBe(true)
     expect(body.assessment_id).toMatch(/^[0-9a-f-]+$/)
@@ -138,7 +143,15 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
     expect(body.booking_url).toMatch(/^https:\/\/smd\.services\/book\?t=/)
     expect(body.outreach_template).toContain(body.booking_url)
     expect(body.outreach_template).toContain('Maria')
+    // No fabricated client content: the body must not promise specific
+    // response times, name a consultant, or commit post-call behavior.
+    // The signature is the brand name only.
+    expect(body.outreach_template).not.toMatch(/\bScott\b/)
+    expect(body.outreach_template).not.toMatch(/\b1 business day\b/i)
+    expect(body.outreach_template).not.toMatch(/\bwithin .* hours?\b/i)
+    expect(body.outreach_template).toContain('— SMD Services')
     expect(body.mailto_url).toMatch(/^mailto:/)
+    expect(body.email_status).toBe('skipped_by_caller')
 
     // --- AC: legacy assessment row exists in scheduled status, no slot yet --
     const assessment = await db
@@ -250,7 +263,13 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
   })
 
   it('defaults meeting_type/duration sensibly when omitted', async () => {
-    const ctx = buildContext({ session: adminSession, entityId: ENTITY_ID, body: {} })
+    // Use send_email: false so this stays a focused unit on parsing
+    // defaults, not exercising the send pipeline.
+    const ctx = buildContext({
+      session: adminSession,
+      entityId: ENTITY_ID,
+      body: { send_email: false },
+    })
     const response = await POST(ctx as unknown as Parameters<typeof POST>[0])
     expect(response.status).toBe(200)
     const body = (await response.json()) as { booking_url: string }
@@ -259,5 +278,115 @@ describe('POST /api/admin/entities/[id]/send-booking-link (#467)', () => {
     if (!verify.ok) throw new Error('expected ok')
     expect(verify.payload.duration_minutes).toBe(30) // BOOKING_CONFIG.slot_minutes default
     expect(verify.payload.meeting_type).toBeNull()
+  })
+
+  it('sends via sendOutreachEmail and records a sent row in outreach_events', async () => {
+    // Default: send_email = true. No RESEND_API_KEY → resend.ts dev-mode
+    // path returns success: true with id 'dev-mode'. The wrapper still
+    // calls recordEvent, which writes a row to outreach_events attributed
+    // to this entity. That is the funnel-attribution invariant we ship for
+    // #587 / #467.
+    const ctx = buildContext({
+      session: adminSession,
+      entityId: ENTITY_ID,
+      body: { duration_minutes: 30, meeting_type: 'discovery' },
+    })
+
+    const response = await POST(ctx as unknown as Parameters<typeof POST>[0])
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as {
+      ok: boolean
+      booking_url: string
+      contact_email: string
+      email_status: string
+      message_id: string | null
+      outreach_event_id: string | null
+    }
+    expect(body.ok).toBe(true)
+    expect(body.email_status).toBe('sent')
+    expect(body.message_id).toBe('dev-mode')
+    expect(body.outreach_event_id).toMatch(/^[0-9a-f-]+$/)
+
+    // outreach_events row exists, attributed to the right entity, with the
+    // synthetic message_id from the dev-mode send.
+    const sentRow = await db
+      .prepare(
+        `SELECT id, org_id, entity_id, event_type, channel, message_id, provider_event_id
+         FROM outreach_events WHERE id = ?`
+      )
+      .bind(body.outreach_event_id)
+      .first<{
+        id: string
+        org_id: string
+        entity_id: string
+        event_type: string
+        channel: string
+        message_id: string
+        provider_event_id: string | null
+      }>()
+    expect(sentRow).not.toBeNull()
+    expect(sentRow!.org_id).toBe(ORG_ID)
+    expect(sentRow!.entity_id).toBe(ENTITY_ID)
+    expect(sentRow!.event_type).toBe('sent')
+    expect(sentRow!.channel).toBe('email')
+    expect(sentRow!.message_id).toBe('dev-mode')
+    expect(sentRow!.provider_event_id).toBeNull()
+  })
+
+  it('skips the send when the entity has no contact email', async () => {
+    await db.prepare(`DELETE FROM contacts WHERE entity_id = ?`).bind(ENTITY_ID).run()
+
+    const ctx = buildContext({
+      session: adminSession,
+      entityId: ENTITY_ID,
+      body: { duration_minutes: 30 },
+    })
+    const response = await POST(ctx as unknown as Parameters<typeof POST>[0])
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as {
+      email_status: string
+      contact_email: string | null
+      booking_url: string
+      mailto_url: string
+    }
+    expect(body.email_status).toBe('skipped_no_recipient')
+    expect(body.contact_email).toBeNull()
+    // Booking link and mailto are still returned so the admin can paste
+    // the URL into a manual outreach.
+    expect(body.booking_url).toMatch(/^https:\/\/smd\.services\/book\?t=/)
+    expect(body.mailto_url).toMatch(/^mailto:/)
+
+    // No outreach_events row was written — there was nothing to send.
+    const count = await db
+      .prepare(`SELECT COUNT(*) as c FROM outreach_events WHERE entity_id = ?`)
+      .bind(ENTITY_ID)
+      .first<{ c: number }>()
+    expect(count!.c).toBe(0)
+  })
+
+  it('records the email status in the outreach_draft context metadata', async () => {
+    const ctx = buildContext({
+      session: adminSession,
+      entityId: ENTITY_ID,
+      body: { duration_minutes: 30 },
+    })
+    const response = await POST(ctx as unknown as Parameters<typeof POST>[0])
+    expect(response.status).toBe(200)
+
+    const contextRow = await db
+      .prepare(
+        `SELECT metadata FROM context
+         WHERE entity_id = ? AND type = 'outreach_draft' AND source = 'send_booking_link'`
+      )
+      .bind(ENTITY_ID)
+      .first<{ metadata: string }>()
+    expect(contextRow).not.toBeNull()
+    const metadata = JSON.parse(contextRow!.metadata) as Record<string, unknown>
+    expect(metadata.email_status).toBe('sent')
+    expect(metadata.recipient_email).toBe('maria@phoenixplumbing.example')
+    expect(metadata.message_id).toBe('dev-mode')
+    expect(metadata.outreach_event_id).toMatch(/^[0-9a-f-]+$/)
   })
 })


### PR DESCRIPTION
Resolves #467. Required by #598 (Engine 1).

## Summary

- Admin "Send booking link" now sends the email server-side by default via `sendOutreachEmail` (see #587), so the send is recorded in `outreach_events` and downstream Resend events (open/click/bounce/reply) re-attribute back to the originating entity. The legacy clipboard + mailto path is preserved as a "Copy" radio in the modal for admins who want to edit the body in their own mail client.
- Removed Pattern A fabrication in the outreach template (hardcoded "Scott" signature) and rewrote to the doctrinal "we" voice. Added a parallel HTML email template (`bookingLinkInviteEmailHtml`) with the same constraints — no response-time promise, no named consultant, no post-call commitment.
- Marketing "Book Assessment" lie referenced in the issue was already neutralized — Hero/FinalCta/Pricing/Nav link "Book a Call" → `/book`, which renders the working booking flow with token-attribution prefill. No marketing component change needed.

## Acceptance criteria (issue #467)

- [x] Button label matches behavior — "Send booking link" creates a meeting row, signs a URL, and sends/queues the email. No more bare stage transition.
- [x] Signed booking URL expires on a reasonable TTL (14 days, `DEFAULT_BOOKING_LINK_TTL_DAYS`).
- [x] Meeting row created at click time in `scheduled` status (with `scheduled_at: null`), via `createMeetingWithLegacyAssessment`.
- [x] Stage transition only after the meeting row exists (the order is enforced in the endpoint and asserted in tests).

## Why server-side send

The original endpoint relied on the admin's mail client. That meant Resend tracking pixels and link rewrites never fired, so opens and clicks for booking-link sends were invisible — and Engine 1 (#598) needs the booking-link path on the same funnel as cold outreach (#588). Threading through `sendOutreachEmail` records a synthetic `sent` row in `outreach_events` attributed to the entity, and Resend webhooks re-resolve `entity_id` from `message_id` on every downstream event.

## Files

- `src/pages/api/admin/entities/[id]/send-booking-link.ts` — added `send_email` flag (default `true`), Resend send via `sendOutreachEmail`, status fields in the response, attribution metadata in the context entry.
- `src/lib/email/templates.ts` — added `bookingLinkInviteEmailHtml`. "we" voice, no fabricated commitments.
- `src/pages/admin/entities/[id].astro` — added "Send the email now / Copy + mailto" radio in the modal; updated submit JS to honor the flag and surface send-fail / no-recipient cases.
- `tests/admin/send-booking-link.test.ts` — assertions for no fabricated content; new tests for the send path, no-recipient skip, and context metadata.

## Test plan

- [x] `npm run verify` — passes (typecheck, lint, format, build, all unit + integration tests).
- [ ] Manual: admin clicks "Send booking link" on a prospect with an email → confirms the modal → sees stage flip to `meetings`, the outreach_events sent row in the timeline, and the prospect receives the email.
- [ ] Manual: prospect clicks the link → lands on `/book?t=...` → name/email prefilled → picks a slot → reserves → assessment_schedule + meeting_schedule rows attribute to the original entity.
- [ ] Manual: admin clicks "Send booking link" with "Copy + mailto" radio → no Resend call, mailto opens.
- [ ] Manual: admin clicks "Send booking link" on a prospect with no contact email → `email_status: skipped_no_recipient`, mailto opens with a blank to:.

## Links

- Issue #467 (this fix)
- Issue #587 / PR #600 — `sendOutreachEmail` and `outreach_events` (the path this change consumes)
- Issue #598 — Engine 1, the downstream consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)