### PR TITLE
fix(enrichment): surface Anthropic API errors instead of silently returning null (#631 follow-up)

### DIFF
--- a/src/lib/enrichment/deep-website.ts
+++ b/src/lib/enrichment/deep-website.ts
@@ -3,6 +3,8 @@
  * Fetches homepage + discoverable subpages, extracts detailed profile.
  */
 
+import { ModuleError } from './instrument'
+
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-sonnet-4-20250514'
@@ -155,7 +157,16 @@ export async function deepWebsiteAnalysis(
     }),
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    // Issue #631 follow-up: surface Anthropic errors as failed runs.
+    // The per-page safeFetch below intentionally returns null on per-page
+    // 404s — that's separate. This is the Claude API call.
+    const body = await response.text().catch(() => '')
+    throw new ModuleError(
+      'api_error',
+      `Anthropic API returned ${response.status}: ${body.slice(0, 500)}`
+    )
+  }
 
   const result = (await response.json()) as {
     content?: Array<{ type: string; text?: string }>

--- a/src/lib/enrichment/dossier.ts
+++ b/src/lib/enrichment/dossier.ts
@@ -3,6 +3,8 @@
  * Synthesizes all accumulated context into a structured 2-3 page assessment.
  */
 
+import { ModuleError } from './instrument'
+
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-sonnet-4-20250514'
@@ -71,7 +73,19 @@ export async function generateDossier(
     }),
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    // Issue #631 follow-up: surface Anthropic errors as failed runs rather
+    // than silently returning null (which records `no_data`). The 2026-04-30
+    // backfill incident demonstrated the cost of silent 401s — 171 entities
+    // marked no_data while the bad key sat unfixed. Throwing here lets the
+    // Workflow's per-step retry handle transients and end the run in
+    // `failed` state on permanent failures, visible in the dashboard.
+    const body = await response.text().catch(() => '')
+    throw new ModuleError(
+      'api_error',
+      `Anthropic API returned ${response.status}: ${body.slice(0, 500)}`
+    )
+  }
 
   const result = (await response.json()) as {
     content?: Array<{ type: string; text?: string }>

--- a/src/lib/enrichment/review-analysis.ts
+++ b/src/lib/enrichment/review-analysis.ts
@@ -3,6 +3,8 @@
  * Reads existing signal context for review evidence, analyzes owner engagement patterns.
  */
 
+import { ModuleError } from './instrument'
+
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-haiku-4-5-20251001'
@@ -42,7 +44,14 @@ export async function analyzeReviewPatterns(
     }),
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    // Issue #631 follow-up: surface Anthropic errors as failed runs.
+    const body = await response.text().catch(() => '')
+    throw new ModuleError(
+      'api_error',
+      `Anthropic API returned ${response.status}: ${body.slice(0, 500)}`
+    )
+  }
 
   const result = (await response.json()) as { content?: Array<{ type: string; text?: string }> }
   const text = result?.content?.find((b) => b.type === 'text')?.text?.trim()

--- a/src/lib/enrichment/review-synthesis.ts
+++ b/src/lib/enrichment/review-synthesis.ts
@@ -3,6 +3,8 @@
  * Reads existing signal and enrichment context, produces unified analysis.
  */
 
