### PR TITLE
refactor(intake): single Get-in-touch CTA, post-engagement booking

### DIFF
--- a/src/components/booking/UnifiedIntake.astro
+++ b/src/components/booking/UnifiedIntake.astro
@@ -5,22 +5,32 @@
  * Replaces the old "/talk vs /book" split with one form that captures
  * required identity (name/email/business/phone), optional website, and
  * an optional free-text "tell us about your business" field with voice
- * dictation. Two CTAs: Send (lower intent — server replies with one AI
- * follow-up) and Book a call (high intent — reveals SlotPicker).
+ * dictation. ONE primary CTA: Get in touch.
+ *
+ * Funnel architecture (post-PR-680 fix):
+ * - Initial state shows only the form + a single "Get in touch" CTA.
+ * - On Send success the response slot opens with either an AI reply
+ *   (when the textarea was non-empty) or a brief acknowledgement (when
+ *   it was empty).
+ * - The booking offer ("Pick a time to talk") reveals as a follow-on
+ *   step beneath the response — never as a parallel choice on first
+ *   paint. Cold visitors are lured by the textarea; the booking ask
+ *   arrives only after they have engaged and been heard.
  *
  * The component owns its own form, textarea, and mic JS. The page
- * (book.astro) listens for `unified-send` and `unified-book` CustomEvents
- * and drives the page-level state machine + API calls.
+ * (book.astro) listens for `unified-send` and `unified-pick-time`
+ * CustomEvents and drives the page-level state machine + API calls.
  *
- * Submit buttons are NOT gated by `form.checkValidity()` to avoid the
- * Safari autofill+JS gap (Safari's autofill does not fire `change`
- * events, which can leave the buttons disabled even when fields are
- * filled). Server-side validation surfaces field errors instead.
+ * The Get-in-touch button is NOT gated by `form.checkValidity()` to
+ * avoid the Safari autofill+JS gap (Safari's autofill does not fire
+ * `change` events, which can leave the button disabled even when fields
+ * are filled). Server-side validation surfaces field errors instead.
  *
- * Voice dictation uses the same Web Speech API pattern as /talk:
- * read-only-while-listening prevents typing/recognizer race; final
- * transcripts append at end with leading-space normalization. No
- * interim transcript display.
+ * Voice dictation: read-only-while-listening prevents typing/recognizer
+ * race; final transcripts append at end with leading-space normalization.
+ * No interim transcript display. Recognition halts on every state
+ * transition out of `idle`/`listening` to prevent late `onresult`
+ * mutating textarea content the server already saw.
  */
 
 interface Props {
@@ -42,17 +52,7 @@ const { values } = Astro.props as Props
   data-state="idle"
   class="rounded-[var(--ss-radius-card)] bg-white p-card sm:p-section"
 >
-  <header>
-    <h2 class="text-2xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-3xl">
-      Talk to us about your business.
-    </h2>
-    <p class="mt-3 text-base text-[color:var(--ss-color-text-secondary)]">
-      Tell us where the business is now, where you're trying to take it, and what's in the way.
-      Brief is fine; details help.
-    </p>
-  </header>
-
-  <form id="unified-intake-form" class="mt-8 space-y-5" novalidate autocomplete="on">
+  <form id="unified-intake-form" class="space-y-5" novalidate autocomplete="on">
     <!-- Honeypot — silently rejected server-side -->
     <div class="absolute -left-[9999px]" aria-hidden="true">
       <input type="text" name="website_url" tabindex="-1" autocomplete="off" />
@@ -211,48 +211,51 @@ const { values } = Astro.props as Props
       address bar, then reload this page. You can still type your message above.
     </div>
 
-    <!-- Two CTAs: Send (lower intent) and Book a call (high intent).
-         Both are always clickable. Server validates and surfaces field
-         errors via the #ui-error div. -->
-    <div class="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <!-- Single primary CTA. Booking is offered AFTER Send + AI reply,
+         not as a parallel choice on first paint. -->
+    <div class="flex justify-end">
       <button
         id="ui-send-btn"
         type="button"
         data-ev="intake-send"
-        class="inline-flex items-center justify-center rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/30 bg-white px-6 py-3 text-base font-medium text-[color:var(--ss-color-text-primary)] shadow-sm transition-all hover:bg-[color:var(--ss-color-text-secondary)]/5 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        Just send instead
-      </button>
-      <button
-        id="ui-book-btn"
-        type="button"
-        data-ev="intake-book"
         class="inline-flex items-center justify-center rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-base font-semibold text-white shadow-sm transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        📅 Book a call
+        Get in touch
       </button>
     </div>
   </form>
 
-  <!-- Send-path AI reply renders here when the server responds. -->
+  <!-- Post-Send response: either an AI reply (with-message) or a brief
+       acknowledgement (empty-message). Either way, the booking offer
+       reveals beneath. -->
   <div id="ui-response-slot" hidden aria-live="polite" class="mt-8">
     <h3
+      id="ui-response-header"
+      hidden
       class="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ss-color-text-secondary)]"
     >
       We hear you
     </h3>
     <div
       id="ui-response-content"
+      hidden
       class="whitespace-pre-wrap rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/20 bg-white px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)] shadow-sm"
     >
     </div>
-    <p
-      id="ui-response-thanks"
-      hidden
-      class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]"
-    >
-      Thanks. A consultant from our team will pick this up.
+    <p id="ui-empty-ack" hidden class="text-base text-[color:var(--ss-color-text-primary)]">
+      Got it.
     </p>
