### PR TITLE
fix: land anti-slop guardrails and admin boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,18 @@ Any information displayed to a client (timelines, schedules, deliverables, prici
 
 **Enforcement.** Violations are P0. Merge gate is `.github/workflows/scope-deferred-todo.yml` (blocks TODO-deferred ACs without the `scope-deferred` label). Issue-close gate is `.github/workflows/unmet-ac-on-close.yml` (reopens issues closed with unchecked ACs).
 
+**Fabrication and drift guardrails.** Pattern A/B is not the full policy. The repo also blocks three adjacent failure modes:
+
+- Shipped user-facing copy must not pick up banned style markers or placeholder copy. No em dashes. No "coming soon" on prospect or client surfaces.
+- Enrichment prompts must stay extractive and evidence-bound. They must not ask for management style, personality, communication preferences, likely objections, or other private-condition inference.
+- Shared product flows must stay shared once canonicalized. If `/book` and `/get-started` drift back into duplicate intake implementations, that is a regression.
+
+**Tests linked to this policy**
+
+- `tests/forbidden-strings.test.ts` - historical Pattern A/B phrases, user-facing style-marker checks, and portal registry guardrails
+- `tests/enrichment-prompt-contracts.test.ts` - source-level prompt-contract checks for dossier, review-analysis, and deep-website
+- `tests/intake-questionnaire.test.ts` - shared-surface regression coverage for the canonical intake questionnaire
+
 ## Tone & Positioning Standard
 
 **These rules apply to ALL external-facing content: website copy, outreach, proposals, collateral, and any client-facing language. They also apply to internal content that may inform external copy (e.g., one-liners, scripts).**

--- a/src/components/admin/AdminFlashNotice.astro
+++ b/src/components/admin/AdminFlashNotice.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  kind?: 'success' | 'error' | 'warning'
+  message: string
+  className?: string
+}
+
+const { kind = 'success', message, className } = Astro.props
+
+const kindClasses: Record<NonNullable<Props['kind']>, string> = {
+  success: 'bg-surface border border-complete text-complete',
+  error: 'bg-surface border border-error text-error',
+  warning: 'bg-surface border border-pending text-pending',
+}
+---
+
+<div
+  class:list={[
+    'text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4',
+    kindClasses[kind],
+    className,
+  ]}
+>
+  {message}
+</div>

--- a/src/components/booking/IntakeQuestionnaire.astro
+++ b/src/components/booking/IntakeQuestionnaire.astro
@@ -1,0 +1,270 @@
+---
+import { ENTITY_VERTICALS } from '../../lib/db/entities'
+import {
+  INTAKE_EMPLOYEE_COUNT_OPTIONS,
+  INTAKE_HOW_HEARD_OPTIONS,
+  INTAKE_YEARS_IN_BUSINESS_OPTIONS,
+  type IntakeQuestionnaireMode,
+} from '../../lib/booking/intake-questionnaire'
+
+interface Props {
+  idPrefix: string
+  mode: IntakeQuestionnaireMode
+  values?: {
+    name?: string
+    email?: string
+    businessName?: string
+    phone?: string
+  }
+}
+
+const { idPrefix, mode, values = {} } = Astro.props
+const includePhone = mode === 'booking'
+---
+
+<div class="space-y-5" data-intake-questionnaire>
+  <div class="grid gap-5 sm:grid-cols-2">
+    <div>
+      <label
+        for={`${idPrefix}-name`}
+        class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+      >
+        Full name <span class="text-red-500">*</span>
+      </label>
+      <input
+        type="text"
+        id={`${idPrefix}-name`}
+        name="name"
+        required
+        maxlength="200"
+        autocomplete="name"
+        value={values.name ?? ''}
+        class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        placeholder="e.g. Maria Garcia"
+      />
+    </div>
+    <div>
+      <label
+        for={`${idPrefix}-email`}
+        class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+      >
+        Work email <span class="text-red-500">*</span>
+      </label>
+      <input
+        type="email"
+        id={`${idPrefix}-email`}
+        name="email"
+        required
+        maxlength="254"
+        autocomplete="email"
+        value={values.email ?? ''}
+        class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        placeholder="maria@example.com"
+      />
+    </div>
+  </div>
+
+  {
+    includePhone ? (
+      <div class="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label
+            for={`${idPrefix}-business`}
+            class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+          >
+            Business name <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id={`${idPrefix}-business`}
+            name="business_name"
+            required
+            maxlength="200"
+            value={values.businessName ?? ''}
+            class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            placeholder="e.g. Phoenix Plumbing Co."
+          />
+        </div>
+        <div>
+          <label
+            for={`${idPrefix}-phone`}
+            class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+          >
+            Phone <span class="text-red-500">*</span>
+          </label>
+          <input
+            type="tel"
+            id={`${idPrefix}-phone`}
+            name="phone"
+            required
+            maxlength="30"
+            autocomplete="tel"
+            value={values.phone ?? ''}
+            class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            placeholder="(602) 555-0123"
+          />
+        </div>
+      </div>
+    ) : (
+      <div>
+        <label
+          for={`${idPrefix}-business`}
+          class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+        >
+          Business name <span class="text-red-500">*</span>
+        </label>
+        <input
+          type="text"
+          id={`${idPrefix}-business`}
+          name="business_name"
+          required
+          maxlength="200"
+          value={values.businessName ?? ''}
+          class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder="e.g. Phoenix Plumbing Co."
+        />
+      </div>
+    )
+  }
+
+  <div class="grid gap-5 sm:grid-cols-2">
+    <div>
+      <label
+        for={`${idPrefix}-vertical`}
+        class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+      >
+        What kind of business?
+      </label>
+      <select
+        id={`${idPrefix}-vertical`}
+        name="vertical"
+        data-intake-other-source="vertical"
+        class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+      >
+        <option value="">Select one</option>
+        {
+          ENTITY_VERTICALS.map((vertical) => (
+            <option value={vertical.value}>{vertical.label}</option>
+          ))
+        }
+      </select>
+      <input
+        type="text"
+        id={`${idPrefix}-vertical-other`}
+        name="vertical_other"
+        data-intake-other-input="vertical"
+        class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        placeholder="Describe your business type"
+      />
+    </div>
+    <div>
+      <label
+        for={`${idPrefix}-employees`}
+        class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+      >
+        Employee count
+      </label>
+      <select
+        id={`${idPrefix}-employees`}
+        name="employee_count"
+        class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+      >
+        <option value="">Select one</option>
+        {
+          INTAKE_EMPLOYEE_COUNT_OPTIONS.map((option) => (
+            <option value={option.value}>{option.label}</option>
+          ))
+        }
+      </select>
+    </div>
+  </div>
+
+  <div class="sm:w-1/2">
+    <label
+      for={`${idPrefix}-years`}
+      class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+    >
+      Years in business
+    </label>
+    <select
+      id={`${idPrefix}-years`}
+      name="years_in_business"
+      class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+    >
+      <option value="">Select one</option>
+      {
+        INTAKE_YEARS_IN_BUSINESS_OPTIONS.map((option) => (
+          <option value={option.value}>{option.label}</option>
+        ))
+      }
+    </select>
+  </div>
+
+  <div>
+    <label
+      for={`${idPrefix}-challenge`}
+      class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+    >
+      What's the single biggest operational challenge right now?
+      <span class="text-red-500">*</span>
+    </label>
+    <p class="mt-0.5 text-xs text-[color:var(--ss-color-text-muted)]">
+      What would make the biggest difference in how your business runs day to day?
+    </p>
+    <textarea
+      id={`${idPrefix}-challenge`}
+      name="biggest_challenge"
+      required
+      rows="3"
+      maxlength="2000"
+      class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+      placeholder="e.g. I want to stop being the bottleneck for every decision..."></textarea>
+  </div>
+
+  <div>
+    <label
+      for={`${idPrefix}-how-heard`}
+      class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
+    >
+      How did you hear about us?
+    </label>
+    <select
+      id={`${idPrefix}-how-heard`}
+      name="how_heard"
+      data-intake-other-source="how_heard"
+      class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+    >
+      <option value="">Select one</option>
+      {
+        INTAKE_HOW_HEARD_OPTIONS.map((option) => (
+          <option value={option.value}>{option.label}</option>
+        ))
+      }
+    </select>
+    <input
+      type="text"
+      id={`${idPrefix}-how-heard-other`}
+      name="how_heard_other"
+      data-intake-other-input="how_heard"
+      class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+      placeholder="Tell us more"
+    />
+  </div>
+</div>
+
+<script>
+  import { bindIntakeConditionalFields } from '../../lib/booking/intake-questionnaire'
+
+  const init = () => {
+    for (const root of document.querySelectorAll('[data-intake-questionnaire]')) {
+      if (!(root instanceof HTMLElement)) continue
+      bindIntakeConditionalFields(root)
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true })
+  } else {
+    init()
+  }
+</script>

--- a/src/components/portal/InvoiceDetail.astro
+++ b/src/components/portal/InvoiceDetail.astro
@@ -248,7 +248,7 @@ const pathname = `/portal/invoices/${invoice.id}`
                   </>
                 ) : (
                   <p class="text-body text-[color:var(--ss-color-text-secondary)]">
-                    Payment link pending — we will send it shortly.
+                    Payment link pending. We will send it shortly.
                   </p>
                 )}
               </div>
@@ -524,7 +524,7 @@ const pathname = `/portal/invoices/${invoice.id}`
               <MoneyDisplay amountCents={invoice.amountCents} size="display" />
             </div>
             <p class="mt-4 text-body text-[color:var(--ss-color-text-secondary)]">
-              Payment link pending — we will send it shortly.
+              Payment link pending. We will send it shortly.
             </p>
           </section>
         )

--- a/src/components/portal/OutsideViewArtifact.astro
+++ b/src/components/portal/OutsideViewArtifact.astro
@@ -62,7 +62,7 @@ const visibleSections: RenderedSection[] = rendered.sections.filter(
       class="font-['Archivo_Narrow'] text-sm md:text-base text-[color:var(--ss-color-text-primary)] m-0"
     >
       Here's what we read from your public footprint. Each section below comes from a specific
-      signal we found — when we couldn't find enough to back something up, we say so rather than
+      signal we found. When we couldn't find enough to back something up, we say so rather than
       guessing.
     </p>
   </div>
@@ -97,7 +97,7 @@ const visibleSections: RenderedSection[] = rendered.sections.filter(
               </>
             ) : (
               <p class="mt-4 text-sm md:text-base italic text-[color:var(--ss-color-text-secondary)] m-0">
-                Insufficient data — {section.insufficientDataNote}
+                Insufficient data: {section.insufficientDataNote}
               </p>
             )}
           </article>
@@ -107,7 +107,7 @@ const visibleSections: RenderedSection[] = rendered.sections.filter(
       <div class="mt-6 border-[3px] border-[color:var(--ss-color-text-primary)] p-6 md:p-8">
         <p class="text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
           We tried to read your public digital footprint and couldn't find enough to produce a
-          useful report. That's actually informative on its own — a thin public footprint is often a
+          useful report. That's actually informative on its own. A thin public footprint is often a
           sign of where we'd start. The most useful next step is a short conversation.
         </p>
       </div>
@@ -122,14 +122,14 @@ const visibleSections: RenderedSection[] = rendered.sections.filter(
       Want a deeper look?
     </h2>
     <p class="mt-3 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
-      Talk through this with our agent and we'll dig past what we can see from outside. Or talk
-      through it with us directly. Both are coming soon.
+      Talk through this with us and we'll dig past what we can see from outside. Use the booking
+      link in your email when you're ready.
     </p>
     <p
       class="mt-2 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] m-0"
     >
       In the meantime: this Outside View is yours to keep. Come back any time. Sharing with a
-      co-owner or partner? Send them the link from your email — same view, same session.
+      co-owner or partner? Send them the link from your email. Same view, same session.
     </p>
   </div>
 

--- a/src/components/portal/PortalListItem.astro
+++ b/src/components/portal/PortalListItem.astro
@@ -177,7 +177,7 @@ const ticketShell = [
       <div class="md:grid md:grid-cols-[56px_1fr_auto_auto_48px] md:items-stretch">
         {/* № cell */}
         <div class="flex md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)] items-center justify-center md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell">
-          {props.serial ? `№${props.serial}` : '№ —'}
+          {props.serial ? `№${props.serial}` : '№'}
         </div>
 
         {/* Main */}
@@ -261,7 +261,7 @@ const ticketShell = [
             Kind
           </span>
           <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
-            {props.kind ?? '—'}
+            {props.kind ?? 'FILE'}
           </span>
         </div>
 
@@ -271,7 +271,7 @@ const ticketShell = [
             Shared
           </span>
           <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
-            {props.eyebrow ?? '—'}
+            {props.eyebrow ?? 'Not provided'}
           </span>
         </div>
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -197,6 +197,21 @@ interface AuthSession {
   expiresAt: string
 }
 
+interface TurnstileRenderOptions {
+  sitekey: string
+  callback?: (token: string) => void
+  'expired-callback'?: () => void
+  'error-callback'?: () => void
+}
+
+interface TurnstileApi {
+  render(container: Element, options: TurnstileRenderOptions): string
+  getResponse(widgetId?: string | null): string
+  reset(widgetId?: string | null): void
+}
+
+declare const turnstile: TurnstileApi | undefined
+
 declare namespace App {
   interface Locals {
     /** Populated by auth middleware on /admin/* and /portal/* routes. Null on public routes. */

--- a/src/lib/admin/engagement-detail-client.ts
+++ b/src/lib/admin/engagement-detail-client.ts
@@ -1,0 +1,218 @@
+function setupDeliverablesUpload(engagementId: string): void {
+  const fileInput = document.getElementById('file-input')
+  const uploadBtn = document.getElementById('upload-btn')
+  const uploadArea = document.getElementById('upload-area')
+  const uploadStatus = document.getElementById('upload-status')
+
+  if (
+    !(fileInput instanceof HTMLInputElement) ||
+    !(uploadBtn instanceof HTMLButtonElement) ||
+    !(uploadArea instanceof HTMLDivElement) ||
+    !(uploadStatus instanceof HTMLDivElement)
+  ) {
+    return
+  }
+
+  const uploadStatusEl = uploadStatus
+
+  uploadBtn.addEventListener('click', () => fileInput.click())
+  fileInput.addEventListener('change', () => uploadFiles(fileInput.files))
+
+  uploadArea.addEventListener('dragover', (e) => {
+    e.preventDefault()
+    uploadArea.classList.add('drag-active')
+  })
+  uploadArea.addEventListener('dragleave', () => {
+    uploadArea.classList.remove('drag-active')
+  })
+  uploadArea.addEventListener('drop', (e) => {
+    e.preventDefault()
+    uploadArea.classList.remove('drag-active')
+    uploadFiles(e.dataTransfer?.files ?? null)
+  })
+
+  async function uploadFiles(files: FileList | null): Promise<void> {
+    if (!files || files.length === 0) return
+    uploadStatusEl.classList.remove('hidden')
+
+    for (const file of files) {
+      uploadStatusEl.textContent = `Uploading ${file.name}...`
+      const form = new FormData()
+      form.append('file', file)
+      try {
+        const res = await fetch(`/api/admin/engagements/${engagementId}/deliverables`, {
+          method: 'POST',
+          body: form,
+        })
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as { error?: string }
+          uploadStatusEl.textContent = `Failed: ${data.error || res.statusText}`
+        } else {
+          uploadStatusEl.textContent = `Uploaded ${file.name}`
+        }
+      } catch (err) {
+        uploadStatusEl.textContent =
+          err instanceof Error ? `Error: ${err.message}` : 'Error: Upload failed'
+      }
+    }
+    window.setTimeout(() => location.reload(), 800)
+  }
+}
+
+function setupConsultantPhoto(engagementId: string): void {
+  const photoInput = document.getElementById('photo-input')
+  const photoChoose = document.getElementById('photo-choose')
+  const photoUpload = document.getElementById('photo-upload')
+  const photoCancel = document.getElementById('photo-cancel')
+  const photoRemove = document.getElementById('photo-remove')
+  const photoPreview = document.getElementById('photo-preview')
+  const photoStatus = document.getElementById('photo-status')
+
+  if (
+    !(photoInput instanceof HTMLInputElement) ||
+    !(photoChoose instanceof HTMLButtonElement) ||
+    !(photoUpload instanceof HTMLButtonElement) ||
+    !(photoCancel instanceof HTMLButtonElement) ||
+    !(photoPreview instanceof HTMLCanvasElement) ||
+    !(photoStatus instanceof HTMLElement)
+  ) {
+    return
+  }
+
+  const photoPreviewEl = photoPreview
+  const photoStatusEl = photoStatus
+  const photoRemoveEl = photoRemove instanceof HTMLButtonElement ? photoRemove : null
+  let pendingBlob: Blob | null = null
+  const TARGET_SIZE = 400
+  const PREVIEW_SIZE = 160
+  const MAX_BYTES = 5 * 1024 * 1024
+
+  function setStatus(msg: string, isError: boolean): void {
+    photoStatusEl.textContent = msg
+    photoStatusEl.className = isError
+      ? 'mt-2 text-xs text-[color:var(--ss-color-error)]'
+      : 'mt-2 text-xs text-[color:var(--ss-color-text-secondary)]'
+  }
+
+  async function cropToSquareWebp(file: File): Promise<Blob> {
+    if (file.size > MAX_BYTES) {
+      throw new Error('Original file exceeds 5 MB. Please pick a smaller image.')
+    }
+    const bitmap = await createImageBitmap(file)
+    const side = Math.min(bitmap.width, bitmap.height)
+    const sx = Math.round((bitmap.width - side) / 2)
+    const sy = Math.round((bitmap.height - side) / 2)
+
+    const canvas = document.createElement('canvas')
+    canvas.width = TARGET_SIZE
+    canvas.height = TARGET_SIZE
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      throw new Error('Could not initialize image processing.')
+    }
+    ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, TARGET_SIZE, TARGET_SIZE)
+
+    photoPreviewEl.width = PREVIEW_SIZE
+    photoPreviewEl.height = PREVIEW_SIZE
+    const previewContext = photoPreviewEl.getContext('2d')
+    if (!previewContext) {
+      throw new Error('Could not initialize preview canvas.')
+    }
+    previewContext.drawImage(canvas, 0, 0, PREVIEW_SIZE, PREVIEW_SIZE)
+    photoPreviewEl.classList.remove('hidden')
+
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (nextBlob) => (nextBlob ? resolve(nextBlob) : reject(new Error('Encoding failed'))),
+        'image/webp',
+        0.9
+      )
+    })
+    if (blob.size > MAX_BYTES) {
+      throw new Error('Encoded photo still exceeds 5 MB. Try a smaller source image.')
+    }
+    return blob
+  }
+
+  photoChoose.addEventListener('click', () => photoInput.click())
+
+  photoInput.addEventListener('change', async () => {
+    const file = photoInput.files?.[0]
+    if (!file) return
+    try {
+      setStatus('Processing image...', false)
+      pendingBlob = await cropToSquareWebp(file)
+      setStatus(`Ready to upload (${(pendingBlob.size / 1024).toFixed(1)} KB WebP)`, false)
+      photoUpload.classList.remove('hidden')
+      photoCancel.classList.remove('hidden')
+    } catch (err) {
+      pendingBlob = null
+      setStatus(err instanceof Error ? err.message : 'Could not process image', true)
+    }
+  })
+
+  photoCancel.addEventListener('click', () => {
+    pendingBlob = null
+    photoInput.value = ''
+    photoPreviewEl.classList.add('hidden')
+    photoUpload.classList.add('hidden')
+    photoCancel.classList.add('hidden')
+    setStatus('', false)
+  })
+
+  photoUpload.addEventListener('click', async () => {
+    if (!pendingBlob) return
+    photoUpload.disabled = true
+    photoCancel.disabled = true
+    setStatus('Uploading...', false)
+    const form = new FormData()
+    form.append('photo', new File([pendingBlob], 'consultant.webp', { type: 'image/webp' }))
+    try {
+      const res = await fetch(`/api/admin/engagements/${engagementId}/consultant-photo`, {
+        method: 'POST',
+        body: form,
+      })
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(data.error || res.statusText)
+      }
+      setStatus('Photo uploaded. Reloading...', false)
+      window.setTimeout(() => location.reload(), 500)
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : 'Upload failed', true)
+      photoUpload.disabled = false
+      photoCancel.disabled = false
+    }
+  })
+
+  if (!photoRemoveEl) return
+
+  photoRemoveEl.addEventListener('click', async () => {
+    if (!confirm('Remove the current consultant photo?')) return
+    photoRemoveEl.disabled = true
+    setStatus('Removing...', false)
+    try {
+      const res = await fetch(`/api/admin/engagements/${engagementId}/consultant-photo`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(data.error || res.statusText)
+      }
+      setStatus('Photo removed. Reloading...', false)
+      window.setTimeout(() => location.reload(), 500)
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : 'Remove failed', true)
+      photoRemoveEl.disabled = false
+    }
+  })
+}
+
+export function initEngagementDetailPage(rootId = 'engagement-page'): void {
+  const root = document.getElementById(rootId)
+  const engagementId = root instanceof HTMLElement ? root.dataset.engagementId : null
+  if (!engagementId) return
+
+  setupDeliverablesUpload(engagementId)
+  setupConsultantPhoto(engagementId)
+}