+import { ModuleError } from './instrument'
+
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-sonnet-4-20250514'
@@ -49,7 +51,14 @@ export async function synthesizeReviews(
     }),
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    // Issue #631 follow-up: surface Anthropic errors as failed runs.
+    const body = await response.text().catch(() => '')
+    throw new ModuleError(
+      'api_error',
+      `Anthropic API returned ${response.status}: ${body.slice(0, 500)}`
+    )
+  }
 
   const result = (await response.json()) as {
     content?: Array<{ type: string; text?: string }>

--- a/src/lib/enrichment/website-analyzer.ts
+++ b/src/lib/enrichment/website-analyzer.ts
@@ -3,6 +3,7 @@
  */
 
 import { detectTechStack, type TechStackResult } from './tech-stack.js'
+import { ModuleError } from './instrument'
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
 const ANTHROPIC_VERSION = '2023-06-01'
@@ -134,7 +135,16 @@ async function extractWithHaiku(
     }),
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    // Issue #631 follow-up: surface Anthropic errors as failed runs. The
+    // earlier `if (!response.ok) return null` for the website-fetch step
+    // (line ~95) is intentionally silent — that's the page fetch, not Claude.
+    const body = await response.text().catch(() => '')
+    throw new ModuleError(
+      'api_error',
+      `Anthropic API returned ${response.status}: ${body.slice(0, 500)}`
+    )
+  }
 
   const result = (await response.json()) as {
     content?: Array<{ type: string; text?: string }>


### PR DESCRIPTION
## Summary

- The 2026-04-30 backfill incident hit a bad ANTHROPIC_API_KEY mid-flight. The legacy `if (!response.ok) return null` pattern in 5 Claude-call sites swallowed every 401, recording 171 entities as `no_data` instead of surfacing the auth error.
- This PR replaces those 5 silent-fail sites with `throw new ModuleError('api_error', ...)`. The Workflow's per-step retry budget handles transients (429/529/500); permanent failures (401/400) end in `failed` state, visible in `enrichment_runs.error_message` and the Cloudflare Workflows dashboard.
- Distinguishes "Anthropic returned 200 with empty content" (still `no_data`, normal sparse-signal behavior) from "Anthropic erred" (now `failed`, operational breakage worth attention).

## Why this matters

Without this fix, a future key rotation, billing issue, or extended Anthropic outage produces a fleet of silent `no_data` outcomes that look identical to legitimate "this entity has no data to brief on." Operators have no signal until manual D1 inspection. The 2026-04-30 incident produced 171 such silent failures and ~$30 of wasted Anthropic spend before the bad key was caught.

With this fix, the same incident would have produced 1-2 `failed` rows in the dashboard within minutes, before the bulk-dispatch could waste the rest.

## What's NOT in scope

The non-Anthropic third-party modules (`google_places`, `outscraper`, `acc_filing`, `roc_license`, `linkedin`, `news_search`/SerpAPI) keep their `return null` patterns. Their silent-fail is lower-stakes — recording `no_data` for "API returned nothing" is acceptable when the API is the discovery surface itself. Worth a separate sweep if a similar incident hits one of those.

The per-page `safeFetch` in `deep-website.ts:180` and the website HTML fetch in `website-analyzer.ts:95` also stay silent — those are best-effort page fetches where 404 on `/careers` is normal, not an operational signal.

## Files changed

- `src/lib/enrichment/dossier.ts` — `generateDossier` (the original incident site)
- `src/lib/enrichment/review-synthesis.ts` — `synthesizeReviews`
- `src/lib/enrichment/review-analysis.ts` — `analyzeReviewPatterns`
- `src/lib/enrichment/deep-website.ts` — Claude call (line 158, not the `safeFetch` at 180)
- `src/lib/enrichment/website-analyzer.ts` — Claude call (line 137, not the page-fetch at ~95)

Each gets:
\`\`\`ts
import { ModuleError } from './instrument'
// ...
if (!response.ok) {
  const body = await response.text().catch(() => '')
  throw new ModuleError(
    'api_error',
    \`Anthropic API returned ${response.status}: ${body.slice(0, 500)}\`
  )
}
\`\`\`

## Test plan

- [x] \`npm run verify\` — exit 0, 1857 tests pass, 0 lint/format errors
- [ ] After merge + deploy, intentionally rotate to an invalid Anthropic key in the workflow Worker, dispatch one Workflow → verify it ends in \`failed\` state with the 401 body in \`enrichment_runs.error_message\`
- [ ] Rotate the key back, re-dispatch, verify the Workflow completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)