### PR TITLE
feat(workers): pipeline thresholds and caps moved to admin config

### DIFF
--- a/migrations/0029_create_pipeline_settings.sql
+++ b/migrations/0029_create_pipeline_settings.sql
@@ -1,0 +1,62 @@
+-- Migration 0029: pipeline_settings + pipeline_settings_audit
+--
+-- Per-org, per-pipeline tunable thresholds and caps. Replaces hardcoded
+-- worker constants (`PAIN_THRESHOLD = 7`, `MAX_REVIEW_CHECKS = 200`,
+-- `OUTSCRAPER_BUDGET_USD_PER_RUN = 1.0`) with admin-config so ops can tune
+-- signal quality and cost guards without a code deploy. Closes issue #595.
+--
+-- Design notes:
+--   - Flat key-value store keyed by (org_id, pipeline, key). One row per
+--     tunable setting. Values are TEXT — workers parse to int/float at
+--     read time. Keeps the schema cheap to extend (new tunable = new key,
+--     no ALTER TABLE).
+--   - Workers read settings at the top of each handler invocation, NOT at
+--     module load. This means the next cron run picks up the latest admin
+--     value without a worker restart. Fallback to hardcoded defaults if
+--     a row is absent — graceful degradation when the table is empty.
+--   - Settings registry (allowed keys + types + defaults + ranges) lives
+--     in src/lib/db/pipeline-settings.ts. The migration intentionally does
+--     NOT enforce key whitelist via CHECK constraints — easier to add
+--     tunables without coupling schema changes to code rollouts. Validation
+--     is enforced in the DAL on write.
+--   - The audit table is append-only. Every admin change records pipeline,
+--     key, old_value, new_value, actor (user_id) and timestamp. This is
+--     the audit log for compliance / "who turned the threshold to 3?"
+--     forensics. Index supports the per-pipeline history view.
+
+CREATE TABLE IF NOT EXISTS pipeline_settings (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  pipeline TEXT NOT NULL CHECK (pipeline IN (
+    'new_business', 'job_monitor', 'review_mining', 'social_listening'
+  )),
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_by TEXT,
+  UNIQUE(org_id, pipeline, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_settings_org_pipeline
+  ON pipeline_settings(org_id, pipeline);
+
+CREATE TABLE IF NOT EXISTS pipeline_settings_audit (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  pipeline TEXT NOT NULL,
+  key TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT NOT NULL,
+  actor_user_id TEXT,
+  actor_email TEXT,
+  changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_settings_audit_org_pipeline_changed
+  ON pipeline_settings_audit(org_id, pipeline, changed_at DESC);
+
+-- down
+-- DROP INDEX IF EXISTS idx_pipeline_settings_audit_org_pipeline_changed;
+-- DROP TABLE IF EXISTS pipeline_settings_audit;
+-- DROP INDEX IF EXISTS idx_pipeline_settings_org_pipeline;
+-- DROP TABLE IF EXISTS pipeline_settings;

--- a/src/lib/db/pipeline-settings.test.ts
+++ b/src/lib/db/pipeline-settings.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Tests for pipeline-settings DAL.
+ *
+ * Mocks D1Database so we can verify:
+ *   - getPipelineSettings returns defaults when the table is empty
+ *   - getPipelineSettings overlays stored values onto defaults
+ *   - getPipelineSettings is graceful with corrupt/unparseable values
+ *   - updatePipelineSettings rejects out-of-range values
+ *   - updatePipelineSettings writes audit rows on real changes only
+ *   - updatePipelineSettings is a no-op when value matches stored
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  getPipelineSettings,
+  updatePipelineSettings,
+  SETTING_SPECS,
+  type PipelineId,
+} from './pipeline-settings'
+
+interface StatementChain {
+  bind: (...args: unknown[]) => StatementChain
+  first: () => Promise<unknown>
+  all: () => Promise<{ results: unknown[] }>
+  run: () => Promise<{ success: boolean }>
+}
+
+interface MockD1State {
+  // Stored settings rows: keyed by `${pipeline}:${key}` -> value string.
+  settings: Map<string, string>
+  // Audit rows captured for assertions.
+  audits: Array<{
+    pipeline: string
+    key: string
+    old_value: string | null
+    new_value: string
+  }>
+  // Inserts captured for assertions.
+  upserts: Array<{ pipeline: string; key: string; value: string }>
+}
+
+function makeMockD1(state: MockD1State): D1Database {
+  const prepare = vi.fn((sql: string): StatementChain => {
+    let pipeline = ''
+    let pendingInsert: { pipeline: string; key: string; value: string } | null = null
+    let pendingAudit: {
+      pipeline: string
+      key: string
+      old_value: string | null
+      new_value: string
+    } | null = null
+
+    const chain: StatementChain = {
+      bind(...args: unknown[]) {
+        // Heuristic dispatch on SQL substring — sufficient for tests.
+        if (
+          sql.includes('FROM pipeline_settings') &&
+          !sql.includes('audit') &&
+          sql.includes('WHERE org_id')
+        ) {
+          pipeline = String(args[1])
+        } else if (sql.includes('INSERT INTO pipeline_settings_audit')) {
+          // (id, org_id, pipeline, key, old_value, new_value, ...)
+          pendingAudit = {
+            pipeline: String(args[2]),
+            key: String(args[3]),
+            old_value: args[4] === null ? null : String(args[4]),
+            new_value: String(args[5]),
+          }
+        } else if (sql.includes('INSERT INTO pipeline_settings')) {
+          // (id, org_id, pipeline, key, value, ...)
+          pendingInsert = {
+            pipeline: String(args[2]),
+            key: String(args[3]),
+            value: String(args[4]),
+          }
+        }
+        return chain
+      },
+      async first() {
+        return null
+      },
+      async all() {
+        if (sql.includes('SELECT key, value FROM pipeline_settings')) {
+          // Internal read inside updatePipelineSettings — return existing.
+          const out: Array<{ key: string; value: string }> = []
+          for (const [k, v] of state.settings.entries()) {
+            const [p, key] = k.split(':')
+            if (p === pipeline) out.push({ key, value: v })
+          }
+          return { results: out }
+        }
+        if (sql.includes('FROM pipeline_settings') && sql.includes('WHERE org_id')) {
+          const out: Array<{ pipeline: string; key: string; value: string }> = []
+          for (const [k, v] of state.settings.entries()) {
+            const [p, key] = k.split(':')
+            if (p === pipeline) out.push({ pipeline: p, key, value: v })
+          }
+          return { results: out }
+        }
+        return { results: [] }
+      },
+      async run() {
+        if (pendingInsert) {
+          state.upserts.push(pendingInsert)
+          state.settings.set(`${pendingInsert.pipeline}:${pendingInsert.key}`, pendingInsert.value)
+          pendingInsert = null
+        }
+        if (pendingAudit) {
+          state.audits.push(pendingAudit)
+          pendingAudit = null
+        }
+        return { success: true }
+      },
+    }
+    return chain
+  })
+
+  return { prepare } as unknown as D1Database
+}
+
+const ORG = 'org-test-001'
+const ACTOR = { userId: 'u-1', email: 'admin@example.com' }
+
+describe('getPipelineSettings', () => {
+  it('returns hardcoded defaults when no rows exist', async () => {
+    const state: MockD1State = { settings: new Map(), audits: [], upserts: [] }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'review_mining')
+    expect(settings.pain_threshold).toBe(7)
+    expect(settings.max_review_checks).toBe(200)
+    expect(settings.outscraper_budget_usd_per_run).toBe(1.0)
+  })
+
+  it('overlays stored values onto defaults', async () => {
+    const state: MockD1State = {
+      settings: new Map([
+        ['review_mining:pain_threshold', '5'],
+        ['review_mining:max_review_checks', '500'],
+      ]),
+      audits: [],
+      upserts: [],
+    }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'review_mining')
+    expect(settings.pain_threshold).toBe(5)
+    expect(settings.max_review_checks).toBe(500)
+    // Untouched key falls back to default
+    expect(settings.outscraper_budget_usd_per_run).toBe(1.0)
+  })
+
+  it('returns default for the same pipeline when value is unparseable', async () => {
+    const state: MockD1State = {
+      settings: new Map([['review_mining:pain_threshold', 'not-a-number']]),
+      audits: [],
+      upserts: [],
+    }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'review_mining')
+    expect(settings.pain_threshold).toBe(7) // default fallback
+  })
+
+  it('parses floats correctly for budget setting', async () => {
+    const state: MockD1State = {
+      settings: new Map([['review_mining:outscraper_budget_usd_per_run', '2.5']]),
+      audits: [],
+      upserts: [],
+    }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'review_mining')
+    expect(settings.outscraper_budget_usd_per_run).toBe(2.5)
+  })
+
+  it('returns defaults for job_monitor pain_threshold', async () => {
+    const state: MockD1State = { settings: new Map(), audits: [], upserts: [] }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'job_monitor')
+    expect(settings.pain_threshold).toBe(7)
+  })
+
+  it('returns defaults for new_business pain_threshold', async () => {
+    const state: MockD1State = { settings: new Map(), audits: [], upserts: [] }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'new_business')
+    expect(settings.pain_threshold).toBe(1)
+  })
+
+  it('ignores unknown keys silently', async () => {
+    const state: MockD1State = {
+      settings: new Map([['review_mining:unknown_key', '99']]),
+      audits: [],
+      upserts: [],
+    }
+    const db = makeMockD1(state)
+    const settings = await getPipelineSettings(db, ORG, 'review_mining')
+    // Defaults intact; no throw.
+    expect(settings.pain_threshold).toBe(7)
+  })
+})
+
+describe('updatePipelineSettings validation', () => {
+  let state: MockD1State
+  beforeEach(() => {
+    state = { settings: new Map(), audits: [], upserts: [] }
+  })
+
+  it('rejects unknown setting keys', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'totally_made_up', value: 5 }],
+      ACTOR
+    )
+    expect(res.ok).toBe(false)
+    expect(res.errors[0]).toContain('Unknown setting')
+    expect(state.upserts).toHaveLength(0)
+  })
+
+  it('rejects out-of-range pain_threshold (below min)', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: 0 }],
+      ACTOR
+    )
+    expect(res.ok).toBe(false)
+    expect(res.errors[0]).toContain('between')
+    expect(state.upserts).toHaveLength(0)
+  })
+
+  it('rejects out-of-range pain_threshold (above max)', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: 11 }],
+      ACTOR
+    )
+    expect(res.ok).toBe(false)
+    expect(state.upserts).toHaveLength(0)
+  })
+
+  it('rejects non-integer when spec.type is int', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: 5.5 }],
+      ACTOR
+    )
+    expect(res.ok).toBe(false)
+    expect(res.errors[0]).toContain('whole number')
+  })
+
+  it('rejects NaN', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: NaN }],
+      ACTOR
+    )
+    expect(res.ok).toBe(false)
+  })
+
+  it('rejects the entire batch if any input is invalid (all-or-nothing)', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [
+        { key: 'pain_threshold', value: 8 },
+        { key: 'max_review_checks', value: -1 },
+      ],
+      ACTOR
+    )
+    expect(res.ok).toBe(false)
+    expect(state.upserts).toHaveLength(0)
+  })
+})
+
+describe('updatePipelineSettings write path', () => {
+  let state: MockD1State
+  beforeEach(() => {
+    state = { settings: new Map(), audits: [], upserts: [] }
+  })
+
+  it('writes a setting row and an audit row on initial save', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: 8 }],
+      ACTOR
+    )
+    expect(res.ok).toBe(true)
+    expect(res.changed).toBe(1)
+    expect(state.upserts).toHaveLength(1)
+    expect(state.upserts[0]).toMatchObject({
+      pipeline: 'review_mining',
+      key: 'pain_threshold',
+      value: '8',
+    })
+    expect(state.audits).toHaveLength(1)
+    expect(state.audits[0]).toMatchObject({
+      pipeline: 'review_mining',
+      key: 'pain_threshold',
+      old_value: null,
+      new_value: '8',
+    })
+  })
+
+  it('records old_value in audit when updating an existing setting', async () => {
+    state.settings.set('review_mining:pain_threshold', '7')
+    const db = makeMockD1(state)
+    await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: 9 }],
+      ACTOR
+    )
+    expect(state.audits).toHaveLength(1)
+    expect(state.audits[0]).toMatchObject({
+      old_value: '7',
+      new_value: '9',
+    })
+  })
+
+  it('skips writes and audit when value is unchanged', async () => {
+    state.settings.set('review_mining:pain_threshold', '7')
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [{ key: 'pain_threshold', value: 7 }],
+      ACTOR
+    )
+    expect(res.ok).toBe(true)
+    expect(res.changed).toBe(0)
+    expect(state.upserts).toHaveLength(0)
+    expect(state.audits).toHaveLength(0)
+  })
+
+  it('writes multiple settings in one batch', async () => {
+    const db = makeMockD1(state)
+    const res = await updatePipelineSettings(
+      db,
+      ORG,
+      'review_mining',
+      [
+        { key: 'pain_threshold', value: 6 },
+        { key: 'max_review_checks', value: 300 },
+        { key: 'outscraper_budget_usd_per_run', value: 2.0 },
+      ],
+      ACTOR
+    )
+    expect(res.ok).toBe(true)
+    expect(res.changed).toBe(3)
+    expect(state.upserts).toHaveLength(3)
+    expect(state.audits).toHaveLength(3)
+  })
+})
+
+describe('SETTING_SPECS coverage', () => {
+  it('has pain_threshold defined for all three pipelines named in issue #595', () => {
+    const required: PipelineId[] = ['review_mining', 'job_monitor', 'new_business']
+    for (const p of required) {
+      expect(SETTING_SPECS[p].pain_threshold).toBeDefined()
+    }
+  })
+
+  it('every setting default sits within its declared range', () => {
+    for (const [, specs] of Object.entries(SETTING_SPECS)) {
+      for (const [, spec] of Object.entries(specs)) {
+        expect(spec.default).toBeGreaterThanOrEqual(spec.min)
+        expect(spec.default).toBeLessThanOrEqual(spec.max)
+      }
+    }
+  })
+})

