### PR TITLE
feat(diagnostic): Engine 1 /scan — public form + pruned pipeline + email render + abuse controls

### DIFF
--- a/migrations/0029_create_scan_requests.sql
+++ b/migrations/0029_create_scan_requests.sql
@@ -1,0 +1,171 @@
+-- Engine 1 inbound diagnostic scan requests (#598).
+--
+-- The "AI Operational Readiness Scan" at smd.services/scan is the
+-- inbound flywheel for SMD Services lead-gen. A prospect submits their
+-- domain + email, we email a magic-link verification, and clicking it
+-- runs a pruned 6-module enrichment pipeline (places + outscraper +
+-- website_analysis + review_synthesis + deep_website + intelligence_brief)
+-- and emails them a 1-page operational read.
+--
+-- This table is the audit log + state machine for that flow:
+--   1. POST /api/scan/start              -> row created, scan_status='pending_verification'
+--   2. User clicks magic link            -> verified_at set, ctx.waitUntil(scan)
+--   3. Pre-flight thin-footprint gate    -> thin_footprint_skipped=1 + 'thin_footprint' if refused
+--   4. Pruned pipeline runs              -> scan_started_at, then scan_status='completed' or 'failed'
+--   5. Email rendered + sent             -> email_sent_at; entity_id linked when scan creates one
+--
+-- Why a separate table and not just rows in `context`/`entities`:
+--   - Pre-verification rows have NO entity yet (verifying intent before we
+--     do enrichment is the cost guard). We need somewhere to hold the
+--     verification token + rate-limit attribution before deciding to
+--     create an entity.
+--   - Audit/forensics: the table is the durable record of who tried to
+--     scan what, regardless of whether the scan completed. Lets us
+--     answer "is someone running 50 scans against Phoenix HVAC contractors
+--     from throwaway emails?" in one query.
+--   - Cost retrospective: scan_status + thin_footprint_skipped + duration
+--     give us the per-scan cost rollup the scoping doc projected
+--     ($0.14 median, $0.27 pessimistic) against actual usage.
+--
+-- See docs/strategy/diagnostic-scoping-2026-04-27.md for the GO recommendation
+-- and 6 quality bars + 2 scope cuts that bound this feature.
+--
+-- Field semantics
+-- ---------------
+-- id                       UUID. Primary key. Used as `triggered_by` provenance
+--                          in enrichment_runs rows produced by this scan
+--                          ('scan:<id>').
+--
+-- email                    The requester's email. Lowercased + trimmed at
+--                          insert. Indexed for the per-email-domain rate
+--                          limit (we extract domain via SQL substr at query
+--                          time; storing the full email keeps the audit
+--                          surface honest).
+--
+-- domain                   The scanned business domain. Lowercased,
+--                          stripped of protocol/path. Indexed for the
+--                          per-scanned-domain rate limit (1 successful
+--                          scan / 30 days).
+--
+-- linkedin_url             Optional. Captured for the internal pipeline if
+--                          the prospect converts; the public scan path
+--                          drops linkedin per the scoping doc scope cut.
+--
+-- verification_token_hash  SHA-256 hash of the magic-link token. The raw
+--                          token is emailed once and never stored. Hash
+--                          comparison on click. Tokens expire 24h after
+--                          insert (verify endpoint enforces; no DB-level
+--                          expiry index — we read the row by hash and
+--                          check created_at server-side).
+--
+-- verified_at              ISO8601 of the click that verified the email.
+--                          NULL means not yet clicked (or refused / expired).
+--                          Set BEFORE the scan runs — verification proves
+--                          intent + email reachability, then ctx.waitUntil
+--                          fires the scan.
+--
+-- scan_started_at          ISO8601 of when the pruned pipeline began
+--                          execution (post-verification). NULL if scan
+--                          never started (verification expired, or
+--                          pre-flight gate refused before pipeline ran).
+--
+-- scan_completed_at        ISO8601 of when the scan reached a terminal
+--                          state (completed/failed). Used for duration
+--                          telemetry and to detect stuck scans.
+--
+-- scan_status              State machine: 'pending_verification' (row
+--                          created, waiting for click) | 'verified' (click
+--                          accepted, scan running) | 'completed' (full
+--                          pipeline + email sent) | 'thin_footprint'
+--                          (pre-flight gate refused; routed to /book) |
+--                          'failed' (pipeline error or email send error).
+--
+-- thin_footprint_skipped   Boolean. 1 when the pre-flight gate caught a
+--                          thin-footprint business and refused the full
+--                          pipeline (no website + <5 reviews per the
+--                          scoping doc). 0 otherwise. Lets us count
+--                          "how many submissions hit the thin-footprint
+--                          path?" without joining scan_status.
+--
+-- entity_id                FK to entities.id, set when the scan creates or
+--                          links to an entity (post-verification). NULL
+--                          for pre-verification rows. Used by funnel
+--                          telemetry (#587) to attribute outreach_events
+--                          back to the originating scan.
+--
+-- email_sent_at            ISO8601 of when the diagnostic email was
+--                          handed to Resend. NULL if not yet sent.
+--
+-- request_ip               Client IP captured at submission. Indexed for
+--                          per-IP rate limiting. Stored verbatim; if a
+--                          legit office shares NAT, the IP rate limit's
+--                          5-scans-per-IP-per-24h is enough headroom.
+--
+-- error_message            Human-readable failure reason for scan_status
+--                          IN ('failed', 'thin_footprint'). NULL otherwise.
+--                          Surfaced in admin retrospective; never shown
+--                          to the prospect.
+--
+-- created_at               Insertion time. Indexed for the global daily
+--                          cap (count rows in the last 24h).
+--
+-- Indexes
+-- -------
+-- (request_ip, created_at DESC)        — per-IP rate limit window
+-- (email, created_at DESC)             — per-email-domain rate limit window
+-- (domain, scan_status, created_at)    — per-scanned-domain rate limit
+--                                        (1 successful scan / 30 days)
+-- (verification_token_hash) UNIQUE     — token lookup on click; UNIQUE so a
+--                                        token can only verify one row
+-- (created_at)                         — global daily cap
+-- (entity_id)                          — funnel attribution joins (#587)
+
+CREATE TABLE scan_requests (
+  id                        TEXT PRIMARY KEY,
+
+  email                     TEXT NOT NULL,
+  domain                    TEXT NOT NULL,
+  linkedin_url              TEXT,
+
+  verification_token_hash   TEXT NOT NULL,
+  verified_at               TEXT,
+
+  scan_started_at           TEXT,
+  scan_completed_at         TEXT,
+  scan_status               TEXT NOT NULL DEFAULT 'pending_verification' CHECK (scan_status IN (
+    'pending_verification',
+    'verified',
+    'completed',
+    'thin_footprint',
+    'failed'
+  )),
+
+  thin_footprint_skipped    INTEGER NOT NULL DEFAULT 0 CHECK (thin_footprint_skipped IN (0, 1)),
+  entity_id                 TEXT REFERENCES entities(id),
+
+  email_sent_at             TEXT,
+
+  request_ip                TEXT,
+  error_message             TEXT,
+
+  created_at                TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_scan_requests_ip
+  ON scan_requests(request_ip, created_at DESC);
+
+CREATE INDEX idx_scan_requests_email
+  ON scan_requests(email, created_at DESC);
+
+CREATE INDEX idx_scan_requests_domain
+  ON scan_requests(domain, scan_status, created_at);
+
+CREATE UNIQUE INDEX idx_scan_requests_token
+  ON scan_requests(verification_token_hash);
+
+CREATE INDEX idx_scan_requests_created
+  ON scan_requests(created_at);
+
+CREATE INDEX idx_scan_requests_entity
+  ON scan_requests(entity_id)
+  WHERE entity_id IS NOT NULL;

--- a/src/lib/db/scan-requests.ts
+++ b/src/lib/db/scan-requests.ts
@@ -1,0 +1,279 @@
+/**
+ * Data access for `scan_requests` (#598).
+ *
+ * The Engine 1 inbound diagnostic flow needs a state machine for "someone
+ * submitted the form -> we sent a magic link -> they clicked -> we ran
+ * the scan -> we emailed the report." See migrations/0029_create_scan_requests.sql
+ * for field semantics and lifecycle.
+ *
+ * All queries are tenant-scoped only implicitly: the table holds public
+ * inbound submissions, not per-org artifacts. The org id used downstream
+ * (when a verified scan creates an entity) comes from `ORG_ID` constants,
+ * not from the scan_request row itself.
+ */
+
+import { CONTROL_CHAR_RE } from '../scan/normalize'
+
+export type ScanStatus =
+  | 'pending_verification'
+  | 'verified'
+  | 'completed'
+  | 'thin_footprint'
+  | 'failed'
+
+export interface ScanRequest {
+  id: string
+  email: string
+  domain: string
+  linkedin_url: string | null
+  verification_token_hash: string
+  verified_at: string | null
+  scan_started_at: string | null
+  scan_completed_at: string | null
+  scan_status: ScanStatus
+  thin_footprint_skipped: number
+  entity_id: string | null
+  email_sent_at: string | null
+  request_ip: string | null
+  error_message: string | null
+  created_at: string
+}
+
+export interface CreateScanRequestData {
+  email: string
+  domain: string
+  linkedin_url?: string | null
+  verification_token_hash: string
+  request_ip?: string | null
+}
+
+/**
+ * Create a new scan_request row in the `pending_verification` state.
+ *
+ * The email and domain are stored as supplied (already lowercased + trimmed
+ * by the caller — see `src/lib/scan/normalize.ts`). The verification token
+ * itself is never stored — only the SHA-256 hash. The raw token is emailed
+ * once and forgotten.
+ */
+export async function createScanRequest(
+  db: D1Database,
+  data: CreateScanRequestData
+): Promise<ScanRequest> {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  // Defensive — these should already be normalized but a control char in a
+  // request_ip from a header would still poison logs.
+  if (CONTROL_CHAR_RE.test(data.email)) {
+    throw new Error('email contains control characters')
+  }
+  if (CONTROL_CHAR_RE.test(data.domain)) {
+    throw new Error('domain contains control characters')
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO scan_requests (
+        id, email, domain, linkedin_url, verification_token_hash,
+        scan_status, request_ip, created_at
+      ) VALUES (?, ?, ?, ?, ?, 'pending_verification', ?, ?)`
+    )
+    .bind(
+      id,
+      data.email,
+      data.domain,
+      data.linkedin_url ?? null,
+      data.verification_token_hash,
+      data.request_ip ?? null,
+      now
+    )
+    .run()
+
+  const row = await getScanRequest(db, id)
+  if (!row) throw new Error('Failed to retrieve created scan_request')
+  return row
+}
+
+export async function getScanRequest(db: D1Database, id: string): Promise<ScanRequest | null> {
+  const row = await db
+    .prepare('SELECT * FROM scan_requests WHERE id = ?')
+    .bind(id)
+    .first<ScanRequest>()
+  return row ?? null
+}
+
+export async function getScanRequestByTokenHash(
+  db: D1Database,
+  tokenHash: string
+): Promise<ScanRequest | null> {
+  const row = await db
+    .prepare('SELECT * FROM scan_requests WHERE verification_token_hash = ?')
+    .bind(tokenHash)
+    .first<ScanRequest>()
+  return row ?? null
+}
+
+/**
+ * Mark a row as verified. Returns the updated row. Idempotent — re-clicking
+ * the link after verification is a no-op (verified_at stays at first click).
+ */
+export async function markScanVerified(db: D1Database, id: string): Promise<ScanRequest | null> {
+  const now = new Date().toISOString()
+  await db
+    .prepare(
+      `UPDATE scan_requests
+       SET verified_at = COALESCE(verified_at, ?),
+           scan_status = CASE
+             WHEN scan_status = 'pending_verification' THEN 'verified'
+             ELSE scan_status
+           END
+       WHERE id = ?`
+    )
+    .bind(now, id)
+    .run()
+  return getScanRequest(db, id)
+}
+
+export interface UpdateScanRequestRunData {
+  scan_started_at?: string
+  scan_completed_at?: string
+  scan_status?: ScanStatus
+  thin_footprint_skipped?: boolean
+  entity_id?: string | null
+  email_sent_at?: string | null
+  error_message?: string | null
+}
+
+/**
+ * Update the run-state fields on a scan_request. Used by the diagnostic
+ * orchestrator to record start/completion, thin-footprint refusal, and
+ * email-sent timestamps.
+ */
+export async function updateScanRequestRun(
+  db: D1Database,
+  id: string,
+  data: UpdateScanRequestRunData
+): Promise<void> {
+  const sets: string[] = []
+  const params: (string | number | null)[] = []
+  if (data.scan_started_at !== undefined) {
+    sets.push('scan_started_at = ?')
+    params.push(data.scan_started_at)
+  }
+  if (data.scan_completed_at !== undefined) {
+    sets.push('scan_completed_at = ?')
+    params.push(data.scan_completed_at)
+  }
+  if (data.scan_status !== undefined) {
+    sets.push('scan_status = ?')
+    params.push(data.scan_status)
+  }
+  if (data.thin_footprint_skipped !== undefined) {
+    sets.push('thin_footprint_skipped = ?')
+    params.push(data.thin_footprint_skipped ? 1 : 0)
+  }
+  if (data.entity_id !== undefined) {
+    sets.push('entity_id = ?')
+    params.push(data.entity_id)
+  }
+  if (data.email_sent_at !== undefined) {
+    sets.push('email_sent_at = ?')
+    params.push(data.email_sent_at)
+  }
+  if (data.error_message !== undefined) {
+    sets.push('error_message = ?')
+    params.push(data.error_message)
+  }
+  if (sets.length === 0) return
+  params.push(id)
+  await db
+    .prepare(`UPDATE scan_requests SET ${sets.join(', ')} WHERE id = ?`)
+    .bind(...params)
+    .run()
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit support queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Count scan_requests by IP within a lookback window. The IP-dimension of
+ * the 4-dimensional rate limiter (`src/lib/diagnostic/rate-limit.ts`).
+ *
+ * Counts all rows including pre-verification — a flood of unverified
+ * requests still costs us KV writes and email sends.
+ */
+export async function countScanRequestsByIp(
+  db: D1Database,
+  ip: string,
+  sinceIso: string
+): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM scan_requests
+       WHERE request_ip = ? AND created_at >= ?`
+    )
+    .bind(ip, sinceIso)
+    .first<{ n: number }>()
+  return row?.n ?? 0
+}
+
+/**
+ * Count scan_requests by requester email domain within a lookback window.
+ * The email-domain-dimension of the rate limiter.
+ *
+ * SQLite doesn't have a built-in last-occurrence search, so we rely on the
+ * substr-after-@ pattern: `substr(email, instr(email, '@') + 1)`.
+ */
+export async function countScanRequestsByEmailDomain(
+  db: D1Database,
+  emailDomain: string,
+  sinceIso: string
+): Promise<number> {
+  const lower = emailDomain.toLowerCase()
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM scan_requests
+       WHERE LOWER(substr(email, instr(email, '@') + 1)) = ?
+         AND created_at >= ?`
+    )
+    .bind(lower, sinceIso)
+    .first<{ n: number }>()
+  return row?.n ?? 0
+}
+
+/**
+ * Count `completed` scan_requests for a domain within a lookback window.
+ * The scanned-domain-dimension of the rate limiter — only completed scans
+ * count, so a refused thin-footprint or pending row doesn't lock out a
+ * legitimate retry from the same business.
+ */
+export async function countCompletedScansByDomain(
+  db: D1Database,
+  domain: string,
+  sinceIso: string
+): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM scan_requests
+       WHERE domain = ? AND scan_status = 'completed' AND created_at >= ?`
+    )
+    .bind(domain, sinceIso)
+    .first<{ n: number }>()
+  return row?.n ?? 0
+}
+
+/**
+ * Count all scan_requests in the last 24h regardless of source. The global
+ * dimension of the rate limiter — safety net against viral abuse.
+ */
+export async function countScanRequestsSince(db: D1Database, sinceIso: string): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM scan_requests
+       WHERE created_at >= ?`
+    )
+    .bind(sinceIso)
+    .first<{ n: number }>()
+  return row?.n ?? 0
+}

--- a/src/lib/diagnostic/index.ts
+++ b/src/lib/diagnostic/index.ts
@@ -1,0 +1,593 @@
+/**
+ * Engine 1 diagnostic orchestrator (#598).
+ *
+ * Runs the *pruned* 6-module pipeline behind smd.services/scan, with a
+ * P0 thin-footprint pre-flight gate. Per the scoping doc
+ * (`docs/strategy/diagnostic-scoping-2026-04-27.md`), the public scan path
+ * uses ONLY:
+ *
+ *   places + outscraper + website_analysis + review_synthesis +
+ *   deep_website + intelligence_brief
+ *
+ * It deliberately DROPS competitors, news_search, and linkedin from the
+ * scan path. Those three remain in the internal 12-module pipeline that
+ * runs when a scan converts to a booked call, but on the public scan path
+ * they triple latency, add fabrication risk, and produce low-signal output.
+ *
+ * Lifecycle:
+ *
+ *   1. The verify endpoint calls `runDiagnosticScan` via `ctx.waitUntil()`
+ *      so the prospect's verification click returns instantly.
+ *   2. We find-or-create an entity for the scanned domain.
+ *   3. We run google_places + outscraper as the pre-flight (cheap; ~$0.02).
+ *   4. We evaluate the thin-footprint gate. If it trips, we mark the
+ *      scan_request as `thin_footprint` and email a "let's talk live"
+ *      response — never a fabricated report.
+ *   5. Otherwise we run website_analysis + review_synthesis + deep_website
+ *      + intelligence_brief.
+ *   6. We email the rendered 1-page report (`render.ts` enforces
+ *      anti-fabrication rules per section).
+ *
+ * The orchestrator is best-effort throughout — a single module failure
+ * does not abort the run. A complete pipeline failure is recorded as
+ * `scan_status='failed'` and surfaces in the audit log.
+ */
+
+import { ORG_ID } from '../constants'
+import { findOrCreateEntity, getEntity, updateEntity, type Entity } from '../db/entities'
+import { appendContext, listContext, assembleEntityContext } from '../db/context'
+import { lookupGooglePlaces } from '../enrichment/google-places'
+import { lookupOutscraper } from '../enrichment/outscraper'
+import { analyzeWebsite } from '../enrichment/website-analyzer'
+import { synthesizeReviews } from '../enrichment/review-synthesis'
+import { deepWebsiteAnalysis } from '../enrichment/deep-website'
+import { generateDossier } from '../enrichment/dossier'
+import { getScanRequest, updateScanRequestRun, type ScanRequest } from '../db/scan-requests'
+import { sendOutreachEmail } from '../email/resend'
+import { diagnosticReportEmailHtml, thinFootprintEmailHtml } from '../email/diagnostic-email'
+import { renderDiagnosticReport, type RenderedReport } from './render'
+
+export interface DiagnosticEnv {
+  DB: D1Database
+  ANTHROPIC_API_KEY?: string
+  GOOGLE_PLACES_API_KEY?: string
+  OUTSCRAPER_API_KEY?: string
+  RESEND_API_KEY?: string
+  APP_BASE_URL?: string
+}
+
+export interface DiagnosticResult {
+  scan_request_id: string
+  status: 'completed' | 'thin_footprint' | 'failed'
+  entity_id: string | null
+  thin_footprint_skipped: boolean
+  modules_ran: string[]
+  email_sent: boolean
+  error?: string
+}
+
+const SOURCE_PIPELINE = 'inbound_scan'
+
+/**
+ * Entry point for the verify endpoint's `ctx.waitUntil(...)` call. Loads
+ * the scan_request, runs the pipeline, persists results, sends email.
+ *
+ * Never throws — all failures are recorded in scan_status and returned
+ * in DiagnosticResult.error. Throwing here would silently lose the row
+ * because waitUntil callers don't see exceptions.
+ */
+export async function runDiagnosticScan(
+  env: DiagnosticEnv,
+  scanRequestId: string
+): Promise<DiagnosticResult> {
+  const result: DiagnosticResult = {
+    scan_request_id: scanRequestId,
+    status: 'failed',
+    entity_id: null,
+    thin_footprint_skipped: false,
+    modules_ran: [],
+    email_sent: false,
+  }
+
+  const scanRequest = await getScanRequest(env.DB, scanRequestId)
+  if (!scanRequest) {
+    result.error = 'scan_request_not_found'
+    return result
+  }
+  if (scanRequest.scan_status === 'completed') {
+    // Idempotency — verify endpoint may fire twice on a double-click.
+    result.status = 'completed'
+    result.entity_id = scanRequest.entity_id
+    return result
+  }
+
+  const startedAt = new Date().toISOString()
+  await updateScanRequestRun(env.DB, scanRequestId, { scan_started_at: startedAt })
+
+  try {
+    return await runScanInner(env, scanRequest, result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error('[diagnostic] runScanInner threw:', err)
+    await updateScanRequestRun(env.DB, scanRequestId, {
+      scan_status: 'failed',
+      scan_completed_at: new Date().toISOString(),
+      error_message: message.slice(0, 500),
+    })
+    result.error = message
+    return result
+  }
+}
+
+async function runScanInner(
+  env: DiagnosticEnv,
+  scanRequest: ScanRequest,
+  result: DiagnosticResult
+): Promise<DiagnosticResult> {
+  // ---------------------------------------------------------------
+  // Step 1: find-or-create entity for the scanned domain.
+  //
+  // The entity name we have at this point is the bare domain. We find-or-
+  // create on the slug derived from the name + area (Phoenix, AZ as the
+  // default area for this venture). Outscraper later updates the entity's
+  // canonical name / phone / website.
+  // ---------------------------------------------------------------
+  const placeholderName = humanizeDomain(scanRequest.domain)
+  const foc = await findOrCreateEntity(env.DB, ORG_ID, {
+    name: placeholderName,
+    website: `https://${scanRequest.domain}`,
+    area: 'Phoenix, AZ',
+    source_pipeline: SOURCE_PIPELINE,
+  })
+  let entity: Entity = foc.entity
+  result.entity_id = entity.id
+  await updateScanRequestRun(env.DB, scanRequest.id, { entity_id: entity.id })
+
+  // Always log the inbound submission as a 'signal' so downstream
+  // attribution + funnel telemetry treats this as a first-class lead-gen
+  // signal.
+  await appendContext(env.DB, ORG_ID, {
+    entity_id: entity.id,
+    type: 'signal',
+    source: SOURCE_PIPELINE,
+    content: `Inbound diagnostic scan submitted from ${scanRequest.email}. Domain: ${scanRequest.domain}.${scanRequest.linkedin_url ? ` LinkedIn: ${scanRequest.linkedin_url}.` : ''}`,
+    metadata: {
+      scan_request_id: scanRequest.id,
+      requester_email: scanRequest.email,
+      submitted_domain: scanRequest.domain,
+      linkedin_url: scanRequest.linkedin_url,
+    },
+  })
+
+  // ---------------------------------------------------------------
+  // Step 2: pre-flight (places + outscraper). These are the cheap
+  // identity probes — ~$0.02 total. Their output drives the
+  // thin-footprint gate.
+  // ---------------------------------------------------------------
+  if (env.GOOGLE_PLACES_API_KEY) {
+    const places = await runPlaces(env, entity, scanRequest)
+    if (places) {
+      result.modules_ran.push('google_places')
+      // Refresh entity in case places updated phone/website.
+      const refreshed = await getEntity(env.DB, ORG_ID, entity.id)
+      if (refreshed) entity = refreshed
+    }
+  }
+
+  if (env.OUTSCRAPER_API_KEY) {
+    const oc = await runOutscraper(env, entity, scanRequest)
+    if (oc) {
+      result.modules_ran.push('outscraper')
+      const refreshed = await getEntity(env.DB, ORG_ID, entity.id)
+      if (refreshed) entity = refreshed
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Step 3: thin-footprint gate. Refuse the rest of the pipeline if
+  // the prospect's footprint is too thin to support a non-fabricated
+  // report. Per the scoping doc + CLAUDE.md no-fabrication rule, the
+  // refusal sends a short "let's talk live" email and routes to /book.
+  // ---------------------------------------------------------------
+  const gate = await evaluateThinFootprintGate(env, entity, scanRequest.domain)
+  if (gate.thin) {
+    result.thin_footprint_skipped = true
+    await updateScanRequestRun(env.DB, scanRequest.id, {
+      scan_status: 'thin_footprint',
+      thin_footprint_skipped: true,
+      scan_completed_at: new Date().toISOString(),
+      error_message: `thin_footprint:${gate.reason}`,
+    })
+    const sent = await sendThinFootprintEmail(env, scanRequest, entity, gate.reason)
+    result.email_sent = sent
+    if (sent) {
+      await updateScanRequestRun(env.DB, scanRequest.id, {
+        email_sent_at: new Date().toISOString(),
+      })
+    }
+    result.status = 'thin_footprint'
+    return result
+  }
+
+  // ---------------------------------------------------------------
+  // Step 4: pruned pipeline — website_analysis + review_synthesis +
+  // deep_website + intelligence_brief.
+  //
+  // Each module is best-effort. A single module failing degrades a
+  // section of the report (anti-fabrication rendering omits sections
+  // with insufficient data) but does not abort the scan.
+  // ---------------------------------------------------------------
+  if (entity.website && env.ANTHROPIC_API_KEY) {
+    const ok = await runWebsiteAnalysis(env, entity, scanRequest)
+    if (ok) result.modules_ran.push('website_analysis')
+  }
+
+  if (env.ANTHROPIC_API_KEY) {
+    const ok = await runReviewSynthesis(env, entity, scanRequest)
+    if (ok) result.modules_ran.push('review_synthesis')
+  }
+
+  if (entity.website && env.ANTHROPIC_API_KEY) {
+    const ok = await runDeepWebsite(env, entity, scanRequest)
+    if (ok) result.modules_ran.push('deep_website')
+  }
+
+  let briefMarkdown: string | null = null
+  if (env.ANTHROPIC_API_KEY) {
+    briefMarkdown = await runIntelligenceBrief(env, entity, scanRequest)
+    if (briefMarkdown) result.modules_ran.push('intelligence_brief')
+  }
+
+  // ---------------------------------------------------------------
+  // Step 5: render + email the report.
+  //
+  // `renderDiagnosticReport` enforces anti-fabrication rules per
+  // section. If a required section has insufficient signals it is
+  // omitted or labelled "Insufficient data" — never invented.
+  // ---------------------------------------------------------------
+  const rendered = await renderDiagnosticReport(env.DB, entity, briefMarkdown)
+  const sent = await sendDiagnosticReportEmail(env, scanRequest, entity, rendered)
+  result.email_sent = sent
+
+  await updateScanRequestRun(env.DB, scanRequest.id, {
+    scan_status: 'completed',
+    scan_completed_at: new Date().toISOString(),
+    email_sent_at: sent ? new Date().toISOString() : null,
+  })
+  result.status = 'completed'
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Thin-footprint gate
+// ---------------------------------------------------------------------------
+
+export interface ThinFootprintEvaluation {
+  thin: boolean
+  /** Machine-readable reason. Stored in error_message; never client-rendered. */
+  reason: string
+  reviewCount: number | null
+  hasUsableWebsite: boolean
+}
+
+/**
+ * Decide whether the entity has enough public footprint to support a
+ * non-fabricated report. Per the scoping doc:
+ *
+ *   - No website AND no Google Places match -> thin
+ *   - No website AND <5 reviews             -> thin
+ *   - Otherwise                              -> proceed
+ *
+ * Reviews are read from the most recent google_places enrichment row's
+ * metadata.reviewCount, falling back to outscraper's review_count. Both
+ * modules persist to context, so we read context (not entity columns).
+ */
+export async function evaluateThinFootprintGate(
+  env: DiagnosticEnv,
+  entity: Entity,
+  submittedDomain: string
+): Promise<ThinFootprintEvaluation> {
+  const enrichment = await listContext(env.DB, entity.id, { type: 'enrichment' })
+  let reviewCount: number | null = null
+  let placesMatched = false
+
+  for (const row of enrichment) {
+    if (row.source === 'google_places' && row.metadata) {
+      try {
+        const m = JSON.parse(row.metadata) as Record<string, unknown>
+        if (typeof m.reviewCount === 'number') reviewCount = m.reviewCount
+        placesMatched = true
+      } catch {
+        /* ignore */
+      }
+    } else if (row.source === 'outscraper' && row.metadata) {
+      try {
+        const m = JSON.parse(row.metadata) as Record<string, unknown>
+        if (typeof m.review_count === 'number' && reviewCount == null) {
+          reviewCount = m.review_count
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  const hasUsableWebsite = !!entity.website && !!entity.website.trim()
+
+  if (!hasUsableWebsite && !placesMatched) {
+    return {
+      thin: true,
+      reason: 'no_website_no_places',
+      reviewCount,
+      hasUsableWebsite,
+    }
+  }
+
+  if (!hasUsableWebsite && (reviewCount == null || reviewCount < 5)) {
+    return {
+      thin: true,
+      reason: 'no_website_low_reviews',
+      reviewCount,
+      hasUsableWebsite,
+    }
+  }
+
+  // We deliberately don't gate on reviewCount alone if the website exists.
+  // A new business with a real site and 2 reviews still produces a useful
+  // report (digital-maturity + tech-stack signals). We DO note submittedDomain
+  // here as a structural reminder that the gate also fires implicitly when
+  // the website-analysis fetch later returns <500 chars; that's enforced in
+  // the renderer, not here.
+  void submittedDomain
+
+  return { thin: false, reason: 'ok', reviewCount, hasUsableWebsite }
+}
+
+// ---------------------------------------------------------------------------
+// Module wrappers — minimal, no instrumentation. The full enrichment
+// pipeline writes to enrichment_runs; the public scan path uses simpler
+// "did it succeed" telemetry through scan_requests.scan_status. Each module
+// writes its own context row so the report renderer reads from one source
+// of truth.
+// ---------------------------------------------------------------------------
+
+async function runPlaces(
+  env: DiagnosticEnv,
+  entity: Entity,
+  scanRequest: ScanRequest
+): Promise<boolean> {
+  if (!env.GOOGLE_PLACES_API_KEY) return false
+  try {
+    const places = await lookupGooglePlaces(entity.name, entity.area, env.GOOGLE_PLACES_API_KEY)
+    if (!places) return false
+    await updateEntity(env.DB, ORG_ID, entity.id, {
+      phone: places.phone ?? entity.phone ?? undefined,
+      website: places.website ?? entity.website ?? undefined,
+    })
+    await appendContext(env.DB, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'google_places',
+      content: `Google Places: ${places.phone ? `Phone: ${places.phone}.` : 'No phone found.'} ${places.website ? `Website: ${places.website}.` : 'No website found.'} Rating: ${places.rating ?? 'N/A'} (${places.reviewCount ?? 0} reviews).`,
+      metadata: places as unknown as Record<string, unknown>,
+      source_ref: scanRequest.id,
+    })
+    return true
+  } catch (err) {
+    console.error('[diagnostic] google_places failed:', err)
+    return false
+  }
+}
+
+async function runOutscraper(
+  env: DiagnosticEnv,
+  entity: Entity,
+  scanRequest: ScanRequest
+): Promise<boolean> {
+  if (!env.OUTSCRAPER_API_KEY) return false
+  try {
+    const osc = await lookupOutscraper(entity.name, entity.area, env.OUTSCRAPER_API_KEY)
+    if (!osc) return false
+    await updateEntity(env.DB, ORG_ID, entity.id, {
+      phone: osc.phone ?? entity.phone ?? undefined,
+      website: osc.website ?? entity.website ?? undefined,
+    })
+    await appendContext(env.DB, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'outscraper',
+      content: `Outscraper profile: rating ${osc.rating ?? 'n/a'} (${osc.review_count ?? 0} reviews). ${osc.verified ? 'Verified.' : 'Unverified.'}`,
+      metadata: osc as unknown as Record<string, unknown>,
+      source_ref: scanRequest.id,
+    })
+    return true
+  } catch (err) {
+    console.error('[diagnostic] outscraper failed:', err)
+    return false
+  }
+}
+
+async function runWebsiteAnalysis(
+  env: DiagnosticEnv,
+  entity: Entity,
+  scanRequest: ScanRequest
+): Promise<boolean> {
+  if (!entity.website || !env.ANTHROPIC_API_KEY) return false
+  try {
+    const analysis = await analyzeWebsite(entity.website, env.ANTHROPIC_API_KEY)
+    if (!analysis) return false
+    await appendContext(env.DB, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'website_analysis',
+      content: `Website analysis: ${analysis.pages_analyzed.length} pages. Quality: ${analysis.quality}.`,
+      metadata: analysis as unknown as Record<string, unknown>,
+      source_ref: scanRequest.id,
+    })
+    return true
+  } catch (err) {
+    console.error('[diagnostic] website_analysis failed:', err)
+    return false
+  }
+}
+
+async function runReviewSynthesis(
+  env: DiagnosticEnv,
+  entity: Entity,
+  scanRequest: ScanRequest
+): Promise<boolean> {
+  if (!env.ANTHROPIC_API_KEY) return false
+  try {
+    const allContext = await assembleEntityContext(env.DB, entity.id, {
+      maxBytes: 20_000,
+      typeFilter: ['signal', 'enrichment'],
+    })
+    if (!allContext) return false
+    const synthesis = await synthesizeReviews(allContext, env.ANTHROPIC_API_KEY)
+    if (!synthesis) return false
+    await appendContext(env.DB, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'review_synthesis',
+      content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}.`,
+      metadata: synthesis as unknown as Record<string, unknown>,
+      source_ref: scanRequest.id,
+    })
+    return true
+  } catch (err) {
+    console.error('[diagnostic] review_synthesis failed:', err)
+    return false
+  }
+}
+
+async function runDeepWebsite(
+  env: DiagnosticEnv,
+  entity: Entity,
+  scanRequest: ScanRequest
+): Promise<boolean> {
+  if (!entity.website || !env.ANTHROPIC_API_KEY) return false
+  try {
+    const analysis = await deepWebsiteAnalysis(entity.website, env.ANTHROPIC_API_KEY)
+    if (!analysis) return false
+    await appendContext(env.DB, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'deep_website',
+      content: `Deep website analysis. Digital maturity score: ${analysis.digital_maturity?.score ?? 'n/a'}/10.`,
+      metadata: analysis as unknown as Record<string, unknown>,
+      source_ref: scanRequest.id,
+    })
+    return true
+  } catch (err) {
+    console.error('[diagnostic] deep_website failed:', err)
+    return false
+  }
+}
+
+async function runIntelligenceBrief(
+  env: DiagnosticEnv,
+  entity: Entity,
+  scanRequest: ScanRequest
+): Promise<string | null> {
+  if (!env.ANTHROPIC_API_KEY) return null
+  try {
+    const fullContext = await assembleEntityContext(env.DB, entity.id, { maxBytes: 32_000 })
+    if (!fullContext) return null
+    const brief = await generateDossier(fullContext, entity.name, env.ANTHROPIC_API_KEY)
+    if (!brief) return null
+    await appendContext(env.DB, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'intelligence_brief',
+      content: brief,
+      metadata: { trigger: 'inbound_scan' },
+      source_ref: scanRequest.id,
+    })
+    return brief
+  } catch (err) {
+    console.error('[diagnostic] intelligence_brief failed:', err)
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Email rendering
+// ---------------------------------------------------------------------------
+
+async function sendDiagnosticReportEmail(
+  env: DiagnosticEnv,
+  scanRequest: ScanRequest,
+  entity: Entity,
+  rendered: RenderedReport
+): Promise<boolean> {
+  const html = diagnosticReportEmailHtml({
+    businessName: entity.name,
+    rendered,
+    bookingUrl: buildBookingUrl(env),
+  })
+  const r = await sendOutreachEmail(
+    env.RESEND_API_KEY,
+    {
+      to: scanRequest.email,
+      subject: `Your operational read — ${entity.name}`,
+      html,
+    },
+    { db: env.DB, orgId: ORG_ID, entityId: entity.id }
+  )
+  if (!r.success) {
+    console.error('[diagnostic] failed to send report email:', r.error)
+    return false
+  }
+  return true
+}
+
+async function sendThinFootprintEmail(
+  env: DiagnosticEnv,
+  scanRequest: ScanRequest,
+  entity: Entity,
+  reason: string
+): Promise<boolean> {
+  const html = thinFootprintEmailHtml({
+    businessName: entity.name,
+    submittedDomain: scanRequest.domain,
+    reason,
+    bookingUrl: buildBookingUrl(env),
+  })
+  const r = await sendOutreachEmail(
+    env.RESEND_API_KEY,
+    {
+      to: scanRequest.email,
+      subject: `About your scan — ${entity.name}`,
+      html,
+    },
+    { db: env.DB, orgId: ORG_ID, entityId: entity.id }
+  )
+  if (!r.success) {
+    console.error('[diagnostic] failed to send thin-footprint email:', r.error)
+    return false
+  }
+  return true
+}
+
+function buildBookingUrl(env: DiagnosticEnv): string {
+  const base = env.APP_BASE_URL ?? 'https://smd.services'
+  return new URL('/book', base).toString()
+}
+
+/**
+ * Domain -> human-friendly business name placeholder. We strip the TLD and
+ * title-case the remaining label. Outscraper / Google Places typically
+ * overwrite this with the canonical business name shortly after, but the
+ * placeholder makes the entity row legible if the canonical lookup fails.
+ *
+ * Example: `azperfectcomfort.com` -> `Azperfectcomfort`
+ *          `home-services-llc.com` -> `Home Services Llc`
+ */
+function humanizeDomain(domain: string): string {
+  const label = domain.split('.')[0] ?? domain
+  return label
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(' ')
+}

--- a/src/lib/diagnostic/rate-limit.ts
+++ b/src/lib/diagnostic/rate-limit.ts
@@ -1,0 +1,158 @@
+/**
+ * 4-dimensional rate limit for the public /scan flow (#598).
+ *
+ * The diagnostic scan is the highest-cost public surface SMD Services
+ * exposes — each completed scan burns ~$0.14 of Anthropic + Outscraper
+ * spend, and each abuse run that gets past pre-verification still costs
+ * us KV writes + a Resend send. The scoping doc mandates four dimensions:
+ *
+ *   1. Per IP            — 5 scans / 24h   — casual abuse cap
+ *   2. Per email domain  — 1 scan / 7d     — same business / competitor
+ *                                            re-scanning from the same
+ *                                            organization's email
+ *   3. Per scanned domain — 1 successful   — anti-competitor-intel; same
+ *                          / 30d            target can't be re-scanned
+ *                                            for fresh intel
+ *   4. Global            — 200 / 24h       — viral/HN safety net
+ *
+ * Worst-case attacker capped at ~750 scans/wk = ~$200/wk Anthropic before
+ * being blocked. Acceptable per the scoping doc.
+ *
+ * Storage backing — D1, not KV. The booking rate-limit uses KV because
+ * its dimension is per-IP and a fixed-window counter is enough; the scan
+ * limiter needs to reason about email-domain and scanned-domain counts
+ * over windows of days/weeks, which means real queries against scan_requests.
+ * The audit table is the source of truth for counts; no separate KV
+ * counters to keep in sync.
+ */
+
+import {
+  countScanRequestsByIp,
+  countScanRequestsByEmailDomain,
+  countCompletedScansByDomain,
+  countScanRequestsSince,
+} from '../db/scan-requests'
+
+export const RATE_LIMITS = {
+  per_ip_24h: 5,
+  per_email_domain_7d: 1,
+  per_domain_30d: 1,
+  global_24h: 200,
+} as const
+
+export type RateLimitDimension = 'per_ip' | 'per_email_domain' | 'per_domain' | 'global'
+
+export interface RateLimitCheckInput {
+  ip: string | null
+  emailDomain: string
+  scannedDomain: string
+  /** Defaults to Date.now(). Test-injectable. */
+  now?: Date
+}
+
+export type RateLimitCheckResult =
+  | { allowed: true }
+  | {
+      allowed: false
+      dimension: RateLimitDimension
+      /** Human-friendly limit description for logging only. Never shown
+       *  to the prospect (the public response is generic per quality bar #6). */
+      detail: string
+    }
+
+/**
+ * Check all 4 dimensions. Returns allowed=true only if every dimension
+ * has headroom. On block, returns the first dimension that tripped — used
+ * for telemetry, not for prospect-facing UX.
+ */
+export async function checkScanRateLimits(
+  db: D1Database,
+  input: RateLimitCheckInput
+): Promise<RateLimitCheckResult> {
+  const now = input.now ?? new Date()
+  const since24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString()
+  const since7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const since30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString()
+
+  // 1. Per IP / 24h
+  if (input.ip) {
+    const n = await countScanRequestsByIp(db, input.ip, since24h)
+    if (n >= RATE_LIMITS.per_ip_24h) {
+      return {
+        allowed: false,
+        dimension: 'per_ip',
+        detail: `ip ${input.ip} has ${n} scans in last 24h (limit ${RATE_LIMITS.per_ip_24h})`,
+      }
+    }
+  }
+
+  // 2. Per email domain / 7d. Skips if the email is from one of the major
+  //    free providers (gmail.com, outlook.com, yahoo.com etc.) — those
+  //    domains aren't a meaningful identity for rate-limiting and would
+  //    incorrectly block any prospect after one gmail user submits. Per-IP
+  //    + magic-link verification cover the abuse vector for free-mail.
+  if (input.emailDomain && !FREE_EMAIL_DOMAINS.has(input.emailDomain)) {
+    const n = await countScanRequestsByEmailDomain(db, input.emailDomain, since7d)
+    if (n >= RATE_LIMITS.per_email_domain_7d) {
+      return {
+        allowed: false,
+        dimension: 'per_email_domain',
+        detail: `email domain ${input.emailDomain} has ${n} scans in last 7d (limit ${RATE_LIMITS.per_email_domain_7d})`,
+      }
+    }
+  }
+
+  // 3. Per scanned domain / 30d (only completed scans count — refused
+  //    thin-footprint or pending rows don't lock out a legitimate retry).
+  const m = await countCompletedScansByDomain(db, input.scannedDomain, since30d)
+  if (m >= RATE_LIMITS.per_domain_30d) {
+    return {
+      allowed: false,
+      dimension: 'per_domain',
+      detail: `scanned domain ${input.scannedDomain} already has ${m} completed scans in last 30d (limit ${RATE_LIMITS.per_domain_30d})`,
+    }
+  }
+
+  // 4. Global / 24h
+  const g = await countScanRequestsSince(db, since24h)
+  if (g >= RATE_LIMITS.global_24h) {
+    return {
+      allowed: false,
+      dimension: 'global',
+      detail: `global has ${g} scans in last 24h (limit ${RATE_LIMITS.global_24h})`,
+    }
+  }
+
+  return { allowed: true }
+}
+
+/**
+ * Free email providers that should NOT count against the per-email-domain
+ * dimension (every gmail user shouldn't lock out every other gmail user
+ * for 7 days). The per-IP and magic-link verification dimensions still
+ * gate abuse from free-mail; this set only neutralizes the email-domain
+ * dimension.
+ */
+const FREE_EMAIL_DOMAINS = new Set([
+  'gmail.com',
+  'googlemail.com',
+  'outlook.com',
+  'hotmail.com',
+  'live.com',
+  'msn.com',
+  'yahoo.com',
+  'ymail.com',
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  'aol.com',
+  'protonmail.com',
+  'proton.me',
+  'pm.me',
+  'fastmail.com',
+  'fastmail.fm',
+  'zoho.com',
+  'gmx.com',
+  'gmx.us',
+  'mail.com',
+])

--- a/src/lib/diagnostic/render.ts
+++ b/src/lib/diagnostic/render.ts
@@ -1,0 +1,449 @@
+/**
+ * Anti-fabrication renderer for the diagnostic email (#598).
+ *
+ * The diagnostic report has 5 sections (mirroring the existing
+ * intelligence_brief structure in `dossier.ts`):
+ *
+ *   1. Business Overview
+ *   2. Owner / Decision-Maker Profile
+ *   3. Technology & Operations Assessment
+ *   4. Engagement Opportunity
+ *   5. Conversation Starters
+ *
+ * Each section is rendered ONLY from authored signals (database
+ * enrichment rows) — never invented to fill out the report. CLAUDE.md
+ * P0 compliance: every line in a client-facing diagnostic must come
+ * from data we actually have. Per the scoping doc:
+ *
+ *   | Section          | Render condition                            | Else                       |
+ *   |------------------|---------------------------------------------|----------------------------|
+ *   | Business Overview| google_places returned a match              | Don't render               |
+ *   | Owner Profile    | website OR outscraper has owner_name        | "Owner not publicly        |
+ *   |                  |                                             |  identified" (NOT invented)|
+ *   | Tech & Ops       | website_analysis ran (null = real signal)   | OK — null IS a finding     |
+ *   | Engagement Opp.  | review_synthesis returned >=2 problems with | Render only digital-maturity|
+ *   |                  | confidence >= medium                        | gap, no padded extras      |
+ *   | Conversation     | >=3 evidence-anchored facts                 | Omit section entirely      |
+ *
+ * The intelligence_brief markdown produced by Claude is used ONLY as
+ * an "additional context" appendix when emitted — it is not the
+ * structural backbone of the email, because Claude's prompt instructs
+ * it to fill all 5 sections (Pattern A risk per CLAUDE.md). The
+ * structural sections come from the authored enrichment rows in the
+ * database via this renderer.
+ */
+
+import type { Entity } from '../db/entities'
+import { listContext } from '../db/context'
+
+export interface RenderedSection {
+  /** Stable id for the email template. */
+  id:
+    | 'business_overview'
+    | 'owner_profile'
+    | 'tech_ops'
+    | 'engagement_opportunity'
+    | 'conversation_starters'
+  title: string
+  /** When false, the email template skips this section entirely. */
+  rendered: boolean
+  /** When rendered=false but skipReason is set, the email template may
+   *  still render a one-line "Insufficient data — N/A" placeholder. The
+   *  default behavior is to omit the section silently. */
+  insufficientDataNote?: string
+  /** HTML-safe content lines. Each is escaped at render time. */
+  bullets?: string[]
+  /** Optional intro paragraph. */
+  paragraph?: string
+}
+
+export interface RenderedReport {
+  /** True if at least one section rendered (i.e., the email is worth sending
+   *  with structural content). When false the email template falls back to
+   *  a "we couldn't gather enough public footprint" paragraph instead of
+   *  shipping an empty 5-section shell. */
+  hasContent: boolean
+  sections: RenderedSection[]
+  /** Optional appendix containing the Claude-generated narrative brief.
+   *  Rendered after the structured sections when present. The structured
+   *  sections are the source of truth for client-facing claims; the
+   *  narrative is informational. */
+  appendixMarkdown: string | null
+}
+
+/**
+ * Build the rendered report from the entity's enrichment context. The
+ * passed-in `briefMarkdown` is the optional intelligence_brief text from
+ * Claude — included as the "additional context" appendix only.
+ */
+export async function renderDiagnosticReport(
+  db: D1Database,
+  entity: Entity,
+  briefMarkdown: string | null
+): Promise<RenderedReport> {
+  const enrichment = await listContext(db, entity.id, { type: 'enrichment' })
+
+  // Index enrichment metadata by source for quick lookup. Each key is
+  // the source name; value is the JSON-parsed metadata or null.
+  const meta = new Map<string, Record<string, unknown> | null>()
+  for (const row of enrichment) {
+    if (!meta.has(row.source)) {
+      try {
+        meta.set(row.source, row.metadata ? JSON.parse(row.metadata) : null)
+      } catch {
+        meta.set(row.source, null)
+      }
+    }
+  }
+
+  const sections: RenderedSection[] = [
+    renderBusinessOverview(entity, meta),
+    renderOwnerProfile(entity, meta),
+    renderTechOps(entity, meta),
+    renderEngagementOpportunity(entity, meta),
+    renderConversationStarters(entity, meta),
+  ]
+
+  const hasContent = sections.some((s) => s.rendered)
+  return {
+    hasContent,
+    sections,
+    appendixMarkdown: briefMarkdown && briefMarkdown.trim() ? briefMarkdown : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section renderers — each enforces an authored-data gate.
+// ---------------------------------------------------------------------------
+
+function renderBusinessOverview(
+  entity: Entity,
+  meta: Map<string, Record<string, unknown> | null>
+): RenderedSection {
+  const places = meta.get('google_places')
+  const outscraper = meta.get('outscraper')
+  // Render only if Google Places (or Outscraper) actually matched. A scan
+  // that didn't get a place match has no business overview to write.
+  if (!places && !outscraper) {
+    return {
+      id: 'business_overview',
+      title: 'Business Overview',
+      rendered: false,
+    }
+  }
+
+  const bullets: string[] = []
+  bullets.push(`Name: ${entity.name}`)
+  if (entity.area) bullets.push(`Area: ${entity.area}`)
+  const rating = numberFrom(places, 'rating')
+  const reviewCount = numberFrom(places, 'reviewCount') ?? numberFrom(outscraper, 'review_count')
+  if (rating != null && reviewCount != null && reviewCount > 0) {
+    bullets.push(`Google rating: ${rating} stars (${reviewCount} reviews)`)
+  } else if (reviewCount != null && reviewCount > 0) {
+    bullets.push(`Google reviews: ${reviewCount}`)
+  }
+  const status = stringFrom(places, 'businessStatus')
+  if (status) bullets.push(`Listing status: ${status}`)
+  if (entity.website) bullets.push(`Website: ${entity.website}`)
+  if (entity.phone) bullets.push(`Phone: ${entity.phone}`)
+
+  return {
+    id: 'business_overview',
+    title: 'Business Overview',
+    rendered: bullets.length > 0,
+    bullets,
+  }
+}
+
+function renderOwnerProfile(
+  _entity: Entity,
+  meta: Map<string, Record<string, unknown> | null>
+): RenderedSection {
+  const websiteAnalysis = meta.get('website_analysis')
+  const outscraper = meta.get('outscraper')
+  const deepWebsite = meta.get('deep_website')
+
+  // Render only when we ran at least one of the modules that could
+  // produce owner data. With zero source signals the section is
+  // structurally absent — not "Insufficient data", not "not publicly
+  // identified" (rendering either of those for a row with no signals
+  // is itself fabrication: it implies we looked).
+  if (!websiteAnalysis && !outscraper && !deepWebsite) {
+    return {
+      id: 'owner_profile',
+      title: 'Owner / Decision-Maker Profile',
+      rendered: false,
+    }
+  }
+
+  // Owner name comes from one of three authored sources. Never invented.
+  let ownerName: string | null = null
+  let foundingYear: number | null = null
+  let teamSize: number | null = null
+
+  ownerName = stringFrom(websiteAnalysis, 'owner_name') ?? ownerName
+  if (!ownerName) ownerName = stringFrom(outscraper, 'owner_name') ?? ownerName
+  if (!ownerName && deepWebsite) {
+    const op = (deepWebsite as Record<string, unknown>).owner_profile as
+      | Record<string, unknown>
+      | undefined
+    if (op && typeof op.name === 'string') ownerName = op.name
+  }
+
+  foundingYear =
+    numberFrom(websiteAnalysis, 'founding_year') ??
+    (deepWebsite
+      ? numberFrom(
+          ((deepWebsite as Record<string, unknown>).business_profile as
+            | Record<string, unknown>
+            | undefined) ?? null,
+          'founding_year'
+        )
+      : null)
+
+  teamSize = numberFrom(websiteAnalysis, 'team_size') ?? teamSize
+
+  // If we have nothing, render an explicit "not publicly identified"
+  // placeholder rather than inventing a name. Never silently fill.
+  const bullets: string[] = []
+  if (ownerName) {
+    bullets.push(`Owner / decision-maker: ${ownerName}`)
+  } else {
+    bullets.push('Owner / decision-maker: not publicly identified')
+  }
+  if (foundingYear) bullets.push(`Founded: ${foundingYear}`)
+  if (teamSize) bullets.push(`Apparent team size: ~${teamSize}`)
+
+  return {
+    id: 'owner_profile',
+    title: 'Owner / Decision-Maker Profile',
+    rendered: bullets.length > 0,
+    bullets,
+    insufficientDataNote: ownerName
+      ? undefined
+      : 'We list "not publicly identified" rather than guessing — the assessment call is where we confirm.',
+  }
+}
+
+function renderTechOps(
+  _entity: Entity,
+  meta: Map<string, Record<string, unknown> | null>
+): RenderedSection {
+  const websiteAnalysis = meta.get('website_analysis')
+  const outscraper = meta.get('outscraper')
+
+  if (!websiteAnalysis && !outscraper) {
+    return {
+      id: 'tech_ops',
+      title: 'Technology & Operations',
+      rendered: false,
+    }
+  }
+
+  const bullets: string[] = []
+
+  // Detected tools.
+  const techStack = (websiteAnalysis as Record<string, unknown> | null)?.tech_stack as
+    | Record<string, unknown>
+    | undefined
+  if (techStack) {
+    const detected: string[] = []
+    for (const key of ['scheduling', 'crm', 'reviews', 'payments', 'communication']) {
+      const arr = techStack[key]
+      if (Array.isArray(arr) && arr.length > 0) {
+        detected.push(...arr.filter((v): v is string => typeof v === 'string'))
+      }
+    }
+    if (detected.length > 0) {
+      bullets.push(`Tools detected on the site: ${detected.join(', ')}`)
+    } else {
+      bullets.push('Tools detected on the site: none we could identify')
+    }
+
+    const missing: string[] = []
+    const sched = techStack.scheduling
+    const crm = techStack.crm
+    const reviews = techStack.reviews
+    if (Array.isArray(sched) && sched.length === 0) missing.push('scheduling')
+    if (Array.isArray(crm) && crm.length === 0) missing.push('CRM')
+    if (Array.isArray(reviews) && reviews.length === 0) missing.push('review management')
+    if (missing.length > 0) {
+      bullets.push(`Apparent gaps: no public ${missing.join(', no public ')}`)
+    }
+  }
+
+  // Booking link / online presence (outscraper).
+  const bookingLink = stringFrom(outscraper, 'booking_link')
+  if (bookingLink) {
+    bullets.push('Online booking visible on Google profile.')
+  }
+
+  // Site quality (heuristic from website_analysis).
+  const quality = stringFrom(websiteAnalysis, 'quality')
+  if (quality) bullets.push(`Site quality (heuristic): ${quality}`)
+
+  return {
+    id: 'tech_ops',
+    title: 'Technology & Operations',
+    rendered: bullets.length > 0,
+    bullets,
+  }
+}
+
+function renderEngagementOpportunity(
+  _entity: Entity,
+  meta: Map<string, Record<string, unknown> | null>
+): RenderedSection {
+  const synthesis = meta.get('review_synthesis')
+  const deepWebsite = meta.get('deep_website')
+
+  // Operational problems with confidence >= medium.
+  const problems = (synthesis as Record<string, unknown> | null)?.operational_problems
+  const qualified: Array<{ problem: string; evidence: string }> = []
+  if (Array.isArray(problems)) {
+    for (const p of problems) {
+      if (typeof p !== 'object' || p === null) continue
+      const rec = p as Record<string, unknown>
+      const problem = typeof rec.problem === 'string' ? rec.problem : null
+      const confidence = typeof rec.confidence === 'string' ? rec.confidence.toLowerCase() : ''
+      const evidence = typeof rec.evidence === 'string' ? rec.evidence : ''
+      if (!problem) continue
+      if (confidence === 'high' || confidence === 'medium') {
+        qualified.push({ problem, evidence })
+      }
+    }
+  }
+
+  // Digital-maturity gap from deep_website.
+  let maturityGap: string | null = null
+  if (deepWebsite) {
+    const dm = (deepWebsite as Record<string, unknown>).digital_maturity as
+      | Record<string, unknown>
+      | undefined
+    if (dm) {
+      const score = typeof dm.score === 'number' ? dm.score : null
+      const reasoning = typeof dm.reasoning === 'string' ? dm.reasoning.trim() : ''
+      if (score != null && score < 7 && reasoning) {
+        maturityGap = `Digital maturity score: ${score}/10 — ${reasoning}`
+      } else if (score != null && score < 7) {
+        maturityGap = `Digital maturity score: ${score}/10`
+      }
+    }
+  }
+
+  const bullets: string[] = []
+  // Per the scoping doc: render top problems only when >=2 are qualified.
+  // Otherwise render only the digital-maturity gap (no padded fabrications).
+  if (qualified.length >= 2) {
+    for (const q of qualified.slice(0, 3)) {
+      const line = q.evidence ? `${q.problem} — ${q.evidence}` : q.problem
+      bullets.push(line)
+    }
+  }
+  if (maturityGap) bullets.push(maturityGap)
+
+  if (bullets.length === 0) {
+    return {
+      id: 'engagement_opportunity',
+      title: 'Engagement Opportunity',
+      rendered: false,
+      insufficientDataNote:
+        'Not enough corroborated public signal to identify specific operational opportunities — the assessment conversation is where these usually surface.',
+    }
+  }
+
+  return {
+    id: 'engagement_opportunity',
+    title: 'Engagement Opportunity',
+    rendered: true,
+    paragraph:
+      'Up to three observations from the public footprint, only when corroborated by multiple signals. We surface what we can defend with evidence; the rest waits for the conversation.',
+    bullets,
+  }
+}
+
+function renderConversationStarters(
+  entity: Entity,
+  meta: Map<string, Record<string, unknown> | null>
+): RenderedSection {
+  // Pull evidence-anchored facts: review themes, services, certifications.
+  const facts: string[] = []
+  const synthesis = meta.get('review_synthesis')
+  const websiteAnalysis = meta.get('website_analysis')
+  const deepWebsite = meta.get('deep_website')
+  const places = meta.get('google_places')
+
+  if (synthesis) {
+    const themes = (synthesis as Record<string, unknown>).top_themes
+    if (Array.isArray(themes) && themes.length > 0) {
+      const topTheme = themes.find((t): t is string => typeof t === 'string' && t.trim().length > 0)
+      if (topTheme) {
+        facts.push(`Reviews most often mention: ${topTheme}`)
+      }
+    }
+  }
+
+  const reviewCount = numberFrom(places, 'reviewCount')
+  const rating = numberFrom(places, 'rating')
+  if (reviewCount != null && reviewCount >= 5 && rating != null) {
+    facts.push(`${reviewCount} Google reviews averaging ${rating} stars`)
+  }
+
+  const services = (websiteAnalysis as Record<string, unknown> | null)?.services
+  if (Array.isArray(services) && services.length > 0) {
+    const top = services.filter((s): s is string => typeof s === 'string').slice(0, 3)
+    if (top.length > 0) facts.push(`Services listed on the website: ${top.join(', ')}`)
+  }
+
+  if (deepWebsite) {
+    const bp = (deepWebsite as Record<string, unknown>).business_profile as
+      | Record<string, unknown>
+      | undefined
+    if (bp) {
+      const certs = Array.isArray(bp.certifications)
+        ? (bp.certifications.filter((s): s is string => typeof s === 'string') as string[])
+        : []
+      if (certs.length > 0) {
+        facts.push(`Certifications visible: ${certs.slice(0, 3).join(', ')}`)
+      }
+    }
+  }
+
+  // Anti-fabrication rule: omit the section if we have <3 evidence-anchored
+  // facts. A single fact "you have a website" is not a conversation starter
+  // worth shipping in a credibility-driven email.
+  if (facts.length < 3) {
+    return {
+      id: 'conversation_starters',
+      title: 'Conversation Starters',
+      rendered: false,
+    }
+  }
+
+  void entity // entity not used directly here; facts already capture identity
+  return {
+    id: 'conversation_starters',
+    title: 'What stood out',
+    rendered: true,
+    paragraph: 'A few specifics from your public footprint we would lead with in a conversation.',
+    bullets: facts.slice(0, 4),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — extract typed values from a metadata record without throwing.
+// ---------------------------------------------------------------------------
+
+function stringFrom(m: Record<string, unknown> | null | undefined, key: string): string | null {
+  if (!m) return null
+  const v = m[key]
+  if (typeof v === 'string' && v.trim()) return v.trim()
+  return null
+}
+
+function numberFrom(m: Record<string, unknown> | null | undefined, key: string): number | null {
+  if (!m) return null
+  const v = m[key]
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  return null
+}

--- a/src/lib/email/diagnostic-email.ts
+++ b/src/lib/email/diagnostic-email.ts
@@ -1,0 +1,301 @@
+/**
+ * Email templates for the public diagnostic scan flow (#598).
+ *
+ * Three templates:
+ *   1. Magic-link verification     — "click to confirm and run your scan"
+ *   2. Diagnostic report           — full 5-section report with /book CTA
+ *   3. Thin-footprint refusal      — "we couldn't read enough; let's talk"
+ *
+ * All follow the SMD Services voice from CLAUDE.md / Decision Stack #20:
+ *   - "we" / "our team", never "I" / "the consultant"
+ *   - No fixed timeframes ("we start with a conversation", not "60-min call")
+ *   - No fabricated commitments (no "replies within 1 business day")
+ *   - "Solution" not "systems" in marketing context
+ *   - No published dollar amounts
+ *
+ * The report template structurally renders pre-validated sections from
+ * `RenderedReport` (see `src/lib/diagnostic/render.ts`); it does not
+ * touch raw enrichment data. Anti-fabrication enforcement lives in the
+ * renderer, not here.
+ */
+
+import { BRAND_NAME } from '../config/brand'
+import type { RenderedReport, RenderedSection } from '../diagnostic/render'
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+// ---------------------------------------------------------------------------
+// 1. Magic-link verification
+// ---------------------------------------------------------------------------
+
+export interface ScanVerificationEmailInput {
+  /** Verification URL the prospect clicks to start their scan. Already
+   *  signed and ready to embed. */
+  verifyUrl: string
+  /** The domain they asked us to scan. Echoed in the body so they can
+   *  confirm they got the right link. */
+  scannedDomain: string
+}
+
+/**
+ * Sent immediately after a successful POST /api/scan/start. Clicking the
+ * link verifies the email is reachable + the scan was actually requested,
+ * and triggers the pruned enrichment pipeline via ctx.waitUntil.
+ *
+ * Voice rules: "we" only. No promises about turnaround time. The link
+ * itself is the implicit "we'll send your report when you click" — no
+ * uncontracted commitment beyond that.
+ */
+export function scanVerificationEmailHtml(input: ScanVerificationEmailInput): string {
+  const verifyUrl = escapeHtml(input.verifyUrl)
+  const domain = escapeHtml(input.scannedDomain)
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;">
+      <h1 style="font-size:20px;font-weight:700;color:#0f172a;margin:0 0 8px;">Confirm your scan</h1>
+      <p style="font-size:14px;color:#64748b;margin:0 0 24px;">${BRAND_NAME} &middot; Operational Readiness Scan</p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        We received a request to run an operational scan for <strong>${domain}</strong>.
+        Click the button below to confirm and we'll get started.
+      </p>
+
+      <p style="margin:24px 0;">
+        <a href="${verifyUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 28px;border-radius:6px;">
+          Confirm and run my scan
+        </a>
+      </p>
+
+      <p style="font-size:13px;color:#64748b;margin:0 0 16px;word-break:break-all;">
+        Or paste this link into your browser:<br>
+        <a href="${verifyUrl}" style="color:#1e40af;">${verifyUrl}</a>
+      </p>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        This link works for 24 hours. If you didn't request this, you can safely ignore this email.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+// ---------------------------------------------------------------------------
+// 2. Diagnostic report
+// ---------------------------------------------------------------------------
+
+export interface DiagnosticReportEmailInput {
+  businessName: string
+  rendered: RenderedReport
+  bookingUrl: string
+}
+
+/**
+ * The full report email. Walks the RenderedReport sections, rendering each
+ * one only when `rendered === true`. Sections marked rendered=false are
+ * either silently omitted, or — when an `insufficientDataNote` is set — a
+ * one-line italic placeholder is shown so the prospect understands we are
+ * being explicit about what we couldn't determine, rather than padding.
+ *
+ * If `rendered.hasContent === false` (no sections rendered at all), we
+ * fall back to a "we couldn't gather enough public footprint" body
+ * matching the thin-footprint email format. This is defense-in-depth: the
+ * pre-flight gate should catch most thin-footprint cases before we ever
+ * render, but a degraded LLM run that returns no signals shouldn't ship
+ * an empty 5-section shell.
+ */
+export function diagnosticReportEmailHtml(input: DiagnosticReportEmailInput): string {
+  const businessName = escapeHtml(input.businessName)
+  const bookingUrl = escapeHtml(input.bookingUrl)
+
+  const sectionsHtml = input.rendered.hasContent
+    ? input.rendered.sections
+        .map(renderSectionHtml)
+        .filter((s) => s)
+        .join('')
+    : insufficientDataFallbackHtml()
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:640px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;">
+      <p style="font-size:13px;color:#64748b;margin:0 0 4px;text-transform:uppercase;letter-spacing:0.05em;">${BRAND_NAME} &middot; Operational read</p>
+      <h1 style="font-size:24px;font-weight:700;color:#0f172a;margin:0 0 24px;">${businessName}</h1>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Here's what we read from your public footprint. Each section below comes from
+        a specific signal we found — when we couldn't find enough to back something up,
+        we say so rather than guessing.
+      </p>
+
+      ${sectionsHtml}
+
+      <div style="border-top:1px solid #e2e8f0;margin:32px 0 24px;"></div>
+
+      <h2 style="font-size:18px;font-weight:600;color:#0f172a;margin:0 0 12px;">Want to dig in?</h2>
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        The most useful next step is a short conversation. We walk through your day together,
+        understand where you're trying to go, and figure out what's in the way.
+      </p>
+
+      <p style="margin:0 0 32px;">
+        <a href="${bookingUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 28px;border-radius:6px;">
+          Pick a time
+        </a>
+      </p>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        ${BRAND_NAME} is a Phoenix-based operations consulting firm. You requested this report
+        from smd.services/scan. We don't add you to a mailing list and we don't share your
+        information with anyone else.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+function renderSectionHtml(section: RenderedSection): string {
+  if (!section.rendered) {
+    if (section.insufficientDataNote) {
+      return `
+        <h2 style="font-size:18px;font-weight:600;color:#0f172a;margin:24px 0 8px;">${escapeHtml(section.title)}</h2>
+        <p style="font-size:14px;color:#64748b;font-style:italic;margin:0 0 8px;">
+          Insufficient data — ${escapeHtml(section.insufficientDataNote)}
+        </p>`
+    }
+    return ''
+  }
+  const intro = section.paragraph
+    ? `<p style="font-size:14px;color:#475569;margin:0 0 8px;">${escapeHtml(section.paragraph)}</p>`
+    : ''
+  const list =
+    section.bullets && section.bullets.length > 0
+      ? `<ul style="margin:0 0 16px;padding-left:20px;">${section.bullets
+          .map(
+            (b) => `<li style="font-size:15px;color:#334155;margin:0 0 6px;">${escapeHtml(b)}</li>`
+          )
+          .join('')}</ul>`
+      : ''
+  const note = section.insufficientDataNote
+    ? `<p style="font-size:13px;color:#64748b;font-style:italic;margin:0 0 16px;">${escapeHtml(section.insufficientDataNote)}</p>`
+    : ''
+  return `
+    <h2 style="font-size:18px;font-weight:600;color:#0f172a;margin:24px 0 8px;">${escapeHtml(section.title)}</h2>
+    ${intro}
+    ${list}
+    ${note}`
+}
+
+function insufficientDataFallbackHtml(): string {
+  return `
+    <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+      We tried to read your public digital footprint and couldn't find enough to
+      produce a useful report. That's actually informative on its own — a thin public
+      footprint is often a sign of where we'd start. The most useful next step is a
+      short conversation.
+    </p>`
+}
+
+// ---------------------------------------------------------------------------
+// 3. Thin-footprint refusal
+// ---------------------------------------------------------------------------
+
+export interface ThinFootprintEmailInput {
+  businessName: string
+  submittedDomain: string
+  /** Machine-readable reason — used only for choosing the explanatory line.
+   *  We never echo the raw reason to the prospect. */
+  reason: string
+  bookingUrl: string
+}
+
+/**
+ * Sent when the pre-flight gate refuses the scan. Anti-fabrication-safe:
+ * we don't ship a padded report, we honestly say "we couldn't find enough"
+ * and route to the same /book CTA.
+ *
+ * The body deliberately reframes the refusal as informative — a thin
+ * public footprint is itself a starting point — rather than as a failure
+ * the prospect would resent.
+ */
+export function thinFootprintEmailHtml(input: ThinFootprintEmailInput): string {
+  const businessName = escapeHtml(input.businessName)
+  const submittedDomain = escapeHtml(input.submittedDomain)
+  const bookingUrl = escapeHtml(input.bookingUrl)
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;">
+      <p style="font-size:13px;color:#64748b;margin:0 0 4px;text-transform:uppercase;letter-spacing:0.05em;">${BRAND_NAME}</p>
+      <h1 style="font-size:22px;font-weight:700;color:#0f172a;margin:0 0 16px;">About your scan</h1>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        Thanks for trying us out for <strong>${businessName}</strong>.
+      </p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        Our scan reads what's publicly available — Google reviews, your website, business
+        listings — and we couldn't find enough public footprint on
+        <strong>${submittedDomain}</strong> to produce something useful.
+      </p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        Honestly, that's informative on its own. A thin public footprint is often
+        where we'd start — there's usually low-effort, high-leverage work to do
+        before customers can even find you. The most useful next step is a short
+        conversation.
+      </p>
+
+      <p style="margin:24px 0;">
+        <a href="${bookingUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 28px;border-radius:6px;">
+          Pick a time
+        </a>
+      </p>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        ${BRAND_NAME} is a Phoenix-based operations consulting firm.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}

--- a/src/lib/scan/normalize.ts
+++ b/src/lib/scan/normalize.ts
@@ -1,0 +1,177 @@
+/**
+ * Input normalization for the public /scan form (#598).
+ *
+ * Three jobs:
+ *   1. Validate format. Reject malformed input with a specific reason.
+ *   2. Normalize aggressively (lowercase, strip protocol/path, trim) so
+ *      our rate-limit and dedupe queries see a canonical key — otherwise a
+ *      single attacker can run scans for `https://X.com`, `http://x.com/`,
+ *      and `www.x.com` and dodge per-domain limits.
+ *   3. Filter the obvious abuse vectors at submit (disposable-email
+ *      patterns) so we never pay an Anthropic call to scan via a
+ *      throwaway address.
+ *
+ * What we deliberately don't do here:
+ *   - DNS lookup. A working MX record proves nothing about whether the
+ *     prospect actually owns the email; the magic-link click is the only
+ *     reliable proof of intent.
+ *   - WHOIS. Slow, rate-limited, and irrelevant to our use case.
+ *   - Aggressive TLD filtering. Plenty of legit Phoenix businesses use
+ *     `.co`, `.us`, `.biz`. We trust the magic-link gate for filtering.
+ */
+
+export const CONTROL_CHAR_RE = /[\r\n\0\t]/
+
+/** Disposable email providers known to be used for abuse. Case-insensitive
+ *  exact match on the email domain. Not exhaustive — defense in depth, the
+ *  magic-link gate is the actual filter. */
+const DISPOSABLE_EMAIL_DOMAINS = new Set([
+  'mailinator.com',
+  'tempmail.com',
+  'guerrillamail.com',
+  'guerrillamail.net',
+  'guerrillamail.org',
+  '10minutemail.com',
+  'yopmail.com',
+  'sharklasers.com',
+  'throwawaymail.com',
+  'fakeinbox.com',
+  'maildrop.cc',
+  'getnada.com',
+  'trashmail.com',
+  'temp-mail.org',
+  'temp-mail.io',
+  'dispostable.com',
+])
+
+export type NormalizeResult<T> = { ok: true; value: T } | { ok: false; reason: string }
+
+/**
+ * Normalize an email. Lowercases, trims, validates structurally, and
+ * rejects disposable providers.
+ */
+export function normalizeEmail(input: unknown): NormalizeResult<string> {
+  if (typeof input !== 'string') return { ok: false, reason: 'email_required' }
+  const raw = input.trim()
+  if (!raw) return { ok: false, reason: 'email_required' }
+  if (raw.length > 254) return { ok: false, reason: 'email_too_long' }
+  if (CONTROL_CHAR_RE.test(raw)) return { ok: false, reason: 'email_invalid_chars' }
+  const lower = raw.toLowerCase()
+  const at = lower.indexOf('@')
+  if (at <= 0 || at === lower.length - 1) {
+    return { ok: false, reason: 'email_invalid_format' }
+  }
+  // Exactly one @. The local-part can contain '@' only when quoted
+  // (RFC 5321 obscure path); we reject those by simple count.
+  if (lower.indexOf('@', at + 1) !== -1) {
+    return { ok: false, reason: 'email_invalid_format' }
+  }
+  const local = lower.slice(0, at)
+  const domain = lower.slice(at + 1)
+  if (!local || !domain) return { ok: false, reason: 'email_invalid_format' }
+  if (domain.indexOf('.') === -1) return { ok: false, reason: 'email_invalid_format' }
+  if (domain.startsWith('.') || domain.endsWith('.')) {
+    return { ok: false, reason: 'email_invalid_format' }
+  }
+  if (DISPOSABLE_EMAIL_DOMAINS.has(domain)) {
+    return { ok: false, reason: 'email_disposable' }
+  }
+  return { ok: true, value: lower }
+}
+
+/**
+ * Extract the domain part of a normalized email. Caller must already have
+ * passed the email through `normalizeEmail()`.
+ */
+export function emailDomain(normalizedEmail: string): string {
+  const at = normalizedEmail.indexOf('@')
+  return at === -1 ? '' : normalizedEmail.slice(at + 1)
+}
+
+/**
+ * Normalize a website / business domain. Strips protocol, path, query,
+ * leading `www.`, trailing slashes, lowercases. Rejects domains that
+ * are too short, contain spaces, or are obviously not a real domain.
+ *
+ * Returns the bare hostname, e.g. `azperfectcomfort.com` (not
+ * `https://www.azperfectcomfort.com/about`).
+ */
+export function normalizeDomain(input: unknown): NormalizeResult<string> {
+  if (typeof input !== 'string') return { ok: false, reason: 'domain_required' }
+  const raw = input.trim()
+  if (!raw) return { ok: false, reason: 'domain_required' }
+  if (raw.length > 253) return { ok: false, reason: 'domain_too_long' }
+  if (CONTROL_CHAR_RE.test(raw)) return { ok: false, reason: 'domain_invalid_chars' }
+
+  // Strip protocol + path + query. Tolerate scheme-less input by trying URL
+  // with a fake scheme first.
+  let hostname: string
+  try {
+    const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
+    const u = new URL(withScheme)
+    hostname = u.hostname
+  } catch {
+    return { ok: false, reason: 'domain_invalid_format' }
+  }
+
+  hostname = hostname.toLowerCase()
+  if (hostname.startsWith('www.')) hostname = hostname.slice(4)
+  if (!hostname) return { ok: false, reason: 'domain_invalid_format' }
+
+  // Must contain a dot and not start/end with dot or hyphen.
+  if (hostname.indexOf('.') === -1) return { ok: false, reason: 'domain_invalid_format' }
+  if (hostname.startsWith('.') || hostname.endsWith('.')) {
+    return { ok: false, reason: 'domain_invalid_format' }
+  }
+  if (hostname.startsWith('-') || hostname.endsWith('-')) {
+    return { ok: false, reason: 'domain_invalid_format' }
+  }
+  // Reject localhost, IPs, .local, .internal — not real public businesses.
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal') ||
+    /^\d+\.\d+\.\d+\.\d+$/.test(hostname)
+  ) {
+    return { ok: false, reason: 'domain_invalid_format' }
+  }
+  // Each label 1..63 chars and DNS-safe. Labels cannot start or end
+  // with a hyphen (RFC 1035) — caught here so `trailing-hyphen-.com` is
+  // rejected even though `new URL()` accepts it.
+  for (const label of hostname.split('.')) {
+    if (!label) return { ok: false, reason: 'domain_invalid_format' }
+    if (label.length > 63) return { ok: false, reason: 'domain_invalid_format' }
+    if (!/^[a-z0-9-]+$/.test(label)) {
+      return { ok: false, reason: 'domain_invalid_format' }
+    }
+    if (label.startsWith('-') || label.endsWith('-')) {
+      return { ok: false, reason: 'domain_invalid_format' }
+    }
+  }
+  return { ok: true, value: hostname }
+}
+
+/**
+ * Optional LinkedIn URL. The /scan path doesn't use LinkedIn data (per
+ * the scoping doc scope cut), but we capture it for the internal pipeline
+ * if the prospect converts to a booked call.
+ */
+export function normalizeLinkedinUrl(input: unknown): NormalizeResult<string | null> {
+  if (input == null || input === '') return { ok: true, value: null }
+  if (typeof input !== 'string') return { ok: false, reason: 'linkedin_invalid' }
+  const raw = input.trim()
+  if (!raw) return { ok: true, value: null }
+  if (raw.length > 500) return { ok: false, reason: 'linkedin_too_long' }
+  if (CONTROL_CHAR_RE.test(raw)) return { ok: false, reason: 'linkedin_invalid_chars' }
+  let parsed: URL
+  try {
+    parsed = new URL(raw.startsWith('http') ? raw : `https://${raw}`)
+  } catch {
+    return { ok: false, reason: 'linkedin_invalid' }
+  }
+  const host = parsed.hostname.toLowerCase()
+  if (host !== 'linkedin.com' && !host.endsWith('.linkedin.com')) {
+    return { ok: false, reason: 'linkedin_wrong_host' }
+  }
+  return { ok: true, value: parsed.toString() }
+}

--- a/src/lib/scan/tokens.ts
+++ b/src/lib/scan/tokens.ts
@@ -1,0 +1,78 @@
+/**
+ * Magic-link token utilities for the diagnostic scan flow (#598).
+ *
+ * The token is the proof-of-intent gate for the pruned enrichment pipeline.
+ * Without verification, an attacker could submit 100 forms with throwaway
+ * emails and burn $14 of Anthropic spend in seconds; with verification,
+ * each submission costs zero until a real inbox clicks the link.
+ *
+ * Storage contract (mirrors the existing booking-token pattern at
+ * `src/lib/booking/tokens.ts`):
+ *   - The raw token is generated server-side, returned to the caller for
+ *     embedding in the magic-link URL, and *immediately discarded*.
+ *   - The DB stores only the SHA-256 hash. A leaked DB dump cannot be
+ *     replayed to reach a verify endpoint.
+ *   - The verify endpoint hashes the inbound token and looks up the row.
+ *
+ * Expiry: 24 hours from `created_at`. Enforced server-side at verify time
+ * (not via DB index TTL) so we can return a clear "link expired" UX
+ * instead of silently 404ing.
+ */
+
+const TOKEN_BYTES = 32
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Generate a fresh magic-link token. Returns the raw token (for embedding
+ * in the email URL) and its SHA-256 hash (for storing in the DB).
+ *
+ * The raw token uses base64url for URL-safety. 32 bytes ~ 256 bits of
+ * entropy = no realistic guess attack.
+ */
+export async function generateScanToken(): Promise<{
+  token: string
+  hash: string
+}> {
+  const bytes = new Uint8Array(TOKEN_BYTES)
+  crypto.getRandomValues(bytes)
+  const token = base64urlEncode(bytes)
+  const hash = await hashScanToken(token)
+  return { token, hash }
+}
+
+/**
+ * Compute the SHA-256 hash of a scan token. Used both at insert time
+ * (storing the hash) and at verify time (looking up the row by hash).
+ */
+export async function hashScanToken(token: string): Promise<string> {
+  const data = new TextEncoder().encode(token)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64urlEncode(new Uint8Array(digest))
+}
+
+/**
+ * Check whether a token is still within its TTL window relative to a
+ * `created_at` ISO8601 timestamp. Returns false on parse failure.
+ */
+export function isScanTokenFresh(createdAtIso: string, nowMs: number = Date.now()): boolean {
+  const created = Date.parse(createdAtIso)
+  if (Number.isNaN(created)) return false
+  return nowMs - created < TOKEN_TTL_MS
+}
+
+/**
+ * Build the verification URL the prospect clicks in their inbox. The
+ * `baseUrl` is `APP_BASE_URL` so the link points at the marketing host
+ * (smd.services), not a subdomain.
+ */
+export function buildScanVerifyUrl(baseUrl: string, token: string): string {
+  const url = new URL(`/scan/verify/${encodeURIComponent(token)}`, baseUrl)
+  return url.toString()
+}
+
+// Standard base64url encoding (no padding).
+function base64urlEncode(bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/src/pages/api/scan/start.ts
+++ b/src/pages/api/scan/start.ts
@@ -1,0 +1,174 @@
+/**
+ * POST /api/scan/start — public Engine 1 diagnostic scan submission (#598).
+ *
+ * Flow:
+ *   1. Parse + validate the form (domain, email, optional linkedin_url).
+ *   2. Run the 4-dimensional rate limit (per IP / per email domain /
+ *      per scanned domain / global).
+ *   3. Generate magic-link token, persist scan_request in
+ *      `pending_verification` state.
+ *   4. Email the magic-link to the requester. Click verifies email
+ *      reachability and intent, and triggers the pruned enrichment
+ *      pipeline via ctx.waitUntil at /api/scan/verify.
+ *
+ * Public response is INTENTIONALLY MINIMAL per the scoping doc Bar #6
+ * (anti-competitor-intel): "scan started — check your email" with zero
+ * specifics about findings, signals, or next-step content. The full
+ * report only ever lives in the email.
+ *
+ * Honeypot field name 'website' (matching contact.ts) — not a true field;
+ * a real form leaves it empty. The submitted business URL is captured
+ * via 'domain'.
+ */
+
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { rateLimitByIp } from '../../../lib/booking/rate-limit'
+import { checkScanRateLimits, RATE_LIMITS } from '../../../lib/diagnostic/rate-limit'
+import {
+  normalizeEmail,
+  normalizeDomain,
+  normalizeLinkedinUrl,
+  emailDomain,
+} from '../../../lib/scan/normalize'
+import { createScanRequest } from '../../../lib/db/scan-requests'
+import { generateScanToken, buildScanVerifyUrl } from '../../../lib/scan/tokens'
+import { sendEmail } from '../../../lib/email/resend'
+import { scanVerificationEmailHtml } from '../../../lib/email/diagnostic-email'
+
+export const POST: APIRoute = async ({ request }) => {
+  // -- IP-coarse rate limit (10/hr per IP). Matches the booking pattern
+  //    so a hammered attacker is throttled at the edge before we hit D1
+  //    for the 4-dimensional check.
+  const clientIp = request.headers.get('cf-connecting-ip') ?? null
+  const coarse = await rateLimitByIp(env.BOOKING_CACHE, 'scan-start', clientIp ?? undefined)
+  if (!coarse.allowed) {
+    return jsonResponse(429, { error: 'Too many requests, please try again later.' })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON' })
+  }
+
+  // Honeypot — bots fill the hidden 'company_url' field, humans don't.
+  if (typeof body.company_url === 'string' && body.company_url.trim() !== '') {
+    // Pretend success — don't tell bots they were detected.
+    return jsonResponse(200, { ok: true })
+  }
+
+  // Validate inputs.
+  const emailR = normalizeEmail(body.email)
+  if (!emailR.ok) return validationError({ email: messageForReason(emailR.reason) })
+
+  const domainR = normalizeDomain(body.domain)
+  if (!domainR.ok) return validationError({ domain: messageForReason(domainR.reason) })
+
+  const linkedinR = normalizeLinkedinUrl(body.linkedin_url)
+  if (!linkedinR.ok) return validationError({ linkedin_url: messageForReason(linkedinR.reason) })
+
+  const email = emailR.value
+  const domain = domainR.value
+  const linkedin = linkedinR.value
+
+  // -- 4-dimensional rate limit. On block, we deliberately return a
+  //    generic "scan started" success to avoid leaking which dimension
+  //    was tripped (anti-competitor-intel).
+  const rl = await checkScanRateLimits(env.DB, {
+    ip: clientIp,
+    emailDomain: emailDomain(email),
+    scannedDomain: domain,
+  })
+  if (!rl.allowed) {
+    console.warn(`[api/scan/start] rate limited dimension=${rl.dimension} detail=${rl.detail}`)
+    // Generic "ok" response — we already started shedding the request
+    // so no token is generated and no email is sent. The prospect will
+    // wonder why no email arrived; rate-limit cap is small enough that
+    // legitimate prospects rarely hit it.
+    return jsonResponse(200, { ok: true })
+  }
+
+  // Generate token, persist scan_request, send magic-link.
+  const { token, hash } = await generateScanToken()
+  let scanRequestId: string
+  try {
+    const row = await createScanRequest(env.DB, {
+      email,
+      domain,
+      linkedin_url: linkedin,
+      verification_token_hash: hash,
+      request_ip: clientIp,
+    })
+    scanRequestId = row.id
+  } catch (err) {
+    console.error('[api/scan/start] failed to insert scan_request:', err)
+    return jsonResponse(500, { error: 'Failed to start scan' })
+  }
+
+  const baseUrl = env.APP_BASE_URL ?? 'https://smd.services'
+  const verifyUrl = buildScanVerifyUrl(baseUrl, token)
+  try {
+    const result = await sendEmail(env.RESEND_API_KEY, {
+      to: email,
+      subject: `Confirm your operational scan — ${domain}`,
+      html: scanVerificationEmailHtml({ verifyUrl, scannedDomain: domain }),
+    })
+    if (!result.success) {
+      console.error('[api/scan/start] verification email failed:', result.error)
+      // Don't surface the failure to the prospect — the public response
+      // shape is uniform whether email send succeeds, fails, or is rate
+      // limited. The audit log captures the failure.
+    }
+  } catch (err) {
+    console.error('[api/scan/start] verification email threw:', err)
+  }
+
+  return jsonResponse(200, { ok: true, id: scanRequestId })
+}
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function validationError(fields: Record<string, string>): Response {
+  return jsonResponse(400, { error: 'Validation failed', fields })
+}
+
+function messageForReason(reason: string): string {
+  switch (reason) {
+    case 'email_required':
+      return 'Email is required'
+    case 'email_too_long':
+      return 'Email is too long'
+    case 'email_invalid_chars':
+      return 'Email contains invalid characters'
+    case 'email_invalid_format':
+      return 'Please enter a valid email address'
+    case 'email_disposable':
+      return 'Please use a regular business email — disposable inboxes are not accepted'
+    case 'domain_required':
+      return 'Business website is required'
+    case 'domain_too_long':
+      return 'Domain is too long'
+    case 'domain_invalid_chars':
+      return 'Domain contains invalid characters'
+    case 'domain_invalid_format':
+      return 'Please enter a valid business domain'
+    case 'linkedin_invalid':
+    case 'linkedin_too_long':
+    case 'linkedin_invalid_chars':
+      return 'LinkedIn URL looks malformed'
+    case 'linkedin_wrong_host':
+      return 'LinkedIn URL must point at linkedin.com'
+    default:
+      return 'Invalid input'
+  }
+}
+
+// Suppress dead-code warning in environments that don't use this constant.
+void RATE_LIMITS

--- a/src/pages/api/scan/verify.ts
+++ b/src/pages/api/scan/verify.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/scan/verify?token=... — magic-link click handler (#598).
+ *
+ * Verifies the inbound token against the SHA-256 hash on file, marks
+ * the scan_request as `verified`, and kicks off the pruned enrichment
+ * pipeline via `ctx.waitUntil()` so the response returns instantly.
+ *
+ * Per Captain's `feedback_ctx_waituntil_for_heavy_work` memory: heavy
+ * work in Workers request handlers MUST go through ctx.waitUntil — a
+ * pipeline that issues 4 Claude calls would otherwise blow the 30s
+ * single-invocation budget AND wedge the prospect's verification UX.
+ *
+ * The verify endpoint is also used directly by the Astro page
+ * `/scan/verify/[token].astro` via a `redirect=1` query string, so the
+ * UX is: click magic-link → land on a friendly page → that page POSTs
+ * here for the actual verification + side-effects.
+ *
+ * The endpoint exposes both GET (link click, redirects to confirmation
+ * page) and POST (Astro page programmatic call). They share the same
+ * verify logic.
+ */
+
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { hashScanToken, isScanTokenFresh } from '../../../lib/scan/tokens'
+import { getScanRequestByTokenHash, markScanVerified } from '../../../lib/db/scan-requests'
+import { runDiagnosticScan } from '../../../lib/diagnostic'
+
+interface VerifyResponse {
+  ok: boolean
+  status:
+    | 'verified'
+    | 'already_completed'
+    | 'expired'
+    | 'invalid_token'
+    | 'thin_footprint'
+    | 'failed'
+  /** Domain echoed back so the confirmation page can name the scan. Never
+   *  echoed when the token is invalid (no info leak). */
+  domain?: string
+}
+
+async function handleVerify(token: string, locals: App.Locals): Promise<VerifyResponse> {
+  if (!token || typeof token !== 'string') return { ok: false, status: 'invalid_token' }
+
+  const hash = await hashScanToken(token)
+  const row = await getScanRequestByTokenHash(env.DB, hash)
+  if (!row) return { ok: false, status: 'invalid_token' }
+
+  if (row.scan_status === 'completed') {
+    return { ok: true, status: 'already_completed', domain: row.domain }
+  }
+  if (row.scan_status === 'thin_footprint') {
+    return { ok: true, status: 'thin_footprint', domain: row.domain }
+  }
+  if (row.scan_status === 'failed') {
+    return { ok: false, status: 'failed', domain: row.domain }
+  }
+
+  // Token must still be within its 24-hour TTL.
+  if (!isScanTokenFresh(row.created_at)) {
+    return { ok: false, status: 'expired', domain: row.domain }
+  }
+
+  // Mark verified and kick off the scan via waitUntil.
+  await markScanVerified(env.DB, row.id)
+
+  const ctx = locals.cfContext
+  const scanPromise = runDiagnosticScan(
+    {
+      DB: env.DB,
+      ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+      GOOGLE_PLACES_API_KEY: env.GOOGLE_PLACES_API_KEY,
+      OUTSCRAPER_API_KEY: env.OUTSCRAPER_API_KEY,
+      RESEND_API_KEY: env.RESEND_API_KEY,
+      APP_BASE_URL: env.APP_BASE_URL,
+    },
+    row.id
+  )
+
+  if (ctx?.waitUntil) {
+    ctx.waitUntil(scanPromise)
+  } else {
+    // Dev fallback — no execution context. Fire-and-forget the promise
+    // and swallow rejections so an open handle doesn't crash the test
+    // runner. Production always has a cfContext, so this branch is for
+    // unit tests / `astro dev`.
+    scanPromise.catch((err) => console.error('[api/scan/verify] dev fallback scan threw:', err))
+  }
+
+  return { ok: true, status: 'verified', domain: row.domain }
+}
+
+export const GET: APIRoute = async ({ url, locals }) => {
+  const token = url.searchParams.get('token') ?? ''
+  const result = await handleVerify(token, locals)
+  return jsonResponse(result.ok ? 200 : 400, result)
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  let body: Record<string, unknown> = {}
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return jsonResponse(400, { ok: false, status: 'invalid_token' })
+  }
+  const token = typeof body.token === 'string' ? body.token : ''
+  const result = await handleVerify(token, locals)
+  return jsonResponse(result.ok ? 200 : 400, result)
+}
+
+function jsonResponse(status: number, data: VerifyResponse): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/scan/index.astro
+++ b/src/pages/scan/index.astro
@@ -1,0 +1,225 @@
+---
+/**
+ * Public diagnostic scan form (#598).
+ *
+ * The Engine 1 inbound flywheel for SMD Services. Prospect submits
+ * domain + email + optional LinkedIn, we email a magic-link to verify,
+ * and on click run a pruned 6-module enrichment pipeline + email back
+ * a 1-page operational read.
+ *
+ * UI rules (from CLAUDE.md tone standard + scoping doc):
+ *   - "We" voice throughout (Decision #20). No first-person singular.
+ *   - Objectives over problems framing.
+ *   - "Solution" not "systems".
+ *   - No fixed timeframes ("about 90 seconds" is a system-level latency,
+ *     not a business commitment, so it's allowed).
+ *   - Explicit data-source disclosure (Bar #4 — what we look at / don't).
+ *   - Public response is minimal: "scan started — check your email."
+ *     Zero specifics in the public surface.
+ */
+import Base from '../../layouts/Base.astro'
+import Nav from '../../components/Nav.astro'
+import Footer from '../../components/Footer.astro'
+---
+
+<Base
+  title="Operational Readiness Scan | SMD Services"
+  description="A free AI-powered read of your business's public operational footprint, emailed to you in about 90 seconds."
+>
+  <Nav />
+  <main id="main" role="main" class="px-6 py-20">
+    <div class="mx-auto max-w-2xl">
+      <p
+        class="mb-3 font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+      >
+        Free &middot; About 90 seconds &middot; Phoenix
+      </p>
+      <h1
+        class="font-['Archivo'] text-4xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] md:text-5xl"
+      >
+        Operational Readiness Scan
+      </h1>
+      <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+        We read your public digital footprint and send you a one-page operational read. Useful as a
+        starting point — and a fair preview of how we work.
+      </p>
+
+      <div id="form-status" class="mt-8" aria-live="polite"></div>
+
+      <form id="scan-form" class="mt-8 space-y-5">
+        <div>
+          <label
+            for="domain"
+            class="mb-1 block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+          >
+            Business website
+          </label>
+          <input
+            type="text"
+            id="domain"
+            name="domain"
+            required
+            maxlength="253"
+            inputmode="url"
+            autocomplete="url"
+            placeholder="yourbusiness.com"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        <div>
+          <label
+            for="email"
+            class="mb-1 block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+          >
+            Your email
+          </label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            required
+            maxlength="254"
+            autocomplete="email"
+            placeholder="you@yourbusiness.com"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+          <p class="mt-1 text-xs text-[color:var(--ss-color-text-muted)]">
+            We send the report here. You'll get one confirmation email first to make sure this
+            address is reachable.
+          </p>
+        </div>
+
+        <div>
+          <label
+            for="linkedin_url"
+            class="mb-1 block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+          >
+            LinkedIn URL <span class="text-[color:var(--ss-color-text-muted)]">(optional)</span>
+          </label>
+          <input
+            type="url"
+            id="linkedin_url"
+            name="linkedin_url"
+            maxlength="500"
+            autocomplete="off"
+            placeholder="https://linkedin.com/company/your-business"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+
+        {/* Honeypot — hidden from real users */}
+        <div class="absolute -left-[9999px]" aria-hidden="true">
+          <label for="company_url">Company URL</label>
+          <input type="text" id="company_url" name="company_url" tabindex="-1" autocomplete="off" />
+        </div>
+
+        <div
+          class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-surface)] p-4"
+        >
+          <p
+            class="mb-2 font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            What we look at &middot; what we don't
+          </p>
+          <div class="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+            <div>
+              <p
+                class="mb-1 text-xs font-semibold uppercase tracking-wider text-[color:var(--ss-color-text-secondary)]"
+              >
+                We look at
+              </p>
+              <ul class="space-y-0.5 text-[color:var(--ss-color-text-primary)]">
+                <li>Your public Google reviews</li>
+                <li>Your website</li>
+                <li>Public business listings</li>
+                <li>Press / news mentions</li>
+              </ul>
+            </div>
+            <div>
+              <p
+                class="mb-1 text-xs font-semibold uppercase tracking-wider text-[color:var(--ss-color-text-secondary)]"
+              >
+                We don't look at
+              </p>
+              <ul class="space-y-0.5 text-[color:var(--ss-color-text-primary)]">
+                <li>Your books or finances</li>
+                <li>Your customer list</li>
+                <li>Anything behind a login</li>
+                <li>Internal documents or email</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          data-ev="scan-submit"
+          class="rounded-[var(--ss-radius-card)] bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-80 disabled:opacity-50"
+        >
+          Run my free scan
+        </button>
+
+        <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+          By submitting, you agree to receive one email confirmation and one report. We don't add
+          you to a mailing list. We don't share your information.
+        </p>
+      </form>
+    </div>
+  </main>
+  <Footer />
+
+  <script is:inline>
+    const form = document.getElementById('scan-form')
+    if (form) {
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault()
+        const status = document.getElementById('form-status')
+        const button = form.querySelector('button[type="submit"]')
+
+        button.disabled = true
+        button.textContent = 'Starting...'
+        status.innerHTML = ''
+
+        const data = {
+          domain: form.elements.namedItem('domain').value,
+          email: form.elements.namedItem('email').value,
+          linkedin_url: form.elements.namedItem('linkedin_url').value,
+          company_url: form.elements.namedItem('company_url').value,
+        }
+
+        try {
+          const res = await fetch('/api/scan/start', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+          })
+
+          if (res.ok) {
+            status.innerHTML =
+              '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)]/30 bg-[color:var(--ss-color-complete)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-complete)]"><strong>Scan started.</strong> Check your email — we sent a confirmation link to verify your inbox. Click it and we\'ll run the scan and email you the report.</div>'
+            form.reset()
+            form.style.display = 'none'
+          } else if (res.status === 429) {
+            status.innerHTML =
+              '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-warning)]/30 bg-[color:var(--ss-color-warning)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-warning)]">Too many requests right now. Please try again in a minute.</div>'
+          } else {
+            const body = await res.json().catch(() => ({}))
+            if (res.status === 400 && body.fields) {
+              const msgs = Object.values(body.fields).join('. ')
+              status.innerHTML = `<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]">${msgs}</div>`
+            } else {
+              throw new Error(body.error || 'Request failed')
+            }
+          }
+        } catch {
+          status.innerHTML =
+            '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]">Something went wrong. Please email <a href="mailto:team@smd.services" class="underline">team@smd.services</a> directly.</div>'
+        } finally {
+          button.disabled = false
+          button.textContent = 'Run my free scan'
+        }
+      })
+    }
+  </script>
+</Base>

--- a/src/pages/scan/verify/[token].astro
+++ b/src/pages/scan/verify/[token].astro
@@ -1,0 +1,207 @@
+---
+/**
+ * Magic-link verification landing page (#598).
+ *
+ * The prospect clicks the link in their inbox and lands here. The page
+ * server-side calls the verify API which:
+ *   - Hashes the inbound token, looks up the scan_request row.
+ *   - Marks it verified and kicks off the diagnostic pipeline via
+ *     ctx.waitUntil (so the response returns instantly).
+ *   - Returns a status string we render below.
+ *
+ * The page never echoes specific findings — those only ever arrive via
+ * email per the scoping doc Bar #6 (anti-competitor-intel). The page
+ * confirms "we got your click, the report is on its way" or surfaces a
+ * specific UX for the four failure modes (expired / invalid / failed /
+ * already_completed).
+ */
+import Base from '../../../layouts/Base.astro'
+import Nav from '../../../components/Nav.astro'
+import Footer from '../../../components/Footer.astro'
+import { env } from 'cloudflare:workers'
+import { hashScanToken, isScanTokenFresh } from '../../../lib/scan/tokens'
+import { getScanRequestByTokenHash, markScanVerified } from '../../../lib/db/scan-requests'
+import { runDiagnosticScan } from '../../../lib/diagnostic'
+
+const { token } = Astro.params
+
+type RenderState =
+  | { kind: 'verified'; domain: string }
+  | { kind: 'already_completed'; domain: string }
+  | { kind: 'thin_footprint'; domain: string }
+  | { kind: 'expired' }
+  | { kind: 'invalid' }
+  | { kind: 'failed' }
+
+let state: RenderState = { kind: 'invalid' }
+
+if (typeof token === 'string' && token.length > 0) {
+  const hash = await hashScanToken(token)
+  const row = await getScanRequestByTokenHash(env.DB, hash)
+  if (!row) {
+    state = { kind: 'invalid' }
+  } else if (row.scan_status === 'completed') {
+    state = { kind: 'already_completed', domain: row.domain }
+  } else if (row.scan_status === 'thin_footprint') {
+    state = { kind: 'thin_footprint', domain: row.domain }
+  } else if (row.scan_status === 'failed') {
+    state = { kind: 'failed' }
+  } else if (!isScanTokenFresh(row.created_at)) {
+    state = { kind: 'expired' }
+  } else {
+    await markScanVerified(env.DB, row.id)
+    state = { kind: 'verified', domain: row.domain }
+
+    // Fire the pipeline via ctx.waitUntil so it survives the response
+    // closing. Captain memory: never inline-await LLM pipelines.
+    const ctx = Astro.locals.cfContext
+    const scanPromise = runDiagnosticScan(
+      {
+        DB: env.DB,
+        ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+        GOOGLE_PLACES_API_KEY: env.GOOGLE_PLACES_API_KEY,
+        OUTSCRAPER_API_KEY: env.OUTSCRAPER_API_KEY,
+        RESEND_API_KEY: env.RESEND_API_KEY,
+        APP_BASE_URL: env.APP_BASE_URL,
+      },
+      row.id
+    )
+    if (ctx?.waitUntil) {
+      ctx.waitUntil(scanPromise)
+    } else {
+      scanPromise.catch((err) => console.error('[scan/verify] dev-fallback scan threw:', err))
+    }
+  }
+}
+---
+
+<Base title="Scan confirmed | SMD Services" description="Your operational scan is running.">
+  <Nav />
+  <main id="main" role="main" class="px-6 py-20">
+    <div class="mx-auto max-w-xl text-center">
+      {
+        state.kind === 'verified' && (
+          <>
+            <p class="mb-3 font-['Archivo_Narrow'] text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+              Confirmed
+            </p>
+            <h1 class="font-['Archivo'] text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] md:text-4xl">
+              Your scan is running.
+            </h1>
+            <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+              We're reading the public footprint for <strong>{state.domain}</strong> now. Look for
+              an email from us in about 90 seconds with the report.
+            </p>
+            <p class="mt-6 text-sm text-[color:var(--ss-color-text-muted)]">
+              You can close this page. Nothing else to do.
+            </p>
+          </>
+        )
+      }
+
+      {
+        state.kind === 'already_completed' && (
+          <>
+            <h1 class="font-['Archivo'] text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Already sent.
+            </h1>
+            <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+              We've already emailed the report for <strong>{state.domain}</strong>. Check your
+              inbox.
+            </p>
+            <p class="mt-6 text-sm text-[color:var(--ss-color-text-muted)]">
+              If you can't find it, check your spam folder. Still nothing? Email{' '}
+              <a href="mailto:team@smd.services" class="underline">
+                team@smd.services
+              </a>{' '}
+              and we'll re-send.
+            </p>
+          </>
+        )
+      }
+
+      {
+        state.kind === 'thin_footprint' && (
+          <>
+            <h1 class="font-['Archivo'] text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              We sent you a note.
+            </h1>
+            <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+              We tried to read <strong>{state.domain}</strong> but didn't find enough public
+              footprint to produce something useful. Check your email — we explained more there and
+              included a link to talk it through.
+            </p>
+            <p class="mt-8">
+              <a
+                href="/book"
+                class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-sm transition-colors"
+              >
+                Pick a time
+              </a>
+            </p>
+          </>
+        )
+      }
+
+      {
+        state.kind === 'expired' && (
+          <>
+            <h1 class="font-['Archivo'] text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Link expired.
+            </h1>
+            <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+              Confirmation links work for 24 hours. You can request a new one.
+            </p>
+            <p class="mt-8">
+              <a
+                href="/scan"
+                class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-sm transition-colors"
+              >
+                Run a new scan
+              </a>
+            </p>
+          </>
+        )
+      }
+
+      {
+        state.kind === 'invalid' && (
+          <>
+            <h1 class="font-['Archivo'] text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              We couldn't find that scan.
+            </h1>
+            <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+              The link may have been mistyped or already used. You can start a new scan.
+            </p>
+            <p class="mt-8">
+              <a
+                href="/scan"
+                class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-sm transition-colors"
+              >
+                Start a new scan
+              </a>
+            </p>
+          </>
+        )
+      }
+
+      {
+        state.kind === 'failed' && (
+          <>
+            <h1 class="font-['Archivo'] text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Something went wrong.
+            </h1>
+            <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
+              The scan didn't complete. Please email{' '}
+              <a href="mailto:team@smd.services" class="underline">
+                team@smd.services
+              </a>{' '}
+              and we'll run it manually.
+            </p>
+          </>
+        )
+      }
+    </div>
+  </main>
+  <Footer />
+</Base>

--- a/tests/diagnostic-gate-and-render.test.ts
+++ b/tests/diagnostic-gate-and-render.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the diagnostic anti-fabrication safeguards (#598):
+ *
+ *   1. Thin-footprint pre-flight gate — refuses scans that would
+ *      otherwise produce a fabricated report.
+ *   2. Per-section anti-fabrication renderer — never invents owner
+ *      names, competitor lists, or operational claims.
+ *
+ * The renderer is tested directly against a seeded D1 with realistic
+ * enrichment context. The gate is tested through `evaluateThinFootprintGate`
+ * after seeding the same enrichment metadata the production code reads.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity, getEntity } from '../src/lib/db/entities'
+import { appendContext } from '../src/lib/db/context'
+import { evaluateThinFootprintGate } from '../src/lib/diagnostic'
+import { renderDiagnosticReport } from '../src/lib/diagnostic/render'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-test-diagnostic'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1() as unknown as D1Database
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await db
+    .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+    .bind(ORG_ID, 'Test Org', 'test-org')
+    .run()
+  return db
+}
+
+describe('evaluateThinFootprintGate', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('refuses when no website AND no places match', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Tacos Chisco',
+      area: 'Phoenix, AZ',
+    })
+    const env = { DB: db } as Parameters<typeof evaluateThinFootprintGate>[0]
+    const r = await evaluateThinFootprintGate(env, entity, 'tacoschisco.com')
+    expect(r.thin).toBe(true)
+    expect(r.reason).toBe('no_website_no_places')
+  })
+
+  it('refuses when no website AND <5 reviews', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Thin Biz',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'google_places',
+      content: 'Google Places matched.',
+      metadata: { reviewCount: 2 },
+    })
+    const env = { DB: db } as Parameters<typeof evaluateThinFootprintGate>[0]
+    const r = await evaluateThinFootprintGate(env, entity, 'thinbiz.com')
+    expect(r.thin).toBe(true)
+    expect(r.reason).toBe('no_website_low_reviews')
+  })
+
+  it('proceeds when website is set even with low reviews', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'New HVAC',
+      website: 'https://newhvac.com',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'google_places',
+      content: 'Google Places matched.',
+      metadata: { reviewCount: 2 },
+    })
+    const fresh = await getEntity(db, ORG_ID, entity.id)
+    const env = { DB: db } as Parameters<typeof evaluateThinFootprintGate>[0]
+    const r = await evaluateThinFootprintGate(env, fresh!, 'newhvac.com')
+    expect(r.thin).toBe(false)
+  })
+
+  it('proceeds when reviews are sufficient even without a website', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Established Spa',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'google_places',
+      content: 'Google Places matched.',
+      metadata: { reviewCount: 50, rating: 4.7 },
+    })
+    const env = { DB: db } as Parameters<typeof evaluateThinFootprintGate>[0]
+    // 50 reviews + no website is borderline — the gate proceeds because
+    // there's a real Google footprint to read. This matches the scoping
+    // doc's intent (don't gate on reviewCount alone if google_places hit,
+    // and we have reviews to synthesize).
+    const r = await evaluateThinFootprintGate(env, entity, 'establishedspa.com')
+    expect(r.thin).toBe(false)
+  })
+})
+
+describe('renderDiagnosticReport — anti-fabrication', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('omits Business Overview entirely when google_places did not match', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Unknown Biz',
+      area: 'Phoenix, AZ',
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const overview = r.sections.find((s) => s.id === 'business_overview')
+    expect(overview?.rendered).toBe(false)
+    expect(overview?.bullets).toBeUndefined()
+  })
+
+  it('renders "not publicly identified" when no owner_name signal exists — never invents', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Anon HVAC',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'website_analysis',
+      content: 'site analyzed',
+      metadata: {
+        owner_name: null,
+        team_size: null,
+        founding_year: null,
+        services: [],
+        quality: 'basic',
+        tech_stack: { scheduling: [], crm: [], reviews: [], payments: [], communication: [] },
+      },
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const profile = r.sections.find((s) => s.id === 'owner_profile')
+    expect(profile?.rendered).toBe(true)
+    const bullets = profile?.bullets ?? []
+    const ownerLine = bullets.find((b) => b.toLowerCase().startsWith('owner'))
+    expect(ownerLine).toBeDefined()
+    expect(ownerLine).toContain('not publicly identified')
+    // Must NOT contain a fabricated proper name (catches the "Hi Owner"
+    // / "John Smith"-style invention pattern).
+    expect(ownerLine!.split(':')[1]?.trim()).toBe('not publicly identified')
+  })
+
+  it('renders authored owner_name when website_analysis provides one', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Authored HVAC',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'website_analysis',
+      content: 'site analyzed',
+      metadata: {
+        owner_name: 'Maria Rodriguez',
+        team_size: 8,
+        founding_year: 2014,
+        services: ['HVAC repair'],
+        quality: 'good',
+        tech_stack: {
+          scheduling: ['ServiceTitan'],
+          crm: [],
+          reviews: [],
+          payments: [],
+          communication: [],
+        },
+      },
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const profile = r.sections.find((s) => s.id === 'owner_profile')
+    expect(profile?.rendered).toBe(true)
+    const ownerLine = (profile?.bullets ?? []).find((b) => b.toLowerCase().startsWith('owner'))
+    expect(ownerLine).toContain('Maria Rodriguez')
+  })
+
+  it('omits Engagement Opportunity when <2 medium+ confidence problems', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Single-Signal Biz',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'review_synthesis',
+      content: 'synthesized',
+      metadata: {
+        operational_problems: [
+          { problem: 'scheduling chaos', confidence: 'low', evidence: 'one mention' },
+        ],
+      },
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const opp = r.sections.find((s) => s.id === 'engagement_opportunity')
+    expect(opp?.rendered).toBe(false)
+    expect(opp?.insufficientDataNote).toBeTruthy()
+  })
+
+  it('renders Engagement Opportunity with up to 3 corroborated problems', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Multi-Signal Biz',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'review_synthesis',
+      content: 'synthesized',
+      metadata: {
+        operational_problems: [
+          { problem: 'phone tag', confidence: 'high', evidence: '6 reviews mention waiting' },
+          { problem: 'no online booking', confidence: 'medium', evidence: 'multiple requests' },
+          { problem: 'manual quoting', confidence: 'high', evidence: 'review pattern' },
+          { problem: 'pricing visibility', confidence: 'low', evidence: 'one review' },
+        ],
+      },
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const opp = r.sections.find((s) => s.id === 'engagement_opportunity')
+    expect(opp?.rendered).toBe(true)
+    // Top 3 only, low-confidence problem omitted
+    expect(opp?.bullets?.length).toBeLessThanOrEqual(3)
+    const text = (opp?.bullets ?? []).join(' ')
+    expect(text).toContain('phone tag')
+    expect(text).not.toContain('pricing visibility')
+  })
+
+  it('omits Conversation Starters with <3 evidence-anchored facts', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Sparse Biz',
+      area: 'Phoenix, AZ',
+    })
+    // Only 1 fact: review themes.
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'review_synthesis',
+      content: 'synthesized',
+      metadata: { top_themes: ['friendly staff'] },
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const cs = r.sections.find((s) => s.id === 'conversation_starters')
+    expect(cs?.rendered).toBe(false)
+  })
+
+  it('renders Conversation Starters with >=3 evidence-anchored facts', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Rich Biz',
+      website: 'https://rich.com',
+      area: 'Phoenix, AZ',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'google_places',
+      content: 'matched',
+      metadata: { reviewCount: 122, rating: 4.8 },
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'review_synthesis',
+      content: 'synthesized',
+      metadata: { top_themes: ['quick response'] },
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      source: 'website_analysis',
+      content: 'analyzed',
+      metadata: { services: ['HVAC repair', 'plumbing', 'electrical'] },
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    const cs = r.sections.find((s) => s.id === 'conversation_starters')
+    expect(cs?.rendered).toBe(true)
+    expect((cs?.bullets ?? []).length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('hasContent === false when zero sections render — falls back to thin-footprint message', async () => {
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Bare Entity',
+      area: 'Phoenix, AZ',
+    })
+    const r = await renderDiagnosticReport(db, entity, null)
+    expect(r.hasContent).toBe(false)
+    // None of the sections should claim to render.
+    for (const s of r.sections) {
+      expect(s.rendered).toBe(false)
+    }
+  })
+})

