### PR TITLE
refine(chrome): footer rebuild + Nav logo fix + Terms/Privacy pages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,46 +2,55 @@
   class="border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-surface-inverse)] text-white"
 >
   <div class="mx-auto w-full max-w-5xl px-6">
-    <!-- Region 1: Masthead — brand mark. -->
+    <!-- Region 1: Masthead. Text-only wordmark, no filled-block accent.
+         Practitioner-firm register: a lawyer's office or doctor's practice
+         marks itself with a wordmark, not a colored block. -->
     <div class="py-12 md:py-14">
       <a
         href="/"
-        class="inline-flex items-baseline gap-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-white"
+        class="inline-block font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-white hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
       >
-        <span
-          class="inline-block bg-[color:var(--ss-color-primary)] text-white px-2.5 py-1 font-black tracking-[-0.01em]"
-          >SMD</span
-        >
-        <span>Services</span>
+        SMD Services
       </a>
     </div>
 
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
-    <!-- Region 2: Sitewide links. Routable destinations not otherwise
-         present in the chrome: AI (capability page, demoted from primary
-         nav per #640), Book a Call (also in nav and FinalCta but useful
-         here as a footer fallback), Contact. Brutalist-sparse mono
-         treatment to match the colophon. -->
+    <!-- Region 2: Footer nav, two-column layout.
+         Left column: conversion paths (Book a Call, Contact). Useful on
+         pages without a FinalCta directly above the footer (/ai, /book,
+         /contact).
+         Right column: legal hygiene (Terms, Privacy). -->
     <nav
       aria-label="Footer"
-      class="py-6 md:py-7 flex flex-wrap gap-x-6 gap-y-2 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+      class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >
-      <a href="/ai" class="hover:text-white" data-ev="footer-ai">AI</a>
-      <a href="/book" class="hover:text-white" data-ev="footer-book">Book a Call</a>
-      <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>
+      <div class="flex flex-wrap gap-x-6 gap-y-2">
+        <a href="/book" class="hover:text-white" data-ev="footer-book">Book a Call</a>
+        <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>
+      </div>
+      <div class="flex flex-wrap gap-x-6 gap-y-2">
+        <a href="/terms" class="hover:text-white" data-ev="footer-terms">Terms</a>
+        <a href="/privacy" class="hover:text-white" data-ev="footer-privacy">Privacy</a>
+      </div>
     </nav>
 
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
-    <!-- Region 3: Colophon — legal left, location right. Nav and CTA are not
-         repeated here because they already live in the sticky header (mobile
-         menu overlay + desktop inline) and in the FinalCta section directly
-         above the footer. -->
+    <!-- Region 3: Colophon. Legal entity + parent company on the left,
+         location on the right. VentureCrane link is the inline anchor inside
+         the corporate identity line, not a standalone nav item. -->
     <div
       class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >
-      <span>&copy; 2026 SMDurgan, LLC</span>
+      <span>
+        &copy; 2026 SMDurgan, LLC, part of <a
+          href="https://venturecrane.com"
+          rel="noopener"
+          class="hover:text-white"
+          data-ev="footer-venturecrane">VentureCrane</a
+        >
+      </span>
       <span>Phoenix, Arizona</span>
     </div>
   </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,13 +11,9 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
   >
     <a
       href="/"
-      class="inline-flex items-baseline gap-2 font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      class="inline-block font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
     >
-      <span
-        class="inline-block bg-[color:var(--ss-color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
-        >SMD</span
-      >
-      <span>Services</span>
+      SMD Services
     </a>
 
     <div class="flex items-center gap-3 md:gap-6">
@@ -66,14 +62,10 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
     <div class="flex h-14 flex-none items-center justify-between px-4 border-b-[3px] border-white">
       <a
         href="/"
-        class="inline-flex items-baseline gap-2 font-['Archivo'] text-base font-black uppercase tracking-[-0.01em] text-white"
+        class="inline-block font-['Archivo'] text-base font-black uppercase tracking-[-0.01em] text-white"
         data-nav-link
       >
