### PR TITLE
feat(talk): voice-in / text-out conversation MVP at /talk

### DIFF
--- a/src/lib/claude/conversation.ts
+++ b/src/lib/claude/conversation.ts
@@ -1,0 +1,184 @@
+/**
+ * Claude API client for the voice-intake conversation agent (`/talk`).
+ *
+ * Uses raw fetch against the Anthropic Messages API — no SDK dependency.
+ * Mirrors the pattern in `src/lib/claude/extract.ts` for fetch posture,
+ * error handling, and constants.
+ *
+ * The agent is the warm, structured listener for the prospect-facing
+ * voice intake. The system prompt encodes the doctrine: curious-not-clever,
+ * past-behavior questions, OARS, hard bans on AI vocabulary and validation
+ * theater, no solutioning during intake, never claim insight into the
+ * prospect's business.
+ */
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
+const ANTHROPIC_VERSION = '2023-06-01'
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 600
+
+/**
+ * Error thrown when the Claude API returns an unexpected response.
+ */
+export class ConversationApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly responseBody?: string
+  ) {
+    super(message)
+    this.name = 'ConversationApiError'
+  }
+}
+
+export interface ConversationTurn {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+/**
+ * The system prompt is the agent's sole behavior contract. The doctrine
+ * encoded here comes from research on clinical history-taking, motivational
+ * interviewing, The Mom Test, and a corpus of real user complaints about
+ * AI sales agents. Every banned phrase is sourced from real user reports.
+ *
+ * Changes to this prompt are P0 — they directly affect every prospect
+ * conversation. Treat with the same care as user-facing copy.
+ */
+export const CONVERSATION_SYSTEM_PROMPT = `You are a conversational AI agent for SMD Services, an operations consultancy serving Phoenix-area small businesses (10-25 employees). Your one job is to listen. You help the prospect put their business into their own words before a human consultant from our team takes over the conversation.
+
+You are not the consultant. You are the listener who prepares the ground. Say so plainly when asked, and once at the start of the conversation: "I'm an AI agent on the SMD Services team. I'm here to listen and learn about your business. The consultant takes it from here once we've covered the basics."
+
+## Your stance
+
+You are curious. You are prepared. You are a collaborator, never an expert on their business. They are the expert. You assume nothing about what their work looks like day-to-day. When they say something you don't understand, you ask. When they say something interesting, you reflect it back in their own language and ask them to say more.
+
+You are not here to sell. You are not here to diagnose. You are not here to suggest solutions. Anyone on our team who tries to pitch during intake has missed the point. So do you.
+
+## Conversation arc
+
+Move through this arc as the conversation unfolds. Not as a script, as a direction:
+1. Welcome and disclose you're AI.
+2. Their business in their own words. ("Tell me about what you do.")
+3. Their objectives. ("Where are you trying to get this business over the next year or two?")
+4. A day in their life. ("Walk me through what yesterday looked like.")
+5. What they've already tried. ("Last time you tried to fix this, what did you try?")
+6. A reflective summary. Read it back to them.
+7. Hand off. ("A consultant from our team will pick this up next.")
+
+## How to ask
+
+- One question at a time. Never stack two questions in one turn.
+- Past behavior, never hypotheticals. Ask "walk me through the last time..." Do not ask "would you find it useful if..."
+- Funnel: open questions first, narrowing questions later, closed yes/no questions only at the very end if at all.
+- OARS: Open questions, Affirmations, Reflective listening, Summaries. Each turn should do at least one of these. The best turns reflect first, then ask.
+
+## How to write
+
+- Short. Default 6 to 12 words per sentence. Hard cap 25.
+- Plain. The way a thoughtful neighbor talks, not a brochure.
+- Two short paragraphs maximum per turn. Often one is enough.
+- No em dashes. Use periods. Use commas.
+- No headers, no bullets, no markdown. This is a conversation.
+- One question per turn, placed at the end.
+
+## Banned words and phrases (do not use, ever)
+
+Validation phrases: "I understand exactly", "great question", "I hear you", "absolutely", "totally", "for sure", "makes complete sense", "what a great point".
+
+AI vocabulary: delve, embark, robust, holistic, seamless, leverage, synergy, pivotal, intricate, navigate, unlock, journey, realm, underscore, tapestry, streamline, comprehensive, ecosystem, dynamic, empower, foster, facilitate, elevate.
+
+Em dashes. Replace with a period or a comma.
+
+Solutioning language during intake: "we could", "you should", "have you tried", "what you need is", "the answer is".
+
+Before you send a turn, scan it for these. If you find any, rewrite.
+
+## Sample turns showing the right shape
+
+Prospect: "We do HVAC, mostly residential, been around about twelve years now."
+You: "Twelve years is a long run in residential HVAC. What does the business look like today, in terms of crews and the kind of work you're taking on?"
+
+Prospect: "Honestly the scheduling is killing me. I'm doing it all in my head and on text messages."
+You: "That sounds like a lot to hold. Walk me through yesterday. How did the schedule come together for today's jobs?"
+
+Prospect: "We tried a software thing last year, it was a disaster."
+You: "Sorry to hear that. What part of it didn't fit how your team actually works?"
+
+## Hard rules
+
+- Never pitch a solution. Not even a small one.
+- Never judge how they're running things. Affirm them.
+- Never claim to understand their business. Ask.
+- Never invent facts about them. If they haven't said it, you don't know it.
+- Never use the banned words above.
+- Never write more than two short paragraphs per turn.
+- Always end on a question, except when summarizing or handing off.`
+
+/**
+ * Call the Claude API to generate a single conversation reply.
+ *
+ * @param apiKey - Anthropic API key
+ * @param userMessage - The prospect's transcribed utterance
+ * @param history - Prior conversation turns (V1 sends empty; V2 multi-turn populates this)
+ * @returns The agent's reply text, trimmed
+ * @throws ConversationApiError on any API or response-shape failure
+ */
+export async function generateConversationReply(
+  apiKey: string,
+  userMessage: string,
+  history: ConversationTurn[] = []
+): Promise<string> {
+  const messages = [
+    ...history.map((h) => ({ role: h.role, content: h.content })),
+    { role: 'user' as const, content: userMessage },
+  ]
+
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: CONVERSATION_SYSTEM_PROMPT,
+      messages,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '<unreadable>')
+    throw new ConversationApiError(
+      `Claude API returned ${response.status}: ${response.statusText}`,
+      response.status,
+      body
+    )
+  }
+
+  const result = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>
+  }
+
+  const contentBlocks = result?.content
+  if (!Array.isArray(contentBlocks) || contentBlocks.length === 0) {
+    throw new ConversationApiError(
+      'Claude API returned empty content',
+      response.status,
+      JSON.stringify(result)
+    )
+  }
+
+  const textBlock = contentBlocks.find((block) => block.type === 'text')
+  if (!textBlock?.text) {
+    throw new ConversationApiError(
+      'Claude API response contained no text content block',
+      response.status,
+      JSON.stringify(result)
+    )
+  }
+
+  return textBlock.text.trim()
+}

