### PR TITLE
feat(outreach): vertical-aware outreach generation across all 5 verticals

### DIFF
--- a/src/lib/claude/outreach.ts
+++ b/src/lib/claude/outreach.ts
@@ -11,6 +11,24 @@
  * - No pricing, no fixed timeframes
  * - No "systems" language — use "solution"
  * - Reference specific evidence from the signals
+ *
+ * Vertical-aware guidance (issue #594):
+ * - One shared backbone (the SYSTEM prompt below).
+ * - When a recognized vertical is supplied, a small per-vertical guidance
+ *   block is appended that names the *general* operational pain areas
+ *   that vertical commonly faces — drawn from CLAUDE.md "Pain Clusters by
+ *   Vertical" and phrased in 5-cat observation vocabulary
+ *   (process_design, customer_pipeline, data_visibility, team_operations,
+ *   tool_systems). Per ADR 0001, outreach speaks observation, not delivery.
+ * - The block is *backbone language only*. It never invents specifics
+ *   (no fake numbers, names, dates, events, or claimed conversations).
+ *   Per-prospect specificity comes exclusively from the assembled
+ *   `enrichment context`, which the model still grounds the email in.
+ * - When the vertical is missing, unknown, or 'other', the block is
+ *   omitted entirely and the generic backbone runs unchanged.
+ *
+ * @see docs/adr/0001-taxonomy-two-layer-model.md
+ * @see CLAUDE.md — "Pain Clusters by Vertical", "No fabricated client-facing content"
  */
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
@@ -31,7 +49,7 @@ The way you stand out: GIVE THEM SOMETHING. An observation about their business 
 1. Use the owner's first name if you know it. If not, use the business name naturally.
 2. Lead with a SPECIFIC, GENUINE insight about their business. Not a compliment, not flattery. A real observation that proves you looked closely. Something like: a gap between their 4.9 rating and the scheduling complaints in their 3-star reviews. Or how their team page lists 3 people but they're hiring for a role that covers 4 different functions. Or that they're ranked #1 locally but their website still doesn't have online booking. Connect real dots.
 3. One sentence connecting that insight to a bigger picture. Not "we can help with that." Instead, name the dynamic at play. The business is growing faster than the operation behind it, or the owner is holding things together that should be running on their own by now. Frame it as a normal phase of growth, not a failure.
-4. End with something low-friction and genuinely useful. NOT "would you be open to a brief conversation" (that's what every sales email says). Instead, offer to send them something specific. A one-page breakdown of what other [their vertical] companies their size have done. A list of tools that might help. Something concrete that costs them nothing and demonstrates value before asking for anything.
+4. End with something low-friction and genuinely useful. NOT "would you be open to a brief conversation" (that's what every sales email says). Instead, offer to send them something specific. A one-page breakdown of what other companies their size have done. A list of tools that might help. Something concrete that costs them nothing and demonstrates value before asking for anything.
 
 ## Hard rules
 - Always "we" / "our team." Never "I" or "the consultant."
@@ -46,7 +64,99 @@ The way you stand out: GIVE THEM SOMETHING. An observation about their business 
 - Maximum 120 words (not counting subject line).
 - Sign off as "-- The SMD Services team"
 
+## Anti-fabrication rule (CRITICAL)
+Every specific detail in the email must trace to the intelligence gathered below. If you do not have evidence for a number, an event, a person's name, a quote, or a date, do not invent one. Phrases like "you mentioned at the trade show", "your three-truck operation", "the conversation we had last month", "your 12-person team" are all forbidden unless those exact facts appear in the intelligence. When you have no specifics, write the generic backbone in our voice instead. Better to be honest and broad than to invent and get caught.
+
 Output ONLY the subject line and email. No commentary, no markdown fences.`
+
+// ---------------------------------------------------------------------------
+// Vertical guidance — backbone language only (no fabricated specifics).
+//
+// Each entry names the general operational pain areas that vertical commonly
+// faces, drawn from CLAUDE.md "Pain Clusters by Vertical". Phrased in 5-cat
+// observation vocabulary per ADR 0001 — never the 6-cat marketing labels.
+//
+// These are HINTS to the model about the language register and which pain
+// areas tend to resonate, not LICENSE to invent prospect-specific details.
+// The model still grounds every concrete claim in the assembled context.
+// ---------------------------------------------------------------------------
+
+export type OutreachVertical =
+  | 'home_services'
+  | 'professional_services'
+  | 'contractor_trades'
+  | 'retail_salon'
+  | 'restaurant_food'
+
+const VERTICAL_GUIDANCE: Record<OutreachVertical, string> = {
+  home_services: `## Vertical context: home services (plumber, HVAC, electrician, etc.)
+Owners in this vertical commonly feel pain in three observation areas:
+- customer_pipeline — leads come in by phone and text, follow-up depends on whoever picks up, jobs slip when the schedule fills
+- process_design — dispatch, intake, and quoting often live in the owner's head; growth past a few crews exposes the gap
+- team_operations — finding and keeping techs is a structural concern, not a recruiting blip
+
+If the intelligence below evidences any of these, lean in. If it doesn't, do not invent specifics. Keep the language grounded in what you can actually point to.`,
+
+  professional_services: `## Vertical context: professional services (accountant, attorney, CPA, consultant, etc.)
+Owners in this vertical commonly feel pain in three observation areas:
+- process_design — the owner is the bottleneck on client-facing work that should be delegable
+- customer_pipeline — manual communication (email threads, phone tag) eats hours that should compound into billable work
+- data_visibility — utilization, realization, pipeline value live in spreadsheets the owner reconciles by hand
+
+If the intelligence below evidences any of these, lean in. If it doesn't, do not invent specifics. Keep the language grounded in what you can actually point to.`,
+
+  retail_salon: `## Vertical context: retail / salon / spa
+Owners in this vertical commonly feel pain in three observation areas:
+- customer_pipeline — booking, no-shows, and rebooking depend on staff remembering to ask, not on a designed flow
+- process_design — front-desk workflows for new clients vs. regulars are inconsistent shift-to-shift
+- data_visibility — revenue per chair, retail attach rate, and product margin are guessed, not measured
+
+If the intelligence below evidences any of these, lean in. If it doesn't, do not invent specifics. Keep the language grounded in what you can actually point to.`,
+
+  contractor_trades: `## Vertical context: contractor / trades (general contractor, remodeler, etc.)
+Owners in this vertical commonly feel pain in three observation areas:
+- process_design — estimating and quoting are the owner's job long after the business should have a repeatable flow
+- customer_pipeline — scheduling subs, crews, and clients across active jobs creates conflicts that get resolved by phone
+- team_operations — keeping experienced field staff through busy and slow seasons is a structural problem, not a hiring blip
+
+If the intelligence below evidences any of these, lean in. If it doesn't, do not invent specifics. Keep the language grounded in what you can actually point to.`,
+
+  restaurant_food: `## Vertical context: restaurant / food service
+Owners in this vertical commonly feel pain in three observation areas:
+- team_operations — communication across shifts (FOH/BOH, AM/PM, owner/manager) breaks down at the seams
+- tool_systems — POS, inventory, and scheduling tools rarely talk to each other, so the same numbers get re-entered
+- data_visibility — food cost, labor percent, and prime cost are reconciled after the month closes, not steered in real time
+
+If the intelligence below evidences any of these, lean in. If it doesn't, do not invent specifics. Keep the language grounded in what you can actually point to.`,
+}
+
+/**
+ * Normalize a free-form vertical string into a recognized OutreachVertical,
+ * or null if it doesn't match. Recognized values come from the canonical
+ * VERTICALS list in src/portal/assessments/extraction-schema.ts.
+ *
+ * Verticals 'healthcare', 'technology', 'manufacturing', 'other', null,
+ * undefined, and any unrecognized string all return null — meaning the
+ * outreach falls back to the generic backbone with no vertical guidance
+ * (per CLAUDE.md no-fabricated-content rule).
+ */
+export function normalizeVertical(value: string | null | undefined): OutreachVertical | null {
+  if (!value) return null
+  if (value in VERTICAL_GUIDANCE) {
+    return value as OutreachVertical
+  }
+  return null
+}
+
+/**
+ * Build the full system prompt with optional vertical guidance appended.
+ * Exported for tests so we can assert the per-vertical content lock without
+ * making real API calls.
+ */
+export function buildOutreachSystemPrompt(vertical: OutreachVertical | null): string {
+  if (!vertical) return OUTREACH_SYSTEM_PROMPT
+  return `${OUTREACH_SYSTEM_PROMPT}\n\n${VERTICAL_GUIDANCE[vertical]}`
+}
 
 /**
  * Generate an outreach email draft from entity context.
@@ -54,6 +164,9 @@ Output ONLY the subject line and email. No commentary, no markdown fences.`
  * @param apiKey - Anthropic API key
  * @param entityName - Business name
  * @param assembledContext - Formatted context from assembleEntityContext()
+ * @param vertical - Optional canonical vertical ID. When recognized, a small
+ *   per-vertical guidance block is appended to the system prompt. When null,
+ *   undefined, or unrecognized, the generic backbone runs unchanged.
  * @returns The generated outreach email draft
  */
 const MAX_RETRIES = 2
@@ -62,8 +175,11 @@ const RETRY_DELAY_MS = 2_000
 export async function generateOutreachDraft(
   apiKey: string,
   entityName: string,
-  assembledContext: string
+  assembledContext: string,
+  vertical?: string | null
 ): Promise<string> {
+  const systemPrompt = buildOutreachSystemPrompt(normalizeVertical(vertical))
+
   const userPrompt = `Write a cold outreach email for this business. Read everything below carefully before writing. The insight you lead with should come from connecting multiple data points, not just restating one fact.
 
 Business: ${entityName}
@@ -75,7 +191,7 @@ ${assembledContext}`
   const body = JSON.stringify({
     model: MODEL,
     max_tokens: MAX_TOKENS,
-    system: OUTREACH_SYSTEM_PROMPT,
+    system: systemPrompt,
     messages: [{ role: 'user', content: userPrompt }],
   })
 

--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -798,7 +798,12 @@ async function regenerateOutreach(
       result.skipped.push('outreach_draft')
       return
     }
-    const draft = await generateOutreachDraft(env.ANTHROPIC_API_KEY, entity.name, context)
+    const draft = await generateOutreachDraft(
+      env.ANTHROPIC_API_KEY,
+      entity.name,
+      context,
+      entity.vertical
+    )
     await appendContext(env.DB, orgId, {
       entity_id: entity.id,
       type: 'outreach_draft',
@@ -807,6 +812,10 @@ async function regenerateOutreach(
       metadata: {
         model: 'claude-sonnet-4-20250514',
         trigger: result.mode === 'full' ? 'at_ingest' : 're_enrich',
+        // Issue #594 — record which vertical guidance the prompt used so
+        // re-runs and audits can see the variant. Null/unrecognized
+        // verticals record as null and the generic backbone was used.
+        vertical: entity.vertical ?? null,
       },
     })
     result.completed.push('outreach_draft')

--- a/tests/outreach-vertical-aware.test.ts
+++ b/tests/outreach-vertical-aware.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Boundary tests for vertical-aware outreach generation (issue #594).
+ *
+ * The outreach prompt is a single shared backbone. When a recognized vertical
+ * is supplied, a small per-vertical guidance block is appended that names the
+ * general operational pain areas that vertical commonly faces. These tests
+ * lock in the contract:
+ *
+ * 1. Per-vertical specificity — each vertical's guidance leans on its own
+ *    pain backbone (contractor estimating/scheduling, salon scheduling/
+ *    communication, etc.) but uses the SAME backbone system prompt.
+ * 2. Generic fallback — when vertical is null/undefined/unrecognized, the
+ *    generic backbone is returned with no vertical-specific block.
+ * 3. Anti-fabrication — the per-vertical guidance contains NO invented
+ *    specifics (no fake numbers, no fake names, no fake events).
+ * 4. Taxonomy boundary — vertical guidance speaks 5-cat observation IDs
+ *    (process_design, tool_systems, data_visibility, customer_pipeline,
+ *    team_operations), never the 6-cat marketing delivery taxonomy.
+ *
+ * @see docs/adr/0001-taxonomy-two-layer-model.md
+ * @see CLAUDE.md — "Pain Clusters by Vertical", "No fabricated client-facing content"
+ * @see https://github.com/venturecrane/ss-console/issues/594
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  buildOutreachSystemPrompt,
+  normalizeVertical,
+  type OutreachVertical,
+} from '../src/lib/claude/outreach.js'
+
+const RECOGNIZED_VERTICALS: OutreachVertical[] = [
+  'home_services',
+  'professional_services',
+  'contractor_trades',
+  'retail_salon',
+  'restaurant_food',
+]
+
+// ---------------------------------------------------------------------------
+// Generic backbone — what every prompt shares regardless of vertical.
+// Asserting these phrases are present in EVERY prompt variant (with or
+// without vertical guidance) is how we lock "shared backbone, injected
+// specifics" as the architecture.
+// ---------------------------------------------------------------------------
+const BACKBONE_MARKERS = [
+  // Voice / Decision Stack #20
+  '"we" / "our team."',
+  // Tone & Positioning rule 1 — objectives over problems
+  'GIVE THEM SOMETHING',
+  // Tone & Positioning rule 3 — no timeframes
+  'No dollar amounts. No pricing. No timeframes.',
+  // Anti-fabrication rule
+  'Anti-fabrication rule (CRITICAL)',
+  // Sign-off
+  '-- The SMD Services team',
+]
+
+describe('outreach: shared backbone is present in all prompt variants', () => {
+  it('generic prompt (no vertical) contains every backbone marker', () => {
+    const prompt = buildOutreachSystemPrompt(null)
+    for (const marker of BACKBONE_MARKERS) {
+      expect(prompt, `generic prompt missing backbone marker "${marker}"`).toContain(marker)
+    }
+  })
+
+  for (const vertical of RECOGNIZED_VERTICALS) {
+    it(`${vertical} prompt contains every backbone marker`, () => {
+      const prompt = buildOutreachSystemPrompt(vertical)
+      for (const marker of BACKBONE_MARKERS) {
+        expect(
+          prompt,
+          `${vertical} prompt missing backbone marker "${marker}" — backbone must be shared across all variants`
+        ).toContain(marker)
+      }
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Per-vertical specificity — each vertical injects its OWN pain backbone.
+// CLAUDE.md "Pain Clusters by Vertical" defines the entry-point pain areas
+// per vertical; these assertions lock the prompt to that table.
+// ---------------------------------------------------------------------------
+describe('outreach: per-vertical guidance leans on the right pain backbone', () => {
+  it('contractor_trades references contractor pain (estimating, scheduling, retention)', () => {
+    const prompt = buildOutreachSystemPrompt('contractor_trades')
+    // CLAUDE.md row: "Contractor/trades — Estimating/quoting + scheduling + employee retention"
+    expect(prompt.toLowerCase()).toContain('estimating')
+    expect(prompt.toLowerCase()).toMatch(/scheduling|crews/)
+    expect(prompt.toLowerCase()).toMatch(/field staff|seasons|retention|keeping/)
+  })
+
+  it('retail_salon references salon pain (scheduling, communication, financial visibility)', () => {
+    const prompt = buildOutreachSystemPrompt('retail_salon')
+    // CLAUDE.md row: "Retail/salon/spa — Scheduling + communication + financial visibility"
+    expect(prompt.toLowerCase()).toMatch(/booking|scheduling/)
+    expect(prompt.toLowerCase()).toMatch(/front-desk|workflows|client/)
+    expect(prompt.toLowerCase()).toMatch(/revenue|margin|measured/)
+  })
+
+  it('restaurant_food references restaurant pain (team comms, inventory, financial visibility)', () => {
+    const prompt = buildOutreachSystemPrompt('restaurant_food')
+    // CLAUDE.md row: "Restaurant/food service — Team communication + inventory + financial visibility"
+    expect(prompt.toLowerCase()).toMatch(/communication|shifts|foh|boh/)
+    expect(prompt.toLowerCase()).toMatch(/pos|inventory|tools/)
+    expect(prompt.toLowerCase()).toMatch(/food cost|labor|prime cost/)
+  })
+
+  it('home_services references home services pain (scheduling, lead follow-up, retention)', () => {
+    const prompt = buildOutreachSystemPrompt('home_services')
+    // CLAUDE.md row: "Home services (plumber, HVAC) — Scheduling + lead follow-up + employee retention"
+    expect(prompt.toLowerCase()).toMatch(/leads|follow-up|phone|text/)
+    expect(prompt.toLowerCase()).toMatch(/dispatch|schedule|crews/)
+    expect(prompt.toLowerCase()).toMatch(/techs|finding|keeping/)
+  })
+
+  it('professional_services references pro services pain (owner bottleneck, manual comms, pipeline)', () => {
+    const prompt = buildOutreachSystemPrompt('professional_services')
+    // CLAUDE.md row: "Professional services (accountant, attorney) — Owner bottleneck + manual communication + pipeline"
+    expect(prompt.toLowerCase()).toMatch(/bottleneck|delegable/)
+    expect(prompt.toLowerCase()).toMatch(/manual communication|email threads|phone tag/)
+    expect(prompt.toLowerCase()).toMatch(/utilization|pipeline|spreadsheet/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Per-vertical contracts are DISTINCT from each other.
+// ---------------------------------------------------------------------------
+describe('outreach: per-vertical guidance is distinct per vertical', () => {
+  it('every recognized vertical produces a unique system prompt', () => {
+    const seen = new Map<string, OutreachVertical>()
+    for (const vertical of RECOGNIZED_VERTICALS) {
+      const prompt = buildOutreachSystemPrompt(vertical)
+      const prior = seen.get(prompt)
+      expect(
+        prior,
+        `${vertical} produced an identical prompt to ${prior} — guidance must vary per vertical`
+      ).toBeUndefined()
+      seen.set(prompt, vertical)
+    }
+  })
+
+  it('every per-vertical prompt is longer than the generic prompt', () => {
+    const generic = buildOutreachSystemPrompt(null)
+    for (const vertical of RECOGNIZED_VERTICALS) {
+      const prompt = buildOutreachSystemPrompt(vertical)
+      expect(
+        prompt.length,
+        `${vertical} prompt should append vertical guidance, growing the prompt`
+      ).toBeGreaterThan(generic.length)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Generic backbone fallback — null / undefined / unrecognized => no
+// vertical guidance. This is the no-fabrication contract: when we don't
+// know the vertical, we don't guess.
+// ---------------------------------------------------------------------------
+describe('outreach: generic backbone fallback for unknown verticals', () => {
+  it('null vertical returns the generic prompt verbatim (no vertical block)', () => {
+    const generic = buildOutreachSystemPrompt(null)
+    expect(generic).not.toContain('## Vertical context:')
+  })
+
+  it('normalizeVertical returns null for null / undefined / empty', () => {
+    expect(normalizeVertical(null)).toBeNull()
+    expect(normalizeVertical(undefined)).toBeNull()
+    expect(normalizeVertical('')).toBeNull()
+  })
+
+  it('normalizeVertical returns null for unrecognized verticals', () => {
+    // 'healthcare', 'technology', 'manufacturing', 'other' are valid Vertical
+    // values per src/portal/assessments/extraction-schema.ts but are NOT in
+    // CLAUDE.md "Pain Clusters by Vertical" — outreach has no authored
+    // backbone for them, so they fall back to the generic prompt.
+    expect(normalizeVertical('healthcare')).toBeNull()
+    expect(normalizeVertical('technology')).toBeNull()
+    expect(normalizeVertical('manufacturing')).toBeNull()
+    expect(normalizeVertical('other')).toBeNull()
+    expect(normalizeVertical('not_a_real_vertical')).toBeNull()
+  })
+
+  it('normalizeVertical recognizes all 5 supported verticals', () => {
+    for (const vertical of RECOGNIZED_VERTICALS) {
+      expect(normalizeVertical(vertical)).toBe(vertical)
+    }
+  })
+
+  it('unrecognized vertical strings produce the generic prompt', () => {
+    const generic = buildOutreachSystemPrompt(null)
+    // Simulate the path generateOutreachDraft takes for these inputs.
+    const fromHealthcare = buildOutreachSystemPrompt(normalizeVertical('healthcare'))
+    const fromOther = buildOutreachSystemPrompt(normalizeVertical('other'))
+    const fromGarbage = buildOutreachSystemPrompt(normalizeVertical('foo_bar_baz'))
+    expect(fromHealthcare).toBe(generic)
+    expect(fromOther).toBe(generic)
+    expect(fromGarbage).toBe(generic)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Anti-fabrication contract — the per-vertical guidance backbone must NOT
+// contain invented prospect-specific details (numbers, names, events,
+// claimed conversations). This locks the architecture: the backbone is
+// register/language hints; specifics come from the assembled enrichment
+// context, not the prompt.
+// ---------------------------------------------------------------------------
+describe('outreach: per-vertical guidance contains no fabricated specifics', () => {
+  // Patterns that would indicate the prompt is inventing prospect-specific
+  // facts. If any per-vertical block adds, say, "your 3-truck operation"
+  // or "the conversation you had at the Vistage breakfast", these regexes
+  // catch the drift at CI time.
+  const FABRICATION_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+    {
+      name: 'specific employee/truck/crew counts',
+      // matches "your 3-truck", "the 12-person team", "10 employees"
+      // Avoids matching "10-25 employees" in the corp backbone (wider regex
+      // around it would, so we only match this in vertical blocks below).
+      pattern:
+        /\b(?:your|the)\s+\d+[-\s](?:truck|person|employee|crew|chair|location|seat|table|tech)/i,
+    },
+    {
+      name: 'specific event or meeting reference',
+      pattern:
+        /\b(?:at|during)\s+the\s+(?:Vistage|EO|trade show|conference|breakfast|lunch|meeting|event)/i,
+    },
+    {
+      name: 'specific claimed conversation',
+      pattern: /(?:you\s+(?:mentioned|told\s+us|said|shared)\s+(?:on|at|during|last|in|that))/i,
+    },
+    {
+      name: 'specific dollar amount',
+      pattern: /\$\d/,
+    },
+    {
+      name: 'specific date or month reference',
+      pattern:
+        /\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d/,
+    },
+    {
+      name: 'specific named person (capitalized first + last name pattern)',
+      // Avoids matching SMD Services / Phoenix etc. by requiring two
+      // consecutive capitalized words that aren't a known proper noun.
+      pattern: /\b(?:Mr|Mrs|Ms|Dr)\.\s+[A-Z]/,
+    },
+  ]
+
+  for (const vertical of RECOGNIZED_VERTICALS) {
+    it(`${vertical} guidance does not invent prospect-specific facts`, () => {
+      const generic = buildOutreachSystemPrompt(null)
+      const withVertical = buildOutreachSystemPrompt(vertical)
+      // Isolate the vertical block — only assert against what was added,
+      // so we don't false-positive on backbone content.
+      const verticalBlock = withVertical.slice(generic.length)
+      for (const { name, pattern } of FABRICATION_PATTERNS) {
+        expect(
+          pattern.test(verticalBlock),
+          `${vertical} vertical block contains fabrication pattern "${name}". ` +
+            `Per-vertical guidance must be backbone language only — never invent specifics.`
+        ).toBe(false)
+      }
+    })
+  }
+
+  // Snapshot-shaped structural lock: the per-vertical block has a stable
+  // shape ("## Vertical context: ..." header, three observation-area
+  // bullets, anti-fabrication footer). This catches accidental shape
+  // drift across all 5 verticals at once.
+  it('every vertical block follows the same structural shape', () => {
+    const generic = buildOutreachSystemPrompt(null)
+    for (const vertical of RECOGNIZED_VERTICALS) {
+      const block = buildOutreachSystemPrompt(vertical).slice(generic.length).trim()
+      // Header
+      expect(block, `${vertical} block missing vertical-context header`).toMatch(
+        /^## Vertical context:/
+      )
+      // Observation-area bullets — each block has exactly 3
+      const bullets = block.split('\n').filter((line) => /^- [a-z_]+ —/.test(line))
+      expect(
+        bullets.length,
+        `${vertical} block should have 3 observation-area bullets, got ${bullets.length}`
+      ).toBe(3)
+      // Anti-fabrication footer
+      expect(block, `${vertical} block missing anti-fabrication footer`).toContain(
+        'do not invent specifics'
+      )
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Taxonomy boundary — per-vertical guidance must speak the 5-cat
+// observation taxonomy, NEVER the 6-cat marketing delivery taxonomy.
+// Mirrors tests/taxonomy-boundary.test.ts but scoped to outreach.ts.
+//
+// The shipped tests/taxonomy-boundary.test.ts already covers
+// src/lead-gen/prompts/* — this extends the lock to the outreach prompt
+// authored by issue #594.
+// ---------------------------------------------------------------------------
+describe('outreach: vertical guidance respects ADR 0001 taxonomy boundary', () => {
+  // 5-cat observation IDs — the language outreach speaks.
+  const OBSERVATION_IDS = [
+    'process_design',
+    'tool_systems',
+    'data_visibility',
+    'customer_pipeline',
+    'team_operations',
+  ]
+
+  // 6-cat marketing delivery taxonomy — forbidden in outreach.
+  const FORBIDDEN_DELIVERY_IDS = [
+    'custom_internal_tools',
+    'systems_integration',
+    'operational_visibility',
+    'vendor_platform_selection',
+    'ai_automation',
+  ]
+  const FORBIDDEN_DELIVERY_PHRASES = [
+    'Custom internal tools',
+    'Vendor/platform selection',
+    'Systems integration',
+    'Operational visibility',
+  ]
+
+  it('outreach.ts source does not reference forbidden delivery taxonomy IDs', () => {
+    const src = readFileSync(resolve('src/lib/claude/outreach.ts'), 'utf-8')
+    for (const id of FORBIDDEN_DELIVERY_IDS) {
+      expect(
+        src,
+        `outreach.ts references marketing delivery ID "${id}" — forbidden by ADR 0001`
+      ).not.toContain(id)
+    }
+  })
+
+  it('outreach.ts source does not contain forbidden delivery taxonomy phrases', () => {
+    const src = readFileSync(resolve('src/lib/claude/outreach.ts'), 'utf-8')
+    for (const phrase of FORBIDDEN_DELIVERY_PHRASES) {
+      expect(
+        src,
+        `outreach.ts contains marketing delivery phrase "${phrase}" — forbidden by ADR 0001`
+      ).not.toContain(phrase)
+    }
+  })
+
+  it('vertical guidance collectively references at least 4 of the 5 observation IDs', () => {
+    // Not every vertical has to name every observation area — that would
+    // flatten the per-vertical signal. But across all 5 verticals, the
+    // guidance should cover most of the taxonomy. Lock at >=4/5 so a
+    // future regression that drops to "everything is process_design"
+    // fails CI.
+    const allBlocks = RECOGNIZED_VERTICALS.map((v) =>
+      buildOutreachSystemPrompt(v).slice(buildOutreachSystemPrompt(null).length)
+    ).join('\n')
+    const referenced = OBSERVATION_IDS.filter((id) => allBlocks.includes(id))
+    expect(
+      referenced.length,
+      `Only ${referenced.length} observation IDs referenced across all vertical blocks: ${referenced.join(', ')}. Need at least 4.`
+    ).toBeGreaterThanOrEqual(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Wiring contract — regenerateOutreach() in src/lib/enrichment/index.ts
+// must thread entity.vertical through to generateOutreachDraft().
+// Without this, the prompt is vertical-aware but the runtime never uses
+// the parameter.
+// ---------------------------------------------------------------------------
+describe('outreach: enrichment pipeline threads entity.vertical', () => {
+  const enrichmentSrc = () => readFileSync(resolve('src/lib/enrichment/index.ts'), 'utf-8')
+
+  it('regenerateOutreach passes entity.vertical to generateOutreachDraft', () => {
+    const src = enrichmentSrc()
+    // The 4-arg signature is the contract: apiKey, entityName, context, vertical.
+    expect(
+      src,
+      'regenerateOutreach must pass entity.vertical as the 4th arg to generateOutreachDraft'
+    ).toMatch(/generateOutreachDraft\([\s\S]{0,200}?entity\.vertical/)
+  })
+
+  it('regenerateOutreach records vertical in outreach_draft metadata', () => {
+    // Auditability — re-runs and audits should see which variant ran.
+    const src = enrichmentSrc()
+    expect(src).toMatch(/vertical:\s*entity\.vertical\s*\?\?\s*null/)
+  })
+})


### PR DESCRIPTION
Closes #594.

## Summary

- Single shared backbone in the outreach system prompt (voice, hard rules, anti-fabrication). Per-vertical guidance is *appended* to the same backbone — never a forked template.
- `generateOutreachDraft()` now accepts an optional `vertical` parameter. Recognized values get a small per-vertical guidance block; null / undefined / unrecognized values fall back to the generic backbone unchanged.
- `regenerateOutreach()` threads `entity.vertical` through and records it in the `outreach_draft` context entry's metadata for re-run auditability.

## Architecture: shared backbone, injected specifics

The per-vertical block is *register/language hints*, drawn from [CLAUDE.md "Pain Clusters by Vertical"](https://github.com/venturecrane/ss-console/blob/main/CLAUDE.md) and phrased in the 5-cat observation vocabulary per [ADR 0001](docs/adr/0001-taxonomy-two-layer-model.md). It is **not** license to invent prospect-specific details. Per-prospect specificity continues to come exclusively from the assembled enrichment context. The model gets a stronger signal about which observation areas tend to resonate for that vertical, but every concrete claim still has to trace to evidence in the context.

Anti-fabrication is enforced both in the prompt itself (an explicit "Anti-fabrication rule (CRITICAL)" section calls out forbidden phrases like "you mentioned at the trade show", "your three-truck operation") and in the test suite (regex sweep over each vertical block for fake numbers, names, events, dollar amounts, dates, and claimed conversations).

## Vertical guidance previews (the sample for each vertical)

These are the per-vertical guidance blocks the model sees on top of the shared backbone. Every block follows the same structural shape (header + 3 observation-area bullets + anti-fabrication footer); the *content* is what varies.

**Contractor / trades** — leans on estimating/quoting, scheduling, field-staff retention. Maps to `process_design`, `customer_pipeline`, `team_operations`. CLAUDE.md row: "Estimating/quoting + scheduling + employee retention."

**Retail / salon / spa** — leans on booking flow, front-desk consistency, revenue/margin visibility. Maps to `customer_pipeline`, `process_design`, `data_visibility`. CLAUDE.md row: "Scheduling + communication + financial visibility."

**Restaurant / food service** — leans on cross-shift communication, POS/inventory tool fragmentation, prime-cost data lag. Maps to `team_operations`, `tool_systems`, `data_visibility`. CLAUDE.md row: "Team communication + inventory + financial visibility."

(The other two verticals — home services and professional services — follow the same shape; see ` src/lib/claude/outreach.ts` for the full table.)

## Why no fabricated email bodies in this PR

The brief asked for sample outreach bodies. Sample bodies would have to be either real LLM output for a real prospect (which would leak prospect data) or invented copy (which violates CLAUDE.md "no fabricated client-facing content"). Instead, the per-vertical *guidance blocks* themselves are the contract — they are what the model sees, and they are committed to source where they can be reviewed. The structural and anti-fabrication tests enforce that the runtime output respects that contract.

## Boundary tests (29 cases, `tests/outreach-vertical-aware.test.ts`)

- Shared-backbone presence in every variant (generic + 5 verticals).
- Per-vertical pain backbone lock — each vertical's prompt references its own CLAUDE.md row.
- Distinct-prompt invariant across all 5 verticals (no two produce identical prompts).
- Generic fallback for null / undefined / `healthcare` / `technology` / `manufacturing` / `other` / unrecognized strings.
- Anti-fabrication regex sweep over the per-vertical block.
- Structural shape lock (header + 3 observation-area bullets + anti-fabrication footer).
- Taxonomy boundary lock — no 6-cat marketing IDs in `outreach.ts`; collective vertical guidance covers >=4/5 observation IDs. Mirrors the existing `tests/taxonomy-boundary.test.ts` (PR #603, issue #591) lock and extends it to outreach.
- Wiring contract — `entity.vertical` threaded to `generateOutreachDraft`; vertical recorded in `outreach_draft` metadata.

## Test plan

- [x] `npm run verify` passes locally (337 files typechecked, 1609 + 40 worker tests pass)
- [x] New 29-test suite passes
- [x] Existing taxonomy-boundary, enrichment-pipeline, forbidden-strings tests pass unchanged
- [ ] Merge + deploy + smoke-test next outreach draft generation in admin

## Refs

- Issue: #594
- ADR: [0001 — Taxonomy Two-Layer Model](docs/adr/0001-taxonomy-two-layer-model.md)
- CLAUDE.md: "Pain Clusters by Vertical" + "No fabricated client-facing content" + "Tone & Positioning Standard"
- Boundary test cousin: PR #603 / `tests/taxonomy-boundary.test.ts`

## Coordination

This PR touches `src/lib/claude/outreach.ts`, `src/lib/enrichment/index.ts`, and `tests/outreach-vertical-aware.test.ts`. It does not touch:
- `src/pages/scan/`, `src/lib/diagnostic/` (#598 — Engine 1)
- workers/admin settings UI (#595 — threshold config)
- new workers (#593 — reserved pipelines)

Per #591/PR #603, it respects the 5-cat observation taxonomy lock — no 6-cat marketing IDs introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)