### PR TITLE
feat(portal): parking lot admin UI (#79)

### DIFF
--- a/src/components/admin/EngagementParkingLotPanel.astro
+++ b/src/components/admin/EngagementParkingLotPanel.astro
@@ -1,0 +1,190 @@
+---
+/**
+ * Parking Lot panel for the admin engagement detail page (Decision Stack #11).
+ *
+ * Renders the list of out-of-scope client requests captured during an
+ * engagement, with inline disposition (fold_in / follow_on / dropped + required
+ * rationale note) and an "+ Log parking lot item" form. Per the protocol,
+ * disposition rationale is required at click time — not pencil-edited later.
+ *
+ * Extracted from src/pages/admin/engagements/[id].astro to keep that page
+ * under its concern-boundary line cap (tests/admin-astro-boundaries.test.ts).
+ */
+import { statusBadgeClass } from '../../lib/ui/status-badge'
+import { formatDate } from '../../lib/admin/engagement-detail-page'
+import type { ParkingLotItem } from '../../lib/db/parking-lot'
+
+interface Props {
+  engagementId: string
+  parkingLot: ParkingLotItem[]
+}
+
+const { engagementId, parkingLot } = Astro.props
+---
+
+<div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]">
+  <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+    <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Parking Lot</h2>
+    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
+      Out-of-scope requests captured during the engagement. Disposition each one at the pre-handoff
+      review.
+    </p>
+  </div>
+  <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+    {
+      parkingLot.length === 0 && (
+        <div class="px-6 py-8 text-center text-sm text-[color:var(--ss-color-text-muted)]">
+          No parking lot items yet.
+        </div>
+      )
+    }
+    {
+      parkingLot.map((item) => (
+        <div class="px-6 py-4 space-y-row">
+          <div class="flex items-start justify-between gap-stack">
+            <div class="flex-1 min-w-0 space-y-1">
+              <div class="flex items-center gap-2">
+                <span class={statusBadgeClass(item.disposition ?? 'pending')}>
+                  {item.disposition ?? 'pending'}
+                </span>
+                <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                  {item.description}
+                </span>
+              </div>
+              <div class="text-xs text-[color:var(--ss-color-text-muted)]">
+                {item.requested_by ? <span>from {item.requested_by} · </span> : null}
+                Logged {formatDate(item.requested_at)}
+                {item.reviewed_at && <span> · Reviewed {formatDate(item.reviewed_at)}</span>}
+              </div>
+              {item.disposition && item.disposition_note && (
+                <p class="text-xs text-[color:var(--ss-color-text-secondary)] whitespace-pre-wrap pt-1">
+                  {item.disposition_note}
+                </p>
+              )}
+            </div>
+            {item.disposition === null && (
+              <form
+                method="POST"
+                action={`/api/admin/engagements/${engagementId}/parking-lot`}
+                class="flex-shrink-0"
+              >
+                <input type="hidden" name="_method" value="DELETE" />
+                <input type="hidden" name="item_id" value={item.id} />
+                <button
+                  type="submit"
+                  class="text-xs px-2 py-1 border border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                  onclick="return confirm('Delete this parking lot item?')"
+                >
+                  Del
+                </button>
+              </form>
+            )}
+          </div>
+          {item.disposition === null && (
+            <details class="border-t border-[color:var(--ss-color-border-subtle)] pt-2">
+              <summary class="cursor-pointer text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]">
+                Disposition →
+              </summary>
+              <form
+                method="POST"
+                action={`/api/admin/engagements/${engagementId}/parking-lot`}
+                class="space-y-row mt-2"
+              >
+                <input type="hidden" name="action" value="disposition" />
+                <input type="hidden" name="item_id" value={item.id} />
+                <textarea
+                  name="disposition_note"
+                  required
+                  rows="2"
+                  placeholder="Rationale (required) — what happens with this and why"
+                  class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+                />
+                <div class="flex gap-2 flex-wrap">
+                  <button
+                    type="submit"
+                    name="disposition"
+                    value="fold_in"
+                    class="text-xs px-2.5 py-1 border border-[color:var(--ss-color-complete)] text-[color:var(--ss-color-complete)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                  >
+                    Fold in
+                  </button>
+                  <button
+                    type="submit"
+                    name="disposition"
+                    value="follow_on"
+                    class="text-xs px-2.5 py-1 border border-[color:var(--ss-color-primary)] text-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                  >
+                    Follow-on
+                  </button>
+                  <button
+                    type="submit"
+                    name="disposition"
+                    value="dropped"
+                    class="text-xs px-2.5 py-1 border border-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                  >
+                    Drop
+                  </button>
+                </div>
+              </form>
+            </details>
+          )}
+        </div>
+      ))
+    }
+  </div>
+
+  <details class="border-t border-[color:var(--ss-color-border-subtle)]">
+    <summary
+      class="px-6 py-3 cursor-pointer text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
+    >
+      + Log parking lot item
+    </summary>
+    <div class="px-6 pb-4">
+      <form
+        method="POST"
+        action={`/api/admin/engagements/${engagementId}/parking-lot`}
+        class="space-y-row"
+      >
+        <div>
+          <label
+            for="pl_description"
+            class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
+          >
+            Description *
+          </label>
+          <input
+            type="text"
+            id="pl_description"
+            name="description"
+            required
+            placeholder="What did the client ask for?"
+            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+          />
+        </div>
+        <div>
+          <label
+            for="pl_requested_by"
+            class="block text-xs font-medium text-[color:var(--ss-color-text-secondary)] mb-1"
+          >
+            Requested by
+          </label>
+          <input
+            type="text"
+            id="pl_requested_by"
+            name="requested_by"
+            placeholder="Optional — name of the person who asked"
+            class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+          />
+        </div>
+        <div class="flex">
+          <button
+            type="submit"
+            class="ml-auto bg-[color:var(--ss-color-primary)] text-white text-xs px-3 py-1.5 hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
+          >
+            Log item
+          </button>
+        </div>
+      </form>
+    </div>
+  </details>
+</div>