--- a/src/pages/api/talk.ts
+++ b/src/pages/api/talk.ts
@@ -1,0 +1,115 @@
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { rateLimitByIp } from '../../lib/booking/rate-limit'
+import {
+  generateConversationReply,
+  ConversationApiError,
+  type ConversationTurn,
+} from '../../lib/claude/conversation'
+
+/**
+ * POST /api/talk
+ *
+ * Voice-intake conversation endpoint. Receives a transcribed utterance
+ * (browser-side STT via Web Speech API), sends it to Claude with the
+ * conversation doctrine system prompt, returns the agent reply.
+ *
+ * V1 is single-turn: each request is independent. The `history` and
+ * `conversation_id` fields are accepted now so the multi-turn V2 client
+ * lands without an API change.
+ *
+ * Public endpoint, no auth. Rate-limited per IP.
+ */
+
+const MAX_TRANSCRIPT_CHARS = 5000
+const MAX_HISTORY_TURNS = 40
+const MAX_CONVERSATION_ID_LEN = 64
+const RATE_LIMIT_PER_HOUR = 30
+
+export const POST: APIRoute = async ({ request }) => {
+  const clientIp = request.headers.get('cf-connecting-ip') ?? undefined
+  const rateLimitResult = await rateLimitByIp(
+    env.BOOKING_CACHE,
+    'talk',
+    clientIp,
+    RATE_LIMIT_PER_HOUR
+  )
+  if (!rateLimitResult.allowed) {
+    return jsonResponse(429, { error: 'Too many requests, please slow down.' })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON' })
+  }
+
+  const transcriptRaw = typeof body.transcript === 'string' ? body.transcript.trim() : ''
+  if (!transcriptRaw) {
+    return jsonResponse(400, { error: 'transcript is required' })
+  }
+  if (transcriptRaw.length > MAX_TRANSCRIPT_CHARS) {
+    return jsonResponse(400, {
+      error: `transcript exceeds maximum length of ${MAX_TRANSCRIPT_CHARS} characters`,
+    })
+  }
+
+  const history = parseHistory(body.history)
+  if (history === null) {
+    return jsonResponse(400, { error: 'history must be an array of {role, content} turns' })
+  }
+
+  const conversationId =
+    typeof body.conversation_id === 'string' &&
+    body.conversation_id.length > 0 &&
+    body.conversation_id.length <= MAX_CONVERSATION_ID_LEN
+      ? body.conversation_id
+      : crypto.randomUUID()
+
+  const apiKey = env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    console.error('[api/talk] ANTHROPIC_API_KEY not configured')
+    return jsonResponse(503, { error: 'Service not configured' })
+  }
+
+  try {
+    const reply = await generateConversationReply(apiKey, transcriptRaw, history)
+    return jsonResponse(200, { ok: true, reply, conversation_id: conversationId })
+  } catch (err) {
+    if (err instanceof ConversationApiError) {
+      console.error('[api/talk] Claude API error:', err.message, {
+        status: err.statusCode,
+        body: err.responseBody?.slice(0, 500),
+      })
+      return jsonResponse(500, { error: 'Conversation service failed' })
+    }
+    console.error('[api/talk] Unexpected error:', err)
+    return jsonResponse(500, { error: 'Conversation service failed' })
+  }
+}
+
+function parseHistory(value: unknown): ConversationTurn[] | null {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) return null
+  if (value.length > MAX_HISTORY_TURNS) return null
+
+  const turns: ConversationTurn[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') return null
+    const role = (entry as Record<string, unknown>).role
+    const content = (entry as Record<string, unknown>).content
+    if (role !== 'user' && role !== 'assistant') return null
+    if (typeof content !== 'string' || !content.trim()) return null
+    if (content.length > MAX_TRANSCRIPT_CHARS) return null
+    turns.push({ role, content })
+  }
+  return turns
+}
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/talk.astro
+++ b/src/pages/talk.astro
@@ -1,0 +1,322 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+---
+
+<Base
+  title="Talk to us | SMD Services"
+  description="Tell us about your business. Tap the mic and talk. We'll listen. A consultant takes it from here."
+>
+  <Nav />
+  <main id="main" role="main" class="px-6 py-20">
+    <div class="mx-auto max-w-2xl">
+      <header class="text-center">
+        <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
+          Tell us about your business.
+        </h1>
+        <p class="mt-3 text-lg text-[color:var(--ss-color-text-secondary)]">
+          Tap the mic and talk. We'll listen. A consultant takes it from here.
+        </p>
+      </header>
+
+      <section id="voice-shell" data-state="idle" class="mt-12 flex flex-col items-center">
+        <button
+          id="mic-btn"
+          type="button"
+          aria-label="Tap to speak"
+          data-ev="talk-mic"
+          class="group flex h-32 w-32 items-center justify-center rounded-full bg-primary text-white shadow-lg transition-all hover:scale-105 hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <span
+            id="mic-icon"
+            class="material-symbols-outlined"
+            style="font-size: 56px;"
+            aria-hidden="true">mic</span
+          >
+        </button>
+
+        <p
+          id="mic-label"
+          class="mt-4 text-sm font-medium text-[color:var(--ss-color-text-secondary)]"
+        >
+          Tap to speak
+        </p>
+
+        <div
+          id="unsupported-browser"
+          hidden
+          class="mt-8 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/30 bg-[color:var(--ss-color-text-secondary)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-text-secondary)]"
+        >
+          Voice input needs Chrome, Edge, or Safari 14.5 or newer. If you'd rather type, send us a
+          note at <a href="/contact" class="underline">contact</a>.
+        </div>
+
+        <div
+          id="permission-error"
+          hidden
+          class="mt-8 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]"
+        >
+          Microphone access was blocked. To allow it, click the lock or mic icon in your browser's
+          address bar, then reload this page.
+        </div>
+
+        <div
+          id="generic-error"
+          hidden
+          class="mt-8 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]"
+        >
+          Something went wrong. Tap the mic to try again.
+        </div>
+
+        <div class="mt-12 w-full space-y-6">
+          <div>
+            <h2
+              class="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ss-color-text-secondary)]"
+            >
+              You said
+            </h2>
+            <div
+              id="transcript-pane"
+              aria-live="polite"
+              class="min-h-[3rem] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/15 bg-white px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)]"
+            >
+              <span
+                id="transcript-placeholder"
+                class="text-[color:var(--ss-color-text-secondary)]/60"
+                >Your words will appear here.</span
+              >
+              <span id="transcript-final"></span>
+              <span
+                id="transcript-interim"
+                class="text-[color:var(--ss-color-text-secondary)]/60 italic"></span>
+            </div>
+          </div>
+
+          <div>
+            <h2
+              class="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ss-color-text-secondary)]"
+            >
+              We hear you
+            </h2>
+            <div
+              id="response-pane"
+              aria-live="polite"
+              class="min-h-[5rem] rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/15 bg-white px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)]"
+            >
+              <span
+                id="response-placeholder"
+                class="text-[color:var(--ss-color-text-secondary)]/60"
+              >
+                Once you've said something, our agent will respond here.
+              </span>
+              <div id="response-content" hidden class="whitespace-pre-wrap"></div>
+              <div
+                id="response-loading"
+                hidden
+                class="text-[color:var(--ss-color-text-secondary)]/60"
+              >
+                Thinking...
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <Footer />
+
+  <style>
+    #voice-shell[data-state='listening'] #mic-btn {
+      background-color: var(--ss-color-error, #dc2626);
+      animation: mic-pulse 1.4s ease-in-out infinite;
+    }
+    #voice-shell[data-state='thinking'] #mic-btn {
+      opacity: 0.6;
+    }
+    @keyframes mic-pulse {
+      0%,
+      100% {
+        box-shadow:
+          0 4px 6px -1px rgb(0 0 0 / 0.1),
+          0 0 0 0 rgb(220 38 38 / 0.4);
+      }
+      50% {
+        box-shadow:
+          0 4px 6px -1px rgb(0 0 0 / 0.1),
+          0 0 0 16px rgb(220 38 38 / 0);
+      }
+    }
+  </style>
+
+  <script is:inline>
+    ;(() => {
+      const SR = window.SpeechRecognition || window.webkitSpeechRecognition
+      const shell = document.getElementById('voice-shell')
+      const micBtn = document.getElementById('mic-btn')
+      const micLabel = document.getElementById('mic-label')
+      const transcriptPlaceholder = document.getElementById('transcript-placeholder')
+      const transcriptFinal = document.getElementById('transcript-final')
+      const transcriptInterim = document.getElementById('transcript-interim')
+      const responsePlaceholder = document.getElementById('response-placeholder')
+      const responseContent = document.getElementById('response-content')
+      const responseLoading = document.getElementById('response-loading')
+      const unsupported = document.getElementById('unsupported-browser')
+      const permissionError = document.getElementById('permission-error')
+      const genericError = document.getElementById('generic-error')
+
+      if (!SR) {
+        unsupported.hidden = false
+        micBtn.disabled = true
+        micLabel.textContent = 'Voice input not supported'
+        return
+      }
+
+      const recognition = new SR()
+      recognition.lang = 'en-US'
+      recognition.interimResults = true
+      recognition.continuous = false
+      recognition.maxAlternatives = 1
+
+      let finalTranscript = ''
+      let interimTranscript = ''
+      let conversationId = null
+      const MIC_LABELS = {
+        idle: 'Tap to speak',
+        listening: 'Listening. Tap to stop.',
+        thinking: 'Thinking...',
+        responded: 'Tap to speak again',
+      }
+
+      const setState = (state) => {
+        shell.dataset.state = state
+        micLabel.textContent = MIC_LABELS[state] || ''
+        micBtn.setAttribute(
+          'aria-label',
+          state === 'listening' ? 'Stop recording' : MIC_LABELS[state] || 'Tap to speak'
+        )
+      }
+
+      const renderTranscript = () => {
+        if (finalTranscript || interimTranscript) {
+          transcriptPlaceholder.hidden = true
+        }
+        transcriptFinal.textContent = finalTranscript
+        transcriptInterim.textContent = interimTranscript ? ' ' + interimTranscript : ''
+      }
+
+      const showResponse = (text) => {
+        responsePlaceholder.hidden = true
+        responseLoading.hidden = true
+        responseContent.hidden = false
+        responseContent.textContent = text
+      }
+
+      const showResponseLoading = () => {
+        responsePlaceholder.hidden = true
+        responseContent.hidden = true
+        responseLoading.hidden = false
+      }
+
+      const clearErrors = () => {
+        permissionError.hidden = true
+        genericError.hidden = true
+      }
+
+      const submitTranscript = async (text) => {
+        showResponseLoading()
+        setState('thinking')
+        try {
+          const res = await fetch('/api/talk', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              transcript: text,
+              conversation_id: conversationId,
+            }),
+          })
+          const body = await res.json().catch(() => ({}))
+          if (!res.ok) {
+            console.error('[talk] API error', res.status, body)
+            genericError.hidden = false
+            responsePlaceholder.hidden = false
+            responseLoading.hidden = true
+            setState('idle')
+            return
+          }
+          conversationId = body.conversation_id || conversationId
+          showResponse(body.reply || '')
+          setState('responded')
+        } catch (err) {
+          console.error('[talk] Network error', err)
+          genericError.hidden = false
+          responsePlaceholder.hidden = false
+          responseLoading.hidden = true
+          setState('idle')
+        }
+      }
+
+      recognition.onresult = (e) => {
+        interimTranscript = ''
+        for (let i = e.resultIndex; i < e.results.length; i++) {
+          const text = e.results[i][0].transcript
+          if (e.results[i].isFinal) {
+            finalTranscript += text
+          } else {
+            interimTranscript += text
+          }
+        }
+        renderTranscript()
+      }
+
+      recognition.onerror = (e) => {
+        if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+          permissionError.hidden = false
+          setState('idle')
+        } else if (e.error === 'no-speech' || e.error === 'aborted') {
+          setState('idle')
+        } else {
+          console.error('[talk] Speech recognition error', e.error)
+          genericError.hidden = false
+          setState('idle')
+        }
+      }
+
+      recognition.onend = () => {
+        const trimmed = finalTranscript.trim()
+        if (trimmed.length > 0 && shell.dataset.state === 'listening') {
+          submitTranscript(trimmed)
+        } else if (shell.dataset.state === 'listening') {
+          setState('idle')
+        }
+      }
+
+      micBtn.addEventListener('click', () => {
+        const state = shell.dataset.state
+        if (state === 'listening') {
+          recognition.stop()
+          return
+        }
+        // idle | thinking | responded — start a fresh utterance
+        if (state === 'thinking') return
+        clearErrors()
+        finalTranscript = ''
+        interimTranscript = ''
+        transcriptFinal.textContent = ''
+        transcriptInterim.textContent = ''
+        transcriptPlaceholder.hidden = false
+        responsePlaceholder.hidden = false
+        responseContent.hidden = true
+        responseLoading.hidden = true
+        setState('listening')
+        try {
+          recognition.start()
+        } catch (err) {
+          // start() throws if already started or in an invalid state
+          console.error('[talk] start() failed', err)
+          setState('idle')
+        }
+      })
+    })()
+  </script>
+</Base>


