### PR TITLE
fix(scan): split shadow-write from magic-link mint + bind PORTAL_BASE_URL (Outside View P0)

### DIFF
--- a/src/lib/diagnostic/workflow.ts
+++ b/src/lib/diagnostic/workflow.ts
@@ -597,22 +597,23 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
         const entity = await loadEntity()
         const rendered = await renderDiagnosticReport(env.DB, entity, briefStep.markdown)
 
-        const portalDelivery = await prepareOutsideViewDelivery(
-          this.env,
-          scanRequestSnapshot,
-          entity,
-          rendered
-        )
+        // Shadow-write the artifact UNCONDITIONALLY. Internal try/catch
+        // guarantees the workflow continues even if this throws.
+        await writeOutsideViewArtifact(this.env, scanRequestSnapshot, entity, rendered)
+
+        // Mint a magic link IF the submitter is a prospect (or has no
+        // user row). Returns null for clients; null for any throw.
+        const { portalLinkUrl } = await mintProspectMagicLink(this.env, scanRequestSnapshot, entity)
 
         const flagOn = isOutsideViewDeliveryOn(this.env.OUTSIDE_VIEW_PORTAL_DELIVERY)
-        const useOutsideViewEmail = flagOn && portalDelivery.portalLinkUrl !== null
+        const useOutsideViewEmail = flagOn && portalLinkUrl !== null
 
         const sent = useOutsideViewEmail
           ? await sendOutsideViewReadyEmail(
               env,
               scanRequestSnapshot,
               entity,
-              portalDelivery.portalLinkUrl as string,
+              portalLinkUrl as string,
               rendered.displayName
             )
           : await sendDiagnosticReportEmail(env, scanRequestSnapshot, entity, rendered)
@@ -642,33 +643,64 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
 }
 
 /**
- * Outside View shadow-write + magic-link mint (ADR 0002 Phase 1 PR-B).
+ * Outside View shadow-write — persists the rendered artifact into
+ * `outside_views` UNCONDITIONALLY (ADR 0002 Phase 1 PR-B).
  *
- * Always runs at the render-and-email step terminal, regardless of
- * `OUTSIDE_VIEW_PORTAL_DELIVERY` flag state. The flag controls only the
- * email destination — the artifact is persisted into `outside_views`
- * either way so Captain can inspect shadow-rendered rows in admin/SQL
- * before flipping the flag.
+ * Split out from the original `prepareOutsideViewDelivery` so it runs
+ * regardless of the submitter's role. The previous implementation
+ * entangled this write with the prospect-user creation path; if the
+ * submitter was an existing client (or any non-prospect role), the
+ * function returned early BEFORE calling createOutsideView. That made
+ * the documented "Captain inspects shadow rows in SQL before flipping
+ * the flag" workflow impossible from any client-role account.
  *
- * Returns `{ portalLinkUrl }` on success. `portalLinkUrl` is non-null
- * iff a prospect path was minted; null when:
- *   1. The submission email matches an existing role='client' user
- *      (privilege-escalation defense — never mint a portal magic-link
- *      to a client via the public scan form).
- *   2. The shadow-write throws (DB error, magic-link insert failure).
- *      We swallow the error rather than failing the workflow so the
- *      legacy email path can still fire.
- *
- * Caller decides whether to use `portalLinkUrl` based on the feature
- * flag. With flag OFF, caller ignores `portalLinkUrl` and sends the
- * legacy email. With flag ON, caller sends the new magic-link email
- * IF `portalLinkUrl` is non-null, otherwise falls back to legacy.
+ * Failures here MUST NOT fail the workflow. The legacy email path is
+ * the safety net. Returns `{ outsideViewId: null }` on any throw,
+ * logged for operator inspection.
  */
