### PR TITLE
chore: dirty-tree cleanup — warning sweep, lost-reasons rename completion, skill workflow fixes

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -362,9 +362,17 @@ gh issue list --repo {ORG}/{REPO_NAME} --label "source:code-review" --state open
 
 If an existing open issue covers the same finding, skip creation and note it in the report.
 
-### Step 9: Done
+### Step 9: Record Completion and Display Summary
 
-Display a summary:
+**9a. Record completion in the Cadence Engine — this MUST happen before the summary.** Past runs have skipped this when it was framed as a tail action; if you skip it now, the briefing will say "Code Review (X) — UNTRACKED" even though the review ran.
+
+```
+crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "success", summary: "Grade: {GRADE}, {N} issues created", completed_by: "crane-mcp")
+```
+
+If `crane_schedule` returns an error, surface it in the summary so the gap is visible — do NOT silently move on.
+
+**9b. Display the summary:**
 
 ```
 Review complete.
@@ -373,6 +381,7 @@ Overall Grade: {GRADE} {trend}
 VCMS Scorecard: stored (tag: code-review)
 Full Report: docs/reviews/code-review-{date}.md
 Issues Created: {N} (or "none")
+Cadence: recorded (or "FAILED — {error}")
 
 Top action items:
 1. {Most important finding}
@@ -381,12 +390,6 @@ Top action items:
 ```
 
 Do NOT automatically commit the full report. The user may want to review it first.
-
-After displaying the summary, record the completion in the Cadence Engine:
-
-```
-crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "success", summary: "Grade: {GRADE}, {N} issues created", completed_by: "crane-mcp")
-```
 
 ---
 

--- a/.claude/commands/eos.md
+++ b/.claude/commands/eos.md
@@ -83,15 +83,18 @@ This writes to D1 via the Crane Context API. The next session's SOD will read it
 If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
 
 1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
-2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
-3. Each handoff summary should cover only the work relevant to that venture.
+2. For each venture EXCEPT THE LAST, call `crane_handoff` with `venture: "<code>"` AND `final: false`. The `final: false` flag tells the API to create the handoff record but keep the session active so the next call doesn't 409 with "Session is not active".
+3. For the FINAL venture, call `crane_handoff` without `final` (or with `final: true`). This call ends the session.
+4. Each handoff summary should cover only the work relevant to that venture.
 
 Example for a session that touched both `dc` and `vc`:
 
 ```
-crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc", final: false)
 crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
 ```
+
+Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
 
 ### 6. Report Completion
 

--- a/docs/design/contributions/round-1/design-technologist.md
+++ b/docs/design/contributions/round-1/design-technologist.md
@@ -319,7 +319,7 @@ This maps motion tokens into Tailwind v4's `duration-*` and `ease-*` utility nam
 
 **Primary:** Utility-first via Tailwind v4. All styling is accomplished through utility classes that resolve to `--ss-*` token values via the `@theme inline` mapping.
 
-**Token references in source:** Components reference tokens directly as `var(--ss-color-*)` inside `[color:var(--ss-color-*)]` bracket syntax and as bare Tailwind utilities (`bg-primary`, `text-caption`, `p-card`, `rounded-card`). Both patterns are valid; new code should prefer the Tailwind utility form where the token map exists.
+**Token references in source:** Components reference color tokens directly via CSS custom properties and via Tailwind arbitrary-value utilities such as `[color:var(--ss-color-text-primary)]`, alongside bare Tailwind utilities (`bg-primary`, `text-caption`, `p-card`, `rounded-card`). Both patterns are valid; new code should prefer the Tailwind utility form where the token map exists.
 
 **`@layer base`:** Establishes body defaults — background, text color, font family, font smoothing. H1/H2/H3 use `--ss-font-display`. No other base overrides.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,10 @@
 import js from '@eslint/js'
+import { defineConfig } from 'eslint/config'
 import tseslint from 'typescript-eslint'
 import astro from 'eslint-plugin-astro'
 import globals from 'globals'
 
