### PR TITLE
refine(home): fold §08 honest-scoping sentiment into §07 About

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -33,9 +33,8 @@
         <p
           class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          We're a Phoenix-based team that works with businesses past the startup phase but not yet
-          big enough for a dedicated operations person. You know where you're trying to go. You just
-          can't get to everything while running the business. That's what we're here for.
+          We're a Phoenix-based team. If we can't draw a clean line around what success looks like,
+          we say so before quoting. Some problems need a conversation before they need a quote.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Follow-up to PR #674. Captain explicitly said when killing §08: *"may fold the sentiment of this part into who we are"* — referring to the "we won't promise outcomes we can't scope" anti-promise. I shipped the kill without the fold; this PR adds it.

Replaces About's second paragraph with a positive (not anti-promise) restatement of the honest-scoping commitment. While in there, also removes two adjacent issues the old paragraph carried.

## What changed

**Before:**
> We're a Phoenix-based team that works with businesses past the startup phase but not yet big enough for a dedicated operations person. You know where you're trying to go. You just can't get to everything while running the business. That's what we're here for.

**After:**
> We're a Phoenix-based team. If we can't draw a clean line around what success looks like, we say so before quoting. Some problems need a conversation before they need a quote.

## Why this paragraph

Three changes in one rewrite:

1. **Adds the §08 honest-scoping fold-in positively framed.** The discipline signal carries without the "we won't" anti-promise framing called out in `feedback_no_defensive_we_wont_copy.md`.

2. **Drops the implicit qualification gate** ("businesses past the startup phase but not yet big enough for a dedicated operations person") — same failure mode as killed §05 and §08 per `feedback_no_artificial_qualification_gates.md`.

3. **Drops the diagnostic "you" addressing** ("You know where you're trying to go. You just can't get to everything") — collaborative-not-diagnostic per `feedback_objectives_not_problems.md`. About now describes how SMD operates, not what the prospect is feeling.

Para 1 (Scott's bio) is untouched.

## Test plan

- [x] `npm run verify` passes locally (clean, no --no-verify needed since UnifiedIntake landed in #675)
- [x] AI-rhetoric grep returns zero matches
- [ ] Cloudflare preview: §07 About reads as a continuous bio + how-we-operate statement; no orphan-wrap on the new paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)