### PR TITLE
feat(ci): auto-tick AC checkboxes on PR merge + scope unmet-ac to manual closes

### DIFF
--- a/.github/workflows/tick-acs-on-merge.yml
+++ b/.github/workflows/tick-acs-on-merge.yml
@@ -1,0 +1,572 @@
+name: Tick ACs on PR merge
+
+# Companion to unmet-ac-on-close.yml. When a PR merges, parse the PR body's
+# "## Acceptance criteria status" table, find rows marked `met`, and tick the
+# corresponding `- [ ]` boxes in the linked issue's body.
+#
+# The two workflows have non-overlapping responsibilities:
+#   - tick-acs-on-merge.yml — owns PR-driven closes (this file).
+#   - unmet-ac-on-close.yml — owns manual closes only; skips when close was
+#     PR-driven.
+#
+# Linked issues are resolved via GitHub's GraphQL `closingIssuesReferences` —
+# the same mechanism GitHub itself uses for auto-close. This handles
+# `Closes #N`, `Closes owner/repo#N`, full URLs, and other syntax variants.
+#
+# Concurrency limitation: two PRs merging within seconds touching the same
+# issue can lose updates. Best-effort retry handles the common case;
+# pathological races may drop an edit. ETag-based hardening is out of scope.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  tick:
+    name: Tick met ACs on linked issues
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tick AC checkboxes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // ---- Fork guard --------------------------------------------------
+            // Forked-PR workflows run with read-only GITHUB_TOKEN regardless of
+            // the `permissions:` block above. Fail loudly instead of silently.
+            const headRepo = pr.head?.repo?.full_name;
+            if (headRepo && headRepo !== `${owner}/${repo}`) {
+              core.notice(
+                `Skipping: PR #${pr.number} is from fork ${headRepo}; ` +
+                `forked workflows have read-only token.`
+              );
+              return;
+            }
+
+            const prBody = pr.body || '';
+
+            // ---- 1. Resolve linked issues via GraphQL ------------------------
+            // GitHub's own close-keyword parser is the source of truth.
+            // Don't reimplement with regex.
+            let linkedIssues = [];
+            try {
+              const result = await github.graphql(
+                `query($owner: String!, $repo: String!, $pr: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      closingIssuesReferences(first: 20) {
+                        nodes {
+                          number
+                          repository { nameWithOwner }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { owner, repo, pr: pr.number }
+              );
+              const nodes = result?.repository?.pullRequest
+                ?.closingIssuesReferences?.nodes || [];
+              linkedIssues = nodes
+                .filter(n => n.repository.nameWithOwner === `${owner}/${repo}`)
+                .map(n => n.number);
+            } catch (e) {
+              core.warning(`GraphQL closingIssuesReferences failed: ${e.message}`);
+              return;
+            }
+
+            if (linkedIssues.length === 0) {
+              core.info(`PR #${pr.number}: no linked issues — nothing to tick.`);
+              return;
+            }
+            core.info(
+              `PR #${pr.number}: linked issues = ${linkedIssues.join(', ')}`
+            );
+
+            // ---- 2. Parse the AC status table from the PR body ---------------
+            const acRows = parseAcStatusTable(prBody);
+            if (acRows === null) {
+              core.info(
+                `PR #${pr.number}: no parseable "Acceptance criteria status" ` +
+                `table — nothing to tick.`
+              );
+              return;
+            }
+
+            // ---- 3. Collect "met" rows ---------------------------------------
+            const metRows = acRows.filter(r =>
+              r.status.toLowerCase().trim() === 'met'
+            );
+            if (metRows.length === 0) {
+              core.info(
+                `PR #${pr.number}: AC table parsed (${acRows.length} row(s)) ` +
+                `but none marked "met".`
+              );
+              return;
+            }
+            core.info(
+              `PR #${pr.number}: ${metRows.length} AC row(s) marked "met".`
+            );
+
+            // ---- 4-7. Per linked issue: match, tick, comment -----------------
+            for (const issueNumber of linkedIssues) {
+              try {
+                await processIssue(issueNumber, metRows, pr, owner, repo,
+                                   github, core);
+              } catch (e) {
+                core.error(
+                  `Issue #${issueNumber}: failed to process: ${e.message}`
+                );
+              }
+            }
+
+            // ==================================================================
+            // Helpers
+            // ==================================================================
+
+            // Parse the PR body's "## Acceptance criteria status" table.
+            // Returns: array of { ac, status, evidence } | null on no/bad match.
+            function parseAcStatusTable(body) {
+              const H2 = /^##\s+(.+?)\s*$/gm;
+              const headings = [...body.matchAll(H2)];
+              let secStart = -1;
+              let secEnd = body.length;
+              for (let i = 0; i < headings.length; i++) {
+                const text = headings[i][1].trim().toLowerCase();
+                if (text.startsWith('acceptance criteria status')) {
+                  secStart = headings[i].index + headings[i][0].length;
+                  if (i + 1 < headings.length) secEnd = headings[i + 1].index;
+                  break;
+                }
+              }
+              if (secStart === -1) return null;
+
+              // Strip HTML comments from section before parsing.
+              const section = body.slice(secStart, secEnd)
+                .replace(/<!--[\s\S]*?-->/g, '');
+
+              const lines = section.split('\n').map(l => l.trim());
+              const rows = [];
+              let sawHeader = false;
+              let sawSeparator = false;
+
+              for (const line of lines) {
+                if (!line.startsWith('|')) {
+                  if (sawSeparator && line === '') continue; // blank within/after table
+                  if (sawSeparator) break;                   // non-pipe content → table ended
+                  continue;
+                }
+                if (!sawHeader) { sawHeader = true; continue; }
+                if (!sawSeparator) { sawSeparator = true; continue; }
+
+                const cells = splitTableRow(line);
+                if (cells.length < 3) continue;
+                const ac = cells[0].trim();
+                const status = cells[1].trim();
+                const evidence = cells[2].trim();
+
+                // Skip the literal template placeholder row (empty AC, or
+                // status that's still the templated `met / deferred / n/a`).
+                if (!ac) continue;
+                if (status.toLowerCase() === 'met / deferred / n/a') continue;
+                if (ac.toLowerCase().includes('verbatim from issue')) continue;
+
+                rows.push({ ac, status, evidence });
+              }
+              return rows.length > 0 ? rows : null;
+            }
+
+            // Split a markdown table row into cells, tolerating escaped pipes.
+            function splitTableRow(line) {
+              // Trim leading/trailing pipes, then split on unescaped pipes.
+              const trimmed = line.replace(/^\|/, '').replace(/\|$/, '');
+              const cells = [];
+              let buf = '';
+              for (let i = 0; i < trimmed.length; i++) {
+                const ch = trimmed[i];
+                if (ch === '\\' && trimmed[i + 1] === '|') {
+                  buf += '|'; i++;
+                } else if (ch === '|') {
+                  cells.push(buf); buf = '';
+                } else {
+                  buf += ch;
+                }
+              }
+              cells.push(buf);
+              return cells;
+            }
+
+            // Normalize AC text for fallback exact-equality matching.
+            function normalize(text) {
+              return text
+                .replace(/\*\*([^*]+)\*\*/g, '$1')
+                .replace(/\*([^*]+)\*/g, '$1')
+                .replace(/`([^`]+)`/g, '$1')
+                .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+                .replace(/\s+/g, ' ')
+                .trim()
+                .toLowerCase()
+                .replace(/[.,;:!?]+$/, '');
+            }
+
+            // Extract a leading H-code (H1, H15, AC2, etc.) if present.
+            function extractHCode(text) {
+              const m = text.match(/^\s*\*\*([A-Z]+\d+)\*\*/) ||
+                        text.match(/^\s*([A-Z]+\d+)\b/);
+              return m ? m[1] : null;
+            }
+
+            // Find the "Acceptance criteria" section in an issue body and
+            // return [{ raw, text, hCode }] for each `- [ ]` line.
+            function extractIssueAcs(body) {
+              const H2 = /^##\s+(.+?)\s*$/gm;
+              const headings = [...body.matchAll(H2)];
+              let secStart = -1;
+              let secEnd = body.length;
+              for (let i = 0; i < headings.length; i++) {
+                const text = headings[i][1].trim().toLowerCase();
+                if (text.startsWith('acceptance')) {
+                  secStart = headings[i].index + headings[i][0].length;
+                  if (i + 1 < headings.length) secEnd = headings[i + 1].index;
+                  break;
+                }
+              }
+              if (secStart === -1) return [];
+
+              const section = body.slice(secStart, secEnd);
+              const UNCHECKED = /^(\s*-\s+\[ \]\s+)(.+?)\s*$/gm;
+              const result = [];
+              let m;
+              while ((m = UNCHECKED.exec(section)) !== null) {
+                result.push({
+                  prefix: m[1],
+                  text: m[2],
+                  hCode: extractHCode(m[2]),
+                });
+              }
+              return result;
+            }
+
+            // Match a "met" AC-table row against issue ACs using the three-tier
+            // matcher. Returns { match: ac | null, tier: 'h-code' | 'text' | 'positional' | null, reason }.
+            function matchAc(metRow, issueAcs, allowPositional, positionalIndex) {
+              const tableHCode = extractHCode(metRow.ac);
+
+              // Tier 1: H-code primary
+              if (tableHCode) {
+                const candidates = issueAcs.filter(a => a.hCode === tableHCode);
+                if (candidates.length === 1) {
+                  return { match: candidates[0], tier: 'h-code' };
+                }
+                if (candidates.length > 1) {
+                  return {
+                    match: null,
+                    tier: null,
+                    reason: `H-code ${tableHCode} matched ${candidates.length} ACs`,
+                  };
+                }
+                // 0 H-code matches → fall through to text matching.
+              }
+
+              // Tier 2: normalized exact text
+              const normTable = normalize(metRow.ac);
+              const candidates = issueAcs.filter(
+                a => normalize(a.text) === normTable
+              );
+              if (candidates.length === 1) {
+                return { match: candidates[0], tier: 'text' };
+              }
+              if (candidates.length > 1) {
+                return {
+                  match: null,
+                  tier: null,
+                  reason: `Text matched ${candidates.length} ACs`,
+                };
+              }
+
+              // Tier 3: positional (gated)
+              if (allowPositional && positionalIndex < issueAcs.length) {
+                return {
+                  match: issueAcs[positionalIndex],
+                  tier: 'positional',
+                };
+              }
+
+              return {
+                match: null,
+                tier: null,
+                reason: 'No match',
+              };
+            }
+
+            // Find the closest issue AC to a given row text (for the "refused"
+            // surfaceing in the audit comment). Levenshtein-lite via shared word
+            // count.
+            function closestIssueAc(rowText, issueAcs) {
+              const rowWords = new Set(
+                normalize(rowText).split(/\s+/).filter(w => w.length > 3)
+              );
+              if (rowWords.size === 0) return null;
+              let best = null;
+              let bestScore = 0;
+              for (const ac of issueAcs) {
+                const acWords = new Set(
+                  normalize(ac.text).split(/\s+/).filter(w => w.length > 3)
+                );
+                let shared = 0;
+                for (const w of rowWords) if (acWords.has(w)) shared++;
+                if (shared > bestScore) { bestScore = shared; best = ac; }
+              }
+              // 1 shared content word is enough for an informational suggestion;
+              // human reads and judges, false suggestions are harmless.
+              return bestScore >= 1 ? best : null;
+            }
+
+            // Apply ticks: replace `- [ ] {text}` with `- [x] {text}` for each
+            // matched AC line. Returns updated body.
+            function applyTicks(body, matches) {
+              let updated = body;
+              for (const { issueAc } of matches) {
+                const target = `${issueAc.prefix}${issueAc.text}`;
+                const ticked = target.replace(/\[ \]/, '[x]');
+                // Replace exactly once. If line not found verbatim, the body
+                // changed since fetch — caller handles via retry.
+                const idx = updated.indexOf(target);
+                if (idx === -1) continue;
+                updated = updated.slice(0, idx) + ticked +
+                          updated.slice(idx + target.length);
+              }
+              return updated;
+            }
+
+            // ==================================================================
+            // Per-issue processing
+            // ==================================================================
+
+            async function processIssue(issueNumber, metRows, pr, owner, repo,
+                                        gh, core) {
+              const MARKER = `<!-- tick-acs-on-merge: pr-${pr.number} -->`;
+              const MAX_RETRIES = 3;
+
+              let lastBody = null;
+              let matches = [];
+              let refused = [];
+
+              for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+                const issue = await gh.rest.issues.get({
+                  owner, repo, issue_number: issueNumber,
+                });
+                const body = issue.data.body || '';
+                lastBody = body;
+
+                const issueAcs = extractIssueAcs(body);
+                if (issueAcs.length === 0) {
+                  core.info(
+                    `Issue #${issueNumber}: no unchecked ACs in body — nothing to tick.`
+                  );
+                  return;
+                }
+
+                // Decide if positional fallback is allowed.
+                const anyHCodes = issueAcs.some(a => a.hCode !== null);
+                const allowPositional =
+                  !anyHCodes && metRows.length === issueAcs.length;
+
+                matches = [];
+                refused = [];
+                let positionalIdx = 0;
+                for (const row of metRows) {
+                  const result = matchAc(
+                    row, issueAcs, allowPositional, positionalIdx
+                  );
+                  if (result.match) {
+                    // Don't double-match the same issue AC.
+                    if (matches.some(m => m.issueAc === result.match)) {
+                      refused.push({ row, reason: 'already matched by another row' });
+                      continue;
+                    }
+                    matches.push({ row, issueAc: result.match, tier: result.tier });
+                    if (result.tier === 'positional') positionalIdx++;
+                  } else {
+                    refused.push({ row, reason: result.reason, issueAcs });
+                  }
+                }
+
+                if (matches.length === 0) {
+                  core.info(
+                    `Issue #${issueNumber}: 0 matches from ${metRows.length} ` +
+                    `met rows; ${refused.length} refused.`
+                  );
+                  break; // no body update needed
+                }
+
+                const updatedBody = applyTicks(body, matches);
+                if (updatedBody === body) {
+                  core.info(
+                    `Issue #${issueNumber}: matches found but body already ` +
+                    `current (idempotent skip).`
+                  );
+                  break;
+                }
+
+                try {
+                  await gh.rest.issues.update({
+                    owner, repo, issue_number: issueNumber, body: updatedBody,
+                  });
+                  core.info(
+                    `Issue #${issueNumber}: ticked ${matches.length} AC(s) ` +
+                    `(attempt ${attempt + 1}).`
+                  );
+                  lastBody = updatedBody;
+                  break;
+                } catch (e) {
+                  if (attempt < MAX_RETRIES - 1) {
+                    core.warning(
+                      `Issue #${issueNumber}: update failed (attempt ` +
+                      `${attempt + 1}): ${e.message}; retrying.`
+                    );
+                    await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+                    continue;
+                  }
+                  throw e;
+                }
+              }
+
+              // ---- Audit comment (find-by-marker, update-or-create) ----------
+              await postAuditComment(
+                issueNumber, pr, matches, refused, MARKER, gh, core, owner, repo
+              );
+
+              // ---- Partial-PR warning on the PR ------------------------------
+              if (lastBody) {
+                const stillUnchecked = (lastBody.match(/^\s*-\s+\[ \]/gm) || []).length;
+                if (stillUnchecked > 0) {
+                  await postPartialWarning(
+                    issueNumber, pr, matches.length, stillUnchecked,
+                    gh, core, owner, repo
+                  );
+                }
+              }
+            }
+
+            async function postAuditComment(
+              issueNumber, pr, matches, refused, MARKER, gh, core, owner, repo
+            ) {
+              const lines = [MARKER, ''];
+              lines.push(`### Auto-ticked from PR #${pr.number}`);
+              lines.push('');
+              if (matches.length > 0) {
+                const tickedLabels = matches.map(m => {
+                  const id = m.issueAc.hCode ||
+                    `"${m.issueAc.text.slice(0, 60)}${m.issueAc.text.length > 60 ? '…' : ''}"`;
+                  return `${id} _(${m.tier})_`;
+                });
+                lines.push(`**Ticked (${matches.length}):** ${tickedLabels.join(', ')}`);
+              } else {
+                lines.push('**Ticked:** none');
+              }
+              if (refused.length > 0) {
+                lines.push('');
+                lines.push(`**Could not auto-tick (${refused.length}):**`);
+                for (const r of refused) {
+                  const closest = r.issueAcs
+                    ? closestIssueAc(r.row.ac, r.issueAcs)
+                    : null;
+                  const rowExcerpt = r.row.ac.slice(0, 80) +
+                    (r.row.ac.length > 80 ? '…' : '');
+                  if (closest) {
+                    const closestLabel = closest.hCode ||
+                      `"${closest.text.slice(0, 60)}${closest.text.length > 60 ? '…' : ''}"`;
+                    lines.push(
+                      `- PR row: \`${rowExcerpt}\` — closest issue AC: ${closestLabel} — ${r.reason}. Edit the table or tick by hand.`
+                    );
+                  } else {
+                    lines.push(
+                      `- PR row: \`${rowExcerpt}\` — ${r.reason}. Tick by hand if applicable.`
+                    );
+                  }
+                }
+              }
+
+              const body = lines.join('\n');
+
+              // Find existing comment by marker.
+              const existing = await findCommentByMarker(
+                issueNumber, MARKER, gh, owner, repo
+              );
+              if (existing) {
+                await gh.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body,
+                });
+                core.info(`Issue #${issueNumber}: updated existing audit comment.`);
+              } else {
+                await gh.rest.issues.createComment({
+                  owner, repo, issue_number: issueNumber, body,
+                });
+                core.info(`Issue #${issueNumber}: posted audit comment.`);
+              }
+            }
+
+            async function findCommentByMarker(
+              issueNumber, marker, gh, owner, repo
+            ) {
+              // Walk pages; markers should appear within the first ~100 comments.
+              for (let page = 1; page <= 5; page++) {
+                const res = await gh.rest.issues.listComments({
+                  owner, repo, issue_number: issueNumber, per_page: 100, page,
+                });
+                const found = res.data.find(c =>
+                  (c.body || '').startsWith(marker)
+                );
+                if (found) return found;
+                if (res.data.length < 100) return null;
+              }
+              return null;
+            }
+
+            async function postPartialWarning(
+              issueNumber, pr, ticked, stillUnchecked, gh, core, owner, repo
+            ) {
+              const PR_MARKER =
+                `<!-- tick-acs-on-merge: partial-warning-issue-${issueNumber} -->`;
+              const body = [
+                PR_MARKER,
+                '',
+                `### Partial close detected`,
+                '',
+                `Ticked ${ticked} AC(s) on #${issueNumber}; ${stillUnchecked} ` +
+                `unchecked item(s) remain in that issue.`,
+                '',
+                `If this PR is partial, consider changing \`Closes #${issueNumber}\` to ` +
+                `\`Refs #${issueNumber}\` in the PR body so the issue stays open ` +
+                `for the remaining work. (GitHub auto-closes on merge regardless ` +
+                `of unchecked boxes — only PR-body edits change that.)`,
+              ].join('\n');
+
+              const existing = await findPrCommentByMarker(
+                pr.number, PR_MARKER, gh, owner, repo
+              );
+              if (existing) return; // already warned
+              await gh.rest.issues.createComment({
+                owner, repo, issue_number: pr.number, body,
+              });
+              core.info(`PR #${pr.number}: posted partial-close warning.`);
+            }
+
+            async function findPrCommentByMarker(
+              prNumber, marker, gh, owner, repo
+            ) {
+              const res = await gh.rest.issues.listComments({
+                owner, repo, issue_number: prNumber, per_page: 100,
+              });
+              return res.data.find(c => (c.body || '').startsWith(marker));
+            }