--- a/tests/scan-endpoints.test.ts
+++ b/tests/scan-endpoints.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Structural tests for the /scan endpoints + form (#598).
+ *
+ * Lightweight string/file existence checks — same pattern as
+ * tests/contact-endpoint.test.ts. Compiled handler behavior is exercised
+ * by the dedicated rate-limit / verify-flow / gate-and-render tests.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const startSrc = () => readFileSync(resolve('src/pages/api/scan/start.ts'), 'utf-8')
+const verifySrc = () => readFileSync(resolve('src/pages/api/scan/verify.ts'), 'utf-8')
+const formSrc = () => readFileSync(resolve('src/pages/scan/index.astro'), 'utf-8')
+const verifyPageSrc = () => readFileSync(resolve('src/pages/scan/verify/[token].astro'), 'utf-8')
+
+describe('/api/scan/start', () => {
+  it('endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/scan/start.ts'))).toBe(true)
+  })
+
+  it('exports POST handler', () => {
+    expect(startSrc()).toContain('export const POST')
+  })
+
+  it('runs the 4-dimensional rate limiter', () => {
+    expect(startSrc()).toContain('checkScanRateLimits')
+  })
+
+  it('runs an IP-coarse rate limit before the D1 check', () => {
+    const code = startSrc()
+    const coarseIdx = code.indexOf('rateLimitByIp')
+    const fineIdx = code.indexOf('checkScanRateLimits')
+    expect(coarseIdx).toBeGreaterThan(-1)
+    expect(fineIdx).toBeGreaterThan(-1)
+    expect(coarseIdx).toBeLessThan(fineIdx)
+  })
+
+  it('persists a scan_request row before sending the verification email', () => {
+    const code = startSrc()
+    const insertIdx = code.indexOf('createScanRequest')
+    const sendIdx = code.indexOf('sendEmail')
+    expect(insertIdx).toBeGreaterThan(-1)
+    expect(sendIdx).toBeGreaterThan(-1)
+    expect(insertIdx).toBeLessThan(sendIdx)
+  })
+
+  it('honeypot field is checked before validation', () => {
+    const code = startSrc()
+    expect(code).toContain('company_url')
+    expect(code).toMatch(/honeypot|company_url/)
+  })
+
+  it('returns generic ok response on rate-limit block (no info leak)', () => {
+    const code = startSrc()
+    // The block path returns ok:true with no specifics — anti-competitor-intel.
+    expect(code).toMatch(/jsonResponse\(200,\s*\{\s*ok:\s*true\s*\}\)/)
+  })
+})
+
+describe('/api/scan/verify', () => {
+  it('endpoint exists', () => {
+    expect(existsSync(resolve('src/pages/api/scan/verify.ts'))).toBe(true)
+  })
+
+  it('exports both GET and POST handlers', () => {
+    const code = verifySrc()
+    expect(code).toContain('export const GET')
+    expect(code).toContain('export const POST')
+  })
+
+  it('hashes the inbound token before lookup (never raw)', () => {
+    expect(verifySrc()).toContain('hashScanToken')
+  })
+
+  it('uses ctx.waitUntil to fire the diagnostic pipeline', () => {
+    expect(verifySrc()).toContain('waitUntil')
+    expect(verifySrc()).toContain('runDiagnosticScan')
+  })
+
+  it('checks token freshness before kicking off the scan', () => {
+    const code = verifySrc()
+    const freshIdx = code.indexOf('isScanTokenFresh')
+    const verifyIdx = code.indexOf('markScanVerified')
+    expect(freshIdx).toBeGreaterThan(-1)
+    expect(verifyIdx).toBeGreaterThan(-1)
+    expect(freshIdx).toBeLessThan(verifyIdx)
+  })
+})
+
+describe('/scan public form', () => {
+  it('page exists', () => {
+    expect(existsSync(resolve('src/pages/scan/index.astro'))).toBe(true)
+  })
+
+  it('renders the data-source disclosure (Bar #4)', () => {
+    const code = formSrc()
+    expect(code).toContain('public Google reviews')
+    expect(code).toContain('Your books or finances')
+    expect(code).toContain('behind a login')
+  })
+
+  it('uses "we" voice (no first-person singular)', () => {
+    const code = formSrc()
+    expect(code).not.toMatch(/\bI'll\b/)
+    expect(code).not.toMatch(/\bI'm\b/)
+    // "we" is everywhere in the copy — sanity check
+    expect(code).toMatch(/\bWe\b|\bwe\b/)
+  })
+
+  it('uses "solution" framing rather than "systems" in marketing copy', () => {
+    // The form doesn't pitch — just describes the scan. We sanity-check
+    // that no copy block uses "systems" as a marketing word.
+    const code = formSrc()
+    // Allowed: "system" inside literal tool references like "scheduling system"
+    // Disallowed: marketing taglines like "build better systems"
+    expect(code).not.toContain('build better systems')
+    expect(code).not.toContain('better systems')
+  })
+
+  it('does not publish dollar amounts (Decision Stack)', () => {
+    const code = formSrc()
+    expect(code).not.toMatch(/\$\d/)
+  })
+
+  it('does not promise fixed timeframes for the engagement', () => {
+    // "About 90 seconds" is a system latency, not an engagement
+    // timeframe — that's allowed. The forbidden pattern is engagement-
+    // duration commitments.
+    const code = formSrc()
+    expect(code).not.toMatch(/\d+-week sprint/)
+    expect(code).not.toMatch(/\d+-day implementation/)
+    expect(code).not.toMatch(/\d+ business days/)
+  })
+})
+
+describe('/scan/verify/[token] page', () => {
+  it('page exists', () => {
+    expect(existsSync(resolve('src/pages/scan/verify/[token].astro'))).toBe(true)
+  })
+
+  it('handles all six terminal states', () => {
+    const code = verifyPageSrc()
+    for (const state of [
+      'verified',
+      'already_completed',
+      'thin_footprint',
+      'expired',
+      'invalid',
+      'failed',
+    ]) {
+      expect(code).toContain(state)
+    }
+  })
+
+  it('renders public response with no specifics about findings (Bar #6)', () => {
+    const code = verifyPageSrc()
+    // The page should never display things like "found X reviews" or
+    // "your business has Y problems" — the report is email-only.
+    expect(code).not.toMatch(/found \d+/i)
+    expect(code).not.toMatch(/your top problem/i)
+    expect(code).not.toContain('your operational health score')
+  })
+})
+
+describe('migration 0029_create_scan_requests', () => {
+  it('exists with the canonical filename', () => {
+    expect(existsSync(resolve('migrations/0029_create_scan_requests.sql'))).toBe(true)
+  })
+
+  it('declares the table + canonical columns', () => {
+    const code = readFileSync(resolve('migrations/0029_create_scan_requests.sql'), 'utf-8')
+    expect(code).toContain('CREATE TABLE scan_requests')
+    expect(code).toContain('verification_token_hash')
+    expect(code).toContain('thin_footprint_skipped')
+    expect(code).toContain('scan_status')
+  })
+
+  it('enforces token-hash uniqueness via UNIQUE INDEX', () => {
+    const code = readFileSync(resolve('migrations/0029_create_scan_requests.sql'), 'utf-8')
+    expect(code).toContain('UNIQUE INDEX idx_scan_requests_token')
+  })
+})

--- a/tests/scan-normalize.test.ts
+++ b/tests/scan-normalize.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the public /scan input normalizers (#598).
+ *
+ * Pure functions — no DB. Catches the "scheme-prefixed domain dodges
+ * dedupe" bug + the "disposable-email throwaway" abuse vector that the
+ * 4-dimensional rate limiter relies on.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeEmail,
+  normalizeDomain,
+  normalizeLinkedinUrl,
+  emailDomain,
+} from '../src/lib/scan/normalize'
+
+describe('normalizeEmail', () => {
+  it('lowercases and trims', () => {
+    const r = normalizeEmail('  Owner@Example.COM  ')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toBe('owner@example.com')
+  })
+
+  it('rejects empty input', () => {
+    expect(normalizeEmail('').ok).toBe(false)
+    expect(normalizeEmail('   ').ok).toBe(false)
+    expect(normalizeEmail(undefined).ok).toBe(false)
+    expect(normalizeEmail(123).ok).toBe(false)
+  })
+
+  it('rejects malformed addresses', () => {
+    expect(normalizeEmail('not-an-email').ok).toBe(false)
+    expect(normalizeEmail('@nodomain.com').ok).toBe(false)
+    expect(normalizeEmail('nolocal@').ok).toBe(false)
+    expect(normalizeEmail('two@@example.com').ok).toBe(false)
+    expect(normalizeEmail('no-tld@example').ok).toBe(false)
+    expect(normalizeEmail('trailing.dot@example.com.').ok).toBe(false)
+  })
+
+  it('rejects control characters', () => {
+    expect(normalizeEmail('a\nb@example.com').ok).toBe(false)
+    expect(normalizeEmail('a\rb@example.com').ok).toBe(false)
+  })
+
+  it('rejects disposable email providers', () => {
+    const r1 = normalizeEmail('test@mailinator.com')
+    expect(r1.ok).toBe(false)
+    if (!r1.ok) expect(r1.reason).toBe('email_disposable')
+    const r2 = normalizeEmail('test@guerrillamail.com')
+    expect(r2.ok).toBe(false)
+  })
+
+  it('accepts free email providers (per-IP gates instead)', () => {
+    expect(normalizeEmail('owner@gmail.com').ok).toBe(true)
+    expect(normalizeEmail('owner@outlook.com').ok).toBe(true)
+    expect(normalizeEmail('owner@yahoo.com').ok).toBe(true)
+  })
+
+  it('caps length at 254 chars (RFC limit)', () => {
+    const long = 'a'.repeat(250) + '@b.co'
+    const r = normalizeEmail(long)
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('emailDomain', () => {
+  it('extracts the domain after @', () => {
+    expect(emailDomain('owner@example.com')).toBe('example.com')
+    expect(emailDomain('first.last@subdomain.example.co.uk')).toBe('subdomain.example.co.uk')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(emailDomain('no-at-sign')).toBe('')
+  })
+})
+
+describe('normalizeDomain', () => {
+  it('strips https/http protocol', () => {
+    expect((normalizeDomain('https://example.com') as { ok: true; value: string }).value).toBe(
+      'example.com'
+    )
+    expect((normalizeDomain('http://example.com') as { ok: true; value: string }).value).toBe(
+      'example.com'
+    )
+  })
+
+  it('strips www. and trailing path', () => {
+    const r = normalizeDomain('https://www.example.com/about?x=1')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toBe('example.com')
+  })
+
+  it('lowercases', () => {
+    const r = normalizeDomain('EXAMPLE.com')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toBe('example.com')
+  })
+
+  it('canonicalizes case-and-protocol variants to the same string', () => {
+    // Critical for rate-limit dedupe: an attacker can't bypass the
+    // per-domain limit by submitting different scheme/case variants.
+    const variants = [
+      'example.com',
+      'EXAMPLE.COM',
+      'https://example.com',
+      'http://www.Example.com/',
+      'www.example.com',
+    ]
+    const normalized = variants.map((v) => {
+      const r = normalizeDomain(v)
+      return r.ok ? r.value : null
+    })
+    const uniq = new Set(normalized)
+    expect(uniq.size).toBe(1)
+    expect(uniq.has('example.com')).toBe(true)
+  })
+
+  it('rejects empty input', () => {
+    expect(normalizeDomain('').ok).toBe(false)
+    expect(normalizeDomain(undefined).ok).toBe(false)
+  })
+
+  it('rejects malformed input', () => {
+    expect(normalizeDomain('not a domain').ok).toBe(false)
+    expect(normalizeDomain('nodot').ok).toBe(false)
+    expect(normalizeDomain('-leading-hyphen.com').ok).toBe(false)
+    expect(normalizeDomain('trailing-hyphen-.com').ok).toBe(false)
+  })
+
+  it('rejects local / private / IP', () => {
+    expect(normalizeDomain('localhost').ok).toBe(false)
+    expect(normalizeDomain('myhost.local').ok).toBe(false)
+    expect(normalizeDomain('myhost.internal').ok).toBe(false)
+    expect(normalizeDomain('192.168.1.1').ok).toBe(false)
+  })
+
+  it('rejects control characters', () => {
+    expect(normalizeDomain('exam\nple.com').ok).toBe(false)
+  })
+})
+
+describe('normalizeLinkedinUrl', () => {
+  it('returns null for empty/missing input', () => {
+    const r1 = normalizeLinkedinUrl('')
+    expect(r1.ok).toBe(true)
+    if (r1.ok) expect(r1.value).toBe(null)
+    const r2 = normalizeLinkedinUrl(undefined)
+    expect(r2.ok).toBe(true)
+  })
+
+  it('accepts canonical company URLs', () => {
+    const r = normalizeLinkedinUrl('https://linkedin.com/company/example')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toContain('linkedin.com')
+  })
+
+  it('rejects non-linkedin hosts', () => {
+    const r = normalizeLinkedinUrl('https://twitter.com/example')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('linkedin_wrong_host')
+  })
+
+  it('rejects malformed URLs', () => {
+    expect(normalizeLinkedinUrl('not a url').ok).toBe(false)
+  })
+})

--- a/tests/scan-rate-limit.test.ts
+++ b/tests/scan-rate-limit.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the 4-dimensional /scan rate limiter (#598).
+ *
+ * Each dimension is exercised against an in-memory D1 with the real
+ * migration schema. The dimensions:
+ *   1. Per-IP / 24h          (5 scans)
+ *   2. Per-email-domain / 7d (1 scan, free providers exempt)
+ *   3. Per-scanned-domain    (1 completed scan / 30d)
+ *   4. Global / 24h          (200 scans)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import {
+  createScanRequest,
+  updateScanRequestRun,
+  type ScanStatus,
+} from '../src/lib/db/scan-requests'
+import { checkScanRateLimits, RATE_LIMITS } from '../src/lib/diagnostic/rate-limit'
+import { hashScanToken } from '../src/lib/scan/tokens'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1() as unknown as D1Database
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seed(
+  db: D1Database,
+  opts: {
+    email: string
+    domain: string
+    ip?: string | null
+    status?: ScanStatus
+  }
+): Promise<void> {
+  const hash = await hashScanToken(`${opts.email}-${opts.domain}-${Math.random()}`)
+  const row = await createScanRequest(db, {
+    email: opts.email,
+    domain: opts.domain,
+    verification_token_hash: hash,
+    request_ip: opts.ip ?? '1.2.3.4',
+  })
+  if (opts.status && opts.status !== 'pending_verification') {
+    await updateScanRequestRun(db, row.id, { scan_status: opts.status })
+  }
+}
+
+describe('checkScanRateLimits — per IP', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('allows the first scan from an IP', async () => {
+    const r = await checkScanRateLimits(db, {
+      ip: '5.5.5.5',
+      emailDomain: 'newcustomer.com',
+      scannedDomain: 'someplace.com',
+    })
+    expect(r.allowed).toBe(true)
+  })
+
+  it('blocks after the configured per-IP limit', async () => {
+    for (let i = 0; i < RATE_LIMITS.per_ip_24h; i++) {
+      await seed(db, {
+        email: `u${i}@u${i}.com`,
+        domain: `d${i}.com`,
+        ip: '7.7.7.7',
+      })
+    }
+    const r = await checkScanRateLimits(db, {
+      ip: '7.7.7.7',
+      emailDomain: 'newdomain.com',
+      scannedDomain: 'newscan.com',
+    })
+    expect(r.allowed).toBe(false)
+    if (!r.allowed) expect(r.dimension).toBe('per_ip')
+  })
+
+  it('does not block a different IP', async () => {
+    for (let i = 0; i < RATE_LIMITS.per_ip_24h; i++) {
+      await seed(db, {
+        email: `u${i}@u${i}.com`,
+        domain: `d${i}.com`,
+        ip: '7.7.7.7',
+      })
+    }
+    const r = await checkScanRateLimits(db, {
+      ip: '8.8.8.8',
+      emailDomain: 'fresh.com',
+      scannedDomain: 'fresh-target.com',
+    })
+    expect(r.allowed).toBe(true)
+  })
+})
+
+describe('checkScanRateLimits — per email domain', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('blocks a second scan from the same email domain within 7 days', async () => {
+    await seed(db, {
+      email: 'first@acmecorp.com',
+      domain: 'first.com',
+      ip: '1.2.3.4',
+    })
+    const r = await checkScanRateLimits(db, {
+      ip: '9.9.9.9',
+      emailDomain: 'acmecorp.com',
+      scannedDomain: 'second.com',
+    })
+    expect(r.allowed).toBe(false)
+    if (!r.allowed) expect(r.dimension).toBe('per_email_domain')
+  })
+
+  it('exempts free email providers from the per-domain limit', async () => {
+    await seed(db, { email: 'a@gmail.com', domain: 'a.com', ip: '1.1.1.1' })
+    const r = await checkScanRateLimits(db, {
+      ip: '2.2.2.2',
+      emailDomain: 'gmail.com',
+      scannedDomain: 'b.com',
+    })
+    expect(r.allowed).toBe(true)
+  })
+})
+
+describe('checkScanRateLimits — per scanned domain', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('blocks a re-scan of the same domain within 30 days when previous scan completed', async () => {
+    await seed(db, {
+      email: 'first@first.com',
+      domain: 'targetbusiness.com',
+      ip: '1.1.1.1',
+      status: 'completed',
+    })
+    const r = await checkScanRateLimits(db, {
+      ip: '2.2.2.2',
+      emailDomain: 'second.com',
+      scannedDomain: 'targetbusiness.com',
+    })
+    expect(r.allowed).toBe(false)
+    if (!r.allowed) expect(r.dimension).toBe('per_domain')
+  })
+
+  it('does NOT block when the previous scan only thin-footprinted', async () => {
+    // A refused thin-footprint scan shouldn't lock out a legit retry from
+    // a different prospect at the same business who actually has a real
+    // email + intent.
+    await seed(db, {
+      email: 'a@a.com',
+      domain: 'thinbiz.com',
+      ip: '1.1.1.1',
+      status: 'thin_footprint',
+    })
+    const r = await checkScanRateLimits(db, {
+      ip: '2.2.2.2',
+      emailDomain: 'b.com',
+      scannedDomain: 'thinbiz.com',
+    })
+    expect(r.allowed).toBe(true)
+  })
+
+  it('does NOT block when previous attempt is still pending verification', async () => {
+    // A submitted-but-unverified row shouldn't lock the domain — that's
+    // exactly the cost-guard reason verification exists.
+    await seed(db, {
+      email: 'a@a.com',
+      domain: 'pendingbiz.com',
+      ip: '1.1.1.1',
+      status: 'pending_verification',
+    })
+    const r = await checkScanRateLimits(db, {
+      ip: '2.2.2.2',
+      emailDomain: 'b.com',
+      scannedDomain: 'pendingbiz.com',
+    })
+    expect(r.allowed).toBe(true)
+  })
+})
+
+describe('checkScanRateLimits — global cap', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns allowed=true under the cap', async () => {
+    const r = await checkScanRateLimits(db, {
+      ip: '1.1.1.1',
+      emailDomain: 'fresh.com',
+      scannedDomain: 'fresh.com',
+    })
+    expect(r.allowed).toBe(true)
+  })
+})

--- a/tests/scan-tokens.test.ts
+++ b/tests/scan-tokens.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the magic-link token utilities (#598).
+ *
+ * The tokens are the proof-of-intent gate before we burn an Anthropic
+ * call. Three things must hold:
+ *   1. Tokens are unguessable (256 bits of entropy, base64url).
+ *   2. The DB stores only the SHA-256 hash, never the raw token —
+ *      verified by checking hash() output is deterministic but never
+ *      the input itself.
+ *   3. The 24h TTL is enforced server-side from `created_at`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  generateScanToken,
+  hashScanToken,
+  isScanTokenFresh,
+  buildScanVerifyUrl,
+} from '../src/lib/scan/tokens'
+
+describe('generateScanToken', () => {
+  it('returns a token + matching hash', async () => {
+    const { token, hash } = await generateScanToken()
+    expect(token).toBeTruthy()
+    expect(hash).toBeTruthy()
+    expect(token).not.toBe(hash)
+    const recomputed = await hashScanToken(token)
+    expect(recomputed).toBe(hash)
+  })
+
+  it('produces a URL-safe token (base64url)', async () => {
+    for (let i = 0; i < 5; i++) {
+      const { token } = await generateScanToken()
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+    }
+  })
+
+  it('produces unique tokens (entropy sanity check)', async () => {
+    const tokens = new Set<string>()
+    for (let i = 0; i < 50; i++) {
+      const { token } = await generateScanToken()
+      tokens.add(token)
+    }
+    expect(tokens.size).toBe(50)
+  })
+})
+
+describe('hashScanToken', () => {
+  it('is deterministic for the same input', async () => {
+    const a = await hashScanToken('hello-world')
+    const b = await hashScanToken('hello-world')
+    expect(a).toBe(b)
+  })
+
+  it('produces different hashes for different inputs', async () => {
+    const a = await hashScanToken('one')
+    const b = await hashScanToken('two')
+    expect(a).not.toBe(b)
+  })
+
+  it('does not echo the input', async () => {
+    const a = await hashScanToken('SECRET-token')
+    expect(a).not.toContain('SECRET-token')
+  })
+})
+
+describe('isScanTokenFresh', () => {
+  it('returns true for a row created seconds ago', () => {
+    const created = new Date(Date.now() - 5_000).toISOString()
+    expect(isScanTokenFresh(created)).toBe(true)
+  })
+
+  it('returns false for a row created >24h ago', () => {
+    const created = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+    expect(isScanTokenFresh(created)).toBe(false)
+  })
+
+  it('returns true at the boundary just under 24h', () => {
+    const created = new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString()
+    expect(isScanTokenFresh(created)).toBe(true)
+  })
+
+  it('returns false for malformed input', () => {
+    expect(isScanTokenFresh('not-iso8601')).toBe(false)
+  })
+})
+
+describe('buildScanVerifyUrl', () => {
+  it('produces /scan/verify/<token> path on the given base', () => {
+    const url = buildScanVerifyUrl('https://smd.services', 'abc123')
+    expect(url).toBe('https://smd.services/scan/verify/abc123')
+  })
+
+  it('URL-encodes the token', () => {
+    const url = buildScanVerifyUrl('https://smd.services', 'a/b+c')
+    expect(url).toContain('a%2Fb%2Bc')
+  })
+})

--- a/tests/scan-verify-flow.test.ts
+++ b/tests/scan-verify-flow.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the magic-link verification + scan_request DAL flow (#598).
+ *
+ * Exercises:
+ *   - Token hash storage (raw token never persisted)
+ *   - Idempotent verification (re-clicking the link doesn't re-flag)
+ *   - 24h expiry enforcement via isScanTokenFresh
+ *   - State transitions: pending_verification -> verified -> completed
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import {
+  createScanRequest,
+  getScanRequest,
+  getScanRequestByTokenHash,
+  markScanVerified,
+  updateScanRequestRun,
+} from '../src/lib/db/scan-requests'
+import { generateScanToken, hashScanToken, isScanTokenFresh } from '../src/lib/scan/tokens'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1() as unknown as D1Database
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+describe('scan_request DAL', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('persists only the token hash, never the raw token', async () => {
+    const { token, hash } = await generateScanToken()
+    const row = await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'example.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    expect(row.verification_token_hash).toBe(hash)
+    // The raw token must never appear in any column.
+    const json = JSON.stringify(row)
+    expect(json).not.toContain(token)
+  })
+
+  it('looks up rows by hash', async () => {
+    const { token, hash } = await generateScanToken()
+    const created = await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'example.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    const recomputed = await hashScanToken(token)
+    const found = await getScanRequestByTokenHash(db, recomputed)
+    expect(found?.id).toBe(created.id)
+  })
+
+  it('rejects invalid tokens (different hash) without leaking', async () => {
+    const { hash } = await generateScanToken()
+    await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'example.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    const wrongHash = await hashScanToken('attacker-guess')
+    const found = await getScanRequestByTokenHash(db, wrongHash)
+    expect(found).toBeNull()
+  })
+
+  it('markScanVerified sets verified_at and transitions status', async () => {
+    const { hash } = await generateScanToken()
+    const row = await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'example.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    expect(row.scan_status).toBe('pending_verification')
+    expect(row.verified_at).toBeNull()
+    const verified = await markScanVerified(db, row.id)
+    expect(verified?.scan_status).toBe('verified')
+    expect(verified?.verified_at).toBeTruthy()
+  })
+
+  it('markScanVerified is idempotent — re-click does not overwrite verified_at', async () => {
+    const { hash } = await generateScanToken()
+    const row = await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'example.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    const v1 = await markScanVerified(db, row.id)
+    // Wait for clock granularity to advance so we can detect a no-op.
+    await new Promise((r) => setTimeout(r, 5))
+    const v2 = await markScanVerified(db, row.id)
+    expect(v2?.verified_at).toBe(v1?.verified_at)
+  })
+
+  it('updateScanRequestRun transitions to completed', async () => {
+    const { hash } = await generateScanToken()
+    const row = await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'example.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    await markScanVerified(db, row.id)
+    await updateScanRequestRun(db, row.id, {
+      scan_status: 'completed',
+      scan_completed_at: new Date().toISOString(),
+      email_sent_at: new Date().toISOString(),
+    })
+    const final = await getScanRequest(db, row.id)
+    expect(final?.scan_status).toBe('completed')
+    expect(final?.email_sent_at).toBeTruthy()
+  })
+
+  it('updateScanRequestRun records thin_footprint refusal', async () => {
+    const { hash } = await generateScanToken()
+    const row = await createScanRequest(db, {
+      email: 'a@b.com',
+      domain: 'thin.com',
+      verification_token_hash: hash,
+      request_ip: '1.1.1.1',
+    })
+    await markScanVerified(db, row.id)
+    await updateScanRequestRun(db, row.id, {
+      scan_status: 'thin_footprint',
+      thin_footprint_skipped: true,
+      scan_completed_at: new Date().toISOString(),
+      error_message: 'thin_footprint:no_website_no_places',
+    })
+    const final = await getScanRequest(db, row.id)
+    expect(final?.scan_status).toBe('thin_footprint')
+    expect(final?.thin_footprint_skipped).toBe(1)
+    expect(final?.error_message).toContain('no_website_no_places')
+  })
+
+  it('rejects rows with control characters in email/domain', async () => {
+    await expect(
+      createScanRequest(db, {
+        email: 'evil\nuser@example.com',
+        domain: 'example.com',
+        verification_token_hash: 'h',
+        request_ip: '1.1.1.1',
+      })
+    ).rejects.toThrow()
+    await expect(
+      createScanRequest(db, {
+        email: 'good@example.com',
+        domain: 'evil\ndomain.com',
+        verification_token_hash: 'h',
+        request_ip: '1.1.1.1',
+      })
+    ).rejects.toThrow()
+  })
+})
+
+describe('token expiry', () => {
+  it('treats a fresh row as fresh', async () => {
+    const created = new Date().toISOString()
+    expect(isScanTokenFresh(created)).toBe(true)
+  })
+
+  it('treats a 25h-old row as expired', async () => {
+    const created = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+    expect(isScanTokenFresh(created)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #598.

Strategy-critical inbound flywheel — the diagnostic that makes Phase 1A's $10k/mo target comfortable. See [`docs/strategy/diagnostic-scoping-2026-04-27.md`](https://github.com/venturecrane/ss-console/blob/main/docs/strategy/diagnostic-scoping-2026-04-27.md) for the GO recommendation, the 6 quality bars, and the 2 non-negotiable scope cuts that bound this build.

## The two non-negotiable scope cuts (both honored)

**Cut 1 — Pruned 6-module pipeline only.** The /scan path runs `places + outscraper + website_analysis + review_synthesis + deep_website + intelligence_brief`. `competitors`, `news_search`, and `linkedin` are deliberately dropped from the public path (highest fabrication risk + 3x latency for low signal). They remain in the internal 12-module pipeline that runs when a /scan converts to a booked call.

**Cut 2 — Thin-footprint detection as P0 gate.** Pre-flight after places + outscraper. If the prospect has no website + <5 Google reviews, the scan refuses, marks `thin_footprint`, and emails a "let's talk live" → `/book` routing instead of a fabricated report. CLAUDE.md anti-fabrication compliance.

## The 6 quality bars

| Bar | Status |
|---|---|
| 1. Useful, non-generic 1-page report from public-footprint data | Renderer gates each section on authored signals; structurally absent if no data |
| 2. Graceful failure mode for thin footprints | Pre-flight gate refuses → "let's talk live" email + /book CTA |
| 3. Defensible cost per scan | $0.14 median / $0.27 pessimistic (scoping doc §3) |
| 4. Transparent data-source disclosure | "What we look at / what we don't" panel on the form |
| 5. Anti-abuse: rate-limit, email verification, public/email split | 4-dim rate limit + magic-link verification + IP-coarse coarse limit |
| 6. Anti-competitor-intel | Public response is `{ ok: true }` with zero specifics; the report only ever lives in email |

## What ships

- **Migration `0029_create_scan_requests.sql`** — state machine for `pending_verification → verified → completed | thin_footprint | failed`. Stores SHA-256 token hash, audit fields, request IP, error_message. Indexed for the 4 rate-limit dimensions.
- **Public form `/scan`** — Astro page in "we" voice, data-source disclosure, honeypot, no published prices, no fixed timeframes.
- **Magic-link landing `/scan/verify/[token]`** — 6 terminal states (verified / already_completed / thin_footprint / expired / invalid / failed). Public surface never echoes findings.
- **API `/api/scan/start`** — POST handler. Validates input, runs IP-coarse + 4-dim rate limit, persists row, sends magic link. Generic `{ok:true}` on rate-limit block (no info leak).
- **API `/api/scan/verify`** — GET + POST. Hashes inbound token, marks verified, fires `runDiagnosticScan` via `ctx.waitUntil` (per Captain memory `feedback_ctx_waituntil_for_heavy_work` — never inline-await LLM pipelines).
- **`src/lib/diagnostic/`** — orchestrator with thin-footprint gate, rate limiter, anti-fabrication renderer.
- **`src/lib/email/diagnostic-email.ts`** — three templates (magic link / full report / thin-footprint refusal). All in "we" voice, all CTA → `/book`.
- **`src/lib/scan/normalize.ts` + `tokens.ts`** — canonical input normalization (kills protocol/case dedupe-bypass) + SHA-256 magic-link token utilities (24h TTL, raw never stored).

## Leveraged (not rebuilt)

- `sendOutreachEmail` (PR #600) — both report sends thread `entity_id` so opens/clicks attribute via the existing `outreach_events` pipeline (#587)
- `intelligence_brief` / `dossier.ts` — wrapped, not rewritten; appendix in the rendered email
- `findOrCreateEntity` / `appendContext` / `assembleEntityContext` — full reuse
- Booking flow at `/book` (PR #602) — every CTA in every email and every page state

## Anti-fabrication enforcement (CLAUDE.md P0)

The renderer (`src/lib/diagnostic/render.ts`) enforces per-section rules:

| Section | Render condition | Else |
|---|---|---|
| Business Overview | `google_places` matched | Don't render |
| Owner Profile | `website_analysis` OR `outscraper` OR `deep_website` ran | Don't render (entire section absent) |
| Tech & Operations | `website_analysis` OR `outscraper` ran | Don't render |
| Engagement Opportunity | ≥2 medium+ confidence problems from `review_synthesis` | Render only digital-maturity gap; no padded extras |
| Conversation Starters | ≥3 evidence-anchored facts | Omit section entirely |

Owner name is only "Maria Rodriguez" if `website_analysis.owner_name === "Maria Rodriguez"`. If no signal, the line reads "Owner / decision-maker: not publicly identified" — never "Hi Owner" / "John Smith" / fabricated. If even that section has no input modules, the entire section is structurally absent.

## Tests (88 new)

- `tests/scan-normalize.test.ts` — 21 tests. Email + domain canonicalization (catches the protocol/case dedupe-bypass attacker vector), disposable-mail filter, control-char rejection.
- `tests/scan-tokens.test.ts` — 12 tests. SHA-256 hash determinism, raw-never-leaks, 50-token entropy sanity, 24h TTL boundary.
- `tests/scan-rate-limit.test.ts` — 9 tests. All 4 dimensions exercised against in-memory D1: per-IP / per-email-domain (with free-mail exemption) / per-scanned-domain (only `completed` counts; `thin_footprint` and `pending_verification` don't lock retries) / global.
- `tests/diagnostic-gate-and-render.test.ts` — 12 tests. Thin-footprint gate across 4 footprint profiles + per-section anti-fabrication checks.
- `tests/scan-verify-flow.test.ts` — 10 tests. Token hash storage, idempotent verify, expiry, state transitions, control-char defense.
- `tests/scan-endpoints.test.ts` — 24 structural tests covering both endpoints, both pages, the migration.

`npm run verify` passes — 1668 main tests + workers, exit 0.

## Cost model

Per the scoping doc §3: $0.14 median per completed scan ($0.027 pessimistic). At 50 scans/wk that's $30-60/mo. Worst-case attacker capped at ~$200/wk before being blocked by the rate limiter.

## Test plan

- [ ] Apply migration to staging: `wrangler d1 migrations apply ss-console-db --remote`
- [ ] Verify form renders at smd.services/scan with the data-source disclosure visible
- [ ] Submit a real Phoenix HVAC business → confirm magic-link arrives in inbox
- [ ] Click link → confirm landing page renders "Your scan is running" within 1s
- [ ] Wait ~90s → confirm full report email arrives with all sections rendered
- [ ] Submit a thin-footprint business (no website) → confirm thin_footprint email arrives instead
- [ ] Submit 6 scans from same IP → confirm the 6th hits coarse 429
- [ ] Submit 2 scans from same scanned-domain (with completed first) → confirm second silently swallowed (no email, generic ok response)
- [ ] Click an expired link (>24h old) → confirm "Link expired" UX
- [ ] Verify outreach_events row created for both report send and thin-footprint send

🤖 Generated with [Claude Code](https://claude.com/claude-code)