### PR TITLE
chore(lead-gen): remove partner_nurture asymmetry; archive Make.com recipe

### DIFF
--- a/docs/archive/pipeline-5-partner-nurture-makedotcom.md
+++ b/docs/archive/pipeline-5-partner-nurture-makedotcom.md
@@ -3,7 +3,7 @@
 > **Status: ARCHIVED 2026-05-05.** Make.com is no longer the doctrinal automation
 > platform for SMD agent ops (per `project_lead_gen_worker.md` — Cloudflare
 > Workers is the going-forward pattern). This recipe is preserved as historical
-> reference for the *business pattern* (cadenced partner check-ins, AI-drafted
+> reference for the _business pattern_ (cadenced partner check-ins, AI-drafted
 > personalization, Gmail-draft-then-human-review). The rebuild is captured in
 > issue #714, gated on first paid engagement.
 >

--- a/docs/archive/pipeline-5-partner-nurture-makedotcom.md
+++ b/docs/archive/pipeline-5-partner-nurture-makedotcom.md
@@ -1,4 +1,15 @@
-# Make.com Recipe: Pipeline 5 — Referral Partner Nurture
+# [ARCHIVED] Make.com Recipe: Pipeline 5 — Referral Partner Nurture
+
+> **Status: ARCHIVED 2026-05-05.** Make.com is no longer the doctrinal automation
+> platform for SMD agent ops (per `project_lead_gen_worker.md` — Cloudflare
+> Workers is the going-forward pattern). This recipe is preserved as historical
+> reference for the *business pattern* (cadenced partner check-ins, AI-drafted
+> personalization, Gmail-draft-then-human-review). The rebuild is captured in
+> issue #714, gated on first paid engagement.
+>
+> Do not implement this recipe.
+
+---
 
 **Purpose:** Step-by-step guide to build a Make.com scenario that drafts personalized check-in emails for bookkeeper/CPA referral partners, creates Gmail drafts for human review, and tracks check-in cadence in Google Sheets.
 

--- a/docs/lead-automation/recipes/index.md
+++ b/docs/lead-automation/recipes/index.md
@@ -12,4 +12,8 @@ Automation pipeline recipes for the SMD Services lead generation system. Each re
 - [pipeline-2-job-monitor.md](./pipeline-2-job-monitor.md) - Pipeline 2: Job monitor
 - [pipeline-3-new-business.md](./pipeline-3-new-business.md) - Pipeline 3: New business signals
 - [pipeline-4-social-listening.md](./pipeline-4-social-listening.md) - Pipeline 4: Social listening
-- [pipeline-5-partner-nurture.md](./pipeline-5-partner-nurture.md) - Pipeline 5: Partner nurture
+
+> _Pipeline 5 (Referral Partner Nurture) was previously documented here as a
+> Make.com recipe. Make.com has been retired for SMD agent ops — the recipe
+> moved to `docs/archive/`. The rebuild is captured under #714, gated on first
+> paid engagement._

--- a/src/lead-gen/prompts/partner-nurture-prompt.ts
+++ b/src/lead-gen/prompts/partner-nurture-prompt.ts
@@ -1,5 +1,14 @@
 /**
- * Partner Nurture Prompt — Pipeline 5
+ * Partner Nurture Prompt — PARKED for rebuild under #714.
+ *
+ * The Make.com scenario this was originally written for has been retired
+ * (Make.com is no longer the doctrinal automation platform per
+ * `project_lead_gen_worker.md`). The prompt is preserved as a starting
+ * point for the Cloudflare Worker rebuild captured in #714, which is
+ * itself gated on first paid engagement.
+ *
+ * No runtime consumer in the current codebase. Lead-gen `PIPELINE_IDS` no
+ * longer includes `partner_nurture`.
  *
  * Drafts personalized check-in emails for bookkeeper/CPA referral partners
  * at different relationship stages. The referral partnership is reciprocal:
@@ -7,7 +16,6 @@
  * bookkeeper. When they have a client drowning in operational chaos, they
  * refer to us.
  *
- * Used in: Make.com scenario → Anthropic module → this prompt
  * Input: Partner data from the prospect list (see partner-email-draft.ts)
  * Output: PartnerEmailDraft JSON (see partner-email-draft.ts)
  *

--- a/src/lead-gen/schemas/lead-scoring-schema.ts
+++ b/src/lead-gen/schemas/lead-scoring-schema.ts
@@ -30,7 +30,6 @@ export const PIPELINE_IDS = [
   'job_monitor',
   'new_business',
   'social_listening',
-  'partner_nurture',
 ] as const
 
 export type PipelineId = (typeof PIPELINE_IDS)[number]
@@ -40,8 +39,14 @@ export const PIPELINE_LABELS: Record<PipelineId, string> = {
   job_monitor: 'Job Posting Monitor',
   new_business: 'New Business Detection',
   social_listening: 'Social Listening',
-  partner_nurture: 'Referral Partner Nurture',
 }
+
+// `partner_nurture` was previously listed here but never reached parity with
+// the DB layer (`lead_signals.source_pipeline` CHECK has only the four
+// pipelines above). Build is captured under #714, gated on first paid
+// engagement. The dormant prompt + schema files at
+// `src/lead-gen/prompts/partner-nurture-prompt.ts` and
+// `src/lead-gen/schemas/partner-email-draft.ts` are parked for that rebuild.
 
 // ---------------------------------------------------------------------------
 // Shared scoring types

--- a/src/lead-gen/schemas/partner-email-draft.ts
+++ b/src/lead-gen/schemas/partner-email-draft.ts
@@ -1,5 +1,14 @@
 /**
- * Partner Email Draft Schema — Pipeline 5 Output Types
+ * Partner Email Draft Schema — PARKED for rebuild under #714.
+ *
+ * The Make.com scenario this was originally written for has been retired
+ * (Make.com is no longer the doctrinal automation platform per
+ * `project_lead_gen_worker.md`). The schema is preserved as a starting
+ * point for the Cloudflare Worker rebuild captured in #714, which is
+ * itself gated on first paid engagement.
+ *
+ * No runtime consumer in the current codebase. Lead-gen `PIPELINE_IDS` no
+ * longer includes `partner_nurture`.
  *
  * Defines the structured output contract for the referral partner nurture prompt.
  * When Claude drafts a personalized check-in email for a bookkeeper/CPA referral

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -123,7 +123,6 @@ const PIPELINE_THRESHOLDS: Record<string, { warn: number; critical: number; labe
   review_mining: { warn: 216, critical: 336, label: 'Review Mining' }, // 9d / 14d
   new_business: { warn: 36, critical: 72, label: 'New Business Detection' },
   social_listening: { warn: 168, critical: 336, label: 'Social Listening' }, // 7d / 14d
-  partner_nurture: { warn: 168, critical: 336, label: 'Referral Partner Nurture' },
   website_scorecard: { warn: 168, critical: 336, label: 'Website Scorecard' },
   website_booking: { warn: 168, critical: 336, label: 'Website Booking' },
   website_intake: { warn: 168, critical: 336, label: 'Website Intake' },


### PR DESCRIPTION
## Summary

- Drops `partner_nurture` from `PIPELINE_IDS`, `PIPELINE_LABELS`, and the admin `PIPELINE_THRESHOLDS` map. The DB CHECK on `lead_signals.source_pipeline` only honored four pipelines; this fixes the long-standing TS-vs-DB asymmetry.
- Archives the Make.com recipe `pipeline-5-partner-nurture.md` under `docs/archive/` with a header explaining why. Make.com is doctrinally dead per `project_lead_gen_worker.md` (Cloudflare Workers is the going-forward pattern).
- Marks the orphaned prompt + schema files as PARKED for the rebuild captured in #714.

Closes #606.

## Why

Per PM team review (#606 audit, 2026-05-05): the original A/B decision in #606 was framed as Worker (Option A, doctrinal) vs Make.com handoff (Option B, dead). But the prerequisites for either don't exist yet — no partner roster seeded, no email-send permission model, zero clients to nurture partners *toward*. Building the worker now is premature; leaving the cross-layer asymmetry misled every future agent reading lead-scoring code into thinking a 5th pipeline existed.

This PR fixes the asymmetry now. The actual build is captured under #714, gated on first paid engagement.

## Files

- `src/lead-gen/schemas/lead-scoring-schema.ts` — drop `partner_nurture` from enum + label map; add comment explaining where it went
- `src/pages/admin/index.astro` — drop `partner_nurture` row from PIPELINE_THRESHOLDS
- `docs/archive/pipeline-5-partner-nurture-makedotcom.md` — moved from `docs/lead-automation/recipes/`; archived header added
- `docs/lead-automation/recipes/index.md` — remove broken link, replace with a paragraph pointing at archive + #714
- `src/lead-gen/prompts/partner-nurture-prompt.ts` — PARKED header
- `src/lead-gen/schemas/partner-email-draft.ts` — PARKED header

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm run test -- --run` — 1736 passed / 2 skipped, no regressions
- [x] Verified DB-side CHECK on `lead_signals.source_pipeline` (migration 0007) only includes the 4 retained pipelines
- [x] Verified the other PipelineId definitions (`src/lib/generators/types.ts`, `src/lib/db/pipeline-settings.ts`) already only had 4 — no asymmetry there

## What's NOT in this PR

- The actual `partner_nurture` worker build (#714) — explicitly out of scope; gated on first paid engagement
- Editing `docs/collateral/lead-automation-blueprint.md` Pipeline 5 sections — they describe the *business strategy* (referral partner nurture is a real future channel), not the dead Make.com mechanics. Left alone intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)