### PR TITLE
refactor(talk): polish pass — placeholder, inline send, left-align header

### DIFF
--- a/src/pages/talk.astro
+++ b/src/pages/talk.astro
@@ -11,7 +11,7 @@ import Footer from '../components/Footer.astro'
   <Nav />
   <main id="main" role="main" class="px-6 py-20">
     <div class="mx-auto max-w-2xl">
-      <header class="text-center">
+      <header>
         <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
           Talk to us about your business.
         </h1>
@@ -27,23 +27,38 @@ import Footer from '../components/Footer.astro'
           <textarea
             id="text-input"
             rows="6"
-            placeholder="We run a 14-truck HVAC company in Mesa. Trying to add a second crew next year but I'm the bottleneck on every quote..."
-            class="block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/20 bg-white px-4 py-3 pr-16 text-base leading-relaxed text-[color:var(--ss-color-text-primary)] shadow-sm transition-colors placeholder:text-[color:var(--ss-color-text-secondary)]/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed read-only:cursor-not-allowed read-only:bg-[color:var(--ss-color-text-secondary)]/5"
+            placeholder="We run a 14-truck HVAC company in Mesa. Trying to add a second crew next year. Quoting is the bottleneck. We lose deals waiting on estimates."
+            class="block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/20 bg-white px-4 py-3 pr-28 text-base leading-relaxed text-[color:var(--ss-color-text-primary)] shadow-sm transition-colors placeholder:text-[color:var(--ss-color-text-secondary)]/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed read-only:cursor-not-allowed read-only:bg-[color:var(--ss-color-text-secondary)]/5"
           ></textarea>
           <button
             id="mic-btn"
             type="button"
             aria-label="Use voice input"
             data-ev="talk-voice-input"
-            class="absolute bottom-3 right-3 flex h-11 w-11 items-center justify-center rounded-full bg-primary text-white shadow-md transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-40"
+            class="absolute bottom-3 right-14 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white shadow-md transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-40"
           >
-            <span class="material-symbols-outlined" style="font-size: 22px;" aria-hidden="true"
+            <span class="material-symbols-outlined" style="font-size: 20px;" aria-hidden="true"
               >mic</span
+            >
+          </button>
+          <button
+            id="send-btn"
+            type="button"
+            aria-label="Send message"
+            disabled
+            data-ev="talk-text-submit"
+            class="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-white shadow-md transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <span
+              id="send-icon"
+              class="material-symbols-outlined"
+              style="font-size: 20px;"
+              aria-hidden="true">arrow_upward</span
             >
           </button>
         </div>
 
-        <div class="mt-4 flex items-center justify-end gap-4">
+        <div class="mt-4 text-right">
           <a
             id="start-over"
             href="#"
@@ -52,15 +67,6 @@ import Footer from '../components/Footer.astro'
             class="text-sm font-medium text-[color:var(--ss-color-text-secondary)] underline underline-offset-4 hover:text-[color:var(--ss-color-text-primary)]"
             >Start over</a
           >
-          <button
-            id="send-btn"
-            type="button"
-            disabled
-            data-ev="talk-text-submit"
-            class="inline-flex items-center justify-center rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-base font-semibold text-white shadow-sm transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            Send it
-          </button>
         </div>
 
         <div
@@ -111,6 +117,9 @@ import Footer from '../components/Footer.astro'
       background-color: var(--ss-color-error, #dc2626);
       animation: mic-pulse 1.4s ease-in-out infinite;
     }
+    #voice-shell[data-state='thinking'] #send-btn #send-icon {
+      animation: send-spin 1s linear infinite;
+    }
     @keyframes mic-pulse {
       0%,
       100% {
@@ -124,6 +133,11 @@ import Footer from '../components/Footer.astro'
           0 0 0 12px rgb(220 38 38 / 0);
       }
     }
+    @keyframes send-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
   </style>
 
   <script is:inline>
@@ -133,6 +147,7 @@ import Footer from '../components/Footer.astro'
       const textInput = document.getElementById('text-input')
       const micBtn = document.getElementById('mic-btn')
       const sendBtn = document.getElementById('send-btn')
