### PR TITLE
refine: match site CTAs to "Get in touch"

### DIFF
--- a/src/components/FinalCta.astro
+++ b/src/components/FinalCta.astro
@@ -11,7 +11,7 @@ import CtaButton from './CtaButton.astro'
     </p>
     <div class="mt-10">
       <CtaButton variant="outline-white" href="/book" data-ev="final-cta-book">
-        Book a Call
+        Get in touch
       </CtaButton>
     </div>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
     <!-- Region 2: Footer nav, two-column layout.
-         Left column: conversion paths (Book a Call, Contact). Useful on
+         Left column: conversion paths (Get in touch, Contact). Useful on
          pages without a FinalCta directly above the footer (/ai, /book,
          /contact).
          Right column: legal hygiene (Terms, Privacy). -->
@@ -26,7 +26,7 @@
       class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >
       <div class="flex flex-wrap gap-x-6 gap-y-2">
-        <a href="/book" class="hover:text-white" data-ev="footer-book">Book a Call</a>
+        <a href="/book" class="hover:text-white" data-ev="footer-book">Get in touch</a>
         <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>
       </div>
       <div class="flex flex-wrap gap-x-6 gap-y-2">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -20,7 +20,7 @@ import CtaButton from './CtaButton.astro'
         </h1>
         <div class="mt-10 md:mt-12 flex flex-col sm:flex-row items-stretch sm:inline-flex">
           <CtaButton href="/book" data-ev="home-primary-cta" class="w-full sm:w-auto">
-            Book a Call
+            Get in touch
           </CtaButton>
         </div>
       </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -31,7 +31,7 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
       <a
         class="inline-flex items-center whitespace-nowrap min-h-11 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] active:bg-[color:var(--ss-color-primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 px-3 md:px-5 py-2 font-['Archivo'] font-bold uppercase tracking-[0.08em] text-white text-xs md:text-sm transition-colors"
         href="/book"
-        data-ev="nav-book">Book a Call</a
+        data-ev="nav-book">Get in touch</a
       >
       <button
         type="button"
@@ -107,7 +107,7 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
         data-nav-link
         data-ev="nav-mobile-book"
         class="flex w-full items-center justify-center whitespace-nowrap border-[3px] border-white bg-[color:var(--ss-color-primary)] hover:bg-[color:var(--ss-color-primary-hover)] px-5 py-4 font-['Archivo'] text-base font-bold uppercase tracking-[0.08em] text-white transition-colors"
-        >Book a Call</a
+        >Get in touch</a
       >
     </div>
   </div>

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -71,7 +71,7 @@ const faqSchema = {
           Some of what you're hearing about AI is useful. A lot of it is noise. We help you sort it
           out.
         </p>
-        <CtaButton href="/book" data-ev="ai-primary-cta">Book a Call</CtaButton>
+        <CtaButton href="/book" data-ev="ai-primary-cta">Get in touch</CtaButton>
       </div>
     </section>
 

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -59,7 +59,7 @@ if (prefillToken) {
 
 <Base
   title="Let's Talk | SMD Services"
-  description="Tell us about your business. Book a call directly, or send a note and we'll reach out."
+  description="Tell us about your business. Get in touch and we'll take it from there."
 >
   <Nav />
   <main id="main" role="main">
@@ -100,7 +100,7 @@ if (prefillToken) {
           )
         }
 
-        <!-- Slot picker — hidden until the prospect clicks "Book a call" -->
+        <!-- Slot picker — hidden until the prospect clicks "Pick a time to talk" post-Send -->
         <div
           id="slot-picker-section"
           hidden


### PR DESCRIPTION
## Summary

After PR #684 changed \`/book\`'s primary CTA to "Get in touch," the Nav, Footer, Hero, FinalCta, and /ai page CTAs were still labeled "Book a Call" — pointing to \`/book\` but signaling an action different from what the page itself offers. Captain flagged the mismatch.

## Changes

- Nav (desktop + mobile): "Book a Call" → "Get in touch"
- Footer nav link: same
- Hero (home page primary): same
- FinalCta: same
- /ai primary CTA: same
- /book meta description updated to match new flow
- One stale code comment in book.astro updated

\`data-ev\` attributes kept for telemetry continuity. Generic prose in \`/privacy\` (data-collection description) left as-is.

## Test plan

- [x] \`npm run verify\` — clean
- [ ] Browser smoke: Nav, Footer, Hero, FinalCta, /ai all show "Get in touch"; clicking still routes to /book
- [ ] Mobile menu shows "Get in touch" as the bottom CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)