--- a/src/lib/admin/engagement-detail-page.ts
+++ b/src/lib/admin/engagement-detail-page.ts
@@ -1,0 +1,103 @@
+import { getEntity } from '../db/entities'
+import { getEngagement, VALID_TRANSITIONS } from '../db/engagements'
+import type { EngagementStatus } from '../db/engagements'
+import { getQuote } from '../db/quotes'
+import { listMilestones, VALID_TRANSITIONS as MILESTONE_TRANSITIONS } from '../db/milestones'
+import type { MilestoneStatus } from '../db/milestones'
+import { listInvoices } from '../db/invoices'
+import { listContext } from '../db/context'
+import { listSignalsForEntity } from '../db/signal-attribution'
+import { listDocuments } from '../storage/r2'
+
+type Database = Parameters<typeof getEntity>[0]
+type StorageBucket = Parameters<typeof listDocuments>[0]
+
+export function contextTypeEyebrowClass(): string {
+  return 'text-label uppercase font-mono text-[color:var(--ss-color-text-secondary)] tracking-[var(--ss-text-letter-spacing-label)]'
+}
+
+export function formatDate(date: string | null): string {
+  if (!date) return '--'
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function fileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function truncateSignal(content: string, max = 80): string {
+  const oneLine = content.replace(/\s+/g, ' ').trim()
+  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max - 1)}…`
+}
+
+export function formatSignalLabel(signal: {
+  source_pipeline: string
+  created_at: string
+  content: string
+}): string {
+  const date = new Date(signal.created_at).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  return `[${signal.source_pipeline}] ${date} - ${truncateSignal(signal.content)}`
+}
+
+export async function loadEngagementDetailPage(params: {
+  db: Database
+  storage: StorageBucket
+  orgId: string
+  engagementId: string
+  url: URL
+}) {
+  const engagement = await getEngagement(params.db, params.orgId, params.engagementId)
+  if (!engagement) return null
+
+  const entity = await getEntity(params.db, params.orgId, engagement.entity_id)
+  const quote = engagement.quote_id
+    ? await getQuote(params.db, params.orgId, engagement.quote_id)
+    : null
+  const milestones = await listMilestones(params.db, params.orgId, params.engagementId)
+  const invoices = await listInvoices(params.db, params.orgId, {
+    engagementId: params.engagementId,
+  })
+  const contextEntries = await listContext(params.db, engagement.entity_id, {
+    engagement_id: params.engagementId,
+  })
+  const entitySignals = await listSignalsForEntity(params.db, params.orgId, engagement.entity_id)
+  const documents = await listDocuments(
+    params.storage,
+    `${params.orgId}/engagements/${params.engagementId}/docs/`
+  )
+
+  const status = engagement.status as EngagementStatus
+  const nextStatuses = VALID_TRANSITIONS[status] ?? []
+  const depositInvoice = invoices.find((invoice) => invoice.type === 'deposit')
+
+  return {
+    engagement,
+    entity,
+    quote,
+    milestones,
+    invoices,
+    contextEntries,
+    entitySignals,
+    documents,
+    status,
+    nextStatuses,
+    depositInvoice,
+    milestoneTransitions: MILESTONE_TRANSITIONS,
+    saved: params.url.searchParams.get('saved'),
+    error: params.url.searchParams.get('error'),
+    milestoneAdded: params.url.searchParams.get('milestone_added'),
+    milestoneDeleted: params.url.searchParams.get('milestone_deleted'),
+  }
+}
+
+export type { MilestoneStatus }

--- a/src/lib/admin/entity-detail-client.ts
+++ b/src/lib/admin/entity-detail-client.ts
@@ -1,0 +1,143 @@
+export function initEntityDetailPage(): void {
+  const form = document.getElementById('re-enrich-form')
+  const btn = document.getElementById('re-enrich-btn') as HTMLButtonElement | null
+  if (form && btn) {
+    form.addEventListener('submit', () => {
+      btn.disabled = true
+      btn.textContent = 'Re-enriching...'
+    })
+  }
+
+  const copyBtn = document.getElementById('copy-outreach-btn') as HTMLButtonElement | null
+  const outreachEl = document.getElementById('outreach-content')
+  if (copyBtn && outreachEl) {
+    copyBtn.addEventListener('click', async () => {
+      await navigator.clipboard.writeText(outreachEl.textContent ?? '')
+      copyBtn.textContent = 'Copied!'
+      window.setTimeout(() => {
+        copyBtn.textContent = 'Copy'
+      }, 2000)
+    })
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('.js-toggle-long').forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      const body = toggle.previousElementSibling as HTMLElement | null
+      if (!body || !body.classList.contains('js-truncated')) return
+      const expanded = body.classList.toggle('is-expanded')
+      toggle.textContent = expanded ? 'Show less' : 'Show more'
+    })
+  })
+
+  const entityId = window.location.pathname.split('/').filter(Boolean).pop()
+  const sblBtn = document.getElementById('send-booking-link-btn')
+  const sblDialog = document.getElementById('send-booking-link-dialog') as HTMLDialogElement | null
+  const sblForm = document.getElementById('send-booking-link-form') as HTMLFormElement | null
+  const sblCancel = document.getElementById('sbl-cancel')
+  const sblSubmit = document.getElementById('sbl-submit') as HTMLButtonElement | null
+  const sblError = document.getElementById('sbl-error')
+
+  if (sblBtn && sblDialog) {
+    sblBtn.addEventListener('click', () => {
+      if (sblError) {
+        sblError.classList.add('hidden')
+        sblError.textContent = ''
+      }
+      sblDialog.showModal()
+    })
+  }
+
+  if (sblCancel && sblDialog) {
+    sblCancel.addEventListener('click', () => sblDialog.close())
+  }
+
+  if (!entityId || !sblForm || !sblDialog || !sblSubmit) return
+
+  sblForm.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    const formData = new FormData(sblForm)
+    const meetingType = (formData.get('meeting_type') ?? '').toString().trim()
+    const durationMinutes = (formData.get('duration_minutes') ?? '30').toString()
+    const sendMode = (formData.get('send_mode') ?? 'email').toString()
+    const wantsServerSend = sendMode === 'email'
+
+    sblSubmit.disabled = true
+    sblSubmit.textContent = wantsServerSend ? 'Sending...' : 'Preparing...'
+    if (sblError) {
+      sblError.classList.add('hidden')
+      sblError.textContent = ''
+    }
+
+    try {
+      const res = await fetch(`/api/admin/entities/${entityId}/send-booking-link`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          meeting_type: meetingType || null,
+          duration_minutes: durationMinutes,
+          send_email: wantsServerSend,
+        }),
+      })
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean
+        booking_url?: string
+        outreach_template?: string
+        mailto_url?: string
+        email_status?: string
+        send_error?: string | null
+        error?: string
+        message?: string
+      }
+      if (!res.ok || !body.ok) {
+        throw new Error(body.message ?? body.error ?? `HTTP ${res.status}`)
+      }
+
+      if (body.email_status === 'send_failed') {
+        if (sblError) {
+          sblError.textContent =
+            'Email send failed. The booking link is on your clipboard. Paste it into mailto or your own mail client.'
+          sblError.classList.remove('hidden')
+        }
+        if (body.outreach_template) {
+          try {
+            await navigator.clipboard.writeText(body.outreach_template)
+          } catch (copyErr) {
+            console.warn('[send-booking-link] clipboard write failed:', copyErr)
+          }
+        }
+        if (body.mailto_url) {
+          window.open(body.mailto_url, '_blank')
+        }
+        window.location.href = `${window.location.pathname}?stage_updated=1&send=failed`
+        return
+      }
+
+      if (body.outreach_template) {
+        try {
+          await navigator.clipboard.writeText(body.outreach_template)
+        } catch (copyErr) {
+          console.warn('[send-booking-link] clipboard write failed:', copyErr)
+        }
+      }
+
+      const skippedServerSend =
+        body.email_status === 'skipped_by_caller' || body.email_status === 'skipped_no_recipient'
+      if (skippedServerSend && body.mailto_url) {
+        window.open(body.mailto_url, '_blank')
+      }
+
+      sblDialog.close()
+
+      const sentParam = body.email_status === 'sent' ? '&send=sent' : ''
+      window.location.href = `${window.location.pathname}?stage_updated=1${sentParam}`
+    } catch (err) {
+      console.error('[send-booking-link] error:', err)
+      if (sblError) {
+        sblError.textContent = err instanceof Error ? err.message : 'Could not send booking link.'
+        sblError.classList.remove('hidden')
+      }
+      sblSubmit.disabled = false
+      sblSubmit.textContent = 'Send link'
+    }
+  })
+}

--- a/src/lib/admin/entity-detail-page.ts
+++ b/src/lib/admin/entity-detail-page.ts
@@ -1,0 +1,360 @@
+import { hasOpenQuoteForEntity, listQuotes } from '../db/quotes'
+import { getEntity } from '../db/entities'
+import type { EntityStage } from '../db/entities'
+import { listContext } from '../db/context'
+import { listContacts } from '../db/contacts'
+import { listMeetings } from '../db/meetings'
+import { listEngagements } from '../db/engagements'
+import { listInvoices } from '../db/invoices'
+import { findDraftableMeeting } from '../../lib/entities/draftable-meeting'
+
+type Database = Parameters<typeof getEntity>[0]
+type EntityRecord = Exclude<Awaited<ReturnType<typeof getEntity>>, null>
+
+export type EntityDetailTransition = {
+  label: string
+  stage: EntityStage
+  variant: 'primary' | 'destructive'
+  action?: string
+}
+
+const RE_ENRICH_STAGES: EntityStage[] = [
+  'prospect',
+  'meetings',
+  'proposing',
+  'engaged',
+  'delivered',
+  'ongoing',
+]
+
+export const ENTITY_DETAIL_TRANSITIONS: Record<EntityStage, EntityDetailTransition[]> = {
+  signal: [
+    {
+      label: 'Promote',
+      stage: 'prospect',
+      variant: 'primary',
+    },
+    {
+      label: 'Dismiss',
+      stage: 'lost',
+      variant: 'destructive',
+    },
+  ],
+  prospect: [{ label: 'Lost', stage: 'lost', variant: 'destructive' }],
+  meetings: [
+    { label: 'Mark as Proposing', stage: 'proposing', variant: 'primary' },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
+  ],
+  proposing: [
+    { label: 'Mark as Engaged', stage: 'engaged', variant: 'primary' },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
+  ],
+  engaged: [{ label: 'Mark as Delivered', stage: 'delivered', variant: 'primary' }],
+  delivered: [
+    { label: 'Mark as Ongoing', stage: 'ongoing', variant: 'primary' },
+    { label: 'Re-engage', stage: 'prospect', variant: 'destructive' },
+  ],
+  ongoing: [
+    { label: 'Re-engage', stage: 'prospect', variant: 'primary' },
+    { label: 'Lost', stage: 'lost', variant: 'destructive' },
+  ],
+  lost: [{ label: 'Re-engage', stage: 'prospect', variant: 'primary' }],
+}
+
+export function contextTypeBadge(_type?: string): string {
+  return 'bg-border-subtle text-text-secondary'
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+export function isOverdue(iso: string | null): boolean {
+  if (!iso) return false
+  return new Date(iso).getTime() < Date.now()
+}
+
+export function parseMetadata(json: string | null): Record<string, unknown> | null {
+  if (!json) return null
+  try {
+    return JSON.parse(json) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function renderSimpleMarkdown(md: string): string {
+  let html = escapeHtml(md)
+
+  html = html.replace(
+    /^## (.+)$/gm,
+    (_match, title) =>
+      `<h4 class="font-semibold text-sm text-[color:var(--ss-color-text-primary)] mt-4 mb-1">${title}</h4>`
+  )
+  html = html.replace(/\*\*(.+?)\*\*/g, (_match, value) => `<strong>${value}</strong>`)
+  html = html.replace(
+    /^- (.+)$/gm,
+    (_match, value) =>
+      `<li class="ml-4 list-disc text-sm text-[color:var(--ss-color-text-primary)]">${value}</li>`
+  )
+  html = html.replace(
+    /^\d+\. (.+)$/gm,
+    (_match, value) =>
+      `<li class="ml-4 list-decimal text-sm text-[color:var(--ss-color-text-primary)]">${value}</li>`
+  )
+  html = html.replace(
+    /((?:<li class="ml-4 list-disc[^>]*>[^<]*<\/li>\n?)+)/g,
+    (_match, value) => `<ul class="mb-2">${value}</ul>`
+  )
+  html = html.replace(
+    /((?:<li class="ml-4 list-decimal[^>]*>[^<]*<\/li>\n?)+)/g,
+    (_match, value) => `<ol class="mb-2">${value}</ol>`
+  )
+  html = html.replace(
+    /^(?!<[hulo])(.+)$/gm,
+    (_match, value) =>
+      `<p class="text-sm text-[color:var(--ss-color-text-primary)] mb-2">${value}</p>`
+  )
+  html = html.replace(
+    /<p class="text-sm text-\[color:var\(--color-text-primary\)\] mb-2"><\/p>/g,
+    ''
+  )
+
+  return html
+}
+
+export function sentimentColor(trend: string): string {
+  if (trend === 'improving') return 'text-text-primary bg-surface'
+  if (trend === 'declining') return 'text-error bg-surface'
+  return 'text-text-secondary bg-background'
+}
+
+export function confidenceColor(confidence?: string): string {
+  if (confidence === 'high') return 'bg-surface text-text-primary border border-border'
+  if (confidence === 'medium') return 'bg-background text-text-secondary border border-border'
+  return 'bg-border-subtle text-text-secondary'
+}
+
+export async function loadEntityDetailPage(params: {
+  db: Database
+  orgId: string
+  entityId: string
+  url: URL
+}): Promise<{
+  entity: EntityRecord
+  contextEntries: Awaited<ReturnType<typeof listContext>>
+  contacts: Awaited<ReturnType<typeof listContacts>>
+  meetings: Awaited<ReturnType<typeof listMeetings>>
+  engagements: Awaited<ReturnType<typeof listEngagements>>
+  quotes: Awaited<ReturnType<typeof listQuotes>>
+  invoices: Awaited<ReturnType<typeof listInvoices>>
+  mostRecentDraftableMeeting: ReturnType<typeof findDraftableMeeting>
+  hasOutreach: boolean
+  filteredEntries: Awaited<ReturnType<typeof listContext>>
+  typeFilter: string
+  typeCounts: Record<string, number>
+  currentLostReason: { code: string; detail: string | null } | null
+  promoted: string | null
+  noteAdded: string | null
+  replyLogged: string | null
+  stageUpdated: string | null
+  dossierGenerated: string | null
+  error: string | null
+  showReEnrichButton: boolean
+  showNewQuoteButton: boolean
+  supersedeCandidates: Awaited<ReturnType<typeof listQuotes>>
+  transitions: EntityDetailTransition[]
+  dossierBrief: Awaited<ReturnType<typeof listContext>>[number] | undefined
+  outreachEntry: Awaited<ReturnType<typeof listContext>>[number] | undefined
+  outreachContact: Awaited<ReturnType<typeof listContacts>>[number] | null
+  outreachMailto: string | null
+  outreachFromDossier: unknown
+  hasDossier: boolean
+  lastEnrichmentAt: string | null
+  latestSentQuoteAt: string | null
+  reviewMeta: {
+    unified_rating?: number | null
+    total_reviews_across_platforms?: number
+    sentiment_trend?: string
+    top_themes?: string[]
+    operational_problems?: Array<{ problem: string; confidence: string; evidence: string }>
+  } | null
+  websiteMeta: { digital_maturity?: { score: number; reasoning: string } } | null
+  competitorMeta: { entity_rank_by_rating?: number | null; total_competitors?: number } | null
+}> {
+  const entity = await getEntity(params.db, params.orgId, params.entityId)
+  if (!entity) return null as never
+
+  const [contextEntries, contacts, meetings, engagements, quotes, invoices] = await Promise.all([
+    listContext(params.db, params.entityId),
+    listContacts(params.db, params.orgId, params.entityId),
+    listMeetings(params.db, params.orgId, params.entityId),
+    listEngagements(params.db, params.orgId, params.entityId),
+    listQuotes(params.db, params.orgId, params.entityId),
+    listInvoices(params.db, params.orgId, { entityId: params.entityId }),
+  ])
+
+  const mostRecentDraftableMeeting = findDraftableMeeting(meetings, quotes)
+  const hasOutreach = contextEntries.some((entry) => entry.type === 'outreach_draft')
+
+  const timelineEntries = [...contextEntries].reverse()
+  const typeFilter = params.url.searchParams.get('type') ?? ''
+  const filteredEntries = typeFilter
+    ? timelineEntries.filter((entry) => entry.type === typeFilter)
+    : timelineEntries
+
+  const typeCounts: Record<string, number> = {}
+  for (const entry of contextEntries) {
+    typeCounts[entry.type] = (typeCounts[entry.type] ?? 0) + 1
+  }
+
+  let currentLostReason: { code: string; detail: string | null } | null = null
+  if (entity.stage === 'lost') {
+    const lostEntries = [...contextEntries]
+      .reverse()
+      .filter((entry) => entry.type === 'stage_change')
+    for (const entry of lostEntries) {
+      if (!entry.metadata) continue
+      try {
+        const meta = JSON.parse(entry.metadata) as Record<string, unknown>
+        if (meta.to === 'lost' && typeof meta.lost_reason === 'string') {
+          currentLostReason = {
+            code: meta.lost_reason,
+            detail: typeof meta.lost_detail === 'string' ? meta.lost_detail : null,
+          }
+          break
+        }
+      } catch {
+        continue
+      }
+    }
+  }
+
+  const promoted = params.url.searchParams.get('promoted')
+  const noteAdded = params.url.searchParams.get('note_added')
+  const replyLogged = params.url.searchParams.get('reply_logged')
+  const stageUpdated = params.url.searchParams.get('stage_updated')
+  const dossierGenerated = params.url.searchParams.get('dossier')
+  const error = params.url.searchParams.get('error')
+
+  const hasOpenQuote = await hasOpenQuoteForEntity(params.db, params.orgId, params.entityId)
+  const showReEnrichButton = RE_ENRICH_STAGES.includes(entity.stage)
+  const showNewQuoteButton =
+    ['signal', 'prospect', 'meetings', 'proposing'].includes(entity.stage) &&
+    !hasOpenQuote &&
+    meetings.length > 0
+  const supersedeCandidates = showNewQuoteButton
+    ? quotes.filter((quote) => quote.status === 'declined' || quote.status === 'expired')
+    : []
+
+  const dossierBrief = contextEntries.filter((entry) => entry.source === 'intelligence_brief').pop()
+  const reviewSynthEntry = contextEntries
+    .filter((entry) => entry.source === 'review_synthesis')
+    .pop()
+  const deepWebsiteEntry = contextEntries.filter((entry) => entry.source === 'deep_website').pop()
+  const competitorEntry = contextEntries.filter((entry) => entry.source === 'competitors').pop()
+  const outreachEntry = contextEntries.filter((entry) => entry.type === 'outreach_draft').pop()
+  const outreachMeta = parseMetadata(outreachEntry?.metadata ?? null)
+  const outreachFromDossier = outreachMeta?.trigger === 'dossier'
+  const hasDossier = !!dossierBrief
+
+  const outreachContact =
+    contacts.find((contact) => contact.email && contact.email.trim().length > 0) ?? null
+  const outreachMailto =
+    outreachEntry && outreachContact?.email
+      ? `mailto:${encodeURIComponent(outreachContact.email)}` +
+        `?subject=${encodeURIComponent(`Reaching out - ${entity.name}`)}` +
+        `&body=${encodeURIComponent(outreachEntry.content)}`
+      : null
+
+  const lastEnrichmentAt =
+    contextEntries
+      .filter((entry) => entry.type === 'enrichment')
+      .map((entry) => entry.created_at)
+      .sort()
+      .pop() ?? null
+
+  const latestSentQuote = quotes
+    .filter((quote) => quote.sent_at)
+    .sort((a, b) => (b.sent_at ?? '').localeCompare(a.sent_at ?? ''))[0]
+  const latestSentQuoteAt = latestSentQuote?.sent_at ?? null
+
+  const reviewMeta = parseMetadata(reviewSynthEntry?.metadata ?? null) as {
+    unified_rating?: number | null
+    total_reviews_across_platforms?: number
+    sentiment_trend?: string
+    top_themes?: string[]
+    operational_problems?: Array<{ problem: string; confidence: string; evidence: string }>
+  } | null
+  const websiteMeta = parseMetadata(deepWebsiteEntry?.metadata ?? null) as {
+    digital_maturity?: { score: number; reasoning: string }
+  } | null
+  const competitorMeta = parseMetadata(competitorEntry?.metadata ?? null) as {
+    entity_rank_by_rating?: number | null
+    total_competitors?: number
+  } | null
+
+  const transitions = ENTITY_DETAIL_TRANSITIONS[entity.stage].map((transition) => ({
+    ...transition,
+    action: transition.action ?? `/api/admin/entities/${entity.id}/stage`,
+  }))
+
+  return {
+    entity,
+    contextEntries,
+    contacts,
+    meetings,
+    engagements,
+    quotes,
+    invoices,
+    mostRecentDraftableMeeting,
+    hasOutreach,
+    filteredEntries,
+    typeFilter,
+    typeCounts,
+    currentLostReason,
+    promoted,
+    noteAdded,
+    replyLogged,
+    stageUpdated,
+    dossierGenerated,
+    error,
+    showReEnrichButton,
+    showNewQuoteButton,
+    supersedeCandidates,
+    transitions,
+    dossierBrief,
+    outreachEntry,
+    outreachContact,
+    outreachMailto,
+    outreachFromDossier,
+    hasDossier,
+    lastEnrichmentAt,
+    latestSentQuoteAt,
+    reviewMeta,
+    websiteMeta,
+    competitorMeta,
+  }
+}

--- a/src/lib/admin/quote-builder-client.ts
+++ b/src/lib/admin/quote-builder-client.ts
@@ -1,0 +1,310 @@
+type QuoteLineItem = {
+  problem: string
+  description: string
+  estimated_hours: number
+}
+
+function formatDollars(amount: number): string {
+  return (
+    '$' +
+    amount.toLocaleString('en-US', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })
+  )
+}
+
+export function initQuoteBuilderPage(rootId = 'quote-builder-page'): void {
+  const root = document.getElementById(rootId)
+  if (!(root instanceof HTMLElement)) return
+
+  const isDraft = root.dataset.isDraft === 'true'
+  if (!isDraft) return
+
+  const rate = Number(root.dataset.rate ?? '0')
+  const initialLineItems = JSON.parse(root.dataset.lineItems ?? '[]') as QuoteLineItem[]
+
+  const body = document.getElementById('line-items-body')
+  const addBtn = document.getElementById('add-line-item-btn')
+  const warning = document.getElementById('line-item-warning')
+  const totalHoursEl = document.getElementById('total-hours')
+  const totalPriceEl = document.getElementById('total-price')
+  const depositAmountEl = document.getElementById('deposit-amount')
+  const completionAmountEl = document.getElementById('completion-amount')
+  const depositSelect = document.getElementById('deposit-pct-select') as HTMLSelectElement | null
+  const saveLineItemsInput = document.getElementById('save-line-items') as HTMLInputElement | null
+  const saveDepositPctInput = document.getElementById('save-deposit-pct') as HTMLInputElement | null
+  const saveScheduleInput = document.getElementById('save-schedule') as HTMLInputElement | null
+  const saveDeliverablesInput = document.getElementById(
+    'save-deliverables'
+  ) as HTMLInputElement | null
+  const saveEngagementOverviewInput = document.getElementById(
+    'save-engagement-overview'
+  ) as HTMLInputElement | null
+  const saveMilestoneLabelInput = document.getElementById(
+    'save-milestone-label'
+  ) as HTMLInputElement | null
+  const saveOriginatingSignalInput = document.getElementById(
+    'save-originating-signal-id'
+  ) as HTMLInputElement | null
+  const scheduleRowsContainer = document.getElementById('schedule-rows') as HTMLElement | null
+  const deliverableRowsContainer = document.getElementById('deliverable-rows') as HTMLElement | null
+  const addScheduleRowBtn = document.getElementById('add-schedule-row-btn')
+  const addDeliverableRowBtn = document.getElementById('add-deliverable-row-btn')
+  const engagementOverviewInput = document.getElementById(
+    'engagement-overview-input'
+  ) as HTMLTextAreaElement | null
+  const milestoneLabelInput = document.getElementById(
+    'milestone-label-input'
+  ) as HTMLInputElement | null
+  const originatingSignalInput = document.getElementById(
+    'originating-signal-input'
+  ) as HTMLSelectElement | null
+  const generatePdfBtn = document.getElementById('generate-pdf-btn') as HTMLButtonElement | null
+  const signBtn = document.getElementById('sign-btn') as HTMLButtonElement | null
+  const saveForm = document.getElementById('save-form')
+  const generatePdfForm = document.getElementById('generate-pdf-form')
+  const signForm = document.getElementById('sign-form')
+
+  if (!(body instanceof HTMLElement)) return
+  const lineItemsBody = body
+
+  function getLineItems(): QuoteLineItem[] {
+    const rows = lineItemsBody.querySelectorAll('.line-item-row')
+    const items: QuoteLineItem[] = []
+    rows.forEach((row) => {
+      const problem = (row.querySelector('.item-problem') as HTMLInputElement | null)?.value ?? ''
+      const description =
+        (row.querySelector('.item-description') as HTMLInputElement | null)?.value ?? ''
+      const hours = parseFloat(
+        (row.querySelector('.item-hours') as HTMLInputElement | null)?.value ?? '0'
+      )
+      if (problem.trim() || description.trim()) {
+        items.push({
+          problem: problem.trim(),
+          description: description.trim(),
+          estimated_hours: Number.isNaN(hours) ? 0 : hours,
+        })
+      }
+    })
+    return items
+  }
+
+  function clearEmptyState(container: HTMLElement | null): void {
+    if (!container) return
+    const empty = container.querySelector('.schedule-empty-state, .deliverable-empty-state')
+    if (empty) empty.remove()
+  }
+
+  function maybeShowEmptyState(container: HTMLElement | null, isDeliverable: boolean): void {
+    if (!container) return
+    const rows = container.querySelectorAll(isDeliverable ? '.deliverable-row' : '.schedule-row')
+    if (rows.length > 0) return
+
+    const div = document.createElement('div')
+    div.className =
+      'text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 ' +
+      (isDeliverable ? 'deliverable-empty-state' : 'schedule-empty-state')
+    div.textContent = container.getAttribute('data-empty-text') ?? ''
+    container.appendChild(div)
+  }
+
+  function getScheduleRows(): Array<{ label: string; body: string }> {
+    if (!scheduleRowsContainer) return []
+    const rows = scheduleRowsContainer.querySelectorAll('.schedule-row')
+    const out: Array<{ label: string; body: string }> = []
+    rows.forEach((row) => {
+      const label =
+        (row.querySelector('.schedule-label') as HTMLInputElement | null)?.value?.trim() ?? ''
+      const bodyText =
+        (row.querySelector('.schedule-body') as HTMLInputElement | null)?.value?.trim() ?? ''
+      if (label.length > 0 || bodyText.length > 0) {
+        out.push({ label, body: bodyText })
+      }
+    })
+    return out
+  }
+
+  function getDeliverableRows(): Array<{ title: string; body: string }> {
+    if (!deliverableRowsContainer) return []
+    const rows = deliverableRowsContainer.querySelectorAll('.deliverable-row')
+    const out: Array<{ title: string; body: string }> = []
+    rows.forEach((row) => {
+      const title =
+        (row.querySelector('.deliverable-title') as HTMLInputElement | null)?.value?.trim() ?? ''
+      const bodyText =
+        (row.querySelector('.deliverable-body') as HTMLTextAreaElement | null)?.value?.trim() ?? ''
+      if (title.length > 0 || bodyText.length > 0) {
+        out.push({ title, body: bodyText })
+      }
+    })
+    return out
+  }
+
+  function syncAuthoredContentInputs(): void {
+    if (saveScheduleInput) saveScheduleInput.value = JSON.stringify(getScheduleRows())
+    if (saveDeliverablesInput) saveDeliverablesInput.value = JSON.stringify(getDeliverableRows())
+    if (saveEngagementOverviewInput && engagementOverviewInput) {
+      saveEngagementOverviewInput.value = engagementOverviewInput.value
+    }
+    if (saveMilestoneLabelInput && milestoneLabelInput) {
+      saveMilestoneLabelInput.value = milestoneLabelInput.value
+    }
+    if (saveOriginatingSignalInput && originatingSignalInput) {
+      saveOriginatingSignalInput.value = originatingSignalInput.value
+    }
+  }
+
+  function renumberRows(): void {
+    const rows = lineItemsBody.querySelectorAll('.line-item-row')
+    rows.forEach((row, i) => {
+      const num = row.querySelector('.row-number')
+      if (num) num.textContent = String(i + 1)
+      row.setAttribute('data-index', String(i))
+    })
+  }
+
+  function recalculate(): void {
+    const items = getLineItems()
+    const totalHours = items.reduce((sum, item) => sum + item.estimated_hours, 0)
+    const totalPrice = totalHours * rate
+    const depositPct = parseFloat(depositSelect?.value ?? '0.5')
+
+    if (totalHoursEl) totalHoursEl.textContent = String(totalHours)
+    if (totalPriceEl) totalPriceEl.textContent = formatDollars(totalPrice)
+
+    const depositAmount = totalPrice * depositPct
+    const completionAmount = totalPrice * (1 - depositPct)
+    if (depositAmountEl) depositAmountEl.textContent = formatDollars(depositAmount)
+    if (completionAmountEl) completionAmountEl.textContent = formatDollars(completionAmount)
+
+    if (warning) {
+      warning.classList.toggle('hidden', items.length < 3)
+    }
+
+    if (saveLineItemsInput) saveLineItemsInput.value = JSON.stringify(items)
+    if (saveDepositPctInput) saveDepositPctInput.value = String(depositPct)
+
+    renumberRows()
+  }
+
+  function addScheduleRow(): void {
+    if (!scheduleRowsContainer) return
+    clearEmptyState(scheduleRowsContainer)
+    const div = document.createElement('div')
+    div.className = 'flex gap-2 mb-2 schedule-row'
+    div.innerHTML = `
+      <input type="text" class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
+      <input type="text" class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
+      <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
+    `
+    scheduleRowsContainer.appendChild(div)
+  }
+
+  function addDeliverableRow(): void {
+    if (!deliverableRowsContainer) return
+    clearEmptyState(deliverableRowsContainer)
+    const div = document.createElement('div')
+    div.className = 'mb-3 deliverable-row'
+    div.innerHTML = `
+      <div class="flex gap-2">
+        <div class="flex-1 space-y-1">
+          <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
+          <textarea class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
+        </div>
+        <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
+      </div>
+    `
+    deliverableRowsContainer.appendChild(div)
+  }
+
+  function addRow(): void {
+    const index = lineItemsBody.querySelectorAll('.line-item-row').length
+    const tr = document.createElement('tr')
+    tr.className = 'border-b border-[color:var(--ss-color-border-subtle)] line-item-row'
+    tr.setAttribute('data-index', String(index))
+    tr.innerHTML = `
+      <td class="py-2 px-2 text-[color:var(--ss-color-text-muted)] row-number">${index + 1}</td>
+      <td class="py-2 px-2">
+        <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
+      </td>
+      <td class="py-2 px-2">
+        <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
+      </td>
+      <td class="py-2 px-2 text-right">
+        <input type="number" class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
+      </td>
+      <td class="py-2 px-2 text-center">
+        <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-item-btn" title="Remove">&times;</button>
+      </td>
+    `
+    lineItemsBody.appendChild(tr)
+    recalculate()
+  }
+
+  if (addScheduleRowBtn) addScheduleRowBtn.addEventListener('click', addScheduleRow)
+  if (addDeliverableRowBtn) addDeliverableRowBtn.addEventListener('click', addDeliverableRow)
+  if (addBtn) addBtn.addEventListener('click', addRow)
+
+  if (scheduleRowsContainer) {
+    scheduleRowsContainer.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement | null
+      if (!target?.classList.contains('remove-schedule-row-btn')) return
+      const row = target.closest('.schedule-row')
+      if (row) {
+        row.remove()
+        maybeShowEmptyState(scheduleRowsContainer, false)
+      }
+    })
+  }
+
+  if (deliverableRowsContainer) {
+    deliverableRowsContainer.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement | null
+      if (!target?.classList.contains('remove-deliverable-row-btn')) return
+      const row = target.closest('.deliverable-row')
+      if (row) {
+        row.remove()
+        maybeShowEmptyState(deliverableRowsContainer, true)
+      }
+    })
+  }
+
+  lineItemsBody.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement | null
+    if (!target?.classList.contains('remove-item-btn')) return
+    const row = target.closest('.line-item-row')
+    if (row && lineItemsBody.querySelectorAll('.line-item-row').length > 1) {
+      row.remove()
+      recalculate()
+    }
+  })
+
+  lineItemsBody.addEventListener('input', recalculate)
+  if (depositSelect) depositSelect.addEventListener('change', recalculate)
+
+  if (saveForm) {
+    saveForm.addEventListener('submit', () => {
+      recalculate()
+      syncAuthoredContentInputs()
+    })
+  }
+
+  if (generatePdfForm && generatePdfBtn) {
+    generatePdfForm.addEventListener('submit', () => {
+      generatePdfBtn.disabled = true
+      generatePdfBtn.textContent = 'Generating...'
+    })
+  }
+
+  if (signForm && signBtn) {
+    signForm.addEventListener('submit', () => {
+      signBtn.disabled = true
+      signBtn.textContent = 'Sending...'
+    })
+  }
+
+  if (warning && initialLineItems.length >= 3) {
+    warning.classList.remove('hidden')
+  }
+}

--- a/src/lib/admin/quote-builder-page.ts
+++ b/src/lib/admin/quote-builder-page.ts
@@ -1,0 +1,111 @@
+import { getEntity } from '../db/entities'
+import {
+  getMissingAuthoredContent,
+  getQuote,
+  parseDeliverables,
+  parseSchedule,
+  QUOTE_STATUSES,
+  VALID_TRANSITIONS,
+} from '../db/quotes'
+import type { DeliverableRow, LineItem, QuoteStatus, ScheduleRow } from '../db/quotes'
+import { listContacts } from '../db/contacts'
+import { listSignalsForEntity } from '../db/signal-attribution'
+import { getSOWStateForQuote } from '../sow/service'
+
+type Database = Parameters<typeof getEntity>[0]
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function formatCurrency(amount: number): string {
+  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+}
+
+export function formatSignalLabel(signal: {
+  source_pipeline: string
+  created_at: string
+  content: string
+}): string {
+  const date = new Date(signal.created_at).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  const oneLine = signal.content.replace(/\s+/g, ' ').trim()
+  const snippet = oneLine.length > 80 ? `${oneLine.slice(0, 79)}…` : oneLine
+  return `[${signal.source_pipeline}] ${date} - ${snippet}`
+}
+
+export async function loadQuoteBuilderPage(params: {
+  db: Database
+  orgId: string
+  entityId: string
+  quoteId: string
+  url: URL
+}) {
+  const [entity, quote, contacts, entitySignals] = await Promise.all([
+    getEntity(params.db, params.orgId, params.entityId),
+    getQuote(params.db, params.orgId, params.quoteId),
+    listContacts(params.db, params.orgId, params.entityId),
+    listSignalsForEntity(params.db, params.orgId, params.entityId),
+  ])
+
+  if (!entity) return { missing: 'entity' as const }
+  if (!quote) return { missing: 'quote' as const }
+
+  const lineItems: LineItem[] = JSON.parse(quote.line_items)
+  const status = quote.status as QuoteStatus
+  const validTransitions = VALID_TRANSITIONS[status] ?? []
+  const isDraft = status === 'draft'
+  const isTerminal = validTransitions.length === 0
+  const schedule: ScheduleRow[] = parseSchedule(quote)
+  const deliverables: DeliverableRow[] = parseDeliverables(quote)
+  const engagementOverview = quote.engagement_overview ?? ''
+  const milestoneLabel = quote.milestone_label ?? ''
+  const missingAuthored = getMissingAuthoredContent(quote)
+
+  const sowState = await getSOWStateForQuote(params.db, params.orgId, params.quoteId)
+  const latestSowRevision = sowState.latestRevision
+  const activeSignatureRequest = sowState.openSignatureRequest
+  const hasSow = !!latestSowRevision
+  const sowGeneratedAt = latestSowRevision ? new Date(latestSowRevision.rendered_at) : null
+  const isSowStale = !!latestSowRevision && latestSowRevision.quote_version !== quote.version
+  const expiresAt = quote.expires_at ? new Date(quote.expires_at) : null
+  const isExpired = expiresAt && expiresAt < new Date()
+  const isThreeMilestone = quote.total_hours >= 40
+  const depositPct = quote.deposit_pct
+
+  return {
+    entity,
+    quote,
+    contacts,
+    entitySignals,
+    lineItems,
+    status,
+    validTransitions,
+    isDraft,
+    isTerminal,
+    schedule,
+    deliverables,
+    engagementOverview,
+    milestoneLabel,
+    missingAuthored,
+    latestSowRevision,
+    activeSignatureRequest,
+    hasSow,
+    sowGeneratedAt,
+    isSowStale,
+    expiresAt,
+    isExpired,
+    isThreeMilestone,
+    depositPct,
+    saved: params.url.searchParams.get('saved'),
+    error: params.url.searchParams.get('error'),
+    QUOTE_STATUSES,
+  }
+}

--- a/src/lib/booking/intake-questionnaire.ts
+++ b/src/lib/booking/intake-questionnaire.ts
@@ -1,0 +1,95 @@
+export type IntakeQuestionnaireMode = 'booking' | 'prep'
+
+export interface IntakeOption {
+  value: string
+  label: string
+}
+
+export const INTAKE_EMPLOYEE_COUNT_OPTIONS: IntakeOption[] = [
+  { value: '1-5', label: '1 - 5' },
+  { value: '6-10', label: '6 - 10' },
+  { value: '11-25', label: '11 - 25' },
+  { value: '26-50', label: '26 - 50' },
+  { value: '50+', label: '50+' },
+]
+
+export const INTAKE_YEARS_IN_BUSINESS_OPTIONS: IntakeOption[] = [
+  { value: '<1', label: 'Less than 1 year' },
+  { value: '1-3', label: '1 - 3 years' },
+  { value: '3-5', label: '3 - 5 years' },
+  { value: '5-10', label: '5 - 10 years' },
+  { value: '10+', label: '10+ years' },
+]
+
+export const INTAKE_HOW_HEARD_OPTIONS: IntakeOption[] = [
+  { value: 'Google Search', label: 'Google Search' },
+  { value: 'Referral', label: 'Referral' },
+  { value: 'BNI / Networking group', label: 'BNI / Networking group' },
+  { value: 'Chamber of Commerce', label: 'Chamber of Commerce' },
+  { value: 'Social Media', label: 'Social Media' },
+  { value: 'SCORE / SBA', label: 'SCORE / SBA' },
+  { value: 'other', label: 'Other' },
+]
+
+type IntakeFormPayload = Record<string, string>
+
+function toggleConditionalInput(source: HTMLSelectElement, target: HTMLInputElement) {
+  if (source.value === 'other') {
+    target.classList.remove('hidden')
+    return
+  }
+
+  target.classList.add('hidden')
+  target.value = ''
+}
+
+export function bindIntakeConditionalFields(root: HTMLElement): void {
+  if (root.dataset.intakeConditionalBound === 'true') {
+    return
+  }
+
+  const sources = root.querySelectorAll('[data-intake-other-source]')
+  for (const source of sources) {
+    if (!(source instanceof HTMLSelectElement)) continue
+
+    const fieldName = source.dataset.intakeOtherSource
+    if (!fieldName) continue
+
+    const target = root.querySelector(`[data-intake-other-input="${fieldName}"]`)
+    if (!(target instanceof HTMLInputElement)) continue
+
+    const sync = () => toggleConditionalInput(source, target)
+    source.addEventListener('change', sync)
+    sync()
+  }
+
+  root.dataset.intakeConditionalBound = 'true'
+}
+
+export function formDataToObject(formData: FormData): IntakeFormPayload {
+  const data: IntakeFormPayload = {}
+
+  formData.forEach((value, key) => {
+    if (typeof value === 'string') {
+      data[key] = value
+    }
+  })
+
+  return data
+}
+
+export function normalizeIntakePayload(data: IntakeFormPayload): IntakeFormPayload {
+  const normalized: IntakeFormPayload = { ...data }
+
+  if (normalized.vertical === 'other' && normalized.vertical_other) {
+    normalized.vertical = normalized.vertical_other
+  }
+  delete normalized.vertical_other
+
+  if (normalized.how_heard === 'other' && normalized.how_heard_other) {
+    normalized.how_heard = normalized.how_heard_other
+  }
+  delete normalized.how_heard_other
+
+  return normalized
+}

--- a/src/lib/db/context.ts
+++ b/src/lib/db/context.ts
@@ -89,6 +89,8 @@ export interface ContextFilters {
   engagement_id?: string
 }
 
+export type ContextAuthority = 'authoritative' | 'non_authoritative'
+
 // ---------------------------------------------------------------------------
 // Append
 // ---------------------------------------------------------------------------
@@ -307,6 +309,36 @@ interface AssembleOptions {
   includeTranscripts?: boolean
   /** Filter to specific context types. */
   typeFilter?: ContextType[]
+  /**
+   * Include model-authored, non-authoritative summaries. Default false.
+   * Downstream prompt assembly should read extractive facts by default.
+   */
+  includeNonAuthoritative?: boolean
+}
+
+const LEGACY_NON_AUTHORITATIVE_SOURCES = new Set([
+  'intelligence_brief',
+  'review_analysis',
+  'review_synthesis',
+])
+
+function parseMetadataJson(metadata: string | null): Record<string, unknown> | null {
+  if (!metadata) return null
+  try {
+    const parsed = JSON.parse(metadata)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function getContextAuthority(entry: ContextEntry): ContextAuthority {
+  const metadata = parseMetadataJson(entry.metadata)
+  const explicit = metadata?.context_authority
+  if (explicit === 'authoritative' || explicit === 'non_authoritative') {
+    return explicit
+  }
+  return LEGACY_NON_AUTHORITATIVE_SOURCES.has(entry.source) ? 'non_authoritative' : 'authoritative'
 }
 
 /**
@@ -326,7 +358,10 @@ export async function assembleEntityContext(
     filters.types = opts.typeFilter
   }
 
-  const entries = await listContext(db, entityId, filters)
+  const listed = await listContext(db, entityId, filters)
+  const entries = opts?.includeNonAuthoritative
+    ? listed
+    : listed.filter((entry) => getContextAuthority(entry) === 'authoritative')
   if (entries.length === 0) return ''
 
   const parts: string[] = []

--- a/src/lib/diagnostic/index.ts
+++ b/src/lib/diagnostic/index.ts
@@ -609,7 +609,11 @@ export async function runReviewSynthesis(
       type: 'enrichment',
       source: 'review_synthesis',
       content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}.`,
