### PR TITLE
feat(portal): contact CRUD + engagement role assignment (#69)

### DIFF
--- a/src/components/admin/EngagementContactsPanel.astro
+++ b/src/components/admin/EngagementContactsPanel.astro
@@ -1,0 +1,189 @@
+---
+/**
+ * Engagement contacts panel for the admin engagement detail page
+ * (PRD US-003, CM-3, CM-4).
+ *
+ * Lists per-engagement role assignments (owner / decision_maker / champion)
+ * with the primary POC marker, and provides:
+ *   - "+ Assign contact" form (existing entity contact + role + primary toggle)
+ *   - Per-row "Make primary" + "Remove" actions
+ *
+ * The same contact can be assigned multiple roles per engagement (OQ-003) —
+ * the form picks one role at a time; submit twice to give one person two roles.
+ *
+ * Schema enforces UNIQUE(engagement_id, contact_id, role); the API handler
+ * surfaces dup attempts as `?error=duplicate_role`.
+ */
+import type { Contact } from '../../lib/db/contacts'
+import {
+  ENGAGEMENT_CONTACT_ROLES,
+  type EngagementContactWithDetails,
+} from '../../lib/db/engagement-contacts'
+
+interface Props {
+  engagementId: string
+  engagementContacts: EngagementContactWithDetails[]
+  entityContacts: Contact[]
+}
+
+const { engagementId, engagementContacts, entityContacts } = Astro.props
+
+const roleLabel = (role: string): string =>
+  ENGAGEMENT_CONTACT_ROLES.find((r) => r.value === role)?.label ?? role
+---
+
+<div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]">
+  <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+    <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">Contacts &amp; Roles</h2>
+    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
+      Owner, decision maker, and champion for this engagement. One contact can hold multiple roles.
+      Mark a single row as the primary point of contact.
+    </p>
+  </div>
+
+  <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+    {
+      engagementContacts.length === 0 && (
+        <div class="px-6 py-8 text-center text-sm text-[color:var(--ss-color-text-muted)]">
+          No role assignments yet.
+        </div>
+      )
+    }
+    {
+      engagementContacts.map((ec) => (
+        <div class="px-6 py-3 flex items-start justify-between gap-stack">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                {ec.contact_name}
+              </span>
+              <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
+                {roleLabel(ec.role)}
+              </span>
+              {ec.is_primary === 1 && (
+                <span class="text-xs bg-[color:var(--ss-color-primary)] text-white px-1.5 py-0.5 rounded">
+                  Primary POC
+                </span>
+              )}
+            </div>
+            <div class="text-xs text-[color:var(--ss-color-text-muted)] flex flex-wrap gap-x-3 mt-0.5">
+              {ec.contact_title && <span>{ec.contact_title}</span>}
+              {ec.contact_email && <span>{ec.contact_email}</span>}
+              {ec.contact_phone && <span>{ec.contact_phone}</span>}
+            </div>
+            {ec.notes && (
+              <p class="text-xs text-[color:var(--ss-color-text-secondary)] whitespace-pre-wrap pt-1">
+                {ec.notes}
+              </p>
+            )}
+          </div>
+          <div class="flex-shrink-0 flex items-center gap-2">
+            {ec.is_primary !== 1 && (
+              <form method="POST" action={`/api/admin/engagements/${engagementId}/contacts`}>
+                <input type="hidden" name="action" value="set_primary" />
+                <input type="hidden" name="engagement_contact_id" value={ec.id} />
+                <button
+                  type="submit"
+                  class="text-xs px-2 py-1 border border-[color:var(--ss-color-primary)] text-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                >
+                  Make primary
+                </button>
+              </form>
+            )}
+            <form method="POST" action={`/api/admin/engagements/${engagementId}/contacts`}>
+              <input type="hidden" name="_method" value="DELETE" />
+              <input type="hidden" name="engagement_contact_id" value={ec.id} />
+              <button
+                type="submit"
+                class="text-xs px-2 py-1 border border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                onclick="return confirm('Remove this role assignment?')"
+              >
+                Remove
+              </button>
+            </form>
+          </div>
+        </div>
+      ))
+    }
+  </div>
+
+  <details class="border-t border-[color:var(--ss-color-border-subtle)]">
+    <summary
+      class="px-6 py-3 cursor-pointer text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
+    >
+      + Assign contact to role
+    </summary>
+    <div class="px-6 pb-4">
+      {
+        entityContacts.length === 0 ? (
+          <p class="text-xs text-[color:var(--ss-color-text-muted)]">
+            No contacts on the entity yet. Add a contact on the entity page first.
+          </p>
+        ) : (
+          <form
+            method="POST"
+            action={`/api/admin/engagements/${engagementId}/contacts`}
+            class="space-y-row"
+          >
+            <div class="grid grid-cols-2 gap-2">
+              <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] col-span-2">
+                Contact *
+                <select
+                  name="contact_id"
+                  required
+                  class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+                >
+                  <option value="">Select a contact…</option>
+                  {entityContacts.map((c) => (
+                    <option value={c.id}>
+                      {c.name}
+                      {c.title ? ` — ${c.title}` : ''}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
+                Role *
+                <select
+                  name="role"
+                  required
+                  class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+                >
+                  {ENGAGEMENT_CONTACT_ROLES.map((r) => (
+                    <option value={r.value}>{r.label}</option>
+                  ))}
+                </select>
+              </label>
+              <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] flex items-center gap-2 mt-5">
+                <input
+                  type="checkbox"
+                  name="is_primary"
+                  value="1"
+                  class="rounded border-[color:var(--ss-color-border)]"
+                />
+                Mark as primary POC
+              </label>
+              <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] col-span-2">
+                Notes
+                <input
+                  type="text"
+                  name="notes"
+                  placeholder="Optional context — e.g. 'Cc on invoices'"
+                  class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+                />
+              </label>
+            </div>
+            <div class="flex">
+              <button
+                type="submit"
+                class="ml-auto bg-[color:var(--ss-color-primary)] text-white text-xs px-3 py-1.5 hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
+              >
+                Assign role
+              </button>
+            </div>
+          </form>
+        )
+      }
+    </div>
+  </details>
+</div>

