### PR TITLE
feat(scan): flip OUTSIDE_VIEW_PORTAL_DELIVERY=1 — prospects receive portal magic-link email

### DIFF
--- a/workers/scan-workflow/wrangler.toml
+++ b/workers/scan-workflow/wrangler.toml
@@ -64,7 +64,7 @@ enabled = true
 [vars]
 APP_BASE_URL = "https://smd.services"
 PORTAL_BASE_URL = "https://portal.smd.services"
-OUTSIDE_VIEW_PORTAL_DELIVERY = "0"
+OUTSIDE_VIEW_PORTAL_DELIVERY = "1"
 
 # ---------- Secrets (set via `wrangler secret put` or `wrangler secret bulk`) ----------
 # All secrets are set per-Worker. Captain provisions these from Infisical


### PR DESCRIPTION
## Summary

PR-3 of 4 in the Outside View ship plan. Flips the feature flag so prospects (non-client submitters) now receive the new portal magic-link email instead of the legacy diagnostic-report email.

## What flips

| Before | After |
|---|---|
| Prospect submits → verification email → click → enrichment → legacy `Your operational read — {business}` email with the report inline | Prospect submits → verification email → click → enrichment → `Your Outside View is ready — {business}` email with a 24h magic-link to `portal.smd.services/auth/verify?token=...` |

Existing **client** submissions (Captain's `smdurgan@venturecrane.com`) continue to receive the legacy email — `mintProspectMagicLink` returns null for `role='client'`, the privilege-escalation defense from PR-1.

## What's already in place from prior PRs

| PR | Capability |
|---|---|
| PR-1 (#656) | Shadow-write `outside_views` row UNCONDITIONALLY; `PORTAL_BASE_URL` bound on workflow Worker |
| PR-2a (#657) | Dispatch failure → `scan_status='failed'` (no isolate-budget exposure); workflow startup asserts `RESEND_API_KEY` and `ANTHROPIC_API_KEY` bound; dev-mode admin alert |
| PR-2b (#658) | `render-and-email` step split into `render-email-send` + `record-send-event`; `recordEvent` dedups synthetic-sent rows on workflow retry |

## Test plan

- [x] One-line config diff (`"0"` → `"1"`)
- [x] `npm run verify` clean
- [ ] Post-deploy: submit fresh non-client scan; click magic link from email; confirm it lands on `https://portal.smd.services/...` (NOT smd.services); confirm portal page renders the Outside View artifact; read the artifact for fabrication tells per CLAUDE.md "no fabricated client-facing content" P0 rule
- [ ] Post-deploy: confirm Captain's client email submission still gets the legacy report

## Rollback

Change `"1"` → `"0"` + redeploy `ss-scan-workflow` (~30s). Touches one config line; no code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)