### PR TITLE
refine(home): §03 HowWeEngage beats 03 + 04

### DIFF
--- a/src/components/HowWeEngage.astro
+++ b/src/components/HowWeEngage.astro
@@ -15,11 +15,11 @@ const beats = [
   },
   {
     title: 'You see the scope and price before you commit',
-    body: "After the conversation, we put together a written scope and a fixed project price. You see both before you commit to anything. If the shape isn't right, we adjust. If it isn't a fit, we say so.",
+    body: "Once we've defined a solution, we put together a written scope and a fixed project price. You see both before you commit. We adjust the shape until it fits, and we'll tell you if we're not the right people for the work.",
   },
   {
-    title: 'We work alongside until handoff',
-    body: 'We design, build, configure, and train alongside your team. The engagement ends when your team is running what we built, with documentation in their hands. No retainer trap, no permanent dependence on us.',
+    title: 'We build until your team runs it',
+    body: 'We design, build, configure, and train alongside your team. The engagement ends when your team is running what we built, with documentation in their hands. We stay available if a follow-up makes sense.',
   },
 ]
 


### PR DESCRIPTION
## Summary

Captain feedback on §03 HowWeEngage beats 03 + 04:

**Beat 03 lede** — grounded in the actual work, not just \"the conversation.\"
- Before: \`After the conversation, we put together a written scope...\`
- After: \`Once we've defined a solution, we put together a written scope...\`

**Beat 03 closer** — drops the parallel-reframe AI-rhetoric (\"If X, we Y. If X, we Y.\"). Keeps the notion of being honest if it isn't right.
- Before: \`If the shape isn't right, we adjust. If it isn't a fit, we say so.\`
- After: \`We adjust the shape until it fits, and we'll tell you if we're not the right people for the work.\`

**Beat 04 title** — addresses Captain's \"alongside until handoff? then what?\" question. Reframes around the actual completion metric (your team running it).
- Before: \`We work alongside until handoff\`
- After: \`We build until your team runs it\`

**Beat 04 body** — drops the negative \"no retainer trap, no permanent dependence\" framing (puts the negative idea in the prospect's head). Replaces with positive availability framing.
- Before: \`...documentation in their hands. No retainer trap, no permanent dependence on us.\`
- After: \`...documentation in their hands. We stay available if a follow-up makes sense.\`

## Test plan

- [x] Doctrine tests pass on the touched file (forbidden-strings + landing-page)
- [ ] Cloudflare preview reads cleanly through §03 beats 01-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)