-export default tseslint.config(
+export default defineConfig(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,

--- a/src/components/booking/SlotPicker.astro
+++ b/src/components/booking/SlotPicker.astro
@@ -200,61 +200,54 @@
       show(el)
     }
 
-    function fetchSlots() {
+    async function fetchSlots() {
       showOnly(loadingEl)
       hide(staleEl)
       selectedSlot = null
 
-      fetch('/api/booking/slots?tz=' + encodeURIComponent(guestTz))
-        .then(function (res) {
-          if (res.status === 503) {
-            return res.json().then(function (body) {
-              showOnly(unavailableEl)
-              if (body.fallback && body.fallback.email) {
-                const mailto =
-                  'mailto:' + body.fallback.email + '?subject=Assessment%20Call%20Request'
-                const link = unavailableEl.querySelector('a')
-                if (link) {
-                  link.href = mailto
-                  link.textContent = 'Email ' + body.fallback.email
-                }
-              }
-              throw new Error('__handled__')
-            })
+      try {
+        const res = await fetch('/api/booking/slots?tz=' + encodeURIComponent(guestTz))
+        if (res.status === 503) {
+          const body = await res.json()
+          showOnly(unavailableEl)
+          if (body.fallback && body.fallback.email) {
+            const mailto = 'mailto:' + body.fallback.email + '?subject=Assessment%20Call%20Request'
+            const link = unavailableEl.querySelector('a')
+            if (link) {
+              link.href = mailto
+              link.textContent = 'Email ' + body.fallback.email
+            }
           }
-          if (!res.ok) {
-            return res.text().then(function (t) {
-              throw new Error('API ' + res.status + ': ' + t)
-            })
-          }
-          return res.json()
-        })
-        .then(function (data) {
-          allDays = (data.days || []).filter(function (d) {
-            return d.slots && d.slots.length > 0
-          })
-          fetchedAt = Date.now()
+          return
+        }
+        if (!res.ok) {
+          throw new Error('API ' + res.status + ': ' + (await res.text()))
+        }
 
-          if (allDays.length === 0) {
-            showOnly(emptyEl)
-            return
-          }
+        const data = await res.json()
+        allDays = (data.days || []).filter(function (d) {
+          return d.slots && d.slots.length > 0
+        })
+        fetchedAt = Date.now()
 
-          tzLabel.textContent = 'Times shown in ' + guestTz.replace(/_/g, ' ')
-          const firstAvailDate = parseLocalDate(allDays[0].date)
-          viewingYear = firstAvailDate.getFullYear()
-          viewingMonth = firstAvailDate.getMonth()
-          selectedDate = allDays[0].date
-          renderDates()
-          renderSlots()
-          showOnly(mainEl)
-        })
-        .catch(function (err) {
-          if (err.message === '__handled__') return
-          console.error('[SlotPicker] fetch failed:', err)
-          errorMsg.textContent = 'Could not load available times. Please try again.'
-          showOnly(errorEl)
-        })
+        if (allDays.length === 0) {
+          showOnly(emptyEl)
+          return
+        }
+
+        tzLabel.textContent = 'Times shown in ' + guestTz.replace(/_/g, ' ')
+        const firstAvailDate = parseLocalDate(allDays[0].date)
+        viewingYear = firstAvailDate.getFullYear()
+        viewingMonth = firstAvailDate.getMonth()
+        selectedDate = allDays[0].date
+        renderDates()
+        renderSlots()
+        showOnly(mainEl)
+      } catch (err) {
+        console.error('[SlotPicker] fetch failed:', err)
+        errorMsg.textContent = 'Could not load available times. Please try again.'
+        showOnly(errorEl)
+      }
     }
 
     function makeDateClickHandler(dateStr) {

--- a/src/components/portal/PortalPageHead.astro
+++ b/src/components/portal/PortalPageHead.astro
@@ -40,7 +40,7 @@ const {
   h1,
   meta = null,
   class: klass = '',
-} = Astro.props
+} = Astro.props as Props
 
 const showCrumb = !!(crumbHref && crumbLabel)
 ---

--- a/src/components/portal/PortalTabs.astro
+++ b/src/components/portal/PortalTabs.astro
@@ -47,7 +47,7 @@ interface Props {
   role?: string
 }
 
-const { pathname, role = 'client' } = Astro.props
+const { pathname, role = 'client' } = Astro.props as Props
 
 interface TabDef {
   href: string

--- a/src/lib/db/entities-bulk.ts
+++ b/src/lib/db/entities-bulk.ts
@@ -12,7 +12,7 @@
 
 import { transitionStage, type Entity } from './entities.js'
 import { appendContext } from './context.js'
-import { isLostReason, labelForLostReason, type LostReason } from './lost-reasons.js'
+import { isLostReasonCode, lostReasonLabel, type LostReasonCode } from './lost-reasons.js'
 
 export interface BulkActionOk {
   id: string
@@ -29,7 +29,7 @@ export interface BulkActionResult {
 }
 
 export interface BulkDismissOptions {
-  reason: LostReason
+  reason: LostReasonCode
   detail?: string | null
 }
 
@@ -52,13 +52,13 @@ export async function bulkDismissEntities(
   ids: string[],
   options: BulkDismissOptions
 ): Promise<BulkActionResult> {
-  if (!isLostReason(options.reason)) {
+  if (!isLostReasonCode(options.reason)) {
     throw new Error(`Invalid lost reason: ${options.reason}`)
   }
 
   const ok: BulkActionOk[] = []
   const failed: BulkActionFailure[] = []
-  const reasonLabel = labelForLostReason(options.reason)
+  const reasonLabel = lostReasonLabel(options.reason) ?? options.reason
   const reasonText = options.detail?.trim()
     ? `${reasonLabel}: ${options.detail.trim()}`
     : reasonLabel

--- a/src/lib/db/lost-reasons.ts
+++ b/src/lib/db/lost-reasons.ts
@@ -115,14 +115,3 @@ export function lostReasonChipClass(code: string | null | undefined): string {
       return 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)]'
   }
 }
-
-/** @deprecated Use LostReasonCode. Back-compat alias for #508 bulk endpoint. */
-export type LostReason = LostReasonCode
-
-/** @deprecated Use isLostReasonCode. Back-compat alias for #508 bulk endpoint. */
-export const isLostReason = isLostReasonCode
-
-/** @deprecated Use lostReasonLabel. Back-compat alias for #508 bulk endpoint. */
-export function labelForLostReason(value: LostReason): string {
-  return lostReasonLabel(value) ?? value
-}

--- a/src/lib/portal/status.ts
+++ b/src/lib/portal/status.ts
@@ -3,7 +3,8 @@
  *
  * Source of truth for status rendering on all portal surfaces. Admin uses
  * src/lib/ui/status-badge.ts (raw Tailwind hex-family classes); portal uses
- * this module (semantic var(--ss-color-*) tokens). They remain separate by
+ * this module (semantic CSS color tokens such as `var(--ss-color-primary)`).
+ * They remain separate by
  * design — the portal is the drift surface and stays tone-based.
  *
  * Contract (UI-PATTERNS.md R7):

--- a/src/pages/admin/entities/[id]/meetings/[meetingId].astro
+++ b/src/pages/admin/entities/[id]/meetings/[meetingId].astro
@@ -437,7 +437,7 @@ const isMeetingTerminal =
       }
     </div>
   </div>
-  <script define:vars={{ entityId, meetingId }}>
+  <script is:inline define:vars={{ entityId, meetingId }}>
     // Live notes auto-save
     const textarea = document.getElementById('live-notes')
     const saveStatus = document.getElementById('save-status')

--- a/src/pages/admin/generators/[type].astro
+++ b/src/pages/admin/generators/[type].astro
@@ -1,10 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
-import {
-  getGeneratorConfig,
-  recordGeneratorRun,
-  upsertGeneratorConfig,
-} from '../../../lib/db/generators'
+import { getGeneratorConfig, upsertGeneratorConfig } from '../../../lib/db/generators'
 import {
   PIPELINE_IDS,
   PIPELINE_LABELS,
@@ -69,8 +65,10 @@ if (Astro.request.method === 'POST') {
     const enabled = form.get('enabled') === 'on'
     const result = await upsertGeneratorConfig(env.DB, session.orgId, type, config, enabled)
     if (!result.ok) {
-      const params = new URLSearchParams({ error: result.errors.join(' · ') })
-      return Astro.redirect(`/admin/generators/${type}?${params.toString()}`, 302)
+      return Astro.redirect(
+        `/admin/generators/${type}?${new URLSearchParams({ error: result.errors.join(' · ') }).toString()}`,
+        302
+      )
     }
     return Astro.redirect(`/admin/generators/${type}?saved=1`, 302)
   }
@@ -87,19 +85,28 @@ if (Astro.request.method === 'POST') {
         headers: { Authorization: `Bearer ${key}` },
       })
       if (!res.ok) {
-        const params = new URLSearchParams({
-          error: `Worker returned ${res.status}`,
-        })
-        return Astro.redirect(`/admin/generators/${type}?${params.toString()}`, 302)
+        return Astro.redirect(
+          `/admin/generators/${type}?${new URLSearchParams({
+            error: `Worker returned ${res.status}`,
+          }).toString()}`,
+          302
+        )
       }
-      const summary = (await res.json()) as { written?: number; qualified?: number }
-      const signals = summary.written ?? summary.qualified ?? 0
-      return Astro.redirect(`/admin/generators/${type}?ran=1&signals=${signals}`, 302)
+      const resultJson = (await res.json()) as { written?: number; qualified?: number }
+      const redirectUrl = new URL(`/admin/generators/${type}`, Astro.url)
+      redirectUrl.searchParams.set('ran', '1')
+      redirectUrl.searchParams.set(
+        'signals',
+        String(resultJson.written ?? resultJson.qualified ?? 0)
+      )
+      return Astro.redirect(`${redirectUrl.pathname}${redirectUrl.search}`, 302)
     } catch (e) {
-      const params = new URLSearchParams({
-        error: e instanceof Error ? e.message : 'Worker unreachable',
-      })
-      return Astro.redirect(`/admin/generators/${type}?${params.toString()}`, 302)
+      return Astro.redirect(
+        `/admin/generators/${type}?${new URLSearchParams({
+          error: e instanceof Error ? e.message : 'Worker unreachable',
+        }).toString()}`,
+        302
+      )
     }
   }
 }