--- a/src/components/admin/EntityContactsPanel.astro
+++ b/src/components/admin/EntityContactsPanel.astro
@@ -1,0 +1,217 @@
+---
+/**
+ * Contacts panel for the admin entity detail page (PRD CM-3, US-003).
+ *
+ * Replaces the read-only contacts list with a CRUD panel:
+ *   - Inline list with per-row edit/delete affordances
+ *   - "Add contact" form (name, email, phone, title, role)
+ *
+ * `role` here is the contact's free-text job role on the contact record,
+ * not the per-engagement role assignment (owner / decision_maker /
+ * champion). Engagement-role assignment lives on the engagement detail page.
+ */
+import type { Contact } from '../../lib/db/contacts'
+
+interface Props {
+  entityId: string
+  contacts: Contact[]
+}
+
+const { entityId, contacts } = Astro.props
+---
+
+<div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]">
+  <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
+    <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">
+      Contacts ({contacts.length})
+    </h2>
+    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
+      People at this organization. Engagement-specific roles (owner / decision maker / champion) are
+      assigned per engagement.
+    </p>
+  </div>
+
+  <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+    {
+      contacts.length === 0 && (
+        <div class="px-6 py-8 text-center text-sm text-[color:var(--ss-color-text-muted)]">
+          No contacts on file.
+        </div>
+      )
+    }
+    {
+      contacts.map((c) => (
+        <div class="px-6 py-3 space-y-row">
+          <div class="flex items-start justify-between gap-stack">
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                  {c.name}
+                </span>
+                {c.title && (
+                  <span class="text-xs text-[color:var(--ss-color-text-secondary)]">{c.title}</span>
+                )}
+                {c.role && (
+                  <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
+                    {c.role}
+                  </span>
+                )}
+              </div>
+              <div class="text-xs text-[color:var(--ss-color-text-muted)] flex flex-wrap gap-x-3 mt-0.5">
+                {c.email && <span>{c.email}</span>}
+                {c.phone && <span>{c.phone}</span>}
+              </div>
+            </div>
+            <div class="flex-shrink-0 flex items-center gap-2">
+              <details class="relative">
+                <summary class="cursor-pointer text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]">
+                  Edit
+                </summary>
+                <form
+                  method="POST"
+                  action={`/api/admin/contacts/${c.id}`}
+                  class="space-y-row mt-2 p-3 border border-[color:var(--ss-color-border)] rounded bg-[color:var(--ss-color-background)]"
+                >
+                  <div class="grid grid-cols-2 gap-2">
+                    <label class="text-xs text-[color:var(--ss-color-text-secondary)] col-span-2">
+                      Name *
+                      <input
+                        type="text"
+                        name="name"
+                        required
+                        value={c.name}
+                        class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
+                      />
+                    </label>
+                    <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                      Email
+                      <input
+                        type="email"
+                        name="email"
+                        value={c.email ?? ''}
+                        class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
+                      />
+                    </label>
+                    <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                      Phone
+                      <input
+                        type="text"
+                        name="phone"
+                        value={c.phone ?? ''}
+                        class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
+                      />
+                    </label>
+                    <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                      Title
+                      <input
+                        type="text"
+                        name="title"
+                        value={c.title ?? ''}
+                        class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
+                      />
+                    </label>
+                    <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+                      Role
+                      <input
+                        type="text"
+                        name="role"
+                        value={c.role ?? ''}
+                        class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
+                      />
+                    </label>
+                  </div>
+                  <div class="flex justify-end">
+                    <button
+                      type="submit"
+                      class="text-xs px-3 py-1 bg-[color:var(--ss-color-primary)] text-white hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </form>
+              </details>
+              <form method="POST" action={`/api/admin/contacts/${c.id}`}>
+                <input type="hidden" name="_method" value="DELETE" />
+                <button
+                  type="submit"
+                  class="text-xs px-2 py-1 border border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+                  onclick="return confirm('Delete this contact? Engagement role assignments referencing it will block deletion.')"
+                >
+                  Del
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      ))
+    }
+  </div>
+
+  <details class="border-t border-[color:var(--ss-color-border-subtle)]">
+    <summary
+      class="px-6 py-3 cursor-pointer text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
+    >
+      + Add contact
+    </summary>
+    <div class="px-6 pb-4">
+      <form method="POST" action={`/api/admin/entities/${entityId}/contacts`} class="space-y-row">
+        <div class="grid grid-cols-2 gap-2">
+          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] col-span-2">
+            Name *
+            <input
+              type="text"
+              name="name"
+              required
+              placeholder="Jane Smith"
+              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
+            Email
+            <input
+              type="email"
+              name="email"
+              placeholder="jane@example.com"
+              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
+            Phone
+            <input
+              type="text"
+              name="phone"
+              placeholder="(555) 123-4567"
+              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
+            Title
+            <input
+              type="text"
+              name="title"
+              placeholder="Operations Manager"
+              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
+            Role
+            <input
+              type="text"
+              name="role"
+              placeholder="Free-form (e.g. owner, ops lead)"
+              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
+            />
+          </label>
+        </div>
+        <div class="flex">
+          <button
+            type="submit"
+            class="ml-auto bg-[color:var(--ss-color-primary)] text-white text-xs px-3 py-1.5 hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
+          >
+            Add contact
+          </button>
+        </div>
+      </form>
+    </div>
+  </details>
+</div>

--- a/src/lib/admin/engagement-detail-page.ts
+++ b/src/lib/admin/engagement-detail-page.ts
@@ -8,6 +8,8 @@ import { listInvoices } from '../db/invoices'
 import { listContext } from '../db/context'
 import { listParkingLot } from '../db/parking-lot'
 import { listSignalsForEntity } from '../db/signal-attribution'
+import { listContacts } from '../db/contacts'
+import { listEngagementContacts } from '../db/engagement-contacts'
 import { listDocuments } from '../storage/r2'
 
 type Database = Parameters<typeof getEntity>[0]
@@ -73,6 +75,12 @@ export async function loadEngagementDetailPage(params: {
   })
   const parkingLot = await listParkingLot(params.db, params.orgId, params.engagementId)
   const entitySignals = await listSignalsForEntity(params.db, params.orgId, engagement.entity_id)