--- a/.github/workflows/unmet-ac-on-close.yml
+++ b/.github/workflows/unmet-ac-on-close.yml
@@ -1,11 +1,20 @@
 name: Unmet AC on close
 
-# #377 Move 2 — block issue-close when ACs are unchecked.
+# #377 Move 2 — block issue-close when ACs are unchecked (manual closes only).
 #
 # When an issue is closed, parse its body for the "Acceptance criteria"
 # section. If any `- [ ]` items remain, reopen the issue and comment with
 # the unchecked list. Override available via the `force-close` label
 # applied before close (visible decision, not silent omission).
+#
+# This workflow now SKIPS when the close was driven by a PR merge — the
+# companion `tick-acs-on-merge.yml` handles those, ticking AC checkboxes
+# from the PR body's "Acceptance criteria status" table. This file remains
+# the safety net for manual issue closes only.
+#
+# `force-close` has dual meaning after the companion shipped:
+#   (a) author closing despite unchecked ACs (original purpose), or
+#   (b) auto-tick failed for a PR-driven close and a human is overriding.
 #
 # Rationale: the retroactive sweep on 2026-04-15 found that 95% of closed
 # issues with an Acceptance criteria section had unchecked items at close
@@ -35,7 +44,14 @@ jobs:
             const H2 = /^##\s+(.+?)\s*$/gm;
             const UNCHECKED = /^\s*-\s+\[ \]\s+(.+?)\s*$/gm;
 
