### PR TITLE
refine(wordmark): all-caps SERVICES descriptor with optical tracking

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,11 +2,11 @@
   class="border-t-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-surface-inverse)] text-white"
 >
   <div class="mx-auto w-full max-w-5xl px-6">
-    <!-- Region 1: Masthead. Refined filled-monogram wordmark — orange "SMD"
-         block + Archivo Narrow Semibold mixed-case "Services" descriptor.
-         The earlier text-only "practitioner-firm register" treatment was a
-         category error for a pre-launch firm with no name equity yet; one
-         deliberate visual anchor (the block) does the recognition work. -->
+    <!-- Region 1: Masthead. Filled-monogram wordmark — orange "SMD" block +
+         Archivo Narrow Semibold all-caps "SERVICES" descriptor. Matched
+         cap-height locks the two halves into a single mark; width-contrast
+         (Archivo Black vs Archivo Narrow) does the visual work that
+         case-contrast was failing to do. -->
     <div class="py-12 md:py-14">
       <a
         href="/"
@@ -17,7 +17,10 @@
           class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
           >SMD</span
         >
-        <span class="font-['Archivo_Narrow'] font-semibold leading-none text-white">Services</span>
+        <span
+          class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-white"
+          >Services</span
+        >
       </a>
     </div>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -19,7 +19,7 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
         >SMD</span
       >
       <span
-        class="font-['Archivo_Narrow'] font-semibold leading-none text-[color:var(--ss-color-text-primary)]"
+        class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-[color:var(--ss-color-text-primary)]"
         >Services</span
       >
     </a>
@@ -78,7 +78,10 @@ const navLinks = [{ href: '/contact', label: 'Contact' }]
           class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
           >SMD</span
         >
-        <span class="font-['Archivo_Narrow'] font-semibold leading-none text-white">Services</span>
+        <span
+          class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-white"
+          >Services</span
+        >
       </a>
       <button
         type="button"


### PR DESCRIPTION
## Summary

- Wordmark descriptor switches from mixed-case "Services" to all-caps "SERVICES" with `tracking-[0.08em]`
- Applied to all three lockup locations: Nav header, mobile menu dialog, Footer masthead
- Captain instinct + independent senior-brand-expert agent both landed on the same call

## Why

Matched cap-height locks the two halves into a single readable mark instead of reading as a signal (the SMD block) plus a separate word. Width-contrast (Archivo Black vs Archivo Narrow Semibold) does the visual work that case-contrast was failing to do — the mixed "S/ervices" descender was softening exactly where the lockup needed to feel locked.

At nav scale (16–18px) word-shape recognition of "Services" provides little real benefit; the unified mark wins. The `tracking-[0.08em]` optical loosening is non-optional — Archivo Narrow at all-caps without it reads cramped against the SMD block.

Reference class: IBM Consulting, BCG — both pair a strong brand block with all-caps descriptor as one mark.

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, build, all tests)
- [ ] Visual: Nav header — "SMD" block + "SERVICES" descriptor read as one mark
- [ ] Visual: Mobile menu dialog (dark bg) — same lockup, white text variant
- [ ] Visual: Footer masthead (dark bg, ~24px) — larger scale validates the casing call holds at size
- [ ] Mobile viewport: lockup remains balanced; no clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)