### PR TITLE
chore(security): close 4 LOW findings to raise Security grade C → A

### DIFF
--- a/src/components/admin/GeneratorConfigForm.astro
+++ b/src/components/admin/GeneratorConfigForm.astro
@@ -58,8 +58,8 @@ const sl = configRow.config as SocialListeningConfig
       name="target_verticals"
       rows="6"
       class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-      set:html={(configRow.config as NewBusinessConfig).target_verticals.join('\n')}
-    />
+      >{(configRow.config as NewBusinessConfig).target_verticals.join('\n')}</textarea
+    >
     <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
       Free-text. Suggestions: {VERTICALS.map((v) => v.replace(/_/g, ' ')).join(', ')}.
     </p>
@@ -116,8 +116,8 @@ const sl = configRow.config as SocialListeningConfig
       name="geos"
       rows="2"
       class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-      set:html={(configRow.config as NewBusinessConfig).geos.join('\n')}
-    />
+      >{(configRow.config as NewBusinessConfig).geos.join('\n')}</textarea
+    >
   </div>
 
   {
@@ -161,8 +161,8 @@ const sl = configRow.config as SocialListeningConfig
           name="search_queries"
           rows="8"
           class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-          set:html={jm.search_queries.join('\n')}
-        />
+          >{jm.search_queries.join('\n')}</textarea
+        >
       </div>
     )
   }
@@ -183,8 +183,8 @@ const sl = configRow.config as SocialListeningConfig
             name="discovery_queries"
             rows="10"
             class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-            set:html={rm.discovery_queries.join('\n')}
-          />
+            >{rm.discovery_queries.join('\n')}</textarea
+          >
         </div>
         <div>
           <label class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1">
@@ -272,8 +272,8 @@ const sl = configRow.config as SocialListeningConfig
           name="search_queries"
           rows="5"
           class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-          set:html={sl.search_queries.join('\n')}
-        />
+          >{sl.search_queries.join('\n')}</textarea
+        >
       </div>
     )
   }

--- a/src/components/admin/GeneratorConfigForm.astro
+++ b/src/components/admin/GeneratorConfigForm.astro
@@ -161,8 +161,9 @@ const sl = configRow.config as SocialListeningConfig
           name="search_queries"
           rows="8"
           class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-          >{jm.search_queries.join('\n')}</textarea
         >
+          {jm.search_queries.join('\n')}
+        </textarea>
       </div>
     )
   }
@@ -183,8 +184,9 @@ const sl = configRow.config as SocialListeningConfig
             name="discovery_queries"
             rows="10"
             class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-            >{rm.discovery_queries.join('\n')}</textarea
           >
+            {rm.discovery_queries.join('\n')}
+          </textarea>
         </div>
         <div>
           <label class="text-sm font-medium text-[color:var(--ss-color-text-primary)] block mb-1">
@@ -272,8 +274,9 @@ const sl = configRow.config as SocialListeningConfig
           name="search_queries"
           rows="5"
           class="w-full border border-[color:var(--ss-color-border)] rounded px-3 py-2 text-sm font-mono"
-          >{sl.search_queries.join('\n')}</textarea
         >
+          {sl.search_queries.join('\n')}
+        </textarea>
       </div>
     )
   }

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -84,7 +84,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     })
 
     if (!result.success) {
-      console.error(`[magic-link] Failed to send email to ${normalizedEmail}: ${result.error}`)
+      console.error('[magic-link] Failed to send portal invite (check Resend dashboard):', result.error)
       // Still show success to prevent enumeration
     }
 

--- a/src/pages/api/auth/magic-link.ts
+++ b/src/pages/api/auth/magic-link.ts
@@ -84,7 +84,10 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     })
 
     if (!result.success) {
-      console.error('[magic-link] Failed to send portal invite (check Resend dashboard):', result.error)
+      console.error(
+        '[magic-link] Failed to send portal invite (check Resend dashboard):',
+        result.error
+      )
       // Still show success to prevent enumeration
     }
 

--- a/src/pages/api/scorecard/submit.ts
+++ b/src/pages/api/scorecard/submit.ts
@@ -14,6 +14,7 @@ import { SCORE_DESCRIPTIONS } from '../../../lib/scorecard/descriptions'
 import { renderScorecardReport } from '../../../lib/pdf/render'
 import { sendEmail } from '../../../lib/email/resend'
 import { scorecardReportEmailHtml } from '../../../lib/email/templates'
+import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 
 import { env } from 'cloudflare:workers'
 
@@ -151,6 +152,13 @@ function buildScorecardMeta(
 }
 
 async function handlePost({ request }: APIContext): Promise<Response> {
+  // Rate limit: 3 requests/hour per IP — checked first, before any DB write or email send
+  const clientIp = request.headers.get('cf-connecting-ip') ?? undefined
+  const rateLimitResult = await rateLimitByIp(env.BOOKING_CACHE, 'scorecard', clientIp, 3)
+  if (!rateLimitResult.allowed) {
+    return jsonResponse(429, { error: 'Too many submissions' })
+  }
+
   let body: Record<string, unknown>
   try {
     body = await request.json()

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -143,7 +143,6 @@ name = "ss-web-staging"
 # GOOGLE_CLIENT_ID         — Google Cloud OAuth 2.0 client ID
 # GOOGLE_CLIENT_SECRET     — Google Cloud OAuth 2.0 client secret
 # BOOKING_ENCRYPTION_KEY   — 32-byte base64 random; AES-GCM encryption of refresh tokens
-# TURNSTILE_SECRET_KEY     — Cloudflare Turnstile secret (paired with PUBLIC_TURNSTILE_SITE_KEY)
 #
 # Bulk-load from Infisical:
 #   infisical export --env=prod --path=/ss --format=dotenv \


### PR DESCRIPTION
## Summary

Bundles four LOW-severity findings from the 2026-05-06 code review into one PR. Closing all four raises Security from C to A in the next review.

### Fixes

- **#725 — Rate-limit POST /api/scorecard/submit.** Adds `rateLimitByIp` (3 req/hr per IP) at the top of the handler, before any DB write or email send. Reuses the existing `BOOKING_CACHE` KV and matches the established pattern from `/api/contact` and `/api/auth/magic-link`. Returns `429 { error: 'Too many submissions' }` on exceed.
- **#729 — Drop user email from magic-link failure log.** Replaces `Failed to send email to ${normalizedEmail}` with a generic message that points ops to the Resend dashboard. Preserves the underlying error detail for debugging without leaking PII into logs.
- **#730 — Remove TURNSTILE_SECRET_KEY drift from `wrangler.toml`.** Turnstile was retired in PR #704; the secret reference in the documentation block is now stale. Verified no other source references remain.
- **#731 — Replace `set:html` with default Astro interpolation in `GeneratorConfigForm.astro` textareas.** Five textareas were using `set:html={value}` for trusted JSON-stored config arrays. Default Astro `>{value}</textarea>` escapes interpolations and is the safe, idiomatic form.

## Test plan

- [x] `npm run lint` — 0 errors (68 pre-existing warnings)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 1736 passed, 2 skipped (after `npm run build`)
- [x] `npm run build` — clean
- [ ] Smoke: submit scorecard 4 times in succession from the same IP → expect 4th to return 429
- [ ] Smoke: trigger magic-link send-failure path (e.g., revoked Resend key) → log line shows no email address
- [ ] Smoke: load `/admin/generators/<type>` config form → all five textareas render the joined values without HTML rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)