### PR TITLE
fix(scan-workflow): bind APP_BASE_URL via [vars]; document correct secret set

### DIFF
--- a/workers/scan-workflow/wrangler.toml
+++ b/workers/scan-workflow/wrangler.toml
@@ -45,12 +45,20 @@ class_name = "ScanDiagnosticWorkflow"
 [observability]
 enabled = true
 
+# Non-secret env vars. APP_BASE_URL is the origin used by outbound URL
+# builders inside the workflow (booking links in the report email, magic-
+# link URLs for Outside View delivery). Must match the production origin
+# the email recipient will click into. Not a secret — committing the value
+# is fine.
+[vars]
+APP_BASE_URL = "https://smd.services"
+
 # ---------- Secrets (set via `wrangler secret put` or `wrangler secret bulk`) ----------
 # All secrets are set per-Worker. Captain provisions these from Infisical
 # after first deploy:
 #
 #   infisical export --env=prod --path=/ss --format=dotenv \
-#     | grep -E '^(RESEND_API_KEY|ANTHROPIC_API_KEY|GOOGLE_PLACES_API_KEY|OUTSCRAPER_API_KEY|LEAD_INGEST_API_KEY|APP_BASE_URL)=' \
+#     | grep -E '^(RESEND_API_KEY|ANTHROPIC_API_KEY|GOOGLE_PLACES_API_KEY|OUTSCRAPER_API_KEY|LEAD_INGEST_API_KEY)=' \
 #     | npx wrangler secret bulk --name ss-scan-workflow
 #
 # RESEND_API_KEY          — Resend transactional email (report + thin-footprint + admin alert)
@@ -58,4 +66,3 @@ enabled = true
 # GOOGLE_PLACES_API_KEY   — Google Places lookup (Tier 1 contact data)
 # OUTSCRAPER_API_KEY      — Outscraper business profile + reviews (Tier 1 contact data)
 # LEAD_INGEST_API_KEY     — Bearer token guarding the internal /dispatch endpoint
-# APP_BASE_URL            — Origin for outbound report links (e.g. https://smd.services)


### PR DESCRIPTION
## Summary

- Adds `[vars] APP_BASE_URL = \"https://smd.services\"` to `workers/scan-workflow/wrangler.toml` so outbound URL builders in the report email + Outside View magic-link email emit canonical origins. Non-secret, committable.
- Updates the documented secret-provisioning command to drop `APP_BASE_URL` (it's now an env var, not a secret) and keep only the 5 actual secrets needed: `RESEND_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_PLACES_API_KEY`, `OUTSCRAPER_API_KEY`, `LEAD_INGEST_API_KEY`.

## Incident context

The `ss-scan-workflow` Worker was deployed in #618 with **zero secrets bound** (caught this turn while diagnosing why a verified scan didn't email a report). With `env.RESEND_API_KEY` undefined, `sendEmail` short-circuited to its dev-mode branch (`return { success: true, id: 'dev-mode' }`). The workflow believed it sent and marked the scan `completed`, but no email left Resend. Diagnosed via the `outreach_events` row showing `message_id: 'dev-mode'`.

Manually provisioned the 5 secrets from Infisical to `ss-scan-workflow` and redeployed. Verified end-to-end: re-triggered the orphaned `azcec.us` scan (id `2413c551-5f26-43b4-9fc5-4bc1d431f10e`); pipeline ran 47.5s through all four Claude calls; Resend returned a real `message_id` (`2bc71dad-c76d-4be2-...`); Captain confirmed receipt.

## Test plan

- [x] `npx wrangler deploy` from `workers/scan-workflow/` succeeds and prints `env.APP_BASE_URL (\"https://smd.services\") Environment Variable` in the bindings list
- [x] Live workflow trigger completes with real Resend message_id
- [ ] Future deploys of `ss-scan-workflow` continue to bind APP_BASE_URL automatically (covered by the committed [vars] block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)