### PR TITLE
test(webhooks): behavioral HMAC verification for SignWell + Stripe (#728)

### DIFF
--- a/tests/webhooks/signwell-verify.test.ts
+++ b/tests/webhooks/signwell-verify.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Behavioral tests for the SignWell webhook HMAC verification path.
+ *
+ * SignWell signs the string "{event_type}@{event_time}" using the webhook
+ * ID as the HMAC-SHA256 key and embeds the hex digest in the JSON body
+ * at `event.hash`. Ref: https://developers.signwell.com/reference/event-hash-verification
+ *
+ * The verification function (`verifyEventHash`) is file-private to
+ * src/pages/api/webhooks/signwell.ts, so we exercise it through the route
+ * handler. We pick a non-dispatching event type (`document_viewed`) so
+ * the route returns 200 immediately after verification — no D1, R2, or
+ * downstream-handler seeding required for what is fundamentally a
+ * crypto-boundary test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { installWorkerdPolyfills } from '@venturecrane/crane-test-harness'
+import { env as testEnv } from 'cloudflare:workers'
+import { POST } from '../../src/pages/api/webhooks/signwell'
+
+installWorkerdPolyfills()
+
+const SECRET = 'test-signwell-webhook-secret'
+const WRONG_SECRET = 'wrong-secret-totally-different'
+
+// ---------------------------------------------------------------------------
+// HMAC helper — must match what SignWell does on its end:
+//   signed_string = `${type}@${time}`
+//   hash = HMAC_SHA256(secret, signed_string).hex()
+// ---------------------------------------------------------------------------
+
+async function computeSignWellHash(type: string, time: number, secret: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(`${type}@${time}`))
+  return Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+interface BuildPayloadOpts {
+  type?: string
+  time?: number
+  hash?: string | null
+  /** When `hash` is undefined we compute one with `secret`. */
+  secret?: string
+}
+
+async function buildPayload(opts: BuildPayloadOpts = {}): Promise<Record<string, unknown>> {
+  const type = opts.type ?? 'document_viewed'
+  const time = opts.time ?? nowSeconds()
+  const hash =
+    opts.hash !== undefined
+      ? opts.hash
+      : await computeSignWellHash(type, time, opts.secret ?? SECRET)
+  // Spread `null` / undefined so we can test the missing-hash case.
+  const event: Record<string, unknown> = { type, time }
+  if (hash !== null) event.hash = hash
+  return {
+    event,
+    data: {
+      object: { id: 'sw-doc-test', name: 'Test', status: 'viewed', completed_at: null },
+      account_id: 'test-account',
+    },
+  }
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  return res.json()
+}
+
+function buildContext(body: unknown) {
+  const request = new Request('http://test.local/api/webhooks/signwell', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return {
+    request,
+    params: {},
+    locals: {},
+    redirect: (url: string, status: number) =>
+      new Response(null, { status, headers: { Location: url } }),
+  } as unknown as Parameters<typeof POST>[0]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/webhooks/signwell — HMAC verification', () => {
+  beforeEach(() => {
+    Object.assign(testEnv, { SIGNWELL_WEBHOOK_SECRET: SECRET })
+    // Negative paths in this handler log via console.error before returning
+    // 4xx/500. Those logs are intentional but produce noise during test runs;
+    // suppress them so the report stays focused on assertion results.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    for (const k of Object.keys(testEnv)) {
+      delete (testEnv as unknown as Record<string, unknown>)[k]
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('accepts a payload with a valid hash + fresh timestamp (returns 200)', async () => {
+    const payload = await buildPayload()
+    const res = await POST(buildContext(payload))
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects a payload whose hash has been tampered with (single bit flip)', async () => {
+    const payload = await buildPayload()
+    // Flip a single bit in the hash — last hex char toggled to its neighbor.
+    // SignWell hash is a 64-char hex string; flipping one char invalidates HMAC.
+    const event = (payload as { event: { hash: string } }).event
+    const lastChar = event.hash.slice(-1)
+    const flipped = lastChar === '0' ? '1' : '0'
+    event.hash = event.hash.slice(0, -1) + flipped
+
+    const res = await POST(buildContext(payload))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('rejects a payload signed with the wrong secret', async () => {
+    const payload = await buildPayload({ secret: WRONG_SECRET })
+    const res = await POST(buildContext(payload))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('rejects a payload missing the hash field', async () => {
+    const payload = await buildPayload({ hash: null })
+    const res = await POST(buildContext(payload))
+    expect(res.status).toBe(400)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Missing event fields')
+  })
+
+  it('rejects a stale payload (timestamp older than 5 minutes)', async () => {
+    // Build a payload whose hash is correct for an old timestamp — that way
+    // we exercise the freshness check, not the hash check.
+    const staleTime = nowSeconds() - 6 * 60
+    const payload = await buildPayload({ time: staleTime })
+    const res = await POST(buildContext(payload))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Stale webhook')
+  })
+
+  it('returns 500 when the webhook secret is not configured (defense in depth)', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).SIGNWELL_WEBHOOK_SECRET
+    const payload = await buildPayload()
+    const res = await POST(buildContext(payload))
+    expect(res.status).toBe(500)
+  })
+})

--- a/tests/webhooks/stripe-verify.test.ts
+++ b/tests/webhooks/stripe-verify.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Behavioral tests for the Stripe webhook signature verification path.
+ *
+ * Stripe-Signature header format: `t=<timestamp>,v1=<hex_signature>`
+ * Signed payload: `<timestamp>.<rawBody>`
+ * Signature: HMAC-SHA256(webhook_secret, signed_payload).hex()
+ * Tolerance: 5 minutes between header timestamp and server clock.
+ *
+ * The verifier is file-private to src/pages/api/webhooks/stripe.ts so we
+ * exercise it through the route. We use an event type the route does NOT
+ * dispatch (anything that isn't `invoice.paid` / `invoice.payment_failed`)
+ * so a successful verification returns 200 without touching D1 — this
+ * keeps the test focused on the crypto boundary.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { installWorkerdPolyfills } from '@venturecrane/crane-test-harness'
+import { env as testEnv } from 'cloudflare:workers'
+import { POST } from '../../src/pages/api/webhooks/stripe'
+
+installWorkerdPolyfills()
+
+const SECRET = 'whsec_test_stripe_webhook_secret'
+const WRONG_SECRET = 'whsec_test_totally_different'
+
+// ---------------------------------------------------------------------------
+// Stripe HMAC helper — must match the verifier:
+//   signed_payload = `${timestamp}.${rawBody}`
+//   v1 = HMAC_SHA256(secret, signed_payload).hex()
+// ---------------------------------------------------------------------------
+
+async function computeStripeV1(timestamp: number, body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(`${timestamp}.${body}`))
+  return Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function buildStripeHeader(timestamp: number, signature: string): string {
+  return `t=${timestamp},v1=${signature}`
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+// ---------------------------------------------------------------------------
+// Test event — non-dispatched type so success returns 200 with ack only.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_EVENT = {
+  id: 'evt_test_123',
+  object: 'event',
+  type: 'customer.subscription.created',
+  data: { object: {} },
+  created: 0,
+}
+
+interface BuildOpts {
+  body?: string
+  signatureHeader?: string | null
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  return res.json()
+}
+
+function buildContext(opts: BuildOpts) {
+  const body = opts.body ?? JSON.stringify(SAMPLE_EVENT)
+  const headers = new Headers({ 'Content-Type': 'application/json' })
+  if (opts.signatureHeader !== null && opts.signatureHeader !== undefined) {
+    headers.set('stripe-signature', opts.signatureHeader)
+  }
+  const request = new Request('http://test.local/api/webhooks/stripe', {
+    method: 'POST',
+    headers,
+    body,
+  })
+  return {
+    request,
+    params: {},
+    locals: {},
+    redirect: (url: string, status: number) =>
+      new Response(null, { status, headers: { Location: url } }),
+  } as unknown as Parameters<typeof POST>[0]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/webhooks/stripe — signature verification', () => {
+  beforeEach(() => {
+    Object.assign(testEnv, { STRIPE_WEBHOOK_SECRET: SECRET })
+    // Suppress expected console.error noise on the negative paths.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    for (const k of Object.keys(testEnv)) {
+      delete (testEnv as unknown as Record<string, unknown>)[k]
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('accepts a request with a valid signature + fresh timestamp', async () => {
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const ts = nowSeconds()
+    const sig = await computeStripeV1(ts, body, SECRET)
+    const res = await POST(buildContext({ body, signatureHeader: buildStripeHeader(ts, sig) }))
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects a request whose signature has been tampered with (single bit flip)', async () => {
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const ts = nowSeconds()
+    const sig = await computeStripeV1(ts, body, SECRET)
+    // Flip one hex char of the signature
+    const flipped = sig.slice(0, -1) + (sig.slice(-1) === '0' ? '1' : '0')
+    const res = await POST(buildContext({ body, signatureHeader: buildStripeHeader(ts, flipped) }))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('rejects a request signed with the wrong secret', async () => {
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const ts = nowSeconds()
+    const sig = await computeStripeV1(ts, body, WRONG_SECRET)
+    const res = await POST(buildContext({ body, signatureHeader: buildStripeHeader(ts, sig) }))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('rejects a request with no Stripe-Signature header', async () => {
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const res = await POST(buildContext({ body, signatureHeader: null }))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('rejects a request whose timestamp is more than 5 minutes old', async () => {
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const staleTs = nowSeconds() - 6 * 60
+    // Sign with the correct secret + stale timestamp so we know the freshness
+    // check is what's rejecting (not the HMAC).
+    const sig = await computeStripeV1(staleTs, body, SECRET)
+    const res = await POST(buildContext({ body, signatureHeader: buildStripeHeader(staleTs, sig) }))
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('rejects a request where the body has been mutated after signing', async () => {
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const ts = nowSeconds()
+    const sig = await computeStripeV1(ts, body, SECRET)
+    // Mutate body to simulate an attacker swapping the payload while
+    // re-using a captured signature.
+    const tampered = body.replace('customer.subscription.created', 'invoice.paid')
+    const res = await POST(
+      buildContext({ body: tampered, signatureHeader: buildStripeHeader(ts, sig) })
+    )
+    expect(res.status).toBe(401)
+    const json = await parseJson<{ error: string }>(res)
+    expect(json.error).toBe('Invalid signature')
+  })
+
+  it('returns 500 when the webhook secret is not configured', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).STRIPE_WEBHOOK_SECRET
+    const body = JSON.stringify(SAMPLE_EVENT)
+    const ts = nowSeconds()
+    const sig = await computeStripeV1(ts, body, SECRET)
+    const res = await POST(buildContext({ body, signatureHeader: buildStripeHeader(ts, sig) }))
+    expect(res.status).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `tests/webhooks/{signwell-verify,stripe-verify}.test.ts` — 13 behavioral tests against the actual webhook routes, exercising every documented failure mode of the file-private verification functions.

## Why behavioral, not unit

`verifyEventHash` (SignWell) and `verifyStripeSignature` (Stripe) are file-private to their route handlers. We exercise them through the routes so the test catches regressions in both the crypto AND the wiring (header parsing, freshness window, secret-not-configured-returns-500). To keep the test focused on the crypto boundary we pick non-dispatched event types — signwell `document_viewed` and stripe `customer.subscription.created` — so a successful verification returns 200 without seeding D1, R2, or downstream-handler state.

## Coverage

Per webhook:

- valid hash + fresh timestamp → 200
- tampered hash (single bit flip) → 401
- wrong secret → 401
- missing signature header / hash field → 401 / 400
- stale timestamp (> 5 min old) → 401
- missing webhook secret env var → 500

Stripe additionally covers **body-mutation-after-sign** — the classic captured-signature replay against a different payload. The freshness window alone doesn't catch this; only the HMAC over `<timestamp>.<rawBody>` does. Worth its own test.

## Test plan

- [x] `npm run test -- tests/webhooks/` — 13/13 pass
- [x] `npm run lint && npm run typecheck && npm test && npm run build` — all green (1749 tests pass, 1736 baseline + 13 new)

Closes #728