-      metadata: synthesis as unknown as Record<string, unknown>,
+      metadata: {
+        ...synthesis,
+        context_authority: 'non_authoritative',
+        evidence_mode: 'model_summary',
+      },
       source_ref: scanRequest.id,
     })
     return true
@@ -631,8 +635,12 @@ export async function runDeepWebsite(
       entity_id: entity.id,
       type: 'enrichment',
       source: 'deep_website',
-      content: `Deep website analysis. Digital maturity score: ${analysis.digital_maturity?.score ?? 'n/a'}/10.`,
-      metadata: analysis as unknown as Record<string, unknown>,
+      content: formatDiagnosticDeepWebsiteEvidence(analysis),
+      metadata: {
+        ...analysis,
+        context_authority: 'authoritative',
+        evidence_mode: 'extractive',
+      },
       source_ref: scanRequest.id,
     })
     return true
@@ -657,13 +665,58 @@ export async function runIntelligenceBrief(
       type: 'enrichment',
       source: 'intelligence_brief',
       content: brief,
-      metadata: { trigger: 'inbound_scan' },
+      metadata: {
+        trigger: 'inbound_scan',
+        context_authority: 'non_authoritative',
+        evidence_mode: 'model_summary',
+      },
       source_ref: scanRequest.id,
     })
     return brief
   } catch (err) {
     throw new ScanModuleError('intelligence_brief', err)
   }
