### PR TITLE
refine: separate /contact (general comms) from /book (lead intake)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,17 +27,20 @@
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
     <!-- Region 2: Footer nav, two-column layout.
-         Left column: conversion paths (Get in touch, Contact). Useful on
-         pages without a FinalCta directly above the footer (/ai, /book,
-         /contact).
+         Left column: corporate parent (VentureCrane) — quietly visible, no
+         "part of" subordination.
          Right column: legal hygiene (Terms, Privacy). -->
     <nav
       aria-label="Footer"
       class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >
       <div class="flex flex-wrap gap-x-6 gap-y-2">
-        <a href="/book" class="hover:text-white" data-ev="footer-book">Get in touch</a>
-        <a href="/contact" class="hover:text-white" data-ev="footer-contact">Contact</a>
+        <a
+          href="https://venturecrane.com"
+          rel="noopener"
+          class="hover:text-white"
+          data-ev="footer-venturecrane">VentureCrane</a
+        >
       </div>
       <div class="flex flex-wrap gap-x-6 gap-y-2">
         <a href="/terms" class="hover:text-white" data-ev="footer-terms">Terms</a>
@@ -47,20 +50,11 @@
 
     <div class="h-px bg-[color:rgba(245,240,227,0.16)]"></div>
 
-    <!-- Region 3: Colophon. Legal entity + parent company on the left,
-         location on the right. VentureCrane link is the inline anchor inside
-         the corporate identity line, not a standalone nav item. -->
+    <!-- Region 3: Colophon. Legal entity on the left, location on the right. -->
     <div
       class="py-6 md:py-7 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-0 font-['Archivo_Narrow'] text-xs uppercase tracking-[0.12em] text-[color:var(--ss-color-text-muted)]"
     >
-      <span>
-        &copy; 2026 SMDurgan, LLC, part of <a
-          href="https://venturecrane.com"
-          rel="noopener"
-          class="hover:text-white"
-          data-ev="footer-venturecrane">VentureCrane</a
-        >
-      </span>
+      <span>&copy; 2026 SMDurgan, LLC</span>
       <span>Phoenix, Arizona</span>
     </div>
   </div>

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -71,7 +71,7 @@ if (prefillToken) {
       <div class="mx-auto max-w-3xl">
         <header class="mb-6">
           <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)] sm:text-4xl">
-            Tell us where you're trying to go.
+            Tell us about your business.
           </h1>
         </header>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,10 +8,7 @@ import Footer from '../components/Footer.astro'
   <Nav />
   <main id="main" role="main" class="px-6 py-20">
     <div class="mx-auto max-w-xl">
-      <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)]">Get in Touch</h1>
-      <p class="mt-2 text-lg text-[color:var(--ss-color-text-secondary)]">
-        Have a question or want to talk about your business? Send us a message.
-      </p>
+      <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)]">Contact Us</h1>
 
       <div id="form-status" class="mt-6" aria-live="polite"></div>
 


### PR DESCRIPTION
## Summary

Two surfaces, two intents — they were leaning on the same words and that read confused. This PR splits them.

- **`/contact` heading** — "Get in Touch" → "Contact Us". Matches the nav link, sheds the collision with the lead-CTA wording. Subtitle removed; the form's purpose is clear from the surrounding context (and from how visitors arrive — typically via the Contact link or from `/terms`/`/privacy`).
- **`/book` heading** — "Tell us where you're trying to go." → "Tell us about your business." A direct ask, anchored on the prospect's situation rather than an aspirational frame.
- **Footer** — drop the conversion-paths column ("Get in touch", "Contact"). The `Get in Touch` nav CTA is the single front door for leads, and `/contact` is a low-stakes secondary surface that doesn't need footer promotion. Drop "part of VentureCrane" subordination in the colophon and reposition `VentureCrane` as a quiet peer link in the footer nav (left of Terms/Privacy).

## Scope

| Surface | Now | Before |
| --- | --- | --- |
| `/contact` h1 | "Contact Us" | "Get in Touch" |
| `/contact` subtitle | _(removed)_ | "Have a question or want to talk about your business? Send us a message." |
| `/book` h1 | "Tell us about your business." | "Tell us where you're trying to go." |
| Footer nav left | `VentureCrane` (link) | `Get in touch` · `Contact` |
| Footer colophon | `© 2026 SMDurgan, LLC` · `Phoenix, Arizona` | `© 2026 SMDurgan, LLC, part of VentureCrane` · `Phoenix, Arizona` |

## Voice

- "We" voice (not About).
- No em dashes. No phrase-level AI markers.
- No fixed-timeframe commitments. No fabricated content.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — clean (only pre-existing warnings in unrelated test files)
- [x] `npm run format:check` — clean
- [x] `npm run test` — green across all worker subdirs
- [ ] Visual check on preview: `/contact` heading reads "Contact Us" with no subtitle
- [ ] Visual check on preview: `/book` heading reads "Tell us about your business."
- [ ] Visual check on preview: footer shows `VentureCrane` link (no `Get in touch` / `Contact`); colophon reads `© 2026 SMDurgan, LLC` with no parental framing
- [ ] Click `VentureCrane` in footer → navigates to https://venturecrane.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)