### PR TITLE
feat(diagnostic): workflow re-aim + portal page (Outside View Phase 1 PR-B, supersedes #627)

### DIFF
--- a/src/components/portal/OutsideViewArtifact.astro
+++ b/src/components/portal/OutsideViewArtifact.astro
@@ -1,0 +1,141 @@
+---
+/**
+ * Outside View artifact (ADR 0002 Phase 1 PR-B).
+ *
+ * Renders the persistent diagnostic artifact stored in `outside_views`.
+ * v1 receives the existing `RenderedReport` shape via the v1 adapter
+ * (`parseArtifactJson`) and renders it in portal chrome.
+ *
+ * Anti-fab semantics from #617 are preserved at the renderer layer
+ * (src/lib/diagnostic/render.ts) — this component just walks the
+ * pre-validated `RenderedSection[]`. Sections marked `rendered=false`
+ * either render their `insufficientDataNote` or are silently omitted.
+ *
+ * Visual chrome follows the Plainspoken Sign Shop conventions used in
+ * other portal pages: 3px ink rules, Archivo Black H1, Archivo Narrow
+ * uppercase eyebrows, tight-tracked mono caption text.
+ *
+ * D2/D3 affordances ("Talk to our agent", "Bring Scott in") are
+ * placeholders in v1 — Phase 3 wires them.
+ */
+
+import type { RenderedReport, RenderedSection } from '../../lib/diagnostic/render'
+
+interface Props {
+  /** The artifact unwrapped via the v1 adapter. */
+  rendered: RenderedReport
+  /** ISO8601 timestamp the artifact was generated. Shown in the meta column. */
+  renderedAt: string
+  /** The entity's display name (or rendered.displayName fallback). */
+  fallbackName: string
+}
+
+const { rendered, renderedAt, fallbackName } = Astro.props
+
+const businessName = (rendered.displayName && rendered.displayName.trim()) || fallbackName
+
+const renderedDate = new Date(renderedAt)
+const renderedLabel = isNaN(renderedDate.getTime())
+  ? renderedAt
+  : renderedDate.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+
+const visibleSections: RenderedSection[] = rendered.sections.filter(
+  (s) => s.rendered || s.insufficientDataNote
+)
+---
+
+<section class="mt-8">
+  <p
+    class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)] mb-3"
+  >
+    Outside View · Rendered {renderedLabel}
+  </p>
+
+  <div
+    class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-6 md:p-8"
+  >
+    <p
+      class="font-['Archivo_Narrow'] text-sm md:text-base text-[color:var(--ss-color-text-primary)] m-0"
+    >
+      Here's what we read from your public footprint. Each section below comes from a specific
+      signal we found — when we couldn't find enough to back something up, we say so rather than
+      guessing.
+    </p>
+  </div>
+
+  {
+    rendered.hasContent ? (
+      <div class="mt-6 flex flex-col gap-6">
+        {visibleSections.map((section) => (
+          <article class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
+            <h2 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] m-0">
+              {section.title}
+            </h2>
+            {section.rendered ? (
+              <>
+                {section.paragraph && (
+                  <p class="mt-4 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
+                    {section.paragraph}
+                  </p>
+                )}
+                {section.bullets && section.bullets.length > 0 && (
+                  <ul class="mt-4 ml-5 list-disc text-base md:text-lg text-[color:var(--ss-color-text-primary)] flex flex-col gap-2">
+                    {section.bullets.map((b) => (
+                      <li>{b}</li>
+                    ))}
+                  </ul>
+                )}
+                {section.insufficientDataNote && (
+                  <p class="mt-4 text-sm md:text-base italic text-[color:var(--ss-color-text-secondary)] m-0">
+                    {section.insufficientDataNote}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p class="mt-4 text-sm md:text-base italic text-[color:var(--ss-color-text-secondary)] m-0">
+                Insufficient data — {section.insufficientDataNote}
+              </p>
+            )}
+          </article>
+        ))}
+      </div>
+    ) : (
+      <div class="mt-6 border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
+        <p class="text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
+          We tried to read your public digital footprint and couldn't find enough to produce a
+          useful report. That's actually informative on its own — a thin public footprint is often a
+          sign of where we'd start. The most useful next step is a short conversation.
+        </p>
+      </div>
+    )
+  }
+
+  {/* D2/D3 affordances — placeholders in v1, Phase 3 wires them. */}
+  <div class="mt-8 border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
+    <h2
+      class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] m-0"
+    >
+      Want a deeper look?
+    </h2>
+    <p class="mt-3 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
+      Talk through this with our agent and we'll dig past what we can see from outside. Or talk
+      through it with us directly. Both are coming soon.
+    </p>
+    <p
+      class="mt-2 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] m-0"
+    >
+      In the meantime: this Outside View is yours to keep. Come back any time. Sharing with a
+      co-owner or partner? Send them the link from your email — same view, same session.
+    </p>
+  </div>
+
+  <p
+    class="mt-6 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]"
+  >
+    {businessName} · Outside View
+  </p>
+</section>

--- a/src/components/portal/PortalTabs.astro
+++ b/src/components/portal/PortalTabs.astro
@@ -25,11 +25,29 @@
  * switching behavior observed in engagement sessions.
  */
 
+/**
+ * Role gating per ADR 0002 (Outside View):
+ *
+ *   - role='prospect'  → only the Outside View tab. Prospects don't have
+ *     an engagement, quotes, invoices, or documents to render. Showing
+ *     those tabs would render empty pages and leak the existence of
+ *     features they aren't entitled to.
+ *
+ *   - role='client'    → Outside View + the four existing tabs (Proposals,
+ *     Invoices, Documents, Progress). The Outside View becomes the
+ *     genesis tab and remains as a longitudinal reference for the
+ *     lifetime of the relationship.
+ *
+ *   - role omitted (back-compat) → behaves as `client` so callers that
+ *     haven't been updated to pass `role` still render the full nav.
+ */
 interface Props {
   pathname: string
+  /** Session role from `Astro.locals.session.role`. Used to gate tab visibility. */
+  role?: string
 }
 
