### PR TITLE
chore: sync /code-review and /eos from crane-console

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -362,9 +362,17 @@ gh issue list --repo {ORG}/{REPO_NAME} --label "source:code-review" --state open
 
 If an existing open issue covers the same finding, skip creation and note it in the report.
 
-### Step 9: Done
+### Step 9: Record Completion and Display Summary
 
-Display a summary:
+**9a. Record completion in the Cadence Engine — this MUST happen before the summary.** Past runs have skipped this when it was framed as a tail action; if you skip it now, the briefing will say "Code Review (X) — UNTRACKED" even though the review ran.
+
+```
+crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "success", summary: "Grade: {GRADE}, {N} issues created", completed_by: "crane-mcp")
+```
+
+If `crane_schedule` returns an error, surface it in the summary so the gap is visible — do NOT silently move on.
+
+**9b. Display the summary:**
 
 ```
 Review complete.
@@ -373,6 +381,7 @@ Overall Grade: {GRADE} {trend}
 VCMS Scorecard: stored (tag: code-review)
 Full Report: docs/reviews/code-review-{date}.md
 Issues Created: {N} (or "none")
+Cadence: recorded (or "FAILED — {error}")
 
 Top action items:
 1. {Most important finding}
@@ -381,12 +390,6 @@ Top action items:
 ```
 
 Do NOT automatically commit the full report. The user may want to review it first.
-
-After displaying the summary, record the completion in the Cadence Engine:
-
-```
-crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "success", summary: "Grade: {GRADE}, {N} issues created", completed_by: "crane-mcp")
-```
 
 ---
 

--- a/.claude/commands/eos.md
+++ b/.claude/commands/eos.md
@@ -83,15 +83,18 @@ This writes to D1 via the Crane Context API. The next session's SOD will read it
 If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
 
 1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
-2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
-3. Each handoff summary should cover only the work relevant to that venture.
+2. For each venture EXCEPT THE LAST, call `crane_handoff` with `venture: "<code>"` AND `final: false`. The `final: false` flag tells the API to create the handoff record but keep the session active so the next call doesn't 409 with "Session is not active".
+3. For the FINAL venture, call `crane_handoff` without `final` (or with `final: true`). This call ends the session.
+4. Each handoff summary should cover only the work relevant to that venture.
 
 Example for a session that touched both `dc` and `vc`:
 
 ```
-crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc", final: false)
 crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
 ```
+
+Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
 
 ### 6. Report Completion
 


### PR DESCRIPTION
## Summary

Picks up two enterprise command updates that landed in crane-console after PR #620 was opened.

- **/code-review** — record cadence completion BEFORE summary, not after (crane #760). Past runs skipped the trailing \`crane_schedule\` call when it was framed as a tail action, leaving briefings showing "Code Review (X) — UNTRACKED" even after successful reviews. Cadence call is now Step 9a, summary 9b, and a \`Cadence:\` line is added to the summary so the gap is visible if the API call fails.
- **/eos** — support multi-venture handoffs via \`final: false\` flag (crane #752). When a session touched multiple ventures, calling \`crane_handoff\` back-to-back returned 409 "Session is not active" on the second call. \`final: false\` on intermediate calls keeps the session open; the last call (omit or \`final: true\`) terminates it.

## Context

This is a follow-up to #620 — that sync was authored 2026-04-27, these crane changes landed after. The \`design-brief.md\` path-fix is already on PR #620 and is intentionally not duplicated here.

Source files in this repo are downstream of crane-console; canonical edits live there.

## Test plan

- [ ] Run \`/code-review\` on a small change and verify the summary now ends with a \`Cadence: recorded\` line and that \`crane_schedule(action: "list")\` shows the completion entry
- [ ] Run \`/eos\` after touching only one venture and confirm session terminates
- [ ] (Optional) Run \`/eos\` after touching two ventures, passing \`final: false\` on the first \`crane_handoff\`, and confirm both handoffs land without 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)