+      const sendIcon = document.getElementById('send-icon')
       const startOverLink = document.getElementById('start-over')
       const responseSlot = document.getElementById('response-slot')
       const responseContent = document.getElementById('response-content')
@@ -196,22 +211,32 @@ import Footer from '../components/Footer.astro'
         shell.dataset.state = state
         if (state === 'listening') {
           textInput.readOnly = true
-          sendBtn.disabled = true
+          // Hide send entirely during listening (no enable/disable flicker
+          // when the recording starts/stops with text already in the box).
+          sendBtn.hidden = true
+          sendIcon.textContent = 'arrow_upward'
         } else if (state === 'thinking') {
           textInput.readOnly = false
           if (supportsVoice) micBtn.disabled = true
-          sendBtn.disabled = true
-          sendBtn.textContent = 'Sending...'
+          sendBtn.hidden = false
+          sendBtn.disabled = false
+          sendIcon.textContent = 'progress_activity'
         } else if (state === 'responded') {
           textInput.readOnly = true
           if (supportsVoice) micBtn.hidden = true
           sendBtn.hidden = true
+          sendIcon.textContent = 'arrow_upward'
           startOverLink.hidden = false
         } else {
+          // idle
           textInput.readOnly = false
-          if (supportsVoice) micBtn.disabled = false
+          if (supportsVoice) {
+            micBtn.disabled = false
+            micBtn.hidden = false
+          }
+          sendBtn.hidden = false
           sendBtn.disabled = isEmpty()
-          sendBtn.textContent = 'Send it'
+          sendIcon.textContent = 'arrow_upward'
         }
       }
 
@@ -229,10 +254,12 @@ import Footer from '../components/Footer.astro'
       const submit = async () => {
         const text = textInput.value.trim()
         if (!text) return
+        if (shell.dataset.state === 'thinking') return
         clearErrors()
         responseSlot.hidden = false
         responseContent.textContent = 'Thinking...'
         setState('thinking')
+        responseSlot.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
 
         timeoutHandle = setTimeout(() => {
           genericError.hidden = false
@@ -279,11 +306,6 @@ import Footer from '../components/Footer.astro'
         responseContent.textContent = ''
         responseSlot.hidden = true
         startOverLink.hidden = true
-        sendBtn.hidden = false
-        if (supportsVoice) {
-          micBtn.hidden = false
-          micBtn.disabled = false
-        }
         conversationId = null
         clearErrors()
         setState('idle')


### PR DESCRIPTION
## Summary

Three small refinements to the just-shipped `/talk` page (PR #667), all approved after PM analysis and a Devil's Advocate critique pass.

- **Placeholder names the system, not the person.** Old: "I'm the bottleneck on every quote" (accusatory). New: "Quoting is the bottleneck. We lose deals waiting on estimates." Per the respect-business-owners doctrine.
- **Send collapses into an inline icon next to the mic** (ChatGPT/Claude/Slack pattern). Both 40pt circles inside the textarea. The standalone Send button below the textarea is gone.
- **Header switches from `text-center` to flush-left** to match the home Hero alignment direction.

## Behavioral refinements (post-critique)

- Send hidden during `listening` (eliminates enable/disable flicker when recording starts/stops with text already in the box).
- Send glyph swaps to `progress_activity` spinner during `thinking`, replacing the "Sending..." text label. Standard chat-app pattern; provides feedback at the point of action.
- `responseSlot.scrollIntoView` after submit so the response area is always in view as it loads (insurance for tall textareas on mobile).
- Submit gated against accidental double-click during `thinking`.
- Aria-label "Send message" added to the new icon button.
- `data-ev="talk-text-submit"` migrated verbatim — telemetry hook preserved.
- Vestigial `flex` container with one child collapsed to a simple `text-right` div.

## Test plan

- [x] `npm run verify` passes clean (typecheck, lint, format, build, all 2064 tests).
- [x] Placeholder confirmed clean against `forbidden-strings.test.ts` regex list (no Pattern A/B match, no em dash, no banned vocab).
- [ ] Browser smoke test on Vercel preview: text path, voice path, voice mid-input, Cmd/Ctrl+Enter submit, tab-to-send + Enter, Start over, mobile viewport, side-by-side header parity with home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)