### PR DESCRIPTION
## Summary

- New public route `/talk` on `smd.services` — prospect taps a mic, browser STT (Web Speech API) transcribes, transcript goes to Claude with a doctrine-loaded system prompt, response renders as text.
- Replaces the killed Outside View D1 scan as the prospect-facing intake surface (per Captain pivot 2026-05-01).
- Single-turn V1; history wiring exists in the API + wrapper so V2 multi-turn is a small client-side diff.

## What's in it

- `src/lib/claude/conversation.ts` — Anthropic wrapper following the existing `extract.ts` pattern (raw fetch, no SDK), plus the full doctrine system prompt as an exported constant.
- `src/pages/api/talk.ts` — POST endpoint, rate-limited 30/hr per IP via existing `rateLimitByIp` + `BOOKING_CACHE` KV. Validates transcript (≤5000 chars), accepts but ignores `history` and `conversation_id` for V1.
- `src/pages/talk.astro` — public page using `Base.astro` + `Nav` + `Footer`. Single mic button (start/stop toggle), live transcript pane (interim + final), response pane. Vanilla TS in an `is:inline` script. State machine on `data-state`.

## Doctrine encoded in the system prompt

Curious-not-clever stance. Past-behavior questions over hypotheticals. OARS (Open questions, Affirmations, Reflective listening, Summaries). Hard bans on validation phrases ("I understand exactly", "great question", etc.) and AI vocabulary (delve, embark, robust, holistic, leverage, synergy, etc.). No em dashes. No solutioning during intake. Never claim insight into the prospect's business.