+}
+
+function formatDiagnosticDeepWebsiteEvidence(
+  analysis: Awaited<ReturnType<typeof deepWebsiteAnalysis>>
+) {
+  if (!analysis) return 'Deep website analysis.'
+
+  const ownerProfile =
+    analysis.owner_profile && typeof analysis.owner_profile === 'object'
+      ? analysis.owner_profile
+      : null
+  const businessProfile =
+    analysis.business_profile && typeof analysis.business_profile === 'object'
+      ? analysis.business_profile
+      : null
+  const contactInfo =
+    analysis.contact_info && typeof analysis.contact_info === 'object'
+      ? analysis.contact_info
+      : null
+  const parts = ['Deep website analysis:']
+  if (ownerProfile && typeof ownerProfile.name === 'string' && ownerProfile.name.trim()) {
+    parts.push(`Owner: ${ownerProfile.name} (${ownerProfile.title ?? 'owner'})`)
+  }
+  const services = Array.isArray(businessProfile?.services) ? businessProfile.services : []
+  if (services.length > 0) {
+    parts.push(`Services: ${services.join(', ')}`)
+  }
+  const certifications = Array.isArray(businessProfile?.certifications)
+    ? businessProfile.certifications
+    : []
+  if (certifications.length > 0) {
+    parts.push(`Certifications: ${certifications.join(', ')}`)
+  }
+  if (contactInfo && typeof contactInfo.email === 'string' && contactInfo.email.trim()) {
+    parts.push(`Email: ${contactInfo.email}`)
+  }
+  if (contactInfo && typeof contactInfo.phone === 'string' && contactInfo.phone.trim()) {
+    parts.push(`Phone: ${contactInfo.phone}`)
+  }
+
+  return parts.join('\n')
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/enrichment/deep-website.ts
+++ b/src/lib/enrichment/deep-website.ts
@@ -1,6 +1,6 @@
 /**
- * Deep website analysis using Claude Sonnet for comprehensive business intelligence.
- * Fetches homepage + discoverable subpages, extracts detailed profile.
+ * Deep website analysis using Claude Sonnet for extractive website facts.
+ * Fetches homepage + discoverable subpages, extracts observable business data.
  */
 
 import { ModuleError } from './instrument'
@@ -10,16 +10,16 @@ const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-sonnet-4-20250514'
 const MAX_TOKENS = 2048
 
-const DEEP_ANALYSIS_PROMPT = `You are analyzing a small business website for comprehensive intelligence. Extract ALL available information. Return ONLY valid JSON:
+const DEEP_ANALYSIS_PROMPT = `You are extracting observable facts from a small business website. Use only information explicitly supported by the supplied pages. Do not infer owner personality, company trajectory, internal capacity, hidden tooling, or unstated operational problems. Use null, false, or [] when the site does not support a field. Return ONLY valid JSON:
 
 {
   "owner_profile": {
     "name": "string or null",
     "title": "string or null",
-    "background": "string or null — bio, education, career history mentioned"
+    "background": "string or null — only if bio, education, or career history is explicitly stated"
   },
   "team": {
-    "size_estimate": "number or null",
+    "size_estimate": "number or null — only when the site explicitly states a headcount or shows a complete named team",
     "named_employees": ["array of {name, role} objects"],
     "departments_visible": ["array of department names"]
   },
@@ -38,8 +38,8 @@ const DEEP_ANALYSIS_PROMPT = `You are analyzing a small business website for com
     "pricing_visible": "boolean"
   },
   "digital_maturity": {
-    "score": "1-10 integer",
-    "reasoning": "1 sentence explanation",
+    "score": "1-10 integer based only on visible website features",
+    "reasoning": "1 sentence citing the visible website features behind the score",
     "online_booking": "boolean",
     "chat_widget": "boolean",
     "blog_active": "boolean — true if blog has posts within last 6 months",

--- a/src/lib/enrichment/dossier.ts
+++ b/src/lib/enrichment/dossier.ts
@@ -1,6 +1,8 @@
 /**
  * Intelligence brief (dossier) generation using Claude Sonnet.
- * Synthesizes all accumulated context into a structured 2-3 page assessment.
+ * Produces a human-readable brief from authoritative context, but the
+ * output itself is non-authoritative and must not be fed back into later
+ * prompt assembly by default.
  */
 
 import { ModuleError } from './instrument'
@@ -10,43 +12,39 @@ const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-sonnet-4-20250514'
 const MAX_TOKENS = 4096
 
-const DOSSIER_PROMPT = `You are generating a comprehensive intelligence brief for a consulting team (SMD Services) that sells operations cleanup engagements to Phoenix-area small businesses. Use "we" voice.
+const DOSSIER_PROMPT = `You are generating an evidence-bound intelligence brief for a consulting team (SMD Services) that sells operations cleanup engagements to Phoenix-area small businesses. Use "we" voice.
+
+Rules:
+- Use only facts present in the supplied context.
+- Do not infer management style, communication preference, personality, likely objections, or private business conditions.
+- When evidence is incomplete, label it as an open question instead of guessing.
+- Distinguish verified facts from hypotheses we should test on the call.
 
 Generate a structured dossier in markdown format with these sections:
 
 ## Business Overview
-- Name, vertical, location, estimated size, founding year
-- Growth trajectory (growing/stable/declining, with evidence)
-- Competitive position (vs. local peers)
+- Name, vertical, location, size indicators, founding year
+- Visible offerings, service area, notable credentials, public reputation signals
 
-## Owner / Decision-Maker Profile
-- Name, role, management style (inferred from review responses, hiring patterns)
-- Likely concerns and priorities
-- Communication preference (responsive to digital, prefers phone, etc.)
+## Verified Operating Signals
+- Specific operational patterns visible in reviews, website facts, tooling, hiring, or public materials
+- Cite the evidence inline for each signal
 
-## Technology & Operations Assessment
-- Current tools detected (and what's missing)
-- Digital maturity score with reasoning
-- Key operational gaps mapped to the 6 universal SMB problems:
-  1. Owner bottleneck
-  2. Lead leakage
-  3. Financial blindness
-  4. Scheduling chaos
-  5. Manual communication
-  6. Employee retention
+## Engagement Hypotheses
+- 2-3 hypotheses worth testing on the call
+- Each item must include:
+  - Confidence: high | medium | low
+  - Evidence: specific supporting facts
+  - What we still need to confirm
 
-## Engagement Opportunity
-- Top 2-3 problems we can address (with confidence level and evidence)
-- Estimated engagement complexity (low/medium/high)
-- Recommended approach and talking points for the assessment call
-- Potential objections and responses
+## Questions For The Call
+- 3-5 targeted questions that would confirm or disprove the hypotheses
 
-## Conversation Starters
-- 3-4 specific, evidence-based opening lines for the assessment call
-- Reference specific things we know about their business
-- Collaborative tone — objectives over problems
+## Outreach Hooks
+- 2-3 evidence-based opening lines grounded in verified facts
+- No fabricated specifics, no objections handling, no personality reads
 
-Keep it concise but thorough. 800-1200 words.`
+Keep it concise but thorough. 600-900 words.`
 
 export async function generateDossier(
   assembledContext: string,

--- a/src/lib/enrichment/index.ts
+++ b/src/lib/enrichment/index.ts
@@ -119,6 +119,16 @@ export type EnrichEnv = {
   SERPAPI_API_KEY?: string
 }
 
+const AUTHORITATIVE_CONTEXT_META = {
+  context_authority: 'authoritative' as const,
+  evidence_mode: 'extractive',
+}
+
+const NON_AUTHORITATIVE_CONTEXT_META = {
+  context_authority: 'non_authoritative' as const,
+  evidence_mode: 'model_summary',
+}
+
 // ---------------------------------------------------------------------------
 // Individual module wrappers — each is best-effort, instruments its own
 // `enrichment_runs` row, and is idempotent (a second run with the same
@@ -385,9 +395,15 @@ export async function tryReviewAnalysis(
       const ce = await appendContext(env.DB, orgId, {
         entity_id: entity.id,
         type: 'enrichment',
-        content: `Review patterns: ${reviewAnalysis.response_pattern} responses, ${reviewAnalysis.engagement_level} engagement. ${reviewAnalysis.owner_accessible ? 'Owner appears accessible.' : ''} ${reviewAnalysis.insights}`,
+        content:
+          `Review response signals: ${reviewAnalysis.response_pattern} response pattern, ${reviewAnalysis.engagement_level} engagement.` +
+          `${reviewAnalysis.owner_accessible ? ' Owner appears reachable through public review responses.' : ''}` +
+          ` Evidence: ${reviewAnalysis.evidence_summary}`,
         source: 'review_analysis',
-        metadata: reviewAnalysis as unknown as Record<string, unknown>,
+        metadata: {
+          ...reviewAnalysis,
+          ...NON_AUTHORITATIVE_CONTEXT_META,
+        },
       })
       return { kind: 'succeeded', context_entry_id: ce.id }
     }
@@ -463,9 +479,13 @@ export async function tryNews(
       const ce = await appendContext(env.DB, orgId, {
         entity_id: entity.id,
         type: 'enrichment',
-        content: `News/press: ${news.summary} (${news.mentions.length} mentions found)`,
+        content: formatNewsEvidence(news),
         source: 'news_search',
-        metadata: { mentions: news.mentions, summary: news.summary },
+        metadata: {
+          mentions: news.mentions,
+          summary: news.summary,
+          ...AUTHORITATIVE_CONTEXT_META,
+        },
       })
       return { kind: 'succeeded', context_entry_id: ce.id }
     }
@@ -498,7 +518,10 @@ export async function tryDeepWebsite(
         type: 'enrichment',
         content: formatDeepWebsite(analysis),
         source: 'deep_website',
-        metadata: analysis as unknown as Record<string, unknown>,
+        metadata: {
+          ...analysis,
+          ...AUTHORITATIVE_CONTEXT_META,
+        },
       })
       return { kind: 'succeeded', context_entry_id: ce.id }
     }
@@ -547,7 +570,10 @@ export async function tryReviewSynthesis(
         type: 'enrichment',
         content: `Review synthesis: ${synthesis.customer_sentiment} Trend: ${synthesis.sentiment_trend}. Themes: ${synthesis.top_themes.join(', ')}. Problems: ${synthesis.operational_problems.map((p) => `${p.problem} (${p.confidence})`).join(', ')}.`,
         source: 'review_synthesis',
-        metadata: synthesis as unknown as Record<string, unknown>,
+        metadata: {
+          ...synthesis,
+          ...NON_AUTHORITATIVE_CONTEXT_META,
+        },
       })
       return { kind: 'succeeded', context_entry_id: ce.id }
     }
@@ -622,7 +648,11 @@ export async function tryIntelligenceBrief(
         type: 'enrichment',
         content: brief,
         source: 'intelligence_brief',
-        metadata: { model: 'claude-sonnet-4-20250514', trigger: 'at_ingest' },
+        metadata: {
+          model: 'claude-sonnet-4-20250514',
+          trigger: 'at_ingest',
+          ...NON_AUTHORITATIVE_CONTEXT_META,
+        },
       })
       return { kind: 'succeeded', context_entry_id: ce.id }
     }
@@ -750,23 +780,32 @@ function formatDeepWebsite(analysis: DeepWebsiteAnalysis): string {
     parts.push(`Owner: ${analysis.owner_profile.name} (${analysis.owner_profile.title ?? 'owner'})`)
   if (analysis.owner_profile.background)
     parts.push(`Background: ${analysis.owner_profile.background}`)
-  if (analysis.team.size_estimate) parts.push(`Team: ~${analysis.team.size_estimate} people`)
   if (analysis.team.named_employees.length > 0)
     parts.push(
       `Named staff: ${analysis.team.named_employees.map((e) => `${e.name} (${e.role})`).join(', ')}`
     )
   if (analysis.business_profile.services.length > 0)
     parts.push(`Services: ${analysis.business_profile.services.join(', ')}`)
+  if (analysis.business_profile.service_areas.length > 0)
+    parts.push(`Service areas: ${analysis.business_profile.service_areas.join(', ')}`)
   if (analysis.business_profile.certifications.length > 0)
     parts.push(`Certifications: ${analysis.business_profile.certifications.join(', ')}`)
   if (analysis.business_profile.awards.length > 0)
     parts.push(`Awards: ${analysis.business_profile.awards.join(', ')}`)
-  parts.push(
-    `Digital maturity: ${analysis.digital_maturity.score}/10 — ${analysis.digital_maturity.reasoning}`
-  )
-  parts.push(
-    `Online booking: ${analysis.digital_maturity.online_booking ? 'Yes' : 'No'}, Chat: ${analysis.digital_maturity.chat_widget ? 'Yes' : 'No'}, Blog active: ${analysis.digital_maturity.blog_active ? 'Yes' : 'No'}`
-  )
+  if (analysis.business_profile.partnerships.length > 0)
+    parts.push(`Partnerships: ${analysis.business_profile.partnerships.join(', ')}`)
   if (analysis.contact_info.email) parts.push(`Email: ${analysis.contact_info.email}`)
+  if (analysis.contact_info.phone) parts.push(`Phone: ${analysis.contact_info.phone}`)
+  if (analysis.contact_info.address) parts.push(`Address: ${analysis.contact_info.address}`)
+  return parts.join('\n')
+}
+
+function formatNewsEvidence(news: {
+  mentions: Array<{ title: string; source: string; snippet: string }>
+}): string {
+  const parts = ['News / press mentions:']
+  for (const mention of news.mentions.slice(0, 3)) {
+    parts.push(`- ${mention.title} (${mention.source}): ${mention.snippet}`)
+  }
   return parts.join('\n')
 }

--- a/src/lib/enrichment/review-analysis.ts
+++ b/src/lib/enrichment/review-analysis.ts
@@ -1,6 +1,6 @@
 /**
- * Review response pattern analysis.
- * Reads existing signal context for review evidence, analyzes owner engagement patterns.
+ * Review-response pattern analysis.
+ * Reads review signals and extracts observable response behavior only.
  */
 
 import { ModuleError } from './instrument'
@@ -10,19 +10,19 @@ const ANTHROPIC_VERSION = '2023-06-01'
 const MODEL = 'claude-haiku-4-5-20251001'
 const MAX_TOKENS = 512
 
-const ANALYSIS_PROMPT = `Analyze these business review signals for owner engagement patterns. Return ONLY valid JSON:
+const ANALYSIS_PROMPT = `Analyze these business review signals for observable review-response behavior only. Do NOT infer management style, personality, communication preference, or private business conditions. Return ONLY valid JSON:
 {
   "response_pattern": "responsive | sporadic | unresponsive | unknown",
   "engagement_level": "high | medium | low | unknown",
   "owner_accessible": true/false,
-  "insights": "1-2 sentence summary of what review patterns reveal about the owner's management style"
+  "evidence_summary": "1-2 sentence summary of the observable review-response behavior"
 }`
 
 export interface ReviewAnalysis {
   response_pattern: string
   engagement_level: string
   owner_accessible: boolean
-  insights: string
+  evidence_summary: string
 }
 
 export async function analyzeReviewPatterns(
@@ -67,6 +67,6 @@ export async function analyzeReviewPatterns(
     response_pattern: parsed.response_pattern ?? 'unknown',
     engagement_level: parsed.engagement_level ?? 'unknown',
     owner_accessible: parsed.owner_accessible ?? false,
-    insights: parsed.insights ?? '',
+    evidence_summary: parsed.evidence_summary ?? '',
   }
 }

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -1,87 +1,47 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
+import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
-import { getEngagement, VALID_TRANSITIONS } from '../../../lib/db/engagements'
-import type { EngagementStatus } from '../../../lib/db/engagements'
-import { getEntity } from '../../../lib/db/entities'
-import { getQuote } from '../../../lib/db/quotes'
-import { listMilestones, VALID_TRANSITIONS as MS_TRANSITIONS } from '../../../lib/db/milestones'
-import type { MilestoneStatus } from '../../../lib/db/milestones'
-import { listInvoices } from '../../../lib/db/invoices'
-import { listContext } from '../../../lib/db/context'
-import { listSignalsForEntity } from '../../../lib/db/signal-attribution'
-import { listDocuments } from '../../../lib/storage/r2'
+import {
+  contextTypeEyebrowClass,
+  fileSize,
+  formatDate,
+  formatSignalLabel,
+  loadEngagementDetailPage,
+  type MilestoneStatus,
+} from '../../../lib/admin/engagement-detail-page'
 import { env } from 'cloudflare:workers'
-
-// Context-entry type → flat eyebrow class. Per Pattern 01 these are
-// category labels above a record, not state — render as ink-on-cream
-// uppercase eyebrow, no fill, no rounded shape.
-function contextTypeEyebrowClass(): string {
-  return 'text-label uppercase font-mono text-[color:var(--ss-color-text-secondary)] tracking-[var(--ss-text-letter-spacing-label)]'
-}
 
 const session = Astro.locals.session!
 if (session.role !== 'admin') return Astro.redirect('/login')
 
 const engagementId = Astro.params.id!
-const engagement = await getEngagement(env.DB, session.orgId, engagementId)
-if (!engagement) return Astro.redirect('/admin/entities?error=not_found')
-
-const entity = await getEntity(env.DB, session.orgId, engagement.entity_id)
-const quote = engagement.quote_id
-  ? await getQuote(env.DB, session.orgId, engagement.quote_id)
-  : null
-const milestones = await listMilestones(env.DB, session.orgId, engagementId)
-const invoices = await listInvoices(env.DB, session.orgId, { engagementId })
-const contextEntries = await listContext(env.DB, engagement.entity_id, {
-  engagement_id: engagementId,
+const pageData = await loadEngagementDetailPage({
+  db: env.DB,
+  storage: env.STORAGE,
+  orgId: session.orgId,
+  engagementId,
+  url: Astro.url,
 })
+if (!pageData) return Astro.redirect('/admin/entities?error=not_found')
 
-// Signals on file for this entity, most-recent first (#589). Powers the
-// originating-signal dropdown in the Edit Details form.
-const entitySignals = await listSignalsForEntity(env.DB, session.orgId, engagement.entity_id)
-
-function truncateSignal(content: string, max = 80): string {
-  const oneLine = content.replace(/\s+/g, ' ').trim()
-  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max - 1)}…`
-}
-
-function formatSignalLabel(s: { source_pipeline: string; created_at: string; content: string }) {
-  const date = new Date(s.created_at).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
-  return `[${s.source_pipeline}] ${date} — ${truncateSignal(s.content)}`
-}
-
-const depositInvoice = invoices.find((i) => i.type === 'deposit')
-
-const prefix = `${session.orgId}/engagements/${engagementId}/docs/`
-const documents = await listDocuments(env.STORAGE, prefix)
-
-const status = engagement.status as EngagementStatus
-const nextStatuses = VALID_TRANSITIONS[status] ?? []
-
-const saved = Astro.url.searchParams.get('saved')
-const error = Astro.url.searchParams.get('error')
-const milestoneAdded = Astro.url.searchParams.get('milestone_added')
-const milestoneDeleted = Astro.url.searchParams.get('milestone_deleted')
-
-function formatDate(d: string | null): string {
-  if (!d) return '--'
-  return new Date(d).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
-}
-
-function fileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
+const {
+  engagement,
+  entity,
+  quote,
+  milestones,
+  invoices,
+  contextEntries,
+  entitySignals,
+  documents,
+  nextStatuses,
+  depositInvoice,
+  milestoneTransitions,
+  saved,
+  error,
+  milestoneAdded,
+  milestoneDeleted,
+} = pageData
 ---
 
 <AdminLayout
@@ -92,39 +52,24 @@ function fileSize(bytes: number): string {
     { label: 'Engagement' },
   ]}
 >
-  <div class="space-y-card">
-    {
-      saved && (
-        <div class="border-l-4 border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
-          Changes saved.
-        </div>
-      )
-    }
-    {
-      milestoneAdded && (
-        <div class="border-l-4 border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
-          Milestone added.
-        </div>
-      )
-    }
-    {
-      milestoneDeleted && (
-        <div class="border-l-4 border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
-          Milestone deleted.
-        </div>
-      )
-    }
+  <div id="engagement-page" data-engagement-id={engagementId} class="space-y-card">
+    {saved && <AdminFlashNotice message="Changes saved." />}
+    {milestoneAdded && <AdminFlashNotice message="Milestone added." />}
+    {milestoneDeleted && <AdminFlashNotice message="Milestone deleted." />}
     {
       error && (
-        <div class="border-l-4 border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-surface)] text-[color:var(--ss-color-text-primary)] px-4 py-2 text-sm">
-          {error === 'invalid_status'
-            ? 'Invalid status transition.'
-            : error === 'invalid_transition'
-              ? 'Invalid transition.'
-              : error === 'not_found'
-                ? 'Resource not found.'
-                : 'An error occurred.'}
-        </div>
+        <AdminFlashNotice
+          kind="error"
+          message={
+            error === 'invalid_status'
+              ? 'Invalid status transition.'
+              : error === 'invalid_transition'
+                ? 'Invalid transition.'
+                : error === 'not_found'
+                  ? 'Resource not found.'
+                  : 'An error occurred.'
+          }
+        />
       )
     }
 
@@ -388,7 +333,7 @@ function fileSize(bytes: number): string {
         {
           milestones.map((ms) => {
             const msStatus = ms.status as MilestoneStatus
-            const msNext = MS_TRANSITIONS[msStatus] ?? []
+            const msNext = milestoneTransitions[msStatus] ?? []
             return (
               <div class="px-6 py-4 flex items-center justify-between gap-stack">
                 <div class="flex-1 min-w-0">
@@ -793,196 +738,10 @@ function fileSize(bytes: number): string {
     </div>
   </div>
 
-  <script define:vars={{ engagementId }}>
-    const fileInput = document.getElementById('file-input')
-    const uploadBtn = document.getElementById('upload-btn')
-    const uploadArea = document.getElementById('upload-area')
-    const uploadStatus = document.getElementById('upload-status')
+  <script>
+    import { initEngagementDetailPage } from '../../../lib/admin/engagement-detail-client'
 
-    uploadBtn.addEventListener('click', () => fileInput.click())
-    fileInput.addEventListener('change', () => uploadFiles(fileInput.files))
-
-    uploadArea.addEventListener('dragover', (e) => {
-      e.preventDefault()
-      uploadArea.classList.add('drag-active')
-    })
-    uploadArea.addEventListener('dragleave', () => {
-      uploadArea.classList.remove('drag-active')
-    })
-    uploadArea.addEventListener('drop', (e) => {
-      e.preventDefault()
-      uploadArea.classList.remove('drag-active')
-      uploadFiles(e.dataTransfer.files)
-    })
-
-    async function uploadFiles(files) {
-      if (!files || files.length === 0) return
-      uploadStatus.classList.remove('hidden')
-
-      for (const file of files) {
-        uploadStatus.textContent = `Uploading ${file.name}...`
-        const form = new FormData()
-        form.append('file', file)
-        try {
-          const res = await fetch(`/api/admin/engagements/${engagementId}/deliverables`, {
-            method: 'POST',
-            body: form,
-          })
-          if (!res.ok) {
-            const data = await res.json().catch(() => ({}))
-            uploadStatus.textContent = `Failed: ${data.error || res.statusText}`
-          } else {
-            uploadStatus.textContent = `Uploaded ${file.name}`
-          }
-        } catch (err) {
-          uploadStatus.textContent = `Error: ${err.message}`
-        }
-      }
-      setTimeout(() => location.reload(), 800)
-    }
-  </script>
-
-  <script define:vars={{ engagementId }}>
-    // Consultant photo: client-side square-crop and WebP encode, then upload.
-    // We crop in the browser to avoid a WASM image pipeline on the Worker — the
-    // server accepts pre-processed WebP/JPEG/PNG under 5 MB and stores to R2.
-    const photoInput = document.getElementById('photo-input')
-    const photoChoose = document.getElementById('photo-choose')
-    const photoUpload = document.getElementById('photo-upload')
-    const photoCancel = document.getElementById('photo-cancel')
-    const photoRemove = document.getElementById('photo-remove')
-    const photoPreview = document.getElementById('photo-preview')
-    const photoStatus = document.getElementById('photo-status')
-
-    let pendingBlob = null
-    const TARGET_SIZE = 400
-    const PREVIEW_SIZE = 160
-    const MAX_BYTES = 5 * 1024 * 1024
-
-    function setStatus(msg, isError) {
-      if (!photoStatus) return
-      photoStatus.textContent = msg
-      photoStatus.className = isError
-        ? 'mt-2 text-xs text-[color:var(--ss-color-error)]'
-        : 'mt-2 text-xs text-[color:var(--ss-color-text-secondary)]'
-    }
-
-    async function cropToSquareWebp(file) {
-      if (file.size > MAX_BYTES) {
-        throw new Error('Original file exceeds 5 MB. Please pick a smaller image.')
-      }
-      const bitmap = await createImageBitmap(file)
-      const side = Math.min(bitmap.width, bitmap.height)
-      const sx = Math.round((bitmap.width - side) / 2)
-      const sy = Math.round((bitmap.height - side) / 2)
-
-      const canvas = document.createElement('canvas')
-      canvas.width = TARGET_SIZE
-      canvas.height = TARGET_SIZE
-      const ctx = canvas.getContext('2d')
-      ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, TARGET_SIZE, TARGET_SIZE)
-
-      if (photoPreview) {
-        photoPreview.width = PREVIEW_SIZE
-        photoPreview.height = PREVIEW_SIZE
-        const pctx = photoPreview.getContext('2d')
-        pctx.drawImage(canvas, 0, 0, PREVIEW_SIZE, PREVIEW_SIZE)
-        photoPreview.classList.remove('hidden')
-      }
-
-      const blob = await new Promise((resolve, reject) => {
-        canvas.toBlob(
-          (b) => (b ? resolve(b) : reject(new Error('Encoding failed'))),
-          'image/webp',
-          0.9
-        )
-      })
-      if (blob.size > MAX_BYTES) {
-        throw new Error('Encoded photo still exceeds 5 MB. Try a smaller source image.')
-      }
-      return blob
-    }
-
-    if (photoChoose && photoInput) {
-      photoChoose.addEventListener('click', () => photoInput.click())
-    }
-
-    if (photoInput) {
-      photoInput.addEventListener('change', async () => {
-        const file = photoInput.files && photoInput.files[0]
-        if (!file) return
-        try {
-          setStatus('Processing image...', false)
-          pendingBlob = await cropToSquareWebp(file)
-          setStatus(`Ready to upload (${(pendingBlob.size / 1024).toFixed(1)} KB WebP)`, false)
-          photoUpload.classList.remove('hidden')
-          photoCancel.classList.remove('hidden')
-        } catch (err) {
-          pendingBlob = null
-          setStatus(err.message || 'Could not process image', true)
-        }
-      })
-    }
-
-    if (photoCancel) {
-      photoCancel.addEventListener('click', () => {
-        pendingBlob = null
-        if (photoInput) photoInput.value = ''
-        if (photoPreview) photoPreview.classList.add('hidden')
-        photoUpload.classList.add('hidden')
-        photoCancel.classList.add('hidden')
-        setStatus('', false)
-      })
-    }
-
-    if (photoUpload) {
-      photoUpload.addEventListener('click', async () => {
-        if (!pendingBlob) return
-        photoUpload.disabled = true
-        photoCancel.disabled = true
-        setStatus('Uploading...', false)
-        const form = new FormData()
-        form.append('photo', new File([pendingBlob], 'consultant.webp', { type: 'image/webp' }))
-        try {
-          const res = await fetch(`/api/admin/engagements/${engagementId}/consultant-photo`, {
-            method: 'POST',
-            body: form,
-          })
-          if (!res.ok) {
-            const data = await res.json().catch(() => ({}))
-            throw new Error(data.error || res.statusText)
-          }
-          setStatus('Photo uploaded. Reloading...', false)
-          setTimeout(() => location.reload(), 500)
-        } catch (err) {
-          setStatus(err.message || 'Upload failed', true)
-          photoUpload.disabled = false
-          photoCancel.disabled = false
-        }
-      })
-    }
-
-    if (photoRemove) {
-      photoRemove.addEventListener('click', async () => {
-        if (!confirm('Remove the current consultant photo?')) return
-        photoRemove.disabled = true
-        setStatus('Removing...', false)
-        try {
-          const res = await fetch(`/api/admin/engagements/${engagementId}/consultant-photo`, {
-            method: 'DELETE',
-          })
-          if (!res.ok) {
-            const data = await res.json().catch(() => ({}))
-            throw new Error(data.error || res.statusText)
-          }
-          setStatus('Photo removed. Reloading...', false)
-          setTimeout(() => location.reload(), 500)
-        } catch (err) {
-          setStatus(err.message || 'Remove failed', true)
-          photoRemove.disabled = false
-        }
-      })
-    }
+    initEngagementDetailPage()
   </script>
 
   <style>

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,356 +1,77 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
+import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
 import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import EnrichmentStatusPanel from '../../../components/admin/EnrichmentStatusPanel.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
 import { adminActionButtonClass } from '../../../lib/ui/admin-action-button'
 import { relativeTime } from '../../../lib/admin/relative-time'
+import {
+  confidenceColor,
+  contextTypeBadge,
+  formatDate,
+  formatDateTime,
+  isOverdue,
+  loadEntityDetailPage,
+  parseMetadata,
+  renderSimpleMarkdown,
+  sentimentColor,
+} from '../../../lib/admin/entity-detail-page'
 import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
 import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
-import { getEntity, ENTITY_STAGES } from '../../../lib/db/entities'
-import type { EntityStage } from '../../../lib/db/entities'
+import { ENTITY_STAGES } from '../../../lib/db/entities'
 import { LOST_REASONS, lostReasonLabel, lostReasonChipClass } from '../../../lib/db/lost-reasons'
-import { listContext, CONTEXT_TYPES } from '../../../lib/db/context'
+import { CONTEXT_TYPES } from '../../../lib/db/context'
 import type { ContextEntry } from '../../../lib/db/context'
-import { listContacts } from '../../../lib/db/contacts'
-import { listMeetings } from '../../../lib/db/meetings'
-import { listEngagements } from '../../../lib/db/engagements'
-import { listQuotes, hasOpenQuoteForEntity } from '../../../lib/db/quotes'
-import { listInvoices } from '../../../lib/db/invoices'
-import { findDraftableMeeting } from '../../../lib/entities/draftable-meeting'
 import { env } from 'cloudflare:workers'
-
-/**
- * Entity detail — unified view of a single business across its lifecycle.
- * Context timeline is the centerpiece; operational data in collapsible panels.
- *
- * Protected by auth middleware (requires admin role).
- */
 
 const session = Astro.locals.session!
 const entityId = Astro.params.id!
+const pageData = await loadEntityDetailPage({
+  db: env.DB,
+  orgId: session.orgId,
+  entityId,
+  url: Astro.url,
+})
+if (!pageData) return Astro.redirect('/admin/entities?error=not_found')
 
-const entity = await getEntity(env.DB, session.orgId, entityId)
-if (!entity) return Astro.redirect('/admin/entities?error=not_found')
-
-const [contextEntries, contacts, meetings, engagements, quotes, invoices] = await Promise.all([
-  listContext(env.DB, entityId),
-  listContacts(env.DB, session.orgId, entityId),
-  listMeetings(env.DB, session.orgId, entityId),
-  listEngagements(env.DB, session.orgId, entityId),
-  listQuotes(env.DB, session.orgId, entityId),
-  listInvoices(env.DB, session.orgId, { entityId }),
-])
-
-// A meeting is "draft-able" if it was completed and no quote has been
-// derived from it yet. See issue #470 — proposal drafting is an explicit
-// admin action, never a side effect of completion. Logic lives in
-// `src/lib/entities/draftable-meeting.ts` so the entity list and detail
-// share one source of truth.
-const mostRecentDraftableMeeting = findDraftableMeeting(meetings, quotes)
-
-// "Has outreach" = at least one outreach_draft context entry exists. Used
-// to gate the "Log reply" toolbar action: if the operator hasn't drafted
-// outreach yet, there's nothing for the prospect to be replying to. See
-// `getEntityIdsWithOutreach` for the batch version used on the list.
-const hasOutreach = contextEntries.some((e) => e.type === 'outreach_draft')
-
-// Reverse for newest-first display
-const timelineEntries = [...contextEntries].reverse()
-
-// Filter by type from URL
-const typeFilter = Astro.url.searchParams.get('type') ?? ''
-const filteredEntries = typeFilter
-  ? timelineEntries.filter((e) => e.type === typeFilter)
-  : timelineEntries
-
-// Count by type for filter buttons
-const typeCounts: Record<string, number> = {}
-for (const e of contextEntries) {
-  typeCounts[e.type] = (typeCounts[e.type] ?? 0) + 1
-}
-
-// Surface the most recent structured lost reason when this entity is
-// currently at the lost stage. Parsed from the latest stage_change
-// context entry's metadata — same source the Lost tab rolls up.
-let currentLostReason: { code: string; detail: string | null } | null = null
-if (entity.stage === 'lost') {
-  const lostEntries = [...contextEntries].reverse().filter((c) => c.type === 'stage_change')
-  for (const entry of lostEntries) {
-    if (!entry.metadata) continue
-    try {
-      const meta = JSON.parse(entry.metadata) as Record<string, unknown>
-      if (meta.to === 'lost' && typeof meta.lost_reason === 'string') {
-        currentLostReason = {
-          code: meta.lost_reason,
-          detail: typeof meta.lost_detail === 'string' ? meta.lost_detail : null,
-        }
-        break
-      }
-    } catch {
-      // ignore malformed metadata
-    }
-  }
-}
-
-const promoted = Astro.url.searchParams.get('promoted')
-const noteAdded = Astro.url.searchParams.get('note_added')
-const replyLogged = Astro.url.searchParams.get('reply_logged')
-const stageUpdated = Astro.url.searchParams.get('stage_updated')
-const dossierGenerated = Astro.url.searchParams.get('dossier')
-const error = Astro.url.searchParams.get('error')
-
-// Re-enrich available for prospect stage and beyond (not signal or lost).
-// Full enrichment now runs automatically at signal ingest — this button is
-// for refreshing the cheap (reviews + news) slice when the data goes stale.
-const reEnrichStages: string[] = [
-  'prospect',
-  'meetings',
-  'proposing',
-  'engaged',
-  'delivered',
-  'ongoing',
-]
-const showReEnrichButton = reEnrichStages.includes(entity.stage)
-
-// "New quote" action (#472): enabled when entity is in Proposing or earlier,
-// no open (draft/sent) quote exists, and at least one meeting is on file
-// (schema requires assessment_id NOT NULL on quotes — reuses the latest
-// meeting id, which post-#504 is the same id as the legacy assessment row).
-const newQuoteStages: string[] = ['signal', 'prospect', 'meetings', 'proposing']
-const hasOpenQuote = await hasOpenQuoteForEntity(env.DB, session.orgId, entityId)
-const showNewQuoteButton =
-  newQuoteStages.includes(entity.stage) && !hasOpenQuote && meetings.length > 0
-
-// Prior quotes eligible for an explicit supersede link — terminal-status
-// quotes the admin might be replacing with v2. We do NOT auto-select one;
-// default is "none" so supersede stays an explicit opt-in.
-const supersedeCandidates = showNewQuoteButton
-  ? quotes.filter((q) => q.status === 'declined' || q.status === 'expired')
-  : []
-
-// Stage transitions. `variant` keys into the admin action-button system
-// (Rule 3 — one primary per view): the forward stage action is `primary`,
-// Lost/Dismiss is `destructive`. Forward labels were renamed from "Send
-// Proposal" / "Engaged" / "Delivered" to "Mark as ..." — the prior labels
-// promised actions (sending the proposal, recording an engagement) but
-// only transitioned the stage. "Mark as ..." is honest about what the
-// click does. The actual proposal-send / engagement-start / delivery-handoff
-// flows live in their own buttons elsewhere on the page.
-type Transition = {
-  label: string
-  stage: EntityStage
-  variant: 'primary' | 'destructive'
-  action?: string
-}
-
-const TRANSITIONS: Record<string, Transition[]> = {
-  signal: [
-    {
-      label: 'Promote',
-      stage: 'prospect',
-      variant: 'primary',
-      action: `/api/admin/entities/${entity.id}/promote`,
-    },
-    {
-      label: 'Dismiss',
-      stage: 'lost',
-      variant: 'destructive',
-    },
-  ],
-  prospect: [
-    // "Send booking link" (#467) IS the entry into the meetings stage — it's
-    // handled by the modal below, not a plain transition. It creates a meeting
-    // row in `scheduled` status and signs a booking URL, then transitions the
-    // stage. #504's "Start Meeting" button is not needed; the booking flow
-    // already produces a meeting row and moves the entity to `meetings`.
-    { label: 'Lost', stage: 'lost', variant: 'destructive' },
-  ],
-  meetings: [
-    { label: 'Mark as Proposing', stage: 'proposing', variant: 'primary' },
-    { label: 'Lost', stage: 'lost', variant: 'destructive' },
-  ],
-  proposing: [
-    { label: 'Mark as Engaged', stage: 'engaged', variant: 'primary' },
-    { label: 'Lost', stage: 'lost', variant: 'destructive' },
-  ],
-  engaged: [{ label: 'Mark as Delivered', stage: 'delivered', variant: 'primary' }],
-  delivered: [
-    { label: 'Mark as Ongoing', stage: 'ongoing', variant: 'primary' },
-    // Re-engage from delivered is a deliberate move backward — keep it
-    // available but as a secondary affordance so it doesn't compete with
-    // the natural forward path into Ongoing.
-    { label: 'Re-engage', stage: 'prospect', variant: 'destructive' },
-  ],
-  ongoing: [
-    { label: 'Re-engage', stage: 'prospect', variant: 'primary' },
-    { label: 'Lost', stage: 'lost', variant: 'destructive' },
-  ],
-  lost: [{ label: 'Re-engage', stage: 'prospect', variant: 'primary' }],
-}
-
-function contextTypeBadge(_type: string): string {
-  return 'bg-border-subtle text-text-secondary'
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
-function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  })
-}
-
-/**
- * Past-relative comparison for `next_action_at`. Anything strictly in the
- * past becomes "Overdue" and renders red rather than the default amber
- * "scheduled in the future" tone — H7 in the entity-lifecycle UX audit.
- */
-function isOverdue(iso: string | null): boolean {
-  if (!iso) return false
-  return new Date(iso).getTime() < Date.now()
-}
-
-function parseMetadata(json: string | null): Record<string, unknown> | null {
-  if (!json) return null
-  try {
-    return JSON.parse(json)
-  } catch {
-    return null
-  }
-}
-
-// --- Dossier summary data extraction ---
-const dossierBrief = contextEntries.filter((e) => e.source === 'intelligence_brief').pop()
-const reviewSynthEntry = contextEntries.filter((e) => e.source === 'review_synthesis').pop()
-const deepWebsiteEntry = contextEntries.filter((e) => e.source === 'deep_website').pop()
-const competitorEntry = contextEntries.filter((e) => e.source === 'competitors').pop()
-const outreachEntry = contextEntries.filter((e) => e.type === 'outreach_draft').pop()
-const outreachMeta = parseMetadata(outreachEntry?.metadata ?? null)
-const outreachFromDossier = outreachMeta?.trigger === 'dossier'
-
-const hasDossier = !!dossierBrief
-
-// --- Outreach mail target (H18) ---
-// First contact with an email becomes the default recipient when the
-// admin clicks "Send outreach" — opens mailto: with the outreach draft
-// pre-populated. Multi-contact entities can edit the recipient in the
-// mail client. We don't impose a "primary" rule on contacts; first-with-
-// email is good enough for the unblock.
-const outreachContact = contacts.find((c) => c.email && c.email.trim().length > 0) ?? null
-const outreachMailto =
-  outreachEntry && outreachContact?.email
-    ? `mailto:${encodeURIComponent(outreachContact.email)}` +
-      `?subject=${encodeURIComponent(`Reaching out — ${entity.name}`)}` +
-      `&body=${encodeURIComponent(outreachEntry.content)}`
-    : null
-
-// --- Freshness indicators (H8) ---
-// Latest enrichment context entry — surfaces "Last enriched {relative}" near
-// the Re-enrich button so the operator can tell if the data is stale before
-// deciding to re-fetch.
-const lastEnrichmentAt =
-  contextEntries
-    .filter((e) => e.type === 'enrichment')
-    .map((e) => e.created_at)
-    .sort()
-    .pop() ?? null
-// Latest sent quote — surfaces "Quote sent {relative}" on Proposing-stage
-// detail so the operator knows how warm the proposal still is.
-const latestSentQuote = quotes
-  .filter((q) => q.sent_at)
-  .sort((a, b) => (b.sent_at ?? '').localeCompare(a.sent_at ?? ''))[0]
-const latestSentQuoteAt = latestSentQuote?.sent_at ?? null
-const reviewMeta = parseMetadata(reviewSynthEntry?.metadata ?? null) as {
-  unified_rating?: number | null
-  total_reviews_across_platforms?: number
-  sentiment_trend?: string
-  top_themes?: string[]
-  operational_problems?: Array<{ problem: string; confidence: string; evidence: string }>
-} | null
-const websiteMeta = parseMetadata(deepWebsiteEntry?.metadata ?? null) as {
-  digital_maturity?: { score: number; reasoning: string }
-} | null
-const competitorMeta = parseMetadata(competitorEntry?.metadata ?? null) as {
-  entity_rank_by_rating?: number | null
-  total_competitors?: number
-} | null
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
-
-function renderSimpleMarkdown(md: string): string {
-  // Escape HTML first to prevent XSS from LLM-generated content
-  let html = escapeHtml(md)
-
-  // Headings: ## -> h4 (sized for card context)
-  html = html.replace(
-    /^## (.+)$/gm,
-    (_m, t) =>
-      `<h4 class="font-semibold text-sm text-[color:var(--ss-color-text-primary)] mt-4 mb-1">${t}</h4>`
-  )
-  // Bold
-  html = html.replace(/\*\*(.+?)\*\*/g, (_m, t) => `<strong>${t}</strong>`)
-  // Unordered list items
-  html = html.replace(
-    /^- (.+)$/gm,
-    (_m, t) =>
-      `<li class="ml-4 list-disc text-sm text-[color:var(--ss-color-text-primary)]">${t}</li>`
-  )
-  // Numbered list items
-  html = html.replace(
-    /^\d+\. (.+)$/gm,
-    (_m, t) =>
-      `<li class="ml-4 list-decimal text-sm text-[color:var(--ss-color-text-primary)]">${t}</li>`
-  )
-  // Wrap consecutive <li> in <ul>/<ol>
-  html = html.replace(
-    /((?:<li class="ml-4 list-disc[^>]*>[^<]*<\/li>\n?)+)/g,
-    (_m, t) => `<ul class="mb-2">${t}</ul>`
-  )
-  html = html.replace(
-    /((?:<li class="ml-4 list-decimal[^>]*>[^<]*<\/li>\n?)+)/g,
-    (_m, t) => `<ol class="mb-2">${t}</ol>`
-  )
-  // Paragraphs: non-empty lines that aren't already wrapped
-  html = html.replace(
-    /^(?!<[hulo])(.+)$/gm,
-    (_m, t) => `<p class="text-sm text-[color:var(--ss-color-text-primary)] mb-2">${t}</p>`
-  )
-  // Clean up empty paragraphs
-  html = html.replace(
-    /<p class="text-sm text-\[color:var\(--color-text-primary\)\] mb-2"><\/p>/g,
-    ''
-  )
-
-  return html
-}
-
-function sentimentColor(trend: string): string {
-  if (trend === 'improving') return 'text-text-primary bg-surface'
-  if (trend === 'declining') return 'text-error bg-surface'
-  return 'text-text-secondary bg-background'
-}
-
-function confidenceColor(_confidence: string): string {
-  return 'bg-border-subtle text-text-secondary'
-}
+const {
+  entity,
+  contextEntries,
+  contacts,
+  meetings,
+  engagements,
+  quotes,
+  invoices,
+  mostRecentDraftableMeeting,
+  hasOutreach,
+  filteredEntries,
+  typeFilter,
+  typeCounts,
+  currentLostReason,
+  promoted,
+  noteAdded,
+  replyLogged,
+  stageUpdated,
+  dossierGenerated,
+  error,
+  showReEnrichButton,
+  showNewQuoteButton,
+  supersedeCandidates,
+  transitions,
+  dossierBrief,
+  outreachEntry,
+  outreachContact,
+  outreachMailto,
+  outreachFromDossier,
+  hasDossier,
+  lastEnrichmentAt,
+  latestSentQuoteAt,
+  reviewMeta,
+  websiteMeta,
+  competitorMeta,
+} = pageData
 ---
 
 <AdminLayout
@@ -376,58 +97,32 @@ function confidenceColor(_confidence: string): string {
       Back to {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage} list
     </span>
   </a>
-  {
-    promoted && (
-      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        {entity.name} promoted to prospect.
-      </div>
-    )
-  }
-  {
-    noteAdded && (
-      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        Note added to {entity.name}.
-      </div>
-    )
-  }
-  {
-    replyLogged && (
-      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        Reply logged on {entity.name}.
-      </div>
-    )
-  }
+  {promoted && <AdminFlashNotice message={`${entity.name} promoted to prospect.`} />}
+  {noteAdded && <AdminFlashNotice message={`Note added to ${entity.name}.`} />}
+  {replyLogged && <AdminFlashNotice message={`Reply logged on ${entity.name}.`} />}
   {
     stageUpdated && (
-      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        {entity.name} moved to{' '}
-        {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}.
-      </div>
+      <AdminFlashNotice
+        message={`${entity.name} moved to ${ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}.`}
+      />
     )
   }
   {
     dossierGenerated === 'queued' && (
-      <div class="bg-surface border border-pending text-pending text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        Re-enrichment queued for {entity.name}. The pipeline runs in the background — refresh in
-        about 30 seconds to see updated reviews, synthesis, news, and outreach draft.
-      </div>
+      <AdminFlashNotice
+        kind="warning"
+        message={`Re-enrichment queued for ${entity.name}. The pipeline runs in the background. Refresh in about 30 seconds to see updated reviews, synthesis, news, and outreach draft.`}
+      />
     )
   }
   {
     dossierGenerated === '1' && (
-      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        Re-enriched {entity.name}. Refreshed reviews, synthesis, news, and outreach draft — see
-        timeline below.
-      </div>
+      <AdminFlashNotice
+        message={`Re-enriched ${entity.name}. Refreshed reviews, synthesis, news, and outreach draft. See timeline below.`}
+      />
     )
   }
-  {
-    error && (
-      <div class="bg-surface border border-error text-error text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        {decodeURIComponent(error)}
-      </div>
-    )
-  }
+  {error && <AdminFlashNotice kind="error" message={decodeURIComponent(error)} />}
 
   {/* Entity Summary */}
   <div
@@ -572,11 +267,9 @@ function confidenceColor(_confidence: string): string {
           )
         }
         {
-          /* H18 — Send outreach via mailto: when an outreach_draft context
-             entry exists and at least one contact has an email. Pre-populates
-             subject + body; admin can edit recipient in their mail client.
-             The "Copy" affordance on the dossier outreach block stays as a
-             fallback for entities without a contact email. */
+          /* Use the latest outreach draft as a pre-filled mailto when a
+             contact email exists. The dossier copy action stays as the
+             fallback when no recipient is available. */
           outreachMailto && (
             <a
               href={outreachMailto}
@@ -588,14 +281,11 @@ function confidenceColor(_confidence: string): string {
           )
         }
         {
-          /* On meetings-stage with a draftable meeting we surface "Draft
-             proposal from meeting" as the primary (above) and the draft
-             endpoint auto-transitions to proposing on success. The "Mark
-             as Proposing" transition becomes redundant — filter it out
-             so we keep "one primary per view" (Rule 3). Lost stays. */
+          /* When a meeting can draft a proposal, the dedicated primary action
+             replaces the generic proposing transition. */
           (entity.stage === 'meetings' && mostRecentDraftableMeeting
-            ? TRANSITIONS[entity.stage]?.filter((t) => t.stage !== 'proposing')
-            : TRANSITIONS[entity.stage]
+            ? transitions.filter((t) => t.stage !== 'proposing')
+            : transitions
           )?.map((t) =>
             t.stage === 'lost' ? (
               <details class="relative lost-picker">
@@ -1319,166 +1009,8 @@ function confidenceColor(_confidence: string): string {
     }
   </style>
   <script>
-    const form = document.getElementById('re-enrich-form')
-    const btn = document.getElementById('re-enrich-btn') as HTMLButtonElement | null
-    if (form && btn) {
-      form.addEventListener('submit', () => {
-        btn.disabled = true
-        btn.textContent = 'Re-enriching...'
-      })
-    }
+    import { initEntityDetailPage } from '../../../lib/admin/entity-detail-client'
 
-    const copyBtn = document.getElementById('copy-outreach-btn')
-    const outreachEl = document.getElementById('outreach-content')
-    if (copyBtn && outreachEl) {
-      copyBtn.addEventListener('click', async () => {
-        await navigator.clipboard.writeText(outreachEl.textContent ?? '')
-        copyBtn.textContent = 'Copied!'
-        setTimeout(() => {
-          copyBtn.textContent = 'Copy'
-        }, 2000)
-      })
-    }
-
-    // Timeline long-entry read-more toggles
-    document.querySelectorAll<HTMLButtonElement>('.js-toggle-long').forEach((toggle) => {
-      toggle.addEventListener('click', () => {
-        const body = toggle.previousElementSibling as HTMLElement | null
-        if (!body || !body.classList.contains('js-truncated')) return
-        const expanded = body.classList.toggle('is-expanded')
-        toggle.textContent = expanded ? 'Show less' : 'Show more'
-      })
-    })
-
-    // --- Send booking link modal (#467) -----------------------------------
-    const sblBtn = document.getElementById('send-booking-link-btn')
-    const sblDialog = document.getElementById(
-      'send-booking-link-dialog'
-    ) as HTMLDialogElement | null
-    const sblForm = document.getElementById('send-booking-link-form') as HTMLFormElement | null
-    const sblCancel = document.getElementById('sbl-cancel')
-    const sblSubmit = document.getElementById('sbl-submit') as HTMLButtonElement | null
-    const sblError = document.getElementById('sbl-error')
-
-    if (sblBtn && sblDialog) {
-      sblBtn.addEventListener('click', () => {
-        if (sblError) {
-          sblError.classList.add('hidden')
-          sblError.textContent = ''
-        }
-        sblDialog.showModal()
-      })
-    }
-
-    if (sblCancel && sblDialog) {
-      sblCancel.addEventListener('click', () => sblDialog.close())
-    }
-
-    if (sblForm && sblDialog && sblSubmit) {
-      sblForm.addEventListener('submit', async (e) => {
-        e.preventDefault()
-        const formData = new FormData(sblForm)
-        const meetingType = (formData.get('meeting_type') ?? '').toString().trim()
-        const durationMinutes = (formData.get('duration_minutes') ?? '30').toString()
-        const sendMode = (formData.get('send_mode') ?? 'email').toString()
-        const wantsServerSend = sendMode === 'email'
-
-        sblSubmit.disabled = true
-        sblSubmit.textContent = wantsServerSend ? 'Sending...' : 'Preparing...'
-        if (sblError) {
-          sblError.classList.add('hidden')
-          sblError.textContent = ''
-        }
-
-        try {
-          const entityId = window.location.pathname.split('/').filter(Boolean).pop()
-          const res = await fetch(`/api/admin/entities/${entityId}/send-booking-link`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              meeting_type: meetingType || null,
-              duration_minutes: durationMinutes,
-              send_email: wantsServerSend,
-            }),
-          })
-          const body = (await res.json().catch(() => ({}))) as {
-            ok?: boolean
-            booking_url?: string
-            outreach_template?: string
-            mailto_url?: string
-            email_status?: string
-            send_error?: string | null
-            error?: string
-            message?: string
-          }
-          if (!res.ok || !body.ok) {
-            throw new Error(body.message ?? body.error ?? `HTTP ${res.status}`)
-          }
-
-          // When the server-side send failed, surface the error and offer
-          // the copy-paste/mailto fallback rather than silently transitioning
-          // — the admin needs to know the prospect did NOT receive the link.
-          if (body.email_status === 'send_failed') {
-            if (sblError) {
-              sblError.textContent =
-                'Email send failed. The booking link is on your clipboard — paste it into mailto or your own mail client.'
-              sblError.classList.remove('hidden')
-            }
-            if (body.outreach_template) {
-              try {
-                await navigator.clipboard.writeText(body.outreach_template)
-              } catch (copyErr) {
-                console.warn('[send-booking-link] clipboard write failed:', copyErr)
-              }
-            }
-            if (body.mailto_url) {
-              window.open(body.mailto_url, '_blank')
-            }
-            // The stage transition still happened on the server, so reload
-            // — but mark the URL so the entity detail can surface a banner
-            // that the send did not complete.
-            window.location.href = `${window.location.pathname}?stage_updated=1&send=failed`
-            return
-          }
-
-          // Copy-paste / mailto path (or no-recipient fallback) — clipboard
-          // + mailto are the deliverable. We still copy on the email path
-          // so the admin has a backup if their mail provider drops it.
-          if (body.outreach_template) {
-            try {
-              await navigator.clipboard.writeText(body.outreach_template)
-            } catch (copyErr) {
-              console.warn('[send-booking-link] clipboard write failed:', copyErr)
-            }
-          }
-
-          // Only open mailto when the server did NOT send. If the email
-          // already went out via Resend, popping a mailto would lead the
-          // admin to send it twice.
-          const skippedServerSend =
-            body.email_status === 'skipped_by_caller' ||
-            body.email_status === 'skipped_no_recipient'
-          if (skippedServerSend && body.mailto_url) {
-            window.open(body.mailto_url, '_blank')
-          }
-
-          sblDialog.close()
-
-          // Reload so the context timeline shows the new outreach_draft entry
-          // and the stage badge reflects the transition.
-          const sentParam = body.email_status === 'sent' ? '&send=sent' : ''
-          window.location.href = `${window.location.pathname}?stage_updated=1${sentParam}`
-        } catch (err) {
-          console.error('[send-booking-link] error:', err)
-          if (sblError) {
-            sblError.textContent =
-              err instanceof Error ? err.message : 'Could not send booking link.'
-            sblError.classList.remove('hidden')
-          }
-          sblSubmit.disabled = false
-          sblSubmit.textContent = 'Send link'
-        }
-      })
-    }
+    initEntityDetailPage()
   </script>
 </AdminLayout>

--- a/src/pages/admin/entities/[id]/quotes/[quoteId].astro
+++ b/src/pages/admin/entities/[id]/quotes/[quoteId].astro
@@ -1,24 +1,13 @@
 ---
 import AdminLayout from '../../../../../layouts/AdminLayout.astro'
+import AdminFlashNotice from '../../../../../components/admin/AdminFlashNotice.astro'
 import { statusBadgeClass } from '../../../../../lib/ui/status-badge'
-import { getEntity } from '../../../../../lib/db/entities'
 import {
-  getQuote,
-  parseSchedule,
-  parseDeliverables,
-  getMissingAuthoredContent,
-  QUOTE_STATUSES,
-  VALID_TRANSITIONS,
-} from '../../../../../lib/db/quotes'
-import type {
-  LineItem,
-  QuoteStatus,
-  ScheduleRow,
-  DeliverableRow,
-} from '../../../../../lib/db/quotes'
-import { listContacts } from '../../../../../lib/db/contacts'
-import { listSignalsForEntity } from '../../../../../lib/db/signal-attribution'
-import { getSOWStateForQuote } from '../../../../../lib/sow/service'
+  formatCurrency,
+  formatDate,
+  formatSignalLabel,
+  loadQuoteBuilderPage,
+} from '../../../../../lib/admin/quote-builder-page'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -39,79 +28,46 @@ const session = Astro.locals.session!
 const entityId = Astro.params.id!
 const quoteId = Astro.params.quoteId!
 
-const [entity, quote, contacts, entitySignals] = await Promise.all([
-  getEntity(env.DB, session.orgId, entityId),
-  getQuote(env.DB, session.orgId, quoteId),
-  listContacts(env.DB, session.orgId, entityId),
-  listSignalsForEntity(env.DB, session.orgId, entityId),
-])
+const pageData = await loadQuoteBuilderPage({
+  db: env.DB,
+  orgId: session.orgId,
+  entityId,
+  quoteId,
+  url: Astro.url,
+})
 
-// Format helper for the originating-signal dropdown (#589). Single-line,
-// truncated, with pipeline + date + content snippet so an admin can pick the
-// right signal at a glance.
-function formatSignalLabel(s: {
-  source_pipeline: string
-  created_at: string
-  content: string
-}): string {
-  const date = new Date(s.created_at).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
-  const oneLine = s.content.replace(/\s+/g, ' ').trim()
-  const snippet = oneLine.length > 80 ? `${oneLine.slice(0, 79)}…` : oneLine
-  return `[${s.source_pipeline}] ${date} — ${snippet}`
-}
+if (pageData?.missing === 'entity') return Astro.redirect('/admin/entities?error=not_found')
+if (pageData?.missing === 'quote')
+  return Astro.redirect(`/admin/entities/${entityId}?error=not_found`)
 
-if (!entity) return Astro.redirect('/admin/entities?error=not_found')
-if (!quote) return Astro.redirect(`/admin/entities/${entityId}?error=not_found`)
-
-const lineItems: LineItem[] = JSON.parse(quote.line_items)
-const status = quote.status as QuoteStatus
-const validTransitions = VALID_TRANSITIONS[status] ?? []
-const isDraft = status === 'draft'
-const isTerminal = validTransitions.length === 0
-
-// Authored client-facing content (#377). NULL/empty until populated.
-const schedule: ScheduleRow[] = parseSchedule(quote)
-const deliverables: DeliverableRow[] = parseDeliverables(quote)
-const engagementOverview = quote.engagement_overview ?? ''
-const milestoneLabel = quote.milestone_label ?? ''
-const missingAuthored = getMissingAuthoredContent(quote)
-
-const sowState = await getSOWStateForQuote(env.DB, session.orgId, quoteId)
-const latestSowRevision = sowState.latestRevision
-const activeSignatureRequest = sowState.openSignatureRequest
-
-// Stale PDF detection (OQ-006)
-const hasSow = !!latestSowRevision
-const sowGeneratedAt = latestSowRevision ? new Date(latestSowRevision.rendered_at) : null
-const isSowStale = !!latestSowRevision && latestSowRevision.quote_version !== quote.version
-
-// Expiration
-const expiresAt = quote.expires_at ? new Date(quote.expires_at) : null
-const isExpired = expiresAt && expiresAt < new Date()
-
-// Payment structure
-const isThreeMilestone = quote.total_hours >= 40
-const depositPct = quote.deposit_pct
-
-// URL params
-const saved = Astro.url.searchParams.get('saved')
-const error = Astro.url.searchParams.get('error')
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
-function formatCurrency(amount: number): string {
-  return `${amount.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
-}
+const {
+  entity,
+  quote,
+  contacts,
+  entitySignals,
+  lineItems,
+  status,
+  validTransitions,
+  isDraft,
+  isTerminal,
+  schedule,
+  deliverables,
+  engagementOverview,
+  milestoneLabel,
+  missingAuthored,
+  latestSowRevision,
+  activeSignatureRequest,
+  hasSow,
+  sowGeneratedAt,
+  isSowStale,
+  expiresAt,
+  isExpired,
+  isThreeMilestone,
+  depositPct,
+  saved,
+  error,
+  QUOTE_STATUSES,
+} = pageData
 ---
 
 <AdminLayout
@@ -123,1018 +79,729 @@ function formatCurrency(amount: number): string {
     { label: 'Quote' },
   ]}
 >
-  {
-    saved && (
-      <div class="bg-surface border border-complete text-complete text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        Quote saved.
-      </div>
-    )
-  }
-  {
-    error && (
-      <div class="bg-surface border border-error text-error text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        {error === 'invalid_transition'
-          ? 'Invalid status transition.'
-          : error === 'no_sow'
-            ? 'Generate a SOW PDF first.'
-            : error === 'already_sent'
-              ? 'SOW already sent for signature.'
-              : error === 'no_contact_email'
-                ? 'No contact email found. Add a contact with email first.'
-                : error === 'client_not_found'
-                  ? 'Client not found.'
-                  : decodeURIComponent(error)}
-      </div>
-    )
-  }
-
-  {/* Stale PDF warning (OQ-006) */}
-  {
-    isSowStale && (
-      <div class="bg-surface border border-border text-text-primary text-sm px-4 py-3 rounded-[var(--ss-radius-card)] mb-4">
-        The quote has been modified since the last SOW PDF was generated. Re-generate the PDF before
-        sending.
-      </div>
-    )
-  }
-
-  {/* Header */}
   <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    id="quote-builder-page"
+    data-is-draft={isDraft ? 'true' : 'false'}
+    data-rate={String(quote.rate)}
+    data-line-items={JSON.stringify(lineItems)}
   >
-    <div class="flex items-start justify-between gap-stack">
-      <div>
-        <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
-            {entity.name}
-          </h2>
-          <span class={statusBadgeClass(status)}>
-            {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
-          </span>
+    {saved && <AdminFlashNotice message="Quote saved." />}
+    {
+      error && (
+        <AdminFlashNotice
+          kind="error"
+          message={
+            error === 'invalid_transition'
+              ? 'Invalid status transition.'
+              : error === 'no_sow'
+                ? 'Generate a SOW PDF first.'
+                : error === 'already_sent'
+                  ? 'SOW already sent for signature.'
+                  : error === 'no_contact_email'
+                    ? 'No contact email found. Add a contact with email first.'
+                    : error === 'client_not_found'
+                      ? 'Client not found.'
+                      : decodeURIComponent(error)
+          }
+        />
+      )
+    }
+
+    {/* Stale PDF warning (OQ-006) */}
+    {
+      isSowStale && (
+        <AdminFlashNotice
+          kind="warning"
+          className="border-border text-text-primary"
+          message="The quote has been modified since the last SOW PDF was generated. Re-generate the PDF before sending."
+        />
+      )
+    }
+
+    {/* Header */}
+    <div
+      class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    >
+      <div class="flex items-start justify-between gap-stack">
+        <div>
+          <div class="flex items-center gap-row mb-2">
+            <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+              {entity.name}
+            </h2>
+            <span class={statusBadgeClass(status)}>
+              {QUOTE_STATUSES.find((s) => s.value === status)?.label ?? status}
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-stack text-sm text-[color:var(--ss-color-text-secondary)]"
+          >
+            <span>Created {formatDate(quote.created_at)}</span>
+            {
+              expiresAt && (
+                <span class={isExpired ? 'text-error font-medium' : ''}>
+                  {isExpired ? 'Expired' : 'Expires'} {formatDate(quote.expires_at!)}
+                </span>
+              )
+            }
+            <span>Rate: {formatCurrency(quote.rate)}/hr</span>
+            <span>v{quote.version}</span>
+          </div>
         </div>
-        <div
-          class="flex items-center gap-stack text-sm text-[color:var(--ss-color-text-secondary)]"
-        >
-          <span>Created {formatDate(quote.created_at)}</span>
+      </div>
+    </div>
+
+    {/* Line Item Editor */}
+    <div
+      class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    >
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">Line Items</h3>
+        <div id="line-item-warning" class="hidden text-sm text-error font-medium">
+          Consider keeping scope focused — 3+ line items may indicate too broad an engagement
+          (OQ-005)
+        </div>
+      </div>
+
+      <div id="line-items-container">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-[color:var(--ss-color-border)]">
+              <th
+                class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-8"
+                >#</th
+              >
+              <th
+                class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-48"
+                >Problem</th
+              >
+              <th
+                class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium"
+                >Description</th
+              >
+              <th
+                class="text-right py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-24"
+                >Est. Hours</th
+              >
+              {isDraft && <th class="py-2 px-2 w-10" />}
+            </tr>
+          </thead>
+          <tbody id="line-items-body">
+            {
+              lineItems.map((item, index) => (
+                <tr
+                  class="border-b border-[color:var(--ss-color-border-subtle)] line-item-row"
+                  data-index={index}
+                >
+                  <td class="py-2 px-2 text-[color:var(--ss-color-text-muted)] row-number">
+                    {index + 1}
+                  </td>
+                  <td class="py-2 px-2">
+                    {isDraft ? (
+                      <input
+                        type="text"
+                        class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-problem"
+                        value={item.problem}
+                        placeholder="e.g., Scheduling chaos"
+                      />
+                    ) : (
+                      <span class="text-[color:var(--ss-color-text-primary)]">{item.problem}</span>
+                    )}
+                  </td>
+                  <td class="py-2 px-2">
+                    {isDraft ? (
+                      <input
+                        type="text"
+                        class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-description"
+                        value={item.description}
+                        placeholder="What we'll deliver"
+                      />
+                    ) : (
+                      <span class="text-[color:var(--ss-color-text-primary)]">
+                        {item.description}
+                      </span>
+                    )}
+                  </td>
+                  <td class="py-2 px-2 text-right">
+                    {isDraft ? (
+                      <input
+                        type="number"
+                        class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours"
+                        value={item.estimated_hours}
+                        min="0.5"
+                        step="0.5"
+                      />
+                    ) : (
+                      <span class="text-[color:var(--ss-color-text-primary)]">
+                        {item.estimated_hours}
+                      </span>
+                    )}
+                  </td>
+                  {isDraft && (
+                    <td class="py-2 px-2 text-center">
+                      <button
+                        type="button"
+                        class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-item-btn"
+                        title="Remove"
+                      >
+                        &times;
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+
+        {
+          isDraft && (
+            <button
+              type="button"
+              id="add-line-item-btn"
+              class="mt-3 text-sm text-primary hover:text-primary-hover transition-colors font-medium"
+            >
+              + Add line item
+            </button>
+          )
+        }
+      </div>
+
+      {/* Totals */}
+      <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border)] flex justify-end">
+        <div class="text-right space-y-1">
+          <div class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            Total hours: <span
+              id="total-hours"
+              class="font-medium text-[color:var(--ss-color-text-primary)]"
+              >{quote.total_hours}</span
+            >
+          </div>
+          <div class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
+            Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {/* Payment Structure */}
+    <div
+      class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    >
+      <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
+        Payment Structure
+      </h3>
+
+      <div class="space-y-row">
+        <div class="flex items-center gap-stack">
+          <label class="text-sm text-[color:var(--ss-color-text-secondary)] w-36"
+            >Deposit percentage:</label
+          >
           {
-            expiresAt && (
-              <span class={isExpired ? 'text-error font-medium' : ''}>
-                {isExpired ? 'Expired' : 'Expires'} {formatDate(quote.expires_at!)}
+            isDraft ? (
+              <select
+                id="deposit-pct-select"
+                class="border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
+              >
+                <option value="0.5" selected={depositPct === 0.5}>
+                  50%
+                </option>
+                <option value="0.4" selected={depositPct === 0.4}>
+                  40%
+                </option>
+              </select>
+            ) : (
+              <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                {Math.round(depositPct * 100)}%
               </span>
             )
           }
-          <span>Rate: {formatCurrency(quote.rate)}/hr</span>
-          <span>v{quote.version}</span>
         </div>
-      </div>
-    </div>
-  </div>
 
-  {/* Line Item Editor */}
-  <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
-  >
-    <div class="flex items-center justify-between mb-4">
-      <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">Line Items</h3>
-      <div id="line-item-warning" class="hidden text-sm text-error font-medium">
-        Consider keeping scope focused — 3+ line items may indicate too broad an engagement (OQ-005)
-      </div>
-    </div>
-
-    <div id="line-items-container">
-      <table class="w-full text-sm">
-        <thead>
-          <tr class="border-b border-[color:var(--ss-color-border)]">
-            <th
-              class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-8"
-              >#</th
-            >
-            <th
-              class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-48"
-              >Problem</th
-            >
-            <th class="text-left py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium"
-              >Description</th
-            >
-            <th
-              class="text-right py-2 px-2 text-[color:var(--ss-color-text-secondary)] font-medium w-24"
-              >Est. Hours</th
-            >
-            {isDraft && <th class="py-2 px-2 w-10" />}
-          </tr>
-        </thead>
-        <tbody id="line-items-body">
-          {
-            lineItems.map((item, index) => (
-              <tr
-                class="border-b border-[color:var(--ss-color-border-subtle)] line-item-row"
-                data-index={index}
-              >
-                <td class="py-2 px-2 text-[color:var(--ss-color-text-muted)] row-number">
-                  {index + 1}
-                </td>
-                <td class="py-2 px-2">
-                  {isDraft ? (
-                    <input
-                      type="text"
-                      class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-problem"
-                      value={item.problem}
-                      placeholder="e.g., Scheduling chaos"
-                    />
-                  ) : (
-                    <span class="text-[color:var(--ss-color-text-primary)]">{item.problem}</span>
-                  )}
-                </td>
-                <td class="py-2 px-2">
-                  {isDraft ? (
-                    <input
-                      type="text"
-                      class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-description"
-                      value={item.description}
-                      placeholder="What we'll deliver"
-                    />
-                  ) : (
-                    <span class="text-[color:var(--ss-color-text-primary)]">
-                      {item.description}
-                    </span>
-                  )}
-                </td>
-                <td class="py-2 px-2 text-right">
-                  {isDraft ? (
-                    <input
-                      type="number"
-                      class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours"
-                      value={item.estimated_hours}
-                      min="0.5"
-                      step="0.5"
-                    />
-                  ) : (
-                    <span class="text-[color:var(--ss-color-text-primary)]">
-                      {item.estimated_hours}
-                    </span>
-                  )}
-                </td>
-                {isDraft && (
-                  <td class="py-2 px-2 text-center">
-                    <button
-                      type="button"
-                      class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-item-btn"
-                      title="Remove"
-                    >
-                      &times;
-                    </button>
-                  </td>
-                )}
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
-
-      {
-        isDraft && (
-          <button
-            type="button"
-            id="add-line-item-btn"
-            class="mt-3 text-sm text-primary hover:text-primary-hover transition-colors font-medium"
-          >
-            + Add line item
-          </button>
-        )
-      }
-    </div>
-
-    {/* Totals */}
-    <div class="mt-4 pt-4 border-t border-[color:var(--ss-color-border)] flex justify-end">
-      <div class="text-right space-y-1">
-        <div class="text-sm text-[color:var(--ss-color-text-secondary)]">
-          Total hours: <span
-            id="total-hours"
-            class="font-medium text-[color:var(--ss-color-text-primary)]">{quote.total_hours}</span
-          >
-        </div>
-        <div class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
-          Project price: <span id="total-price">{formatCurrency(quote.total_price)}</span>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {/* Payment Structure */}
-  <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
-  >
-    <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
-      Payment Structure
-    </h3>
-
-    <div class="space-y-row">
-      <div class="flex items-center gap-stack">
-        <label class="text-sm text-[color:var(--ss-color-text-secondary)] w-36"
-          >Deposit percentage:</label
-        >
         {
-          isDraft ? (
-            <select
-              id="deposit-pct-select"
-              class="border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
-            >
-              <option value="0.5" selected={depositPct === 0.5}>
-                50%
-              </option>
-              <option value="0.4" selected={depositPct === 0.4}>
-                40%
-              </option>
-            </select>
+          isThreeMilestone && (
+            <div class="text-sm text-text-primary bg-surface border border-border px-3 py-2 rounded">
+              40+ hour engagement — 3-milestone payment applies (40% deposit, 30% mid-engagement,
+              30% completion)
+            </div>
+          )
+        }
+
+        <div class="text-sm text-[color:var(--ss-color-text-secondary)] space-y-1">
+          <div class="flex justify-between max-w-xs">
+            <span>Deposit:</span>
+            <span id="deposit-amount" class="font-medium text-[color:var(--ss-color-text-primary)]">
+              {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
+            </span>
+          </div>
+          {
+            isThreeMilestone ? (
+              <>
+                <div class="flex justify-between max-w-xs">
+                  <span>Mid-engagement milestone:</span>
+                  <span class="font-medium text-[color:var(--ss-color-text-primary)]">
+                    {formatCurrency(quote.total_price * 0.3)}
+                  </span>
+                </div>
+                <div class="flex justify-between max-w-xs">
+                  <span>Completion:</span>
+                  <span class="font-medium text-[color:var(--ss-color-text-primary)]">
+                    {formatCurrency(quote.total_price * 0.3)}
+                  </span>
+                </div>
+              </>
+            ) : (
+              <div class="flex justify-between max-w-xs">
+                <span>Completion:</span>
+                <span
+                  id="completion-amount"
+                  class="font-medium text-[color:var(--ss-color-text-primary)]"
+                >
+                  {formatCurrency(quote.total_price * (1 - depositPct))}
+                </span>
+              </div>
+            )
+          }
+        </div>
+      </div>
+    </div>
+
+    {/* Authored client-facing content (#377) */}
+    <div
+      class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+    >
+      <div class="flex items-start justify-between mb-1">
+        <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
+          Client-facing content
+        </h3>
+        {
+          missingAuthored.length > 0 ? (
+            <span class="text-xs px-2 py-0.5 rounded bg-surface border border-error text-error font-medium">
+              Required to send: {missingAuthored.join(', ')}
+            </span>
           ) : (
-            <span class="text-sm text-[color:var(--ss-color-text-primary)]">
-              {Math.round(depositPct * 100)}%
+            <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary font-medium">
+              Ready to send
             </span>
           )
         }
       </div>
+      <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-5">
+        Authored per engagement. Renders on the client proposal page and SOW PDF. Quotes cannot be
+        sent until the schedule and deliverables are populated.
+      </p>
 
-      {
-        isThreeMilestone && (
-          <div class="text-sm text-text-primary bg-surface border border-border px-3 py-2 rounded">
-            40+ hour engagement — 3-milestone payment applies (40% deposit, 30% mid-engagement, 30%
-            completion)
-          </div>
-        )
-      }
-
-      <div class="text-sm text-[color:var(--ss-color-text-secondary)] space-y-1">
-        <div class="flex justify-between max-w-xs">
-          <span>Deposit:</span>
-          <span id="deposit-amount" class="font-medium text-[color:var(--ss-color-text-primary)]">
-            {formatCurrency(quote.deposit_amount ?? quote.total_price * depositPct)}
-          </span>
-        </div>
-        {
-          isThreeMilestone ? (
-            <>
-              <div class="flex justify-between max-w-xs">
-                <span>Mid-engagement milestone:</span>
-                <span class="font-medium text-[color:var(--ss-color-text-primary)]">
-                  {formatCurrency(quote.total_price * 0.3)}
-                </span>
-              </div>
-              <div class="flex justify-between max-w-xs">
-                <span>Completion:</span>
-                <span class="font-medium text-[color:var(--ss-color-text-primary)]">
-                  {formatCurrency(quote.total_price * 0.3)}
-                </span>
-              </div>
-            </>
-          ) : (
-            <div class="flex justify-between max-w-xs">
-              <span>Completion:</span>
-              <span
-                id="completion-amount"
-                class="font-medium text-[color:var(--ss-color-text-primary)]"
+      {/* Schedule */}
+      <div class="mb-6">
+        <div class="flex items-center justify-between mb-2">
+          <label class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
+            How we'll work (schedule)
+          </label>
+          {
+            isDraft && (
+              <button
+                type="button"
+                id="add-schedule-row-btn"
+                class="text-xs text-primary hover:text-primary-hover transition-colors font-medium"
               >
-                {formatCurrency(quote.total_price * (1 - depositPct))}
-              </span>
-            </div>
-          )
-        }
-      </div>
-    </div>
-  </div>
-
-  {/* Authored client-facing content (#377) */}
-  <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
-  >
-    <div class="flex items-start justify-between mb-1">
-      <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)]">
-        Client-facing content
-      </h3>
-      {
-        missingAuthored.length > 0 ? (
-          <span class="text-xs px-2 py-0.5 rounded bg-surface border border-error text-error font-medium">
-            Required to send: {missingAuthored.join(', ')}
-          </span>
-        ) : (
-          <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary font-medium">
-            Ready to send
-          </span>
-        )
-      }
-    </div>
-    <p class="text-sm text-[color:var(--ss-color-text-secondary)] mb-5">
-      Authored per engagement. Renders on the client proposal page and SOW PDF. Quotes cannot be
-      sent until the schedule and deliverables are populated.
-    </p>
-
-    {/* Schedule */}
-    <div class="mb-6">
-      <div class="flex items-center justify-between mb-2">
-        <label class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
-          How we'll work (schedule)
-        </label>
-        {
-          isDraft && (
-            <button
-              type="button"
-              id="add-schedule-row-btn"
-              class="text-xs text-primary hover:text-primary-hover transition-colors font-medium"
-            >
-              + Add row
-            </button>
-          )
-        }
-      </div>
-      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
-        One row per phase. The label sits in the left gutter (e.g. "Discovery", "Build").
-      </p>
-      <div id="schedule-rows" data-empty-text="No schedule rows authored yet.">
-        {
-          schedule.length === 0 ? (
-            <div class="text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 schedule-empty-state">
-              No schedule rows authored yet.
-            </div>
-          ) : (
-            schedule.map((row) => (
-              <div class="flex gap-2 mb-2 schedule-row">
-                {isDraft ? (
-                  <>
-                    <input
-                      type="text"
-                      class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label"
-                      value={row.label}
-                      placeholder="Label"
-                    />
-                    <input
-                      type="text"
-                      class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body"
-                      value={row.body}
-                      placeholder="What happens in this phase"
-                    />
-                    <button
-                      type="button"
-                      class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-schedule-row-btn px-2"
-                      title="Remove"
-                    >
-                      &times;
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <span class="w-32 text-sm font-medium text-[color:var(--ss-color-text-secondary)]">
-                      {row.label}
-                    </span>
-                    <span class="flex-1 text-sm text-[color:var(--ss-color-text-primary)]">
-                      {row.body}
-                    </span>
-                  </>
-                )}
+                + Add row
+              </button>
+            )
+          }
+        </div>
+        <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
+          One row per phase. The label sits in the left gutter (e.g. "Discovery", "Build").
+        </p>
+        <div id="schedule-rows" data-empty-text="No schedule rows authored yet.">
+          {
+            schedule.length === 0 ? (
+              <div class="text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 schedule-empty-state">
+                No schedule rows authored yet.
               </div>
-            ))
-          )
-        }
-      </div>
-    </div>
-
-    {/* Deliverables */}
-    <div class="mb-6">
-      <div class="flex items-center justify-between mb-2">
-        <label class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
-          What you'll get (deliverables)
-        </label>
-        {
-          isDraft && (
-            <button
-              type="button"
-              id="add-deliverable-row-btn"
-              class="text-xs text-primary hover:text-primary-hover transition-colors font-medium"
-            >
-              + Add row
-            </button>
-          )
-        }
-      </div>
-      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
-        Authored deliverables replace the line-item-derived list on the proposal page.
-      </p>
-      <div id="deliverable-rows" data-empty-text="No deliverables authored yet.">
-        {
-          deliverables.length === 0 ? (
-            <div class="text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 deliverable-empty-state">
-              No deliverables authored yet.
-            </div>
-          ) : (
-            deliverables.map((row) => (
-              <div class="mb-3 deliverable-row">
-                {isDraft ? (
-                  <div class="flex gap-2">
-                    <div class="flex-1 space-y-1">
+            ) : (
+              schedule.map((row) => (
+                <div class="flex gap-2 mb-2 schedule-row">
+                  {isDraft ? (
+                    <>
                       <input
                         type="text"
-                        class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title"
-                        value={row.title}
-                        placeholder="Title"
+                        class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label"
+                        value={row.label}
+                        placeholder="Label"
                       />
-                      <textarea
-                        class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body"
-                        rows="2"
-                        placeholder="Description"
+                      <input
+                        type="text"
+                        class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body"
+                        value={row.body}
+                        placeholder="What happens in this phase"
+                      />
+                      <button
+                        type="button"
+                        class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-schedule-row-btn px-2"
+                        title="Remove"
                       >
+                        &times;
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <span class="w-32 text-sm font-medium text-[color:var(--ss-color-text-secondary)]">
+                        {row.label}
+                      </span>
+                      <span class="flex-1 text-sm text-[color:var(--ss-color-text-primary)]">
                         {row.body}
-                      </textarea>
-                    </div>
-                    <button
-                      type="button"
-                      class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-deliverable-row-btn px-2"
-                      title="Remove"
-                    >
-                      &times;
-                    </button>
-                  </div>
-                ) : (
-                  <div>
-                    <p class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
-                      {row.title}
-                    </p>
-                    <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{row.body}</p>
-                  </div>
-                )}
-              </div>
-            ))
-          )
-        }
+                      </span>
+                    </>
+                  )}
+                </div>
+              ))
+            )
+          }
+        </div>
       </div>
-    </div>
 
-    {/* Engagement overview (SOW PDF) */}
-    <div class="mb-6">
-      <label
-        class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
-        for="engagement-overview-input"
-      >
-        Engagement overview (SOW PDF)
-      </label>
-      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
-        Renders on the SOW PDF "Engagement overview" page. Required before generating the SOW PDF.
-      </p>
-      {
-        isDraft ? (
-          <textarea
-            id="engagement-overview-input"
-            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
-            rows="3"
-            placeholder="What this engagement is about, in one or two sentences."
-          >
-            {engagementOverview}
-          </textarea>
-        ) : (
-          <p class="text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap">
-            {engagementOverview || (
-              <span class="italic text-[color:var(--ss-color-text-muted)]">Not authored.</span>
-            )}
-          </p>
-        )
-      }
-    </div>
-
-    {/* Originating signal (#589) */}
-    <div class="mb-6">
-      <label
-        class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
-        for="originating-signal-input"
-      >
-        Originating signal
-      </label>
-      <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
-        Pipeline signal that produced this engagement. Defaults to the most recent signal on file.
-        Used for ROI-per-pipeline reporting; never rendered to the client.
-      </p>
-      {
-        isDraft ? (
-          <select
-            id="originating-signal-input"
-            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
-          >
-            <option value="__none__" selected={!quote.originating_signal_id}>
-              — Unattributed —
-            </option>
-            {entitySignals.map((s) => (
-              <option value={s.id} selected={quote.originating_signal_id === s.id}>
-                {formatSignalLabel(s)}
-              </option>
-            ))}
-          </select>
-        ) : quote.originating_signal_id ? (
-          <p class="text-sm text-[color:var(--ss-color-text-primary)]">
-            {(() => {
-              const s = entitySignals.find((x) => x.id === quote.originating_signal_id)
-              return s ? formatSignalLabel(s) : 'Attributed (signal no longer visible).'
-            })()}
-          </p>
-        ) : (
-          <p class="text-sm italic text-[color:var(--ss-color-text-muted)]">Unattributed.</p>
-        )
-      }
-    </div>
-
-    {/* Milestone label (three-milestone only) */}
-    {
-      isThreeMilestone && (
-        <div class="mb-2">
-          <label
-            class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
-            for="milestone-label-input"
-          >
-            Mid-engagement milestone label
+      {/* Deliverables */}
+      <div class="mb-6">
+        <div class="flex items-center justify-between mb-2">
+          <label class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
+            What you'll get (deliverables)
           </label>
-          <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
-            Per-engagement label for the 30% mid-engagement milestone (e.g. "First-pass review",
-            "Pilot rollout"). Optional; the SOW renders neutral wording when empty.
-          </p>
-          {isDraft ? (
-            <input
-              id="milestone-label-input"
-              type="text"
+          {
+            isDraft && (
+              <button
+                type="button"
+                id="add-deliverable-row-btn"
+                class="text-xs text-primary hover:text-primary-hover transition-colors font-medium"
+              >
+                + Add row
+              </button>
+            )
+          }
+        </div>
+        <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
+          Authored deliverables replace the line-item-derived list on the proposal page.
+        </p>
+        <div id="deliverable-rows" data-empty-text="No deliverables authored yet.">
+          {
+            deliverables.length === 0 ? (
+              <div class="text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 deliverable-empty-state">
+                No deliverables authored yet.
+              </div>
+            ) : (
+              deliverables.map((row) => (
+                <div class="mb-3 deliverable-row">
+                  {isDraft ? (
+                    <div class="flex gap-2">
+                      <div class="flex-1 space-y-1">
+                        <input
+                          type="text"
+                          class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title"
+                          value={row.title}
+                          placeholder="Title"
+                        />
+                        <textarea
+                          class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body"
+                          rows="2"
+                          placeholder="Description"
+                        >
+                          {row.body}
+                        </textarea>
+                      </div>
+                      <button
+                        type="button"
+                        class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-deliverable-row-btn px-2"
+                        title="Remove"
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  ) : (
+                    <div>
+                      <p class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]">
+                        {row.title}
+                      </p>
+                      <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{row.body}</p>
+                    </div>
+                  )}
+                </div>
+              ))
+            )
+          }
+        </div>
+      </div>
+
+      {/* Engagement overview (SOW PDF) */}
+      <div class="mb-6">
+        <label
+          class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
+          for="engagement-overview-input"
+        >
+          Engagement overview (SOW PDF)
+        </label>
+        <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
+          Renders on the SOW PDF "Engagement overview" page. Required before generating the SOW PDF.
+        </p>
+        {
+          isDraft ? (
+            <textarea
+              id="engagement-overview-input"
               class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
-              value={milestoneLabel}
-              placeholder="Optional label for the mid-engagement milestone"
-            />
+              rows="3"
+              placeholder="What this engagement is about, in one or two sentences."
+            >
+              {engagementOverview}
+            </textarea>
           ) : (
-            <p class="text-sm text-[color:var(--ss-color-text-primary)]">
-              {milestoneLabel || (
+            <p class="text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap">
+              {engagementOverview || (
                 <span class="italic text-[color:var(--ss-color-text-muted)]">Not authored.</span>
               )}
             </p>
-          )}
-        </div>
-      )
-    }
-  </div>
-
-  {/* SOW PDF Status */}
-  {
-    hasSow && (
-      <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
-        <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
-          SOW PDF
-        </h3>
-        <div class="text-sm text-[color:var(--ss-color-text-secondary)] space-y-1">
-          <div>
-            Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
-          </div>
-          {activeSignatureRequest?.provider_request_id && (
-            <div class="text-text-primary">Sent for signature via SignWell</div>
-          )}
-        </div>
+          )
+        }
       </div>
-    )
-  }
 
-  {/* Actions */}
-  <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
-  >
-    <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">Actions</h3>
-    <div class="flex flex-wrap gap-row">
-      {/* Save Draft */}
-      {
-        isDraft && (
-          <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="save-form">
-            <input type="hidden" name="action" value="update" />
-            <input
-              type="hidden"
-              name="line_items"
-              id="save-line-items"
-              value={JSON.stringify(lineItems)}
-            />
-            <input
-              type="hidden"
-              name="deposit_pct"
-              id="save-deposit-pct"
-              value={String(depositPct)}
-            />
-            <input
-              type="hidden"
-              name="schedule"
-              id="save-schedule"
-              value={JSON.stringify(schedule)}
-            />
-            <input
-              type="hidden"
-              name="deliverables"
-              id="save-deliverables"
-              value={JSON.stringify(deliverables)}
-            />
-            <input
-              type="hidden"
-              name="engagement_overview"
-              id="save-engagement-overview"
-              value={engagementOverview}
-            />
-            <input
-              type="hidden"
-              name="milestone_label"
-              id="save-milestone-label"
-              value={milestoneLabel}
-            />
-            <input
-              type="hidden"
-              name="originating_signal_id"
-              id="save-originating-signal-id"
-              value={quote.originating_signal_id ?? '__none__'}
-            />
-            <button
-              type="submit"
-              class="px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors text-sm font-medium"
-            >
-              Save Draft
-            </button>
-          </form>
-        )
-      }
-
-      {/* Generate SOW PDF */}
-      {
-        isDraft && (
-          <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="generate-pdf-form">
-            <input type="hidden" name="action" value="generate-pdf" />
-            <button
-              type="submit"
-              class="px-4 py-2 border border-border bg-surface text-text-primary rounded hover:bg-background transition-colors text-sm font-medium"
-              id="generate-pdf-btn"
-            >
-              {hasSow ? 'Re-generate SOW PDF' : 'Generate SOW PDF'}
-            </button>
-          </form>
-        )
-      }
-
-      {/* Send via SignWell */}
-      {
-        (isDraft || status === 'sent') && hasSow && !activeSignatureRequest && (
-          <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
+      {/* Originating signal (#589) */}
+      <div class="mb-6">
+        <label
+          class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
+          for="originating-signal-input"
+        >
+          Originating signal
+        </label>
+        <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
+          Pipeline signal that produced this engagement. Defaults to the most recent signal on file.
+          Used for ROI-per-pipeline reporting; never rendered to the client.
+        </p>
+        {
+          isDraft ? (
             <select
-              name="signer_contact_id"
-              class="px-3 py-2 border border-[color:var(--ss-color-border)] rounded text-sm bg-surface"
-              required
+              id="originating-signal-input"
+              class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
             >
-              {contacts
-                .filter((contact) => contact.email)
-                .map((contact) => (
-                  <option value={contact.id}>
-                    {contact.name} {contact.email ? `(${contact.email})` : ''}
-                  </option>
-                ))}
+              <option value="__none__" selected={!quote.originating_signal_id}>
+                — Unattributed —
+              </option>
+              {entitySignals.map((s) => (
+                <option value={s.id} selected={quote.originating_signal_id === s.id}>
+                  {formatSignalLabel(s)}
+                </option>
+              ))}
             </select>
-            <button
-              type="submit"
-              class="px-4 py-2 border border-border bg-surface text-text-primary rounded hover:bg-background transition-colors text-sm font-medium"
-              id="sign-btn"
-            >
-              Send via SignWell
-            </button>
-          </form>
-        )
-      }
-      {/* Decline */}
-      {
-        validTransitions.includes('declined') && (
-          <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
-            <input type="hidden" name="action" value="decline" />
-            <button
-              type="submit"
-              class="px-4 py-2 bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] rounded hover:bg-[color:var(--ss-color-border)] transition-colors text-sm font-medium"
-            >
-              Decline
-            </button>
-          </form>
-        )
-      }
+          ) : quote.originating_signal_id ? (
+            <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+              {(() => {
+                const s = entitySignals.find((x) => x.id === quote.originating_signal_id)
+                return s ? formatSignalLabel(s) : 'Attributed (signal no longer visible).'
+              })()}
+            </p>
+          ) : (
+            <p class="text-sm italic text-[color:var(--ss-color-text-muted)]">Unattributed.</p>
+          )
+        }
+      </div>
 
-      {/* Mark Expired */}
+      {/* Milestone label (three-milestone only) */}
       {
-        validTransitions.includes('expired') && (
-          <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
-            <input type="hidden" name="action" value="expire" />
-            <button
-              type="submit"
-              class="px-4 py-2 bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] rounded hover:bg-[color:var(--ss-color-border)] transition-colors text-sm font-medium"
+        isThreeMilestone && (
+          <div class="mb-2">
+            <label
+              class="block text-sm font-semibold text-[color:var(--ss-color-text-primary)] mb-1"
+              for="milestone-label-input"
             >
-              Mark Expired
-            </button>
-          </form>
+              Mid-engagement milestone label
+            </label>
+            <p class="text-xs text-[color:var(--ss-color-text-secondary)] mb-2">
+              Per-engagement label for the 30% mid-engagement milestone (e.g. "First-pass review",
+              "Pilot rollout"). Optional; the SOW renders neutral wording when empty.
+            </p>
+            {isDraft ? (
+              <input
+                id="milestone-label-input"
+                type="text"
+                class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm"
+                value={milestoneLabel}
+                placeholder="Optional label for the mid-engagement milestone"
+              />
+            ) : (
+              <p class="text-sm text-[color:var(--ss-color-text-primary)]">
+                {milestoneLabel || (
+                  <span class="italic text-[color:var(--ss-color-text-muted)]">Not authored.</span>
+                )}
+              </p>
+            )}
+          </div>
         )
       }
     </div>
 
+    {/* SOW PDF Status */}
     {
-      isTerminal && (
-        <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
-          This quote is in a terminal state ({status}) and cannot be modified.
-        </p>
+      hasSow && (
+        <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6">
+          <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
+            SOW PDF
+          </h3>
+          <div class="text-sm text-[color:var(--ss-color-text-secondary)] space-y-1">
+            <div>
+              Generated: {sowGeneratedAt ? formatDate(latestSowRevision!.rendered_at) : 'Unknown'}
+            </div>
+            {activeSignatureRequest?.provider_request_id && (
+              <div class="text-text-primary">Sent for signature via SignWell</div>
+            )}
+          </div>
+        </div>
       )
     }
-  </div>
-  <script define:vars={{ lineItems, isDraft, rate: quote.rate }}>
-    if (!isDraft) {
-      // Read-only mode — no interactive behavior needed
-    } else {
-      const body = document.getElementById('line-items-body')
-      const addBtn = document.getElementById('add-line-item-btn')
-      const warning = document.getElementById('line-item-warning')
-      const totalHoursEl = document.getElementById('total-hours')
-      const totalPriceEl = document.getElementById('total-price')
-      const depositAmountEl = document.getElementById('deposit-amount')
-      const completionAmountEl = document.getElementById('completion-amount')
-      const depositSelect = document.getElementById('deposit-pct-select')
-      const saveLineItemsInput = document.getElementById('save-line-items')
-      const saveDepositPctInput = document.getElementById('save-deposit-pct')
-      const saveScheduleInput = document.getElementById('save-schedule')
-      const saveDeliverablesInput = document.getElementById('save-deliverables')
-      const saveEngagementOverviewInput = document.getElementById('save-engagement-overview')
-      const saveMilestoneLabelInput = document.getElementById('save-milestone-label')
-      const saveOriginatingSignalInput = document.getElementById('save-originating-signal-id')
-      const scheduleRowsContainer = document.getElementById('schedule-rows')
-      const deliverableRowsContainer = document.getElementById('deliverable-rows')
-      const addScheduleRowBtn = document.getElementById('add-schedule-row-btn')
-      const addDeliverableRowBtn = document.getElementById('add-deliverable-row-btn')
-      const engagementOverviewInput = document.getElementById('engagement-overview-input')
-      const milestoneLabelInput = document.getElementById('milestone-label-input')
-      const originatingSignalInput = document.getElementById('originating-signal-input')
-      const generatePdfBtn = document.getElementById('generate-pdf-btn')
-      const signBtn = document.getElementById('sign-btn')
 
-      function getLineItems() {
-        const rows = body.querySelectorAll('.line-item-row')
-        const items = []
-        rows.forEach((row) => {
-          const problem = row.querySelector('.item-problem')?.value ?? ''
-          const description = row.querySelector('.item-description')?.value ?? ''
-          const hours = parseFloat(row.querySelector('.item-hours')?.value ?? '0')
-          if (problem.trim() || description.trim()) {
-            items.push({
-              problem: problem.trim(),
-              description: description.trim(),
-              estimated_hours: isNaN(hours) ? 0 : hours,
-            })
-          }
-        })
-        return items
-      }
-
-      function recalculate() {
-        const items = getLineItems()
-        const totalHours = items.reduce((sum, item) => sum + item.estimated_hours, 0)
-        const totalPrice = totalHours * rate
-        const depositPct = parseFloat(depositSelect?.value ?? '0.5')
-
-        if (totalHoursEl) totalHoursEl.textContent = String(totalHours)
-        if (totalPriceEl) {
-          totalPriceEl.textContent =
-            '$' +
-            totalPrice.toLocaleString('en-US', {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 0,
-            })
+    {/* Actions */}
+    <div
+      class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    >
+      <h3 class="text-lg font-semibold text-[color:var(--ss-color-text-primary)] mb-4">Actions</h3>
+      <div class="flex flex-wrap gap-row">
+        {/* Save Draft */}
+        {
+          isDraft && (
+            <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="save-form">
+              <input type="hidden" name="action" value="update" />
+              <input
+                type="hidden"
+                name="line_items"
+                id="save-line-items"
+                value={JSON.stringify(lineItems)}
+              />
+              <input
+                type="hidden"
+                name="deposit_pct"
+                id="save-deposit-pct"
+                value={String(depositPct)}
+              />
+              <input
+                type="hidden"
+                name="schedule"
+                id="save-schedule"
+                value={JSON.stringify(schedule)}
+              />
+              <input
+                type="hidden"
+                name="deliverables"
+                id="save-deliverables"
+                value={JSON.stringify(deliverables)}
+              />
+              <input
+                type="hidden"
+                name="engagement_overview"
+                id="save-engagement-overview"
+                value={engagementOverview}
+              />
+              <input
+                type="hidden"
+                name="milestone_label"
+                id="save-milestone-label"
+                value={milestoneLabel}
+              />
+              <input
+                type="hidden"
+                name="originating_signal_id"
+                id="save-originating-signal-id"
+                value={quote.originating_signal_id ?? '__none__'}
+              />
+              <button
+                type="submit"
+                class="px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors text-sm font-medium"
+              >
+                Save Draft
+              </button>
+            </form>
+          )
         }
 
-        const depositAmount = totalPrice * depositPct
-        const completionAmount = totalPrice * (1 - depositPct)
-        if (depositAmountEl) {
-          depositAmountEl.textContent =
-            '$' +
-            depositAmount.toLocaleString('en-US', {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 0,
-            })
-        }
-        if (completionAmountEl) {
-          completionAmountEl.textContent =
-            '$' +
-            completionAmount.toLocaleString('en-US', {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 0,
-            })
+        {/* Generate SOW PDF */}
+        {
+          isDraft && (
+            <form method="POST" action={`/api/admin/quotes/${quoteId}`} id="generate-pdf-form">
+              <input type="hidden" name="action" value="generate-pdf" />
+              <button
+                type="submit"
+                class="px-4 py-2 border border-border bg-surface text-text-primary rounded hover:bg-background transition-colors text-sm font-medium"
+                id="generate-pdf-btn"
+              >
+                {hasSow ? 'Re-generate SOW PDF' : 'Generate SOW PDF'}
+              </button>
+            </form>
+          )
         }
 
-        // OQ-005: soft warning at 3+ line items
-        if (warning) {
-          warning.classList.toggle('hidden', items.length < 3)
+        {/* Send via SignWell */}
+        {
+          (isDraft || status === 'sent') && hasSow && !activeSignatureRequest && (
+            <form method="POST" action={`/api/admin/quotes/${quoteId}/sign`} id="sign-form">
+              <select
+                name="signer_contact_id"
+                class="px-3 py-2 border border-[color:var(--ss-color-border)] rounded text-sm bg-surface"
+                required
+              >
+                {contacts
+                  .filter((contact) => contact.email)
+                  .map((contact) => (
+                    <option value={contact.id}>
+                      {contact.name} {contact.email ? `(${contact.email})` : ''}
+                    </option>
+                  ))}
+              </select>
+              <button
+                type="submit"
+                class="px-4 py-2 border border-border bg-surface text-text-primary rounded hover:bg-background transition-colors text-sm font-medium"
+                id="sign-btn"
+              >
+                Send via SignWell
+              </button>
+            </form>
+          )
+        }
+        {/* Decline */}
+        {
+          validTransitions.includes('declined') && (
+            <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+              <input type="hidden" name="action" value="decline" />
+              <button
+                type="submit"
+                class="px-4 py-2 bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] rounded hover:bg-[color:var(--ss-color-border)] transition-colors text-sm font-medium"
+              >
+                Decline
+              </button>
+            </form>
+          )
         }
 
-        // Update hidden form fields
-        if (saveLineItemsInput) saveLineItemsInput.value = JSON.stringify(items)
-        if (saveDepositPctInput) saveDepositPctInput.value = String(depositPct)
+        {/* Mark Expired */}
+        {
+          validTransitions.includes('expired') && (
+            <form method="POST" action={`/api/admin/quotes/${quoteId}`}>
+              <input type="hidden" name="action" value="expire" />
+              <button
+                type="submit"
+                class="px-4 py-2 bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] rounded hover:bg-[color:var(--ss-color-border)] transition-colors text-sm font-medium"
+              >
+                Mark Expired
+              </button>
+            </form>
+          )
+        }
+      </div>
 
-        renumberRows()
-      }
-
-      // ---- Authored client-facing content (#377) ----
-
-      function clearEmptyState(container) {
-        if (!container) return
-        const empty = container.querySelector('.schedule-empty-state, .deliverable-empty-state')
-        if (empty) empty.remove()
-      }
-
-      function maybeShowEmptyState(container, isDeliverable) {
-        if (!container) return
-        const rows = container.querySelectorAll(
-          isDeliverable ? '.deliverable-row' : '.schedule-row'
+      {
+        isTerminal && (
+          <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+            This quote is in a terminal state ({status}) and cannot be modified.
+          </p>
         )
-        if (rows.length === 0) {
-          const div = document.createElement('div')
-          div.className =
-            'text-sm text-[color:var(--ss-color-text-secondary)] italic py-2 ' +
-            (isDeliverable ? 'deliverable-empty-state' : 'schedule-empty-state')
-          div.textContent = container.getAttribute('data-empty-text') ?? ''
-          container.appendChild(div)
-        }
       }
+    </div>
+  </div>
+  <script>
+    import { initQuoteBuilderPage } from '../../../../../lib/admin/quote-builder-client'
 
-      function getScheduleRows() {
-        if (!scheduleRowsContainer) return []
-        const rows = scheduleRowsContainer.querySelectorAll('.schedule-row')
-        const out = []
-        rows.forEach((row) => {
-          const label = row.querySelector('.schedule-label')?.value?.trim() ?? ''
-          const bodyText = row.querySelector('.schedule-body')?.value?.trim() ?? ''
-          if (label.length > 0 || bodyText.length > 0) {
-            out.push({ label, body: bodyText })
-          }
-        })
-        return out
-      }
-
-      function getDeliverableRows() {
-        if (!deliverableRowsContainer) return []
-        const rows = deliverableRowsContainer.querySelectorAll('.deliverable-row')
-        const out = []
-        rows.forEach((row) => {
-          const title = row.querySelector('.deliverable-title')?.value?.trim() ?? ''
-          const bodyText = row.querySelector('.deliverable-body')?.value?.trim() ?? ''
-          if (title.length > 0 || bodyText.length > 0) {
-            out.push({ title, body: bodyText })
-          }
-        })
-        return out
-      }
-
-      function syncAuthoredContentInputs() {
-        if (saveScheduleInput) saveScheduleInput.value = JSON.stringify(getScheduleRows())
-        if (saveDeliverablesInput) {
-          saveDeliverablesInput.value = JSON.stringify(getDeliverableRows())
-        }
-        if (saveEngagementOverviewInput && engagementOverviewInput) {
-          saveEngagementOverviewInput.value = engagementOverviewInput.value
-        }
-        if (saveMilestoneLabelInput && milestoneLabelInput) {
-          saveMilestoneLabelInput.value = milestoneLabelInput.value
-        }
-        if (saveOriginatingSignalInput && originatingSignalInput) {
-          // Mirror the dropdown value (#589) into the save form. The "__none__"
-          // sentinel is sent verbatim — the API endpoint translates it back to
-          // null. Real signal ids pass through unchanged.
-          saveOriginatingSignalInput.value = originatingSignalInput.value
-        }
-      }
-
-      function addScheduleRow() {
-        if (!scheduleRowsContainer) return
-        clearEmptyState(scheduleRowsContainer)
-        const div = document.createElement('div')
-        div.className = 'flex gap-2 mb-2 schedule-row'
-        div.innerHTML = `
-          <input type="text" class="w-32 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-label" placeholder="Label" />
-          <input type="text" class="flex-1 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm schedule-body" placeholder="What happens in this phase" />
-          <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-schedule-row-btn px-2" title="Remove">&times;</button>
-        `
-        scheduleRowsContainer.appendChild(div)
-      }
-
-      function addDeliverableRow() {
-        if (!deliverableRowsContainer) return
-        clearEmptyState(deliverableRowsContainer)
-        const div = document.createElement('div')
-        div.className = 'mb-3 deliverable-row'
-        div.innerHTML = `
-          <div class="flex gap-2">
-            <div class="flex-1 space-y-1">
-              <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-title" placeholder="Title" />
-              <textarea class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm deliverable-body" rows="2" placeholder="Description"></textarea>
-            </div>
-            <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-deliverable-row-btn px-2" title="Remove">&times;</button>
-          </div>
-        `
-        deliverableRowsContainer.appendChild(div)
-      }
-
-      if (addScheduleRowBtn) addScheduleRowBtn.addEventListener('click', addScheduleRow)
-      if (addDeliverableRowBtn) addDeliverableRowBtn.addEventListener('click', addDeliverableRow)
-
-      if (scheduleRowsContainer) {
-        scheduleRowsContainer.addEventListener('click', (e) => {
-          if (e.target.classList.contains('remove-schedule-row-btn')) {
-            const row = e.target.closest('.schedule-row')
-            if (row) {
-              row.remove()
-              maybeShowEmptyState(scheduleRowsContainer, false)
-            }
-          }
-        })
-      }
-
-      if (deliverableRowsContainer) {
-        deliverableRowsContainer.addEventListener('click', (e) => {
-          if (e.target.classList.contains('remove-deliverable-row-btn')) {
-            const row = e.target.closest('.deliverable-row')
-            if (row) {
-              row.remove()
-              maybeShowEmptyState(deliverableRowsContainer, true)
-            }
-          }
-        })
-      }
-
-      function renumberRows() {
-        const rows = body.querySelectorAll('.line-item-row')
-        rows.forEach((row, i) => {
-          const num = row.querySelector('.row-number')
-          if (num) num.textContent = String(i + 1)
-          row.setAttribute('data-index', String(i))
-        })
-      }
-
-      function addRow() {
-        const index = body.querySelectorAll('.line-item-row').length
-        const tr = document.createElement('tr')
-        tr.className = 'border-b border-[color:var(--ss-color-border-subtle)] line-item-row'
-        tr.setAttribute('data-index', String(index))
-        tr.innerHTML = `
-            <td class="py-2 px-2 text-[color:var(--ss-color-text-muted)] row-number">${index + 1}</td>
-            <td class="py-2 px-2">
-              <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-problem" value="" placeholder="e.g., Scheduling chaos" />
-            </td>
-            <td class="py-2 px-2">
-              <input type="text" class="w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm item-description" value="" placeholder="What we'll deliver" />
-            </td>
-            <td class="py-2 px-2 text-right">
-              <input type="number" class="w-20 border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm text-right item-hours" value="0" min="0.5" step="0.5" />
-            </td>
-            <td class="py-2 px-2 text-center">
-              <button type="button" class="text-[color:var(--ss-color-text-muted)] hover:text-error transition-colors remove-item-btn" title="Remove">&times;</button>
-            </td>
-          `
-        body.appendChild(tr)
-        recalculate()
-      }
-
-      if (addBtn) addBtn.addEventListener('click', addRow)
-
-      // Event delegation for remove buttons and input changes
-      body.addEventListener('click', (e) => {
-        if (e.target.classList.contains('remove-item-btn')) {
-          const row = e.target.closest('.line-item-row')
-          if (row && body.querySelectorAll('.line-item-row').length > 1) {
-            row.remove()
-            recalculate()
-          }
-        }
-      })
-
-      body.addEventListener('input', recalculate)
-      if (depositSelect) depositSelect.addEventListener('change', recalculate)
-
-      // Before form submit, sync line items + authored content to hidden fields
-      const saveForm = document.getElementById('save-form')
-      if (saveForm) {
-        saveForm.addEventListener('submit', () => {
-          recalculate()
-          syncAuthoredContentInputs()
-        })
-      }
-
-      // Disable buttons on submit to prevent double-clicks
-      const generatePdfForm = document.getElementById('generate-pdf-form')
-      if (generatePdfForm && generatePdfBtn) {
-        generatePdfForm.addEventListener('submit', () => {
-          generatePdfBtn.disabled = true
-          generatePdfBtn.textContent = 'Generating...'
-        })
-      }
-
-      const signForm = document.getElementById('sign-form')
-      if (signForm && signBtn) {
-        signForm.addEventListener('submit', () => {
-          signBtn.disabled = true
-          signBtn.textContent = 'Sending...'
-        })
-      }
-
-      // Initial state check for OQ-005
-      if (warning && lineItems.length >= 3) {
-        warning.classList.remove('hidden')
-      }
-    }
+    initQuoteBuilderPage()
   </script>
 </AdminLayout>

--- a/src/pages/auth/login.astro
+++ b/src/pages/auth/login.astro
@@ -33,7 +33,7 @@ const errorMessage = error ? (errorMessages[error] ?? errorMessages.server) : nu
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <title>Sign In — SMD Services</title>
+    <title>Sign In | SMD Services</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/auth/portal-login.astro
+++ b/src/pages/auth/portal-login.astro
@@ -16,7 +16,7 @@ const error = Astro.url.searchParams.get('error')
 const prefillEmail = Astro.url.searchParams.get('email') ?? ''
 
 const statusMessages: Record<string, { text: string; type: 'success' | 'error' }> = {
-  sent: { text: 'Check your email — we just sent you a sign-in link.', type: 'success' },
+  sent: { text: 'Check your email. We just sent you a sign-in link.', type: 'success' },
   expired: { text: 'That link has expired. Enter your email to get a new one.', type: 'error' },
   invalid: { text: 'That link is invalid or has already been used.', type: 'error' },
   no_account: {
@@ -44,7 +44,7 @@ const message = status ? statusMessages[status] : error ? statusMessages[error] 
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <title>Sign In — SMD Services Portal</title>
+    <title>Sign In | SMD Services Portal</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -5,7 +5,8 @@ import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import SlotPicker from '../components/booking/SlotPicker.astro'
-import { ENTITY_VERTICALS, getEntity } from '../lib/db/entities'
+import IntakeQuestionnaire from '../components/booking/IntakeQuestionnaire.astro'
+import { getEntity } from '../lib/db/entities'
 import { getContact } from '../lib/db/contacts'
 import { resolveTurnstileConfig } from '../lib/booking/turnstile'
 import { verifyBookingLink } from '../lib/booking/signed-link'
@@ -83,8 +84,8 @@ if (prefillToken) {
             prefillTokenError && (
               <div class="mb-6 rounded-[var(--ss-radius-card)] bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
                 {prefillTokenError === 'expired'
-                  ? 'This booking link has expired. You can still pick a time below — we will just take a few extra details.'
-                  : 'This booking link is not valid. You can still pick a time below — we will just take a few extra details.'}
+                  ? 'This booking link has expired. You can still pick a time below. We will just take a few extra details.'
+                  : 'This booking link is not valid. You can still pick a time below. We will just take a few extra details.'}
               </div>
             )
           }
@@ -105,7 +106,7 @@ if (prefillToken) {
             <a href="/outside-view" class="font-medium text-primary underline hover:text-primary/80"
               >See what we see</a
             >
-            — drop your URL and we'll send you back an Outside View.
+            . Drop your URL and we'll send you back an Outside View.
           </p>
 
           <!-- Step 2: Intake form (appears after slot selection) -->
@@ -149,7 +150,12 @@ if (prefillToken) {
               </button>
             </div>
 
-            <form id="booking-form" class="mt-6 space-y-5" novalidate>
+            <form
+              id="booking-form"
+              class="mt-6 space-y-5"
+              novalidate
+              data-turnstile-site-key={turnstileSiteKey}
+            >
               {
                 /* Prefill token from admin "Send booking link" action (#467).
                    When present, the reserve endpoint anchors this booking to
@@ -168,211 +174,15 @@ if (prefillToken) {
                 <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
               </div>
 
-              <!-- Name + Email -->
-              <div class="grid gap-5 sm:grid-cols-2">
-                <div>
-                  <label
-                    for="bf-name"
-                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                  >
-                    Full name <span class="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    id="bf-name"
-                    name="name"
-                    required
-                    maxlength="200"
-                    autocomplete="name"
-                    value={prefillContactName ?? ''}
-                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                    placeholder="e.g. Maria Garcia"
-                  />
-                </div>
-                <div>
-                  <label
-                    for="bf-email"
-                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                  >
-                    Work email <span class="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="email"
-                    id="bf-email"
-                    name="email"
-                    required
-                    maxlength="254"
-                    autocomplete="email"
-                    value={prefillEmail ?? ''}
-                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                    placeholder="maria@example.com"
-                  />
-                </div>
-              </div>
-
-              <!-- Business name + Phone -->
-              <div class="grid gap-5 sm:grid-cols-2">
-                <div>
-                  <label
-                    for="bf-business"
-                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                  >
-                    Business name <span class="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    id="bf-business"
-                    name="business_name"
-                    required
-                    maxlength="200"
-                    value={prefillBusinessName ?? ''}
-                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                    placeholder="e.g. Phoenix Plumbing Co."
-                  />
-                </div>
-                <div>
-                  <label
-                    for="bf-phone"
-                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                  >
-                    Phone <span class="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="tel"
-                    id="bf-phone"
-                    name="phone"
-                    required
-                    maxlength="30"
-                    autocomplete="tel"
-                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                    placeholder="(602) 555-0123"
-                  />
-                </div>
-              </div>
-
-              <!-- Vertical + Employee count -->
-              <div class="grid gap-5 sm:grid-cols-2">
-                <div>
-                  <label
-                    for="bf-vertical"
-                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                  >
-                    What kind of business?
-                  </label>
-                  <select
-                    id="bf-vertical"
-                    name="vertical"
-                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  >
-                    <option value="">Select one</option>
-                    {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
-                  </select>
-                  <input
-                    type="text"
-                    id="bf-vertical-other"
-                    name="vertical_other"
-                    class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                    placeholder="Describe your business type"
-                  />
-                </div>
-                <div>
-                  <label
-                    for="bf-employees"
-                    class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                  >
-                    Employee count
-                  </label>
-                  <select
-                    id="bf-employees"
-                    name="employee_count"
-                    class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  >
-                    <option value="">Select one</option>
-                    <option value="1-5">1 - 5</option>
-                    <option value="6-10">6 - 10</option>
-                    <option value="11-25">11 - 25</option>
-                    <option value="26-50">26 - 50</option>
-                    <option value="50+">50+</option>
-                  </select>
-                </div>
-              </div>
-
-              <!-- Years in business -->
-              <div class="sm:w-1/2">
-                <label
-                  for="bf-years"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  Years in business
-                </label>
-                <select
-                  id="bf-years"
-                  name="years_in_business"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                >
-                  <option value="">Select one</option>
-                  <option value="<1">Less than 1 year</option>
-                  <option value="1-3">1 - 3 years</option>
-                  <option value="3-5">3 - 5 years</option>
-                  <option value="5-10">5 - 10 years</option>
-                  <option value="10+">10+ years</option>
-                </select>
-              </div>
-
-              <!-- Biggest challenge -->
-              <div>
-                <label
-                  for="bf-challenge"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  What's the single biggest operational challenge right now? <span
-                    class="text-red-500">*</span
-                  >
-                </label>
-                <p class="mt-0.5 text-xs text-[color:var(--ss-color-text-muted)]">
-                  What would make the biggest difference in how your business runs day to day?
-                </p>
-                <textarea
-                  id="bf-challenge"
-                  name="biggest_challenge"
-                  required
-                  rows="3"
-                  maxlength="2000"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="e.g. I want to stop being the bottleneck for every decision..."
-                ></textarea>
-              </div>
-
-              <!-- How heard -->
-              <div>
-                <label
-                  for="bf-how-heard"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  How did you hear about us?
-                </label>
-                <select
-                  id="bf-how-heard"
-                  name="how_heard"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                >
-                  <option value="">Select one</option>
-                  <option value="Google Search">Google Search</option>
-                  <option value="Referral">Referral</option>
-                  <option value="BNI / Networking group">BNI / Networking group</option>
-                  <option value="Chamber of Commerce">Chamber of Commerce</option>
-                  <option value="Social Media">Social Media</option>
-                  <option value="SCORE / SBA">SCORE / SBA</option>
-                  <option value="other">Other</option>
-                </select>
-                <input
-                  type="text"
-                  id="bf-how-heard-other"
-                  name="how_heard_other"
-                  class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="Tell us more"
-                />
-              </div>
+              <IntakeQuestionnaire
+                idPrefix="bf"
+                mode="booking"
+                values={{
+                  name: prefillContactName ?? undefined,
+                  email: prefillEmail ?? undefined,
+                  businessName: prefillBusinessName ?? undefined,
+                }}
+              />
 
               <!-- Turnstile -->
               <div id="turnstile-container"></div>
@@ -435,7 +245,7 @@ if (prefillToken) {
                   href="/get-started?booked=1"
                   class="font-medium text-primary underline hover:text-primary/80"
                   data-ev="book-post-confirm-intake">Help us prepare for your call</a
-                > — a few quick questions so we can make the most of our time together.
+                >. A few quick questions will help us make the most of our time together.
               </p>
             </div>
 
@@ -653,54 +463,75 @@ if (prefillToken) {
     )
   }
 
-  <script is:inline define:vars={{ turnstileSiteKey }}>
-    ;(function () {
-      const picker = document.getElementById('slot-picker')
-      const intakeSection = document.getElementById('intake-section')
-      const form = document.getElementById('booking-form')
-      const submitBtn = document.getElementById('bf-submit')
-      const errorBanner = document.getElementById('bf-error')
-      const slotTakenBanner = document.getElementById('bf-slot-taken')
-      const selectedSlotText = document.getElementById('selected-slot-text')
-      const changeSlotBtn = document.getElementById('change-slot-btn')
-      const confirmPanel = document.getElementById('confirmation-panel')
-      const emailFallback = document.getElementById('email-fallback-panel')
-      const turnstileContainer = document.getElementById('turnstile-container')
+  <script>
+    import { formDataToObject, normalizeIntakePayload } from '../lib/booking/intake-questionnaire'
 
-      // "Other" toggles
-      const verticalSelect = document.getElementById('bf-vertical')
-      const verticalOther = document.getElementById('bf-vertical-other')
-      const howHeardSelect = document.getElementById('bf-how-heard')
-      const howHeardOther = document.getElementById('bf-how-heard-other')
+    interface BookingSlot {
+      start_utc: string
+      timezone: string
+      label: string
+    }
 
-      verticalSelect.addEventListener('change', function () {
-        if (this.value === 'other') {
-          verticalOther.classList.remove('hidden')
-        } else {
-          verticalOther.classList.add('hidden')
-          verticalOther.value = ''
-        }
-      })
+    interface BookingResponse {
+      slot_label?: string
+      meet_url?: string | null
+      manage_url?: string | null
+      error?: string
+      message?: string
+      fallback?: {
+        email?: string
+      }
+    }
 
-      howHeardSelect.addEventListener('change', function () {
-        if (this.value === 'other') {
-          howHeardOther.classList.remove('hidden')
-        } else {
-          howHeardOther.classList.add('hidden')
-          howHeardOther.value = ''
-        }
-      })
+    ;(() => {
+      const pickerElement = document.getElementById('slot-picker')
+      const intakeSectionElement = document.getElementById('intake-section')
+      const formElement = document.getElementById('booking-form')
+      const submitBtnElement = document.getElementById('bf-submit')
+      const errorBannerElement = document.getElementById('bf-error')
+      const slotTakenBannerElement = document.getElementById('bf-slot-taken')
+      const selectedSlotTextElement = document.getElementById('selected-slot-text')
+      const changeSlotBtnElement = document.getElementById('change-slot-btn')
+      const confirmPanelElement = document.getElementById('confirmation-panel')
+      const emailFallbackElement = document.getElementById('email-fallback-panel')
+      const turnstileContainerElement = document.getElementById('turnstile-container')
 
-      // Track selected slot
-      let currentSlot = null
-      let turnstileWidgetId = null
+      if (
+        !(pickerElement instanceof HTMLElement) ||
+        !(intakeSectionElement instanceof HTMLElement) ||
+        !(formElement instanceof HTMLFormElement) ||
+        !(submitBtnElement instanceof HTMLButtonElement) ||
+        !(errorBannerElement instanceof HTMLElement) ||
+        !(slotTakenBannerElement instanceof HTMLElement) ||
+        !(selectedSlotTextElement instanceof HTMLElement) ||
+        !(changeSlotBtnElement instanceof HTMLButtonElement) ||
+        !(confirmPanelElement instanceof HTMLElement) ||
+        !(emailFallbackElement instanceof HTMLElement) ||
+        !(turnstileContainerElement instanceof HTMLElement)
+      ) {
+        return
+      }
+
+      const picker = pickerElement as HTMLElement & { refetchSlots?: () => void }
+      const intakeSection = intakeSectionElement
+      const form = formElement
+      const submitBtn = submitBtnElement
+      const errorBanner = errorBannerElement
+      const slotTakenBanner = slotTakenBannerElement
+      const selectedSlotText = selectedSlotTextElement
+      const changeSlotBtn = changeSlotBtnElement
+      const confirmPanel = confirmPanelElement
+      const emailFallback = emailFallbackElement
+      const turnstileContainer = turnstileContainerElement
+      const turnstileSiteKey = form.dataset.turnstileSiteKey || ''
+      let currentSlot: BookingSlot | null = null
+      let turnstileWidgetId: string | undefined
       let turnstileReady = false
       let turnstileTimedOut = false
 
-      // Render Turnstile widget when the script loads
       if (turnstileSiteKey) {
         const initTurnstile = function () {
-          if (typeof turnstile !== 'undefined' && turnstileContainer && !turnstileReady) {
+          if (typeof turnstile !== 'undefined' && !turnstileReady) {
             turnstileWidgetId = turnstile.render(turnstileContainer, {
               sitekey: turnstileSiteKey,
               callback: function () {
@@ -716,14 +547,13 @@ if (prefillToken) {
             turnstileReady = true
           }
         }
-        // Try immediately, retry if script not yet loaded
+
         initTurnstile()
         if (!turnstileReady) {
           const checkInterval = setInterval(function () {
             initTurnstile()
             if (turnstileReady) clearInterval(checkInterval)
           }, 200)
-          // Give up after 10 seconds — if widget never rendered, bypass client gating
           setTimeout(function () {
             clearInterval(checkInterval)
             if (!turnstileReady) {
@@ -744,16 +574,15 @@ if (prefillToken) {
         submitBtn.disabled = !(hasSlot && formValid && turnstileOk)
       }
 
-      // Listen for form input changes to update submit state
       form.addEventListener('input', updateSubmitState)
       form.addEventListener('change', updateSubmitState)
 
-      // Slot selection
-      picker.addEventListener('slot-selected', function (e) {
-        currentSlot = e.detail
+      picker.addEventListener('slot-selected', function (event) {
+        currentSlot = (event as CustomEvent<BookingSlot>).detail
+        if (!currentSlot) return
+
         intakeSection.style.display = ''
 
-        // Build readable label
         const d = new Date(currentSlot.start_utc)
         const dayNames = [
           'Sunday',
@@ -787,24 +616,19 @@ if (prefillToken) {
           ' at ' +
           currentSlot.label
 
-        // Hide any previous error banners
         errorBanner.classList.add('hidden')
         slotTakenBanner.classList.add('hidden')
 
         updateSubmitState()
-
-        // Scroll intake into view
         intakeSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
       })
 
-      // Change slot button
       changeSlotBtn.addEventListener('click', function () {
         picker.scrollIntoView({ behavior: 'smooth', block: 'start' })
       })
 
-      // Form submission
-      form.addEventListener('submit', function (e) {
-        e.preventDefault()
+      form.addEventListener('submit', async function (event) {
+        event.preventDefault()
         if (!currentSlot) return
 
         submitBtn.disabled = true
@@ -812,34 +636,15 @@ if (prefillToken) {
         errorBanner.classList.add('hidden')
         slotTakenBanner.classList.add('hidden')
 
-        const formData = new FormData(form)
-        const data = {}
-        formData.forEach(function (value, key) {
-          data[key] = value
-        })
-
-        // Resolve "Other" fields
-        if (data.vertical === 'other' && data.vertical_other) {
-          data.vertical = data.vertical_other
-        }
-        delete data.vertical_other
-        if (data.how_heard === 'other' && data.how_heard_other) {
-          data.how_heard = data.how_heard_other
-        }
-        delete data.how_heard_other
-
-        // Add slot data
+        const data = normalizeIntakePayload(formDataToObject(new FormData(form)))
         data.slot_start_utc = currentSlot.start_utc
         data.timezone = currentSlot.timezone
 
-        // Add Turnstile token
         if (turnstileSiteKey && typeof turnstile !== 'undefined') {
           data.turnstile_token = turnstile.getResponse(turnstileWidgetId) || ''
         }
 
-        // Honeypot check client-side (quick exit for bots)
         if (data.website_url && data.website_url.trim() !== '') {
-          // Show fake success to bots
           showConfirmation({
             slot_label: 'Your call is booked',
             meet_url: null,
@@ -848,69 +653,59 @@ if (prefillToken) {
           return
         }
 
-        fetch('/api/booking/reserve', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data),
-        })
-          .then(function (res) {
-            return res.json().then(function (body) {
-              return { status: res.status, body: body }
-            })
+        try {
+          const res = await fetch('/api/booking/reserve', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
           })
-          .then(function (result) {
-            const status = result.status
-            const body = result.body
+          const body = (await res.json()) as BookingResponse
 
-            if (status === 201) {
-              showConfirmation(body)
-              return
-            }
+          if (res.status === 201) {
+            showConfirmation(body)
+            return
+          }
 
-            if (status === 409) {
-              // Slot taken — refetch and show banner
-              slotTakenBanner.classList.remove('hidden')
-              currentSlot = null
-              intakeSection.style.display = 'none'
-              if (picker.refetchSlots) picker.refetchSlots()
-              picker.scrollIntoView({ behavior: 'smooth', block: 'start' })
-              resetSubmit()
-              return
-            }
-
-            if (status === 429) {
-              showError('Too many booking attempts. Please wait a few minutes and try again.')
-              resetSubmit()
-              return
-            }
-
-            if (status === 403 && body.error === 'turnstile_failed') {
-              showError('Security check failed. Please try again.')
-              if (turnstileSiteKey && typeof turnstile !== 'undefined') {
-                turnstile.reset(turnstileWidgetId)
-              }
-              resetSubmit()
-              return
-            }
-
-            if (status === 503) {
-              // Calendar unavailable — show email fallback
-              showEmailFallback(body)
-              return
-            }
-
-            // Generic error
-            showError(body.message || body.error || 'Something went wrong. Please try again.')
+          if (res.status === 409) {
+            slotTakenBanner.classList.remove('hidden')
+            currentSlot = null
+            intakeSection.style.display = 'none'
+            if (picker.refetchSlots) picker.refetchSlots()
+            picker.scrollIntoView({ behavior: 'smooth', block: 'start' })
             resetSubmit()
-          })
-          .catch(function (err) {
-            console.error('[book] reserve error:', err)
-            showError('Could not reach the server. Please check your connection and try again.')
+            return
+          }
+
+          if (res.status === 429) {
+            showError('Too many booking attempts. Please wait a few minutes and try again.')
             resetSubmit()
-          })
+            return
+          }
+
+          if (res.status === 403 && body.error === 'turnstile_failed') {
+            showError('Security check failed. Please try again.')
+            if (turnstileSiteKey && typeof turnstile !== 'undefined') {
+              turnstile.reset(turnstileWidgetId)
+            }
+            resetSubmit()
+            return
+          }
+
+          if (res.status === 503) {
+            showEmailFallback(body)
+            return
+          }
+
+          showError(body.message || body.error || 'Something went wrong. Please try again.')
+          resetSubmit()
+        } catch (err) {
+          console.error('[book] reserve error:', err)
+          showError('Could not reach the server. Please check your connection and try again.')
+          resetSubmit()
+        }
       })
 
-      function showError(msg) {
+      function showError(msg: string) {
         errorBanner.textContent = msg
         errorBanner.classList.remove('hidden')
       }
@@ -921,56 +716,58 @@ if (prefillToken) {
         updateSubmitState()
       }
 
-      function showConfirmation(body) {
-        // Hide picker + form, show confirmation
+      function showConfirmation(body: BookingResponse) {
         const pickerCard = document.querySelector('[data-component="slot-picker"]')
-        if (pickerCard) {
+        if (pickerCard instanceof HTMLElement) {
           const card = pickerCard.closest('.rounded-[var(--ss-radius-card)]')
-          if (card) card.style.display = 'none'
+          if (card instanceof HTMLElement) card.style.display = 'none'
         }
         intakeSection.style.display = 'none'
 
-        // Populate confirmation details
         const confSlot = document.getElementById('conf-slot')
-        confSlot.textContent = body.slot_label || 'Your call is booked'
+        if (confSlot instanceof HTMLElement) {
+          confSlot.textContent = body.slot_label || 'Your call is booked'
+        }
 
         if (body.meet_url) {
           const meetRow = document.getElementById('conf-meet-row')
           const meetLink = document.getElementById('conf-meet-link')
-          meetRow.classList.remove('hidden')
-          meetLink.href = body.meet_url
+          if (meetRow instanceof HTMLElement) meetRow.classList.remove('hidden')
+          if (meetLink instanceof HTMLAnchorElement) meetLink.href = body.meet_url
         }
 
         if (body.manage_url) {
           const manageRow = document.getElementById('conf-manage-row')
           const manageLink = document.getElementById('conf-manage-link')
-          manageRow.classList.remove('hidden')
-          manageLink.href = body.manage_url
+          if (manageRow instanceof HTMLElement) manageRow.classList.remove('hidden')
+          if (manageLink instanceof HTMLAnchorElement) manageLink.href = body.manage_url
         }
 
         confirmPanel.classList.remove('hidden')
         confirmPanel.scrollIntoView({ behavior: 'smooth', block: 'start' })
       }
 
-      function showEmailFallback(body) {
-        const fallbackEmail = (body.fallback && body.fallback.email) || 'team@smd.services'
+      function showEmailFallback(body: BookingResponse) {
+        const fallbackEmail = body.fallback?.email || 'team@smd.services'
         const mailtoEl = document.getElementById('fallback-mailto')
-        const nameVal = form.elements.namedItem('name') ? form.elements.namedItem('name').value : ''
-        const businessVal = form.elements.namedItem('business_name')
-          ? form.elements.namedItem('business_name').value
-          : ''
+        const nameField = form.elements.namedItem('name')
+        const businessField = form.elements.namedItem('business_name')
+        const nameVal = nameField instanceof HTMLInputElement ? nameField.value : ''
+        const businessVal = businessField instanceof HTMLInputElement ? businessField.value : ''
         const subject = encodeURIComponent('Assessment Call Request')
         const bodyText = encodeURIComponent(
           "Hi, I'd like to schedule an assessment call.\n\n" +
             (nameVal ? 'Name: ' + nameVal + '\n' : '') +
             (businessVal ? 'Business: ' + businessVal + '\n' : '')
         )
-        mailtoEl.href = 'mailto:' + fallbackEmail + '?subject=' + subject + '&body=' + bodyText
-        mailtoEl.textContent = 'Email ' + fallbackEmail
 
-        // Hide picker + form, show fallback
-        const pickerEl = picker.closest('.rounded-[var(--ss-radius-card)]')
-        if (pickerEl) pickerEl.style.display = 'none'
+        if (mailtoEl instanceof HTMLAnchorElement) {
+          mailtoEl.href = 'mailto:' + fallbackEmail + '?subject=' + subject + '&body=' + bodyText
+          mailtoEl.textContent = 'Email ' + fallbackEmail
+        }
+
+        const pickerCard = picker.closest('.rounded-[var(--ss-radius-card)]')
+        if (pickerCard instanceof HTMLElement) pickerCard.style.display = 'none'
         intakeSection.style.display = 'none'
         emailFallback.classList.remove('hidden')
         emailFallback.scrollIntoView({ behavior: 'smooth', block: 'start' })

--- a/src/pages/book/manage/index.astro
+++ b/src/pages/book/manage/index.astro
@@ -21,7 +21,7 @@ if (token) {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Manage Your Booking — SMD Services</title>
+    <title>Manage Your Booking | SMD Services</title>
   </head>
   <body style="font-family: 'Inter', sans-serif; background: #f8fafc;">
     <SkipToMain />

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -4,7 +4,7 @@ export const prerender = false
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
-import { ENTITY_VERTICALS } from '../lib/db/entities'
+import IntakeQuestionnaire from '../components/booking/IntakeQuestionnaire.astro'
 import { resolveTurnstileConfig } from '../lib/booking/turnstile'
 import { env } from 'cloudflare:workers'
 
@@ -93,193 +93,18 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
           id="intake-form-container"
           class="mt-10 rounded-[var(--ss-radius-card)] bg-white p-6 sm:p-8"
         >
-          <form id="intake-form" class="space-y-5" novalidate>
+          <form
+            id="intake-form"
+            class="space-y-5"
+            novalidate
+            data-turnstile-site-key={turnstileSiteKey}
+          >
             <!-- Honeypot -->
             <div class="absolute -left-[9999px]" aria-hidden="true">
               <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
             </div>
 
-            <!-- Name + Email -->
-            <div class="grid gap-5 sm:grid-cols-2">
-              <div>
-                <label
-                  for="gs-name"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  Full name <span class="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  id="gs-name"
-                  name="name"
-                  required
-                  maxlength="200"
-                  autocomplete="name"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="e.g. Maria Garcia"
-                />
-              </div>
-              <div>
-                <label
-                  for="gs-email"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  Work email <span class="text-red-500">*</span>
-                </label>
-                <input
-                  type="email"
-                  id="gs-email"
-                  name="email"
-                  required
-                  maxlength="254"
-                  autocomplete="email"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="maria@example.com"
-                />
-              </div>
-            </div>
-
-            <!-- Business name -->
-            <div>
-              <label
-                for="gs-business"
-                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-              >
-                Business name <span class="text-red-500">*</span>
-              </label>
-              <input
-                type="text"
-                id="gs-business"
-                name="business_name"
-                required
-                maxlength="200"
-                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                placeholder="e.g. Phoenix Plumbing Co."
-              />
-            </div>
-
-            <!-- Vertical + Employee count -->
-            <div class="grid gap-5 sm:grid-cols-2">
-              <div>
-                <label
-                  for="gs-vertical"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  What kind of business?
-                </label>
-                <select
-                  id="gs-vertical"
-                  name="vertical"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                >
-                  <option value="">Select one</option>
-                  {ENTITY_VERTICALS.map((v) => <option value={v.value}>{v.label}</option>)}
-                </select>
-                <input
-                  type="text"
-                  id="gs-vertical-other"
-                  name="vertical_other"
-                  class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                  placeholder="Describe your business type"
-                />
-              </div>
-              <div>
-                <label
-                  for="gs-employees"
-                  class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >
-                  Employee count
-                </label>
-                <select
-                  id="gs-employees"
-                  name="employee_count"
-                  class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                >
-                  <option value="">Select one</option>
-                  <option value="1-5">1 - 5</option>
-                  <option value="6-10">6 - 10</option>
-                  <option value="11-25">11 - 25</option>
-                  <option value="26-50">26 - 50</option>
-                  <option value="50+">50+</option>
-                </select>
-              </div>
-            </div>
-
-            <!-- Years in business -->
-            <div class="sm:w-1/2">
-              <label
-                for="gs-years"
-                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-              >
-                Years in business
-              </label>
-              <select
-                id="gs-years"
-                name="years_in_business"
-                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              >
-                <option value="">Select one</option>
-                <option value="<1">Less than 1 year</option>
-                <option value="1-3">1 - 3 years</option>
-                <option value="3-5">3 - 5 years</option>
-                <option value="5-10">5 - 10 years</option>
-                <option value="10+">10+ years</option>
-              </select>
-            </div>
-
-            <!-- Biggest challenge -->
-            <div>
-              <label
-                for="gs-challenge"
-                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-              >
-                What's the single biggest operational challenge right now?
-                <span class="text-red-500">*</span>
-              </label>
-              <p class="mt-0.5 text-xs text-[color:var(--ss-color-text-muted)]">
-                What would make the biggest difference in how your business runs day to day?
-              </p>
-              <textarea
-                id="gs-challenge"
-                name="biggest_challenge"
-                required
-                rows="3"
-                maxlength="2000"
-                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                placeholder="e.g. I want to stop being the bottleneck for every decision..."
-              ></textarea>
-            </div>
-
-            <!-- How heard -->
-            <div>
-              <label
-                for="gs-how-heard"
-                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-              >
-                How did you hear about us?
-              </label>
-              <select
-                id="gs-how-heard"
-                name="how_heard"
-                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              >
-                <option value="">Select one</option>
-                <option value="Google Search">Google Search</option>
-                <option value="Referral">Referral</option>
-                <option value="BNI / Networking group">BNI / Networking group</option>
-                <option value="Chamber of Commerce">Chamber of Commerce</option>
-                <option value="Social Media">Social Media</option>
-                <option value="SCORE / SBA">SCORE / SBA</option>
-                <option value="other">Other</option>
-              </select>
-              <input
-                type="text"
-                id="gs-how-heard-other"
-                name="how_heard_other"
-                class="mt-2 hidden w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                placeholder="Tell us more"
-              />
-            </div>
+            <IntakeQuestionnaire idPrefix="gs" mode="prep" />
 
             <!-- Turnstile -->
             <div id="turnstile-container"></div>
@@ -357,46 +182,45 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
     )
   }
 
-  <script is:inline define:vars={{ turnstileSiteKey }}>
-    ;(function () {
-      const form = document.getElementById('intake-form')
-      const formContainer = document.getElementById('intake-form-container')
-      const submitBtn = document.getElementById('gs-submit')
-      const errorBanner = document.getElementById('gs-error')
-      const successPanel = document.getElementById('success-panel')
-      const turnstileContainer = document.getElementById('turnstile-container')
+  <script>
+    import { formDataToObject, normalizeIntakePayload } from '../lib/booking/intake-questionnaire'
 
-      // "Other" toggles
-      const verticalSelect = document.getElementById('gs-vertical')
-      const verticalOther = document.getElementById('gs-vertical-other')
-      const howHeardSelect = document.getElementById('gs-how-heard')
-      const howHeardOther = document.getElementById('gs-how-heard-other')
+    interface IntakeResponse {
+      error?: string
+    }
 
-      verticalSelect.addEventListener('change', function () {
-        if (this.value === 'other') {
-          verticalOther.classList.remove('hidden')
-        } else {
-          verticalOther.classList.add('hidden')
-          verticalOther.value = ''
-        }
-      })
+    ;(() => {
+      const formElement = document.getElementById('intake-form')
+      const formContainerElement = document.getElementById('intake-form-container')
+      const submitBtnElement = document.getElementById('gs-submit')
+      const errorBannerElement = document.getElementById('gs-error')
+      const successPanelElement = document.getElementById('success-panel')
+      const turnstileContainerElement = document.getElementById('turnstile-container')
 
-      howHeardSelect.addEventListener('change', function () {
-        if (this.value === 'other') {
-          howHeardOther.classList.remove('hidden')
-        } else {
-          howHeardOther.classList.add('hidden')
-          howHeardOther.value = ''
-        }
-      })
+      if (
+        !(formElement instanceof HTMLFormElement) ||
+        !(formContainerElement instanceof HTMLElement) ||
+        !(submitBtnElement instanceof HTMLButtonElement) ||
+        !(errorBannerElement instanceof HTMLElement) ||
+        !(successPanelElement instanceof HTMLElement) ||
+        !(turnstileContainerElement instanceof HTMLElement)
+      ) {
+        return
+      }
 
-      // Turnstile
-      let turnstileWidgetId = null
+      const form = formElement
+      const formContainer = formContainerElement
+      const submitBtn = submitBtnElement
+      const errorBanner = errorBannerElement
+      const successPanel = successPanelElement
+      const turnstileContainer = turnstileContainerElement
+      const turnstileSiteKey = form.dataset.turnstileSiteKey || ''
+      let turnstileWidgetId: string | undefined
       let turnstileReady = false
 
       if (turnstileSiteKey) {
         const initTurnstile = function () {
-          if (typeof turnstile !== 'undefined' && turnstileContainer && !turnstileReady) {
+          if (typeof turnstile !== 'undefined' && !turnstileReady) {
             turnstileWidgetId = turnstile.render(turnstileContainer, {
               sitekey: turnstileSiteKey,
               callback: function () {},
@@ -418,31 +242,14 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
         }
       }
 
-      // Form submission
-      form.addEventListener('submit', async function (e) {
-        e.preventDefault()
+      form.addEventListener('submit', async function (event) {
+        event.preventDefault()
         errorBanner.classList.add('hidden')
         submitBtn.disabled = true
         submitBtn.textContent = 'Sending...'
 
-        const formData = new FormData(form)
-        const data = {}
-        formData.forEach(function (value, key) {
-          data[key] = value
-        })
+        const data = normalizeIntakePayload(formDataToObject(new FormData(form)))
 
-        // Resolve "Other" fields
-        if (data.vertical === 'other' && data.vertical_other) {
-          data.vertical = data.vertical_other
-        }
-        delete data.vertical_other
-
-        if (data.how_heard === 'other' && data.how_heard_other) {
-          data.how_heard = data.how_heard_other
-        }
-        delete data.how_heard_other
-
-        // Add Turnstile token
         if (turnstileSiteKey && typeof turnstile !== 'undefined') {
           data.turnstile_token = turnstile.getResponse(turnstileWidgetId) || ''
         }
@@ -458,12 +265,11 @@ const turnstileSiteKey = resolveTurnstileConfig(env).siteKey
             formContainer.classList.add('hidden')
             successPanel.classList.remove('hidden')
           } else {
-            const body = await res.json()
+            const body = (await res.json()) as IntakeResponse
             errorBanner.textContent = body.error || 'Something went wrong. Please try again.'
             errorBanner.classList.remove('hidden')
             submitBtn.disabled = false
             submitBtn.textContent = 'Send'
-            // Reset Turnstile on error
             if (turnstileSiteKey && typeof turnstile !== 'undefined') {
               turnstile.reset(turnstileWidgetId)
             }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,8 +36,8 @@ import Footer from '../components/Footer.astro'
           Not sure where to start?
         </h2>
         <p class="mx-auto mt-4 max-w-xl text-lg text-[color:var(--ss-color-text-secondary)]">
-          Drop your URL and we'll send you back an Outside View — what we see when an experienced
-          outsider looks at your business. Yours to keep.
+          Drop your URL and we'll send you back an Outside View. It's what we see when an
+          experienced outsider looks at your business. Yours to keep.
         </p>
         <a
           href="/outside-view"

--- a/src/pages/outside-view/index.astro
+++ b/src/pages/outside-view/index.astro
@@ -41,8 +41,8 @@ import Footer from '../../components/Footer.astro'
         See what we see
       </h1>
       <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
-        Drop your URL and email. We read your public footprint and send you back an Outside View —
-        what an experienced outsider sees when they look at your business. Yours to keep.
+        Drop your URL and email. We read your public footprint and send you back an Outside View.
+        It's what an experienced outsider sees when they look at your business. Yours to keep.
       </p>
 
       <div id="form-status" class="mt-8" aria-live="polite"></div>
@@ -198,7 +198,7 @@ import Footer from '../../components/Footer.astro'
 
           if (res.ok) {
             status.innerHTML =
-              '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)]/30 bg-[color:var(--ss-color-complete)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-complete)]"><strong>Started.</strong> Check your email — we sent a confirmation link to verify your inbox. Click it and we\'ll send your Outside View.</div>'
+              '<div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-complete)]/30 bg-[color:var(--ss-color-complete)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-complete)]"><strong>Started.</strong> Check your email. We sent a confirmation link to verify your inbox. Click it and we\'ll send your Outside View.</div>'
             form.reset()
             form.style.display = 'none'
           } else if (res.status === 429) {

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -120,7 +120,7 @@ function fileExtFor(name: string, isPdf: boolean): string {
  * otherwise an em-dash placeholder matches the empty-state pattern.
  */
 function kindFor(doc: DocumentEntry): string {
-  return doc.category ? doc.category.toUpperCase() : '—'
+  return doc.category ? doc.category.toUpperCase() : 'FILE'
 }
 ---
 
@@ -139,7 +139,7 @@ function kindFor(doc: DocumentEntry): string {
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Documents — {BRAND_NAME}</title>
+    <title>Documents | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -88,7 +88,7 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Progress — {BRAND_NAME}</title>
+    <title>Progress | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -301,7 +301,7 @@ const touchpointText: string | null = (() => {
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Portal — {BRAND_NAME}</title>
+    <title>Portal | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -203,7 +203,7 @@ const consultantFirstName: string | null = consultantName
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Invoice — {BRAND_NAME}</title>
+    <title>Invoice | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -79,7 +79,7 @@ const totalCents = invoices.reduce((sum, i) => sum + Math.round(i.amount * 100),
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Invoices — {BRAND_NAME}</title>
+    <title>Invoices | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/portal/outside-view/index.astro
+++ b/src/pages/portal/outside-view/index.astro
@@ -90,7 +90,7 @@ const isProspect = user.role === 'prospect'
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <title>Outside View — {BRAND_NAME}</title>
+    <title>Outside View | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />
@@ -124,18 +124,17 @@ const isProspect = user.role === 'prospect'
                 About your scan
               </h2>
               <p class="mt-4 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
-                Our scan reads what's publicly available — Google reviews, your website, business
-                listings — and we couldn't find enough public footprint on your domain to produce
+                Our scan reads what's publicly available: Google reviews, your website, and business
+                listings. We couldn't find enough public footprint on your domain to produce
                 something useful.
               </p>
               <p class="mt-4 text-base md:text-lg text-[color:var(--ss-color-text-primary)] m-0">
                 Honestly, that's informative on its own. A thin public footprint is often where we'd
-                start — there's usually low-effort, high-leverage work to do before customers can
+                start. There's usually low-effort, high-leverage work to do before customers can
                 even find you. The most useful next step is a short conversation.
               </p>
               <p class="mt-6 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] m-0">
-                Talk to us — coming soon to this page. In the meantime, you can request a call from
-                the email we sent you.
+                Ready to talk it through? Use the booking link in the email we sent you.
               </p>
             </div>
           </section>

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -160,7 +160,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Proposal — Portal — {BRAND_NAME}</title>
+    <title>Proposal | Portal | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -74,7 +74,7 @@ const eyebrowText = eyebrowParts.join(' · ').toUpperCase()
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>Proposals — {BRAND_NAME}</title>
+    <title>Proposals | {BRAND_NAME}</title>
   </head>
   <body class="min-h-screen bg-[color:var(--ss-color-background)]">
     <SkipToMain />

--- a/src/pages/scan/verify/[token].astro
+++ b/src/pages/scan/verify/[token].astro
@@ -128,7 +128,7 @@ if (typeof token === 'string' && token.length > 0) {
             </h1>
             <p class="mt-4 text-lg text-[color:var(--ss-color-text-secondary)]">
               We tried to read <strong>{state.domain}</strong> but didn't find enough public
-              footprint to produce something useful. Check your email — we explained more there and
+              footprint to produce something useful. Check your email. We explained more there and
               included a link to talk it through.
             </p>
             <p class="mt-8">

--- a/tests/admin-astro-boundaries.test.ts
+++ b/tests/admin-astro-boundaries.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const entityPageSrc = readFileSync(resolve('src/pages/admin/entities/[id].astro'), 'utf-8')
+const quotePageSrc = readFileSync(
+  resolve('src/pages/admin/entities/[id]/quotes/[quoteId].astro'),
+  'utf-8'
+)
+const engagementPageSrc = readFileSync(resolve('src/pages/admin/engagements/[id].astro'), 'utf-8')
+
+function lineCount(source: string): number {
+  return source.split('\n').length
+}
+
+describe('admin Astro boundary rules', () => {
+  it('routes heavy admin pages through extracted loader modules', () => {
+    expect(entityPageSrc).toContain('loadEntityDetailPage')
+    expect(quotePageSrc).toContain('loadQuoteBuilderPage')
+    expect(engagementPageSrc).toContain('loadEngagementDetailPage')
+  })
+
+  it('boots client behavior from dedicated admin client modules', () => {
+    expect(entityPageSrc).toContain(
+      "import { initEntityDetailPage } from '../../../lib/admin/entity-detail-client'"
+    )
+    expect(quotePageSrc).toContain(
+      "import { initQuoteBuilderPage } from '../../../../../lib/admin/quote-builder-client'"
+    )
+    expect(engagementPageSrc).toContain(
+      "import { initEngagementDetailPage } from '../../../lib/admin/engagement-detail-client'"
+    )
+  })
+
+  it('keeps direct DOM wiring out of the Astro page source', () => {
+    for (const pageSrc of [entityPageSrc, quotePageSrc, engagementPageSrc]) {
+      expect(pageSrc).not.toContain('document.getElementById')
+      expect(pageSrc).not.toContain('addEventListener(')
+      expect(pageSrc).not.toContain('querySelectorAll<')
+    }
+  })
+
+  it('caps the largest admin detail surfaces at their new concern boundaries', () => {
+    expect(lineCount(entityPageSrc)).toBeLessThanOrEqual(1050)
+    expect(lineCount(quotePageSrc)).toBeLessThanOrEqual(900)
+    expect(lineCount(engagementPageSrc)).toBeLessThanOrEqual(850)
+  })
+})

--- a/tests/context-assembly.test.ts
+++ b/tests/context-assembly.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+
+import { createEntity } from '../src/lib/db/entities'
+import { appendContext, assembleEntityContext } from '../src/lib/db/context'
+import { ORG_ID } from '../src/lib/constants'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1() as unknown as D1Database
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+describe('assembleEntityContext', () => {
+  it('excludes non-authoritative model summaries by default', async () => {
+    const db = await freshDb()
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Assembly Test Co',
+      area: 'Phoenix',
+      source_pipeline: 'test',
+    })
+
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'signal',
+      content: 'Signal: repeated complaints about schedule delays.',
+      source: 'test_signal',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: 'Legacy intelligence brief that should not feed later prompts.',
+      source: 'intelligence_brief',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: 'Model summary that should stay out of downstream prompts.',
+      source: 'custom_summary',
+      metadata: {
+        context_authority: 'non_authoritative',
+        evidence_mode: 'model_summary',
+      },
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: 'Deep website analysis:\nServices: Water heater repair\nEmail: owner@example.com',
+      source: 'deep_website',
+      metadata: {
+        context_authority: 'authoritative',
+        evidence_mode: 'extractive',
+      },
+    })
+
+    const assembled = await assembleEntityContext(db, entity.id)
+
+    expect(assembled).toContain('Signal: repeated complaints about schedule delays.')
+    expect(assembled).toContain('Services: Water heater repair')
+    expect(assembled).not.toContain('Legacy intelligence brief')
+    expect(assembled).not.toContain('Model summary that should stay out')
+  })
+
+  it('can include non-authoritative summaries when explicitly requested', async () => {
+    const db = await freshDb()
+    const entity = await createEntity(db, ORG_ID, {
+      name: 'Assembly Opt In Co',
+      area: 'Phoenix',
+      source_pipeline: 'test',
+    })
+
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'signal',
+      content: 'Signal: owner replies to multiple review complaints.',
+      source: 'test_signal',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'enrichment',
+      content: 'Review synthesis: likely manual dispatch bottleneck.',
+      source: 'review_synthesis',
+      metadata: {
+        context_authority: 'non_authoritative',
+        evidence_mode: 'model_summary',
+      },
+    })
+
+    const assembled = await assembleEntityContext(db, entity.id, {
+      includeNonAuthoritative: true,
+    })
+
+    expect(assembled).toContain('Signal: owner replies to multiple review complaints.')
+    expect(assembled).toContain('Review synthesis: likely manual dispatch bottleneck.')
+  })
+})

--- a/tests/enrichment-prompt-contracts.test.ts
+++ b/tests/enrichment-prompt-contracts.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const dossierSrc = readFileSync(resolve('src/lib/enrichment/dossier.ts'), 'utf-8')
+const reviewAnalysisSrc = readFileSync(resolve('src/lib/enrichment/review-analysis.ts'), 'utf-8')
+const deepWebsiteSrc = readFileSync(resolve('src/lib/enrichment/deep-website.ts'), 'utf-8')
+
+describe('enrichment prompt contracts', () => {
+  it('keeps the dossier prompt evidence-bound and free of subjective inference sections', () => {
+    expect(dossierSrc).toContain('Use only facts present in the supplied context.')
+    expect(dossierSrc).toContain(
+      'Do not infer management style, communication preference, personality, likely objections, or private business conditions.'
+    )
+    expect(dossierSrc).toContain(
+      'When evidence is incomplete, label it as an open question instead of guessing.'
+    )
+    expect(dossierSrc).not.toContain('## Management Style')
+    expect(dossierSrc).not.toContain('## Communication Preferences')
+    expect(dossierSrc).not.toContain('## Likely Objections')
+    expect(dossierSrc).not.toContain('## Talking Points')
+  })
+
+  it('keeps review-analysis scoped to observable response behavior', () => {
+    expect(reviewAnalysisSrc).toContain('observable review-response behavior only')
+    expect(reviewAnalysisSrc).toContain(
+      'Do NOT infer management style, personality, communication preference, or private business conditions.'
+    )
+    expect(reviewAnalysisSrc).not.toContain('"management_style"')
+    expect(reviewAnalysisSrc).not.toContain('"communication_preference"')
+    expect(reviewAnalysisSrc).not.toContain('"likely_objections"')
+  })
+
+  it('keeps deep-website extractive instead of speculative', () => {
+    expect(deepWebsiteSrc).toContain('extracting observable facts from a small business website')
+    expect(deepWebsiteSrc).toContain(
+      'Use only information explicitly supported by the supplied pages.'
+    )
+    expect(deepWebsiteSrc).toContain(
+      'Do not infer owner personality, company trajectory, internal capacity, hidden tooling, or unstated operational problems.'
+    )
+    expect(deepWebsiteSrc).not.toContain('"pain_points"')
+    expect(deepWebsiteSrc).not.toContain('"operational_problems"')
+    expect(deepWebsiteSrc).not.toContain('"likely_objections"')
+  })
+})

--- a/tests/enrichment-workflow.test.ts
+++ b/tests/enrichment-workflow.test.ts
@@ -218,7 +218,7 @@ describe('EnrichmentWorkflow — idempotency', () => {
       response_pattern: 'responsive',
       engagement_level: 'high',
       owner_accessible: true,
-      insights: 'engaged',
+      evidence_summary: 'The owner responds to public reviews with regular follow-up.',
     } as unknown as Awaited<ReturnType<typeof analyzeReviewPatterns>>)
     vi.mocked(synthesizeReviews).mockResolvedValue({
       customer_sentiment: 'positive',
@@ -385,6 +385,62 @@ describe('EnrichmentWorkflow — outreach instrumentation', () => {
     expect(rows[0].status).toBe('failed')
     expect(rows[0].error_message).toContain('Anthropic 529')
   })
+
+  it('excludes non-authoritative enrichment summaries from outreach prompt assembly', async () => {
+    const entityId = await seedEntity(db, { website: 'https://example.com' })
+
+    await appendContext(db, ORG_ID, {
+      entity_id: entityId,
+      type: 'signal',
+      content:
+        'Signal: customers praise fast response times but complain about scheduling confusion.',
+      source: 'test',
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entityId,
+      type: 'enrichment',
+      content: 'Review synthesis: likely owner bottleneck and manual dispatch issues.',
+      source: 'review_synthesis',
+      metadata: {
+        context_authority: 'non_authoritative',
+        evidence_mode: 'model_summary',
+      },
+    })
+    await appendContext(db, ORG_ID, {
+      entity_id: entityId,
+      type: 'enrichment',
+      content:
+        'Deep website analysis:\nServices: Drain cleaning, water heater repair\nEmail: owner@example.com',
+      source: 'deep_website',
+      metadata: {
+        context_authority: 'authoritative',
+        evidence_mode: 'extractive',
+      },
+    })
+
+    vi.mocked(lookupGooglePlaces).mockResolvedValue(null)
+    vi.mocked(analyzeWebsite).mockResolvedValue(null)
+    vi.mocked(analyzeReviewPatterns).mockResolvedValue(null)
+    vi.mocked(synthesizeReviews).mockResolvedValue(null)
+    vi.mocked(searchNews).mockResolvedValue(null)
+    vi.mocked(generateDossier).mockResolvedValue('# Brief\nHypothesis-heavy summary')
+    vi.mocked(generateOutreachDraft).mockResolvedValue('Hi there')
+
+    await runWorkflow(bindings(db), {
+      entityId,
+      orgId: ORG_ID,
+      mode: 'full',
+      triggered_by: 'test',
+    })
+
+    const outreachCall = vi.mocked(generateOutreachDraft).mock.calls.at(-1)
+    expect(outreachCall).toBeDefined()
+    const assembledContext = outreachCall?.[2] ?? ''
+    expect(assembledContext).toContain('Signal: customers praise fast response times')
+    expect(assembledContext).toContain('Services: Drain cleaning, water heater repair')
+    expect(assembledContext).not.toContain('likely owner bottleneck and manual dispatch issues')
+    expect(assembledContext).not.toContain('Hypothesis-heavy summary')
+  })
 })
 
 // ===========================================================================
@@ -429,7 +485,7 @@ describe('EnrichmentWorkflow — no skip-succeeded semantics', () => {
       response_pattern: 'responsive',
       engagement_level: 'high',
       owner_accessible: true,
-      insights: 'engaged',
+      evidence_summary: 'The owner responds to public reviews with regular follow-up.',
     } as unknown as Awaited<ReturnType<typeof analyzeReviewPatterns>>)
     vi.mocked(synthesizeReviews).mockResolvedValue(null)
     vi.mocked(searchNews).mockResolvedValue(null)

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -15,6 +15,17 @@ import { readdirSync, readFileSync, statSync } from 'fs'
 import { resolve, join, extname } from 'path'
 
 const SRC_ROOT = resolve('src')
+const PAGES_ROOT = resolve('src/pages')
+const COMPONENTS_ROOT = resolve('src/components')
+const LAYOUTS_ROOT = resolve('src/layouts')
+
+const USER_FACING_EXCLUDED_DIRS = [
+  resolve('src/pages/admin'),
+  resolve('src/pages/api'),
+  resolve('src/pages/design-preview'),
+  resolve('src/pages/dev'),
+  resolve('src/components/admin'),
+]
 
 /** Collect all .astro, .ts, .tsx files under src/ (excluding test files and dev harness) */
 function collectSourceFiles(dir: string): string[] {
@@ -38,6 +49,35 @@ function collectSourceFiles(dir: string): string[] {
     }
   }
   return files
+}
+
+function isWithinDir(path: string, dir: string): boolean {
+  return path === dir || path.startsWith(`${dir}/`)
+}
+
+function collectAstroFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry)
+    if (USER_FACING_EXCLUDED_DIRS.some((excludedDir) => isWithinDir(fullPath, excludedDir))) {
+      continue
+    }
+
+    const stat = statSync(fullPath)
+    if (stat.isDirectory()) {
+      files.push(...collectAstroFiles(fullPath))
+    } else if (extname(entry) === '.astro') {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
 }
 
 const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp | string }> = [
@@ -153,6 +193,22 @@ const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp | string }> = [
 ]
 
 const sourceFiles = collectSourceFiles(SRC_ROOT)
+const userFacingSurfaceFiles = [
+  ...collectAstroFiles(PAGES_ROOT),
+  ...collectAstroFiles(COMPONENTS_ROOT),
+  ...collectAstroFiles(LAYOUTS_ROOT),
+]
+
+const USER_FACING_COPY_GUARDS: Array<{ label: string; pattern: RegExp }> = [
+  {
+    label: 'no em dashes in shipped user-facing surfaces',
+    pattern: /—/,
+  },
+  {
+    label: 'no "coming soon" placeholder copy in shipped user-facing surfaces',
+    pattern: /\bcoming soon\b/i,
+  },
+]
 
 describe('forbidden-strings: Pattern A/B violations must not appear in shipped source', () => {
   for (const { label, pattern } of FORBIDDEN_PATTERNS) {
@@ -166,6 +222,25 @@ describe('forbidden-strings: Pattern A/B violations must not appear in shipped s
           // Compute a relative path for readable failure messages
           const rel = file.replace(SRC_ROOT, 'src')
           violations.push(rel)
+        }
+      }
+      expect(violations).toEqual([])
+    })
+  }
+})
+
+describe('user-facing copy guardrails', () => {
+  it('finds shipped user-facing Astro surfaces to check (sanity)', () => {
+    expect(userFacingSurfaceFiles.length).toBeGreaterThan(0)
+  })
+
+  for (const { label, pattern } of USER_FACING_COPY_GUARDS) {
+    it(`must enforce: ${label}`, () => {
+      const violations: string[] = []
+      for (const file of userFacingSurfaceFiles) {
+        const content = stripComments(readFileSync(file, 'utf-8'))
+        if (pattern.test(content)) {
+          violations.push(file.replace(SRC_ROOT, 'src'))
         }
       }
       expect(violations).toEqual([])

--- a/tests/intake-questionnaire.test.ts
+++ b/tests/intake-questionnaire.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  INTAKE_EMPLOYEE_COUNT_OPTIONS,
+  INTAKE_HOW_HEARD_OPTIONS,
+  INTAKE_YEARS_IN_BUSINESS_OPTIONS,
+  normalizeIntakePayload,
+} from '../src/lib/booking/intake-questionnaire'
+
+describe('intake questionnaire canonical helper', () => {
+  it('exports the shared employee-count options', () => {
+    expect(INTAKE_EMPLOYEE_COUNT_OPTIONS).toEqual([
+      { value: '1-5', label: '1 - 5' },
+      { value: '6-10', label: '6 - 10' },
+      { value: '11-25', label: '11 - 25' },
+      { value: '26-50', label: '26 - 50' },
+      { value: '50+', label: '50+' },
+    ])
+  })
+
+  it('exports the shared years-in-business options', () => {
+    expect(INTAKE_YEARS_IN_BUSINESS_OPTIONS).toEqual([
+      { value: '<1', label: 'Less than 1 year' },
+      { value: '1-3', label: '1 - 3 years' },
+      { value: '3-5', label: '3 - 5 years' },
+      { value: '5-10', label: '5 - 10 years' },
+      { value: '10+', label: '10+ years' },
+    ])
+  })
+
+  it('exports the shared how-heard options', () => {
+    expect(INTAKE_HOW_HEARD_OPTIONS).toEqual([
+      { value: 'Google Search', label: 'Google Search' },
+      { value: 'Referral', label: 'Referral' },
+      { value: 'BNI / Networking group', label: 'BNI / Networking group' },
+      { value: 'Chamber of Commerce', label: 'Chamber of Commerce' },
+      { value: 'Social Media', label: 'Social Media' },
+      { value: 'SCORE / SBA', label: 'SCORE / SBA' },
+      { value: 'other', label: 'Other' },
+    ])
+  })
+
+  it('normalizes shared other-field payloads once for both surfaces', () => {
+    expect(
+      normalizeIntakePayload({
+        vertical: 'other',
+        vertical_other: 'Commercial laundry',
+        how_heard: 'other',
+        how_heard_other: 'Existing client intro',
+        biggest_challenge: 'Scheduling',
+      })
+    ).toEqual({
+      vertical: 'Commercial laundry',
+      how_heard: 'Existing client intro',
+      biggest_challenge: 'Scheduling',
+    })
+  })
+})
+
+describe('book and get-started intake surfaces', () => {
+  const bookSrc = readFileSync(resolve('src/pages/book.astro'), 'utf-8')
+  const getStartedSrc = readFileSync(resolve('src/pages/get-started.astro'), 'utf-8')
+  const componentSrc = readFileSync(
+    resolve('src/components/booking/IntakeQuestionnaire.astro'),
+    'utf-8'
+  )
+
+  it('both pages import the shared questionnaire primitive', () => {
+    expect(bookSrc).toContain(
+      "import IntakeQuestionnaire from '../components/booking/IntakeQuestionnaire.astro'"
+    )
+    expect(getStartedSrc).toContain(
+      "import IntakeQuestionnaire from '../components/booking/IntakeQuestionnaire.astro'"
+    )
+  })
+
+  it('renders booking mode on /book and prep mode on /get-started', () => {
+    expect(bookSrc).toContain('<IntakeQuestionnaire')
+    expect(bookSrc).toContain('mode="booking"')
+    expect(getStartedSrc).toContain('<IntakeQuestionnaire idPrefix="gs" mode="prep" />')
+  })
+
+  it('routes both page scripts through the shared normalization helper', () => {
+    expect(bookSrc).toContain(
+      "import { formDataToObject, normalizeIntakePayload } from '../lib/booking/intake-questionnaire'"
+    )
+    expect(getStartedSrc).toContain(
+      "import { formDataToObject, normalizeIntakePayload } from '../lib/booking/intake-questionnaire'"
+    )
+    expect(bookSrc).toContain('normalizeIntakePayload(formDataToObject(new FormData(form)))')
+    expect(getStartedSrc).toContain('normalizeIntakePayload(formDataToObject(new FormData(form)))')
+  })
+
+  it('renders select options from the canonical helper module inside the shared component', () => {
+    expect(componentSrc).toContain("from '../../lib/booking/intake-questionnaire'")
+    expect(componentSrc).toContain('INTAKE_EMPLOYEE_COUNT_OPTIONS')
+    expect(componentSrc).toContain('INTAKE_YEARS_IN_BUSINESS_OPTIONS')
+    expect(componentSrc).toContain('INTAKE_HOW_HEARD_OPTIONS')
+  })
+})

--- a/tests/quotes-authored-content.test.ts
+++ b/tests/quotes-authored-content.test.ts
@@ -473,58 +473,62 @@ describe('portal proposal page: render gating', () => {
 })
 
 describe('admin quote builder: authoring UI + send gate', () => {
-  const source = () =>
+  const pageSource = () =>
     readFileSync(resolve('src/pages/admin/entities/[id]/quotes/[quoteId].astro'), 'utf-8')
+  const loaderSource = () => readFileSync(resolve('src/lib/admin/quote-builder-page.ts'), 'utf-8')
+  const clientSource = () => readFileSync(resolve('src/lib/admin/quote-builder-client.ts'), 'utf-8')
 
-  it('imports parsing helpers', () => {
-    const code = source()
+  it('routes authored-content parsing through the extracted loader', () => {
+    expect(pageSource()).toContain('loadQuoteBuilderPage')
+    const code = loaderSource()
     expect(code).toContain('parseSchedule')
     expect(code).toContain('parseDeliverables')
     expect(code).toContain('getMissingAuthoredContent')
   })
 
   it('renders schedule row editor', () => {
-    const code = source()
+    const code = pageSource()
     expect(code).toContain('add-schedule-row-btn')
     expect(code).toContain('schedule-label')
     expect(code).toContain('schedule-body')
   })
 
   it('renders deliverable row editor', () => {
-    const code = source()
+    const code = pageSource()
     expect(code).toContain('add-deliverable-row-btn')
     expect(code).toContain('deliverable-title')
     expect(code).toContain('deliverable-body')
   })
 
   it('renders engagement-overview textarea', () => {
-    const code = source()
+    const code = pageSource()
     expect(code).toContain('engagement-overview-input')
     expect(code).toContain('Engagement overview')
   })
 
   it('renders milestone-label input behind isThreeMilestone gate', () => {
-    const code = source()
+    const code = pageSource()
     expect(code).toContain('milestone-label-input')
     expect(code).toContain('isThreeMilestone &&')
   })
 
   it('shows missing-authored-content banner when fields are empty', () => {
-    const code = source()
+    const code = pageSource()
     expect(code).toContain('missingAuthored')
     expect(code).toContain('Required to send')
   })
 
   it('hidden fields submit schedule, deliverables, overview, milestone_label', () => {
-    const code = source()
+    const code = pageSource()
     expect(code).toContain('save-schedule')
     expect(code).toContain('save-deliverables')
     expect(code).toContain('save-engagement-overview')
     expect(code).toContain('save-milestone-label')
   })
 
-  it('serializes authored rows into hidden inputs before submit', () => {
-    const code = source()
+  it('serializes authored rows into hidden inputs in the extracted client module', () => {
+    expect(pageSource()).toContain('initQuoteBuilderPage')
+    const code = clientSource()
     expect(code).toContain('syncAuthoredContentInputs')
     expect(code).toContain('getScheduleRows')
     expect(code).toContain('getDeliverableRows')

--- a/tests/quotes.test.ts
+++ b/tests/quotes.test.ts
@@ -277,6 +277,8 @@ describe('quotes: repeat-quote flow (#472)', () => {
     readFileSync(resolve('src/pages/api/admin/entities/[id]/quotes.ts'), 'utf-8')
   const entityPageSource = () =>
     readFileSync(resolve('src/pages/admin/entities/[id].astro'), 'utf-8')
+  const entityLoaderSource = () =>
+    readFileSync(resolve('src/lib/admin/entity-detail-page.ts'), 'utf-8')
 
   it('exports hasOpenQuoteForEntity helper', () => {
     expect(dalSource()).toContain('export async function hasOpenQuoteForEntity')
@@ -345,11 +347,11 @@ describe('quotes: repeat-quote flow (#472)', () => {
     expect(code).not.toContain("'superseded'")
   })
 
-  it('entity detail page computes showNewQuoteButton with correct preconditions', () => {
-    const code = entityPageSource()
+  it('entity detail loader computes showNewQuoteButton with correct preconditions', () => {
+    const code = entityLoaderSource()
     expect(code).toContain('showNewQuoteButton')
     expect(code).toContain('hasOpenQuoteForEntity')
-    expect(code).toContain('newQuoteStages')
+    expect(code).toContain("['signal', 'prospect', 'meetings', 'proposing'].includes(entity.stage)")
     expect(code).toContain("'proposing'")
   })
 


### PR DESCRIPTION
## Summary
- stop speculative enrichment summaries from feeding back into shared context, and add prompt-contract coverage around extractive evidence
- extract the shared intake questionnaire, tighten shipped copy guards, and remove em-dash and placeholder regressions from client and portal surfaces
- split the largest admin Astro detail pages into loader and client modules, add shared admin primitives, and lock the boundary with regression tests

## Test plan
- [x] `npm run verify`
- [x] Targeted regression coverage for context assembly, prompt contracts, intake sharing, admin Astro boundaries, and quote admin architecture

🤖 Generated with OpenAI Codex
