### PR TITLE
fix(/book): hide Turnstile widget via appearance: interaction-only

### DIFF
--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -466,6 +466,7 @@ if (prefillToken) {
         container: HTMLElement,
         options: {
           sitekey: string
+          appearance?: 'always' | 'execute' | 'interaction-only'
           callback?: () => void
           'expired-callback'?: () => void
           'error-callback'?: () => void
@@ -540,6 +541,15 @@ if (prefillToken) {
           if (ts && !turnstileReady) {
             turnstileWidgetId = ts.render(turnstileContainer, {
               sitekey: turnstileSiteKey,
+              // 'interaction-only' hides the widget for visitors who pass
+              // the silent challenge (the vast majority). The visible
+              // "Verifying..." Cloudflare-branded box was undermining the
+              // page's polish without adding security: the silent challenge
+              // already runs and produces a token regardless of appearance.
+              // For the small fraction of visitors flagged as needing an
+              // interactive challenge, the widget appears for them — at
+              // which point seeing it is the expected affordance.
+              appearance: 'interaction-only',
               callback: () => {},
               'expired-callback': () => {},
               'error-callback': () => {},


### PR DESCRIPTION
## Summary

Captain reported the visible "Verifying..." Cloudflare-branded widget below the /book form was undermining the page's polish. PR #700 (idle-render) addressed main-thread cost but missed the actual visual artifact — the widget itself was still visibly rendered after the idle callback fired.

This PR adds \`appearance: 'interaction-only'\` to the \`ts.render()\` call. Per Cloudflare docs, with managed widget type this hides the widget for visitors who pass the silent challenge (the vast majority). The widget only appears for visitors flagged as needing an interactive challenge — and for those, seeing the widget is the expected affordance.

## What changed

- \`src/pages/book.astro\` — added \`appearance: 'interaction-only'\` to \`ts.render()\` options, plus expanded the local \`TurnstileApi\` type so typecheck catches future drift.

## What did NOT change

- Bot defense layers: silent Turnstile challenge still runs and produces a token regardless of appearance setting. \`rendered_at\` 2s timestamp check unchanged. IP rate limit (10/hr) unchanged. Server-side verify call identical.
- Idle-render scheduling from PR #700 is preserved.

## Test plan

- [x] \`npm run verify\` — typecheck + lint + format + build + tests (2062 pass)
- [ ] Production smoke: open https://smd.services/book, confirm no visible "Verifying..." widget below form
- [ ] Production smoke: fill form, submit "Get in touch", confirm Send path completes (silent challenge token still works)
- [ ] Production smoke: pick a time, click "Book Your Call", confirm calendar booking still completes

## Reference

[Cloudflare Turnstile appearance modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes) — \`interaction-only\` "shows the widget only when visitor interaction is required, offering the cleanest experience as most visitors will not see it."