### PR TITLE
refine(home): §06 add AI fits/doesn't-fit patterns; flow text-balance everywhere

### DIFF
--- a/src/components/CaseStudies.astro
+++ b/src/components/CaseStudies.astro
@@ -36,6 +36,24 @@ const studies = [
       "A structured onboarding process so new hires know what to expect and aren't guessing from day one. Documented workflows for common policy types so the team handles things consistently. Simple tracking so managers can see workload and spot problems before they turn into resignations.",
     problems: ['Talent gaps', 'Process design', 'Operational visibility'],
   },
+  {
+    vertical: 'Home Services',
+    pattern: 'Estimates from field notes',
+    challenge:
+      'The owner takes photos and voice notes during a site visit, then writes up the estimate at home that night. Two or three hours per estimate, often after a twelve-hour day. The first one of the night reads sharp; the last one reads tired. Customers are waiting two or three days to hear back.',
+    solution:
+      "AI drafts a structured estimate from the photos and voice notes, following the firm's template. The owner reviews and edits in ten or fifteen minutes instead of writing from scratch. AI handles the structured-text part it is actually good at; the owner keeps the judgment about scope and price.",
+    problems: ['Owner bottleneck', 'AI and automation'],
+  },
+  {
+    vertical: 'Professional Services',
+    pattern: 'When AI is the wrong tool',
+    challenge:
+      'The firm wanted AI to draft client memos. They had seen demos and were worried about falling behind. Each memo required reading the file, understanding the relevant law, and making judgment calls about what the client needed to know. The drafting was not the slow part; the thinking was.',
+    solution:
+      'We said no to AI here. We built a stronger memo template library, a checklist the associate runs through, and a one-page reference for the most common matter types. The associates ship cleaner first drafts in less time. AI would have generated text that took longer to review and correct than to write from a good template.',
+    problems: ['Process design', 'Vendor and platform selection'],
+  },
 ]
 ---
 
@@ -53,9 +71,11 @@ const studies = [
       >
         Patterns We See
       </h2>
-      <p class="mt-6 max-w-2xl font-['Archivo'] text-[color:var(--ss-color-text-secondary)]">
-        Composite patterns drawn from problems we keep seeing across businesses your size. Not
-        specific engagements. As we close real engagements, those replace what is here.
+      <p
+        class="mt-6 max-w-2xl font-['Archivo'] text-lg text-balance text-[color:var(--ss-color-text-secondary)]"
+      >
+        Composite patterns drawn from problems we keep seeing. Not specific engagements. As we close
+        real ones, those replace what is here.
       </p>
     </div>
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -28,7 +28,7 @@ import CtaButton from './CtaButton.astro'
         class="md:col-span-4 flex flex-col items-start py-10 md:pt-24 md:pb-14 md:pl-10 md:border-l-[3px] md:border-[color:var(--ss-color-text-primary)]"
       >
         <p
-          class="font-['Archivo'] text-sm md:text-base leading-relaxed text-[color:var(--ss-color-text-secondary)]"
+          class="font-['Archivo'] text-sm md:text-base leading-relaxed text-balance text-[color:var(--ss-color-text-secondary)]"
         >
           You know where you want to go. We help you figure out what needs to change and build it
           with you.


### PR DESCRIPTION
## Summary

- §06 Patterns We See: add two AI-themed pattern entries — one where AI is the right answer, one where it isn't. Demonstrates the positioning called out in CLAUDE.md ("we do AI work when AI is the right answer, and we say so plainly").
- Add `text-balance` to the two remaining ledes still missing it: §06 CaseStudies (Captain flagged orphan-wrap on production) and Hero's narrow-column sub-paragraph. Page-wide audit confirms every lede now balanced.
- Scrub "businesses your size" from §06 lede — same implicit-qualification-gate failure mode just memorialized in `feedback_no_artificial_qualification_gates.md`.

## The two new patterns

**AI fits — Home Services: Estimates from field notes**
> The owner takes photos and voice notes during a site visit, then writes up the estimate at home that night. Two or three hours per estimate, often after a twelve-hour day. AI drafts a structured estimate from the photos and voice notes; the owner reviews and edits in ten or fifteen minutes instead of writing from scratch. AI handles the structured-text part it is actually good at; the owner keeps the judgment about scope and price.

**AI doesn't fit — Professional Services: When AI is the wrong tool**
> The firm wanted AI to draft client memos. Each memo required reading the file, understanding the relevant law, and making judgment calls about what the client needed to know. The drafting was not the slow part; the thinking was. We said no to AI here. We built a stronger memo template library and a checklist instead. AI would have generated text that took longer to review and correct than to write from a good template.

The two together demonstrate SMD's judgment — AI is a capability we use when it's right, not a brand we lead with.

## Doctrine compliance

- AI-rhetoric grep clean (`load-bearing`, `shape of [noun]`, `aspirational`, `from X to Y`, em dashes, `backfill`)
- No published dollars
- No fixed engagement timeframes (the time references are descriptive of the situation, not engagement promises)
- "We" voice preserved
- No claim to know the prospect's business

## Test plan

- [x] `npm run verify` passes locally
- [x] AI-rhetoric grep on changed files returns zero matches
- [x] Page-wide audit confirms text-balance on all marketing-component ledes
- [ ] Cloudflare preview: §06 lede no orphan-wrap; six pattern blocks render in order; Hero narrow column lede balances cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)