### PR TITLE
refine(chrome): restore filled-monogram wordmark (refined)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,15 +2,22 @@
   class="border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-surface-inverse)] text-white"
 >
   <div class="mx-auto w-full max-w-5xl px-6">
-    <!-- Region 1: Masthead. Text-only wordmark, no filled-block accent.
-         Practitioner-firm register: a lawyer's office or doctor's practice
-         marks itself with a wordmark, not a colored block. -->
+    <!-- Region 1: Masthead. Refined filled-monogram wordmark — orange "SMD"
+         block + Archivo Narrow Semibold mixed-case "Services" descriptor.
+         The earlier text-only "practitioner-firm register" treatment was a
+         category error for a pre-launch firm with no name equity yet; one
+         deliberate visual anchor (the block) does the recognition work. -->
     <div class="py-12 md:py-14">
       <a
         href="/"
-        class="inline-block font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-white hover:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
+        aria-label="SMD Services"
+        class="inline-flex items-baseline gap-2 text-xl md:text-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
       >
-        SMD Services
+        <span
+          class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
+          >SMD</span
+        >
+        <span class="font-['Archivo_Narrow'] font-semibold leading-none text-white">Services</span>
       </a>
     </div>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,9 +11,17 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
   >
     <a
       href="/"
-      class="inline-block font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)] active:text-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      aria-label="SMD Services"
+      class="inline-flex items-baseline gap-2 text-base md:text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
     >
-      SMD Services
+      <span
+        class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
+        >SMD</span
+      >
+      <span
+        class="font-['Archivo_Narrow'] font-semibold leading-none text-[color:var(--ss-color-text-primary)]"
+        >Services</span
+      >
     </a>
 
     <div class="flex items-center gap-3 md:gap-6">
@@ -62,10 +70,15 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
     <div class="flex h-14 flex-none items-center justify-between px-4 border-b-[3px] border-white">
       <a
         href="/"
-        class="inline-block font-['Archivo'] text-base font-black uppercase tracking-[-0.01em] text-white"
+        aria-label="SMD Services"
+        class="inline-flex items-baseline gap-2 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--ss-color-surface-inverse)]"
         data-nav-link
       >
-        SMD Services
+        <span
+          class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
+          >SMD</span
+        >
+        <span class="font-['Archivo_Narrow'] font-semibold leading-none text-white">Services</span>
       </a>
       <button
         type="button"


### PR DESCRIPTION
## Summary

Captain reviewed the chrome and flagged the plain "SMD SERVICES" wordmark as a design regression. PR #685 had stripped the orange filled-block "SMD" anchor in favor of plain Archivo Black uppercase, on the rationale of "practitioner-firm register" (lawyer/doctor wordmarks).

A senior brand-identity expert pass identified that reasoning as a category error: firms like Cravath or McKinsey can drop visual identity because the name itself has 200 years of equity. SMD is pre-launch with zero recognition; the right reference class is Linear / Stripe / Basecamp / Pentagram — firms whose wordmark uses either bespoke letterforms OR a color anchor. Plain stock-typeface uppercase isn't restraint; it's the default state of any unstyled project.

Bringing the orange block back, **refined** per expert spec:

- **Rectangular block** (not square): tight horizontal padding (\`px-1.5\`) proportioned to cap-height of "SMD." Compact, deliberate, not chunky.
- **"Services" in Archivo Narrow Semibold mixed-case** (not Archivo Black uppercase): clean typographic hierarchy — "SMD" is the brand, "Services" is the descriptor. Different role, different register.
- **Tightened gap** (\`gap-2\`) so block + descriptor read as a single mark.
- **\`items-baseline\` alignment** so "Services" sits on the same baseline as "SMD" inside the block.
- **\`aria-label="SMD Services"\`** on each wordmark link (split-span structure could otherwise read awkwardly to screen readers).

Applied in three locations:
- Nav header (cream bg, ~16-18px)
- Nav mobile menu dialog (dark warm-brown bg)
- Footer masthead (dark warm-brown bg, ~24px)

Two files. CSS-only. No new dependencies.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run test\` — 2062 passing
- [x] \`npm run build\` — clean
- [ ] Browser smoke: orange "SMD" block visible in Nav (cream), Footer (dark), and mobile menu (dark) at appropriate scales. "Services" sits on the same baseline as "SMD" in all three.
- [ ] No layout shift vs. existing chrome height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)