### PR TITLE
refine(/contact): drop placeholder text from form fields

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -26,8 +26,7 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="200"
             autocomplete="name"
-            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            placeholder="Your name"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           />
         </div>
 
@@ -44,8 +43,7 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="254"
             autocomplete="email"
-            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            placeholder="you@example.com"
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           />
         </div>
 
@@ -61,8 +59,8 @@ import Footer from '../components/Footer.astro'
             required
             maxlength="5000"
             rows="6"
-            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            placeholder="What's on your mind?"></textarea>
+            class="w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-[color:var(--ss-color-text-primary)] focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          ></textarea>
         </div>
 
         {/* Honeypot — hidden from real users */}


### PR DESCRIPTION
## Summary

Labels already say "Name", "Email", "Message" — the placeholders ("Your name", "you@example.com", "What's on your mind?") just repeat the same information in lighter type. Visitors don't need a hint about what an email field expects. Removing the noise.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — clean (only pre-existing warnings in unrelated test files)
- [x] `npm run format:check` — clean
- [ ] Visual check on preview: `/contact` form fields render with empty inputs and visible labels above each

🤖 Generated with [Claude Code](https://claude.com/claude-code)