### PR TITLE
feat(commands): add /new-client and /new-engagement slash commands

### DIFF
--- a/.claude/commands/new-client.md
+++ b/.claude/commands/new-client.md
@@ -1,0 +1,104 @@
+# /new-client - Set Up a New SS Client
+
+Adds a client entity under the SS venture. A client is the billing entity; engagements (the unit of work) live underneath.
+
+This is **wiring**, not process — no SOW, kickoff, lifecycle states, or templates. Just the registry and Infisical entries needed for `/new-engagement` to work for that client.
+
+## Prerequisites (one-time, manual)
+
+These must already be done before any client can be onboarded. See `docs/process/new-engagement-setup-checklist.md` for details:
+
+1. `smdservices-clients` GitHub org exists
+2. `smdservices-platform` GitHub App created and installed on the org
+3. `INFISICAL_MANAGEMENT_TOKEN` set as a secret on `crane-context` (staging + production), scoped to `/ss/clients/*`
+4. `smdservices-clients/engagement-template` repo exists with branch protection on `main` and CODEOWNERS pointing to Captain
+
+## Execution
+
+### Step 1: Gather information
+
+Ask the user for:
+
+- **Client slug** (kebab-case, regex `^[a-z][a-z0-9-]{1,31}$`, e.g., `acme`)
+- **Display name** (e.g., `Acme Co`)
+- **Client GitHub org** (optional override — leave blank unless the client wants their work in their own org)
+
+Confirm before proceeding.
+
+### Step 2: Verify uniqueness
+
+```bash
+jq -e ".ventures[] | select(.code == \"ss\") | .clients[]? | select(.slug == \"<slug>\")" config/ventures.json && echo "EXISTS"
+```
+
+If the client exists, abort.
+
+### Step 3: Append to ventures.json
+
+```bash
+cp config/ventures.json config/ventures.json.bak
+jq --arg slug "<slug>" --arg name "<displayName>" --arg org "<githubOrg-or-default>" '
+  (.ventures[] | select(.code == "ss") | .clients) += [{
+    "slug": $slug,
+    "displayName": $name,
+    "githubOrg": $org,
+    "infisicalPath": "/ss/clients/\($slug)",
+    "engagements": []
+  }]
+' config/ventures.json > config/ventures.json.tmp
+jq empty config/ventures.json.tmp || { mv config/ventures.json.bak config/ventures.json; exit 1; }
+mv config/ventures.json.tmp config/ventures.json
+rm -f config/ventures.json.bak
+```
+
+If the venture entry has no `clients` array yet, the jq above creates it via `+=` on null returning `null` — initialize first if needed:
+
+```bash
+jq '(.ventures[] | select(.code == "ss") | .clients) //= []' config/ventures.json > config/ventures.json.tmp && mv config/ventures.json.tmp config/ventures.json
+```
+
+### Step 4: Provision Infisical folder
+
+```bash
+curl -fsS -X POST "$CRANE_CONTEXT_URL/admin/provision-engagement" \
+  -H "X-Admin-Key: $CRANE_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"client_slug\":\"<slug>\"}"
+```
+
+Idempotent — existing folder returns success.
+
+### Step 5: Create local directory
+
+```bash
+mkdir -p ~/dev/ss/<slug>/
+```
+
+This is where engagements for this client will be cloned.
+
+### Step 6: Commit + redeploy
+
+```bash
+git add config/ventures.json
+git commit -m "chore(ss): add client <slug>"
+git push
+cd workers/crane-context && npm run deploy && npm run deploy:prod
+cd packages/crane-mcp && npm run build
+```
+
+The crane-context worker imports `ventures.json` at build time — redeploy is required for the new client to be visible to the worker. Rebuilding crane-mcp picks up the new client in the launcher's `INFISICAL_PATHS` map.
+
+### Step 7: Verify
+
+```bash
+crane --list  # Should show the new client (no engagements yet) under SS
+```
+
+The user can now run `/new-engagement <slug> <engagement-slug> "<name>"` to create the first engagement.
+
+## Reference Files
+
+- **ventures.json:** `config/ventures.json` (single source of truth)
+- **Provisioning endpoint:** `workers/crane-context/src/endpoints/admin-provision-engagement.ts`
+- **Engagement skill:** `.claude/commands/new-engagement.md`
+- **Setup checklist:** `docs/process/new-engagement-setup-checklist.md`