+  const entityContacts = await listContacts(params.db, params.orgId, engagement.entity_id)
+  const engagementContacts = await listEngagementContacts(
+    params.db,
+    params.orgId,
+    params.engagementId
+  )
   const documents = await listDocuments(
     params.storage,
     `${params.orgId}/engagements/${params.engagementId}/docs/`
@@ -91,6 +99,8 @@ export async function loadEngagementDetailPage(params: {
     contextEntries,
     parkingLot,
     entitySignals,
+    entityContacts,
+    engagementContacts,
     documents,
     status,
     nextStatuses,
@@ -103,6 +113,9 @@ export async function loadEngagementDetailPage(params: {
     parkingLotAdded: params.url.searchParams.get('parking_lot_added'),
     parkingLotDispositioned: params.url.searchParams.get('parking_lot_dispositioned'),
     parkingLotDeleted: params.url.searchParams.get('parking_lot_deleted'),
+    engagementContactAdded: params.url.searchParams.get('engagement_contact_added'),
+    engagementContactRemoved: params.url.searchParams.get('engagement_contact_removed'),
+    engagementContactPrimarySet: params.url.searchParams.get('engagement_contact_primary_set'),
   }
 }
 

--- a/src/lib/admin/entity-detail-page.ts
+++ b/src/lib/admin/entity-detail-page.ts
@@ -181,6 +181,9 @@ export async function loadEntityDetailPage(params: {
   replyLogged: string | null
   stageUpdated: string | null
   dossierGenerated: string | null
+  contactAdded: string | null
+  contactUpdated: string | null
+  contactDeleted: string | null
   error: string | null
   showReEnrichButton: boolean
   showNewQuoteButton: boolean
@@ -257,6 +260,9 @@ export async function loadEntityDetailPage(params: {
   const replyLogged = params.url.searchParams.get('reply_logged')
   const stageUpdated = params.url.searchParams.get('stage_updated')
   const dossierGenerated = params.url.searchParams.get('dossier')
+  const contactAdded = params.url.searchParams.get('contact_added')
+  const contactUpdated = params.url.searchParams.get('contact_updated')
+  const contactDeleted = params.url.searchParams.get('contact_deleted')
   const error = params.url.searchParams.get('error')
 
   const hasOpenQuote = await hasOpenQuoteForEntity(params.db, params.orgId, params.entityId)
@@ -340,6 +346,9 @@ export async function loadEntityDetailPage(params: {
     replyLogged,
     stageUpdated,
     dossierGenerated,
+    contactAdded,
+    contactUpdated,
+    contactDeleted,
     error,
     showReEnrichButton,
     showNewQuoteButton,

--- a/src/lib/db/engagement-contacts.test.ts
+++ b/src/lib/db/engagement-contacts.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for the engagement_contacts data access layer.
+ *
+ * Covers:
+ *   - Source-level invariants (parameterized queries, JOIN-based scoping,
+ *     UUID generation)
+ *   - Single-primary behaviour: addEngagementContact with is_primary=true
+ *     clears any existing primary on the same engagement; without is_primary
+ *     it does not touch existing primaries
+ *   - setEngagementContactPrimary clears OTHER primaries but never the row
+ *     being promoted
+ *   - removeEngagementContact returns false for cross-org rows
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  addEngagementContact,
+  removeEngagementContact,
+  setEngagementContactPrimary,
+} from './engagement-contacts'
+
+const SOURCE_PATH = resolve('src/lib/db/engagement-contacts.ts')
+const source = () => readFileSync(SOURCE_PATH, 'utf-8')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORG_ID = 'org-001'
+const ENGAGEMENT_ID = 'eng-001'
+const CONTACT_ID = 'contact-001'
+
+interface CapturedCall {
+  sql: string
+  params: unknown[]
+}
+
+function buildMockDb(options: {
+  firstResults?: Record<string, unknown>
+  allResults?: Record<string, unknown>
+}): { db: D1Database; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = []
+  const db = {
+    prepare: vi.fn().mockImplementation((sql: string) => ({
+      bind: vi.fn().mockImplementation((...params: unknown[]) => {
+        calls.push({ sql, params })
+        return {
+          first: vi.fn().mockImplementation(async () => {
+            for (const [snippet, result] of Object.entries(options.firstResults ?? {})) {
+              if (sql.includes(snippet)) return result
+            }
+            return null
+          }),
+          all: vi.fn().mockImplementation(async () => {
+            for (const [snippet, result] of Object.entries(options.allResults ?? {})) {
+              if (sql.includes(snippet)) return { results: result }
+            }
+            return { results: [] }
+          }),
+          run: vi.fn().mockResolvedValue({}),
+        }
+      }),
+    })),
+  } as unknown as D1Database
+  return { db, calls }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Source-level invariants
+// ---------------------------------------------------------------------------
+
+describe('engagement-contacts: source-level invariants', () => {
+  it('engagement-contacts.ts exists', () => {
+    expect(existsSync(SOURCE_PATH)).toBe(true)
+  })
+
+  it('exports the role enum and label list', () => {
+    const code = source()
+    expect(code).toContain('export type EngagementContactRole')
+    expect(code).toContain("'owner'")
+    expect(code).toContain("'decision_maker'")
+    expect(code).toContain("'champion'")
+    expect(code).toContain('export const ENGAGEMENT_CONTACT_ROLES')
+  })
+
+  it('exports the four mutation/read functions', () => {
+    const code = source()
+    expect(code).toContain('export async function listEngagementContacts')
+    expect(code).toContain('export async function getEngagementContact')
+    expect(code).toContain('export async function addEngagementContact')
+    expect(code).toContain('export async function setEngagementContactPrimary')
+    expect(code).toContain('export async function removeEngagementContact')
+  })
+
+  it('uses parameterized queries (no string interpolation in SQL)', () => {
+    const code = source()
+    expect(code).toContain('.bind(')
+    expect(code).not.toMatch(/prepare\(`[^`]*\$\{/)
+  })
+
+  it('generates UUIDs for primary keys', () => {
+    expect(source()).toContain('crypto.randomUUID()')
+  })
+
+  it('listEngagementContacts enforces org scoping via JOIN through engagements', () => {
+    const code = source()
+    expect(code).toMatch(/listEngagementContacts[\s\S]*INNER JOIN engagements/)
+    expect(code).toContain('e.org_id = ?')
+  })
+
+  it('getEngagementContact enforces org scoping via JOIN through engagements', () => {
+    const code = source()
+    expect(code).toMatch(/getEngagementContact[\s\S]*INNER JOIN engagements/)
+  })
+
+  it('addEngagementContact clears existing primary before insert when is_primary=true', () => {
+    const code = source()
+    expect(code).toMatch(/UPDATE engagement_contacts SET is_primary = 0[\s\S]*WHERE engagement_id/)
+  })
+
+  it('setEngagementContactPrimary clears other rows but not the target row (id <> ?)', () => {
+    const code = source()
+    expect(code).toContain('id <> ?')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Single-primary behaviour: addEngagementContact
+// ---------------------------------------------------------------------------
+
+describe('addEngagementContact: single-primary invariant', () => {
+  it('clears existing primary on the engagement when is_primary=true', async () => {
+    const { db, calls } = buildMockDb({
+      firstResults: {
+        // Final retrieve after insert
+        'SELECT * FROM engagement_contacts WHERE id = ?': {
+          id: 'ec-new',
+          engagement_id: ENGAGEMENT_ID,
+          contact_id: CONTACT_ID,
+          role: 'owner',
+          is_primary: 1,
+          notes: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      },
+    })
+
+    await addEngagementContact(db, ENGAGEMENT_ID, {
+      contact_id: CONTACT_ID,
+      role: 'owner',
+      is_primary: true,
+    })
+
+    const clearCall = calls.find(
+      (c) =>
+        c.sql.includes('UPDATE engagement_contacts SET is_primary = 0') &&
+        c.sql.includes('WHERE engagement_id = ? AND is_primary = 1')
+    )
+    expect(clearCall).toBeDefined()
+    expect(clearCall?.params).toEqual([ENGAGEMENT_ID])
+
+    const insertCall = calls.find((c) => c.sql.includes('INSERT INTO engagement_contacts'))
+    expect(insertCall).toBeDefined()
+    // Insert binds: id, engagementId, contactId, role, is_primary (1), notes
+    expect(insertCall?.params[1]).toBe(ENGAGEMENT_ID)
+    expect(insertCall?.params[2]).toBe(CONTACT_ID)
+    expect(insertCall?.params[3]).toBe('owner')
+    expect(insertCall?.params[4]).toBe(1)
+  })
+
+  it('does NOT clear existing primary when is_primary=false', async () => {
+    const { db, calls } = buildMockDb({
+      firstResults: {
+        'SELECT * FROM engagement_contacts WHERE id = ?': {
+          id: 'ec-new',
+          engagement_id: ENGAGEMENT_ID,
+          contact_id: CONTACT_ID,
+          role: 'champion',
+          is_primary: 0,
+          notes: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      },
+    })
+
+    await addEngagementContact(db, ENGAGEMENT_ID, {
+      contact_id: CONTACT_ID,
+      role: 'champion',
+      is_primary: false,
+    })
+
+    const clearCall = calls.find((c) =>
+      c.sql.includes('UPDATE engagement_contacts SET is_primary = 0')
+    )
+    expect(clearCall).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Single-primary behaviour: setEngagementContactPrimary
+// ---------------------------------------------------------------------------
+
+describe('setEngagementContactPrimary: single-primary invariant', () => {
+  it('clears every other primary row on the engagement, then sets target', async () => {
+    const existingRow = {
+      id: 'ec-target',
+      engagement_id: ENGAGEMENT_ID,
+      contact_id: CONTACT_ID,
+      role: 'decision_maker',
+      is_primary: 0,
+      notes: null,
+      created_at: '2026-05-01T00:00:00Z',
+    }
+    const { db, calls } = buildMockDb({
+      firstResults: {
+        // Both the precondition lookup and the post-update reload return the row.
+        'SELECT ec.* FROM engagement_contacts ec': existingRow,
+      },
+    })
+
+    const result = await setEngagementContactPrimary(db, ORG_ID, 'ec-target')
+
+    expect(result).toEqual(existingRow)
+
+    // The clear-others UPDATE excludes the target row via `id <> ?`.
+    const clearOthers = calls.find(
+      (c) =>
+        c.sql.includes('UPDATE engagement_contacts SET is_primary = 0') && c.sql.includes('id <> ?')
+    )
+    expect(clearOthers).toBeDefined()
+    expect(clearOthers?.params).toEqual([ENGAGEMENT_ID, 'ec-target'])
+
+    const setSelf = calls.find(
+      (c) =>
+        c.sql.includes('UPDATE engagement_contacts SET is_primary = 1') &&
+        c.sql.includes('WHERE id = ?')
+    )
+    expect(setSelf).toBeDefined()
+    expect(setSelf?.params).toEqual(['ec-target'])
+  })
+
+  it('returns null and writes nothing when row is not in caller org', async () => {
+    const { db, calls } = buildMockDb({
+      // No firstResults for the JOIN lookup → returns null → cross-org or missing.
+    })
+
+    const result = await setEngagementContactPrimary(db, ORG_ID, 'ec-other-org')
+
+    expect(result).toBeNull()
+    const writes = calls.filter((c) => c.sql.includes('UPDATE engagement_contacts'))
+    expect(writes).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeEngagementContact
+// ---------------------------------------------------------------------------
+
+describe('removeEngagementContact', () => {
+  it('returns false and writes nothing when row is not in caller org', async () => {
+    const { db, calls } = buildMockDb({})
+    const ok = await removeEngagementContact(db, ORG_ID, 'ec-other-org')
+    expect(ok).toBe(false)
+    const deletes = calls.filter((c) => c.sql.includes('DELETE FROM engagement_contacts'))
+    expect(deletes).toHaveLength(0)
+  })
+
+  it('issues a DELETE bound to the row id when row is in scope', async () => {
+    const { db, calls } = buildMockDb({
+      firstResults: {
+        'SELECT ec.* FROM engagement_contacts ec': {
+          id: 'ec-target',
+          engagement_id: ENGAGEMENT_ID,
+          contact_id: CONTACT_ID,
+          role: 'owner',
+          is_primary: 0,
+          notes: null,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      },
+    })
+    const ok = await removeEngagementContact(db, ORG_ID, 'ec-target')
+    expect(ok).toBe(true)
+    const del = calls.find((c) => c.sql.startsWith('DELETE FROM engagement_contacts'))
+    expect(del).toBeDefined()
+    expect(del?.params).toEqual(['ec-target'])
+  })
+})

--- a/src/lib/db/engagement-contacts.ts
+++ b/src/lib/db/engagement-contacts.ts
@@ -1,0 +1,204 @@
+/**
+ * Engagement contacts data access layer.
+ *
+ * Per PRD US-003 (CM-3, CM-4) and Decision Stack: each engagement has
+ * a set of contact role assignments — owner, decision_maker, champion —
+ * and at most one row may carry is_primary = 1 (the engagement's primary
+ * point of contact). The same contact can be assigned multiple roles
+ * (OQ-003: owner-as-champion is the common case).
+ *
+ * Schema note: engagement_contacts has NO `org_id` column. Org scoping
+ * is enforced by JOINing through engagements.org_id on every read, and
+ * the endpoint layer pre-validates engagement + contact ownership before
+ * any write. Same pattern as parking-lot.ts.
+ *
+ * Single-primary invariant is enforced at the application layer because
+ * the schema does not (the migration uses UNIQUE(engagement_id, contact_id,
+ * role), not a partial unique on is_primary).
+ *
+ * All queries are parameterized to prevent SQL injection.
+ */
+
+export type EngagementContactRole = 'owner' | 'decision_maker' | 'champion'
+
+export const ENGAGEMENT_CONTACT_ROLES: { value: EngagementContactRole; label: string }[] = [
+  { value: 'owner', label: 'Owner' },
+  { value: 'decision_maker', label: 'Decision Maker' },
+  { value: 'champion', label: 'Champion' },
+]
+
+export interface EngagementContact {
+  id: string
+  engagement_id: string
+  contact_id: string
+  role: EngagementContactRole
+  is_primary: number
+  notes: string | null
+  created_at: string
+}
+
+export interface EngagementContactWithDetails extends EngagementContact {
+  contact_name: string
+  contact_email: string | null
+  contact_phone: string | null
+  contact_title: string | null
+}
+
+export interface AddEngagementContactData {
+  contact_id: string
+  role: EngagementContactRole
+  is_primary?: boolean
+  notes?: string | null
+}
+
+/**
+ * List engagement contact assignments joined with contact details, ordered
+ * by primary first, then role, then contact name. Scoped to the caller's
+ * org via JOIN to prevent cross-tenant reads.
+ */
+export async function listEngagementContacts(
+  db: D1Database,
+  orgId: string,
+  engagementId: string
+): Promise<EngagementContactWithDetails[]> {
+  const result = await db
+    .prepare(
+      `SELECT
+         ec.id,
+         ec.engagement_id,
+         ec.contact_id,
+         ec.role,
+         ec.is_primary,
+         ec.notes,
+         ec.created_at,
+         c.name AS contact_name,
+         c.email AS contact_email,
+         c.phone AS contact_phone,
+         c.title AS contact_title
+       FROM engagement_contacts ec
+       INNER JOIN engagements e ON e.id = ec.engagement_id
+       INNER JOIN contacts c ON c.id = ec.contact_id
+       WHERE ec.engagement_id = ? AND e.org_id = ?
+       ORDER BY ec.is_primary DESC, ec.role ASC, c.name ASC`
+    )
+    .bind(engagementId, orgId)
+    .all<EngagementContactWithDetails>()
+  return result.results
+}
+
+/**
+ * Get a single engagement contact assignment by id, scoped to the caller's
+ * org via JOIN. Returns null (not 403) when the row exists but belongs to
+ * a different org, to prevent tenant enumeration.
+ */
+export async function getEngagementContact(
+  db: D1Database,
+  orgId: string,
+  engagementContactId: string
+): Promise<EngagementContact | null> {
+  const result = await db
+    .prepare(
+      `SELECT ec.* FROM engagement_contacts ec
+       INNER JOIN engagements e ON e.id = ec.engagement_id
+       WHERE ec.id = ? AND e.org_id = ?`
+    )
+    .bind(engagementContactId, orgId)
+    .first<EngagementContact>()
+  return result ?? null
+}
+
+/**
+ * Add a contact-role assignment to an engagement. The caller MUST validate
+ * that contact_id belongs to the engagement's entity (not just the org)
+ * before calling — the endpoint layer enforces this.
+ *
+ * If `is_primary` is true, all other rows on the engagement are cleared
+ * first (single-primary invariant). The clear + insert run as best-effort
+ * sequential calls; D1 lacks multi-statement transactions in the bound
+ * client, so a failed insert after a successful clear leaves the prior
+ * primary unset. This is acceptable: the operator sees an error and re-adds.
+ *
+ * UNIQUE(engagement_id, contact_id, role) prevents duplicate role
+ * assignments. The schema-level UNIQUE will surface as a thrown D1 error
+ * which the endpoint translates to a friendly message.
+ */
+export async function addEngagementContact(
+  db: D1Database,
+  engagementId: string,
+  data: AddEngagementContactData
+): Promise<EngagementContact> {
+  const id = crypto.randomUUID()
+  const isPrimary = data.is_primary ? 1 : 0
+
+  if (isPrimary === 1) {
+    await db
+      .prepare(
+        `UPDATE engagement_contacts SET is_primary = 0
+         WHERE engagement_id = ? AND is_primary = 1`
+      )
+      .bind(engagementId)
+      .run()
+  }
+
+  await db
+    .prepare(
+      `INSERT INTO engagement_contacts (id, engagement_id, contact_id, role, is_primary, notes)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(id, engagementId, data.contact_id, data.role, isPrimary, data.notes ?? null)
+    .run()
+
+  const row = await db
+    .prepare('SELECT * FROM engagement_contacts WHERE id = ?')
+    .bind(id)
+    .first<EngagementContact>()
+  if (!row) {
+    throw new Error('Failed to retrieve created engagement contact')
+  }
+  return row
+}
+
+/**
+ * Mark a single engagement contact row as the primary POC. Clears any other
+ * primary on the same engagement first. Returns the updated row, or null if
+ * the row is not in the caller's org.
+ */
+export async function setEngagementContactPrimary(
+  db: D1Database,
+  orgId: string,
+  engagementContactId: string
+): Promise<EngagementContact | null> {
+  const existing = await getEngagementContact(db, orgId, engagementContactId)
+  if (!existing) return null
+
+  await db
+    .prepare(
+      `UPDATE engagement_contacts SET is_primary = 0
+       WHERE engagement_id = ? AND is_primary = 1 AND id <> ?`
+    )
+    .bind(existing.engagement_id, engagementContactId)
+    .run()
+
+  await db
+    .prepare('UPDATE engagement_contacts SET is_primary = 1 WHERE id = ?')
+    .bind(engagementContactId)
+    .run()
+
+  return getEngagementContact(db, orgId, engagementContactId)
+}
+
+/**
+ * Remove an engagement contact assignment. Returns true on success, false
+ * if the row was not in the caller's org.
+ */
+export async function removeEngagementContact(
+  db: D1Database,
+  orgId: string,
+  engagementContactId: string
+): Promise<boolean> {
+  const existing = await getEngagementContact(db, orgId, engagementContactId)
+  if (!existing) return false
+
+  await db.prepare('DELETE FROM engagement_contacts WHERE id = ?').bind(engagementContactId).run()
+  return true
+}

--- a/src/pages/admin/engagements/[id].astro
+++ b/src/pages/admin/engagements/[id].astro
@@ -2,6 +2,7 @@
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
 import EngagementParkingLotPanel from '../../../components/admin/EngagementParkingLotPanel.astro'
+import EngagementContactsPanel from '../../../components/admin/EngagementContactsPanel.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import {
   contextTypeEyebrowClass,
@@ -35,6 +36,8 @@ const {
   contextEntries,
   parkingLot,
   entitySignals,
+  entityContacts,
+  engagementContacts,
   documents,
   nextStatuses,
   depositInvoice,
@@ -46,6 +49,9 @@ const {
   parkingLotAdded,
   parkingLotDispositioned,
   parkingLotDeleted,
+  engagementContactAdded,
+  engagementContactRemoved,
+  engagementContactPrimarySet,
 } = pageData
 ---
 
@@ -64,6 +70,9 @@ const {
     {parkingLotAdded && <AdminFlashNotice message="Parking lot item logged." />}
     {parkingLotDispositioned && <AdminFlashNotice message="Parking lot item dispositioned." />}
     {parkingLotDeleted && <AdminFlashNotice message="Parking lot item deleted." />}
+    {engagementContactAdded && <AdminFlashNotice message="Contact role assigned." />}
+    {engagementContactRemoved && <AdminFlashNotice message="Role assignment removed." />}
+    {engagementContactPrimarySet && <AdminFlashNotice message="Primary POC updated." />}
     {
       error && (
         <AdminFlashNotice
@@ -79,9 +88,17 @@ const {
                     ? 'Disposition note is required.'
                     : error === 'cannot_delete_dispositioned'
                       ? 'Cannot delete a dispositioned parking lot item.'
-                      : error === 'not_found'
-                        ? 'Resource not found.'
-                        : 'An error occurred.'
+                      : error === 'invalid_role'
+                        ? 'Invalid engagement role.'
+                        : error === 'invalid_contact'
+                          ? 'Selected contact does not belong to this engagement.'
+                          : error === 'missing_contact'
+                            ? 'Select a contact to assign.'
+                            : error === 'duplicate_role'
+                              ? 'That contact already holds this role on the engagement.'
+                              : error === 'not_found'
+                                ? 'Resource not found.'
+                                : 'An error occurred.'
           }
         />
       )
@@ -525,6 +542,12 @@ const {
         </div>
       </details>
     </div>
+
+    <EngagementContactsPanel
+      engagementId={engagementId}
+      engagementContacts={engagementContacts}
+      entityContacts={entityContacts}
+    />
 
     <EngagementParkingLotPanel engagementId={engagementId} parkingLot={parkingLot} />
 

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -3,6 +3,7 @@ import AdminLayout from '../../../layouts/AdminLayout.astro'
 import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
 import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import EnrichmentStatusPanel from '../../../components/admin/EnrichmentStatusPanel.astro'
+import EntityContactsPanel from '../../../components/admin/EntityContactsPanel.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
 import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
 import { adminActionButtonClass } from '../../../lib/ui/admin-action-button'
@@ -55,6 +56,9 @@ const {
   replyLogged,
   stageUpdated,
   dossierGenerated,
+  contactAdded,
+  contactUpdated,
+  contactDeleted,
   error,
   showReEnrichButton,
   showNewQuoteButton,
@@ -122,6 +126,9 @@ const {
       />
     )
   }
+  {contactAdded && <AdminFlashNotice message="Contact added." />}
+  {contactUpdated && <AdminFlashNotice message="Contact updated." />}
+  {contactDeleted && <AdminFlashNotice message="Contact deleted." />}
   {error && <AdminFlashNotice kind="error" message={decodeURIComponent(error)} />}
 
   {/* Entity Summary */}
@@ -837,38 +844,9 @@ const {
   }
 
   {/* Related Data Panels */}
-  {
-    contacts.length > 0 && (
-      <details
-        class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
-        open
-      >
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
-          Contacts ({contacts.length})
-        </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
-          {contacts.map((c) => (
-            <div class="py-2 flex items-center justify-between">
-              <div>
-                <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
-                  {c.name}
-                </span>
-                {c.role && (
-                  <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded ml-2">
-                    {c.role}
-                  </span>
-                )}
-              </div>
-              <div class="text-xs text-[color:var(--ss-color-text-muted)] flex gap-row">
-                {c.email && <span>{c.email}</span>}
-                {c.phone && <span>{c.phone}</span>}
-              </div>
-            </div>
-          ))}
-        </div>
-      </details>
-    )
-  }
+  <div class="mb-4">
+    <EntityContactsPanel entityId={entity.id} contacts={contacts} />
+  </div>
 
   {
     meetings.length > 0 && (

--- a/src/pages/api/admin/contacts/[id].ts
+++ b/src/pages/api/admin/contacts/[id].ts
@@ -1,0 +1,82 @@
+import type { APIRoute } from 'astro'
+import { getContact, updateContact, deleteContact } from '../../../../lib/db/contacts'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/contacts/:id
+ *
+ * Edit (default) or delete (with `_method=DELETE`) a contact. Redirects back
+ * to the entity detail page on success. Org-scoped via getContact pre-check.
+ *
+ * Form fields for edit:
+ *   - name, email, phone, title, role (all optional — sparse update)
+ *
+ * Form fields for delete:
+ *   - _method: "DELETE"
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const contactId = params.id
+  if (!contactId) {
+    return new Response(JSON.stringify({ error: 'Contact ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const contact = await getContact(env.DB, session.orgId, contactId)
+    if (!contact) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    const detailUrl = `/admin/entities/${contact.entity_id}`
+    const formData = await request.formData()
+    const method = formData.get('_method')
+
+    if (method === 'DELETE') {
+      const ok = await deleteContact(env.DB, session.orgId, contactId)
+      if (!ok) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+      return redirect(`${detailUrl}?contact_deleted=1`, 302)
+    }
+
+    // Sparse update: only fields the form sent (and that differ).
+    const stringOrNull = (key: string): string | null | undefined => {
+      if (!formData.has(key)) return undefined
+      const v = formData.get(key)
+      if (typeof v !== 'string') return null
+      const trimmed = v.trim()
+      return trimmed ? trimmed : null
+    }
+
+    const nameRaw = formData.get('name')
+    const name =
+      nameRaw && typeof nameRaw === 'string' && nameRaw.trim() ? nameRaw.trim() : undefined
+
+    if (formData.has('name') && !name) {
+      return redirect(`${detailUrl}?error=missing_name`, 302)
+    }
+
+    await updateContact(env.DB, session.orgId, contactId, {
+      ...(name !== undefined ? { name } : {}),
+      email: stringOrNull('email'),
+      phone: stringOrNull('phone'),
+      title: stringOrNull('title'),
+      role: stringOrNull('role'),
+    })
+
+    return redirect(`${detailUrl}?contact_updated=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/contacts/[id]] Error:', err)
+    return redirect('/admin/entities?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/engagements/[id]/contacts.ts
+++ b/src/pages/api/admin/engagements/[id]/contacts.ts
@@ -1,0 +1,195 @@
+import type { APIRoute } from 'astro'
+import { getEngagement } from '../../../../../lib/db/engagements'
+import { getContact } from '../../../../../lib/db/contacts'
+import {
+  addEngagementContact,
+  getEngagementContact,
+  removeEngagementContact,
+  setEngagementContactPrimary,
+  ENGAGEMENT_CONTACT_ROLES,
+} from '../../../../../lib/db/engagement-contacts'
+import type { EngagementContactRole } from '../../../../../lib/db/engagement-contacts'
+import { appendContext } from '../../../../../lib/db/context'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/engagements/:id/contacts
+ *
+ * Manages engagement_contacts rows: add a role assignment, remove one, or
+ * mark a row as the primary POC. Single endpoint with action dispatcher,
+ * mirroring the parking-lot.ts pattern.
+ *
+ * Protected by auth middleware (requires admin role).
+ *
+ * Form fields for create (default action):
+ *   - contact_id (required, must belong to engagement's entity)
+ *   - role (required, one of: owner | decision_maker | champion)
+ *   - is_primary (optional, "1" to set)
+ *   - notes (optional)
+ *
+ * Form fields for set-primary:
+ *   - action: "set_primary"
+ *   - engagement_contact_id (required)
+ *
+ * Form fields for delete:
+ *   - _method: "DELETE"
+ *   - engagement_contact_id (required)
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const engagementId = params.id
+  if (!engagementId) {
+    return new Response(JSON.stringify({ error: 'Engagement ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const engagement = await getEngagement(env.DB, session.orgId, engagementId)
+    if (!engagement) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    const formData = await request.formData()
+    const method = formData.get('_method')
+    const action = formData.get('action')
+    const detailUrl = `/admin/engagements/${engagementId}`
+
+    // DELETE
+    if (method === 'DELETE') {
+      const ecId = formData.get('engagement_contact_id')
+      if (!ecId || typeof ecId !== 'string') {
+        return redirect(`${detailUrl}?error=missing`, 302)
+      }
+      const existing = await getEngagementContact(env.DB, session.orgId, ecId.trim())
+      if (!existing || existing.engagement_id !== engagementId) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+      await removeEngagementContact(env.DB, session.orgId, ecId.trim())
+
+      const contact = await getContact(env.DB, session.orgId, existing.contact_id)
+      await appendContext(env.DB, session.orgId, {
+        entity_id: engagement.entity_id,
+        type: 'engagement_log',
+        content: `Removed ${existing.role} role assignment for ${contact?.name ?? 'contact'}`,
+        source: 'admin',
+        source_ref: `engagement_contact:${existing.id}:removed`,
+        metadata: {
+          engagement_contact_id: existing.id,
+          contact_id: existing.contact_id,
+          role: existing.role,
+        },
+        engagement_id: engagementId,
+      })
+
+      return redirect(`${detailUrl}?engagement_contact_removed=1`, 302)
+    }
+
+    // Set primary
+    if (action === 'set_primary') {
+      const ecId = formData.get('engagement_contact_id')
+      if (!ecId || typeof ecId !== 'string') {
+        return redirect(`${detailUrl}?error=missing`, 302)
+      }
+      const existing = await getEngagementContact(env.DB, session.orgId, ecId.trim())
+      if (!existing || existing.engagement_id !== engagementId) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      const updated = await setEngagementContactPrimary(env.DB, session.orgId, ecId.trim())
+      if (!updated) {
+        return redirect(`${detailUrl}?error=not_found`, 302)
+      }
+
+      const contact = await getContact(env.DB, session.orgId, existing.contact_id)
+      await appendContext(env.DB, session.orgId, {
+        entity_id: engagement.entity_id,
+        type: 'engagement_log',
+        content: `Set ${contact?.name ?? 'contact'} as primary POC`,
+        source: 'admin',
+        source_ref: `engagement_contact:${existing.id}:set_primary`,
+        metadata: {
+          engagement_contact_id: existing.id,
+          contact_id: existing.contact_id,
+          role: existing.role,
+        },
+        engagement_id: engagementId,
+      })
+
+      return redirect(`${detailUrl}?engagement_contact_primary_set=1`, 302)
+    }
+
+    // Default action: add
+    const contactIdRaw = formData.get('contact_id')
+    const roleRaw = formData.get('role')
+    const isPrimaryRaw = formData.get('is_primary')
+    const notesRaw = formData.get('notes')
+
+    if (!contactIdRaw || typeof contactIdRaw !== 'string' || !contactIdRaw.trim()) {
+      return redirect(`${detailUrl}?error=missing_contact`, 302)
+    }
+    if (
+      !roleRaw ||
+      typeof roleRaw !== 'string' ||
+      !ENGAGEMENT_CONTACT_ROLES.some((r) => r.value === roleRaw)
+    ) {
+      return redirect(`${detailUrl}?error=invalid_role`, 302)
+    }
+
+    const contactId = contactIdRaw.trim()
+
+    // Org + entity scoping: contact must belong to this engagement's entity.
+    const contact = await getContact(env.DB, session.orgId, contactId)
+    if (!contact || contact.entity_id !== engagement.entity_id) {
+      return redirect(`${detailUrl}?error=invalid_contact`, 302)
+    }
+
+    const isPrimary = isPrimaryRaw === '1' || isPrimaryRaw === 'on' || isPrimaryRaw === 'true'
+    const notes =
+      notesRaw && typeof notesRaw === 'string' && notesRaw.trim() ? notesRaw.trim() : null
+
+    try {
+      const created = await addEngagementContact(env.DB, engagementId, {
+        contact_id: contactId,
+        role: roleRaw as EngagementContactRole,
+        is_primary: isPrimary,
+        notes,
+      })
+
+      await appendContext(env.DB, session.orgId, {
+        entity_id: engagement.entity_id,
+        type: 'engagement_log',
+        content: `Assigned ${contact.name} as ${roleRaw}${isPrimary ? ' (primary POC)' : ''}`,
+        source: 'admin',
+        source_ref: `engagement_contact:${created.id}:added`,
+        metadata: {
+          engagement_contact_id: created.id,
+          contact_id: contactId,
+          role: roleRaw,
+          is_primary: isPrimary,
+        },
+        engagement_id: engagementId,
+      })
+
+      return redirect(`${detailUrl}?engagement_contact_added=1`, 302)
+    } catch (err) {
+      // UNIQUE(engagement_id, contact_id, role) constraint hit.
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('UNIQUE') || message.includes('constraint')) {
+        return redirect(`${detailUrl}?error=duplicate_role`, 302)
+      }
+      throw err
+    }
+  } catch (err) {
+    console.error('[api/admin/engagements/[id]/contacts] Error:', err)
+    return redirect('/admin/entities?error=server', 302)
+  }
+}

--- a/src/pages/api/admin/entities/[id]/contacts.ts
+++ b/src/pages/api/admin/entities/[id]/contacts.ts
@@ -1,0 +1,72 @@
+import type { APIRoute } from 'astro'
+import { getEntity } from '../../../../../lib/db/entities'
+import { createContact } from '../../../../../lib/db/contacts'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/admin/entities/:id/contacts
+ *
+ * Create a contact attached to an entity. Edit + delete live on
+ * /api/admin/contacts/[id].
+ *
+ * Form fields:
+ *   - name (required)
+ *   - email (optional — required before portal invitations, enforced
+ *     elsewhere in the codepath that issues invites)
+ *   - phone (optional)
+ *   - title (optional)
+ *   - role (optional, free-text job role on the contact record itself —
+ *     distinct from per-engagement role assignment)
+ */
+export const POST: APIRoute = async ({ request, locals, redirect, params }) => {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) {
+    return new Response(JSON.stringify({ error: 'Entity ID required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const entity = await getEntity(env.DB, session.orgId, entityId)
+    if (!entity) {
+      return redirect('/admin/entities?error=not_found', 302)
+    }
+
+    const detailUrl = `/admin/entities/${entityId}`
+    const formData = await request.formData()
+
+    const nameRaw = formData.get('name')
+    if (!nameRaw || typeof nameRaw !== 'string' || !nameRaw.trim()) {
+      return redirect(`${detailUrl}?error=missing_name`, 302)
+    }
+
+    const stringOrNull = (key: string): string | null => {
+      const v = formData.get(key)
+      if (typeof v !== 'string') return null
+      const trimmed = v.trim()
+      return trimmed ? trimmed : null
+    }
+
+    await createContact(env.DB, session.orgId, entityId, {
+      name: nameRaw.trim(),
+      email: stringOrNull('email'),
+      phone: stringOrNull('phone'),
+      title: stringOrNull('title'),
+      role: stringOrNull('role'),
+    })
+
+    return redirect(`${detailUrl}?contact_added=1`, 302)
+  } catch (err) {
+    console.error('[api/admin/entities/[id]/contacts] Error:', err)
+    return redirect('/admin/entities?error=server', 302)
+  }
+}


### PR DESCRIPTION
## Summary

Closes the four unmet ACs on #69 (reopened in #377 triage):

- **Admin can add contacts to a client** — new CRUD panel on `/admin/entities/[id]` (add / inline edit / delete)
- **Admin can assign contacts to engagement roles** — new Contacts & Roles panel on `/admin/engagements/[id]`
- **Same contact can be assigned multiple roles** — surfaced in the role picker; schema's `UNIQUE(engagement_id, contact_id, role)` blocks dupes; endpoint surfaces a friendly error on collision (`?error=duplicate_role`)
- **Primary POC flag is settable per engagement** — checkbox on the assign form plus a per-row "Make primary" action; single-primary invariant enforced at the application layer (schema lacks a partial unique)

Also closes the related "contact role assignment" AC noted on #77.

## How it's wired

- DAL: `src/lib/db/engagement-contacts.ts` — mirrors `parking-lot.ts` pattern (no `org_id` column on the table; org scoping via `INNER JOIN engagements ... AND e.org_id = ?` on every read; cross-org rows return null, no enumeration leak).
- Endpoints validate that `contact_id` belongs to the engagement's entity (not just the org) before writing — multi-tenant safety.
- All mutations append a `context` row of type `engagement_log` so the timeline reflects role-assignment activity.
- Two components extracted to keep page line caps green:
  - `EntityContactsPanel.astro` (replaces the read-only contacts list on the entity page)
  - `EngagementContactsPanel.astro` (new role-assignment panel on the engagement page)

## Tests

- `src/lib/db/engagement-contacts.test.ts` — 15 specs covering source-level invariants (parameterized SQL, JOIN-based scoping, UUIDs) and behavioural single-primary semantics:
  - `addEngagementContact` with `is_primary=true` clears existing primary first; with `is_primary=false` it does not touch existing primaries
  - `setEngagementContactPrimary` clears every other primary on the engagement (`id <> ?`) but never the row being promoted
  - cross-org rows produce `null` / `false` and zero writes
- Full `npm run verify` passes (typecheck × 7, lint, build, 101+6 test suites).

## Test plan

- [ ] Open `/admin/entities/<id>` — Contacts panel renders; add / edit / delete a contact
- [ ] Open `/admin/engagements/<id>` — Contacts & Roles panel renders; assign a contact as `owner`, then `champion` (same contact, two roles); confirm both rows appear
- [ ] Assign with "Mark as primary POC" → row badged Primary POC; assign another with primary toggle → first loses badge
- [ ] Click "Make primary" on a non-primary row → primary moves
- [ ] Try to assign the same role twice to the same contact → friendly "already holds this role" error
- [ ] Remove an assignment → flash + audit-trail entry on the engagement timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)