-        <span
-          class="inline-block bg-[color:var(--ss-color-primary)] text-white px-2 py-0.5 font-black tracking-[-0.01em]"
-          >SMD</span
-        >
-        <span>Services</span>
+        SMD Services
       </a>
       <button
         type="button"

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,52 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+---
+
+<Base
+  title="Privacy | SMD Services"
+  description="Privacy policy for smd.services. We collect only what you provide directly and use it only to respond to you."
+>
+  <Nav />
+  <main id="main" role="main" class="bg-[color:var(--ss-color-background)] px-6 py-20 md:py-24">
+    <div class="mx-auto max-w-2xl">
+      <h1
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+      >
+        Privacy
+      </h1>
+
+      <div
+        class="mt-10 space-y-6 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+      >
+        <p>
+          smd.services collects only the information you provide directly: form submissions for
+          inquiries, scheduling data when you book a call, and email content when you contact us. We
+          use it only to respond to you and prepare for our conversation. We do not sell, rent, or
+          share this information with third parties.
+        </p>
+
+        <p>
+          The site uses minimal session cookies required for the booking flow. We do not run
+          third-party advertising trackers or behavioral profiling.
+        </p>
+
+        <p>
+          Email <a
+            href="mailto:team@smd.services"
+            class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >team@smd.services</a
+          > with any privacy question or to request deletion of your information.
+        </p>
+      </div>
+
+      <p
+        class="mt-12 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+      >
+        Last updated: 2026-05-04
+      </p>
+    </div>
+  </main>
+  <Footer />
+</Base>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,61 @@
+---
+import Base from '../layouts/Base.astro'
+import Nav from '../components/Nav.astro'
+import Footer from '../components/Footer.astro'
+---
+
+<Base
+  title="Terms | SMD Services"
+  description="Terms of use for the smd.services website. Engagement-specific terms are documented in the Statement of Work for each engagement."
+>
+  <Nav />
+  <main id="main" role="main" class="bg-[color:var(--ss-color-background)] px-6 py-20 md:py-24">
+    <div class="mx-auto max-w-2xl">
+      <h1
+        class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+      >
+        Terms
+      </h1>
+
+      <div
+        class="mt-10 space-y-6 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+      >
+        <p>
+          These terms govern your use of the smd.services website. Engagement-specific terms,
+          including scope, deliverables, schedule, pricing, and obligations, are documented in the
+          Statement of Work for each engagement and supersede anything stated here.
+        </p>
+
+        <p>
+          The site is provided as-is. We make no warranty about uninterrupted availability or
+          fitness for any particular purpose.
+        </p>
+
+        <p>
+          Content on this site, including text, design, code, and images, is owned by SMDurgan, LLC.
+          Use beyond personal browsing requires written permission.
+        </p>
+
+        <p>
+          Arizona law governs these terms. Any disputes are resolved in courts in Maricopa County,
+          Arizona.
+        </p>
+
+        <p>
+          Questions: <a
+            href="mailto:team@smd.services"
+            class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+            >team@smd.services</a
+          >.
+        </p>
+      </div>
+
+      <p
+        class="mt-12 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+      >
+        Last updated: 2026-05-04
+      </p>
+    </div>
+  </main>
+  <Footer />
+</Base>


### PR DESCRIPTION
## Summary

Captain reviewed the footer and asked for a holistic team review of the marketing site. Three experts (IA / chrome, brand / visual, content / positioning) converged on this PR's changes.

## Captain's directives (mandatory)

- [x] Remove the AI link from the footer
- [x] Add Terms and Privacy links
- [x] Add a link to venturecrane.com

## Brand-expert addition (Captain confirmed)

- [x] Drop the burnt-orange "SMD" filled block from both Nav and Footer logos. The colored-block treatment was the biggest visual mismatch with the practitioner-firm positioning authored 2026-05-03 (lawyers, doctors, craftsmen mark themselves with restrained wordmarks, not colored blocks). Burnt-orange budget remains healthy in CTA buttons and section markers where it carries semantic weight.

## Footer structure

Three regions, hairline-separated:

- **Region 1 — Masthead:** text-only "SMD Services" wordmark.
- **Region 2 — Two-column nav:** Left (conversion) `Book a Call · Contact`. Right (legal) `Terms · Privacy`.
- **Region 3 — Colophon:** "© 2026 SMDurgan, LLC, part of VentureCrane" left, "Phoenix, Arizona" right. VentureCrane is the inline link to https://venturecrane.com.

## New pages

- **`/terms`** — minimal honest stub. Engagement-specific terms live in SOW per engagement; public page is hygiene.
- **`/privacy`** — minimal honest stub. Captures what the site actually collects and what's done with it.

Both use `team@smd.services` as the contact address (matches the existing fallback in `/contact`).

## Out of scope (filed as follow-ups in plan)

These came up in the team review and warrant separate PRs:

1. `/book` FAQ "What size business is this for?" — qualification-gate violation matching the §05 failure mode.
2. `/ai` page "What We Won't Do With AI" — anti-promise section matching the §08 failure mode.
3. Mobile menu "§ 01 Contact" label confuses on non-home pages.
4. `DESIGN.md` describes a different visual identity than what's shipped; status check needed.

## Test plan

- [x] `npm run verify` passes locally
- [x] AI-rhetoric grep returns zero matches across changed files
- [x] No `href="/ai"` in Footer
- [x] No `bg-[color:var(--ss-color-primary)]` on logo spans in Nav or Footer
- [ ] Cloudflare preview: text-only wordmarks render in nav header and footer; `/terms` and `/privacy` resolve; VentureCrane link opens `https://venturecrane.com`; AI link gone from footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)