### PR TITLE
fix(auth): prevent session cookie collision when prospect clicks magic link from already-signed-in browser

### DIFF
--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -80,5 +80,14 @@ const response = new Response(null, { status: 302 })
 response.headers.set('Location', location)
 response.headers.set('Set-Cookie', setCookie)
 
+// Prevent the middleware's sliding-window refresh from appending a second
+// Set-Cookie with the OLD inbound session cookie (src/middleware.ts:194-204).
+// If the prospect/client clicked this magic link from a browser where they
+// were already signed in (e.g. Captain testing his own prospect link from
+// his client browser), the stale cookie would otherwise win. Nulling
+// Astro.locals.session here makes the middleware skip the refresh block;
+// the only Set-Cookie on the response is the new session.
+Astro.locals.session = null
+
 return response
 ---

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -178,3 +178,38 @@ describe('magic links', () => {
     })
   })
 })
+
+describe('/auth/verify.astro page', () => {
+  // Static-source assertions only — Astro frontmatter is hard to unit-test
+  // without spinning up the full SSR runtime. The fix (nulling
+  // Astro.locals.session before returning) is structural; a regression
+  // would either remove the line or fail to set Set-Cookie correctly.
+  const { readFileSync } = require('fs') as typeof import('fs')
+  const { resolve: resolvePath } = require('path') as typeof import('path')
+  const verifyPageSrc = readFileSync(
+    resolvePath(process.cwd(), 'src/pages/auth/verify.astro'),
+    'utf-8'
+  )
+
+  it('nulls Astro.locals.session before returning so middleware skips refresh of the OLD cookie', () => {
+    // The bug: middleware at src/middleware.ts:194-204 refreshes the inbound
+    // session cookie via Set-Cookie append AFTER the page returns. If a user
+    // arrives at /auth/verify with a pre-existing session cookie (e.g.
+    // Captain testing his prospect link from his client browser), the
+    // middleware's append wins over the page's Set-Cookie. Result: the new
+    // session never takes effect.
+    //
+    // Fix: page sets Astro.locals.session = null before returning so the
+    // middleware's `if (context.locals.session && token)` check fails and
+    // the refresh block is skipped. The page's Set-Cookie (carrying the new
+    // session token) is the only one in the response.
+    expect(verifyPageSrc).toMatch(/Astro\.locals\.session\s*=\s*null/)
+    // The null-assignment must come AFTER the Set-Cookie header is built
+    // (otherwise the page would set null before the response is composed,
+    // which is fine — but we want it adjacent to the return for clarity).
+    const setCookieIdx = verifyPageSrc.indexOf("response.headers.set('Set-Cookie'")
+    const nullIdx = verifyPageSrc.indexOf('Astro.locals.session = null')
+    expect(setCookieIdx).toBeGreaterThan(-1)
+    expect(nullIdx).toBeGreaterThan(setCookieIdx)
+  })
+})


### PR DESCRIPTION
## Summary

When a portal magic link is clicked from a browser that already has a portal session (e.g. Captain testing his prospect link from the same browser where he's a client of his own venture), the new session cookie never takes effect. The user lands on the WRONG portal home — the existing client's dashboard, not the new prospect's Outside View.

## Mechanism

Verified in production today (2026-05-01) immediately after the Outside View flag flip.

1. Middleware parses the inbound (OLD) session cookie, sets `context.locals.session` to the OLD session
2. `verify.astro` runs: validates magic-link, creates NEW session in D1+SESSIONS KV, sets `Set-Cookie` carrying the NEW token
3. Middleware post-processing (`src/middleware.ts:194-204`) sees `context.locals.session` is non-null AND inbound token is non-null, so it APPENDS a second `Set-Cookie` refreshing the OLD session token (sliding-window refresh)
4. Browser receives two `Set-Cookie` headers; second wins → OLD client cookie persists
5. `/portal` reads `session.role === 'client'` → renders client home instead of prospect Outside View

## Fix

`src/pages/auth/verify.astro` sets `Astro.locals.session = null` after building the response. Astro shares the locals object with middleware, so the post-`await next()` check `if (context.locals.session && token)` becomes false and the refresh block is skipped. The only `Set-Cookie` on the response is the new session.

## Test plan

- [x] `npm run verify` clean (2063 main + all worker suites)
- [x] New regression-guard test in `tests/magic-link.test.ts` asserts `Astro.locals.session = null` appears AFTER the `Set-Cookie` header is built
- [ ] Post-deploy: Captain re-clicks an existing magic link (or fresh one if needed) from the same browser; lands on `/portal/outside-view` showing the Azcec artifact, NOT the Precision Plumbing AZ client home

## Out of scope

Invalidating the OLD session record in D1+SESSIONS KV. The inbound cookie is overwritten so it cannot be re-sent by the same browser, but the OLD session row persists until natural expiry or logout. Worth a follow-up but not blocking the immediate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)