### PR TITLE
feat(analytics): activate GA4 (G-QL8FNDRB7W) for smd.services

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,6 @@
-# GA4 measurement ID. Captain populates after creating the property in
-# analytics.google.com (Admin → Data Streams → Web stream for smd.services).
-# Blank → Analytics.astro renders nothing (safe-merge state).
-PUBLIC_GA4_MEASUREMENT_ID=
+# GA4 measurement ID for the smd.services web stream (Venture Crane account,
+# SMD Services property, stream ID 14810424978). Created 2026-05-04.
+PUBLIC_GA4_MEASUREMENT_ID=G-QL8FNDRB7W
 
 # Hosts treated as internal (filtered out / tagged traffic_type=internal).
 # Localhost + Cloudflare Workers preview hosts. To flag your prod browser


### PR DESCRIPTION
## Summary

One-line follow-up to #707: populates `PUBLIC_GA4_MEASUREMENT_ID` with the live measurement ID for the `smd.services` data stream. On deploy, `Analytics.astro` flips from inert (blank ID gate) to firing gtag on the apex marketing surface.

**Property setup** (created in GA4 admin, 2026-05-04):
- Account: Venture Crane (sibling to `venturecrane.com` — separate property, separate data)
- Property: SMD Services
- Web stream: `smd.services`, stream ID `14810424978`
- Measurement ID: `G-QL8FNDRB7W`

## Captain post-merge action

Visit `https://smd.services/?internal=1` once from your primary browser — sets a localStorage flag so your Realtime testing is tagged `traffic_type=internal` and doesn't pollute reports. Clear later with `?internal=0`.

## Test plan

- [ ] After deploy, view-source on `https://smd.services/` confirms the gtag script and `/js/ga4-init.js` in `<head>`.
- [ ] GA4 Realtime view (SMD Services property) shows live traffic from `smd.services`.
- [ ] Authenticated surfaces (`/admin/*`, `/portal/*`, `/auth/login`) and token routes (`/book/manage/[token]`, `/404`) confirm NO gtag — guards from #707 still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)