--- a/src/lib/admin/engagement-detail-page.ts
+++ b/src/lib/admin/engagement-detail-page.ts
@@ -6,6 +6,7 @@ import { listMilestones, VALID_TRANSITIONS as MILESTONE_TRANSITIONS } from '../d
 import type { MilestoneStatus } from '../db/milestones'
 import { listInvoices } from '../db/invoices'
 import { listContext } from '../db/context'
+import { listParkingLot } from '../db/parking-lot'
 import { listSignalsForEntity } from '../db/signal-attribution'
 import { listDocuments } from '../storage/r2'
 
@@ -70,6 +71,7 @@ export async function loadEngagementDetailPage(params: {
   const contextEntries = await listContext(params.db, engagement.entity_id, {
     engagement_id: params.engagementId,
   })
+  const parkingLot = await listParkingLot(params.db, params.orgId, params.engagementId)
   const entitySignals = await listSignalsForEntity(params.db, params.orgId, engagement.entity_id)
   const documents = await listDocuments(
     params.storage,
@@ -87,6 +89,7 @@ export async function loadEngagementDetailPage(params: {
     milestones,
     invoices,
     contextEntries,
+    parkingLot,
     entitySignals,
     documents,
     status,
@@ -97,6 +100,9 @@ export async function loadEngagementDetailPage(params: {
     error: params.url.searchParams.get('error'),
     milestoneAdded: params.url.searchParams.get('milestone_added'),
     milestoneDeleted: params.url.searchParams.get('milestone_deleted'),
+    parkingLotAdded: params.url.searchParams.get('parking_lot_added'),
+    parkingLotDispositioned: params.url.searchParams.get('parking_lot_dispositioned'),
+    parkingLotDeleted: params.url.searchParams.get('parking_lot_deleted'),
   }
 }
 

--- a/src/lib/db/parking-lot.ts
+++ b/src/lib/db/parking-lot.ts
@@ -1,0 +1,154 @@
+/**
+ * Parking lot data access layer.
+ *
+ * Per Decision Stack #11 (Scope Creep Protocol): out-of-scope client requests
+ * captured during an engagement, then dispositioned at the pre-handoff review
+ * as fold_in / follow_on / dropped. Items are immutable once created — the
+ * description doesn't change after the fact; corrections are made by deleting
+ * + re-logging.
+ *
+ * Schema note: parking_lot has NO `org_id` column (unlike milestones). Org
+ * scoping is enforced by JOINing through `engagements.org_id` on every read,
+ * and by the endpoint layer pre-validating engagement ownership before any
+ * write. Cross-org reads return null/empty (no enumeration leak) rather than
+ * throwing — same convention as `getMilestone`.
+ *
+ * All queries are parameterized to prevent SQL injection.
+ */
+
+export type Disposition = 'fold_in' | 'follow_on' | 'dropped'
+
+export const DISPOSITIONS: Disposition[] = ['fold_in', 'follow_on', 'dropped']
+
+export interface ParkingLotItem {
+  id: string
+  engagement_id: string
+  description: string
+  requested_by: string | null
+  requested_at: string
+  disposition: Disposition | null
+  disposition_note: string | null
+  reviewed_at: string | null
+  follow_on_quote_id: string | null
+  created_at: string
+}
+
+export interface CreateParkingLotData {
+  description: string
+  requested_by?: string | null
+}
+
+/**
+ * List parking lot items for an engagement, oldest first.
+ * Scoped to the caller's org via JOIN to prevent cross-tenant reads.
+ */
+export async function listParkingLot(
+  db: D1Database,
+  orgId: string,
+  engagementId: string
+): Promise<ParkingLotItem[]> {
+  const result = await db
+    .prepare(
+      `SELECT pl.* FROM parking_lot pl
+       INNER JOIN engagements e ON e.id = pl.engagement_id
+       WHERE pl.engagement_id = ? AND e.org_id = ?
+       ORDER BY pl.created_at ASC`
+    )
+    .bind(engagementId, orgId)
+    .all<ParkingLotItem>()
+  return result.results
+}
+
+/**
+ * Get a single parking lot item by ID, scoped to the caller's org via JOIN.
+ * Returns null (not 403) when the item exists but belongs to a different org,
+ * to prevent tenant enumeration.
+ */
+export async function getParkingLotItem(
+  db: D1Database,
+  orgId: string,
+  itemId: string
+): Promise<ParkingLotItem | null> {
+  const result = await db
+    .prepare(
+      `SELECT pl.* FROM parking_lot pl
+       INNER JOIN engagements e ON e.id = pl.engagement_id
+       WHERE pl.id = ? AND e.org_id = ?`
+    )
+    .bind(itemId, orgId)
+    .first<ParkingLotItem>()
+  return result ?? null
+}
+
+/**
+ * Create a new parking lot item linked to an engagement. Returns the created
+ * record. The caller MUST validate engagement ownership before invoking.
+ */
+export async function createParkingLotItem(
+  db: D1Database,
+  orgId: string,
+  engagementId: string,
+  data: CreateParkingLotData
+): Promise<ParkingLotItem> {
+  const id = crypto.randomUUID()
+
+  await db
+    .prepare(
+      `INSERT INTO parking_lot (id, engagement_id, description, requested_by)
+       VALUES (?, ?, ?, ?)`
+    )
+    .bind(id, engagementId, data.description, data.requested_by ?? null)
+    .run()
+
+  const item = await getParkingLotItem(db, orgId, id)
+  if (!item) {
+    throw new Error('Failed to retrieve created parking lot item')
+  }
+  return item
+}
+
+/**
+ * Set or replace the disposition + note on an item. Stamps reviewed_at to
+ * now(). Idempotent — re-dispositioning replaces both fields and refreshes
+ * reviewed_at. Returns null if the item is not in the caller's org.
+ */
+export async function dispositionParkingLotItem(
+  db: D1Database,
+  orgId: string,
+  itemId: string,
+  disposition: Disposition,
+  note: string
+): Promise<ParkingLotItem | null> {
+  const existing = await getParkingLotItem(db, orgId, itemId)
+  if (!existing) return null
+
+  await db
+    .prepare(
+      `UPDATE parking_lot
+       SET disposition = ?, disposition_note = ?, reviewed_at = ?
+       WHERE id = ?`
+    )
+    .bind(disposition, note, new Date().toISOString(), itemId)
+    .run()
+
+  return getParkingLotItem(db, orgId, itemId)
+}
+
+/**
+ * Delete a parking lot item. Only allowed when disposition IS NULL — once
+ * dispositioned, the item is part of the audit trail and stays. Returns
+ * 'not_found' for cross-org or missing items, 'dispositioned' if the caller
+ * tried to delete a dispositioned row, 'ok' on success.
+ */
+export async function deleteParkingLotItem(
+  db: D1Database,
+  orgId: string,
+  itemId: string
+): Promise<'ok' | 'not_found' | 'dispositioned'> {
+  const existing = await getParkingLotItem(db, orgId, itemId)
+  if (!existing) return 'not_found'
+  if (existing.disposition !== null) return 'dispositioned'
+
+  await db.prepare('DELETE FROM parking_lot WHERE id = ?').bind(itemId).run()
+  return 'ok'
+}

--- a/src/lib/ui/status-badge.ts
+++ b/src/lib/ui/status-badge.ts
@@ -46,6 +46,11 @@ const TONE: Record<string, string> = {
   pending: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
   in_progress: 'bg-[color:var(--ss-color-primary)] text-white',
   skipped: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
+
+  // Parking lot disposition (Decision #11)
+  fold_in: 'bg-[color:var(--ss-color-complete)] text-white',
+  follow_on: 'bg-[color:var(--ss-color-primary)] text-white',
+  dropped: 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]',
 }
 
 const FALLBACK = 'bg-[color:var(--ss-color-border)] text-[color:var(--ss-color-text-secondary)]'

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -1,6 +1,7 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
+import EngagementParkingLotPanel from '../../../components/admin/EngagementParkingLotPanel.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import {
   contextTypeEyebrowClass,
@@ -32,6 +33,7 @@ const {
   milestones,
   invoices,
   contextEntries,
+  parkingLot,
   entitySignals,
   documents,
   nextStatuses,
@@ -41,6 +43,9 @@ const {
   error,
   milestoneAdded,
   milestoneDeleted,
+  parkingLotAdded,
+  parkingLotDispositioned,
+  parkingLotDeleted,
 } = pageData
 ---
 
@@ -56,6 +61,9 @@ const {
     {saved && <AdminFlashNotice message="Changes saved." />}
     {milestoneAdded && <AdminFlashNotice message="Milestone added." />}
     {milestoneDeleted && <AdminFlashNotice message="Milestone deleted." />}
+    {parkingLotAdded && <AdminFlashNotice message="Parking lot item logged." />}
+    {parkingLotDispositioned && <AdminFlashNotice message="Parking lot item dispositioned." />}
+    {parkingLotDeleted && <AdminFlashNotice message="Parking lot item deleted." />}
     {
       error && (
         <AdminFlashNotice
@@ -65,9 +73,15 @@ const {
               ? 'Invalid status transition.'
               : error === 'invalid_transition'
                 ? 'Invalid transition.'
-                : error === 'not_found'
-                  ? 'Resource not found.'
-                  : 'An error occurred.'
+                : error === 'invalid_disposition'
+                  ? 'Invalid disposition.'
+                  : error === 'missing_note'
+                    ? 'Disposition note is required.'
+                    : error === 'cannot_delete_dispositioned'
+                      ? 'Cannot delete a dispositioned parking lot item.'
+                      : error === 'not_found'
+                        ? 'Resource not found.'
+                        : 'An error occurred.'
           }
         />
       )
@@ -511,6 +525,8 @@ const {
         </div>
       </details>
     </div>
+
+    <EngagementParkingLotPanel engagementId={engagementId} parkingLot={parkingLot} />
 
     <!-- Consultant photo -->
     <div

--- a/src/pages/api/admin/engagements/[id]/parking-lot.ts
+++ b/src/pages/api/admin/engagements/[id]/parking-lot.ts
@@ -1,0 +1,187 @@
+import type { APIRoute } from 'astro'
+import { getEngagement } from '../../../../../lib/db/engagements'
+import {
+  createParkingLotItem,
+  dispositionParkingLotItem,
+  deleteParkingLotItem,
+  getParkingLotItem,
+  DISPOSITIONS,
+} from '../../../../../lib/db/parking-lot'
+import type { Disposition } from '../../../../../lib/db/parking-lot'
+import { appendContext } from '../../../../../lib/db/context'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/engagements/:id/parking-lot
+ *
+ * Manages parking lot items on an engagement (Decision Stack #11). Single
+ * endpoint with action dispatcher, mirroring the milestones pattern.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields for create:
+ *   - description (required)
+ *   - requested_by (optional)
+ *
+ * Form fields for disposition:
+ *   - action: "disposition"
+ *   - item_id (required)
+ *   - disposition (required, one of: fold_in | follow_on | dropped)
+ *   - disposition_note (required, non-empty)
+ *
+ * Form fields for delete:
+ *   - _method: "DELETE"
+ *   - item_id (required)
+ *
+ * Note: disposition_note is required at click time per Decision #11 — the
+ * methodology demands a rationale at the moment of disposition, not as a
+ * pencil-edit later.
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const engagementId = params.id
+  if (!engagementId) {
+    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+    if (!engagement) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const method = formData.get('_method')
+    const action = formData.get('action')
+
+    const detailUrl = `/admin/engagements/${engagementId}`
+
+    // Handle DELETE
+    if (method === 'DELETE') {
+      const itemId = formData.get('item_id')
+      if (!itemId || typeof itemId !== 'string') {
+        return redirect(`${detailUrl}?error=missing`, 302)
+      }
+
+      const item = await getParkingLotItem(env.DB, session.orgId, itemId.trim())
+      if (!item || item.engagement_id !== engagementId) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      const result = await deleteParkingLotItem(env.DB, session.orgId, itemId.trim())
+      if (result === 'dispositioned') {
+        return redirect(`${detailUrl}?error=cannot_delete_dispositioned`, 302)
+      }
+      if (result !== 'ok') {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      // Audit trail: capture the original description so the timeline shows
+      // what was logged, not just that something was deleted.
+      await appendContext(env.DB, session.orgId, {
+        entity_id: engagement.entity_id,
+        type: 'parking_lot',
+        content: `Deleted parking lot item: ${item.description}`,
+        source: 'admin',
+        source_ref: `parking_lot:${item.id}:deleted`,
+        metadata: { item_id: item.id },
+        engagement_id: engagementId,
+      })
+
+      return redirect(`${detailUrl}?parking_lot_deleted=1`, 302)
+    }
+
+    // Handle disposition
+    if (action === 'disposition') {
+      const itemId = formData.get('item_id')
+      const disposition = formData.get('disposition')
+      const note = formData.get('disposition_note')
+
+      if (!itemId || typeof itemId !== 'string') {
+        return redirect(`${detailUrl}?error=missing`, 302)
+      }
+
+      if (
+        !disposition ||
+        typeof disposition !== 'string' ||
+        !DISPOSITIONS.includes(disposition as Disposition)
+      ) {
+        return redirect(`${detailUrl}?error=invalid_disposition`, 302)
+      }
+
+      if (!note || typeof note !== 'string' || !note.trim()) {
+        return redirect(`${detailUrl}?error=missing_note`, 302)
+      }
+
+      const item = await getParkingLotItem(env.DB, session.orgId, itemId.trim())
+      if (!item || item.engagement_id !== engagementId) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      const updated = await dispositionParkingLotItem(
+        env.DB,
+        session.orgId,
+        itemId.trim(),
+        disposition as Disposition,
+        note.trim()
+      )
+
+      if (!updated) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      await appendContext(env.DB, session.orgId, {
+        entity_id: engagement.entity_id,
+        type: 'parking_lot',
+        content: `Dispositioned as ${disposition}: ${note.trim()}`,
+        source: 'admin',
+        source_ref: `parking_lot:${updated.id}:dispositioned`,
+        metadata: { disposition, item_id: updated.id },
+        engagement_id: engagementId,
+      })
+
+      return redirect(`${detailUrl}?parking_lot_dispositioned=1`, 302)
+    }
+
+    // Handle create (default)
+    const description = formData.get('description')
+    if (!description || typeof description !== 'string' || !description.trim()) {
+      return redirect(`${detailUrl}?error=missing`, 302)
+    }
+
+    const requestedBy = formData.get('requested_by')
+
+    const item = await createParkingLotItem(env.DB, session.orgId, engagementId, {
+      description: description.trim(),
+      requested_by:
+        requestedBy && typeof requestedBy === 'string' && requestedBy.trim()
+          ? requestedBy.trim()
+          : null,
+    })
+
+    await appendContext(env.DB, session.orgId, {
+      entity_id: engagement.entity_id,
+      type: 'parking_lot',
+      content: item.description,
+      source: 'admin',
+      source_ref: `parking_lot:${item.id}:created`,
+      metadata: { requested_by: item.requested_by, item_id: item.id },
+      engagement_id: engagementId,
+    })
+
+    return redirect(`${detailUrl}?parking_lot_added=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/engagements/[id]/parking-lot] Error:', err)
+    return redirect('/admin/entities?error=server', 302)
+  }
+}

--- a/tests/parking-lot.test.ts
+++ b/tests/parking-lot.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('parking-lot: data access layer', () => {
+  const source = () => readFileSync(resolve('src/lib/db/parking-lot.ts'), 'utf-8')
+
+  it('parking-lot.ts exists', () => {
+    expect(existsSync(resolve('src/lib/db/parking-lot.ts'))).toBe(true)
+  })
+
+  it('exports listParkingLot function', () => {
+    expect(source()).toContain('export async function listParkingLot')
+  })
+
+  it('exports getParkingLotItem function', () => {
+    expect(source()).toContain('export async function getParkingLotItem')
+  })
+
+  it('exports createParkingLotItem function', () => {
+    expect(source()).toContain('export async function createParkingLotItem')
+  })
+
+  it('exports dispositionParkingLotItem function', () => {
+    expect(source()).toContain('export async function dispositionParkingLotItem')
+  })
+
+  it('exports deleteParkingLotItem function', () => {
+    expect(source()).toContain('export async function deleteParkingLotItem')
+  })
+
+  it('exports Disposition type with three valid values', () => {
+    const code = source()
+    expect(code).toContain('export type Disposition')
+    expect(code).toContain("'fold_in'")
+    expect(code).toContain("'follow_on'")
+    expect(code).toContain("'dropped'")
+  })
+
+  it('exports DISPOSITIONS constant for endpoint validation', () => {
+    expect(source()).toContain('export const DISPOSITIONS')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('orders parking lot items by created_at ASC (oldest first)', () => {
+    expect(source()).toContain('ORDER BY pl.created_at ASC')
+  })
+
+  it('listParkingLot enforces org scoping via JOIN through engagements', () => {
+    // parking_lot has no org_id column; all reads must JOIN engagements
+    // and filter on engagements.org_id to prevent cross-tenant leaks.
+    const code = source()
+    expect(code).toContain('INNER JOIN engagements')
+    expect(code).toContain('e.org_id = ?')
+  })
+
+  it('getParkingLotItem returns null for cross-org items (no enumeration leak)', () => {
+    const code = source()
+    expect(code).toMatch(/getParkingLotItem[\s\S]*INNER JOIN engagements/)
+    expect(code).toContain('return result ?? null')
+  })
+
+  it('createParkingLotItem inserts only the four schema-required write fields', () => {
+    const code = source()
+    expect(code).toContain('INSERT INTO parking_lot')
+    expect(code).toContain('id, engagement_id, description, requested_by')
+  })
+
+  it('dispositionParkingLotItem stamps reviewed_at on update', () => {
+    const code = source()
+    expect(code).toContain('UPDATE parking_lot')
+    expect(code).toContain('reviewed_at')
+    expect(code).toContain('new Date().toISOString()')
+  })
+
+  it('dispositionParkingLotItem returns null for cross-org items', () => {
+    // Pre-checks via getParkingLotItem (org-scoped); returns null if not found.
+    const code = source()
+    expect(code).toMatch(/dispositionParkingLotItem[\s\S]*getParkingLotItem/)
+    expect(code).toMatch(/if \(!existing\)[\s\S]*return null/)
+  })
+
+  it('deleteParkingLotItem refuses to delete dispositioned items', () => {
+    const code = source()
+    expect(code).toMatch(
+      /deleteParkingLotItem[\s\S]*disposition !== null[\s\S]*return 'dispositioned'/
+    )
+  })
+
+  it('deleteParkingLotItem returns not_found for cross-org items', () => {
+    const code = source()
+    expect(code).toMatch(/deleteParkingLotItem[\s\S]*getParkingLotItem[\s\S]*return 'not_found'/)
+  })
+})
+
+describe('parking-lot: API endpoint', () => {
+  const source = () =>
+    readFileSync(resolve('src/pages/api/admin/engagements/[id]/parking-lot.ts'), 'utf-8')
+
+  it('endpoint file exists', () => {
+    expect(existsSync(resolve('src/pages/api/admin/engagements/[id]/parking-lot.ts'))).toBe(true)
+  })
+
+  it('rejects non-admin sessions with 401', () => {
+    const code = source()
+    expect(code).toContain("session.role !== 'admin'")
+    expect(code).toContain('status: 401')
+  })
+
+  it('validates engagement ownership via getEngagement', () => {
+    const code = source()
+    expect(code).toContain('getEngagement(env.DB, session.orgId, engagementId)')
+  })
+
+  it('redirects unknown/cross-org engagements to /admin/entities?error=not_found', () => {
+    const code = source()
+    expect(code).toContain("'/admin/entities?error=not_found'")
+  })
+
+  it('dispatches on _method=DELETE, action=disposition, and default=create', () => {
+    const code = source()
+    expect(code).toContain("method === 'DELETE'")
+    expect(code).toContain("action === 'disposition'")
+  })
+
+  it('requires non-empty disposition_note (Decision #11 demands rationale)', () => {
+    const code = source()
+    expect(code).toContain('error=missing_note')
+    expect(code).toMatch(/!note\.trim\(\)/)
+  })
+
+  it('validates disposition value against DISPOSITIONS constant', () => {
+    const code = source()
+    expect(code).toContain('DISPOSITIONS.includes')
+    expect(code).toContain('error=invalid_disposition')
+  })
+
+  it('blocks delete of dispositioned items with explicit error code', () => {
+    const code = source()
+    expect(code).toContain('error=cannot_delete_dispositioned')
+  })
+
+  it('appends a context audit entry on every mutation (create/disposition/delete)', () => {
+    const code = source()
+    // appendContext should appear three times: once per mutation path.
+    const matches = code.match(/appendContext\(env\.DB/g) ?? []
+    expect(matches.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('audit entries use type=parking_lot and engagement_id for timeline filtering', () => {
+    const code = source()
+    expect(code).toContain("type: 'parking_lot'")
+    expect(code).toContain('engagement_id: engagementId')
+  })
+
+  it('audit source_refs are namespaced parking_lot:<id>:<action>', () => {
+    const code = source()
+    expect(code).toMatch(/parking_lot:\$\{[^}]+\}:created/)
+    expect(code).toMatch(/parking_lot:\$\{[^}]+\}:dispositioned/)
+    expect(code).toMatch(/parking_lot:\$\{[^}]+\}:deleted/)
+  })
+
+  it('emits success flash params parking_lot_added/dispositioned/deleted', () => {
+    const code = source()
+    expect(code).toContain('parking_lot_added=1')
+    expect(code).toContain('parking_lot_dispositioned=1')
+    expect(code).toContain('parking_lot_deleted=1')
+  })
+
+  it('rejects items belonging to a different engagement under the same org', () => {
+    // Defense-in-depth: even within an org, an item_id must belong to the
+    // URL-path engagement, not a sibling engagement.
+    const code = source()
+    expect(code).toContain('item.engagement_id !== engagementId')
+  })
+})
+
+describe('parking-lot: engagement detail page wiring', () => {
+  it('engagement-detail-page.ts loads parking lot data', () => {
+    const code = readFileSync(resolve('src/lib/admin/engagement-detail-page.ts'), 'utf-8')
+    expect(code).toContain("import { listParkingLot } from '../db/parking-lot'")
+    expect(code).toContain('listParkingLot(params.db, params.orgId, params.engagementId)')
+    expect(code).toContain('parkingLotAdded')
+    expect(code).toContain('parkingLotDispositioned')
+    expect(code).toContain('parkingLotDeleted')
+  })
+
+  it('engagement detail page mounts the parking lot panel component', () => {
+    const code = readFileSync(resolve('src/pages/admin/engagements/[id].astro'), 'utf-8')
+    expect(code).toContain('EngagementParkingLotPanel')
+    expect(code).toContain('parkingLot={parkingLot}')
+  })
+
+  it('parking lot panel component exists and renders the list + add form', () => {
+    const path = 'src/components/admin/EngagementParkingLotPanel.astro'
+    expect(existsSync(resolve(path))).toBe(true)
+    const code = readFileSync(resolve(path), 'utf-8')
+    expect(code).toContain('Parking Lot')
+    expect(code).toContain('parkingLot.map')
+    expect(code).toContain('parking-lot') // form action url
+    expect(code).toContain('+ Log parking lot item')
+  })
+})
+
+describe('parking-lot: status badge tones', () => {
+  it('status-badge.ts defines tones for fold_in, follow_on, dropped', () => {
+    const code = readFileSync(resolve('src/lib/ui/status-badge.ts'), 'utf-8')
+    expect(code).toContain('fold_in:')
+    expect(code).toContain('follow_on:')
+    expect(code).toContain('dropped:')
+  })
+})


### PR DESCRIPTION
## Summary

Ships the admin surface for Decision Stack #11 (Scope Creep Protocol): log out-of-scope client requests during an engagement, then disposition each one at the pre-handoff review as `fold_in` / `follow_on` / `dropped` with a required rationale note. Closes 3 of 4 ACs on #79; the 4th is split out to #653.

## ACs

From #79:
- [x] Admin can log parking lot items during engagement
- [x] Admin can disposition items at pre-handoff review
- [x] Disposition notes captured (required at click time, not pencil-edited later — Decision #11 demands the rationale at the moment of disposition)
- [ ] Follow-on quote can be initiated from parking lot item — **deferred to #653** (schema lineage problem with `createQuote` needs its own design pass)

## Implementation

- `src/lib/db/parking-lot.ts` — data layer: list/get/create/disposition/delete. parking_lot has no `org_id` column, so reads JOIN through `engagements.org_id` and writes are gated on endpoint-layer engagement ownership. Cross-org reads return null/empty (no enumeration leak).
- `src/pages/api/admin/engagements/[id]/parking-lot.ts` — POST endpoint with action dispatcher (create / disposition / delete) modeled on `milestones.ts`. Same auth, validation, and redirect-flash patterns. Disposition note is required and must be non-whitespace.
- `src/components/admin/EngagementParkingLotPanel.astro` — extracted UI panel keeps `engagements/[id].astro` under its 850-line concern-boundary cap (currently 771).
- Every mutation appends a `context` entry of `type: 'parking_lot'` with namespaced `source_ref` (`parking_lot:<id>:created|dispositioned|deleted`) so the existing engagement Context Timeline picks up the audit trail without further wiring.
- Three new disposition tones added to the shared `status-badge` utility (collision-checked: no existing consumers).

## Test plan

Programmatic (all green on `npm run verify`):
- [x] `tests/parking-lot.test.ts` — source-introspection coverage of data layer, endpoint dispatch, audit appends, page wiring, badge tones (matches `tests/milestones.test.ts` pattern)
- [x] `npm run typecheck` — 0 errors, 0 warnings, 0 hints
- [x] `npm run lint` — clean
- [x] `npm run test` — 2031 tests pass
- [x] `npm run verify` — full pipeline green
- [x] `tests/admin-astro-boundaries.test.ts` — engagement page line cap honored (panel extracted to component)

Manual (Captain to walk through after merge with an authenticated admin session, since pre-launch venture has no real engagements yet):
- [ ] Open `/admin/engagements/<id>`, confirm Parking Lot panel renders between Milestones and Consultant Photo
- [ ] Log an item → flash banner + new row + new context-timeline entry
- [ ] Disposition empty-note submit → `?error=missing_note`, no DB change
- [ ] Disposition with note → badge flips, note renders, second context entry appears
- [ ] Delete un-dispositioned item → row disappears, deletion context entry preserves the original description
- [ ] Cross-org POST → `302` to `/admin/entities?error=not_found`, no row inserted

## Closes

Closes #79 (with 4th AC split to #653 — apply `force-close` label on merge if the unmet-AC reopen workflow fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)