### PR TITLE
feat(auth): restore users.role CHECK constraint + UserRole TS union

### DIFF
--- a/migrations/0035_restore_users_role_check.sql
+++ b/migrations/0035_restore_users_role_check.sql
@@ -1,0 +1,138 @@
+-- Migration 0035: Restore users.role CHECK constraint to ('admin', 'client').
+--
+-- Reverses the CHECK-removal half of migration 0033. With Outside View
+-- retired (0034), the role enum is back to the closed two-value set the
+-- original schema enforced, and the "future role additions become zero-
+-- migration" rationale no longer applies — there is no roadmap item that
+-- needs a third role.
+--
+-- Pre-flight verification (run before applying):
+--   npx wrangler d1 execute ss-console-db --remote --command \
+--     "SELECT DISTINCT role FROM users"
+--
+-- All distinct values MUST be in ('admin', 'client'). Migration 0034 already
+-- verified prospect=0 at retirement; reverify at apply time because
+-- intervening time has passed.
+--
+-- FK ceremony (same as 0033). SQLite has no ALTER TABLE DROP/ADD CONSTRAINT,
+-- so rebuilding `users` requires the full FK-chain dance:
+--   sessions.user_id and magic_links.user_id REFERENCE users(id),
+--   so SQLite refuses DROP TABLE users while either child holds rows.
+--
+-- Verified-working approach (mirrors 0033):
+--   1. Drop the FKs from sessions and magic_links (recreate without REFERENCES users)
+--   2. Recreate users WITH the CHECK constraint
+--   3. Re-add the FKs (recreate sessions and magic_links with REFERENCES users restored)
+--   4. Recreate all 7 indexes
+--
+-- D1 transaction semantics: wrangler wraps this file in a single atomic
+-- transaction (verified empirically against the original 0033 failure).
+-- Partial-apply leaving prod in a half-state is not a risk.
+--
+-- Three "obvious" fixes that don't work — same as 0033, documented for
+-- future contributors who will inevitably try them:
+--   1. PRAGMA foreign_keys = OFF is a no-op inside a transaction.
+--   2. PRAGMA defer_foreign_keys = ON does not decrement SQLite's deferred-
+--      violation counter when a parent table is dropped and recreated under
+--      the same name. (We still set it because it's harmless and signals intent.)
+--   3. PRAGMA writable_schema = ON is blocked by D1: SQLITE_AUTH error.
+--
+-- Manual-only rollback at migrations/rollbacks/0035_restore_users_role_check_down.sql.
+
+PRAGMA defer_foreign_keys = ON;
+
+-- Step 1: Drop FK from sessions to users (recreate sessions without
+-- REFERENCES users). org_id REFERENCES organizations(id) is preserved.
+CREATE TABLE sessions_tmp (
+  id          TEXT PRIMARY KEY,
+  token       TEXT NOT NULL UNIQUE,
+  user_id     TEXT NOT NULL,
+  org_id      TEXT NOT NULL REFERENCES organizations(id),
+  role        TEXT NOT NULL,
+  email       TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO sessions_tmp (id, token, user_id, org_id, role, email, expires_at, created_at)
+SELECT id, token, user_id, org_id, role, email, expires_at, created_at FROM sessions;
+DROP TABLE sessions;
+ALTER TABLE sessions_tmp RENAME TO sessions;
+
+-- Step 2: Drop FK from magic_links to users (same pattern). org_id FK preserved.
+CREATE TABLE magic_links_tmp (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  user_id         TEXT NOT NULL,
+  email           TEXT NOT NULL,
+  token           TEXT NOT NULL UNIQUE,
+  expires_at      TEXT NOT NULL,
+  used_at         TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO magic_links_tmp (id, org_id, user_id, email, token, expires_at, used_at, created_at)
+SELECT id, org_id, user_id, email, token, expires_at, used_at, created_at FROM magic_links;
+DROP TABLE magic_links;
+ALTER TABLE magic_links_tmp RENAME TO magic_links;
+
+-- Step 3: Recreate users WITH role CHECK constraint restored.
+-- No children FK to users at this point, so DROP succeeds. Schema otherwise
+-- matches the post-0001+0004+0018 layout exactly (same as 0033 step 3),
+-- with CHECK added back at line marked below.
+CREATE TABLE users_new (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  email           TEXT NOT NULL,
+  name            TEXT NOT NULL,
+  role            TEXT NOT NULL CHECK (role IN ('admin', 'client')),
+  last_login_at   TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  password_hash   TEXT,
+  entity_id       TEXT,
+  UNIQUE(org_id, email)
+);
+INSERT INTO users_new (id, org_id, email, name, role, last_login_at, created_at, password_hash, entity_id)
+SELECT id, org_id, email, name, role, last_login_at, created_at, password_hash, entity_id FROM users;
+DROP TABLE users;
+ALTER TABLE users_new RENAME TO users;
+
+-- Step 4: Re-add FK from sessions to the new users table.
+CREATE TABLE sessions_new (
+  id          TEXT PRIMARY KEY,
+  token       TEXT NOT NULL UNIQUE,
+  user_id     TEXT NOT NULL REFERENCES users(id),
+  org_id      TEXT NOT NULL REFERENCES organizations(id),
+  role        TEXT NOT NULL,
+  email       TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO sessions_new (id, token, user_id, org_id, role, email, expires_at, created_at)
+SELECT id, token, user_id, org_id, role, email, expires_at, created_at FROM sessions;
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;
+
+-- Step 5: Re-add FK from magic_links to the new users table.
+CREATE TABLE magic_links_new (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  user_id         TEXT NOT NULL REFERENCES users(id),
+  email           TEXT NOT NULL,
+  token           TEXT NOT NULL UNIQUE,
+  expires_at      TEXT NOT NULL,
+  used_at         TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO magic_links_new (id, org_id, user_id, email, token, expires_at, used_at, created_at)
+SELECT id, org_id, user_id, email, token, expires_at, used_at, created_at FROM magic_links;
+DROP TABLE magic_links;
+ALTER TABLE magic_links_new RENAME TO magic_links;
+
+-- Step 6: Recreate all 7 indexes that the rebuilds dropped.
+-- Names match prod sqlite_master exactly (verified via 0033 hotfix).
+CREATE INDEX idx_users_entity ON users(org_id, entity_id);
+CREATE INDEX idx_sessions_token ON sessions(token);
+CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_expires ON sessions(expires_at);
+CREATE INDEX idx_magic_links_org_email ON magic_links(org_id, email);
+CREATE INDEX idx_magic_links_expires ON magic_links(expires_at);
+CREATE INDEX idx_magic_links_user_expires ON magic_links(user_id, expires_at);

--- a/migrations/rollbacks/0035_restore_users_role_check_down.sql
+++ b/migrations/rollbacks/0035_restore_users_role_check_down.sql
@@ -1,0 +1,105 @@
+-- Rollback for migration 0035 (restore users.role CHECK constraint).
+--
+-- MANUAL-ONLY. This file lives in /rollbacks/ so wrangler does NOT
+-- auto-apply it. Apply with:
+--   npx wrangler d1 execute ss-console-db --remote --file migrations/rollbacks/0035_restore_users_role_check_down.sql
+--
+-- Reverts the CHECK constraint added in 0035, restoring the schema state
+-- left by 0033 (and unchanged by 0034). The full FK-chain dance is required
+-- because SQLite has no ALTER TABLE DROP CONSTRAINT.
+--
+-- This rollback is safe at any time: dropping a CHECK is strictly more
+-- permissive than keeping it. No data validation needed pre-apply.
+
+PRAGMA defer_foreign_keys = ON;
+
+-- Step 1: Drop FK from sessions to users.
+CREATE TABLE sessions_tmp (
+  id          TEXT PRIMARY KEY,
+  token       TEXT NOT NULL UNIQUE,
+  user_id     TEXT NOT NULL,
+  org_id      TEXT NOT NULL REFERENCES organizations(id),
+  role        TEXT NOT NULL,
+  email       TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO sessions_tmp (id, token, user_id, org_id, role, email, expires_at, created_at)
+SELECT id, token, user_id, org_id, role, email, expires_at, created_at FROM sessions;
+DROP TABLE sessions;
+ALTER TABLE sessions_tmp RENAME TO sessions;
+
+-- Step 2: Drop FK from magic_links to users.
+CREATE TABLE magic_links_tmp (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  user_id         TEXT NOT NULL,
+  email           TEXT NOT NULL,
+  token           TEXT NOT NULL UNIQUE,
+  expires_at      TEXT NOT NULL,
+  used_at         TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO magic_links_tmp (id, org_id, user_id, email, token, expires_at, used_at, created_at)
+SELECT id, org_id, user_id, email, token, expires_at, used_at, created_at FROM magic_links;
+DROP TABLE magic_links;
+ALTER TABLE magic_links_tmp RENAME TO magic_links;
+
+-- Step 3: Recreate users WITHOUT the role CHECK constraint.
+CREATE TABLE users_new (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  email           TEXT NOT NULL,
+  name            TEXT NOT NULL,
+  role            TEXT NOT NULL,
+  last_login_at   TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  password_hash   TEXT,
+  entity_id       TEXT,
+  UNIQUE(org_id, email)
+);
+INSERT INTO users_new (id, org_id, email, name, role, last_login_at, created_at, password_hash, entity_id)
+SELECT id, org_id, email, name, role, last_login_at, created_at, password_hash, entity_id FROM users;
+DROP TABLE users;
+ALTER TABLE users_new RENAME TO users;
+
+-- Step 4: Re-add FK from sessions to users.
+CREATE TABLE sessions_new (
+  id          TEXT PRIMARY KEY,
+  token       TEXT NOT NULL UNIQUE,
+  user_id     TEXT NOT NULL REFERENCES users(id),
+  org_id      TEXT NOT NULL REFERENCES organizations(id),
+  role        TEXT NOT NULL,
+  email       TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO sessions_new (id, token, user_id, org_id, role, email, expires_at, created_at)
+SELECT id, token, user_id, org_id, role, email, expires_at, created_at FROM sessions;
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;
+
+-- Step 5: Re-add FK from magic_links to users.
+CREATE TABLE magic_links_new (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  user_id         TEXT NOT NULL REFERENCES users(id),
+  email           TEXT NOT NULL,
+  token           TEXT NOT NULL UNIQUE,
+  expires_at      TEXT NOT NULL,
+  used_at         TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT INTO magic_links_new (id, org_id, user_id, email, token, expires_at, used_at, created_at)
+SELECT id, org_id, user_id, email, token, expires_at, used_at, created_at FROM magic_links;
+DROP TABLE magic_links;
+ALTER TABLE magic_links_new RENAME TO magic_links;
+
+-- Step 6: Recreate all 7 indexes.
+CREATE INDEX idx_users_entity ON users(org_id, entity_id);
+CREATE INDEX idx_sessions_token ON sessions(token);
+CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_expires ON sessions(expires_at);
+CREATE INDEX idx_magic_links_org_email ON magic_links(org_id, email);
+CREATE INDEX idx_magic_links_expires ON magic_links(expires_at);
+CREATE INDEX idx_magic_links_user_expires ON magic_links(user_id, expires_at);

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -14,5 +14,6 @@ export {
   SESSION_COOKIE_NAME,
   SESSION_DURATION_MS,
 } from './session'
-export type { SessionData } from './session'
+export type { SessionData, UserRole } from './session'
+export { asUserRole } from './session'
 export { createMagicLink, verifyMagicLink, MAGIC_LINK_EXPIRY_MS } from './magic-link'

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -21,6 +21,24 @@ export const CLIENT_SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 export const SESSION_DURATION_MS = ADMIN_SESSION_DURATION_MS
 
 /**
+ * Closed set of user roles, mirroring the `users.role` CHECK constraint
+ * restored in migration 0035. Defense-in-depth pairing: DB enforces at
+ * write, TS enforces at read.
+ */
+export type UserRole = 'admin' | 'client'
+
+/**
+ * Narrow an unknown role string (e.g. from a raw D1 query) to UserRole.
+ * Throws if the value is unexpected — should never happen with the CHECK
+ * constraint in place, but the throw catches drift if the constraint is
+ * dropped in a future migration without updating this union.
+ */
+export function asUserRole(role: string): UserRole {
+  if (role === 'admin' || role === 'client') return role
+  throw new Error(`Invalid user role: ${role}`)
+}
+
+/**
  * Return session duration based on role.
  *
  * Clients get 30 days — infrequent portal visitors who shouldn't be
@@ -33,7 +51,7 @@ export function getSessionDurationMs(role?: string): number {
 export interface SessionData {
   userId: string
   orgId: string
-  role: string
+  role: UserRole
   email: string
   expiresAt: string
 }
@@ -43,7 +61,7 @@ export interface SessionRow {
   token: string
   user_id: string
   org_id: string
-  role: string
+  role: UserRole
   email: string
   expires_at: string
   created_at: string
@@ -56,7 +74,7 @@ export interface SessionRow {
 export async function createSession(
   db: D1Database,
   kv: KVNamespace,
-  user: { id: string; orgId: string; role: string; email: string }
+  user: { id: string; orgId: string; role: UserRole; email: string }
 ): Promise<string> {
   const token = crypto.randomUUID()
   const sessionId = crypto.randomUUID()

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro'
 import { verifyPassword } from '../../../lib/auth/password'
-import { createSession, buildSessionCookie } from '../../../lib/auth/session'
+import { asUserRole, createSession, buildSessionCookie } from '../../../lib/auth/session'
 import { ORG_ID } from '../../../lib/constants'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import { env } from 'cloudflare:workers'
@@ -76,7 +76,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     const token = await createSession(env.DB, env.SESSIONS, {
       id: user.id,
       orgId: user.org_id,
-      role: user.role,
+      role: asUserRole(user.role),
       email: user.email,
     })
 

--- a/src/pages/auth/verify.astro
+++ b/src/pages/auth/verify.astro
@@ -1,7 +1,7 @@
 ---
 import '../../styles/global.css'
 import { verifyMagicLink } from '../../lib/auth/magic-link'
-import { createSession, buildSessionCookie } from '../../lib/auth/session'
+import { asUserRole, createSession, buildSessionCookie } from '../../lib/auth/session'
 import { getPortalBaseUrl } from '../../lib/config/app-url'
 import { env } from 'cloudflare:workers'
 
@@ -63,7 +63,7 @@ await env.DB.prepare(`UPDATE users SET last_login_at = datetime('now') WHERE id 
 const sessionToken = await createSession(env.DB, env.SESSIONS, {
   id: user.id,
   orgId: user.org_id,
-  role: user.role,
+  role: asUserRole(user.role),
   email: user.email,
 })
 const location = (() => {


### PR DESCRIPTION
## Summary

- Restores `users.role CHECK (role IN ('admin', 'client'))` (migration 0035) — reverses the CHECK-removal half of 0033 now that Outside View is retired and the role enum is back to a closed two-value set
- Adds `UserRole = 'admin' | 'client'` TS union at `src/lib/auth/session.ts` mirroring the schema
- `asUserRole(role: string)` narrowing helper at the two `createSession` call sites (login + verify) catches drift at the D1 boundary

Closes #706.

## Why

Per PM team review (#706 audit, 2026-05-05): the original "drop CHECK for migration ergonomics" rationale required a future of evolving roles. With Outside View retired (PR #703), that future evaporated. Production `users WHERE role NOT IN ('admin','client')`: 0 rows. Keeping CHECK off pays an ongoing correctness tax (silent corruption from a fat-fingered `wrangler d1 execute` is invisible until login fails) for an option value with no roadmap to spend.

## Pre-flight (must run before merge → deploy)

```
npx wrangler d1 execute ss-console-db --remote --command \
  "SELECT DISTINCT role FROM users"
```

All values must be in `('admin', 'client')`. Migration 0034 already verified `prospect=0` at retirement; reverify at apply time because intervening time has passed.

## Migration approach

Mirrors 0033's FK-chain dance step-for-step. SQLite has no ALTER TABLE DROP/ADD CONSTRAINT, so rebuilding `users` requires:
1. Drop FKs from `sessions` and `magic_links` to `users` (recreate without REFERENCES users)
2. Recreate `users` WITH the CHECK constraint
3. Re-add the FKs (recreate sessions and magic_links with REFERENCES users restored)
4. Recreate all 7 indexes

D1 wraps each migration in an atomic transaction (verified empirically against 0033's failure history). Three "obvious" PRAGMA fixes that don't work are documented in the file header.

Manual-only rollback at `migrations/rollbacks/0035_restore_users_role_check_down.sql`.

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings (only pre-existing hints unrelated to this change)
- [x] `npm run test -- --run` — 1736 passed / 2 skipped, no regressions
- [ ] Pre-flight `SELECT DISTINCT role FROM users` against prod returns only `admin` / `client`
- [ ] Smoke: admin login still works post-deploy
- [ ] Smoke: client magic-link verify still works post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)