### PR TITLE
refine(legal): polish Terms & Privacy + contact-form CTA + casing

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro'
 
 <Base
   title="Privacy | SMD Services"
-  description="Privacy policy for smd.services. We collect only what you provide directly and use it only to respond to you."
+  description="Privacy policy for the SMD Services website. We collect only what you provide directly and use it only to respond to you."
 >
   <Nav />
   <main id="main" role="main" class="bg-[color:var(--ss-color-background)] px-6 py-20 md:py-24">
@@ -17,35 +17,97 @@ import Footer from '../components/Footer.astro'
         Privacy
       </h1>
 
-      <div
-        class="mt-10 space-y-6 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
-      >
-        <p>
-          smd.services collects only the information you provide directly: form submissions for
-          inquiries, scheduling data when you book a call, and email content when you contact us. We
-          use it only to respond to you and prepare for our conversation. We do not sell, rent, or
-          share this information with third parties.
-        </p>
-
-        <p>
-          The site uses minimal session cookies required for the booking flow. We do not run
-          third-party advertising trackers or behavioral profiling.
-        </p>
-
-        <p>
-          Email <a
-            href="mailto:team@smd.services"
-            class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
-            >team@smd.services</a
-          > with any privacy question or to request deletion of your information.
-        </p>
-      </div>
-
       <p
-        class="mt-12 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+        class="mt-3 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
       >
-        Last updated: 2026-05-04
+        Effective: 2026-05-04
       </p>
+
+      <div
+        class="mt-10 space-y-10 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+      >
+        <p>
+          We collect only what you give us, use it to respond and prepare for our conversation, and
+          never sell or share it with third parties.
+        </p>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            What we collect
+          </h2>
+          <p>
+            Information you submit through forms on this site, including your name, email, and
+            message. Scheduling data when you book a call. Email content when you reach out to us
+            directly.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            How we use it
+          </h2>
+          <p>
+            To respond to your inquiry, prepare for our conversation, and deliver the work if we are
+            engaged. We do not sell, rent, or share this information with third parties.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Service providers
+          </h2>
+          <p>
+            We use a small set of operational service providers, including web hosting, email
+            delivery, and scheduling, under standard confidentiality terms. They process information
+            only as needed to support the site and our communication with you.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Cookies and tracking
+          </h2>
+          <p>
+            We use minimal session cookies required for the booking flow. We do not run third-party
+            advertising trackers or behavioral profiling.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Your rights
+          </h2>
+          <p>
+            You can request a copy of any information we hold about you, or ask us to delete it.
+            Reach out and we will respond within a reasonable time.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Contact
+          </h2>
+          <p>
+            For any privacy question, <a
+              href="/contact"
+              class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              >reach out through our contact form</a
+            >.
+          </p>
+        </section>
+      </div>
     </div>
   </main>
   <Footer />

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -5,8 +5,8 @@ import Footer from '../components/Footer.astro'
 ---
 
 <Base
-  title="Terms | SMD Services"
-  description="Terms of use for the smd.services website. Engagement-specific terms are documented in the Statement of Work for each engagement."
+  title="Terms of Use | SMD Services"
+  description="Terms of use for the SMD Services website. Engagement-specific terms are documented in the Statement of Work for each engagement."
 >
   <Nav />
   <main id="main" role="main" class="bg-[color:var(--ss-color-background)] px-6 py-20 md:py-24">
@@ -14,47 +14,100 @@ import Footer from '../components/Footer.astro'
       <h1
         class="font-['Archivo'] text-4xl md:text-5xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
       >
-        Terms
+        Terms of Use
       </h1>
 