--- a/.claude/commands/new-engagement.md
+++ b/.claude/commands/new-engagement.md
@@ -1,0 +1,72 @@
+# /new-engagement - Set Up a New SS Engagement
+
+Creates a new engagement repo under an existing client and wires it into the launcher. An engagement is the unit of billable work for a client.
+
+This is **wiring**, not process — no SOW scaffolding, kickoff documents, status reporting cadence, or lifecycle states. The agent inside the engagement repo writes whatever the engagement actually needs.
+
+## Prerequisites
+
+The client must already exist. Run `/new-client <slug> "<name>"` first if needed.
+
+Manual one-time prereqs (`docs/process/new-engagement-setup-checklist.md`): `smdservices-clients` GitHub org exists, `smdservices-platform` GitHub App installed, `INFISICAL_MANAGEMENT_TOKEN` configured on `crane-context`, `engagement-template` repo exists with branch protection.
+
+## Execution
+
+### Step 1: Gather information
+
+Ask the user for:
+
+- **Client slug** (must already exist in `config/ventures.json` under SS clients)
+- **Engagement slug** (kebab-case, regex `^[a-z][a-z0-9-]{1,31}$`, unique within the client)
+- **Display name**
+
+Verify the client exists:
+
+```bash
+jq -e ".ventures[] | select(.code == \"ss\") | .clients[] | select(.slug == \"<client>\")" config/ventures.json
+```
+
+### Step 2: Run the setup script
+
+```bash
+./scripts/setup-new-engagement.sh <client-slug> <engagement-slug> "<display-name>"
+```
+
+**Dry run first** to preview what will happen:
+
+```bash
+DRY_RUN=true ./scripts/setup-new-engagement.sh <client-slug> <engagement-slug> "<display-name>"
+```
+
+The script handles, in order:
+
+1. Validation (args, client exists, slug uniqueness within client)
+2. **Infisical provisioning first** (folder creation via crane-context `/admin/provision-engagement`) — fails before any registry mutation if Infisical is down
+3. GitHub repo creation from `smdservices-clients/engagement-template` (or `<client.githubOrg>/engagement-template` for external-repo clients)
+4. ventures.json append (with backup + ERR trap rollback covering the rest of the script)
+5. Clone to `~/dev/ss/<client>/<engagement>/`
+6. Drop `.infisical.json` and `.claude/settings.json` (with `additionalDirectories` locked to the engagement path only)
+7. Commit + push initial scaffold
+8. Rebuild crane-mcp (so the launcher sees the new engagement)
+9. Redeploy crane-context (so the worker sees the new engagement)
+
+### Step 3: Verify
+
+```bash
+crane --list                              # Should show ss/<client>/<engagement>
+crane ss/<client>/<engagement> --debug    # Confirms launcher resolves and fetches secrets via crane-context proxy
+```
+
+If the agent doesn't launch, check:
+
+- `gh repo view smdservices-clients/<client>-<engagement>` — repo exists
+- `crane-context` deployed with the new ventures.json baked in
+- `INFISICAL_MANAGEMENT_TOKEN` set on the worker
+
+## Reference Files
+
+- **Setup script:** `scripts/setup-new-engagement.sh`
+- **Provisioning endpoints:** `workers/crane-context/src/endpoints/admin-provision-engagement.ts`
+- **Launcher dispatch:** `packages/crane-mcp/src/cli/launch-lib.ts` (search `parseEngagementArg`, `launchEngagement`)
+- **Setup checklist:** `docs/process/new-engagement-setup-checklist.md`
+- **Client skill:** `.claude/commands/new-client.md`


### PR DESCRIPTION
## Summary

- Adds `/new-client` slash command (104 lines) — registers a billing entity under the SS venture and provisions Infisical entries.
- Adds `/new-engagement` slash command (72 lines) — creates an engagement repo under an existing client and wires it into the launcher.

Both are **wiring only** — no SOW scaffolding, kickoff documents, lifecycle states, or templates. The agent inside the engagement repo is responsible for whatever the engagement actually needs.

## Test plan

- [ ] Confirm both commands appear in the slash command picker after merge
- [ ] Dry-run `/new-client` against the registry to verify the wiring path
- [ ] Dry-run `/new-engagement` for an existing client to verify the launcher hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)