### PR TITLE
chore: ignore Claude Code parallel-isolation-log artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ coverage/
 # Ephemeral agent worktrees (created by EnterWorktree tool)
 .claude/worktrees/
 
+# Claude Code harness session-tracking artifacts
+.claude/parallel-isolation-log/
+
 # Playwright MCP output (screenshots, console dumps, snapshots)
 .playwright-mcp/
 


### PR DESCRIPTION
## Summary
- Adds `.claude/parallel-isolation-log/` to `.gitignore`
- The Claude Code harness writes session-tracking files (`sessions.log`) here on session start; they're local-only artifacts, not project state
- Eliminates noise in `git status` for every new session

## Test plan
- [x] `npm run verify` passes
- [x] `git status` clean after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)