+    <div id="ui-booking-offer" hidden class="mt-6">
+      <p id="ui-booking-prompt" class="text-base text-[color:var(--ss-color-text-secondary)]"></p>
+      <button
+        id="ui-pick-time-btn"
+        type="button"
+        data-ev="intake-pick-time"
+        class="mt-3 inline-flex items-center justify-center rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-base font-semibold text-white shadow-sm transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40"
+      >
+        Pick a time to talk
+      </button>
+    </div>
   </div>
 </section>
 
@@ -278,23 +281,22 @@ const { values } = Astro.props as Props
 
 <script is:inline>
   ;(() => {
-    // Self-contained voice input + form-level UI helpers.
-    // The page (book.astro) handles submit-button clicks and API calls
-    // by listening for the `unified-send` and `unified-book` CustomEvents.
-
     const SR = window.SpeechRecognition || window.webkitSpeechRecognition
     const shell = document.getElementById('unified-intake')
     const form = document.getElementById('unified-intake-form')
     const textInput = document.getElementById('ui-message')
     const micBtn = document.getElementById('ui-mic-btn')
     const sendBtn = document.getElementById('ui-send-btn')
-    const bookBtn = document.getElementById('ui-book-btn')
     const errorDiv = document.getElementById('ui-error')
     const voiceUnsupported = document.getElementById('ui-voice-unsupported')
     const permissionError = document.getElementById('ui-voice-permission-error')
     const responseSlot = document.getElementById('ui-response-slot')
+    const responseHeader = document.getElementById('ui-response-header')
     const responseContent = document.getElementById('ui-response-content')
-    const responseThanks = document.getElementById('ui-response-thanks')
+    const emptyAck = document.getElementById('ui-empty-ack')
+    const bookingOffer = document.getElementById('ui-booking-offer')
+    const bookingPrompt = document.getElementById('ui-booking-prompt')
+    const pickTimeBtn = document.getElementById('ui-pick-time-btn')
 
     let recognition = null
     const supportsVoice = !!SR
@@ -339,13 +341,32 @@ const { values } = Astro.props as Props
       textInput.readOnly = on
     }
 
+    function stopRecognitionIfActive() {
+      if (recognition && shell.dataset.state === 'listening') {
+        try {
+          recognition.stop()
+        } catch (err) {
+          // benign — recognition may already be stopping
+        }
+      }
+    }
+
+    function hidePostSendUi() {
+      responseSlot.hidden = true
+      responseHeader.hidden = true
+      responseContent.hidden = true
+      responseContent.textContent = ''
+      emptyAck.hidden = true
+      bookingOffer.hidden = true
+      bookingPrompt.textContent = ''
+    }
+
     if (supportsVoice && micBtn) {
       micBtn.addEventListener('click', () => {
         if (shell.dataset.state === 'listening') {
           recognition.stop()
           return
         }
-        // Don't start mic in non-idle states (form locked / sending / etc).
         if (shell.dataset.state !== 'idle') return
         permissionError.hidden = true
         setListening(true)
@@ -375,35 +396,51 @@ const { values } = Astro.props as Props
       const data = readFormData()
       shell.dispatchEvent(new CustomEvent('unified-send', { detail: data, bubbles: true }))
     })
-    bookBtn.addEventListener('click', () => {
-      const data = readFormData()
-      shell.dispatchEvent(new CustomEvent('unified-book', { detail: data, bubbles: true }))
+
+    pickTimeBtn.addEventListener('click', () => {
+      shell.dispatchEvent(new CustomEvent('unified-pick-time', { bubbles: true }))
     })
 
     // Page-side state controls. The page calls these via dispatchEvent on #unified-intake.
     shell.addEventListener('unified-set-state', (e) => {
       const next = e.detail?.state
       if (!next) return
+      const prev = shell.dataset.state
+      // Halt any active speech recognition before locking the form so
+      // late-arriving onresult cannot mutate textarea content the server
+      // already saw.
+      if (next !== 'idle' && next !== 'listening' && prev === 'listening') {
+        stopRecognitionIfActive()
+      }
       shell.dataset.state = next
       const fields = form.querySelectorAll('input, textarea')
       const locked = next === 'send_thinking' || next === 'send_done' || next === 'booked'
-      const formDisabled = locked
       fields.forEach((f) => {
-        f.readOnly = formDisabled
+        f.readOnly = locked
       })
       if (next === 'send_thinking') {
         sendBtn.disabled = true
-        bookBtn.disabled = true
         sendBtn.textContent = 'Sending...'
       } else if (next === 'send_done') {
         sendBtn.disabled = true
-        bookBtn.disabled = true
-        sendBtn.textContent = 'Sent'
+        sendBtn.hidden = true
         if (supportsVoice) micBtn.hidden = true
+      } else if (next === 'booked') {
+        sendBtn.disabled = true
+        sendBtn.hidden = true
+        if (supportsVoice) micBtn.hidden = true
+        // Page-level confirmation panel takes over rendering.
       } else if (next === 'idle') {
         sendBtn.disabled = false
-        bookBtn.disabled = false
-        sendBtn.textContent = 'Just send instead'
+        sendBtn.hidden = false
+        sendBtn.textContent = 'Get in touch'
+        if (supportsVoice) {
+          micBtn.hidden = false
+          micBtn.disabled = false
+        }
+        // Recovery from a failed Send: scrub any post-send UI so a
+        // stale booking offer can't appear above a still-editable form.
+        hidePostSendUi()
       }
     })
 
@@ -418,14 +455,29 @@ const { values } = Astro.props as Props
       errorDiv.textContent = ''
     })
 
+    // Two-mode response handler. With-message: render AI reply. Empty-message:
+    // brief acknowledgement. In both, reveal the booking offer below as the
+    // sequential next step.
+    //
+    // Note: no scrollIntoView here. The booking offer is offered passively;
+    // scroll fires only when the user clicks Pick-a-time (page-side), so we
+    // never jump the page while the prospect is mid-read.
     shell.addEventListener('unified-show-ai-reply', (e) => {
-      const reply = e.detail?.reply || ''
+      const reply = (e.detail?.reply || '').trim()
+      responseSlot.hidden = false
       if (reply) {
+        responseHeader.hidden = false
         responseContent.textContent = reply
-        responseSlot.hidden = false
+        responseContent.hidden = false
+        emptyAck.hidden = true
+        bookingPrompt.textContent = 'Want to keep the conversation going?'
+      } else {
+        responseHeader.hidden = true
+        responseContent.hidden = true
+        emptyAck.hidden = false
+        bookingPrompt.textContent = 'Ready to talk?'
       }
-      responseThanks.hidden = false
-      responseSlot.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      bookingOffer.hidden = false
     })
   })()
 </script>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -69,6 +69,12 @@ if (prefillToken) {
       data-turnstile-site-key={turnstileSiteKey}
     >
       <div class="mx-auto max-w-3xl">
+        <header class="mb-6">
+          <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
+            Tell us where you're trying to go.
+          </h1>
+        </header>
+
         {
           prefillTokenError && (
             <div class="mb-6 rounded-[var(--ss-radius-card)] border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
@@ -577,6 +583,21 @@ if (prefillToken) {
       }
 
       // ----- Send path -----
+      //
+      // After the architectural fix (post-PR-680): there is only one initial
+      // CTA on the page, "Get in touch", which fires `unified-send`. The
+      // booking offer reveals only after Send succeeds — gated by the
+      // `sendSucceeded` flag so a Send failure can never strand a booking
+      // offer above a still-editable form.
+      //
+      // The form values submitted on Send are snapshotted into `submittedData`
+      // so the eventual booking POST uses exactly what was sent (rather than
+      // re-reading the live DOM, which could drift if late voice-recognition
+      // results land or anything else mutates the textarea after Send).
+
+      let sendSucceeded = false
+      let submittedData: UnifiedFormData | null = null
+
       intakeRoot.addEventListener('unified-send', async (event) => {
         const data = (event as CustomEvent<UnifiedFormData>).detail
         clearIntakeError()
@@ -622,6 +643,8 @@ if (prefillToken) {
           const body = (await res.json().catch(() => ({}))) as IntakeSendResponse
 
           if (res.ok && body.ok) {
+            sendSucceeded = true
+            submittedData = { ...data }
             setIntakeState('send_done')
             showAiReply(body.ai_reply ?? null)
             return
@@ -648,30 +671,14 @@ if (prefillToken) {
         }
       })
 
-      // ----- Book path -----
-      let pendingBookData: UnifiedFormData | null = null
+      // ----- Pick-a-time path -----
+      //
+      // Fires only when the user clicks the post-send "Pick a time to talk"
+      // button. Defensively gated on `sendSucceeded` so a stale offer can't
+      // open the slot picker without a captured lead behind it.
 
-      intakeRoot.addEventListener('unified-book', (event) => {
-        const data = (event as CustomEvent<UnifiedFormData>).detail
-        clearIntakeError()
-
-        // Honeypot
-        if (data.website_url && data.website_url.trim() !== '') return
-
-        // Validate required fields before opening the slot picker — no point
-        // letting the prospect spend time picking a slot if they're going to
-        // fail validation.
-        const missing: string[] = []
-        if (!data.name) missing.push('name')
-        if (!data.email) missing.push('email')
-        if (!data.business_name) missing.push('business name')
-        if (!data.phone) missing.push('phone')
-        if (missing.length > 0) {
-          showIntakeError(`Please fill in: ${missing.join(', ')} before booking.`)
-          return
-        }
-
-        pendingBookData = data
+      intakeRoot.addEventListener('unified-pick-time', () => {
+        if (!sendSucceeded || !submittedData) return
         slotPickerSection.hidden = false
         slotPickerSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
       })
@@ -748,7 +755,7 @@ if (prefillToken) {
       const showEmailFallback = (body: BookingResponse): void => {
         const fallbackEmail = body.fallback?.email || 'team@smd.services'
         const mailtoEl = document.getElementById('fallback-mailto')
-        const data = pendingBookData
+        const data = submittedData
         const subject = encodeURIComponent('Assessment Call Request')
         const bodyText = encodeURIComponent(
           "Hi, I'd like to schedule an assessment call.\n\n" +
@@ -766,7 +773,7 @@ if (prefillToken) {
       }
 
       bookSubmitBtn.addEventListener('click', async () => {
-        if (!currentSlot || !pendingBookData) return
+        if (!currentSlot || !submittedData) return
 
         bookSubmitBtn.disabled = true
         bookSubmitBtn.textContent = 'Booking...'
@@ -774,13 +781,18 @@ if (prefillToken) {
         slotTakenBanner.hidden = true
 
         const turnstileToken = getTurnstileToken()
+        // Booking POST. The user message was already persisted by Send
+        // (and the AI reply context row written from /api/intake/send),
+        // so we deliberately pass an empty `message` here. intake-core
+        // skips the context append when the message is empty, avoiding
+        // a duplicate intake row on the entity timeline.
         const payload: Record<string, unknown> = {
-          name: pendingBookData.name,
-          email: pendingBookData.email,
-          business_name: pendingBookData.business_name,
-          phone: pendingBookData.phone,
-          website: pendingBookData.website,
-          message: pendingBookData.message,
+          name: submittedData.name,
+          email: submittedData.email,
+          business_name: submittedData.business_name,
+          phone: submittedData.phone,
+          website: submittedData.website,
+          message: '',
           slot_start_utc: currentSlot.start_utc,
           timezone: currentSlot.timezone,
           turnstile_token: turnstileToken,

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -113,6 +113,14 @@ const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp | string }> = [
     pattern: /will reach out/i,
   },
   {
+    label: 'Pattern A: hardcoded "we\'ll be in touch" outbound-contact promise',
+    // 2026-05-04 /book intake architecture review caught this same class
+    // creeping back in as a Send-acknowledgement copy ("Got it. We'll be
+    // in touch.") before merge. Same false-promise shape as `will reach
+    // out` — commits SMD to an outbound action that no system guarantees.
+    pattern: /we'll be in touch/i,
+  },
+  {
     label: 'Pattern B: synthesized "Kickoff next:" next-step copy',
     // 2026-04-17 audit finding: signed-state copy synthesized
     // `Kickoff next: ${engagement.scope_summary}.` when next_touchpoint_label


### PR DESCRIPTION
## Summary

Fixes the funnel inversion identified by Captain in PR #680's unified intake. The primary CTA was "Book a call" — which serves the small already-decided minority and loses the curious majority. Secondary "Just send instead" was broken copy on first impression (orphan "instead").

A four-expert pass + Devil's Advocate critique landed this architecture:

- **Initial state:** form + single "Get in touch" primary CTA. No competing buttons.
- **After Send:** AI reply renders (or "Got it." for empty-message), then a follow-on "Pick a time to talk" button appears beneath — gated by a \`sendSucceeded\` flag so Send-failures can't strand a stale offer.
- **Booking offer copy is two-mode:** "Want to keep the conversation going?" (with AI reply) or "Ready to talk?" (empty message).
- **Page H1:** "Tell us where you're trying to go." Left-aligned, default typography. No subhead.

## Critique fixes (all adopted)

1. **Duplicate context rows.** Booking POST now sends \`message: ''\` so intake-core's existing empty-message guard skips writing a second intake context row. The Send path already persisted the message + AI reply.
2. **False-promise copy killed.** Replaced "Got it. We'll be in touch." with "Got it." Replaced the soft-promise subhead "We'll read it before we talk." with no subhead. Added \`/we'll be in touch/i\` to forbidden-strings as a regression guard.
3. **Send-failure recovery.** Page tracks \`sendSucceeded\` and snapshots \`submittedData\` on Send success. unified-pick-time early-returns if Send hadn't succeeded. Component scrubs all post-send UI on state→idle.
4. **Voice-after-Send drift.** Component stops active speech recognition on every state transition out of idle/listening, preventing late onresult mutating textarea content.
5. **Header layout pinned.** \`max-w-3xl\` container, H1 left-aligned by default, default typography (not Hero's Archivo Black) — explicit, no "match Hero" ambiguity.
6. **No scroll fight.** scrollIntoView fires only on explicit Pick-a-time click, not on AI-reply reveal.

## Files

- \`src/components/booking/UnifiedIntake.astro\` — single CTA, two-mode response slot, recognition-stop on transitions, hide-post-send-on-idle.
- \`src/pages/book.astro\` — page H1 added; \`unified-book\` listener and \`pendingBookData\` removed; \`unified-pick-time\` listener added; \`sendSucceeded\` flag and \`submittedData\` snapshot pattern; booking POST sends \`message: ''\`.
- \`tests/forbidden-strings.test.ts\` — \`/we'll be in touch/i\` regression guard.

Untouched: \`/api/intake/send\`, \`/api/booking/reserve\`, \`intake-core.ts\`, \`SlotPicker\`, \`/contact\`, \`/get-started\`, \`/talk\` (still 301-redirects to /book).

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run test\` — 2062 passing
- [x] \`npm run build\` — clean
- [ ] Browser smoke test on Vercel preview:
  - **Empty-message path:** fill required fields, click Get in touch → "Got it." + "Ready to talk? [Pick a time to talk]" → click Pick a time → SlotPicker reveals → pick slot → confirm.
  - **With-message path:** fill required + textarea, click Get in touch → "We hear you" header + AI reply + "Want to keep the conversation going? [Pick a time to talk]" → click Pick a time → SlotPicker → confirm.
  - **D1 verification (with-message):** ONE entity, ONE contact, TWO intake context rows (message + AI reply). NO third row from booking POST.
  - **Send-failure recovery:** simulate failure → form unlocks, booking offer NOT visible.
  - **Voice mid-input then Send:** dictation halts cleanly on state transition.
- [ ] \`/contact\`, \`/get-started\`, \`/talk\` redirect, \`/book/manage\` all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)