-            const issue = context.payload.issue;
+            // Fetch fresh issue state — companion `tick-acs-on-merge` may have
+            // updated the body in parallel.
+            const fresh = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+            });
+            const issue = fresh.data;
             const labelNames = (issue.labels || []).map(l => l.name);
 
             if (labelNames.includes(OVERRIDE_LABEL)) {
@@ -44,6 +60,34 @@ jobs:
                 `closure approved without AC check.`
               );
               return;
+            }
+
+            // Skip when the close was driven by a PR merge — the companion
+            // workflow tick-acs-on-merge.yml owns that path. PR-driven closes
+            // have `commit_id` set on the most recent `closed` timeline event
+            // (the merge commit SHA). Manual closes do not.
+            try {
+              const events = await github.rest.issues.listEvents({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const mostRecentClose = events.data
+                .filter(e => e.event === 'closed')
+                .pop();
+              if (mostRecentClose && mostRecentClose.commit_id != null) {
+                core.info(
+                  `Issue #${issue.number}: PR-driven close (commit ${mostRecentClose.commit_id.slice(0, 8)}) — ` +
+                  `companion workflow tick-acs-on-merge owns AC ticking. Skipping.`
+                );
+                return;
+              }
+            } catch (e) {
+              core.warning(
+                `Could not determine close source for #${issue.number}: ` +
+                `${e.message}. Proceeding with manual-close path (safe default).`
+              );
             }
 
             const body = issue.body || '';


### PR DESCRIPTION
## Summary

Today's backlog audit hit a wall: 25 issues with `Closes #N` PRs had to be `force-close`d because the AC checkboxes in their issue bodies were never ticked. The existing `unmet-ac-on-close.yml` workflow can't tell shipped-but-unticked from genuinely-abandoned, so it reopens both. This PR closes that gap.

- New `tick-acs-on-merge.yml` parses the PR template's "Acceptance criteria status" table on PR merge and ticks matching boxes in the linked issue.
- `unmet-ac-on-close.yml` patched to skip when the close was driven by a PR merge — the companion handles those. The existing workflow remains as the manual-close safety net it was originally designed for.

## Linked issue

None — process improvement spun out of the audit. No tracking issue filed.

## Acceptance criteria status

| AC (verbatim from issue) | Status               | Evidence                         |
| ------------------------ | -------------------- | -------------------------------- |
| n/a                      | n/a                  | no linked issue                  |

## Design highlights

**Linked-issue resolution via GraphQL.** Uses `closingIssuesReferences` on the PR — GitHub's own close-keyword parser, handles `Closes owner/repo#N`, full URLs, and edge cases regex misses.

**Three-tier matcher:**
1. **H-code primary** — matches `**H1**`-style identifiers Captain uses on horizontal/audit issues (e.g., #547 `**H15**`, `**H16**`).
2. **Normalized exact-text fallback** — strips markdown formatting, collapses whitespace, lowercase. Exact equality only (no substring).
3. **Positional tertiary** — gated on (no H-codes in issue) AND (count of `met` rows == count of unchecked items). Only ticks in order under both conditions.

Refuses on ambiguous matches (0 or ≥2 candidates) and surfaces refused rows alongside closest-match suggestions in the audit comment, so authors know exactly what to fix manually.

**Audit comment idempotency.** Stable HTML marker (`<!-- tick-acs-on-merge: pr-N -->`) lets re-runs update the existing comment instead of duplicating.

**Read-modify-write retry.** 3 attempts with backoff, handles concurrent-merge collision (rare). Pathological races may still drop an edit — documented as known limitation.

**Partial-PR warning.** If `Closes #N` was used but unchecked items remain after ticking, posts a comment on the PR (not the issue) suggesting `Refs #N` instead.

**Race fix in unmet-ac-on-close.** Detects PR-driven closes via `commit_id` on the most recent close timeline event. Also switched from stale `payload.issue.body` snapshot to fresh `issues.get` fetch.

## Test plan

- [x] `npm run verify` passes (1857 tests)
- [x] Local fixture suite (28 tests) covers: valid PR table parse, templated/empty table, HTML-comment exclusion, H-code matching, plain-text matching, positional gating with count match, positional refusal on count mismatch, body update preserves untouched ACs, closest-AC suggestion, real-world #547 fixture (5 ACs, 3 met, all ticked correctly via H-code tier)
- [ ] Live smoke after merge: open a no-op PR with a single H-coded AC marked `met`. Verify box flipped, audit comment posted, `unmet-ac-on-close` logs "PR-driven close — skipping"
- [ ] Live partial: PR declares 1 of 2 ACs `met`. Verify partial-PR warning on the PR
- [ ] Manual-close path unchanged: close an issue manually with unchecked ACs (no recent PR). Verify reopen behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)