### PR TITLE
feat(analytics): install GA4 on apex marketing surface (smd.services)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,10 @@
+# GA4 measurement ID. Captain populates after creating the property in
+# analytics.google.com (Admin → Data Streams → Web stream for smd.services).
+# Blank → Analytics.astro renders nothing (safe-merge state).
+PUBLIC_GA4_MEASUREMENT_ID=
+
+# Hosts treated as internal (filtered out / tagged traffic_type=internal).
+# Localhost + Cloudflare Workers preview hosts. To flag your prod browser
+# as internal, visit any page on smd.services with ?internal=1 — sets a
+# localStorage flag that persists across visits until cleared with ?internal=0.
+PUBLIC_GA4_INTERNAL_HOST_PATTERNS=localhost,127.0.0.1,*.workers.dev

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 # Environment
 .env
 .env.*
+!.env.production
 .dev.vars
 
 # Cloudflare

--- a/public/js/ga4-init.js
+++ b/public/js/ga4-init.js
@@ -1,0 +1,77 @@
+;(function () {
+  var scriptEl = document.currentScript
+  if (!scriptEl) return
+
+  var measurementId = scriptEl.dataset.ga4MeasurementId
+  if (!measurementId) return
+
+  var INTERNAL_STORAGE_KEY = 'ss_internal_traffic'
+  var searchParams = new URLSearchParams(window.location.search)
+  var internalOverride = searchParams.get('internal')
+
+  if (internalOverride === '1') {
+    window.localStorage.setItem(INTERNAL_STORAGE_KEY, '1')
+  } else if (internalOverride === '0') {
+    window.localStorage.removeItem(INTERNAL_STORAGE_KEY)
+  }
+
+  var rawPatterns = scriptEl.dataset.internalHostPatterns || ''
+  var patternList = rawPatterns
+    .split(',')
+    .map(function (value) {
+      return value.trim().toLowerCase()
+    })
+    .filter(Boolean)
+
+  var hostname = window.location.hostname.toLowerCase()
+  var internalFromHost = patternList.some(function (pattern) {
+    if (pattern === hostname) return true
+    if (!pattern.startsWith('*.')) return false
+    var suffix = pattern.slice(1)
+    return hostname.endsWith(suffix)
+  })
+
+  var internalFromStorage = window.localStorage.getItem(INTERNAL_STORAGE_KEY) === '1'
+  var isInternalTraffic = internalFromHost || internalFromStorage
+
+  window.dataLayer = window.dataLayer || []
+  window.gtag =
+    window.gtag ||
+    function () {
+      window.dataLayer.push(arguments)
+    }
+
+  if (isInternalTraffic) {
+    window.gtag('set', 'traffic_type', 'internal')
+  }
+
+  window.gtag('js', new Date())
+  window.gtag('config', measurementId, {
+    anonymize_ip: true,
+    allow_google_signals: false,
+    traffic_type: isInternalTraffic ? 'internal' : undefined,
+    user_properties: {
+      internal_traffic: isInternalTraffic ? 'true' : 'false',
+    },
+  })
+
+  window.ssTrackEvent = function (eventName, params) {
+    if (!eventName || typeof window.gtag !== 'function') return
+    window.gtag('event', eventName, params || {})
+  }
+
+  document.addEventListener('click', function (event) {
+    var link = event.target.closest && event.target.closest('a[href]')
+    if (!link) return
+    if (!link.href) return
+
+    var isExternal = link.origin && link.origin !== window.location.origin
+    if (!isExternal) return
+
+    window.ssTrackEvent('outbound_click', {
+      link_url: link.href,
+      link_domain: link.hostname,
+      link_path: link.pathname,
+    })
+  })
+})()

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,0 +1,25 @@
+---
+// Adapted from vc-web/src/components/Analytics.astro. The hostname guard
+// is ss-console-specific: a 404 on admin.smd.services would otherwise
+// render Base.astro and load gtag under the admin hostname.
+
+const measurementId = import.meta.env.PUBLIC_GA4_MEASUREMENT_ID?.trim() ?? ''
+const internalHostPatterns =
+  import.meta.env.PUBLIC_GA4_INTERNAL_HOST_PATTERNS?.trim() ?? 'localhost,127.0.0.1,*.workers.dev'
+
+const hostname = Astro.url.hostname
+const isAuthSubdomain = hostname.startsWith('admin.') || hostname.startsWith('portal.')
+---
+
+{
+  measurementId && !isAuthSubdomain && (
+    <>
+      <script async src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`} />
+      <script
+        src="/js/ga4-init.js"
+        data-ga4-measurement-id={measurementId}
+        data-internal-host-patterns={internalHostPatterns}
+      />
+    </>
+  )
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -155,3 +155,12 @@ declare namespace App {
     cfContext?: ExecutionContext
   }
 }
+
+interface ImportMetaEnv {
+  readonly PUBLIC_GA4_MEASUREMENT_ID?: string
+  readonly PUBLIC_GA4_INTERNAL_HOST_PATTERNS?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,15 +3,20 @@ import '../styles/global.css'
 import JsonLd from '../components/JsonLd.astro'
 import SkipToMain from '../components/SkipToMain.astro'
 import EventsTracker from '../components/EventsTracker.astro'
+import Analytics from '../components/Analytics.astro'
 
 interface Props {
   title: string
   description?: string
+  // Set on routes that must not leak the URL to GA4 (token-bearing paths,
+  // unmatched 404s where pathname can echo a token from a bad URL).
+  disableAnalytics?: boolean
 }
 
 const {
   title,
   description = 'Operations consulting for Phoenix-area small businesses. We help growing businesses find the right path forward and get it done.',
+  disableAnalytics = false,
 } = Astro.props
 
 const canonicalUrl = new URL(Astro.url.pathname, 'https://smd.services')
@@ -50,6 +55,7 @@ const ogImageUrl = new URL('/og-image.png', 'https://smd.services')
 
     <title>{title}</title>
     <JsonLd />
+    {!disableAnalytics && <Analytics />}
   </head>
   <body>
     <SkipToMain />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -15,7 +15,7 @@ import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 ---
 
-<Base title="Page Not Found | SMD Services">
+<Base title="Page Not Found | SMD Services" disableAnalytics>
   <Nav />
   <main id="main" role="main" class="mx-auto max-w-4xl px-4 py-16 text-center">
     <h1 class="text-3xl font-bold text-[color:var(--ss-color-text-primary)]">Page not found</h1>

--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -9,6 +9,7 @@ import Footer from '../../../components/Footer.astro'
 <Base
   title="Manage Your Booking | SMD Services"
   description="View, reschedule, or cancel your assessment call with SMD Services."
+  disableAnalytics
 >
   <Nav />
   <main id="main" role="main">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -76,8 +76,15 @@ import Footer from '../components/Footer.astro'
             Cookies and tracking
           </h2>
           <p>
-            We use minimal session cookies required for the booking flow. We do not run third-party
-            advertising trackers or behavioral profiling.
+            We use a first-party session cookie to support the booking and contact flows. We use
+            Google Analytics 4 to measure overall site traffic, with IP addresses anonymized and
+            Google's advertising and personalization signals disabled. We do not run advertising
+            trackers or behavioral profiling. See <a
+              href="https://policies.google.com/privacy"
+              class="underline decoration-[color:var(--ss-color-primary)] decoration-2 underline-offset-4 hover:text-[color:var(--ss-color-primary)]"
+              rel="noopener noreferrer"
+              target="_blank">Google's privacy policy</a
+            > for how Analytics processes data.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary

Installs GA4 on ss-console's apex marketing surface (smd.services). Ports vc-web's pattern: env-driven `<Analytics />` component, external init script for CSP, internal-host filtering with `?internal=1/0` localStorage override, IP anonymization, Google Signals disabled, outbound-link auto-tracking. Mounted only from `Base.astro`; admin/portal/auth/dev layouts stay isolated.

**ss-console-specific divergences from vc-web:**

1. **Hostname guard in `Analytics.astro`** — refuses to render under `admin.*` / `portal.*` hostnames. Defense-in-depth for a 404 fallback rendering `Base.astro` on an authenticated subdomain.
2. **`disableAnalytics` prop on `Base.astro`** — token-bearing routes (`/book/manage/[token]`, `/404`) opt out so bearer tokens never reach Google in `page_location`.
3. **Namespace rename** — `ss_internal_traffic` localStorage key, `window.ssTrackEvent` global. Matches the existing `ss_sid` cookie convention used by `EventsTracker`.

**Decisions called out:**

- **GA4 + EventsTracker run side-by-side**, intentionally on different concerns. EventsTracker = first-party funnel events to `/api/events` (consumed by SS portal/admin). GA4 = organic / acquisition / outbound.
- **No cookie consent banner.** SS is a B2B AZ/US site, GA4 IP-anonymized + Google Signals disabled keeps the cookie surface minimal. Revisit if traffic mix shifts (e.g. EU campaigns).
- **No GTM**. Direct gtag is sufficient for current needs. Add only if a use case emerges.
- **GA4 measurement ID is its own SS property**, not the doc's "unified" `G-T7J4T1STFH` (not actually wired anywhere in any repo) and not vc-web's `G-G80J8KTBW7`. SS is a service brand semantically distinct from the venturecrane.com cluster; mixing data couples brands. Consolidating later is trivial; un-mixing isn't.

**Why `.gitignore` had to change:** ss-console's `.gitignore` line 13 (`.env.*`) silently ignores `.env.production`. Without `!.env.production` negation, this PR ships as a no-op — Astro reads no value, the script never renders, and there's no signal anything is wrong. Verified post-fix with `git add -n .env.production` reporting `add '.env.production'`.

**Why `wrangler.toml` is not touched:** Astro `PUBLIC_*` env is build-time inlined via `import.meta.env`. Worker `[vars]` are runtime bindings under `Astro.locals.runtime.env`. Different mechanisms; `wrangler.toml` does not feed `import.meta.env`.

## Captain action items (post-merge)

These are out-of-band steps the code can't do for you:

1. **Create the GA4 property** at `analytics.google.com` → Admin → Create Property → Web data stream for `https://smd.services`. Copy the `G-XXXXXXXXXX` measurement ID.
2. **Populate the ID** in `.env.production` (same file this PR creates), commit, redeploy. Analytics activates on next deploy.
3. **Tag your browser as internal** — first visit after the deploy, go to `https://smd.services/?internal=1`. Sets a localStorage flag so your Realtime testing doesn't pollute reports. Clear with `?internal=0`.

Until step 2, `Analytics.astro` gates on truthy ID and renders nothing — safe-merge.

## Pre-existing main breakage (unrelated)

`npm run verify` fails on `typecheck:workers` because `workers/scan-workflow/` is a stale post-rebase directory (only `.wrangler/` and `node_modules/` remain after the Outside View retirement deleted all committed source — no `package.json`, so the verify loop trips). All scoped checks for this PR's surface area are green:

- `npm run typecheck` → 0 errors, 0 warnings, 7 pre-existing hints
- `npm run format:check` → clean
- `npm run lint` → 0 errors, 2 pre-existing warnings (unrelated `require()` imports in `tests/magic-link.test.ts`)
- `npm run build` → ✓ Complete
- `npm run test` → 1736 passed, 2 skipped

Suggest landing this PR and filing a separate cleanup for the stale `workers/scan-workflow/` directory.

## Test plan

- [ ] Local `npm run dev` with a temp test ID populated in `.env.production` — visit `/`, view-source confirms the gtag tag and `/js/ga4-init.js` in `<head>`.
- [ ] Visit `/admin/login`, `/auth/login`, `/portal/*` — confirm NO gtag script.
- [ ] Visit `/book/manage/abc123` — confirm NO gtag script (token route, `disableAnalytics`).
- [ ] Visit `/this-route-does-not-exist` (404) — confirm NO gtag script.
- [ ] Visit `/?internal=0` → DevTools Network tab confirms POST to `https://www.google-analytics.com/g/collect`. Inspect the beacon: `dl=` and `dp=` must NOT contain a token.
- [ ] Empty-ID guard: clear `PUBLIC_GA4_MEASUREMENT_ID` in `.env.production`, rebuild → confirm no gtag script renders. Safe-merge state.
- [ ] After Captain populates ID + visits `?internal=1` → GA4 Realtime view shows live `smd.services` traffic with Captain's session tagged `traffic_type=internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)