### PR TITLE
fix(scan): close foot-guns — failed-state on dispatch error + workflow startup secret guard + dev-mode detection

### DIFF
--- a/src/lib/diagnostic/index.ts
+++ b/src/lib/diagnostic/index.ts
@@ -1,6 +1,33 @@
 /**
  * Engine 1 diagnostic orchestrator (#598, hardened in #612).
  *
+ * ⚠️  DIVERGED FROM PRODUCTION SEMANTICS — DEV/TEST ONLY  ⚠️
+ * ----------------------------------------------------------------
+ * `runDiagnosticScan` is the legacy in-process pipeline. Production
+ * uses `ScanDiagnosticWorkflow` in `./workflow.ts`, dispatched as a
+ * Cloudflare Workflow on the `ss-scan-workflow` Worker. This file
+ * exists ONLY as the dev/test fallback at `src/lib/scan/verify-handler.ts`
+ * (the no-binding branch) and as the source of module wrappers that
+ * the Workflow class re-imports.
+ *
+ * Known divergences from production:
+ *   - Tier 2 modules (website_analysis + review_synthesis) run
+ *     SEQUENTIALLY here; the Workflow runs them in parallel via Promise.all.
+ *   - The Outside View shadow-write (`createOutsideView` into the
+ *     `outside_views` table) is NOT performed here. The Workflow's
+ *     render-and-email step writes the artifact; this orchestrator
+ *     does not.
+ *   - The Outside View magic-link mint is NOT performed here.
+ *   - The dispatch-failure admin alert path is NOT exercised here.
+ *
+ * If you find yourself calling `runDiagnosticScan` from a NEW production
+ * code path, stop — use `env.SCAN_WORKFLOW_SERVICE` to dispatch the
+ * Workflow instead. The verify-handler's production error path
+ * intentionally marks scans `failed` rather than falling back to this
+ * legacy implementation, because doing so would re-create the original
+ * Worker isolate-budget bug (#614).
+ * ----------------------------------------------------------------
+ *
  * Runs the *pruned* 6-module pipeline behind smd.services/scan, with a
  * P0 thin-footprint pre-flight gate. Per the scoping doc
  * (`docs/strategy/diagnostic-scoping-2026-04-27.md`), the public scan path

--- a/src/lib/diagnostic/workflow.ts
+++ b/src/lib/diagnostic/workflow.ts
@@ -328,6 +328,28 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
       return
     }
 
+    // ---------------------------------------------------------------
+    // Startup assertion: required secrets must be bound before we burn
+    // any compute. This Workflow is only ever invoked in production
+    // (the dev/test path uses the legacy in-process pipeline), so a
+    // missing secret here is a misconfiguration, not a dev convenience.
+    //
+    // Without this guard the pipeline would run all 4 Claude calls
+    // (~$0.14 of Anthropic spend per scan) and then silently send a
+    // dev-mode email that never leaves Resend. Captain debugged exactly
+    // this incident on 2026-05-01 — the ss-scan-workflow Worker had
+    // shipped with zero secrets bound for ~3 weeks before anyone noticed.
+    //
+    // Placed AFTER the idempotency short-circuit so an already-completed
+    // re-dispatch is a no-op even when this Worker is mid-secret-rotation.
+    // ---------------------------------------------------------------
+    if (!env.RESEND_API_KEY) {
+      throw new Error('[scan-workflow] RESEND_API_KEY unbound — cannot deliver report')
+    }
+    if (!env.ANTHROPIC_API_KEY) {
+      throw new Error('[scan-workflow] ANTHROPIC_API_KEY unbound — enrichment will be empty')
+    }
+
     // Mark scan_started_at on the row. Idempotent — Workflows may replay
     // this step on a retry; the column ends up with the latest start
     // time in the worst case, which is fine.
@@ -617,6 +639,38 @@ export class ScanDiagnosticWorkflow extends WorkflowEntrypoint<
               rendered.displayName
             )
           : await sendDiagnosticReportEmail(env, scanRequestSnapshot, entity, rendered)
+
+        // Detection net for the dev-mode silent-failure pattern: if the
+        // RESEND_API_KEY was bound BUT corrupt/revoked, sendEmail's
+        // dev-mode short-circuit at resend.ts fires and the synthetic
+        // outreach_events row gets message_id='dev-mode'. The startup
+        // assertion above only catches the unbound case; this catches
+        // the runtime-failure case. Best-effort, never throws.
+        if (sent) {
+          try {
+            const recent = await env.DB.prepare(
+              `SELECT message_id FROM outreach_events
+               WHERE entity_id = ? AND event_type = 'sent'
+               ORDER BY created_at DESC LIMIT 1`
+            )
+              .bind(entity.id)
+              .first<{ message_id: string | null }>()
+            if (recent?.message_id === 'dev-mode') {
+              console.error(
+                '[scan-workflow] Resend returned dev-mode message_id — RESEND_API_KEY is corrupt/revoked'
+              )
+              await sendScanFailureAlert(env.RESEND_API_KEY, {
+                scanRequestId: scanRequestSnapshot.id,
+                submittedDomain: scanRequestSnapshot.domain,
+                requesterEmail: scanRequestSnapshot.email,
+                failingModule: 'resend-dev-mode',
+                errorMessage: 'sendEmail returned dev-mode in production',
+              }).catch((err) => console.error('[scan-workflow] dev-mode alert failed:', err))
+            }
+          } catch (err) {
+            console.error('[scan-workflow] dev-mode check failed:', err)
+          }
+        }
 
         return { emailSent: sent }
       }

--- a/src/lib/scan/verify-handler.ts
+++ b/src/lib/scan/verify-handler.ts
@@ -25,6 +25,7 @@ import {
   updateScanRequestRun,
 } from '../db/scan-requests'
 import { runDiagnosticScan } from '../diagnostic'
+import { sendScanFailureAlert } from '../diagnostic/admin-alert'
 
 export interface VerifyResponse {
   ok: boolean
@@ -112,21 +113,50 @@ export async function handleVerify(token: string, locals: App.Locals): Promise<V
         console.error('[scan/verify-handler] failed to persist workflow_run_id:', err)
       })
     } catch (err) {
-      // If the service binding itself or its handler rejects, fall
-      // through to the dev fallback below so the scan still runs — but
-      // log loudly: this is the new hot path and a silent failure here
-      // is the bug class #618 was chartered to prevent.
-      console.error('[scan/verify-handler] SCAN_WORKFLOW_SERVICE dispatch failed:', err)
-      runFallback(row.id, locals)
+      // Production path: service binding is bound but the dispatch call
+      // failed. Do NOT fall back to the legacy in-process pipeline —
+      // that would re-create the original isolate-budget bug (#614)
+      // by running runDiagnosticScan inside the ss-web Worker isolate.
+      // Instead, mark the scan as failed and surface that to the user;
+      // the operator can re-dispatch from admin tooling once the
+      // ss-scan-workflow Worker is reachable again.
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('[scan/verify-handler] SCAN_WORKFLOW_SERVICE dispatch failed:', message)
+      await updateScanRequestRun(env.DB, row.id, {
+        scan_status: 'failed',
+        error_message: `dispatch_failed: ${message}`.slice(0, 500),
+        scan_status_reason: `dispatch: ${message}`.slice(0, 500),
+      }).catch((dbErr) => {
+        console.error('[scan/verify-handler] failed to mark scan failed:', dbErr)
+      })
+      // Best-effort admin alert. Wrapped in .catch so a thrown alert
+      // (e.g. from PR-2a's RESEND_API_KEY guard) cannot escape this
+      // function and produce a 500 to the prospect.
+      await sendScanFailureAlert(env.RESEND_API_KEY, {
+        scanRequestId: row.id,
+        submittedDomain: row.domain,
+        requesterEmail: row.email,
+        failingModule: 'dispatch',
+        errorMessage: message,
+      }).catch((alertErr) => {
+        console.error('[scan/verify-handler] admin alert failed:', alertErr)
+      })
+      return { ok: false, status: 'failed', domain: row.domain }
     }
     return { ok: true, status: 'verified', domain: row.domain }
   }
 
   // Dev / test fallback: no service binding configured. Run the legacy
   // ctx.waitUntil pipeline so `astro dev`, vitest, and any environment
-  // without the bound `ss-scan-workflow` Worker continue to work. This
-  // branch must never run in production — verified by the [[services]]
-  // binding in wrangler.toml + the smoke test in #618.
+  // without the bound `ss-scan-workflow` Worker continue to work.
+  //
+  // PRODUCTION REACHABILITY: this branch is only entered when
+  // `env.SCAN_WORKFLOW_SERVICE` is undefined or has no `fetch` method.
+  // In production the [[services]] binding is declared in root
+  // wrangler.toml and resolves at runtime; so this branch is dev/test
+  // only. The original 30s-isolate-budget bug (#614) cannot recur in
+  // production because the dispatch-failure path above explicitly
+  // routes to scan_status='failed' rather than calling runFallback.
   runFallback(row.id, locals)
   return { ok: true, status: 'verified', domain: row.domain }
 }

--- a/tests/diagnostic-workflow.test.ts
+++ b/tests/diagnostic-workflow.test.ts
@@ -275,6 +275,49 @@ describe('ScanDiagnosticWorkflow — happy path', () => {
   })
 })
 
+describe('ScanDiagnosticWorkflow — startup assertion (PR-2a)', () => {
+  let db: D1Database
+  beforeEach(async () => {
+    db = await freshDb()
+    vi.clearAllMocks()
+  })
+
+  it('throws when RESEND_API_KEY is unbound (post-idempotency-check)', async () => {
+    const id = await seedScan(db, 'realbiz.com')
+    // Workflow's outer try/catch records 'failed' rather than re-throwing,
+    // so we assert via the scan_request row state.
+    await runWorkflow(
+      { DB: db, ANTHROPIC_API_KEY: 'test', GOOGLE_PLACES_API_KEY: 'test' /* RESEND missing */ },
+      id
+    )
+    const row = await getScanRequest(db, id)
+    expect(row?.scan_status).toBe('failed')
+    expect(row?.error_message).toMatch(/RESEND_API_KEY unbound/)
+  })
+
+  it('throws when ANTHROPIC_API_KEY is unbound', async () => {
+    const id = await seedScan(db, 'realbiz.com')
+    await runWorkflow(
+      { DB: db, RESEND_API_KEY: 'test', GOOGLE_PLACES_API_KEY: 'test' /* ANTHROPIC missing */ },
+      id
+    )
+    const row = await getScanRequest(db, id)
+    expect(row?.scan_status).toBe('failed')
+    expect(row?.error_message).toMatch(/ANTHROPIC_API_KEY unbound/)
+  })
+
+  it('does NOT throw on already-completed scan even if secrets missing (idempotency holds)', async () => {
+    const id = await seedScan(db, 'realbiz.com')
+    // Pre-mark the scan completed.
+    await db.prepare("UPDATE scan_requests SET scan_status='completed' WHERE id=?").bind(id).run()
+    // Run with NO secrets — should short-circuit cleanly without throwing.
+    await runWorkflow({ DB: db }, id)
+    const row = await getScanRequest(db, id)
+    // Status unchanged from the pre-marked 'completed' value.
+    expect(row?.scan_status).toBe('completed')
+  })
+})
+
 describe('ScanDiagnosticWorkflow — shadow-write decoupled from mint (ADR 0002)', () => {
   let db: D1Database
   beforeEach(async () => {
@@ -440,7 +483,16 @@ describe('ScanDiagnosticWorkflow — retry behavior', () => {
       ['tier1-places-and-outscraper', { failTimes: 1, maxAttempts: 2 }],
     ])
 
-    const { stats } = await runWorkflow({ DB: db, GOOGLE_PLACES_API_KEY: 'test' }, id, overrides)
+    const { stats } = await runWorkflow(
+      {
+        DB: db,
+        GOOGLE_PLACES_API_KEY: 'test',
+        ANTHROPIC_API_KEY: 'test',
+        RESEND_API_KEY: 'test',
+      },
+      id,
+      overrides
+    )
 
     expect(stats.callsByStep.get('tier1-places-and-outscraper')).toBe(2)
 
@@ -574,7 +626,10 @@ describe('ScanDiagnosticWorkflow — thin-footprint gate', () => {
     // assertion below to match whichever reason fires.
 
     await runWorkflow(
-      { DB: db, RESEND_API_KEY: 'test' }, // No Places key, no Anthropic.
+      // No Places key by design (test case is "no website + no Places match").
+      // ANTHROPIC_API_KEY required by the runtime startup assertion (PR-2a)
+      // even though Tier 2/3 modules won't run after the gate trips.
+      { DB: db, RESEND_API_KEY: 'test', ANTHROPIC_API_KEY: 'test' },
       id
     )
 

--- a/tests/scan-verify-workflow-dispatch.test.ts
+++ b/tests/scan-verify-workflow-dispatch.test.ts
@@ -172,14 +172,21 @@ describe('/api/scan/verify — service-binding dispatch (#618)', () => {
     expect(vi.mocked(runDiagnosticScan)).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back when the service binding fetch throws', async () => {
+  // PR-2a contract change: when SCAN_WORKFLOW_SERVICE is BOUND but the
+  // dispatch fails (throw / 5xx / malformed), the verify-handler must
+  // mark the scan as failed instead of falling back to runDiagnosticScan.
+  // The previous "fall back to ctx.waitUntil" behavior re-created the
+  // original 30s-isolate-budget bug (#614) on any transient binding
+  // failure. New contract: dispatch failure → scan_status='failed', no
+  // legacy fallback call, no waitUntil invocation.
+  it('marks scan failed when service binding fetch throws (no runDiagnosticScan fallback)', async () => {
     const binding = makeServiceBinding(async () => {
       throw new Error('binding offline')
     })
     Object.assign(testEnv, { SCAN_WORKFLOW_SERVICE: binding })
 
     const { token, hash } = await generateScanToken()
-    await createScanRequest(db, {
+    const created = await createScanRequest(db, {
       email: 'a@b.com',
       domain: 'example.com',
       verification_token_hash: hash,
@@ -192,17 +199,24 @@ describe('/api/scan/verify — service-binding dispatch (#618)', () => {
       url,
       locals: { session: null, cfContext: { waitUntil } as never },
     } as never)
-    expect(response.status).toBe(200)
-    const body = (await response.json()) as { ok: boolean; status: string }
-    expect(body.status).toBe('verified')
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { ok: boolean; status: string; domain: string }
+    expect(body.ok).toBe(false)
+    expect(body.status).toBe('failed')
+    expect(body.domain).toBe('example.com')
 
-    // Dispatch was attempted; fallback was invoked when it threw.
+    // Dispatch was attempted; legacy fallback path was NOT invoked.
     expect(binding.fetch).toHaveBeenCalledTimes(1)
-    expect(waitUntil).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(runDiagnosticScan)).toHaveBeenCalledTimes(1)
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(vi.mocked(runDiagnosticScan)).not.toHaveBeenCalled()
+
+    // The scan_request row carries the failure detail.
+    const updated = await getScanRequest(db, created.id)
+    expect(updated?.scan_status).toBe('failed')
+    expect(updated?.error_message).toMatch(/dispatch_failed: binding offline/)
   })
 
-  it('falls back when the dispatch endpoint returns a non-2xx response', async () => {
+  it('marks scan failed when dispatch returns non-2xx (no runDiagnosticScan fallback)', async () => {
     const binding = makeServiceBinding(
       async () =>
         new Response(JSON.stringify({ ok: false, error: 'workflow_binding_missing' }), {
@@ -213,7 +227,7 @@ describe('/api/scan/verify — service-binding dispatch (#618)', () => {
     Object.assign(testEnv, { SCAN_WORKFLOW_SERVICE: binding })
 
     const { token, hash } = await generateScanToken()
-    await createScanRequest(db, {
+    const created = await createScanRequest(db, {
       email: 'a@b.com',
       domain: 'example.com',
       verification_token_hash: hash,
@@ -226,16 +240,21 @@ describe('/api/scan/verify — service-binding dispatch (#618)', () => {
       url,
       locals: { session: null, cfContext: { waitUntil } as never },
     } as never)
-    expect(response.status).toBe(200)
+    expect(response.status).toBe(400)
     const body = (await response.json()) as { ok: boolean; status: string }
-    expect(body.status).toBe('verified')
+    expect(body.ok).toBe(false)
+    expect(body.status).toBe('failed')
 
     expect(binding.fetch).toHaveBeenCalledTimes(1)
-    expect(waitUntil).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(runDiagnosticScan)).toHaveBeenCalledTimes(1)
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(vi.mocked(runDiagnosticScan)).not.toHaveBeenCalled()
+
+    const updated = await getScanRequest(db, created.id)
+    expect(updated?.scan_status).toBe('failed')
+    expect(updated?.error_message).toMatch(/dispatch_failed:.*500/)
   })
 
-  it('falls back when the dispatch returns 2xx but malformed payload (no workflow_run_id)', async () => {
+  it('marks scan failed when dispatch returns 2xx but malformed payload (no fallback)', async () => {
     const binding = makeServiceBinding(
       async () =>
         new Response(JSON.stringify({ ok: true }), {
@@ -246,7 +265,7 @@ describe('/api/scan/verify — service-binding dispatch (#618)', () => {
     Object.assign(testEnv, { SCAN_WORKFLOW_SERVICE: binding })
 
     const { token, hash } = await generateScanToken()
-    await createScanRequest(db, {
+    const created = await createScanRequest(db, {
       email: 'a@b.com',
       domain: 'example.com',
       verification_token_hash: hash,
@@ -259,13 +278,17 @@ describe('/api/scan/verify — service-binding dispatch (#618)', () => {
       url,
       locals: { session: null, cfContext: { waitUntil } as never },
     } as never)
-    expect(response.status).toBe(200)
+    expect(response.status).toBe(400)
     const body = (await response.json()) as { ok: boolean; status: string }
-    expect(body.status).toBe('verified')
+    expect(body.status).toBe('failed')
 
     expect(binding.fetch).toHaveBeenCalledTimes(1)
-    expect(waitUntil).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(runDiagnosticScan)).toHaveBeenCalledTimes(1)
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(vi.mocked(runDiagnosticScan)).not.toHaveBeenCalled()
+
+    const updated = await getScanRequest(db, created.id)
+    expect(updated?.scan_status).toBe('failed')
+    expect(updated?.error_message).toMatch(/dispatch_failed:.*workflow_run_id/)
   })
 
   it('returns invalid_token without invoking the workflow on a bad token', async () => {


### PR DESCRIPTION
## Summary

PR-2a of 4 in the same-session Outside View ship plan. Closes the silent-failure classes that compound under PR-1.

| # | Change | Why |
|---|---|---|
| 1 | `verify-handler.ts` dispatch-failure path: replaces `runFallback` with `scan_status='failed'` + admin alert | The previous catch invoked `ctx.waitUntil(runDiagnosticScan(...))` in the ss-web isolate on any transient binding failure — recreating the original 30s isolate-budget bug (#614). |
| 2 | `workflow.ts` startup assertion: throws if `RESEND_API_KEY` or `ANTHROPIC_API_KEY` unbound | Without this, the pipeline burned ~$0.14 of Anthropic credit before silently sending a dev-mode email. Captain debugged exactly this on 2026-05-01. Placed AFTER the idempotency check so already-completed re-dispatches still no-op. |
| 3 | `workflow.ts` post-send dev-mode detection: checks `outreach_events.message_id` for `'dev-mode'` after Resend send, fires admin alert | Catches the case where the key is bound but corrupt/revoked at runtime (which the startup assertion can't detect). |
| 4 | `diagnostic/index.ts` DIVERGED file-header block | Formalizes that `runDiagnosticScan` is dev/test-only and lists known divergences from production (sequential Tier 2, no shadow-write). Adding new production callers is now structurally forbidden. |

## Test changes

- 3 dispatch-failure tests rewritten to new contract: throw / 5xx / malformed-body all assert `scan_status='failed'` and `runDiagnosticScan` NOT called.
- 3 new startup-assertion tests: throws on missing RESEND, throws on missing ANTHROPIC, does NOT throw on already-completed (idempotency preserved).
- 2 existing tests updated to bind `RESEND_API_KEY` and `ANTHROPIC_API_KEY` (production-shape assumption).

## Acceptance criteria

- [x] `npm run verify` clean (2054 main + all worker suites green)
- [x] No runtime-environment detection in any code change (per Devil's Advocate critic Issue 1)
- [x] Existing dispatch-binding-bound happy-path test still passes
- [x] Idempotency test still passes (already-completed scan does not throw on missing secrets)
- [ ] Post-deploy: submit fresh scan; confirm `scan_status='completed'`, real Resend `message_id`, no `[scan-workflow]` error logs

## Plan reference

See `/Users/scottdurgan/.claude/plans/proceed-with-the-plan-resilient-bentley.md`. Next: PR-2b (idempotency hardening), PR-3 (flag flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)