Sourced from clinical history-taking, motivational interviewing, The Mom Test, and a corpus of real user complaints about AI sales agents.

## Test plan

- [x] npm run verify passes (typecheck, lint, format, all test suites)
- [x] GET /talk renders: heading, lead copy, mic button, both panes, fallbacks
- [x] POST /api/talk 400s on invalid JSON, missing transcript, oversized transcript
- [x] POST /api/talk 503s when ANTHROPIC_API_KEY is unset
- [x] End-to-end Claude call returns a doctrine-compliant response
- [ ] Browser smoke test: Chrome desktop — mic permission prompt, live transcription, response renders
- [ ] Browser smoke test: Safari macOS 14.5+
- [ ] Browser smoke test: Safari iOS 16+ (real device)
- [ ] Browser smoke test: Firefox renders the unsupported-browser message gracefully

## Known limitations (V1, accepted)

- Firefox: no Web Speech API support; users see the unsupported-browser message
- Auto-submit on speech-end risks premature submit if the user pauses mid-thought (mitigation: add explicit "Send" button if testing reveals this)
- Web Speech accuracy depends on Google's (Chrome) or Apple's (Safari) STT services
- No persistence in V1 — conversations are not logged. Path identified (extend context table with conversation_turn type) but not built.

## Out of scope (deferred follow-ups)

- Multi-turn conversation
- Persistence to D1
- Marketing site CTA placement (where the link to /talk lives on /, nav, etc.)
- Silent-prep enrichment feeding the agent context before the conversation
- Killed Outside View code cleanup

Generated with Claude Code