-async function prepareOutsideViewDelivery(
+async function writeOutsideViewArtifact(
   env: ScanWorkflowBindings,
   scanRequest: ScanRequest,
   entity: Entity,
   rendered: RenderedReport
+): Promise<{ outsideViewId: string | null }> {
+  try {
+    const created = await createOutsideView(env.DB, {
+      org_id: ORG_ID,
+      entity_id: entity.id,
+      scan_request_id: scanRequest.id,
+      depth: 'd1',
+      artifact_version: 1,
+      artifact_json: renderedReportToArtifactJsonV1(rendered),
+      rendered_at: new Date().toISOString(),
+    })
+    return { outsideViewId: created.id }
+  } catch (err) {
+    console.error('[outside-view] writeOutsideViewArtifact failed:', err)
+    return { outsideViewId: null }
+  }
+}
+
+/**
+ * Mint a 24h portal magic-link bound to a prospect user (ADR 0002 Phase 1 PR-B).
+ *
+ * Gated on the submitter's role:
+ *   - role='client'   → return null (privilege-escalation defense; never
+ *                       hand a 24h auth credential to an existing client
+ *                       via a public, unauthenticated form).
+ *   - role='prospect' → reuse the existing user row, mint a fresh link.
+ *   - role='admin' or any other non-prospect existing role → return null
+ *                       (the role!='client' fallthrough used to throw on
+ *                       UNIQUE(org_id, email); now handled cleanly).
+ *   - no existing row → create a prospect user, mint a link.
+ *
+ * Failures here MUST NOT fail the workflow. The legacy email path is
+ * the safety net. Returns `{ portalLinkUrl: null }` on any throw or skip.
+ */
+async function mintProspectMagicLink(
+  env: ScanWorkflowBindings,
+  scanRequest: ScanRequest,
+  entity: Entity
 ): Promise<{ portalLinkUrl: string | null }> {
   try {
     const existingUser = await env.DB.prepare(
@@ -677,13 +709,13 @@ async function prepareOutsideViewDelivery(
       .bind(ORG_ID, scanRequest.email)
       .first<{ id: string; role: string }>()
 
-    if (existingUser?.role === 'client') {
-      // Privilege-escalation defense (per /critique 3 Devil's Advocate
-      // #4). Never mint a portal magic-link to an existing client via
-      // the public, unauthenticated /scan form. The legacy email path
-      // still fires; the client gets their report.
+    if (existingUser && existingUser.role !== 'prospect') {
+      // role='client' is the privilege-escalation defense; any other
+      // non-prospect role (admin, etc.) falls through here too — we
+      // never hand a portal session cookie to an account that already
+      // has a different relationship with the org.
       console.log(
-        `[outside-view] skipping prospect path: existing client matched on ${scanRequest.email}`
+        `[outside-view] skipping mint: existing user role=${existingUser.role} for ${scanRequest.email}`
       )
       return { portalLinkUrl: null }
     }
@@ -700,32 +732,10 @@ async function prepareOutsideViewDelivery(
         `INSERT INTO users (id, org_id, email, name, role, entity_id)
          VALUES (?, ?, ?, ?, 'prospect', ?)`
       )
-        .bind(
-          prospectUserId,
-          ORG_ID,
-          scanRequest.email,
-          // No human name yet; use the email address as a placeholder.
-          // The name is internal-only (admin entity view); prospects
-          // never see it.
-          scanRequest.email,
-          entity.id
-        )
+        .bind(prospectUserId, ORG_ID, scanRequest.email, scanRequest.email, entity.id)
         .run()
     }
 
-    // Insert the outside_views row (v1 stores the existing RenderedReport
-    // shape verbatim; canonical 5-field contract ships in v2).
-    await createOutsideView(env.DB, {
-      org_id: ORG_ID,
-      entity_id: entity.id,
-      scan_request_id: scanRequest.id,
-      depth: 'd1',
-      artifact_version: 1,
-      artifact_json: renderedReportToArtifactJsonV1(rendered),
-      rendered_at: new Date().toISOString(),
-    })
-
-    // Mint a 24h portal magic-link bound to the prospect user.
     const token = await createMagicLink(
       env.DB,
       {
@@ -736,21 +746,12 @@ async function prepareOutsideViewDelivery(
       PROSPECT_MAGIC_LINK_EXPIRY_MS
     )
 
-    // Build the verify URL on the portal host. PORTAL_BASE_URL is
-    // preferred; fall back to APP_BASE_URL if unset (the portal lives
-    // on the same Worker under a subdomain rewrite). The verify
-    // endpoint at /auth/verify on portal.smd.services consumes the
-    // token, sets the session cookie, and lands the prospect at
-    // /portal which redirects them onward to /portal/outside-view.
     const portalBase = env.PORTAL_BASE_URL ?? env.APP_BASE_URL ?? 'https://portal.smd.services'
     const portalLinkUrl = `${portalBase.replace(/\/$/, '')}/auth/verify?token=${encodeURIComponent(token)}`
 
     return { portalLinkUrl }
   } catch (err) {
-    // Shadow-write failures must not fail the workflow. The legacy email
-    // path is the safety net. Log and return null so the caller falls
-    // back to the legacy email regardless of flag state.
-    console.error('[outside-view] prepareOutsideViewDelivery failed:', err)
+    console.error('[outside-view] mintProspectMagicLink failed:', err)
     return { portalLinkUrl: null }
   }
 }

--- a/tests/diagnostic-workflow.test.ts
+++ b/tests/diagnostic-workflow.test.ts
@@ -260,6 +260,156 @@ describe('ScanDiagnosticWorkflow — happy path', () => {
     expect(vi.mocked(sendOutreachEmail)).toHaveBeenCalled()
     // Admin alert was NOT called — the scan completed cleanly.
     expect(vi.mocked(sendScanFailureAlert)).not.toHaveBeenCalled()
+
+    // ADR 0002 PR-B shadow-write: outside_views row written
+    // unconditionally for every successful scan, regardless of feature
+    // flag state. Adding this assertion would have caught the
+    // page-orphan / role='client' silent-skip bug class earlier.
+    const ovRow = await db
+      .prepare('SELECT id, depth, scan_request_id FROM outside_views WHERE scan_request_id = ?')
+      .bind(id)
+      .first<{ id: string; depth: string; scan_request_id: string }>()
+    expect(ovRow).not.toBeNull()
+    expect(ovRow?.depth).toBe('d1')
+    expect(ovRow?.scan_request_id).toBe(id)
+  })
+})
+
+describe('ScanDiagnosticWorkflow — shadow-write decoupled from mint (ADR 0002)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+    vi.clearAllMocks()
+    // Wire mocks the same way the happy-path test does so the workflow
+    // reaches the render-and-email step.
+    vi.mocked(lookupGooglePlaces).mockResolvedValue({
+      phone: '+1 555 0123',
+      website: 'https://realbiz.com/',
+      rating: 4.6,
+      reviewCount: 33,
+      businessStatus: 'OPERATIONAL',
+      address: 'Phoenix, AZ',
+    })
+    vi.mocked(lookupOutscraper).mockResolvedValue({
+      phone: '+1 555 0123',
+      website: 'https://realbiz.com',
+      rating: 4.6,
+      review_count: 33,
+      verified: true,
+    } as unknown as Awaited<ReturnType<typeof lookupOutscraper>>)
+    vi.mocked(analyzeWebsite).mockResolvedValue({
+      pages_analyzed: ['/'],
+      quality: 'medium',
+      tech_stack: { scheduling: [], crm: [], reviews: [], payments: [], communication: [] },
+    } as unknown as Awaited<ReturnType<typeof analyzeWebsite>>)
+    vi.mocked(synthesizeReviews).mockResolvedValue({
+      customer_sentiment: 'positive',
+      sentiment_trend: 'stable',
+      top_themes: ['responsive scheduling'],
+      operational_problems: [],
+    } as unknown as Awaited<ReturnType<typeof synthesizeReviews>>)
+    vi.mocked(deepWebsiteAnalysis).mockResolvedValue({
+      digital_maturity: { score: 6, reasoning: 'partial CRM coverage' },
+    } as unknown as Awaited<ReturnType<typeof deepWebsiteAnalysis>>)
+    vi.mocked(generateDossier).mockResolvedValue('# Brief\n\nNarrative content.')
+  })
+
+  /**
+   * Pre-fix bug: prepareOutsideViewDelivery returned early for
+   * existing client-role users BEFORE calling createOutsideView,
+   * so Captain (role='client') could never inspect his own scan
+   * artifacts. This test asserts the unconditional shadow-write
+   * fires regardless of role.
+   */
+  it('writes outside_views row even when submission email matches existing client', async () => {
+    const submitted = 'realbiz.com'
+    const email = 'returning-client@example.com'
+    const id = await seedScan(db, submitted, email)
+
+    // Seed an existing client-role user with the prospect email.
+    const orgRow = await db.prepare('SELECT id FROM organizations LIMIT 1').first<{ id: string }>()
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role)
+         VALUES (?, ?, ?, ?, 'client')`
+      )
+      .bind('seed-client-user', orgRow!.id, email, 'Existing Client')
+      .run()
+
+    await runWorkflow(
+      {
+        DB: db,
+        GOOGLE_PLACES_API_KEY: 'test',
+        OUTSCRAPER_API_KEY: 'test',
+        ANTHROPIC_API_KEY: 'test',
+        RESEND_API_KEY: 'test',
+      },
+      id
+    )
+
+    // Shadow-write fired despite the client-skip on the mint.
+    const ovRow = await db
+      .prepare('SELECT id FROM outside_views WHERE scan_request_id = ?')
+      .bind(id)
+      .first()
+    expect(ovRow).not.toBeNull()
+
+    // No magic_link minted — the privilege-escalation defense held.
+    const magicRow = await db
+      .prepare('SELECT id FROM magic_links WHERE email = ?')
+      .bind(email)
+      .first()
+    expect(magicRow).toBeNull()
+  })
+
+  /**
+   * Q4 secondary failure mode from the code review: when an admin-role
+   * user matches the submission email, the pre-split implementation
+   * fell through to INSERT INTO users with role='prospect', which hit
+   * UNIQUE(org_id, email) and threw — silently swallowed by the
+   * outer catch. Post-split: artifact still writes, mint cleanly
+   * returns null without throwing.
+   */
+  it('writes outside_views row + skips mint cleanly when submission email matches admin user', async () => {
+    const submitted = 'realbiz.com'
+    const email = 'admin@example.com'
+    const id = await seedScan(db, submitted, email)
+
+    const orgRow = await db.prepare('SELECT id FROM organizations LIMIT 1').first<{ id: string }>()
+    await db
+      .prepare(
+        `INSERT INTO users (id, org_id, email, name, role)
+         VALUES (?, ?, ?, ?, 'admin')`
+      )
+      .bind('seed-admin-user', orgRow!.id, email, 'Existing Admin')
+      .run()
+
+    await runWorkflow(
+      {
+        DB: db,
+        GOOGLE_PLACES_API_KEY: 'test',
+        OUTSCRAPER_API_KEY: 'test',
+        ANTHROPIC_API_KEY: 'test',
+        RESEND_API_KEY: 'test',
+      },
+      id
+    )
+
+    const ovRow = await db
+      .prepare('SELECT id FROM outside_views WHERE scan_request_id = ?')
+      .bind(id)
+      .first()
+    expect(ovRow).not.toBeNull()
+
+    const magicRow = await db
+      .prepare('SELECT id FROM magic_links WHERE email = ?')
+      .bind(email)
+      .first()
+    expect(magicRow).toBeNull()
+
+    // The scan still completed — mint failure does not fail the workflow.
+    const sr = await getScanRequest(db, id)
+    expect(sr?.scan_status).toBe('completed')
   })
 })
 

--- a/tests/outside-view-pr-b.test.ts
+++ b/tests/outside-view-pr-b.test.ts
@@ -64,19 +64,25 @@ describe('PR-B: workflow terminal step shadow-write + flag', () => {
     expect(src).toMatch(/sendOutsideViewReadyEmail/)
   })
 
-  it('terminal step calls prepareOutsideViewDelivery before email', () => {
-    expect(src).toMatch(/prepareOutsideViewDelivery/)
+  it('terminal step calls writeOutsideViewArtifact before mintProspectMagicLink', () => {
+    expect(src).toMatch(/writeOutsideViewArtifact/)
+    expect(src).toMatch(/mintProspectMagicLink/)
+    const idxArtifact = src.indexOf('writeOutsideViewArtifact(this.env')
+    const idxMint = src.indexOf('mintProspectMagicLink(')
+    expect(idxArtifact).toBeGreaterThan(0)
+    expect(idxMint).toBeGreaterThan(idxArtifact)
   })
 
-  it('shadow-write runs ALWAYS (not gated by flag)', () => {
-    // The flag check is on the email branch, not on prepareOutsideViewDelivery.
-    // prepareOutsideViewDelivery should be called before isOutsideViewDeliveryOn.
-    const idxPrepare = src.indexOf('prepareOutsideViewDelivery(')
+  it('shadow-write runs UNCONDITIONALLY (no role/flag gate before artifact write)', () => {
+    // writeOutsideViewArtifact must run before mintProspectMagicLink AND
+    // before the flag check. The split decouples shadow-write from the
+    // mint so client-role submitters still produce outside_views rows.
+    const idxArtifact = src.indexOf('writeOutsideViewArtifact(this.env')
     const idxFlagCheck = src.indexOf(
       'isOutsideViewDeliveryOn(this.env.OUTSIDE_VIEW_PORTAL_DELIVERY)'
     )
-    expect(idxPrepare).toBeGreaterThan(0)
-    expect(idxFlagCheck).toBeGreaterThan(idxPrepare)
+    expect(idxArtifact).toBeGreaterThan(0)
+    expect(idxFlagCheck).toBeGreaterThan(idxArtifact)
   })
 
   it('falls back to legacy email when flag OFF or magic-link unavailable', () => {
@@ -85,9 +91,13 @@ describe('PR-B: workflow terminal step shadow-write + flag', () => {
     )
   })
 
-  it('privilege-escalation defense: skips prospect path on existing client email', () => {
-    // The helper function should check role === 'client' and bail.
-    expect(src).toMatch(/existingUser\?\.role === 'client'[\s\S]*portalLinkUrl: null/)
+  it('mintProspectMagicLink skips for any non-prospect existing role (client, admin, etc.)', () => {
+    // The single guard `existingUser && existingUser.role !== 'prospect'`
+    // covers both the privilege-escalation defense (client) AND the
+    // admin-INSERT-throws bug class (Q4 in the code review).
+    expect(src).toMatch(
+      /existingUser && existingUser\.role !== 'prospect'[\s\S]*portalLinkUrl: null/
+    )
   })
 
   it('magic-link uses 24h TTL (PROSPECT_MAGIC_LINK_EXPIRY_MS)', () => {
@@ -99,15 +109,31 @@ describe('PR-B: workflow terminal step shadow-write + flag', () => {
   })
 
   it('portal URL points at /auth/verify (not directly at /portal/outside-view)', () => {
-    // The verify endpoint sets the cookie; landing direct at /portal would
-    // hit middleware without a session and bounce.
     expect(src).toMatch(/\/auth\/verify\?token=/)
   })
 
-  it('shadow-write swallows errors and returns null portalLinkUrl', () => {
+  it('writeOutsideViewArtifact swallows errors and returns outsideViewId: null', () => {
     expect(src).toMatch(
-      /catch\s*\(err\)\s*\{[\s\S]*prepareOutsideViewDelivery failed[\s\S]*return\s*\{\s*portalLinkUrl:\s*null/
+      /catch\s*\(err\)\s*\{[\s\S]*writeOutsideViewArtifact failed[\s\S]*return\s*\{\s*outsideViewId:\s*null/
     )
+  })
+
+  it('mintProspectMagicLink swallows errors and returns portalLinkUrl: null', () => {
+    expect(src).toMatch(
+      /catch\s*\(err\)\s*\{[\s\S]*mintProspectMagicLink failed[\s\S]*return\s*\{\s*portalLinkUrl:\s*null/
+    )
+  })
+})
+
+describe('PR-B: workers/scan-workflow wrangler.toml binds PORTAL_BASE_URL', () => {
+  const wranglerSrc = readFileSync(resolve('workers/scan-workflow/wrangler.toml'), 'utf-8')
+
+  it('declares PORTAL_BASE_URL in [vars] (not just as a comment)', () => {
+    expect(wranglerSrc).toMatch(/^PORTAL_BASE_URL\s*=\s*"https:\/\/portal\.smd\.services"/m)
+  })
+
+  it('declares OUTSIDE_VIEW_PORTAL_DELIVERY in [vars] for explicit flag state', () => {
+    expect(wranglerSrc).toMatch(/^OUTSIDE_VIEW_PORTAL_DELIVERY\s*=\s*"[01]"/m)
   })
 })
 

--- a/workers/scan-workflow/src/index.ts
+++ b/workers/scan-workflow/src/index.ts
@@ -80,6 +80,20 @@ export interface Env {
   GOOGLE_PLACES_API_KEY?: string
   OUTSCRAPER_API_KEY?: string
   APP_BASE_URL?: string
+  /**
+   * Portal origin for outbound magic-link URLs minted by the Outside View
+   * delivery path. Without this, the fallback in workflow.ts resolves to
+   * APP_BASE_URL (https://smd.services, the marketing host) and prospects
+   * land on the wrong site after clicking the magic link.
+   */
+  PORTAL_BASE_URL?: string
+  /**
+   * Outside View Phase 1 PR-B feature flag. "1" routes the prospect to
+   * the new portal-magic-link email; "0" (or unset) keeps the legacy
+   * diagnostic-report email path. Declared in [vars] in wrangler.toml so
+   * the OFF state is explicit and any flip is a one-line, reviewable commit.
+   */
+  OUTSIDE_VIEW_PORTAL_DELIVERY?: string
 }
 
 interface DispatchRequestBody {

--- a/workers/scan-workflow/wrangler.toml
+++ b/workers/scan-workflow/wrangler.toml
@@ -50,8 +50,21 @@ enabled = true
 # link URLs for Outside View delivery). Must match the production origin
 # the email recipient will click into. Not a secret — committing the value
 # is fine.
+#
+# PORTAL_BASE_URL is required for the Outside View magic-link emails:
+# without it, the fallback at workflow.ts (`env.PORTAL_BASE_URL ?? env.APP_BASE_URL`)
+# resolves to https://smd.services (marketing host) and prospects land on
+# the wrong site after clicking the link.
+#
+# OUTSIDE_VIEW_PORTAL_DELIVERY is the Outside View Phase 1 PR-B feature
+# flag. Declared explicitly as "0" (OFF) so the current value is visible
+# in git history and any future flip is a one-line, reviewable commit.
+# Flip to "1" to route prospects to the portal-magic-link email instead
+# of the legacy diagnostic-report email.
 [vars]
 APP_BASE_URL = "https://smd.services"
+PORTAL_BASE_URL = "https://portal.smd.services"
+OUTSIDE_VIEW_PORTAL_DELIVERY = "0"
 
 # ---------- Secrets (set via `wrangler secret put` or `wrangler secret bulk`) ----------
 # All secrets are set per-Worker. Captain provisions these from Infisical


### PR DESCRIPTION
## Summary

PR-1 of 4 in the same-session Outside View ship plan.

- Splits `prepareOutsideViewDelivery` into `writeOutsideViewArtifact` (unconditional shadow-write) + `mintProspectMagicLink` (gated by role). The pre-fix code returned early at `workflow.ts:680-689` for `existingUser?.role === 'client'` BEFORE `createOutsideView`, so Captain (role='client') could never produce shadow rows from his own submissions — making the documented "inspect outside_views in admin/SQL before flag flip" workflow impossible from his vantage point.
- Adds `PORTAL_BASE_URL = "https://portal.smd.services"` and `OUTSIDE_VIEW_PORTAL_DELIVERY = "0"` to `workers/scan-workflow/wrangler.toml` `[vars]` block. Without `PORTAL_BASE_URL`, the fallback at `workflow.ts:745` resolves to `APP_BASE_URL` = `https://smd.services` (marketing host) and prospects land on the wrong site after clicking the magic link. Explicit `=0` declaration makes any future flip a one-line, reviewable commit.

## Failure modes closed

| Bug class | Mechanism |
|---|---|
| Captain's `role='client'` test scans never produce `outside_views` rows | Shadow-write was inside the same try-block as the magic-link mint; client-skip branch returned before the artifact write. Now decoupled. |
| Admin-role submissions silently throw on `INSERT INTO users` (UNIQUE constraint) and the swallowed catch returns null portalLinkUrl with no shadow row | `mintProspectMagicLink` guard widened to `existingUser && role !== 'prospect'` covers all non-prospect existing roles cleanly. |
| Magic-link emails point at marketing host when flag flips on | `PORTAL_BASE_URL` now bound. |

## Test plan

- [x] `npm run verify` clean (2051 main tests + all workers green)
- [x] New tests: shadow-write fires for client-role submitter, admin-role submitter
- [x] Regression-guard: `writeOutsideViewArtifact` must run before `mintProspectMagicLink` AND before `isOutsideViewDeliveryOn` flag check
- [x] New wrangler.toml assertion: `PORTAL_BASE_URL` declared in `[vars]`
- [ ] Post-deploy: submit fresh scan from `smdurgan+ovtest@venturecrane.com`; verify `outside_views` row + `magic_links` row both written
- [ ] Post-deploy: submit from Captain's client account; verify `outside_views` row written + `magic_links` row NOT written for that email

## Plan reference

See `/Users/scottdurgan/.claude/plans/proceed-with-the-plan-resilient-bentley.md`. Subsequent PRs in this sequence: PR-2a (foot-guns), PR-2b (idempotency hardening), PR-3 (flag flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)