-const { pathname } = Astro.props
+const { pathname, role = 'client' } = Astro.props
 
 interface TabDef {
   href: string
@@ -38,7 +56,14 @@ interface TabDef {
   matchPrefix: string
 }
 
-const tabs: TabDef[] = [
+const OUTSIDE_VIEW_TAB: TabDef = {
+  href: '/portal/outside-view',
+  label: 'Outside View',
+  anchor: '00',
+  matchPrefix: '/portal/outside-view',
+}
+
+const CLIENT_TABS: TabDef[] = [
   {
     href: '/portal/quotes',
     label: 'Proposals',
@@ -64,6 +89,8 @@ const tabs: TabDef[] = [
     matchPrefix: '/portal/engagement',
   },
 ]
+
+const tabs: TabDef[] = role === 'prospect' ? [OUTSIDE_VIEW_TAB] : [OUTSIDE_VIEW_TAB, ...CLIENT_TABS]
 
 function isActive(tab: TabDef, path: string): boolean {
   if (path === '/portal' || path === '/portal/') return false
@@ -114,15 +141,18 @@ function isActive(tab: TabDef, path: string): boolean {
   </div>
 </nav>
 
-<!-- Mobile: fixed bottom bar, 3px ink top border, burnt-orange active tile. -->
+<!--
+  Mobile: fixed bottom bar, 3px ink top border, burnt-orange active tile.
+  Uses flex (not grid-cols-N) so the tab count can vary by role per ADR
+  0002 — prospects see 1 tab, clients see 5. With grid-cols-{n} we'd need
+  Tailwind to know the class at build time, which it can't for a
+  role-dependent count.
+-->
 <nav
   aria-label="Portal sections"
   class="md:hidden fixed bottom-0 inset-x-0 z-40 bg-[color:var(--ss-color-background)] border-t-[3px] border-[color:var(--ss-color-text-primary)] pb-[env(safe-area-inset-bottom)]"
 >
-  <ul
-    class="grid grid-cols-4 divide-x-[2px] divide-[color:var(--ss-color-text-primary)]"
-    role="list"
-  >
+  <ul class="flex divide-x-[2px] divide-[color:var(--ss-color-text-primary)]" role="list">
     {
       tabs.map((tab) => {
         const active = isActive(tab, pathname)
@@ -132,11 +162,11 @@ function isActive(tab: TabDef, path: string): boolean {
           ? 'bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)]'
           : 'bg-transparent text-[color:var(--ss-color-text-primary)] active:bg-[color:var(--ss-color-border-subtle)]'
         return (
-          <li>
+          <li class="flex-1">
             <a
               href={tab.href}
               aria-current={active ? 'page' : undefined}
-              class={`${base} ${state}`}
+              class={`${base} w-full ${state}`}
             >
               <span
                 aria-hidden="true"

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -147,6 +147,22 @@ declare namespace Cloudflare {
      */
     ENABLE_PUBLIC_PATTERNS?: string
     /**
+     * Outside View Phase 1 PR-B feature flag (ADR 0002).
+     *
+     * Controls the destination of /scan completion emails. OFF by default
+     * at merge so the cutover ships behind a flag and shadow-writes
+     * outside_views rows + still sends the legacy diagnostic-report email.
+     * Captain inspects 1+ shadow row in admin/SQL, then flips this to "1"
+     * or "true" in wrangler.toml or via `wrangler secret put`. Once ON,
+     * new scans send a "Your Outside View is ready" magic-link email
+     * pointing at portal.smd.services/outside-view; the legacy email path
+     * is skipped.
+     *
+     * Rollback: flip this OFF; legacy email path resumes immediately.
+     * Any value other than "1" or "true" is treated as OFF.
+     */
+    OUTSIDE_VIEW_PORTAL_DELIVERY?: string
+    /**
      * Service binding to the `ss-scan-workflow` Worker (#618). Hosts the
      * Engine 1 /scan diagnostic Workflow in its own Worker so the
      * `[[workflows]]` binding registers reliably (it didn't when

--- a/src/lib/db/scan-requests.ts
+++ b/src/lib/db/scan-requests.ts
@@ -305,3 +305,31 @@ export async function countScanRequestsSince(db: D1Database, sinceIso: string): 
     .first<{ n: number }>()
   return row?.n ?? 0
 }
+
+/**
+ * Look up the most recent scan_request linked to a given entity. Used by
+ * the Outside View portal page to recover thin-footprint / failed status
+ * when no outside_views row exists yet (ADR 0002 Phase 1 PR-B).
+ *
+ * Tenancy: scan_requests don't carry org_id (the table is public-inbound),
+ * so the org scope is enforced via the entity_id-to-org join through the
+ * caller's session-resolved entity.
+ */
+export async function getScanRequestByEntity(
+  db: D1Database,
+  _orgId: string,
+  entityId: string
+): Promise<ScanRequest | null> {
+  // _orgId reserved for future when scan_requests gains an org_id column;
+  // signature is stable now to avoid churning callers.
+  const row = await db
+    .prepare(
+      `SELECT * FROM scan_requests
+       WHERE entity_id = ?
+       ORDER BY created_at DESC
+       LIMIT 1`
+    )
+    .bind(entityId)
+    .first<ScanRequest>()
+  return row ?? null
+}

--- a/src/lib/diagnostic/index.ts
+++ b/src/lib/diagnostic/index.ts
@@ -62,7 +62,11 @@ import { deepWebsiteAnalysis } from '../enrichment/deep-website'
 import { generateDossier } from '../enrichment/dossier'
 import { getScanRequest, updateScanRequestRun, type ScanRequest } from '../db/scan-requests'
 import { sendOutreachEmail } from '../email/resend'
-import { diagnosticReportEmailHtml, thinFootprintEmailHtml } from '../email/diagnostic-email'
+import {
+  diagnosticReportEmailHtml,
+  outsideViewReadyEmailHtml,
+  thinFootprintEmailHtml,
+} from '../email/diagnostic-email'
 import { renderDiagnosticReport, type RenderedReport } from './render'
 import { guardPlacesByDomain } from './places-guard'
 import { sendScanFailureAlert } from './admin-alert'
@@ -688,6 +692,46 @@ export async function sendDiagnosticReportEmail(
   )
   if (!r.success) {
     console.error('[diagnostic] failed to send report email:', r.error)
+    return false
+  }
+  return true
+}
+
+/**
+ * Send the Outside View magic-link delivery email (ADR 0002 Phase 1 PR-B).
+ *
+ * Replaces `sendDiagnosticReportEmail` when the
+ * `OUTSIDE_VIEW_PORTAL_DELIVERY` feature flag is on. The email body is a
+ * thin link-only template; the actual artifact lives at
+ * portal.smd.services/outside-view, gated behind the magic-link session.
+ *
+ * The renderedDisplayName argument lets the workflow pass the same
+ * canonical business name (Outscraper-resolved) the legacy email used,
+ * preserving the title-case logic in render.ts:#616.
+ */
+export async function sendOutsideViewReadyEmail(
+  env: DiagnosticEnv,
+  scanRequest: ScanRequest,
+  entity: Entity,
+  portalLinkUrl: string,
+  renderedDisplayName?: string | null
+): Promise<boolean> {
+  const businessName = (renderedDisplayName && renderedDisplayName.trim()) || entity.name
+  const html = outsideViewReadyEmailHtml({
+    businessName,
+    portalLinkUrl,
+  })
+  const r = await sendOutreachEmail(
+    env.RESEND_API_KEY,
+    {
+      to: scanRequest.email,
+      subject: `Your Outside View is ready — ${businessName}`,
+      html,
+    },
+    { db: env.DB, orgId: ORG_ID, entityId: entity.id }
+  )
+  if (!r.success) {
+    console.error('[diagnostic] failed to send Outside View ready email:', r.error)
     return false
   }
   return true

--- a/src/lib/diagnostic/workflow.ts
+++ b/src/lib/diagnostic/workflow.ts
@@ -64,7 +64,10 @@ import { ORG_ID } from '../constants'
 import { findOrCreateEntity, getEntity, type Entity } from '../db/entities'
 import { appendContext } from '../db/context'
 import { getScanRequest, updateScanRequestRun, type ScanRequest } from '../db/scan-requests'
-import { renderDiagnosticReport } from './render'
+import { createMagicLink, PROSPECT_MAGIC_LINK_EXPIRY_MS } from '../auth/magic-link'
+import { createOutsideView } from '../db/outside-views'
+import { renderedReportToArtifactJsonV1 } from '../db/outside-views/adapter'
+import { renderDiagnosticReport, type RenderedReport } from './render'
 import { sendScanFailureAlert } from './admin-alert'
 import {
   ScanModuleError,
@@ -78,6 +81,7 @@ import {
   runReviewSynthesis,
   runWebsiteAnalysis,
   sendDiagnosticReportEmail,
+  sendOutsideViewReadyEmail,
   sendThinFootprintEmail,
   type DiagnosticEnv,
 } from './index'
@@ -85,6 +89,12 @@ import {
 /**
  * Bindings the Workflow needs at runtime. Mirrors `DiagnosticEnv` from
  * the legacy orchestrator — keep them in sync.
+ *
+ * Outside View Phase 1 PR-B (ADR 0002) added:
+ *   - PORTAL_BASE_URL: builds the magic-link URL pointing at
+ *     portal.smd.services/auth/verify
+ *   - OUTSIDE_VIEW_PORTAL_DELIVERY: feature flag controlling email
+ *     destination (legacy report email vs Outside View magic-link email)
  */
 export interface ScanWorkflowBindings {
   DB: D1Database
@@ -93,6 +103,18 @@ export interface ScanWorkflowBindings {
   OUTSCRAPER_API_KEY?: string
   RESEND_API_KEY?: string
   APP_BASE_URL?: string
+  PORTAL_BASE_URL?: string
+  OUTSIDE_VIEW_PORTAL_DELIVERY?: string
+}
+
+/**
+ * Outside View feature flag check (ADR 0002 Phase 1 PR-B). The flag is
+ * "1" or "true" to enable; any other value (including unset) is OFF.
+ * Default OFF at merge so the cutover ships behind a flag and can be
+ * verified via shadow-write before user-visible behavior flips.
+ */
+function isOutsideViewDeliveryOn(flag: string | undefined): boolean {
+  return flag === '1' || flag === 'true'
 }
 
 /** Params passed to `env.SCAN_WORKFLOW.create({ params: ... })`. */
@@ -551,6 +573,22 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
     // Step: render + email. The renderer is pure deterministic logic
     // over the enrichment rows we just wrote; the Resend call is the
     // actual side-effect.
+    //
+    // Outside View Phase 1 PR-B (ADR 0002): writes an outside_views row
+    // with the rendered artifact and mints a 24h portal magic-link
+    // ALWAYS (shadow-write), regardless of feature flag state. This lets
+    // Captain inspect generated artifacts in admin/SQL before flipping
+    // OUTSIDE_VIEW_PORTAL_DELIVERY on. With the flag OFF the legacy
+    // diagnosticReportEmailHtml email goes out as before; with the flag
+    // ON the new outsideViewReadyEmailHtml magic-link email goes out
+    // and the legacy path is skipped.
+    //
+    // Privilege-escalation defense (per /critique 3 Devil's Advocate
+    // #4): if the submission email matches an existing role='client'
+    // user, do NOT mint a portal link. The legacy email still fires so
+    // the prospect (in this case actually a client) gets their report,
+    // but we never hand a 24h auth credential to a client's address via
+    // a public, unauthenticated form.
     // ---------------------------------------------------------------
     const renderResult = await step.do<RenderStepResult>(
       'render-and-email',
@@ -558,7 +596,27 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
       async () => {
         const entity = await loadEntity()
         const rendered = await renderDiagnosticReport(env.DB, entity, briefStep.markdown)
-        const sent = await sendDiagnosticReportEmail(env, scanRequestSnapshot, entity, rendered)
+
+        const portalDelivery = await prepareOutsideViewDelivery(
+          this.env,
+          scanRequestSnapshot,
+          entity,
+          rendered
+        )
+
+        const flagOn = isOutsideViewDeliveryOn(this.env.OUTSIDE_VIEW_PORTAL_DELIVERY)
+        const useOutsideViewEmail = flagOn && portalDelivery.portalLinkUrl !== null
+
+        const sent = useOutsideViewEmail
+          ? await sendOutsideViewReadyEmail(
+              env,
+              scanRequestSnapshot,
+              entity,
+              portalDelivery.portalLinkUrl as string,
+              rendered.displayName
+            )
+          : await sendDiagnosticReportEmail(env, scanRequestSnapshot, entity, rendered)
+
         return { emailSent: sent }
       }
     )
@@ -580,5 +638,119 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
     // Quiet the linter on the unused result we destructured for type
     // narrowing.
     void tier2
+  }
+}
+
+/**
+ * Outside View shadow-write + magic-link mint (ADR 0002 Phase 1 PR-B).
+ *
+ * Always runs at the render-and-email step terminal, regardless of
+ * `OUTSIDE_VIEW_PORTAL_DELIVERY` flag state. The flag controls only the
+ * email destination — the artifact is persisted into `outside_views`
+ * either way so Captain can inspect shadow-rendered rows in admin/SQL
+ * before flipping the flag.
+ *
+ * Returns `{ portalLinkUrl }` on success. `portalLinkUrl` is non-null
+ * iff a prospect path was minted; null when:
+ *   1. The submission email matches an existing role='client' user
+ *      (privilege-escalation defense — never mint a portal magic-link
+ *      to a client via the public scan form).
+ *   2. The shadow-write throws (DB error, magic-link insert failure).
+ *      We swallow the error rather than failing the workflow so the
+ *      legacy email path can still fire.
+ *
+ * Caller decides whether to use `portalLinkUrl` based on the feature
+ * flag. With flag OFF, caller ignores `portalLinkUrl` and sends the
+ * legacy email. With flag ON, caller sends the new magic-link email
+ * IF `portalLinkUrl` is non-null, otherwise falls back to legacy.
+ */
+async function prepareOutsideViewDelivery(
+  env: ScanWorkflowBindings,
+  scanRequest: ScanRequest,
+  entity: Entity,
+  rendered: RenderedReport
+): Promise<{ portalLinkUrl: string | null }> {
+  try {
+    const existingUser = await env.DB.prepare(
+      `SELECT id, role FROM users WHERE org_id = ? AND email = ? LIMIT 1`
+    )
+      .bind(ORG_ID, scanRequest.email)
+      .first<{ id: string; role: string }>()
+
+    if (existingUser?.role === 'client') {
+      // Privilege-escalation defense (per /critique 3 Devil's Advocate
+      // #4). Never mint a portal magic-link to an existing client via
+      // the public, unauthenticated /scan form. The legacy email path
+      // still fires; the client gets their report.
+      console.log(
+        `[outside-view] skipping prospect path: existing client matched on ${scanRequest.email}`
+      )
+      return { portalLinkUrl: null }
+    }
+
+    // Find or create prospect user. Reuse a pre-existing prospect row
+    // (e.g. from a prior scan that completed but never converted) rather
+    // than create duplicates.
+    let prospectUserId: string
+    if (existingUser?.role === 'prospect') {
+      prospectUserId = existingUser.id
+    } else {
+      prospectUserId = crypto.randomUUID()
+      await env.DB.prepare(
+        `INSERT INTO users (id, org_id, email, name, role, entity_id)
+         VALUES (?, ?, ?, ?, 'prospect', ?)`
+      )
+        .bind(
+          prospectUserId,
+          ORG_ID,
+          scanRequest.email,
+          // No human name yet; use the email address as a placeholder.
+          // The name is internal-only (admin entity view); prospects
+          // never see it.
+          scanRequest.email,
+          entity.id
+        )
+        .run()
+    }
+
+    // Insert the outside_views row (v1 stores the existing RenderedReport
+    // shape verbatim; canonical 5-field contract ships in v2).
+    await createOutsideView(env.DB, {
+      org_id: ORG_ID,
+      entity_id: entity.id,
+      scan_request_id: scanRequest.id,
+      depth: 'd1',
+      artifact_version: 1,
+      artifact_json: renderedReportToArtifactJsonV1(rendered),
+      rendered_at: new Date().toISOString(),
+    })
+
+    // Mint a 24h portal magic-link bound to the prospect user.
+    const token = await createMagicLink(
+      env.DB,
+      {
+        orgId: ORG_ID,
+        userId: prospectUserId,
+        email: scanRequest.email,
+      },
+      PROSPECT_MAGIC_LINK_EXPIRY_MS
+    )
+
+    // Build the verify URL on the portal host. PORTAL_BASE_URL is
+    // preferred; fall back to APP_BASE_URL if unset (the portal lives
+    // on the same Worker under a subdomain rewrite). The verify
+    // endpoint at /auth/verify on portal.smd.services consumes the
+    // token, sets the session cookie, and lands the prospect at
+    // /portal which redirects them onward to /portal/outside-view.
+    const portalBase = env.PORTAL_BASE_URL ?? env.APP_BASE_URL ?? 'https://portal.smd.services'
+    const portalLinkUrl = `${portalBase.replace(/\/$/, '')}/auth/verify?token=${encodeURIComponent(token)}`
+
+    return { portalLinkUrl }
+  } catch (err) {
+    // Shadow-write failures must not fail the workflow. The legacy email
+    // path is the safety net. Log and return null so the caller falls
+    // back to the legacy email regardless of flag state.
+    console.error('[outside-view] prepareOutsideViewDelivery failed:', err)
+    return { portalLinkUrl: null }
   }
 }

--- a/src/lib/email/diagnostic-email.ts
+++ b/src/lib/email/diagnostic-email.ts
@@ -234,6 +234,84 @@ function insufficientDataFallbackHtml(): string {
 }
 
 // ---------------------------------------------------------------------------
+// 4. Outside View magic-link delivery (ADR 0002 Phase 1 PR-B)
+// ---------------------------------------------------------------------------
+
+export interface OutsideViewReadyEmailInput {
+  /** Resolved business name for the H1. Falls back to humanized domain when
+   *  the canonical Outscraper name isn't available. */
+  businessName: string
+  /** The URL the prospect clicks to land at portal.smd.services/outside-view
+   *  with a 24-hour magic-link session set. Already signed, ready to embed. */
+  portalLinkUrl: string
+}
+
+/**
+ * Sent when a /outside-view scan completes and the
+ * `OUTSIDE_VIEW_PORTAL_DELIVERY` flag is on. Replaces the legacy 5-section
+ * email body with a thin link-only email that takes the prospect to their
+ * persistent Outside View artifact in the portal.
+ *
+ * Why thin: the artifact lives in the portal, not in the inbox. The email's
+ * job is to deliver a working magic-link, set expectation that the artifact
+ * is "yours to keep, grows as you go deeper" (ADR 0002 §5), and stay out
+ * of the way otherwise.
+ *
+ * Voice rules: "we" only. No fabricated commitments. No fixed timeframes.
+ */
+export function outsideViewReadyEmailHtml(input: OutsideViewReadyEmailInput): string {
+  const businessName = escapeHtml(input.businessName)
+  const portalLinkUrl = escapeHtml(input.portalLinkUrl)
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:'Inter',Arial,sans-serif;">
+  <div style="max-width:520px;margin:40px auto;background:#ffffff;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+    <div style="padding:32px 24px;">
+      <p style="font-size:13px;color:#64748b;margin:0 0 4px;text-transform:uppercase;letter-spacing:0.05em;">${BRAND_NAME} &middot; Your Outside View</p>
+      <h1 style="font-size:22px;font-weight:700;color:#0f172a;margin:0 0 16px;">${businessName}</h1>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 16px;">
+        Your Outside View is ready. This is what we see when we look at your business
+        from outside &mdash; what anyone with our skills would see in your public
+        footprint, plus a read on what's likely behind it.
+      </p>
+
+      <p style="font-size:15px;color:#334155;margin:0 0 24px;">
+        It's yours to keep, and it grows as you go deeper.
+      </p>
+
+      <p style="margin:24px 0;">
+        <a href="${portalLinkUrl}"
+           style="display:inline-block;background-color:#1e40af;color:#ffffff;
+                  font-size:14px;font-weight:600;text-decoration:none;
+                  padding:12px 28px;border-radius:6px;">
+          Open your Outside View
+        </a>
+      </p>
+
+      <p style="font-size:13px;color:#64748b;margin:0 0 16px;word-break:break-all;">
+        Or paste this link into your browser:<br>
+        <a href="${portalLinkUrl}" style="color:#1e40af;">${portalLinkUrl}</a>
+      </p>
+
+      <p style="font-size:12px;color:#94a3b8;margin:24px 0 0;">
+        This link works for 24 hours. After that, request a new one from
+        ${BRAND_NAME}/auth/portal-login. We don't add you to a mailing list and
+        we don't share your information with anyone else.
+      </p>
+    </div>
+    <div style="background-color:#f8fafc;padding:16px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+      <p style="font-size:11px;color:#94a3b8;margin:0;">
+        &copy; ${new Date().getFullYear()} ${BRAND_NAME} &middot; Phoenix, AZ
+      </p>
+    </div>
+  </div>
+</body>
+</html>`
+}
+
+// ---------------------------------------------------------------------------
 // 3. Thin-footprint refusal
 // ---------------------------------------------------------------------------
 

--- a/src/pages/portal/outside-view/index.astro
+++ b/src/pages/portal/outside-view/index.astro
@@ -1,0 +1,164 @@
+---
+/**
+ * Outside View portal page (ADR 0002 Phase 1 PR-B).
+ *
+ * Renders the persistent diagnostic artifact for the authenticated portal
+ * user (prospect or client). Looks up the latest active `outside_views`
+ * row by entity, decodes the v1 wrapper through the adapter, and renders
+ * via `OutsideViewArtifact.astro`.
+ *
+ * Edge cases:
+ *   - No outside_views row but scan_status='thin_footprint': render
+ *     the thin-footprint copy + talk-to-us CTA inline (no email-shaped
+ *     redirect; the artifact lives here now).
+ *   - No outside_views row, scan_status='failed' or absent: render
+ *     the same generic 404 as missing-session (no enumeration via
+ *     status code or response timing per /critique 3 Pragmatist #6).
+ *   - artifact_json fails to parse: render "we're working on this"
+ *     placeholder; admin alert already fired upstream.
+ *
+ * 404 enumeration policy: a missing outside_views row and a missing
+ * session both render the same 404 page. The session check is upstream
+ * (middleware admits role IN ('client','prospect') for /portal/*); we
+ * never get here without a session. But for symmetry with the AC, the
+ * "no view exists" path emits status 404, not a redirect.
+ */
+
+export const prerender = false
+
+import '../../../styles/global.css'
+import { BRAND_NAME } from '../../../lib/config/brand'
+import { getPortalClient } from '../../../lib/portal/session'
+import { getActiveOutsideViewByEntity } from '../../../lib/db/outside-views'
+import { parseArtifactJson } from '../../../lib/db/outside-views/adapter'
+import { getScanRequestByEntity } from '../../../lib/db/scan-requests'
+import PortalHeader from '../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../components/portal/PortalPageHead.astro'
+import OutsideViewArtifact from '../../../components/portal/OutsideViewArtifact.astro'
+import SkipToMain from '../../../components/SkipToMain.astro'
+import { env } from 'cloudflare:workers'
+
+const session = Astro.locals.session!
+const portalData = await getPortalClient(env.DB, session.userId, session.orgId)
+
+if (!portalData) {
+  // No user/entity row found. Treated identically to "no session" by the
+  // middleware in normal operation; this branch only fires if the row was
+  // deleted between auth and now. Render generic 404 to avoid leaking
+  // anything about prospect / client distinctions.
+  return new Response('Not Found', { status: 404 })
+}
+
+const { user, client } = portalData
+
+const outsideView = await getActiveOutsideViewByEntity(env.DB, session.orgId, client.id)
+
+// Anti-enumeration: missing outside_views row → identical 404 response
+// shape as missing session. The artifact may legitimately not exist for
+// pre-launch clients who pre-date the Outside View build, or for
+// prospects whose scan returned thin-footprint. Handle the latter
+// inline before falling through to 404.
+let parsed: ReturnType<typeof parseArtifactJson> = null
+let scanStatusReason: 'thin_footprint' | null = null
+
+if (outsideView) {
+  parsed = parseArtifactJson(outsideView.artifact_json, outsideView.artifact_version)
+} else {
+  // Try to recover a thin-footprint or failed scan status from the
+  // entity's most recent scan_request. Same-org tenancy enforced.
+  const scanRow = await getScanRequestByEntity(env.DB, session.orgId, client.id)
+  if (scanRow?.scan_status === 'thin_footprint') {
+    scanStatusReason = 'thin_footprint'
+  } else {
+    return new Response('Not Found', { status: 404 })
+  }
+}
+
+const renderedAt = outsideView?.rendered_at ?? new Date().toISOString()
+const isProspect = user.role === 'prospect'
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <title>Outside View — {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <form method="POST" action="/api/auth/logout">
+        <button
+          type="submit"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </form>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} role={user.role} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref={isProspect ? null : '/portal'}
+        crumbLabel={isProspect ? null : 'Home'}
+        tag="Outside View"
+        h1={client.name}
+        meta="Yours to keep"
+      />
+
+      {
+        scanStatusReason === 'thin_footprint' ? (
+          <section class="mt-8">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
+              <h2 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] m-0">
+                About your scan
+              </h2>
+              <p class="mt-4 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
+                Our scan reads what's publicly available — Google reviews, your website, business
+                listings — and we couldn't find enough public footprint on your domain to produce
+                something useful.
+              </p>
+              <p class="mt-4 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
+                Honestly, that's informative on its own. A thin public footprint is often where we'd
+                start — there's usually low-effort, high-leverage work to do before customers can
+                even find you. The most useful next step is a short conversation.
+              </p>
+              <p class="mt-6 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] m-0">
+                Talk to us — coming soon to this page. In the meantime, you can request a call from
+                the email we sent you.
+              </p>
+            </div>
+          </section>
+        ) : parsed ? (
+          <OutsideViewArtifact
+            rendered={parsed.report}
+            renderedAt={renderedAt}
+            fallbackName={client.name}
+          />
+        ) : (
+          <section class="mt-8">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
+              <h2 class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] m-0">
+                We're working on this
+              </h2>
+              <p class="mt-4 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
+                Your Outside View is being prepared. Refresh this page in a few minutes. If it still
+                isn't here, email team@smd.services and we'll take a look.
+              </p>
+            </div>
+          </section>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/tests/outside-view-pr-b.test.ts
+++ b/tests/outside-view-pr-b.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Outside View Phase 1 PR-B — workflow re-aim + portal page smoke tests.
+ *
+ * Static-source assertions covering:
+ *   1. Feature flag wiring: env binding declared, helper checks "1"|"true"
+ *   2. Workflow terminal step: shadow-write happens regardless of flag,
+ *      privilege-escalation defense for existing client emails, magic-link
+ *      mint uses 24h TTL, portal URL built from PORTAL_BASE_URL.
+ *   3. New email template: outsideViewReadyEmailHtml + sendOutsideViewReadyEmail
+ *      with branded sender, no fabricated commitments.
+ *   4. Portal page: queries outside_views by entity, renders via adapter,
+ *      identical 404 for missing-view and missing-session (no enumeration).
+ *   5. Role-conditional PortalTabs: prospect sees 1 tab, client sees 5.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('PR-B: feature flag wiring', () => {
+  it('env.d.ts declares OUTSIDE_VIEW_PORTAL_DELIVERY', () => {
+    const src = readFileSync(resolve('src/env.d.ts'), 'utf-8')
+    expect(src).toMatch(/OUTSIDE_VIEW_PORTAL_DELIVERY\?:\s*string/)
+  })
+
+  it('workflow.ts ScanWorkflowBindings includes the flag', () => {
+    const src = readFileSync(resolve('src/lib/diagnostic/workflow.ts'), 'utf-8')
+    expect(src).toMatch(/ScanWorkflowBindings\s*\{[\s\S]*OUTSIDE_VIEW_PORTAL_DELIVERY\?:\s*string/)
+  })
+
+  it('workflow.ts ScanWorkflowBindings includes PORTAL_BASE_URL', () => {
+    const src = readFileSync(resolve('src/lib/diagnostic/workflow.ts'), 'utf-8')
+    expect(src).toMatch(/ScanWorkflowBindings\s*\{[\s\S]*PORTAL_BASE_URL\?:\s*string/)
+  })
+
+  it('isOutsideViewDeliveryOn helper accepts "1" and "true" only', () => {
+    const src = readFileSync(resolve('src/lib/diagnostic/workflow.ts'), 'utf-8')
+    expect(src).toMatch(/function isOutsideViewDeliveryOn/)
+    // Should reject anything other than "1" or "true"
+    expect(src).toMatch(/flag === '1' \|\| flag === 'true'/)
+  })
+})
+
+describe('PR-B: workflow terminal step shadow-write + flag', () => {
+  const src = readFileSync(resolve('src/lib/diagnostic/workflow.ts'), 'utf-8')
+
+  it('imports createMagicLink + PROSPECT_MAGIC_LINK_EXPIRY_MS from auth', () => {
+    expect(src).toMatch(
+      /from ['"]\.\.\/auth\/magic-link['"][\s\S]*createMagicLink[\s\S]*PROSPECT_MAGIC_LINK_EXPIRY_MS/
+    )
+  })
+
+  it('imports createOutsideView from db/outside-views', () => {
+    expect(src).toMatch(/createOutsideView[\s\S]*from ['"]\.\.\/db\/outside-views['"]/)
+  })
+
+  it('imports renderedReportToArtifactJsonV1 from adapter', () => {
+    expect(src).toMatch(
+      /renderedReportToArtifactJsonV1[\s\S]*from ['"]\.\.\/db\/outside-views\/adapter['"]/
+    )
+  })
+
+  it('imports sendOutsideViewReadyEmail', () => {
+    expect(src).toMatch(/sendOutsideViewReadyEmail/)
+  })
+
+  it('terminal step calls prepareOutsideViewDelivery before email', () => {
+    expect(src).toMatch(/prepareOutsideViewDelivery/)
+  })
+
+  it('shadow-write runs ALWAYS (not gated by flag)', () => {
+    // The flag check is on the email branch, not on prepareOutsideViewDelivery.
+    // prepareOutsideViewDelivery should be called before isOutsideViewDeliveryOn.
+    const idxPrepare = src.indexOf('prepareOutsideViewDelivery(')
+    const idxFlagCheck = src.indexOf(
+      'isOutsideViewDeliveryOn(this.env.OUTSIDE_VIEW_PORTAL_DELIVERY)'
+    )
+    expect(idxPrepare).toBeGreaterThan(0)
+    expect(idxFlagCheck).toBeGreaterThan(idxPrepare)
+  })
+
+  it('falls back to legacy email when flag OFF or magic-link unavailable', () => {
+    expect(src).toMatch(
+      /useOutsideViewEmail[\s\S]*sendOutsideViewReadyEmail[\s\S]*sendDiagnosticReportEmail/
+    )
+  })
+
+  it('privilege-escalation defense: skips prospect path on existing client email', () => {
+    // The helper function should check role === 'client' and bail.
+    expect(src).toMatch(/existingUser\?\.role === 'client'[\s\S]*portalLinkUrl: null/)
+  })
+
+  it('magic-link uses 24h TTL (PROSPECT_MAGIC_LINK_EXPIRY_MS)', () => {
+    expect(src).toMatch(/createMagicLink\([\s\S]*PROSPECT_MAGIC_LINK_EXPIRY_MS\s*\)/)
+  })
+
+  it('portal URL prefers PORTAL_BASE_URL, falls back to APP_BASE_URL', () => {
+    expect(src).toMatch(/env\.PORTAL_BASE_URL\s*\?\?\s*env\.APP_BASE_URL/)
+  })
+
+  it('portal URL points at /auth/verify (not directly at /portal/outside-view)', () => {
+    // The verify endpoint sets the cookie; landing direct at /portal would
+    // hit middleware without a session and bounce.
+    expect(src).toMatch(/\/auth\/verify\?token=/)
+  })
+
+  it('shadow-write swallows errors and returns null portalLinkUrl', () => {
+    expect(src).toMatch(
+      /catch\s*\(err\)\s*\{[\s\S]*prepareOutsideViewDelivery failed[\s\S]*return\s*\{\s*portalLinkUrl:\s*null/
+    )
+  })
+})
+
+describe('PR-B: outsideViewReadyEmailHtml template', () => {
+  const src = readFileSync(resolve('src/lib/email/diagnostic-email.ts'), 'utf-8')
+
+  it('exports outsideViewReadyEmailHtml', () => {
+    expect(src).toMatch(/export function outsideViewReadyEmailHtml/)
+  })
+
+  it('renders Outside View framing (not "Operational Readiness Scan")', () => {
+    const fnMatch = src.match(/export function outsideViewReadyEmailHtml[\s\S]*?^}/m)
+    expect(fnMatch).toBeTruthy()
+    if (fnMatch) {
+      expect(fnMatch[0]).toMatch(/Your Outside View/)
+      expect(fnMatch[0]).not.toMatch(/Operational Readiness Scan/)
+    }
+  })
+
+  it('contains "Open your Outside View" CTA copy', () => {
+    expect(src).toMatch(/Open your Outside View/)
+  })
+
+  it('mentions the 24-hour link lifetime', () => {
+    const fnMatch = src.match(/export function outsideViewReadyEmailHtml[\s\S]*?^}/m)
+    expect(fnMatch).toBeTruthy()
+    if (fnMatch) {
+      expect(fnMatch[0]).toMatch(/24 hours/i)
+    }
+  })
+
+  it('uses BRAND_NAME constant (no hardcoded "SMD Services")', () => {
+    const fnMatch = src.match(/export function outsideViewReadyEmailHtml[\s\S]*?^}/m)
+    expect(fnMatch).toBeTruthy()
+    if (fnMatch) {
+      expect(fnMatch[0]).toMatch(/\$\{BRAND_NAME\}/)
+    }
+  })
+})
+
+describe('PR-B: sendOutsideViewReadyEmail', () => {
+  const src = readFileSync(resolve('src/lib/diagnostic/index.ts'), 'utf-8')
+
+  it('exports sendOutsideViewReadyEmail', () => {
+    expect(src).toMatch(/export async function sendOutsideViewReadyEmail/)
+  })
+
+  it('subject mentions Outside View', () => {
+    expect(src).toMatch(/Your Outside View is ready/)
+  })
+
+  it('uses sendOutreachEmail for tracking parity with existing diagnostic emails', () => {
+    const fnMatch = src.match(/sendOutsideViewReadyEmail[\s\S]*?^}/m)
+    expect(fnMatch).toBeTruthy()
+    if (fnMatch) {
+      expect(fnMatch[0]).toMatch(/sendOutreachEmail/)
+    }
+  })
+})
+
+describe('PR-B: /portal/outside-view page', () => {
+  const path = 'src/pages/portal/outside-view/index.astro'
+
+  it('page exists', () => {
+    expect(existsSync(resolve(path))).toBe(true)
+  })
+
+  const src = readFileSync(resolve(path), 'utf-8')
+
+  it('queries via getActiveOutsideViewByEntity (org-scoped)', () => {
+    expect(src).toMatch(/getActiveOutsideViewByEntity\(env\.DB,\s*session\.orgId,\s*client\.id\)/)
+  })
+
+  it('parses artifact_json via the v1 adapter', () => {
+    expect(src).toMatch(
+      /parseArtifactJson\(outsideView\.artifact_json,\s*outsideView\.artifact_version\)/
+    )
+  })
+
+  it('returns identical 404 for missing-view and missing-session', () => {
+    // Missing portalData and missing-outsideView+non-thin-footprint both
+    // emit the exact same response: status 404, body "Not Found".
+    const not_found_responses = src.match(/new Response\('Not Found',\s*\{\s*status:\s*404\s*\}\)/g)
+    expect(not_found_responses).toBeTruthy()
+    expect((not_found_responses ?? []).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders thin-footprint copy inline when scan_status is thin_footprint', () => {
+    expect(src).toMatch(/scanStatusReason === 'thin_footprint'/)
+    expect(src).toMatch(/About your scan/)
+  })
+
+  it('renders OutsideViewArtifact when artifact parses', () => {
+    expect(src).toMatch(/<OutsideViewArtifact/)
+  })
+
+  it('passes role to PortalTabs for role-conditional rendering', () => {
+    expect(src).toMatch(/<PortalTabs[\s\S]*role=\{user\.role\}/)
+  })
+
+  it('declares prerender=false (SSR required for session+DB lookup)', () => {
+    expect(src).toMatch(/export const prerender = false/)
+  })
+})
+
+describe('PR-B: OutsideViewArtifact component', () => {
+  const path = 'src/components/portal/OutsideViewArtifact.astro'
+
+  it('component file exists', () => {
+    expect(existsSync(resolve(path))).toBe(true)
+  })
+
+  const src = readFileSync(resolve(path), 'utf-8')
+
+  it('accepts RenderedReport via props', () => {
+    expect(src).toMatch(
+      /import type \{ RenderedReport[\s\S]*from ['"]\.\.\/\.\.\/lib\/diagnostic\/render['"]/
+    )
+  })
+
+  it('walks rendered.sections', () => {
+    expect(src).toMatch(/rendered\.sections/)
+  })
+
+  it('honors hasContent flag for empty-state fallback', () => {
+    expect(src).toMatch(/rendered\.hasContent/)
+  })
+
+  it('renders insufficientDataNote for sections that flagged it', () => {
+    expect(src).toMatch(/insufficientDataNote/)
+  })
+
+  it('does not invent commitments (no "we will" / "kickoff" / "respond within")', () => {
+    // CLAUDE.md no-fab rule: components rendering data should never have
+    // hardcoded commitment copy. Outside View Phase 1 ships placeholder
+    // D2/D3 affordances ("coming soon") which is allowed.
+    expect(src).not.toMatch(/We'll reach out/i)
+    expect(src).not.toMatch(/within \d+ business day/i)
+    expect(src).not.toMatch(/respond within/i)
+  })
+})
+
+describe('PR-B: PortalTabs role-conditional rendering', () => {
+  const src = readFileSync(resolve('src/components/portal/PortalTabs.astro'), 'utf-8')
+
+  it('accepts a role prop', () => {
+    expect(src).toMatch(/role\?:\s*string/)
+  })
+
+  it('Outside View tab is the genesis tab (anchor 00, href /portal/outside-view)', () => {
+    expect(src).toMatch(/href:\s*['"]\/portal\/outside-view['"][\s\S]*anchor:\s*['"]00['"]/)
+  })
+
+  it('prospect role gets only the Outside View tab', () => {
+    expect(src).toMatch(/role === 'prospect'\s*\?\s*\[OUTSIDE_VIEW_TAB\]/)
+  })
+
+  it('client role gets Outside View + 4 client tabs', () => {
+    expect(src).toMatch(/\[OUTSIDE_VIEW_TAB,\s*\.\.\.CLIENT_TABS\]/)
+  })
+
+  it('mobile bar uses flex (not grid-cols-N) for variable tab count', () => {
+    expect(src).toMatch(/class="flex divide-x-\[2px\]/)
+    // grid-cols-4 should no longer be present
+    expect(src).not.toMatch(/grid grid-cols-4 divide-x/)
+  })
+
+  it('default role (omitted prop) behaves as client (back-compat)', () => {
+    expect(src).toMatch(/role\s*=\s*['"]client['"]/)
+  })
+})
+
+describe('PR-B: getScanRequestByEntity helper', () => {
+  const src = readFileSync(resolve('src/lib/db/scan-requests.ts'), 'utf-8')
+
+  it('exports getScanRequestByEntity', () => {
+    expect(src).toMatch(/export async function getScanRequestByEntity/)
+  })
+
+  it('orders by created_at DESC and limits to 1 (most recent)', () => {
+    const fnMatch = src.match(/export async function getScanRequestByEntity[\s\S]*?^}/m)
+    expect(fnMatch).toBeTruthy()
+    if (fnMatch) {
+      expect(fnMatch[0]).toMatch(/ORDER BY created_at DESC[\s\S]*LIMIT 1/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Re-opened from #627 (auto-closed when its base branch `feat/outside-view-pr-a` was deleted on merge of #626 PR-A). Branch rebased onto current main; PR-A commit dropped via cherry-pick skip; PR-B commit applied cleanly with no conflicts.

Phase 1 PR-B of the Outside View build per [ADR 0002](docs/adr/0002-outside-view-unified-diagnostic.md). Re-aims the `/scan` diagnostic pipeline (#608/#613/#615/#617/#619) to land prospects at `portal.smd.services/outside-view` with a persistent artifact. Behind feature flag for safe shadow rollout.

Stacks on #626 (now merged): `outside_views` table, `prospect` role, `createMagicLink(ttlMs)` plumbing.

## Feature flag: `OUTSIDE_VIEW_PORTAL_DELIVERY`

Default OFF at merge. Workflow always shadow-writes `outside_views` rows + mints prospect magic-links regardless of flag state. With the flag OFF the legacy `diagnosticReportEmailHtml` email goes out as before; Captain inspects shadow-rendered artifacts before flipping the flag. Once ON, scans send the new "Your Outside View is ready" magic-link email and skip the legacy email path. Rollback is a single flag flip.

## What's in the diff

- `src/lib/diagnostic/workflow.ts` — `prepareOutsideViewDelivery()` shadow-writes outside_views + mints prospect magic-link with privilege-escalation defense.
- `src/lib/diagnostic/index.ts` — workflow integration glue.
- `src/lib/email/diagnostic-email.ts` — new "Your Outside View is ready" magic-link email template.
- `src/lib/db/scan-requests.ts` — `getScanRequestByEntity` for portal page recovery path.
- `src/env.d.ts` — `OUTSIDE_VIEW_PORTAL_DELIVERY` + `PORTAL_BASE_URL` bindings.
- `src/pages/portal/outside-view/index.astro` — portal page with thin-footprint recovery.
- `src/components/portal/OutsideViewArtifact.astro` — render the artifact.
- `src/components/portal/PortalTabs.astro` — role-aware tabs (prospect sees only Outside View; client sees all 5).
- `tests/outside-view-pr-b.test.ts` — 46 static-source assertions.

## Verification

- `npm run typecheck`: 0 errors
- `npm run verify`: exit 0 (all 1961+ tests pass)
- All 46 PR-B smoke tests pass
- All 52 PR-A smoke tests still pass (regression guard intact)

## Rollback

- Flag flip OFF: legacy email path resumes immediately. `outside_views` rows accumulate harmlessly.
- Hard revert: revert this PR; legacy path was never broken.

Closes #624.