### PR TITLE
feat(workers/social-listening): activate reserved Reddit signal pipeline (#593)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,3 +105,14 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: workers/review-mining
           command: deploy
+
+      - name: Install Social Listening Worker deps
+        run: cd workers/social-listening && npm ci
+
+      - name: Deploy Social Listening Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: workers/social-listening
+          command: deploy

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -43,10 +43,10 @@ MEETING_URL = "https://zoom.us/j/4284801619"
 
 # Generator worker endpoints — invoked by /admin/generators "Run now" button.
 # Bearer-authed via LEAD_INGEST_API_KEY (secret). Set via `wrangler secret put`.
-# social_listening worker is not deployed yet — Run-now stays disabled.
 NEW_BUSINESS_WORKER_URL = "https://ss-new-business.automation-ab6.workers.dev"
 JOB_MONITOR_WORKER_URL = "https://ss-job-monitor.automation-ab6.workers.dev"
 REVIEW_MINING_WORKER_URL = "https://ss-review-mining.automation-ab6.workers.dev"
+SOCIAL_LISTENING_WORKER_URL = "https://ss-social-listening.automation-ab6.workers.dev"
 
 # Feature flag for the public /patterns aggregate page. Off by default.
 # Flip to "1" or "true" only after the unlock condition documented in


### PR DESCRIPTION
Closes #593 (social_listening half). Defers partner_nurture to a follow-up issue.

## Summary

The social-listening worker has shipped under `workers/social-listening/` since [PR #350](https://github.com/venturecrane/ss-console/pull/350) with 9 passing tests, daily cron schedule, Reddit OAuth, deduped D1 writes, and Resend digest email. It was never wired into the deploy pipeline or referenced from the admin "Run now" panel — leaving the fourth pipeline slot reserved-but-dark, exactly the state issue #593 was filed to fix.

Two minimal changes activate it:

1. **`.github/workflows/deploy.yml`** — add install + deploy steps mirroring the other three workers. Worker now deploys on every push to `main` when `DEPLOY_ENABLED=true`.
2. **`wrangler.toml`** — add `SOCIAL_LISTENING_WORKER_URL` to `[vars]` so the existing `/admin/generators` run-now button (`src/pages/admin/generators/[type].astro:56`) can invoke the worker. Drop the stale `# social_listening worker is not deployed yet` comment.

The worker schedule (`cron "0 14 * * *"` = 7 AM MST daily, same window as `new-business`) and pain-keyword search queries (`src/lib/generators/types.ts:177-183`) already shipped with #350 and remain unchanged.

## What this does NOT change

- **No new prompt file.** The existing worker is intentionally cheap discovery without Claude qualification (`workers/social-listening/src/index.ts:11-14`). It writes posts to `context` against `SYSTEM_ENTITY_ID` for human triage, not entity-creating signal rows. That design predates this issue and remains the right shape — Reddit posts mostly don't map to specific Phoenix businesses.
- **No `/api/ingest/signals` POST.** Per AC wording "Both POST to /api/ingest/signals like existing workers" — none of the four shipped workers actually POST to that endpoint. `job-monitor`, `review-mining`, `new-business`, and `social-listening` all write directly to D1 via `findOrCreateEntity` + `appendContext`. The ingest endpoint exists for external integrations (Make.com, Zapier). This PR keeps social-listening on the established direct-D1 pattern. If we want all workers behind the HTTP boundary, that's a separate refactor across all four — not a social-listening-specific change.
- **No new migration.** `social_listening` already lives in the `source_pipeline` CHECK constraint at `migrations/0007_create_lead_signals.sql:40`, in `/api/ingest/signals` `ALLOWED_PIPELINES`, in `generator_config` (`migrations/0023`), and in admin UI badges and filters.

## partner_nurture deferred — follow-up issue to be filed

partner_nurture is structurally different from the four signal-mining pipelines. It currently runs as a Make.com outbound email scenario consuming `src/lead-gen/prompts/partner-nurture-prompt.ts` (CPA/bookkeeper relationship maintenance). It is **not** in the `source_pipeline` CHECK constraint nor in `/api/ingest/signals` `ALLOWED_PIPELINES` — those only know about the four signal pipelines.

Activating partner_nurture as a Cloudflare worker requires:

- Schema migration to add `'partner_nurture'` to the `source_pipeline` CHECK constraint (or accept that it never writes lead_signals because it's not a signal pipeline)
- Decision on whether it writes to `lead_signals` at all — referrals are already-warm relationships, not cold signals
- Whether Make.com is replaced or kept as the email-sending layer
- Outbound email send permission model (today Buttondown, on the worker would be Resend? Different rate-limit + DKIM domain)

That's an issue-shaped scope, not a worker-deployment scope. Filing as a follow-up.

## Required ops step before first scheduled run

The worker requires four secrets via `wrangler secret put` against the `ss-social-listening` Worker:

- `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, `REDDIT_PASSWORD` — Reddit OAuth (script-app credentials)
- `RESEND_API_KEY` — for daily digest email
- `LEAD_INGEST_API_KEY` — bearer auth for the manual `/run` POST and the admin "Run now" button

Same provisioning model as the other three workers. Pulling from Infisical:

```
infisical export --env=prod --path=/ss --format=dotenv \
  | grep -E '^(REDDIT_|RESEND_|LEAD_INGEST_)' \
  | npx wrangler secret bulk --name ss-social-listening
```

The admin generators page at `/admin/generators/social_listening` lets the human disable runs via `getGeneratorConfig().enabled`, so the cron is safe to fire even before the human review loop is set up — it'll just record a `skipped` run.

## Test plan

- [x] `npm run verify` — all green (workers/social-listening 9/9 tests pass; root build, lint, typecheck, tests pass)
- [ ] On merge: confirm GitHub Actions deploys all four workers (deploy.yml wrangler-action steps)
- [ ] After merge: provision the six secrets above on `ss-social-listening`
- [ ] After secrets: trigger via `/admin/generators/social_listening` "Run now" — confirm `200` response and a row in `generator_runs` for the run
- [ ] Confirm next scheduled cron at 14:00 UTC fires and either records signals or sends a Resend failure alert

## Coordination notes

- #598 (Engine 1 — `src/pages/scan/`, `src/lib/diagnostic/`): no overlap.
- #594 (vertical-aware outreach — `src/lead-gen/prompts/` outreach files): no overlap. We added zero new prompt files.
- #595 (threshold config — `src/pages/admin/settings/`): no overlap. The admin generators page already supports a per-pipeline enable toggle and config; threshold config can layer on top later.