### PR TITLE
refine(home): §07 in Scott's first-person voice; practitioner-firm exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,14 @@ No dollar amounts appear on the website or in marketing materials. The client se
 
 Always "we" / "our team." Never "I" / "the consultant." See Decision Stack #20 for full details.
 
+**Practitioner-firm exception (added 2026-05-03):** §07 "Who We Are" on the marketing home page is the one place where Scott speaks in first person. SMD is positioned as a practitioner firm — like a lawyer's office, a doctor's practice, or a craftsman's shop — where the founder _is_ the firm and there is a real team behind him. In that model, forced "we" voice in the founder bio reads insincere; first person is the only sincere voice. About speaks as Scott; every other section ships in firm-level "we" voice. The voice-standard test in `tests/landing-page.test.ts` excludes `About.astro` for this reason. Do not rewrite About to "we" voice without Captain explicitly reversing this call.
+
+**Identity-marker rule (added 2026-05-03):** Words that describe an aspirational self-quality (Captain's examples: "magic," "artist," "creative") must SHAPE the voice without being STATED on the page. Stating them reads as overclaim or self-flattery. Convey wonder via concrete language and what the work does, not by calling it magic. Convey creativity by showing it, not by calling it artistry. The rule applies to all marketing surfaces, not just About.
+
+### 7. No claim to know the prospect's business
+
+We do not write copy that implies pre-knowledge of a specific prospect's business. We are collaborators who learn the situation through conversation, not diagnosticians who arrive with answers. This rule covers both first-person ("I know what's wrong with your business") and implied ("This is what your business needs"). See `feedback_no_pretend_to_know_business.md`.
+
 ---
 
 ## The Business Model

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -26,24 +26,26 @@
         <p
           class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
         >
-          Scott built software and led product teams at scale for two decades. The same operational
-          problems showed up at every size of company he worked with: work that wasn't written down,
-          tools that didn't talk to each other, people closest to the problem who didn't have what
-          they needed. SMD exists to put that experience to use for the businesses without an
-          enterprise's layers of help.
+          I've been building software since the '90s. I still find it endlessly fascinating. I
+          started as a self-taught developer, moved into product management, and spent two decades
+          on enterprise web applications for Fortune 500 and Fortune 100 clients. I have a wealth of
+          experience across a broad spectrum of business problems.
         </p>
         <p
           class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-secondary)]"
         >
-          Scott owns the engagement and the relationship. The work spans process design, tool
-          configuration, integration, and custom builds. We bring in specialists where the scope
-          requires it.
+          I started SMD because I like helping people. Using what I've built up over this career to
+          do more of that is one of the things that brings me joy in life.
         </p>
         <p
           class="font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
         >
-          We build, not just advise. We design the work around your situation. When we are done,
-          your team runs what we built.
+          It's a particularly interesting time to be in this field. Every business is leveraging
+          technology in one way or another, and so much of it is accessible now. But software has a
+          way of getting complicated faster than you expect, and it's easy to end up with a lot of
+          things just about working, right up until they aren't. You need somebody who can come in,
+          put the pieces together, wire it up, connect the dots, and get you over the current
+          hurdle. I like to be that person.
         </p>
       </div>
     </div>

--- a/tests/landing-page.test.ts
+++ b/tests/landing-page.test.ts
@@ -75,6 +75,11 @@ describe('content integrity', () => {
 })
 
 describe('voice standard', () => {
+  // About.astro is intentionally excluded: SMD is positioned as a practitioner
+  // firm (lawyer / doctor / craftsman model) where the founder *is* the firm.
+  // §07 Who We Are uses Scott's first-person voice; the rest of the page stays
+  // in firm-level "we" voice. See CLAUDE.md "Voice standard" practitioner-firm
+  // exception.
   const marketingComponents = [
     'Hero.astro',
     'ProblemCards.astro',
@@ -82,7 +87,6 @@ describe('voice standard', () => {
     'HowWeEngage.astro',
     'HowWePrice.astro',
     'WhatYouGet.astro',
-    'About.astro',
     'FinalCta.astro',
   ]
 


### PR DESCRIPTION
## Summary

Captain authored a doctrine shift after rejecting the prior third-person + "we"-voice rebuild as corporate-AI register: SMD is a practitioner firm — like a lawyer's office, a doctor's practice, or a craftsman's shop — where Scott IS the firm and there is a real team behind him. Direct quote: *"the 1st person voice is the only the voice that is sincere. we will only be sincere."*

§07 About now ships in Scott's first-person voice, sourced verbatim or near-verbatim from Captain's own dictated transcript. Every other section stays in firm-level "we" voice.

## Copy

> I've been building software since the '90s. I still find it endlessly fascinating. I started as a self-taught developer, moved into product management, and spent two decades on enterprise web applications for Fortune 500 and Fortune 100 clients. I have a wealth of experience across a broad spectrum of business problems.
>
> I started SMD because I like helping people. Using what I've built up over this career to do more of that is one of the things that brings me joy in life.
>
> It's a particularly interesting time to be in this field. Every business is leveraging technology in one way or another, and so much of it is accessible now. But software has a way of getting complicated faster than you expect, and it's easy to end up with a lot of things just about working, right up until they aren't. You need somebody who can come in, put the pieces together, wire it up, connect the dots, and get you over the current hurdle. I like to be that person.

~150 words. Three paragraphs. Voice sourced from Captain's transcript; agent role was edit and structure, not author (per `feedback_voice_copy_from_captain_not_generate.md`).

## Doctrine changes

1. **`CLAUDE.md` "Voice standard"** — adds the **practitioner-firm exception** to Decision Stack #20: §07 About uses first-person Scott voice; every other section uses "we" voice. Adds the **identity-marker rule**: words like "magic" and "artist" SHAPE voice silently and must not be stated as words on marketing copy.
2. **`tests/landing-page.test.ts`** — voice-standard test no longer scans `About.astro`. Inline comment cites the practitioner-firm exception.
3. **Memory:** `feedback_practitioner_firm_voice.md` saved so future agents see the rule.

## Why this lands where the prior versions didn't

Three failed attempts taught the lesson:
- v1 (PR #676 fold-in) — thin, defensive
- v2 (PR #681 third-person + "we" + "operational pattern" diagnosis) — passed every anti-pattern check (no Pattern A, no X-not-Y, no em dashes) but still corporate-AI register
- v3 (this PR) — sourced from Captain's own words, first-person, identity markers held out

The phrase-level anti-pattern checks (forbidden-strings, AI-rhetoric grep, no-em-dash) are necessary but not sufficient. Voice has to come from Captain. That's now memorialized.

## Test plan

- [x] `npm run verify` passes locally
- [x] AI-rhetoric + identity-marker grep on About.astro returns zero matches
- [x] forbidden-strings.test.ts passes (46/46)
- [x] voice-standard test still passes on the seven other marketing components
- [ ] Cloudflare preview: §07 reads as Scott talking, not as a marketing page describing Scott

🤖 Generated with [Claude Code](https://claude.com/claude-code)