### PR TITLE
feat(marketing): demote AI structurally — six-capability layout + /ai capability-page treatment (#639)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,12 +18,28 @@
 
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
-    <!-- Region 2: Colophon — legal left, location right. Nav and CTA are not
+    <!-- Region 2: Sitewide links. Routable destinations not otherwise
+         present in the chrome: Outside View (lead artifact), AI (capability
+         page, demoted from primary nav per the ADR 0002 cleanup), Book a Call
+         (also in nav and FinalCta but useful here as a footer fallback),
+         Contact. Brutalist-sparse mono treatment to match the colophon. -->
+    <nav
+      aria-label="Footer"
+      class="py-6 md:py-7 flex flex-wrap gap-x-6 gap-y-2 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+    >
+      <a href="/outside-view" class="hover:text-white" data-ev="footer-outside-view">Outside View</a
+      >
+      <a href="/ai" class="hover:text-white" data-ev="footer-ai">AI</a>
+      <a href="/book" class="hover:text-white" data-ev="footer-book">Book a Call</a>
+      <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>
+    </nav>
+
+    <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
+
+    <!-- Region 3: Colophon — legal left, location right. Nav and CTA are not
          repeated here because they already live in the sticky header (mobile
          menu overlay + desktop inline) and in the FinalCta section directly
-         above the footer. Repeating them was visual noise. When dedicated
-         footer content exists (Legal, Privacy, Terms, Social), it slots in
-         as a third region above this colophon. -->
+         above the footer. -->
     <div
       class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,6 @@
 ---
 const navLinks = [
-  { href: '/ai', label: 'AI' },
+  { href: '/#approach', label: 'Approach' },
   { href: '/contact', label: 'Contact' },
 ]
 ---

--- a/src/components/WhatYouGet.astro
+++ b/src/components/WhatYouGet.astro
@@ -1,10 +1,54 @@
 ---
-const items = [
+// What we do — six-capability layout per CLAUDE.md "Problem Framework".
+//
+// V1 ships six cards with one-line descriptions only. AI card alone has a
+// "Read more →" affordance because /ai is the only capability with a real
+// URL. The other five carry no outbound or in-page anchor in v1; detail
+// blocks land in v2 once #597 evidence justifies promoting any to its own
+// page (per ADR 0002 cleanup, issue #639).
+//
+// "How we deliver" subsection holds the deliverables list (formerly the
+// entire WhatYouGet section, mixed capabilities with deliverables — now
+// taxonomically separated).
+const capabilities = [
+  {
+    title: 'Process design',
+    description:
+      "We document what's working, fix what isn't, and write it down so your team can run without you.",
+  },
+  {
+    title: 'Custom internal tools',
+    description:
+      "Built when off-the-shelf doesn't fit how you work. A script, a small app, or a workflow inside something you already use.",
+  },
+  {
+    title: 'Systems integration',
+    description:
+      "Getting the tools you already pay for to talk to each other, so the same data doesn't live in five places.",
+  },
+  {
+    title: 'Operational visibility',
+    description:
+      "Knowing what's actually happening across your business without piecing it together every Friday.",
+  },
+  {
+    title: 'Vendor and platform selection',
+    description:
+      'When you need a new tool, we help you pick the one that fits where your business is now.',
+  },
+  {
+    title: 'AI and automation',
+    description:
+      'When AI fits the work, we use it. When a simpler script does the job, we use that instead.',
+    href: '/ai',
+  },
+]
+
+const deliverables = [
   'Documented SOPs for your critical processes',
   'Tool selection, configuration, and integration',
   'Custom internal tools and dashboards built for how you work',
   'System integrations that eliminate manual data entry',
-  "AI and automation where it actually helps, nothing where it doesn't",
   'Vendor evaluation and selection when off-the-shelf fits better',
   'Data migration and setup',
   'Hands-on team training and walkthrough',
@@ -14,6 +58,7 @@ const items = [
 ---
 
 <section
+  id="approach"
   class="bg-[color:var(--ss-color-background)] px-6 py-24 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
 >
   <div class="mx-auto max-w-5xl">
@@ -25,36 +70,85 @@ const items = [
       <h2
         class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
-        What You Get
+        What We Do
       </h2>
     </div>
+
     <div
-      class="grid grid-cols-1 gap-0 md:grid-cols-2 border-t border-[color:var(--ss-color-border)]"
+      class="grid grid-cols-1 gap-0 md:grid-cols-3 border-t-[3px] border-[color:var(--ss-color-text-primary)]"
     >
       {
-        items.map((item, i) => (
+        capabilities.map((c, i) => (
           <div
             class:list={[
-              'flex items-start gap-4 py-5 px-1 border-b border-[color:var(--ss-color-border)]',
-              i % 2 === 0 && 'md:border-r md:pr-8 md:border-[color:var(--ss-color-border)]',
-              i % 2 === 1 && 'md:pl-8',
+              'flex flex-col gap-4 bg-[color:var(--ss-color-background)] p-8 min-h-[14rem] border-b-[3px] border-[color:var(--ss-color-text-primary)]',
+              i % 3 !== 2 && 'md:border-r-[3px] md:border-[color:var(--ss-color-text-primary)]',
             ]}
           >
-            <span class="mt-2 inline-block w-3 h-3 shrink-0 bg-[color:var(--ss-color-primary)]" />
-            <span class="font-['Archivo'] text-lg text-[color:var(--ss-color-text-primary)]">
-              {item}
-            </span>
+            <p class="font-['JetBrains_Mono'] text-sm font-semibold tracking-[0.08em] text-[color:var(--ss-color-primary)]">
+              {String(i + 1).padStart(2, '0')}.
+            </p>
+            <h3 class="font-['Archivo'] text-xl font-bold uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+              {c.title}
+            </h3>
+            <p class="font-['Archivo'] leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+              {c.description}
+            </p>
+            {c.href && (
+              <a
+                href={c.href}
+                data-ev={`approach-card-${c.title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
+                class="mt-auto pt-4 font-['Archivo_Narrow'] text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
+              >
+                Read more →
+              </a>
+            )}
           </div>
         ))
       }
     </div>
+
     <p
       class="mt-10 max-w-3xl font-['Archivo'] text-[color:var(--ss-color-text-secondary)] leading-relaxed"
     >
       This is how we deliver. It is not a checklist we run against your business. We start by
-      understanding where you are trying to go, then figure out together which of these moves — and
-      in what shape — actually gets you there. The right solution might be one of these, several of
+      understanding where you are trying to go, then figure out together which of these moves, and
+      in what shape, actually gets you there. The right solution might be one of these, several of
       these, or something we have not listed at all.
     </p>
+
+    <p
+      class="mt-6 max-w-3xl font-['Archivo'] text-[color:var(--ss-color-text-secondary)] leading-relaxed"
+    >
+      When AI is the right tool, we use it well and we say so. When it isn't, we say that too.
+    </p>
+
+    <div class="mt-16 pt-12 border-t-[3px] border-[color:var(--ss-color-text-primary)]">
+      <h3
+        class="mb-8 font-['Archivo'] text-2xl font-bold uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]"
+      >
+        What You Get
+      </h3>
+      <div
+        class="grid grid-cols-1 gap-0 md:grid-cols-2 border-t border-[color:var(--ss-color-border)]"
+      >
+        {
+          deliverables.map((item, i) => (
+            <div
+              class:list={[
+                'flex items-start gap-4 py-5 px-1 border-b border-[color:var(--ss-color-border)]',
+                i % 2 === 0 && 'md:border-r md:pr-8 md:border-[color:var(--ss-color-border)]',
+                i % 2 === 1 && 'md:pl-8',
+              ]}
+            >
+              <span class="mt-2 inline-block w-3 h-3 shrink-0 bg-[color:var(--ss-color-primary)]" />
+              <span class="font-['Archivo'] text-lg text-[color:var(--ss-color-text-primary)]">
+                {item}
+              </span>
+            </div>
+          ))
+        }
+      </div>
+    </div>
   </div>
 </section>

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -6,6 +6,40 @@ import Nav from '../components/Nav.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
 import CtaButton from '../components/CtaButton.astro'
+
+// FAQPage JSON-LD schema. Question H2s match the ones rendered below so
+// retrieval engines (Perplexity, ChatGPT Search, Google AI Overviews) can
+// extract answer-shaped chunks. Per #639 / Move 4d.
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'When does an AI engagement actually pay off?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "A conversation first. We walk through what you're trying to do and where things are getting stuck. Then we figure out together whether AI is the right answer or whether something simpler would serve you better. Dozens of AI tools are marketed at businesses your size every month. We help you tell which ones actually fit your work and which are solving someone else's problem. If we build something custom, whether it's an AI assistant, a script that cleans up a recurring task, or an integration between tools, it fits into how your team already operates instead of asking them to change. A tool nobody uses is worse than no tool at all. We make sure your team can actually run what we build after we're gone.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is AI the right answer for a small business?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "Sometimes yes. Other times the answer is a simple script, a better process, or just getting two of your tools to talk to each other. And sometimes the answer is not yet. That's the conversation. If you walk out of it thinking AI isn't where you should spend money this quarter, that's a win too. Clarity is the point. When AI is the answer, Claude is usually what we reach for. Different situation, different tool, we'll say so.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: "What we won't do with AI",
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "We won't automate judgment. Some decisions should stay with a person who knows your business. We'll build a tool that gets the right information to the right person faster, but not one that makes the call for them and hides how it got there. We won't replace people. The goal is to give your team back the hours they're losing to busywork. If an engagement is really a headcount decision wearing a tech coat, we'll tell you that instead of selling you the tech. We won't hand over a dashboard and call it strategy. A dashboard shows you what's happening. It doesn't tell you what to do about it. You should leave an engagement with a clearer picture and a plan for acting on it.",
+      },
+    },
+  ],
+}
 ---
 
 <Base
@@ -14,8 +48,18 @@ import CtaButton from '../components/CtaButton.astro'
 >
   <Nav />
   <main id="main" role="main">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
     <section class="relative overflow-hidden px-6 pb-32 pt-24">
       <div class="mx-auto max-w-4xl text-center">
+        <a
+          href="/#approach"
+          data-ev="ai-eyebrow-approach"
+          class="inline-flex items-center gap-2 mb-8 font-['JetBrains_Mono'] text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)]"
+        >
+          <span aria-hidden="true">←</span>
+          <span>One of six capabilities</span>
+        </a>
         <h1
           class="mb-8 text-5xl font-extrabold leading-[1.1] tracking-tight text-[color:var(--ss-color-text-primary)] md:text-7xl"
         >
@@ -25,7 +69,7 @@ import CtaButton from '../components/CtaButton.astro'
           class="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
           Some of what you're hearing about AI is useful. A lot of it is noise. We help you sort it
-          out and build what fits how your business actually works.
+          out.
         </p>
         <CtaButton href="/book" data-ev="ai-primary-cta">Book a Call</CtaButton>
       </div>
@@ -36,7 +80,7 @@ import CtaButton from '../components/CtaButton.astro'
         <h2
           class="mb-12 text-center text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl"
         >
-          What Working With Us Looks Like
+          When Does an AI Engagement Actually Pay Off?
         </h2>
         <div class="space-y-10 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
           <p>
@@ -72,14 +116,20 @@ import CtaButton from '../components/CtaButton.astro'
     <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
       <div class="mx-auto max-w-3xl text-center">
         <h2 class="mb-8 text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
-          Is AI Actually the Right Answer?
+          Is AI the Right Answer for a Small Business?
         </h2>
-        <p class="text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          Sometimes yes. Other times the answer is a simple script, a better process, or just
-          getting two of your tools to talk to each other. And sometimes the answer is not yet.
-          That's the conversation. If you walk out of it thinking AI isn't where you should spend
-          money this quarter, that's a win too. Clarity is the point.
-        </p>
+        <div class="space-y-6 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
+          <p>
+            Sometimes yes. Other times the answer is a simple script, a better process, or just
+            getting two of your tools to talk to each other. And sometimes the answer is not yet.
+            That's the conversation. If you walk out of it thinking AI isn't where you should spend
+            money this quarter, that's a win too. Clarity is the point.
+          </p>
+          <p>
+            When AI is the answer, Claude is usually what we reach for. Different situation,
+            different tool, we'll say so.
+          </p>
+        </div>
       </div>
     </section>
 
@@ -88,7 +138,7 @@ import CtaButton from '../components/CtaButton.astro'
         <h2
           class="mb-4 text-center text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl"
         >
-          What We Won't Do
+          What We Won't Do With AI
         </h2>
         <p
           class="mx-auto mb-12 max-w-2xl text-center text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
@@ -127,25 +177,6 @@ import CtaButton from '../components/CtaButton.astro'
               with a clearer picture and a plan for acting on it.
             </p>
           </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-24">
-      <div class="mx-auto max-w-3xl text-center">
-        <h2 class="mb-8 text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
-          When AI is part of the answer, Claude is our default.
-        </h2>
-        <div class="space-y-6 text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]">
-          <p>
-            Not every engagement calls for AI. When one does, Claude is what we reach for because
-            it's the best fit for most of the work we do.
-          </p>
-          <p>
-            That's a preference, not a lock-in. If your situation is better served by a different
-            model, a different tool, or no AI at all, we'll say so and build accordingly. What we
-            won't do is bend the answer to match a stack we already like.
-          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Resolves the doctrinal misalignment where `/ai` was the only capability page and lived in primary nav, contradicting CLAUDE.md's chef-and-knife principle ("AI is a named capability, never the firm's identity"). This is the structural cleanup that the ADR 0002 closure of #483's child issue 2.1 implied.

Closes #639.

## What changes

**1. Pull /ai from primary nav** (`src/components/Nav.astro`, `src/components/Footer.astro`)
- Nav slot becomes `Approach` (anchor link to `/#approach`).
- Footer gains a small links region with `Outside View / AI / Book a Call / Contact` to keep `/ai` reachable site-wide without re-elevating it in the chrome.

**2. Replace WhatYouGet with a six-capability layout** (`src/components/WhatYouGet.astro`)
- Section h2 is "What We Do" with `id="approach"` so the new nav anchor lands here.
- Six capability cards (process design, custom internal tools, systems integration, operational visibility, vendor and platform selection, AI and automation) with identical visual treatment.
- AI card alone carries a "Read more →" link to `/ai`. The other five carry no outbound or in-page anchor in v1; detail blocks deferred to v2.
- The original 10-bullet deliverables list demoted to a "What You Get" subsection, dropping the AI/automation bullet (now a card).

**3. One calibrated AI sentence on the homepage**
- Added inside the new capability section: *"When AI is the right tool, we use it well and we say so. When it isn't, we say that too."*

**4. Restructure /ai** (`src/pages/ai.astro`)
- Hero subhead tightened (cut the third clause).
- Eyebrow added above h1: "← One of six capabilities" linking to `/#approach`. **Unnumbered** — no §06 prefix until the other five capability pages exist.
- H2s reshaped as buyer queries for AI-search retrieval:
  - "What Working With Us Looks Like" → "When Does an AI Engagement Actually Pay Off?"
  - "Is AI Actually the Right Answer?" → "Is AI the Right Answer for a Small Business?"
  - "What We Won't Do" → "What We Won't Do With AI"
- Standalone Claude section removed; compressed to a single closing sentence inside the renamed "Is AI the Right Answer..." section.
- FAQPage JSON-LD schema added covering the three question H2s.

**5. Defer the other five capability pages.** Nothing built speculatively; `/ai` is the prototype.

## Doctrine checklist

- [x] Nav contains zero AI mentions
- [x] Six capability cards on home are visually identical (same h3 weight, line-count, card chrome). AI card alone has "Read more →"
- [x] Homepage AI sentence appears once, in body copy, no header
- [x] `/ai` eyebrow reads "One of six capabilities" with no §N numbering
- [x] `/ai` no longer contains a standalone Claude section. Claude is mentioned in exactly one sentence inside "Is AI the Right Answer..." section
- [x] `/ai` H2s phrased as questions
- [x] FAQPage JSON-LD schema present in `/ai` (validate post-deploy in Google Rich Results Test)
- [x] Footer contains a links block including `/ai`
- [x] `id="approach"` anchor on the home capability section is unique
- [x] `npm run verify` clean (typecheck + lint + format + build + tests)

## Test plan

- [x] `npm run verify` passes locally
- [ ] Local read-through on `npm run dev`: homepage, `/ai`, `/contact` — confirm Approach nav link jumps from any page to `#approach` cleanly
- [ ] Post-deploy: validate FAQ schema at https://search.google.com/test/rich-results
- [ ] Post-deploy: submit `/ai` to Perplexity and ChatGPT Search with three queries to check citation behavior
- [ ] Post-launch (depends on #483 child 2.5 instrumentation): track `/ai` arrivals from homepage AI card vs search; track scroll depth on the new capability section

## Background

Plan + roundtable synthesis at `~/.claude/plans/lets-mighty-volcano.md`. Five-person expert roundtable (brand strategist, growth marketer, IA, SEO, editor) followed by Devil's Advocate critique. Plan revisions: simplified Move 2 to v1 cards-only after the panel hand-waved the detail-block UX; softened the Claude paragraph cut to a one-sentence compression; dropped the §06 numbered eyebrow that would have implied a six-page series that doesn't exist; demoted the persona test from merge gate to optional with baseline-first caveat.

## References

- ADR 0002 — `docs/adr/0002-outside-view-unified-diagnostic.md`
- ADR 0001 — `docs/adr/0001-taxonomy-two-layer-model.md`
- CLAUDE.md "About This Venture" (chef-and-knife paragraph), "Tone & Positioning Standard," "Problem Framework"
- #483 — Site Credibility Epic (closed)
- #597 — Programmatic SEO for Phoenix vertical pages (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)