--- a/src/lib/db/pipeline-settings.ts
+++ b/src/lib/db/pipeline-settings.ts
@@ -1,0 +1,389 @@
+/**
+ * Pipeline-settings DAL — admin-tunable thresholds and caps for the four
+ * lead-gen workers (review_mining, job_monitor, new_business,
+ * social_listening). Closes issue #595.
+ *
+ * Design intent
+ * -------------
+ *  - Workers call `getPipelineSettings(db, orgId, pipeline)` at the TOP of
+ *    each invocation (cron or fetch). This means the next run picks up
+ *    the latest admin-set values without a worker restart. Reads at
+ *    module-load time would defeat the purpose.
+ *  - When a setting row is absent, fall back to the hardcoded default in
+ *    the registry below. Never throw on missing rows — admin may not have
+ *    touched anything yet, and the worker must still run.
+ *  - Defaults are pinned to the values that shipped before this migration,
+ *    so the deploy is a no-op until ops explicitly tunes a value.
+ *  - Validation lives in `SETTING_SPECS`. Each tunable declares a parser
+ *    (string -> number / int / etc.), an optional range, and a default.
+ *    `updatePipelineSettings` rejects out-of-range or unparseable values
+ *    rather than silently coercing.
+ *  - Every change writes a row to `pipeline_settings_audit`. This is the
+ *    forensic trail for "who lowered the threshold to 3?"
+ *
+ * The shape of `PipelineSettings` is the canonical, fully-resolved view
+ * — every tunable is present, with either the stored value or the default
+ * filled in. Workers and the admin UI both consume this same shape.
+ */
+
+export type PipelineId = 'review_mining' | 'job_monitor' | 'new_business' | 'social_listening'
+
+export const PIPELINE_IDS: readonly PipelineId[] = [
+  'review_mining',
+  'job_monitor',
+  'new_business',
+  'social_listening',
+] as const
+
+// ---------------------------------------------------------------------------
+// Setting registry — the source of truth for tunables, defaults, ranges.
+// ---------------------------------------------------------------------------
+
+export interface NumericSettingSpec {
+  type: 'int' | 'float'
+  default: number
+  min: number
+  max: number
+  label: string
+  help: string
+}
+
+export type SettingSpec = NumericSettingSpec
+
+/**
+ * Registry of all admin-tunable settings, by pipeline.
+ *
+ * Defaults match the constants that shipped before this migration. Do NOT
+ * change a default casually — it is the deployed behavior when a fresh org
+ * has no settings rows. Range bounds (`min`/`max`) are validated on write
+ * by `updatePipelineSettings`.
+ */
+export const SETTING_SPECS: Record<PipelineId, Record<string, SettingSpec>> = {
+  review_mining: {
+    pain_threshold: {
+      type: 'int',
+      default: 7,
+      min: 1,
+      max: 10,
+      label: 'Pain threshold',
+      help: 'Minimum Claude pain_score (1-10) for a business to qualify and be written to D1. Lower = more leads, lower signal quality.',
+    },
+    max_review_checks: {
+      type: 'int',
+      default: 200,
+      min: 1,
+      max: 5000,
+      label: 'Max review checks per run',
+      help: 'Cap on businesses sent to Outscraper per run. Each check is ~$0.003 of Outscraper spend.',
+    },
+    outscraper_budget_usd_per_run: {
+      type: 'float',
+      default: 1.0,
+      min: 0.01,
+      max: 100.0,
+      label: 'Outscraper budget per run (USD)',
+      help: 'Belt-and-suspenders cost guard. Stops the loop early if projected Outscraper spend would exceed this dollar value.',
+    },
+  },
+  job_monitor: {
+    pain_threshold: {
+      type: 'int',
+      default: 7,
+      min: 1,
+      max: 10,
+      label: 'Pain threshold',
+      help: 'Minimum derived pain score (1-10) for a job posting to qualify and be written to D1. Score is derived from Claude confidence + problem count. Lower = more leads, lower signal quality.',
+    },
+  },
+  new_business: {
+    pain_threshold: {
+      type: 'int',
+      default: 1,
+      min: 0,
+      max: 10,
+      label: 'Pain threshold',
+      help: 'Minimum derived score for a permit to qualify (0-10). Score is derived from Claude outreach_timing: immediate=10, wait_30_days=7, wait_60_days=5, not_recommended=0. Default 1 preserves prior behavior (skip only not_recommended).',
+    },
+  },
+  social_listening: {},
+}
+
+// ---------------------------------------------------------------------------
+// Resolved-settings shape per pipeline (every tunable, with default if unset)
+// ---------------------------------------------------------------------------
+
+export interface ReviewMiningSettings {
+  pain_threshold: number
+  max_review_checks: number
+  outscraper_budget_usd_per_run: number
+}
+
+export interface JobMonitorSettings {
+  pain_threshold: number
+}
+
+export interface NewBusinessSettings {
+  pain_threshold: number
+}
+
+// Reserved — no tunables yet for social_listening.
+export type SocialListeningSettings = Record<string, never>
+
+export type PipelineSettings<P extends PipelineId> = P extends 'review_mining'
+  ? ReviewMiningSettings
+  : P extends 'job_monitor'
+    ? JobMonitorSettings
+    : P extends 'new_business'
+      ? NewBusinessSettings
+      : SocialListeningSettings
+
+// ---------------------------------------------------------------------------
+// D1 access
+// ---------------------------------------------------------------------------
+
+interface RawRow {
+  pipeline: PipelineId
+  key: string
+  value: string
+  updated_at: string
+  updated_by: string | null
+}
+
+/**
+ * Parse a stored TEXT value into the type declared by the registry.
+ * On parse failure, return the registry default (graceful degradation —
+ * workers still run with sensible values even if a row is corrupt).
+ */
+function parseValue(spec: SettingSpec, raw: string): number {
+  if (spec.type === 'int') {
+    const n = Number.parseInt(raw, 10)
+    if (!Number.isFinite(n)) return spec.default
+    return n
+  }
+  // float
+  const n = Number.parseFloat(raw)
+  if (!Number.isFinite(n)) return spec.default
+  return n
+}
+
+/**
+ * Read all tunables for one pipeline in one query, merge with defaults,
+ * return the canonical resolved shape.
+ *
+ * Workers call this at the top of every invocation. Cheap query (4 rows
+ * max for review_mining today), idempotent, no caching required.
+ */
+export async function getPipelineSettings<P extends PipelineId>(
+  db: D1Database,
+  orgId: string,
+  pipeline: P
+): Promise<PipelineSettings<P>> {
+  const specs = SETTING_SPECS[pipeline]
+  const out: Record<string, number> = {}
+  for (const [key, spec] of Object.entries(specs)) {
+    out[key] = spec.default
+  }
+
+  const rows = await db
+    .prepare(
+      `SELECT pipeline, key, value, updated_at, updated_by
+       FROM pipeline_settings
+       WHERE org_id = ? AND pipeline = ?`
+    )
+    .bind(orgId, pipeline)
+    .all<RawRow>()
+
+  for (const row of rows.results ?? []) {
+    const spec = specs[row.key]
+    if (!spec) continue // unknown key — ignore
+    out[row.key] = parseValue(spec, row.value)
+  }
+
+  return out as unknown as PipelineSettings<P>
+}
+
+/**
+ * Read the raw rows (with metadata: updated_at, updated_by) for the admin
+ * UI — distinguishes "stored value" from "default fallback" so the form
+ * can show provenance.
+ */
+export interface RawSetting {
+  key: string
+  value: string
+  updated_at: string
+  updated_by: string | null
+}
+
+export async function getPipelineSettingsRaw(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId
+): Promise<RawSetting[]> {
+  const rows = await db
+    .prepare(
+      `SELECT key, value, updated_at, updated_by
+       FROM pipeline_settings
+       WHERE org_id = ? AND pipeline = ?
+       ORDER BY key`
+    )
+    .bind(orgId, pipeline)
+    .all<RawSetting>()
+  return rows.results ?? []
+}
+
+// ---------------------------------------------------------------------------
+// Write path
+// ---------------------------------------------------------------------------
+
+export interface UpdateInput {
+  key: string
+  value: number
+}
+
+export interface UpdateResult {
+  ok: boolean
+  errors: string[]
+  changed: number
+}
+
+export interface Actor {
+  userId: string | null
+  email: string | null
+}
+
+/**
+ * Validate and persist a batch of setting changes for one pipeline.
+ * Each change is checked against the registry (key must be known, value
+ * must be in range). On any error the entire batch is rejected and
+ * `errors[]` is populated — partial saves would let the admin walk away
+ * thinking everything saved.
+ *
+ * Audit rows are written for every actually-changed key. No-op writes
+ * (value identical to stored) skip the audit row. Auth/role enforcement
+ * is the caller's responsibility (the admin page is behind middleware).
+ */
+export async function updatePipelineSettings(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId,
+  inputs: UpdateInput[],
+  actor: Actor
+): Promise<UpdateResult> {
+  const specs = SETTING_SPECS[pipeline]
+  const errors: string[] = []
+
+  for (const input of inputs) {
+    const spec = specs[input.key]
+    if (!spec) {
+      errors.push(`Unknown setting "${input.key}" for pipeline ${pipeline}`)
+      continue
+    }
+    if (!Number.isFinite(input.value)) {
+      errors.push(`${spec.label}: value must be a number`)
+      continue
+    }
+    if (spec.type === 'int' && !Number.isInteger(input.value)) {
+      errors.push(`${spec.label}: must be a whole number`)
+      continue
+    }
+    if (input.value < spec.min || input.value > spec.max) {
+      errors.push(`${spec.label}: must be between ${spec.min} and ${spec.max}`)
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors, changed: 0 }
+  }
+
+  // Read existing values so we can populate audit `old_value` and skip
+  // no-op writes. One round-trip up front is cheaper than per-key reads.
+  const existingRows = await db
+    .prepare(`SELECT key, value FROM pipeline_settings WHERE org_id = ? AND pipeline = ?`)
+    .bind(orgId, pipeline)
+    .all<{ key: string; value: string }>()
+  const existingByKey = new Map<string, string>()
+  for (const r of existingRows.results ?? []) existingByKey.set(r.key, r.value)
+
+  const now = new Date().toISOString()
+  let changed = 0
+
+  for (const input of inputs) {
+    const newValueStr = String(input.value)
+    const oldValue = existingByKey.get(input.key) ?? null
+    if (oldValue === newValueStr) continue
+
+    const id = crypto.randomUUID()
+    await db
+      .prepare(
+        `INSERT INTO pipeline_settings (id, org_id, pipeline, key, value, updated_at, updated_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(org_id, pipeline, key) DO UPDATE SET
+           value = excluded.value,
+           updated_at = excluded.updated_at,
+           updated_by = excluded.updated_by`
+      )
+      .bind(id, orgId, pipeline, input.key, newValueStr, now, actor.email ?? actor.userId)
+      .run()
+
+    const auditId = crypto.randomUUID()
+    await db
+      .prepare(
+        `INSERT INTO pipeline_settings_audit (
+           id, org_id, pipeline, key, old_value, new_value,
+           actor_user_id, actor_email, changed_at
+         )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        auditId,
+        orgId,
+        pipeline,
+        input.key,
+        oldValue,
+        newValueStr,
+        actor.userId,
+        actor.email,
+        now
+      )
+      .run()
+
+    changed++
+  }
+
+  return { ok: true, errors: [], changed }
+}
+
+// ---------------------------------------------------------------------------
+// Audit log read
+// ---------------------------------------------------------------------------
+
+export interface AuditRow {
+  id: string
+  pipeline: PipelineId
+  key: string
+  old_value: string | null
+  new_value: string
+  actor_user_id: string | null
+  actor_email: string | null
+  changed_at: string
+}
+
+export async function listPipelineSettingsAudit(
+  db: D1Database,
+  orgId: string,
+  pipeline: PipelineId,
+  limit = 25
+): Promise<AuditRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT id, pipeline, key, old_value, new_value,
+              actor_user_id, actor_email, changed_at
+       FROM pipeline_settings_audit
+       WHERE org_id = ? AND pipeline = ?
+       ORDER BY changed_at DESC
+       LIMIT ?`
+    )
+    .bind(orgId, pipeline, limit)
+    .all<AuditRow>()
+  return rows.results ?? []
+}

--- a/src/pages/admin/generators/index.astro
+++ b/src/pages/admin/generators/index.astro
@@ -166,6 +166,13 @@ function vlabel(v: string): string {
         >.
       </p>
     </div>
+    <a
+      href="/admin/settings/pipelines"
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[color:var(--ss-color-text-primary)] border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] hover:border-[color:var(--ss-color-text-primary)] transition-colors"
+    >
+      <span class="material-symbols-outlined text-base">tune</span>
+      Pipeline settings
+    </a>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-card">

--- a/src/pages/admin/settings/pipelines.astro
+++ b/src/pages/admin/settings/pipelines.astro
@@ -1,0 +1,313 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro'
+import {
+  PIPELINE_IDS,
+  SETTING_SPECS,
+  getPipelineSettings,
+  getPipelineSettingsRaw,
+  listPipelineSettingsAudit,
+  updatePipelineSettings,
+  type PipelineId,
+  type SettingSpec,
+} from '../../../lib/db/pipeline-settings'
+import { PIPELINE_LABELS } from '../../../lib/generators/types'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Pipeline settings — admin-tunable thresholds and caps for the lead-gen
+ * workers. Closes issue #595.
+ *
+ * Form layout:
+ *   - One section per pipeline that has tunables (review_mining, job_monitor,
+ *     new_business). Pipelines with no tunables (social_listening) are
+ *     omitted entirely so the page does not show empty placeholders.
+ *   - Numeric inputs with `min`/`max` bound to each setting's spec range.
+ *   - "Reset to default" link per row writes the spec default back.
+ *
+ * Validation happens twice — HTML attributes give immediate feedback, and
+ * the DAL re-validates on POST so a hand-edited form cannot bypass the
+ * range checks. Ranges and defaults are owned by `SETTING_SPECS` in the
+ * DAL — this page is a thin form over that registry.
+ *
+ * Audit log: every change writes a row to `pipeline_settings_audit`. The
+ * recent-changes table at the bottom is the visible side of that log.
+ *
+ * Protected by auth middleware (admin role only).
+ */
+
+const session = Astro.locals.session!
+
+// Pipelines that actually have admin-tunable settings. Drives both the
+// form layout and the audit-log loop. Omits social_listening (no tunables).
+const TUNABLE_PIPELINES: PipelineId[] = PIPELINE_IDS.filter(
+  (p) => Object.keys(SETTING_SPECS[p]).length > 0
+)
+
+// ---------------------------------------------------------------------------
+// POST handler — save a pipeline's settings
+// ---------------------------------------------------------------------------
+
+if (Astro.request.method === 'POST') {
+  const form = await Astro.request.formData()
+  const pipeline = String(form.get('pipeline') ?? '') as PipelineId
+  if (!PIPELINE_IDS.includes(pipeline)) {
+    return Astro.redirect('/admin/settings/pipelines?error=unknown_pipeline', 302)
+  }
+
+  const inputs: Array<{ key: string; value: number }> = []
+  for (const [key, spec] of Object.entries(SETTING_SPECS[pipeline])) {
+    const raw = form.get(key)
+    if (typeof raw !== 'string' || raw.trim() === '') continue
+    const value = spec.type === 'int' ? Number.parseInt(raw, 10) : Number.parseFloat(raw)
+    inputs.push({ key, value })
+  }
+
+  const result = await updatePipelineSettings(env.DB, session.orgId, pipeline, inputs, {
+    userId: session.userId,
+    email: session.email,
+  })
+
+  if (!result.ok) {
+    const params = new URLSearchParams({ error: result.errors.join(' · '), pipeline })
+    return Astro.redirect(`/admin/settings/pipelines?${params.toString()}`, 302)
+  }
+
+  return Astro.redirect(
+    `/admin/settings/pipelines?saved=${pipeline}&changed=${result.changed}`,
+    302
+  )
+}
+
+// ---------------------------------------------------------------------------
+// GET — load resolved settings + raw rows for provenance + audit history
+// ---------------------------------------------------------------------------
+
+interface PipelineView {
+  pipeline: PipelineId
+  resolved: Record<string, number>
+  // Map key -> stored raw row (or undefined if defaulted)
+  rawByKey: Record<string, { value: string; updated_at: string; updated_by: string | null }>
+  specs: Record<string, SettingSpec>
+}
+
+const views: PipelineView[] = []
+for (const pipeline of TUNABLE_PIPELINES) {
+  const resolved = (await getPipelineSettings(
+    env.DB,
+    session.orgId,
+    pipeline
+  )) as unknown as Record<string, number>
+  const rawRows = await getPipelineSettingsRaw(env.DB, session.orgId, pipeline)
+  const rawByKey: Record<string, { value: string; updated_at: string; updated_by: string | null }> =
+    {}
+  for (const r of rawRows) {
+    rawByKey[r.key] = { value: r.value, updated_at: r.updated_at, updated_by: r.updated_by }
+  }
+  views.push({
+    pipeline,
+    resolved,
+    rawByKey,
+    specs: SETTING_SPECS[pipeline],
+  })
+}
+
+// Recent audit entries across all pipelines. We render them as a single
+// activity feed since per-pipeline history is rarely large enough to
+// justify three separate scrolling lists.
+const auditByPipeline = await Promise.all(
+  TUNABLE_PIPELINES.map((p) => listPipelineSettingsAudit(env.DB, session.orgId, p, 10))
+)
+const allAudit = auditByPipeline.flat().sort((a, b) => b.changed_at.localeCompare(a.changed_at))
+const recentAudit = allAudit.slice(0, 25)
+
+// URL feedback parameters for save/error banners.
+const url = new URL(Astro.request.url)
+const savedParam = url.searchParams.get('saved')
+const changedParam = url.searchParams.get('changed')
+const errorParam = url.searchParams.get('error')
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return ''
+  const diff = Date.now() - new Date(iso).getTime()
+  const hours = Math.round(diff / (1000 * 60 * 60))
+  if (hours < 1) return 'Just now'
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.round(hours / 24)}d ago`
+}
+
+function inputStep(spec: SettingSpec): string {
+  return spec.type === 'int' ? '1' : '0.01'
+}
+---
+
+<AdminLayout
+  title="Pipeline settings — SMD Services"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Generators', href: '/admin/generators' },
+    { label: 'Pipeline settings' },
+  ]}
+>
+  <div class="mb-6">
+    <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+      Pipeline settings
+    </h2>
+    <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+      Tunable thresholds and caps for the lead-gen workers. Each cron run reads these values at the
+      start of the run, so changes take effect on the next scheduled invocation without a deploy.
+    </p>
+    <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+      Defaults match the constants that previously shipped in worker source. An empty settings table
+      preserves the old behavior. Closes <a
+        href="https://github.com/venturecrane/ss-console/issues/595"
+        class="underline hover:text-[color:var(--ss-color-primary)]">issue #595</a
+      >.
+    </p>
+  </div>
+
+  {
+    savedParam && (
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-complete)]/10 border border-[color:var(--ss-color-complete)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-complete)]">
+          Saved {savedParam} settings. {changedParam ?? '0'} value
+          {changedParam === '1' ? '' : 's'} changed. Next run will pick up the new values.
+        </p>
+      </div>
+    )
+  }
+  {
+    errorParam && (
+      <div class="mb-6 p-stack bg-[color:var(--ss-color-error)]/10 border border-[color:var(--ss-color-error)]/30 rounded-[var(--ss-radius-card)]">
+        <p class="text-sm text-[color:var(--ss-color-error)]">{errorParam}</p>
+      </div>
+    )
+  }
+
+  <div class="space-y-8">
+    {
+      views.map((view) => (
+        <section
+          aria-labelledby={`heading-${view.pipeline}`}
+          class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+        >
+          <header class="mb-4">
+            <h3
+              id={`heading-${view.pipeline}`}
+              class="text-base font-semibold text-[color:var(--ss-color-text-primary)]"
+            >
+              {PIPELINE_LABELS[view.pipeline]}
+            </h3>
+            <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
+              <a
+                href={`/admin/generators/${view.pipeline}`}
+                class="underline hover:text-[color:var(--ss-color-primary)]"
+              >
+                View pipeline detail and run history
+              </a>
+            </p>
+          </header>
+          <form method="POST" class="space-y-stack">
+            <input type="hidden" name="pipeline" value={view.pipeline} />
+            {Object.entries(view.specs).map(([key, spec]) => {
+              const stored = view.rawByKey[key]
+              const value = view.resolved[key]
+              const isDefault = !stored
+              return (
+                <div>
+                  <div class="flex items-center justify-between gap-2 mb-1">
+                    <label
+                      for={`${view.pipeline}_${key}`}
+                      class="text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+                    >
+                      {spec.label}{' '}
+                      <span class="text-xs text-[color:var(--ss-color-text-secondary)] font-normal">
+                        ({spec.min}–{spec.max})
+                      </span>
+                    </label>
+                    {isDefault ? (
+                      <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                        Default ({spec.default})
+                      </span>
+                    ) : (
+                      <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                        Set {formatRelative(stored.updated_at)}
+                        {stored.updated_by ? ` by ${stored.updated_by}` : ''}
+                      </span>
+                    )}
+                  </div>
+                  <input
+                    type="number"
+                    id={`${view.pipeline}_${key}`}
+                    name={key}
+                    value={value}
+                    min={spec.min}
+                    max={spec.max}
+                    step={inputStep(spec)}
+                    required
+                    class="w-full max-w-xs border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
+                  />
+                  <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
+                    {spec.help}
+                  </p>
+                </div>
+              )
+            })}
+
+            <div class="pt-1">
+              <button
+                type="submit"
+                class="px-4 py-2 text-sm font-medium text-white bg-primary rounded-[var(--ss-radius-card)] hover:bg-primary/90 transition-colors"
+              >
+                Save {PIPELINE_LABELS[view.pipeline]} settings
+              </button>
+            </div>
+          </form>
+        </section>
+      ))
+    }
+  </div>
+
+  <section aria-labelledby="audit-heading" class="mt-10">
+    <h3
+      id="audit-heading"
+      class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3"
+    >
+      Recent changes
+    </h3>
+    {
+      recentAudit.length === 0 ? (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No setting changes yet. Once admin tunes a value, the change history appears here.
+          </p>
+        </div>
+      ) : (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] divide-y divide-[color:var(--ss-color-border-subtle)]">
+          {recentAudit.map((row) => (
+            <div class="px-6 py-3 flex items-start justify-between gap-3 text-sm">
+              <div class="min-w-0 flex-1">
+                <p class="text-[color:var(--ss-color-text-primary)]">
+                  <span class="font-medium">{PIPELINE_LABELS[row.pipeline]}</span>
+                  <span class="text-[color:var(--ss-color-text-muted)]"> · </span>
+                  <code class="font-mono text-xs">{row.key}</code>
+                  <span class="text-[color:var(--ss-color-text-muted)]">: </span>
+                  <span class="font-mono text-xs">
+                    {row.old_value ?? '<unset>'} → {row.new_value}
+                  </span>
+                </p>
+                {row.actor_email && (
+                  <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-0.5">
+                    by {row.actor_email}
+                  </p>
+                )}
+              </div>
+              <span class="text-xs text-[color:var(--ss-color-text-muted)] whitespace-nowrap">
+                {formatRelative(row.changed_at)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )
+    }
+  </section>
+</AdminLayout>

--- a/workers/job-monitor/src/alert.ts
+++ b/workers/job-monitor/src/alert.ts
@@ -8,6 +8,7 @@ export interface RunSummary {
   newJobs: number
   qualified: number
   disqualified: number
+  belowThreshold: number
   written: number
   errors: number
   errorDetails: string[]
@@ -27,6 +28,7 @@ export async function sendFailureAlert(summary: RunSummary, resendApiKey: string
     `Existing entities seen again: ${summary.existingAppended}`,
     `Qualified: ${summary.qualified}`,
     `Disqualified: ${summary.disqualified}`,
+    `Below pain threshold: ${summary.belowThreshold}`,
     `Written to D1: ${summary.written}`,
     `Errors: ${summary.errors}`,
     ``,

--- a/workers/job-monitor/src/index.test.ts
+++ b/workers/job-monitor/src/index.test.ts
@@ -22,6 +22,10 @@ vi.mock('../../../src/lib/db/generators.js', () => ({
   recordGeneratorRun: vi.fn(),
 }))
 
+vi.mock('../../../src/lib/db/pipeline-settings.js', () => ({
+  getPipelineSettings: vi.fn(),
+}))
+
 vi.mock('../../../src/lib/enrichment/index.js', () => ({
   enrichEntity: vi.fn().mockResolvedValue(undefined),
 }))
@@ -49,10 +53,11 @@ vi.mock('./alert.js', () => ({
 
 import worker from './index'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
+import { getPipelineSettings } from '../../../src/lib/db/pipeline-settings.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { searchJobs } from './serpapi.js'
-import { qualifyJob } from './qualify.js'
+import { qualifyJob, derivePainScore } from './qualify.js'
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -147,6 +152,8 @@ function makeQualification(overrides = {}) {
 describe('job-monitor fetch handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(8)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(searchJobs).mockResolvedValue([])
@@ -190,6 +197,7 @@ describe('job-monitor fetch handler', () => {
 describe('job-monitor disabled generator', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeDisabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
   })
@@ -211,6 +219,8 @@ describe('job-monitor disabled generator', () => {
 describe('job-monitor happy path', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(8)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(searchJobs).mockResolvedValue([makeSerpJob()])
@@ -239,6 +249,8 @@ describe('job-monitor happy path', () => {
 describe('job-monitor SerpAPI failure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(8)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(searchJobs).mockRejectedValue(new Error('SerpAPI: 401 Unauthorized'))
@@ -260,6 +272,8 @@ describe('job-monitor SerpAPI failure', () => {
 describe('job-monitor Claude failure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(8)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(searchJobs).mockResolvedValue([makeSerpJob()])
@@ -283,6 +297,8 @@ describe('job-monitor Claude failure', () => {
 describe('job-monitor scheduled handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(8)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(searchJobs).mockResolvedValue([])
@@ -292,5 +308,53 @@ describe('job-monitor scheduled handler', () => {
     await expect(
       worker.scheduled({} as ScheduledController, makeEnv(), makeCtx())
     ).resolves.toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: pain_threshold setting (issue #595)
+// ---------------------------------------------------------------------------
+
+describe('job-monitor pain_threshold from settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
+    vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
+    vi.mocked(searchJobs).mockResolvedValue([makeSerpJob()])
+    vi.mocked(qualifyJob).mockResolvedValue(makeQualification() as never)
+    vi.mocked(findOrCreateEntity).mockResolvedValue({
+      entity: { id: 'entity-001', name: 'Acme Plumbing' },
+    } as never)
+    vi.mocked(appendContext).mockResolvedValue(undefined as never)
+  })
+
+  it('skips a job with derived pain score below threshold', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 9 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(7)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.belowThreshold).toBe(1)
+    expect(body.qualified).toBe(0)
+    expect(body.written).toBe(0)
+    expect(appendContext).not.toHaveBeenCalled()
+  })
+
+  it('writes a low-confidence job when admin lowers threshold', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 5 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(5)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.qualified).toBe(1)
+    expect(body.written).toBe(1)
+  })
+
+  it('uses default threshold of 7 from DAL', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 7 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(7)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    // pain_score=7 with threshold=7 should pass (>=)
+    expect(body.qualified).toBe(1)
+    expect(body.written).toBe(1)
   })
 })

--- a/workers/job-monitor/src/index.ts
+++ b/workers/job-monitor/src/index.ts
@@ -14,6 +14,7 @@ import { ORG_ID } from '../../../src/lib/constants.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
+import { getPipelineSettings } from '../../../src/lib/db/pipeline-settings.js'
 import type { JobMonitorConfig } from '../../../src/lib/generators/types.js'
 import { enrichEntity } from '../../../src/lib/enrichment/index.js'
 import { searchJobs } from './serpapi.js'
@@ -40,11 +41,17 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
     newJobs: 0,
     qualified: 0,
     disqualified: 0,
+    belowThreshold: 0,
     written: 0,
     errors: 0,
     errorDetails: [],
     existingAppended: 0,
   }
+
+  // Resolve admin-tunable settings at the TOP of every run so the next cron
+  // tick picks up admin changes without a worker restart (issue #595).
+  const settings = await getPipelineSettings(env.DB, ORG_ID, 'job_monitor')
+  const painThreshold = settings.pain_threshold
 
   const configRow = await getGeneratorConfig(env.DB, ORG_ID, 'job_monitor')
   if (!configRow.enabled) {
@@ -117,6 +124,17 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
         continue
       }
 
+      // Apply admin-tunable pain_threshold (issue #595). The derived score
+      // collapses Claude `confidence` + `problems_signaled.length` into a
+      // 1-10 scale (see derivePainScore). Default threshold is 7, matching
+      // prior shipped behavior — but ops can lower it to surface medium-
+      // confidence single-problem jobs without redeploying.
+      const painScore = derivePainScore(qualification)
+      if (painScore < painThreshold) {
+        summary.belowThreshold++
+        continue
+      }
+
       summary.qualified++
 
       // Find or create entity
@@ -137,7 +155,6 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
 
       // Build metadata
       const dateFound = new Date().toISOString().split('T')[0]
-      const painScore = derivePainScore(qualification)
       const metadata: Record<string, unknown> = {
         job_hash: job.job_id,
         job_url: job.apply_options?.[0]?.link ?? null,
@@ -183,8 +200,8 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
 
   console.log(
     `Run complete: ${summary.newJobs} new, ${summary.existingAppended} existing, ` +
-      `${summary.qualified} qualified, ${summary.disqualified} disqualified, ` +
-      `${summary.written} written, ${summary.errors} errors`
+      `${summary.qualified} qualified (pain>=${painThreshold}), ${summary.disqualified} disqualified, ` +
+      `${summary.belowThreshold} below threshold, ${summary.written} written, ${summary.errors} errors`
   )
 
   await recordGeneratorRun(env.DB, ORG_ID, 'job_monitor', {

--- a/workers/new-business/src/alert.ts
+++ b/workers/new-business/src/alert.ts
@@ -8,6 +8,7 @@ export interface RunSummary {
   newPermits: number
   qualified: number
   disqualified: number
+  belowThreshold: number
   written: number
   errors: number
   errorDetails: string[]
@@ -22,6 +23,7 @@ export async function sendFailureAlert(summary: RunSummary, resendApiKey: string
     `New (not deduped): ${summary.newPermits}`,
     `Qualified: ${summary.qualified}`,
     `Disqualified: ${summary.disqualified}`,
+    `Below pain threshold: ${summary.belowThreshold}`,
     `Written to D1: ${summary.written}`,
     `Errors: ${summary.errors}`,
     ``,

--- a/workers/new-business/src/index.test.ts
+++ b/workers/new-business/src/index.test.ts
@@ -22,6 +22,10 @@ vi.mock('../../../src/lib/db/generators.js', () => ({
   recordGeneratorRun: vi.fn(),
 }))
 
+vi.mock('../../../src/lib/db/pipeline-settings.js', () => ({
+  getPipelineSettings: vi.fn(),
+}))
+
 vi.mock('../../../src/lib/enrichment/index.js', () => ({
   enrichEntity: vi.fn().mockResolvedValue(undefined),
 }))
@@ -36,6 +40,7 @@ vi.mock('./soda.js', () => ({
 
 vi.mock('./qualify.js', () => ({
   qualifyNewBusiness: vi.fn(),
+  derivePainScore: vi.fn().mockReturnValue(10),
 }))
 
 vi.mock('./alert.js', () => ({
@@ -48,10 +53,11 @@ vi.mock('./alert.js', () => ({
 
 import worker from './index'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
+import { getPipelineSettings } from '../../../src/lib/db/pipeline-settings.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { fetchAllPermits } from './soda.js'
-import { qualifyNewBusiness } from './qualify.js'
+import { qualifyNewBusiness, derivePainScore } from './qualify.js'
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -148,6 +154,8 @@ function makeQualification(overrides = {}) {
 describe('new-business fetch handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(10)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(fetchAllPermits).mockResolvedValue([])
@@ -190,6 +198,7 @@ describe('new-business fetch handler', () => {
 describe('new-business disabled generator', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeDisabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
   })
@@ -210,6 +219,8 @@ describe('new-business disabled generator', () => {
 describe('new-business happy path', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(10)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(fetchAllPermits).mockResolvedValue([makePermit()])
@@ -237,6 +248,9 @@ describe('new-business happy path', () => {
 describe('new-business not_recommended qualification', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
+    // not_recommended → score 0 < threshold 1 → counted under disqualified
+    vi.mocked(derivePainScore).mockReturnValue(0)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(fetchAllPermits).mockResolvedValue([makePermit()])
@@ -261,6 +275,8 @@ describe('new-business not_recommended qualification', () => {
 describe('new-business Claude failure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(10)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(fetchAllPermits).mockResolvedValue([makePermit()])
@@ -283,6 +299,8 @@ describe('new-business Claude failure', () => {
 describe('new-business scheduled handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(10)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(fetchAllPermits).mockResolvedValue([])
@@ -292,5 +310,44 @@ describe('new-business scheduled handler', () => {
     await expect(
       worker.scheduled({} as ScheduledController, makeEnv(), makeCtx())
     ).resolves.toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: pain_threshold setting (issue #595)
+// ---------------------------------------------------------------------------
+
+describe('new-business pain_threshold from settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
+    vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
+    vi.mocked(fetchAllPermits).mockResolvedValue([makePermit()])
+    vi.mocked(qualifyNewBusiness).mockResolvedValue(
+      makeQualification({ outreach_timing: 'wait_60_days' }) as never
+    )
+    vi.mocked(findOrCreateEntity).mockResolvedValue({
+      entity: { id: 'entity-001', name: 'Desert Bloom Florist' },
+    } as never)
+    vi.mocked(appendContext).mockResolvedValue(undefined as never)
+  })
+
+  it('writes wait_60_days permit (score 5) when threshold is default 1', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 1 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(5)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.qualified).toBe(1)
+    expect(body.written).toBe(1)
+  })
+
+  it('skips wait_60_days permit (score 5) when admin raises threshold to 6', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue({ pain_threshold: 6 } as never)
+    vi.mocked(derivePainScore).mockReturnValue(5)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.belowThreshold).toBe(1)
+    expect(body.written).toBe(0)
+    expect(appendContext).not.toHaveBeenCalled()
   })
 })

--- a/workers/new-business/src/index.ts
+++ b/workers/new-business/src/index.ts
@@ -15,10 +15,11 @@ import { ORG_ID } from '../../../src/lib/constants.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
+import { getPipelineSettings } from '../../../src/lib/db/pipeline-settings.js'
 import type { NewBusinessConfig } from '../../../src/lib/generators/types.js'
 import { enrichEntity } from '../../../src/lib/enrichment/index.js'
 import { fetchAllPermits, type SodaCity } from './soda.js'
-import { qualifyNewBusiness } from './qualify.js'
+import { qualifyNewBusiness, derivePainScore } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
 
 export interface Env {
@@ -42,10 +43,16 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
     newPermits: 0,
     qualified: 0,
     disqualified: 0,
+    belowThreshold: 0,
     written: 0,
     errors: 0,
     errorDetails: [],
   }
+
+  // Resolve admin-tunable pain_threshold at the TOP of every run so the next
+  // cron tick picks up admin changes without a worker restart (issue #595).
+  const settings = await getPipelineSettings(env.DB, ORG_ID, 'new_business')
+  const painThreshold = settings.pain_threshold
 
   const configRow = await getGeneratorConfig(env.DB, ORG_ID, 'new_business')
   if (!configRow.enabled) {
@@ -84,8 +91,19 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
         continue
       }
 
-      if (qualification.outreach_timing === 'not_recommended') {
-        summary.disqualified++
+      // Apply admin-tunable pain_threshold (issue #595). For new_business we
+      // derive a 0-10 score from `outreach_timing` (immediate=10,
+      // wait_30_days=7, wait_60_days=5, not_recommended=0). Default threshold
+      // is 1 — meaning only `not_recommended` permits are filtered, matching
+      // the prior shipped behavior. Ops can raise it to 6 to skip
+      // wait_60_days permits, or to 8 to act only on immediate-timing leads.
+      const painScore = derivePainScore(qualification)
+      if (painScore < painThreshold) {
+        if (qualification.outreach_timing === 'not_recommended') {
+          summary.disqualified++
+        } else {
+          summary.belowThreshold++
+        }
         continue
       }
 
@@ -118,6 +136,7 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
         vertical_match: qualification.vertical_match,
         size_estimate: qualification.size_estimate,
         outreach_timing: qualification.outreach_timing,
+        pain_score: painScore,
         ...(qualification.outreach_angle ? { outreach_angle: qualification.outreach_angle } : {}),
         date_found: dateFound,
       }
@@ -157,8 +176,9 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   }
 
   console.log(
-    `Run complete: ${summary.newPermits} new, ${summary.qualified} qualified, ` +
-      `${summary.disqualified} disqualified, ${summary.written} written, ${summary.errors} errors`
+    `Run complete: ${summary.newPermits} new, ${summary.qualified} qualified (pain>=${painThreshold}), ` +
+      `${summary.disqualified} disqualified, ${summary.belowThreshold} below threshold, ` +
+      `${summary.written} written, ${summary.errors} errors`
   )
 
   await recordGeneratorRun(env.DB, ORG_ID, 'new_business', {

--- a/workers/new-business/src/qualify.ts
+++ b/workers/new-business/src/qualify.ts
@@ -83,3 +83,37 @@ export async function qualifyNewBusiness(
 
   return parsed as NewBusinessQualification
 }
+
+/**
+ * Derive a 0-10 pain score from a new-business qualification.
+ *
+ * The new-business pipeline qualifies via Claude `outreach_timing` (one of
+ * `immediate` / `wait_30_days` / `wait_60_days` / `not_recommended`) — there
+ * is no native numeric pain. We collapse it to a uniform scale so the
+ * admin-tunable `pain_threshold` setting (issue #595) has consistent
+ * semantics across all three pipelines.
+ *
+ * Mapping (immediate = strongest signal, sooner outreach):
+ *   - immediate       → 10
+ *   - wait_30_days    →  7
+ *   - wait_60_days    →  5
+ *   - not_recommended →  0
+ *
+ * The default threshold (1) preserves prior behavior: only `not_recommended`
+ * permits are filtered out. Ops can raise to 6 to skip wait_60_days, or to
+ * 8 to act only on immediate-timing leads.
+ */
+export function derivePainScore(q: NewBusinessQualification): number {
+  switch (q.outreach_timing) {
+    case 'immediate':
+      return 10
+    case 'wait_30_days':
+      return 7
+    case 'wait_60_days':
+      return 5
+    case 'not_recommended':
+      return 0
+    default:
+      return 0
+  }
+}

--- a/workers/review-mining/src/index.test.ts
+++ b/workers/review-mining/src/index.test.ts
@@ -22,6 +22,10 @@ vi.mock('../../../src/lib/db/generators.js', () => ({
   recordGeneratorRun: vi.fn(),
 }))
 
+vi.mock('../../../src/lib/db/pipeline-settings.js', () => ({
+  getPipelineSettings: vi.fn(),
+}))
+
 vi.mock('../../../src/lib/enrichment/index.js', () => ({
   enrichEntity: vi.fn().mockResolvedValue(undefined),
 }))
@@ -49,6 +53,7 @@ vi.mock('./alert.js', () => ({
 
 import worker from './index'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
+import { getPipelineSettings } from '../../../src/lib/db/pipeline-settings.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { discoverBusinesses, fetchReviews } from './outscraper.js'
@@ -66,6 +71,21 @@ function makeEnv(overrides: Partial<Env> = {}): Env {
     ANTHROPIC_API_KEY: 'sk-test-anthropic',
     RESEND_API_KEY: 'sk-test-resend',
     LEAD_INGEST_API_KEY: 'sk-test-ingest-key',
+    ...overrides,
+  }
+}
+
+function makeSettings(
+  overrides: Partial<{
+    pain_threshold: number
+    max_review_checks: number
+    outscraper_budget_usd_per_run: number
+  }> = {}
+) {
+  return {
+    pain_threshold: 7,
+    max_review_checks: 200,
+    outscraper_budget_usd_per_run: 1.0,
     ...overrides,
   }
 }
@@ -163,6 +183,7 @@ function makeScoring(overrides = {}) {
 describe('review-mining fetch handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(discoverBusinesses).mockResolvedValue([])
@@ -207,6 +228,7 @@ describe('review-mining fetch handler', () => {
 describe('review-mining disabled generator', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeDisabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
   })
@@ -227,6 +249,7 @@ describe('review-mining disabled generator', () => {
 describe('review-mining happy path', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(discoverBusinesses).mockResolvedValue([makeDiscoveredBusiness()])
@@ -255,6 +278,7 @@ describe('review-mining happy path', () => {
 describe('review-mining below threshold', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(discoverBusinesses).mockResolvedValue([makeDiscoveredBusiness()])
@@ -278,6 +302,7 @@ describe('review-mining below threshold', () => {
 describe('review-mining Outscraper failure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(discoverBusinesses).mockResolvedValue([makeDiscoveredBusiness()])
@@ -300,6 +325,7 @@ describe('review-mining Outscraper failure', () => {
 describe('review-mining discovery failure', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(discoverBusinesses).mockRejectedValue(new Error('Google Places: 403'))
@@ -323,6 +349,7 @@ describe('review-mining discovery failure', () => {
 describe('review-mining scheduled handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(discoverBusinesses).mockResolvedValue([])
@@ -337,12 +364,14 @@ describe('review-mining scheduled handler', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: per-run cap + Outscraper budget guard (issue #592)
+// Tests: per-run cap + Outscraper budget guard
+// (settings-driven since #595 — was env-var-driven under #592)
 // ---------------------------------------------------------------------------
 
 describe('review-mining cap and budget guard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
     vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
     vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
     vi.mocked(fetchReviews).mockResolvedValue([])
@@ -352,16 +381,15 @@ describe('review-mining cap and budget guard', () => {
     vi.mocked(appendContext).mockResolvedValue(undefined as never)
   })
 
-  it('respects MAX_REVIEW_CHECKS env override (caps at 5 of 12 discovered)', async () => {
+  it('respects max_review_checks setting (caps at 5 of 12 discovered)', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue(
+      makeSettings({ max_review_checks: 5 }) as never
+    )
     const businesses = Array.from({ length: 12 }, (_, i) =>
       makeDiscoveredBusiness({ place_id: `p-${i}` })
     )
     vi.mocked(discoverBusinesses).mockResolvedValue(businesses)
-    const res = await worker.fetch(
-      makeRequest('Bearer sk-test-ingest-key'),
-      makeEnv({ MAX_REVIEW_CHECKS: '5' }),
-      makeCtx()
-    )
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
     const body = (await res.json()) as Record<string, unknown>
     expect(body.discovered).toBe(12)
     expect(body.reviewChecksAttempted).toBe(5)
@@ -370,25 +398,24 @@ describe('review-mining cap and budget guard', () => {
     expect(body.budgetGuardTripped).toBe(false)
   })
 
-  it('stops early when the Outscraper budget guard would be exceeded', async () => {
+  it('stops early when the Outscraper budget guard setting would be exceeded', async () => {
     // 30 discovered, batch size 10, $0.003 each. Budget $0.04 allows
     // at most 1 batch ($0.030); the 2nd batch would push to $0.060 > $0.040.
+    vi.mocked(getPipelineSettings).mockResolvedValue(
+      makeSettings({ outscraper_budget_usd_per_run: 0.04 }) as never
+    )
     const businesses = Array.from({ length: 30 }, (_, i) =>
       makeDiscoveredBusiness({ place_id: `p-${i}` })
     )
     vi.mocked(discoverBusinesses).mockResolvedValue(businesses)
-    const res = await worker.fetch(
-      makeRequest('Bearer sk-test-ingest-key'),
-      makeEnv({ OUTSCRAPER_BUDGET_USD_PER_RUN: '0.04' }),
-      makeCtx()
-    )
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
     const body = (await res.json()) as Record<string, unknown>
     expect(body.budgetGuardTripped).toBe(true)
     expect(body.reviewChecksAttempted).toBe(10)
     expect(body.outscraperSpendUsd).toBeCloseTo(0.03, 5)
   })
 
-  it('uses the 200 default when MAX_REVIEW_CHECKS is unset', async () => {
+  it('uses the 200 default when settings are unset (defaults from DAL)', async () => {
     const businesses = Array.from({ length: 250 }, (_, i) =>
       makeDiscoveredBusiness({ place_id: `p-${i}` })
     )
@@ -399,5 +426,52 @@ describe('review-mining cap and budget guard', () => {
     expect(body.reviewChecksAttempted).toBe(200)
     expect(body.outscraperSpendUsd).toBeCloseTo(0.6, 5)
     expect(body.budgetGuardTripped).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: pain_threshold setting (issue #595)
+// ---------------------------------------------------------------------------
+
+describe('review-mining pain_threshold from settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getGeneratorConfig).mockResolvedValue(makeEnabledConfig() as never)
+    vi.mocked(recordGeneratorRun).mockResolvedValue(undefined as never)
+    vi.mocked(discoverBusinesses).mockResolvedValue([makeDiscoveredBusiness()])
+    vi.mocked(fetchReviews).mockResolvedValue([makeBusinessWithReviews()])
+    vi.mocked(findOrCreateEntity).mockResolvedValue({
+      entity: { id: 'entity-001', name: 'Desert HVAC' },
+    } as never)
+    vi.mocked(appendContext).mockResolvedValue(undefined as never)
+  })
+
+  it('writes a pain=6 business when admin lowers threshold to 5', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings({ pain_threshold: 5 }) as never)
+    vi.mocked(scoreReviews).mockResolvedValue(makeScoring({ pain_score: 6 }) as never)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.qualified).toBe(1)
+    expect(body.written).toBe(1)
+  })
+
+  it('skips a pain=8 business when admin raises threshold to 9', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings({ pain_threshold: 9 }) as never)
+    vi.mocked(scoreReviews).mockResolvedValue(makeScoring({ pain_score: 8 }) as never)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.belowThreshold).toBe(1)
+    expect(body.written).toBe(0)
+    expect(appendContext).not.toHaveBeenCalled()
+  })
+
+  it('uses default 7 when settings table returns DAL defaults', async () => {
+    vi.mocked(getPipelineSettings).mockResolvedValue(makeSettings() as never)
+    vi.mocked(scoreReviews).mockResolvedValue(makeScoring({ pain_score: 7 }) as never)
+    const res = await worker.fetch(makeRequest('Bearer sk-test-ingest-key'), makeEnv(), makeCtx())
+    const body = (await res.json()) as Record<string, unknown>
+    // pain_score=7 with threshold=7 should pass (>=)
+    expect(body.qualified).toBe(1)
+    expect(body.written).toBe(1)
   })
 })

--- a/workers/review-mining/src/index.ts
+++ b/workers/review-mining/src/index.ts
@@ -15,6 +15,7 @@ import { ORG_ID } from '../../../src/lib/constants.js'
 import { findOrCreateEntity } from '../../../src/lib/db/entities.js'
 import { appendContext } from '../../../src/lib/db/context.js'
 import { getGeneratorConfig, recordGeneratorRun } from '../../../src/lib/db/generators.js'
+import { getPipelineSettings } from '../../../src/lib/db/pipeline-settings.js'
 import type { ReviewMiningConfig } from '../../../src/lib/generators/types.js'
 import { enrichEntity } from '../../../src/lib/enrichment/index.js'
 import { discoverBusinesses, fetchReviews } from './outscraper.js'
@@ -22,29 +23,16 @@ import { scoreReviews } from './qualify.js'
 import { sendFailureAlert, type RunSummary } from './alert.js'
 import type { DiscoveredBusiness } from './outscraper.js'
 
-const PAIN_THRESHOLD = 7
-
 // Per-business Outscraper cost. Reviews extraction is ~$3 per 1,000 place_ids
 // queried regardless of how many reviews come back. Source:
 // docs/lead-automation/specs/outscraper-queries.md ("Outscraper Pricing").
 const OUTSCRAPER_USD_PER_PLACE = 0.003
 
-// Default cap on businesses sent to Outscraper per run. Raised from 50 to 200
-// per issue #592 to lift the artificial top-of-funnel constraint identified
-// in the 2026-04-25 lead-gen audit. At ~$0.003/business that is ~$0.60/run,
-// ~$2.40/month at the weekly cron cadence. Both this cap and PAIN_THRESHOLD
-// will move into admin config under issue #595; until then they are constants
-// here, with `MAX_REVIEW_CHECKS` and `OUTSCRAPER_BUDGET_USD_PER_RUN` env vars
-// available as escape hatches without a code deploy.
-const DEFAULT_MAX_REVIEW_CHECKS = 200
-
-// Hard ceiling on how much a single run may spend on Outscraper. The cap above
-// is the primary constraint; this is a belt-and-suspenders guard so a future
-// change to discovery queries, geo radius, or batch logic can't blow through
-// the budget unobserved. At default settings (200 places, $0.003/place) a run
-// spends ~$0.60, comfortably under the $1.00 default. Override per environment
-// via the `OUTSCRAPER_BUDGET_USD_PER_RUN` env var.
-const DEFAULT_OUTSCRAPER_BUDGET_USD_PER_RUN = 1.0
+// Pain threshold + per-run cap + Outscraper budget guard now read from the
+// `pipeline_settings` table at the top of every run (issue #595). Defaults
+// in `src/lib/db/pipeline-settings.ts` match the constants that previously
+// shipped here (pain=7, cap=200, budget=$1.00) so the deploy is a no-op
+// until ops explicitly tunes a value via the admin UI.
 
 export interface Env {
   DB: D1Database
@@ -56,23 +44,6 @@ export interface Env {
   // Optional keys used by the at-ingest enrichment pipeline.
   SERPAPI_API_KEY?: string
   PROXYCURL_API_KEY?: string
-  // Optional overrides for the per-run cap and budget guard. Both are strings
-  // because Wrangler vars are strings; parsed at run start with sane fallbacks.
-  // Will be replaced by admin-config in issue #595.
-  MAX_REVIEW_CHECKS?: string
-  OUTSCRAPER_BUDGET_USD_PER_RUN?: string
-}
-
-function parsePositiveInt(value: string | undefined, fallback: number): number {
-  if (!value) return fallback
-  const parsed = Number.parseInt(value, 10)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
-}
-
-function parsePositiveFloat(value: string | undefined, fallback: number): number {
-  if (!value) return fallback
-  const parsed = Number.parseFloat(value)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
 async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
@@ -91,14 +62,14 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
     budgetGuardTripped: false,
   }
 
-  // Resolve the per-run cap and budget guard. Env vars are escape hatches so
-  // we can tune live without a code deploy; defaults are the values that
-  // shipped with #592. Both move into admin config under #595.
-  const maxReviewChecks = parsePositiveInt(env.MAX_REVIEW_CHECKS, DEFAULT_MAX_REVIEW_CHECKS)
-  const budgetUsd = parsePositiveFloat(
-    env.OUTSCRAPER_BUDGET_USD_PER_RUN,
-    DEFAULT_OUTSCRAPER_BUDGET_USD_PER_RUN
-  )
+  // Resolve admin-tunable settings at the TOP of every run so the next cron
+  // tick picks up admin changes without a worker restart (issue #595). The
+  // DAL transparently falls back to compiled-in defaults when the table is
+  // empty, so this is also the safe behavior on a fresh deploy.
+  const settings = await getPipelineSettings(env.DB, ORG_ID, 'review_mining')
+  const painThreshold = settings.pain_threshold
+  const maxReviewChecks = settings.max_review_checks
+  const budgetUsd = settings.outscraper_budget_usd_per_run
 
   const configRow = await getGeneratorConfig(env.DB, ORG_ID, 'review_mining')
   if (!configRow.enabled) {
@@ -203,7 +174,7 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
         continue
       }
 
-      if (scoring.pain_score < PAIN_THRESHOLD) {
+      if (scoring.pain_score < painThreshold) {
         summary.belowThreshold++
         continue
       }
@@ -276,7 +247,7 @@ async function run(env: Env, ctx?: ExecutionContext): Promise<RunSummary> {
   }
 
   console.log(
-    `Run complete: ${summary.newBusinesses} new, ${summary.qualified} qualified (pain>=${PAIN_THRESHOLD}), ` +
+    `Run complete: ${summary.newBusinesses} new, ${summary.qualified} qualified (pain>=${painThreshold}), ` +
       `${summary.belowThreshold} below threshold, ${summary.written} written, ${summary.errors} errors, ` +
       `Outscraper spend ~$${summary.outscraperSpendUsd.toFixed(2)}` +
       (summary.budgetGuardTripped ? ' (budget guard tripped)' : '')


### PR DESCRIPTION
## Summary

Closes #595. Replaces hardcoded worker constants (`PAIN_THRESHOLD = 7`, `MAX_REVIEW_CHECKS = 200`, `OUTSCRAPER_BUDGET_USD_PER_RUN = 1.0`) with admin-tunable values stored in a new `pipeline_settings` D1 table. Workers re-read settings at the top of every cron invocation, so changes take effect on the next run without a worker restart or code deploy. Defaults match the constants that previously shipped, so the deploy is a no-op until ops explicitly tunes a value.

## Constants migrated to admin config

| Pipeline | Setting | Default | Range | Was |
| --- | --- | --- | --- | --- |
| `review_mining` | `pain_threshold` | 7 | 1–10 | `PAIN_THRESHOLD` constant |
| `review_mining` | `max_review_checks` | 200 | 1–5000 | `DEFAULT_MAX_REVIEW_CHECKS` + `MAX_REVIEW_CHECKS` env var |
| `review_mining` | `outscraper_budget_usd_per_run` | 1.0 | 0.01–100 | `DEFAULT_OUTSCRAPER_BUDGET_USD_PER_RUN` + env var |
| `job_monitor` | `pain_threshold` | 7 | 1–10 | _new filter_ — applied to `derivePainScore(qualification)` |
| `new_business` | `pain_threshold` | 1 | 0–10 | _new filter_ — applied to a score derived from `outreach_timing` (immediate=10, wait_30_days=7, wait_60_days=5, not_recommended=0). Default 1 preserves prior behavior (skip only `not_recommended`). |

## Schema

`migrations/0029_create_pipeline_settings.sql` adds two tables:

- **`pipeline_settings`** — keyed by `(org_id, pipeline, key)`, value stored as `TEXT` and parsed by the worker at read time. Flat key-value so adding a tunable is registry-only, no schema migration.
- **`pipeline_settings_audit`** — append-only row per change with `old_value`, `new_value`, `actor_user_id`, `actor_email`, `changed_at`. Surfaces in the admin UI as a "Recent changes" feed.

## DAL — `src/lib/db/pipeline-settings.ts`

- `SETTING_SPECS` registry is the source of truth: type (`int` / `float`), default, min, max, label, help. Admin form, write-path validation, and worker reads all consume from it.
- `getPipelineSettings(db, orgId, pipeline)` — workers call this at the **top of every run**. Falls back to defaults silently when rows are missing (graceful degradation on fresh deploy).
- `updatePipelineSettings(...)` — all-or-nothing batch write with range and type validation. No-op when value matches stored. Audit row on every real change.
- `listPipelineSettingsAudit(...)` — recent changes for the admin activity feed.

## Worker refactor

All three workers now resolve the threshold/cap at the start of each invocation:

```ts
const settings = await getPipelineSettings(env.DB, ORG_ID, 'review_mining')
const painThreshold = settings.pain_threshold
const maxReviewChecks = settings.max_review_checks
const budgetUsd = settings.outscraper_budget_usd_per_run
```

The previous escape-hatch env vars (`MAX_REVIEW_CHECKS`, `OUTSCRAPER_BUDGET_USD_PER_RUN`) are removed — the settings table replaces them. Set values via the admin UI.

## Admin UI

New page at `/admin/settings/pipelines` (`src/pages/admin/settings/pipelines.astro`). One section per pipeline that has tunables (review_mining, job_monitor, new_business). Numeric inputs with HTML `min`/`max` attributes plus DAL re-validation on POST. Save banner, error banner. Linked from the existing `/admin/generators` index page.

## Tests

- 19 DAL tests in `src/lib/db/pipeline-settings.test.ts` — defaults, stored-value overlay, parse failure → fall back to default, validation (unknown key, out-of-range, non-int when spec is int, NaN, all-or-nothing batch), audit row content (old_value populated correctly), no-op on identical value, multi-key batch.
- Worker tests added/updated in all three workers — settings-table-override replaces the env-var-override tests from #592, plus per-pipeline pain_threshold filter tests.
- `npm run verify` green: typecheck (pages + 4 workers), format, lint, build, all unit tests, all worker tests.

## Test plan

- [x] DAL unit tests cover defaults / overlay / validation / audit
- [x] Worker tests cover settings-driven cap, budget guard, pain threshold across all three pipelines
- [x] `npm run verify` green
- [ ] After merge: apply migration to prod D1, deploy admin app, change `review_mining.pain_threshold` to 6 in the admin UI, watch next cron run pick up the new value (Mon 15:00 UTC)
- [ ] Verify audit row appears in "Recent changes" with email + before/after values

## Coordination notes

Confined to `migrations/`, `src/lib/db/pipeline-settings.*`, `src/pages/admin/settings/`, `src/pages/admin/generators/index.astro` (linked-only), and the three lead-gen worker `src/index.ts` files. No collision with #598 (Engine 1 — `src/pages/scan/`), #594 (vertical-aware outreach — `src/lead-gen/prompts/`), or admin entity views/edit forms. The reserved-pipelines work (#593) lives in `workers/social-listening/` which already has zero tunables in this PR's registry — easy to extend by adding a key to `SETTING_SPECS.social_listening`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)