### PR TITLE
perf(book): lazy-fetch /api/booking/slots until picker is revealed

### DIFF
--- a/src/components/booking/SlotPicker.astro
+++ b/src/components/booking/SlotPicker.astro
@@ -508,7 +508,8 @@
       }
     })
 
-    // Public method for parent to refetch (e.g., after a 409)
+    // Public method for parent to fetch (first reveal) or refetch (after a 409).
+    // Idempotent on repeated calls within the stale window.
     picker.refetchSlots = fetchSlots
 
     // Public method to get guest tz
@@ -516,7 +517,9 @@
       return guestTz
     }
 
-    // Initial fetch
-    fetchSlots()
+    // No automatic fetch on mount. /book hides the slot-picker section until
+    // the user clicks "Pick a time to talk" post-Send; fetching slots eagerly
+    // wastes a /api/booking/slots round trip on every visitor (most never open
+    // the picker). The parent calls picker.refetchSlots() when revealing.
   })()
 </script>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -677,9 +677,17 @@ if (prefillToken) {
       // button. Defensively gated on `sendSucceeded` so a stale offer can't
       // open the slot picker without a captured lead behind it.
 
+      let slotsFetched = false
       intakeRoot.addEventListener('unified-pick-time', () => {
         if (!sendSucceeded || !submittedData) return
         slotPickerSection.hidden = false
+        // Lazy-fetch: SlotPicker no longer auto-fetches on mount (saves one
+        // /api/booking/slots round trip per visit for the majority of users
+        // who never open the picker). Trigger the first fetch on reveal.
+        if (!slotsFetched && picker.refetchSlots) {
+          picker.refetchSlots()
+          slotsFetched = true
+        }
         slotPickerSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
       })
 


### PR DESCRIPTION
## Summary

- SlotPicker no longer auto-fetches `/api/booking/slots` on mount
- `/book` triggers the first fetch when the user clicks "Pick a time to talk" post-Send
- `slotsFetched` flag guards against double-fetch on repeat reveals; 409 retry path still bypasses to re-fetch fresh

## Why

Measured live on production — Performance Resource API showed `/api/booking/slots` firing at 143ms after navigation with a 325ms duration on every visit, even when the slot-picker section was `[hidden]`. The majority of /book visitors never open the slot picker (they Send or bounce), so this was wasted backend work and JSON parsing on every visit.

This is one of two perf issues identified in the diagnosis. The other one (lazy-render Turnstile) is deferred per Captain's decision. Autofill behavior is also unaddressed in this PR — the most likely lever there is the honeypot field structure, also deferred for a separate decision.

## Test plan

- [x] `npm run verify` passes
- [ ] Live: open `/book` → DevTools Network tab shows NO request to `/api/booking/slots` on initial page load
- [ ] Live: fill form, click "Get in touch" → AI reply renders → click "Pick a time to talk" → /api/booking/slots fires once, slot picker calendar renders normally
- [ ] Live: pick a slot, attempt to book, force a 409 (slot taken simultaneously) → picker re-fetches fresh slots (existing 409 path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)