--- a/src/pages/admin/generators/index.astro
+++ b/src/pages/admin/generators/index.astro
@@ -105,15 +105,15 @@ const metrics = await Promise.all(
   PIPELINES.map(async (p) => ({ pipeline: p, metrics: await getPipelineMetrics(p.id) }))
 )
 
-function avgPainScore(pipeline: string): Promise<number | null> {
-  return env.DB.prepare(
+async function avgPainScore(pipeline: string): Promise<number | null> {
+  const row = await env.DB.prepare(
     `SELECT AVG(pain_score) as avg
      FROM entities
      WHERE stage = 'signal' AND org_id = ? AND source_pipeline = ? AND pain_score IS NOT NULL`
   )
     .bind(session.orgId, pipeline)
     .first<{ avg: number | null }>()
-    .then((r) => r?.avg ?? null)
+  return row?.avg ?? null
 }
 
 const painAvgs = await Promise.all(

--- a/src/pages/admin/settings/pipelines.astro
+++ b/src/pages/admin/settings/pipelines.astro
@@ -68,8 +68,13 @@ if (Astro.request.method === 'POST') {
   })
 
   if (!result.ok) {
-    const params = new URLSearchParams({ error: result.errors.join(' · '), pipeline })
-    return Astro.redirect(`/admin/settings/pipelines?${params.toString()}`, 302)
+    return Astro.redirect(
+      `/admin/settings/pipelines?${new URLSearchParams({
+        error: result.errors.join(' · '),
+        pipeline,
+      }).toString()}`,
+      302
+    )
   }
 
   return Astro.redirect(

--- a/src/pages/api/admin/entities/bulk.ts
+++ b/src/pages/api/admin/entities/bulk.ts
@@ -5,7 +5,7 @@ import {
   listEntitiesForExport,
   type BulkActionResult,
 } from '../../../../lib/db/entities-bulk'
-import { isLostReason, type LostReason } from '../../../../lib/db/lost-reasons'
+import { isLostReasonCode, type LostReasonCode } from '../../../../lib/db/lost-reasons'
 
 /**
  * POST /api/admin/entities/bulk
@@ -14,7 +14,7 @@ import { isLostReason, type LostReason } from '../../../../lib/db/lost-reasons'
  *   {
  *     ids: string[],
  *     action: 'dismiss' | 'export',
- *     reason?: LostReason,              // required when action='dismiss'
+ *     reason?: LostReasonCode,          // required when action='dismiss'
  *     reasonDetail?: string | null      // optional when action='dismiss'
  *   }
  *
@@ -70,7 +70,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   try {
     if (action === 'dismiss') {
-      if (!isLostReason(reason)) {
+      if (!isLostReasonCode(reason)) {
         return jsonResponse(
           {
             error:
@@ -83,7 +83,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         typeof reasonDetail === 'string' && reasonDetail.trim() ? reasonDetail.trim() : null
 
       const result: BulkActionResult = await bulkDismissEntities(env.DB, session.orgId, stringIds, {
-        reason: reason as LostReason,
+        reason: reason as LostReasonCode,
         detail,
       })
       return jsonResponse(result, result.failed.length === 0 ? 200 : 207)

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -65,23 +65,20 @@ await env.DB.prepare(`UPDATE users SET last_login_at = datetime('now') WHERE id 
   .bind(user.id)
   .run()
 
-// Create session
 const sessionToken = await createSession(env.DB, env.SESSIONS, {
   id: user.id,
   orgId: user.org_id,
   role: user.role,
   email: user.email,
 })
+const location = (() => {
+  const portalBaseUrl = getPortalBaseUrl(env)
+  return portalBaseUrl ? `${portalBaseUrl}/` : '/portal'
+})()
+const setCookie = buildSessionCookie(sessionToken, user.role)
+const response = new Response(null, { status: 302 })
+response.headers.set('Location', location)
+response.headers.set('Set-Cookie', setCookie)
 
-// Redirect to portal with session cookie
-const portalBaseUrl = getPortalBaseUrl(env)
-const redirectTo = portalBaseUrl ? `${portalBaseUrl}/` : '/portal'
-
-return new Response(null, {
-  status: 302,
-  headers: {
-    Location: redirectTo,
-    'Set-Cookie': buildSessionCookie(sessionToken, user.role),
-  },
-})
+return response
 ---

--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -287,49 +287,45 @@ import Footer from '../../../components/Footer.astro'
 
     let bookingData = null
 
-    function loadBooking(tkn) {
-      fetch('/api/booking/manage/' + tkn)
-        .then(function (res) {
-          return res.json().then(function (d) {
-            return { status: res.status, data: d }
-          })
-        })
-        .then(function (result) {
-          hide('loading')
-          if (result.status === 404) {
-            showError('Booking not found', result.data.message || 'This link is not valid.')
-            return
-          }
-          if (result.status === 410) {
-            showError('Link expired', result.data.message || 'This manage link has expired.')
-            return
-          }
-          if (result.status >= 400) {
-            showError('Something went wrong', result.data.message || 'Please try again.')
-            return
-          }
+    async function loadBooking(tkn) {
+      try {
+        const res = await fetch('/api/booking/manage/' + tkn)
+        const data = await res.json()
 
-          bookingData = result.data
-          if (bookingData.cancelled_at) {
-            show('cancelled-state')
-            return
-          }
+        hide('loading')
+        if (res.status === 404) {
+          showError('Booking not found', data.message || 'This link is not valid.')
+          return
+        }
+        if (res.status === 410) {
+          showError('Link expired', data.message || 'This manage link has expired.')
+          return
+        }
+        if (res.status >= 400) {
+          showError('Something went wrong', data.message || 'Please try again.')
+          return
+        }
 
-          document.getElementById('meeting-label').textContent = bookingData.meeting_label
-          document.getElementById('slot-label').textContent = bookingData.slot_label
-          document.getElementById('guest-name').textContent = bookingData.guest_name
-          if (bookingData.google_meet_url) {
-            const ml = document.getElementById('meet-link')
-            ml.href = bookingData.google_meet_url
-            ml.textContent = bookingData.google_meet_url
-            show('meet-link-container')
-          }
-          show('booking-details')
-        })
-        .catch(function () {
-          hide('loading')
-          showError('Something went wrong', "We couldn't load your booking. Please try again.")
-        })
+        bookingData = data
+        if (bookingData.cancelled_at) {
+          show('cancelled-state')
+          return
+        }
+
+        document.getElementById('meeting-label').textContent = bookingData.meeting_label
+        document.getElementById('slot-label').textContent = bookingData.slot_label
+        document.getElementById('guest-name').textContent = bookingData.guest_name
+        if (bookingData.google_meet_url) {
+          const ml = document.getElementById('meet-link')
+          ml.href = bookingData.google_meet_url
+          ml.textContent = bookingData.google_meet_url
+          show('meet-link-container')
+        }
+        show('booking-details')
+      } catch {
+        hide('loading')
+        showError('Something went wrong', "We couldn't load your booking. Please try again.")
+      }
     }
 
     document.getElementById('cancel-btn').addEventListener('click', function () {
@@ -439,47 +435,42 @@ import Footer from '../../../components/Footer.astro'
         })
     }
 
-    function confirmReschedule(startUtc, timeLabel, dayLabel) {
+    async function confirmReschedule(startUtc, timeLabel, dayLabel) {
       if (!confirm('Reschedule to ' + dayLabel + ' at ' + timeLabel + '?')) return
       const btns = document.querySelectorAll('#slots-container button')
       btns.forEach(function (b) {
         b.disabled = true
         b.classList.add('opacity-50')
       })
-      fetch('/api/booking/manage/' + token + '/reschedule', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slot_start_utc: startUtc }),
-      })
-        .then(function (r) {
-          return r.json().then(function (d) {
-            return { status: r.status, data: d }
-          })
+      try {
+        const r = await fetch('/api/booking/manage/' + token + '/reschedule', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slot_start_utc: startUtc }),
         })
-        .then(function (result) {
-          if (result.data.ok) {
-            hide('reschedule-panel')
-            showSuccess(
-              'Booking rescheduled',
-              'Your call has been moved to ' +
-                result.data.slot_label +
-                ". We'll send a confirmation email with the updated details."
-            )
-          } else {
-            btns.forEach(function (b) {
-              b.disabled = false
-              b.classList.remove('opacity-50')
-            })
-            alert(result.data.message || 'Failed to reschedule.')
-          }
-        })
-        .catch(function () {
+        const data = await r.json()
+        if (data.ok) {
+          hide('reschedule-panel')
+          showSuccess(
+            'Booking rescheduled',
+            'Your call has been moved to ' +
+              data.slot_label +
+              ". We'll send a confirmation email with the updated details."
+          )
+        } else {
           btns.forEach(function (b) {
             b.disabled = false
             b.classList.remove('opacity-50')
           })
-          alert('Something went wrong.')
+          alert(data.message || 'Failed to reschedule.')
+        }
+      } catch {
+        btns.forEach(function (b) {
+          b.disabled = false
+          b.classList.remove('opacity-50')
         })
+        alert('Something went wrong.')
+      }
     }
 
     function show(id) {

--- a/tests/draftable-meeting.test.ts
+++ b/tests/draftable-meeting.test.ts
@@ -15,7 +15,6 @@ type M = {
   completed_at: string | null
   created_at: string
 }
-type Q = { meeting_id: string | null; assessment_id: string }
 
 const completed = (id: string, completedAt: string | null = null, createdAt = '2026-01-01'): M => ({
   id,

--- a/tests/entities-bulk.test.ts
+++ b/tests/entities-bulk.test.ts
@@ -59,7 +59,7 @@ describe('entities-bulk: DAL', () => {
 
   it('validates the reason enum before doing any work', () => {
     const code = source()
-    expect(code).toContain('isLostReason(options.reason)')
+    expect(code).toContain('isLostReasonCode(options.reason)')
   })
 
   it('listEntitiesForExport uses parameterized IN query with per-id placeholders', () => {
@@ -103,8 +103,8 @@ describe('api/admin/entities/bulk: endpoint', () => {
     expect(source()).toContain('batch size capped')
   })
 
-  it('validates reason via canonical isLostReason', () => {
-    expect(source()).toContain('isLostReason(reason)')
+  it('validates reason via canonical isLostReasonCode', () => {
+    expect(source()).toContain('isLostReasonCode(reason)')
   })
 
   it('returns 207 when some entities fail (partial success)', () => {

--- a/tests/lost-reasons.test.ts
+++ b/tests/lost-reasons.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
-import { LOST_REASONS, isLostReason, labelForLostReason } from '../src/lib/db/lost-reasons'
+import { LOST_REASONS, isLostReasonCode, lostReasonLabel } from '../src/lib/db/lost-reasons'
 
 describe('lost-reasons: canonical enum (shared with #477)', () => {
   it('module exists', () => {
@@ -30,17 +30,17 @@ describe('lost-reasons: canonical enum (shared with #477)', () => {
     }
   })
 
-  it('isLostReason narrows unknown input', () => {
-    expect(isLostReason('not-a-fit')).toBe(true)
-    expect(isLostReason('no-budget')).toBe(true)
-    expect(isLostReason('bogus')).toBe(false)
-    expect(isLostReason(null)).toBe(false)
-    expect(isLostReason(42)).toBe(false)
+  it('isLostReasonCode narrows unknown input', () => {
+    expect(isLostReasonCode('not-a-fit')).toBe(true)
+    expect(isLostReasonCode('no-budget')).toBe(true)
+    expect(isLostReasonCode('bogus')).toBe(false)
+    expect(isLostReasonCode(null)).toBe(false)
+    expect(isLostReasonCode(42)).toBe(false)
   })
 
-  it('labelForLostReason returns the canonical label', () => {
-    expect(labelForLostReason('not-a-fit')).toBe('Not a fit')
-    expect(labelForLostReason('declined-quote')).toBe('Declined quote')
+  it('lostReasonLabel returns the canonical label', () => {
+    expect(lostReasonLabel('not-a-fit')).toBe('Not a fit')
+    expect(lostReasonLabel('declined-quote')).toBe('Declined quote')
   })
 
   it('source does not invent extra values (single source of truth)', () => {

--- a/tests/sow-render.test.ts
+++ b/tests/sow-render.test.ts
@@ -19,42 +19,6 @@ import { describe, it, expect } from 'vitest'
 // import { renderSow } from '../src/lib/pdf/render'
 // import { writeFileSync } from 'fs'
 
-const baseProps = {
-  client: {
-    businessName: 'Desert Bloom Landscaping',
-    contactName: 'Maria Rodriguez',
-    contactTitle: 'Owner',
-  },
-  document: {
-    date: 'April 12, 2026',
-    expirationDate: 'April 17, 2026',
-    sowNumber: 'SOW-202604-001',
-  },
-  engagement: {
-    overview: 'Operations cleanup engagement as discussed during assessment.',
-    startDate: 'TBD upon deposit',
-    endDate: 'TBD based on scope',
-  },
-  items: [
-    {
-      name: 'Owner bottleneck',
-      description:
-        'Document key processes, build SOPs for scheduling and estimates, establish delegation framework',
-    },
-    {
-      name: 'Scheduling chaos',
-      description:
-        'Configure centralized scheduling tool, set up automated reminders, build crew assignment workflow, train team',
-    },
-  ],
-  payment: {
-    schedule: 'two_part' as const,
-    totalPrice: '$2,700',
-    deposit: '$1,350',
-    completion: '$1,350',
-  },
-}
-
 // Skipped: WASM not available in vitest/Node.js environment.
 // Validated via Astro build and live deployment.
 describe.skip('sow-render: PDF generation', () => {

--- a/workers/social-listening/src/index.ts
+++ b/workers/social-listening/src/index.ts
@@ -346,7 +346,7 @@ export default {
     }
   },
 
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const auth = request.headers.get('Authorization')
     if (auth !== `Bearer ${env.LEAD_INGEST_API_KEY}`) {
       return new Response('Unauthorized', { status: 401 })


### PR DESCRIPTION
## Summary

Bundled cleanup pass to clear ~22 dirty files left over from PR #647. The previous session held them back to scope #647 to issue-work only. All edits are warning-cleanup, rename-completion, or skill workflow fixes — no behavior changes.

**Lost-reasons rename completion (5 files).** Drops the back-compat aliases #508 added (`LostReason`, `isLostReason`, `labelForLostReason`) now that all callers use the canonical `Code`-suffixed names. Verified zero remaining callers on the old names.

**Warning cleanup (~14 files).** Typed `Astro.props` in PortalPageHead/PortalTabs; async/await conversions in SlotPicker, generators/index, book/manage/[token]; URL-builder pattern in admin redirect handlers; `is:inline` on define:vars script; `_ctx` rename for unused param in social-listening worker; dead-code removal in skipped tests; comment refinements (no `--ss-*` token globbing in prose).

**Skill workflow fixes (2 files).** `code-review.md` records cadence completion BEFORE the summary so the briefing stops reading "UNTRACKED" when reviews actually ran. `eos.md` documents `final: false` for cross-venture handoffs so the non-final calls don't 409 on session termination.

**Tooling refresh (1 file).** `eslint.config.js` switches to `defineConfig()` from `eslint/config` (eslint v9+ pattern). Lint stays green.

**Out of scope, handled separately:**
- `.claude/commands/design-brief.md` regression that reversed dot-flattened VCMS paths back to slashed paths — reverted (memory documents that slashed paths 404).
- `.claude/commands/new-client.md` and `new-engagement.md` untracked duplicates of canonicals in crane-console — deleted. The skills + supporting infra (`config/ventures.json`, `setup-new-engagement.sh`, `crane-context` worker) all live in crane-console; the duplicates in ss-console are byte-identical but would be broken here because every relative path assumes crane-console PWD. Follow-up to promote them to enterprise skills (`.agents/skills/`) so they sync into every venture is tracked separately.

## Test plan
- [x] `npm run typecheck` — 0 errors across 388 files
- [x] `npm run typecheck:workers` — all 6 worker dirs clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — green
- [x] `npm run test` — 1989/1989 pass, 2 intentionally skipped (sow-render WASM)
- [x] `npm run test:workers` — all 6 worker test suites pass
- [ ] CI green
- [ ] Smoke-check `/portal/quotes/*` and `/admin/entities/*` after merge to confirm portal status rendering and bulk-dismiss endpoint are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)