### PR TITLE
refine(home): §02 RoiMath copy + text-pretty sweep across home ledes

### DIFF
--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -5,7 +5,7 @@ import CtaButton from './CtaButton.astro'
 <section id="book" class="bg-[color:var(--ss-color-surface-inverse)] px-6 py-24">
   <div class="mx-auto max-w-5xl text-center">
     <h2 class="text-3xl font-bold text-white">Let's Talk About Your Business</h2>
-    <p class="mx-auto mt-4 max-w-2xl text-lg text-[color:var(--ss-color-text-muted)]">
+    <p class="mx-auto mt-4 max-w-2xl text-lg text-pretty text-[color:var(--ss-color-text-muted)]">
       We'll ask how things run and where you're trying to go. You'll walk away with a clearer
       picture of how to get there, whether we work together or not.
     </p>

--- a/src/components/HowWeEngage.astro
+++ b/src/components/HowWeEngage.astro
@@ -46,7 +46,7 @@ const priceShape = [
         How We Engage
       </h2>
       <p
-        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-secondary)]"
+        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-pretty text-[color:var(--ss-color-text-secondary)]"
       >
         From first conversation to full handoff. Same shape every time, scoped to your business.
       </p>

--- a/src/components/RoiMath.astro
+++ b/src/components/RoiMath.astro
@@ -1,6 +1,5 @@
 ---
-// The math you're not doing — owner-does-the-math ROI education per
-// Decision #15 (ROI Anchor Math).
+// Owner-does-the-math ROI education per Decision #15 (ROI Anchor Math).
 //
 // Doctrine: we provide the formula and the variables. The owner does the
 // multiplication against their own numbers. SMD never asserts a dollar
@@ -41,14 +40,12 @@ const beats = [
       <h2
         class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
-        The Math You're Not Doing
+        What Is It Costing?
       </h2>
       <p
-        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-secondary)]"
+        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-pretty text-[color:var(--ss-color-text-secondary)]"
       >
-        Most owners can name the pain but have not priced it. A few minutes with these usually
-        reframes the question from <em>can we afford to fix this?</em>
-        to <em>can we afford not to?</em>
+        Four formulas. Run them against your business.
       </p>
     </div>
 
@@ -75,18 +72,6 @@ const beats = [
           </div>
         ))
       }
-    </div>
-
-    <div class="mt-12 max-w-3xl">
-      <p class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]">
-        Run those numbers against your business. That is the math behind whether a fix pays for
-        itself.
-      </p>
-      <p
-        class="mt-4 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]"
-      >
-        Next: whether a fix fits your budget.
-      </p>
     </div>
   </div>
 </section>

--- a/src/components/WhatWeWontDo.astro
+++ b/src/components/WhatWeWontDo.astro
@@ -42,7 +42,7 @@ const disciplines = [
         What We Won't Do
       </h2>
       <p
-        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-secondary)]"
+        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-pretty text-[color:var(--ss-color-text-secondary)]"
       >
         A few lines we hold because they matter more than any one engagement.
       </p>

--- a/src/components/WhoWeHelp.astro
+++ b/src/components/WhoWeHelp.astro
@@ -43,7 +43,7 @@ const segments = [
         Who We Help
       </h2>
       <p
-        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-[color:var(--ss-color-text-secondary)]"
+        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-pretty text-[color:var(--ss-color-text-secondary)]"
       >
         Three stages of business we know well. The capabilities we point to are the typical starting
         point, not a promise of what the work will be.


### PR DESCRIPTION
## Summary

§02 RoiMath copy refinement (Captain feedback during section-by-section walkthrough) plus a small typography hygiene sweep across four matching ledes.

**§02 RoiMath copy:**
- H2 \`The Math You're Not Doing\` → \`What Is It Costing?\` (question form, drops the negligence framing).
- Lede → \`Four formulas. Run them against your business.\` (drops population claim, outcome claim, and covert from-X-to-Y reframe).
- Removed the orphan \`Run those numbers...\` paragraph and the \`Next: whether a fix fits your budget\` eyebrow at the section tail. §03 HowWeEngage self-bridges.

**text-pretty sweep** on the four other ledes that share the same \`max-w-2xl + text-lg\` shape and the same orphan-wrap defect Captain flagged:
- \`HowWeEngage.astro\`
- \`WhoWeHelp.astro\`
- \`WhatWeWontDo.astro\`
- \`FinalCta.astro\`

Bundling here eliminates four follow-up PRs.

## Test plan

- [x] \`npm run verify\` passes locally (typecheck, lint, format, full vitest suite, build)
- [ ] Cloudflare preview visual check at 375 / 768 / 1280 viewports — verify \`text-pretty\` resolves the orphan-wrap on the §02 lede and the four sweep targets
- [ ] §02 → §03 reads cleanly without the deleted bridge eyebrow

If \`text-pretty\` does not render cleanly on iOS 16 Safari (no native support; falls back to standard wrap), deterministic fallback options on hand: \`&nbsp;\` between last two words, explicit \`<br>\`, or shorten prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)