-      <div
-        class="mt-10 space-y-6 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
-      >
-        <p>
-          These terms govern your use of the smd.services website. Engagement-specific terms,
-          including scope, deliverables, schedule, pricing, and obligations, are documented in the
-          Statement of Work for each engagement and supersede anything stated here.
-        </p>
-
-        <p>
-          The site is provided as-is. We make no warranty about uninterrupted availability or
-          fitness for any particular purpose.
-        </p>
-
-        <p>
-          Content on this site, including text, design, code, and images, is owned by SMDurgan, LLC.
-          Use beyond personal browsing requires written permission.
-        </p>
-
-        <p>
-          Arizona law governs these terms. Any disputes are resolved in courts in Maricopa County,
-          Arizona.
-        </p>
-
-        <p>
-          Questions: <a
-            href="mailto:team@smd.services"
-            class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
-            >team@smd.services</a
-          >.
-        </p>
-      </div>
-
       <p
-        class="mt-12 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
+        class="mt-3 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
       >
-        Last updated: 2026-05-04
+        Effective: 2026-05-04
       </p>
+
+      <div
+        class="mt-10 space-y-10 font-['Archivo'] text-lg leading-relaxed text-[color:var(--ss-color-text-primary)]"
+      >
+        <p>
+          These terms apply to your use of the SMD Services website. Engagement-specific terms,
+          including scope, deliverables, schedule, pricing, and obligations, are documented in the
+          Statement of Work signed for each engagement and supersede anything stated here.
+        </p>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            The site
+          </h2>
+          <p>
+            The site is provided as-is. We make no warranty about uninterrupted availability or
+            fitness for any particular purpose. Information presented is general and does not
+            constitute professional advice for your specific situation.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Intellectual property
+          </h2>
+          <p>
+            Content on this site, including text, design, code, and images, is owned by SMDurgan,
+            LLC. Use beyond personal browsing requires written permission.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            No reliance
+          </h2>
+          <p>
+            Visiting this site does not create a consulting relationship. A relationship begins only
+            when both parties sign a Statement of Work.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Governing law
+          </h2>
+          <p>
+            Arizona law governs these terms. Any disputes are resolved in the state and federal
+            courts of Maricopa County, Arizona.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Changes
+          </h2>
+          <p>
+            We may update these terms from time to time. The effective date above reflects the most
+            recent revision.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            class="mb-3 font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)]"
+          >
+            Contact
+          </h2>
+          <p>
+            For any question about these terms, <a
+              href="/contact"
+              class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              >reach out through our contact form</a
+            >.
+          </p>
+        </section>
+      </div>
     </div>
   </main>
   <Footer />


### PR DESCRIPTION
## Summary

Captain noted three issues on the Terms and Privacy pages:

1. **Polish & professionalism.** Both pages were 3-5 short paragraphs with no structure. Restructured with sectional `h2` eyebrows and a top-of-page "Effective" date, the standard shape for legal pages. Added missing-but-standard clauses: no-reliance, governing-law, and changes-to-terms on Terms; service-providers and your-rights on Privacy. Plain-English lead paragraph on Privacy.
2. **Contact form, not email.** `mailto:team@smd.services` links replaced with anchors to `/contact`. Better UX (single talk-to-us surface) and removes the email from page source for spam hygiene.
3. **Casing.** "smd.services" in body copy treated the firm as a domain string. The firm is **SMD Services**; reserve `smd.services` for literal domain references. The subject of "collects" is now "We" (firm voice), not the domain.

## Visual

- H1 chrome unchanged ("PRIVACY" / "TERMS OF USE" — Archivo Black uppercase).
- Sub-sections use Archivo Narrow small caps in primary orange, matching the existing eyebrow vocabulary across the site.
- `space-y-10` between sections lets the page breathe.

## Voice

- "We" voice throughout (these aren't About).
- No em dashes. No phrase-level AI markers.
- No fixed-timeframe commitments. No fabricated content.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — clean (only pre-existing warnings in unrelated files)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm run test` — 2062/2062 pass
- [x] `tests/forbidden-strings.test.ts` — 47/47 pass (em-dash + voice guards)
- [x] `tests/landing-page.test.ts` — 25/25 pass
- [x] Local dev visual check on `/privacy` and `/terms`
- [ ] Visual check on preview deploy
- [ ] Click "reach out through our contact form" link from each page lands on `/contact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)