### PR TITLE
chore(ci): build social-listening worker on every PR (#726)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,8 +67,5 @@ jobs:
       - name: Build Review Mining Worker
         run: cd workers/review-mining && npm ci && npx wrangler deploy --dry-run --outdir=dist
 
-      # NOTE: workers/social-listening is not built or deployed here. It has
-      # never been deployed to prod — CI-verifying undeployed code creates
-      # false confidence and masks drift. See venture-tracked issue for
-      # Pipeline 4 first-deploy (secrets provisioning, dry-run via /run,
-      # digest-routing review). Re-add the build step when that issue ships.
+      - name: Build Social Listening Worker
+        run: cd workers/social-listening && npm ci && npx wrangler deploy --dry-run --outdir=dist


### PR DESCRIPTION
## Summary

- Adds a wrangler dry-run build step for `workers/social-listening` to `.github/workflows/verify.yml`, matching the existing pattern for `job-monitor`, `new-business`, and `review-mining`.
- Removes the inline NOTE that justified the prior exclusion. The argument was that CI-verifying undeployed code creates false confidence — but the actual job of these steps is to catch drift before first deploy, not after. Excluding the worker meant Pipeline 4 changes shipped to `main` without a syntax/typecheck gate at the worker boundary.

## Test plan

- [x] `cd workers/social-listening && npm ci && npx wrangler deploy --dry-run --outdir=dist` succeeds locally (build emits `Total Upload: 45.38 KiB / gzip: 11.33 KiB`, D1 binding resolved).
- [x] `npm run lint && npm run typecheck && npm run build && npm test` — green.
- [ ] Wait for `Verify` workflow on this PR — the new step should pass; if it fails, that itself is the finding the gap was supposed to catch.

Closes #726