### PR TITLE
chore: path-to-a cleanup bundle (8 fixes)

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -6,6 +6,8 @@ sidebar:
 
 Architecture Decision Records (ADRs) capturing strategic and technical decisions made during the SMD Services platform build.
 
+> **Looking for the substantive decision corpus?** The 43+ numbered go-to-market decisions (buy box, scope, pricing, assessment, distribution, delivery) live in [decision-stack.md](./decision-stack.md). The numbered ADRs below capture narrower architectural choices.
+
 ## Files
 
 - [decision-stack.md](./decision-stack.md) - SMD Services Decision Stack - complete reference across all 6 go-to-market layers

--- a/docs/design/brief.md
+++ b/docs/design/brief.md
@@ -507,15 +507,15 @@ No illustration anywhere. Empty states render nothing or a "TBD in SOW" marker �
 
 ### 5.1 `smd.services` — Marketing (Public)
 
-| URL                    | Purpose               | Primary Action       | Status |
-| ---------------------- | --------------------- | -------------------- | ------ |
-| `/`                    | Marketing home        | Book assessment      | Exists |
-| `/get-started`         | Warm landing          | Book assessment      | Exists |
+| URL                    | Purpose               | Primary Action       | Status                                                                                                              |
+| ---------------------- | --------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `/`                    | Marketing home        | Book assessment      | Exists                                                                                                              |
+| `/get-started`         | Warm landing          | Book assessment      | Exists                                                                                                              |
 | `/scorecard`           | Self-serve assessment | Complete & book      | Retired (301 → /) — public route retired in PR #702/#703; `POST /api/scorecard/submit` remains as internal endpoint |
-| `/book`                | Booking form          | Confirm booking      | Exists |
-| `/book/manage/[token]` | Booking management    | Reschedule or cancel | Exists |
-| `/contact`             | General inquiry       | Submit inquiry       | Exists |
-| `/404`                 | Not-found             | Back to home         | Exists |
+| `/book`                | Booking form          | Confirm booking      | Exists                                                                                                              |
+| `/book/manage/[token]` | Booking management    | Reschedule or cancel | Exists                                                                                                              |
+| `/contact`             | General inquiry       | Submit inquiry       | Exists                                                                                                              |
+| `/404`                 | Not-found             | Back to home         | Exists                                                                                                              |
 
 **Auth entry points:**
 

--- a/docs/design/brief.md
+++ b/docs/design/brief.md
@@ -511,7 +511,7 @@ No illustration anywhere. Empty states render nothing or a "TBD in SOW" marker �
 | ---------------------- | --------------------- | -------------------- | ------ |
 | `/`                    | Marketing home        | Book assessment      | Exists |
 | `/get-started`         | Warm landing          | Book assessment      | Exists |
-| `/scorecard`           | Self-serve assessment | Complete & book      | Exists |
+| `/scorecard`           | Self-serve assessment | Complete & book      | Retired (301 → /) — public route retired in PR #702/#703; `POST /api/scorecard/submit` remains as internal endpoint |
 | `/book`                | Booking form          | Confirm booking      | Exists |
 | `/book/manage/[token]` | Booking management    | Reschedule or cancel | Exists |
 | `/contact`             | General inquiry       | Submit inquiry       | Exists |

--- a/docs/design/contributions/round-1/interaction-designer.md
+++ b/docs/design/contributions/round-1/interaction-designer.md
@@ -11,16 +11,16 @@
 
 ### `smd.services` — Marketing (Public)
 
-| URL                    | Purpose                                                  | Primary Action       | PRD Feature                                | Status |
-| ---------------------- | -------------------------------------------------------- | -------------------- | ------------------------------------------ | ------ |
-| `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (no PRD feature ID; supports §2) | Exists |
-| `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                                  | Exists |
+| URL                    | Purpose                                                  | Primary Action       | PRD Feature                                | Status                                                   |
+| ---------------------- | -------------------------------------------------------- | -------------------- | ------------------------------------------ | -------------------------------------------------------- |
+| `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (no PRD feature ID; supports §2) | Exists                                                   |
+| `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                                  | Exists                                                   |
 | `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                                  | Retired (301 → /) — public route retired in PR #702/#703 |
-| `/book`                | Assessment booking form (Calendly-embed or equivalent)   | Confirm booking      | Pre-sales / US-001 upstream                | Exists |
-| `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream                            | Exists |
-| `/book/manage/`        | Fallback when no token in query string                   | Book a call instead  | —                                          | Exists |
-| `/contact`             | General inquiry form                                     | Submit inquiry       | Pre-sales                                  | Exists |
-| `/404`                 | Not-found, subdomain-aware                               | Back to home         | —                                          | Exists |
+| `/book`                | Assessment booking form (Calendly-embed or equivalent)   | Confirm booking      | Pre-sales / US-001 upstream                | Exists                                                   |
+| `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream                            | Exists                                                   |
+| `/book/manage/`        | Fallback when no token in query string                   | Book a call instead  | —                                          | Exists                                                   |
+| `/contact`             | General inquiry form                                     | Submit inquiry       | Pre-sales                                  | Exists                                                   |
+| `/404`                 | Not-found, subdomain-aware                               | Back to home         | —                                          | Exists                                                   |
 
 Auth entry points (on `smd.services` domain, redirect to subdomain sessions):
 

--- a/docs/design/contributions/round-1/interaction-designer.md
+++ b/docs/design/contributions/round-1/interaction-designer.md
@@ -15,7 +15,7 @@
 | ---------------------- | -------------------------------------------------------- | -------------------- | ------------------------------------------ | ------ |
 | `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (no PRD feature ID; supports §2) | Exists |
 | `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                                  | Exists |
-| `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                                  | Exists |
+| `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                                  | Retired (301 → /) — public route retired in PR #702/#703 |
 | `/book`                | Assessment booking form (Calendly-embed or equivalent)   | Confirm booking      | Pre-sales / US-001 upstream                | Exists |
 | `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream                            | Exists |
 | `/book/manage/`        | Fallback when no token in query string                   | Book a call instead  | —                                          | Exists |

--- a/docs/design/contributions/round-2/interaction-designer.md
+++ b/docs/design/contributions/round-2/interaction-designer.md
@@ -40,16 +40,16 @@
 
 ### `smd.services` — Marketing (Public)
 
-| URL                    | Purpose                                                  | Primary Action       | PRD Feature                 | Status |
-| ---------------------- | -------------------------------------------------------- | -------------------- | --------------------------- | ------ |
-| `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (supports §2)     | Exists |
-| `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                   | Exists |
+| URL                    | Purpose                                                  | Primary Action       | PRD Feature                 | Status                                                   |
+| ---------------------- | -------------------------------------------------------- | -------------------- | --------------------------- | -------------------------------------------------------- |
+| `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (supports §2)     | Exists                                                   |
+| `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                   | Exists                                                   |
 | `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                   | Retired (301 → /) — public route retired in PR #702/#703 |
-| `/book`                | Assessment booking form                                  | Confirm booking      | Pre-sales / US-001 upstream | Exists |
-| `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream             | Exists |
-| `/book/manage/`        | Fallback when no token                                   | Book a call instead  | —                           | Exists |
-| `/contact`             | General inquiry form                                     | Submit inquiry       | Pre-sales                   | Exists |
-| `/404`                 | Not-found, subdomain-aware                               | Back to home         | —                           | Exists |
+| `/book`                | Assessment booking form                                  | Confirm booking      | Pre-sales / US-001 upstream | Exists                                                   |
+| `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream             | Exists                                                   |
+| `/book/manage/`        | Fallback when no token                                   | Book a call instead  | —                           | Exists                                                   |
+| `/contact`             | General inquiry form                                     | Submit inquiry       | Pre-sales                   | Exists                                                   |
+| `/404`                 | Not-found, subdomain-aware                               | Back to home         | —                           | Exists                                                   |
 
 Auth entry points (on `smd.services` domain, redirect to subdomain sessions):
 

--- a/docs/design/contributions/round-2/interaction-designer.md
+++ b/docs/design/contributions/round-2/interaction-designer.md
@@ -44,7 +44,7 @@
 | ---------------------- | -------------------------------------------------------- | -------------------- | --------------------------- | ------ |
 | `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (supports §2)     | Exists |
 | `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                   | Exists |
-| `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                   | Exists |
+| `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                   | Retired (301 → /) — public route retired in PR #702/#703 |
 | `/book`                | Assessment booking form                                  | Confirm booking      | Pre-sales / US-001 upstream | Exists |
 | `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream             | Exists |
 | `/book/manage/`        | Fallback when no token                                   | Book a call instead  | —                           | Exists |

--- a/docs/design/contributions/round-3/interaction-designer.md
+++ b/docs/design/contributions/round-3/interaction-designer.md
@@ -57,7 +57,7 @@
 | ---------------------- | -------------------------------------------------------- | -------------------- | --------------------------- | ------ |
 | `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (supports §2)     | Exists |
 | `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                   | Exists |
-| `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                   | Exists |
+| `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                   | Retired (301 → /) — public route retired in PR #702/#703 |
 | `/book`                | Assessment booking form                                  | Confirm booking      | Pre-sales / US-001 upstream | Exists |
 | `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream             | Exists |
 | `/book/manage/`        | Fallback when no token                                   | Book a call instead  | —                           | Exists |

--- a/docs/design/contributions/round-3/interaction-designer.md
+++ b/docs/design/contributions/round-3/interaction-designer.md
@@ -53,16 +53,16 @@
 
 ### `smd.services` — Marketing (Public)
 
-| URL                    | Purpose                                                  | Primary Action       | PRD Feature                 | Status |
-| ---------------------- | -------------------------------------------------------- | -------------------- | --------------------------- | ------ |
-| `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (supports §2)     | Exists |
-| `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                   | Exists |
+| URL                    | Purpose                                                  | Primary Action       | PRD Feature                 | Status                                                   |
+| ---------------------- | -------------------------------------------------------- | -------------------- | --------------------------- | -------------------------------------------------------- |
+| `/`                    | Marketing home — credibility, positioning, guide-persona | Book assessment      | Pre-sales (supports §2)     | Exists                                                   |
+| `/get-started`         | Onboarding CTA / warm landing                            | Book assessment      | Pre-sales                   | Exists                                                   |
 | `/scorecard`           | Self-serve assessment wizard                             | Complete & book      | Pre-sales                   | Retired (301 → /) — public route retired in PR #702/#703 |
-| `/book`                | Assessment booking form                                  | Confirm booking      | Pre-sales / US-001 upstream | Exists |
-| `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream             | Exists |
-| `/book/manage/`        | Fallback when no token                                   | Book a call instead  | —                           | Exists |
-| `/contact`             | General inquiry form                                     | Submit inquiry       | Pre-sales                   | Exists |
-| `/404`                 | Not-found, subdomain-aware                               | Back to home         | —                           | Exists |
+| `/book`                | Assessment booking form                                  | Confirm booking      | Pre-sales / US-001 upstream | Exists                                                   |
+| `/book/manage/[token]` | Booking management via email token (reschedule/cancel)   | Reschedule or cancel | US-001 upstream             | Exists                                                   |
+| `/book/manage/`        | Fallback when no token                                   | Book a call instead  | —                           | Exists                                                   |
+| `/contact`             | General inquiry form                                     | Submit inquiry       | Pre-sales                   | Exists                                                   |
+| `/404`                 | Not-found, subdomain-aware                               | Back to home         | —                           | Exists                                                   |
 
 Auth entry points:
 

--- a/docs/design/operations-health-scorecard.md
+++ b/docs/design/operations-health-scorecard.md
@@ -1,8 +1,10 @@
 # Operations Health Scorecard — Functional Design Spec
 
 **Issue:** #147
-**Status:** Design
+**Status:** Retired (2026-05-04)
 **Last updated:** 2026-04-02
+
+> **Retired 2026-05-04.** The public `/scorecard` route was retired in PR #702/#703 alongside the broader Outside View retirement. The route now 301-redirects to `/`. Only `POST /api/scorecard/submit` remains as an internal endpoint. This spec is preserved for historical reference; do not implement against it.
 
 ---
 

--- a/docs/handoffs/workers-migration-validation.md
+++ b/docs/handoffs/workers-migration-validation.md
@@ -10,7 +10,7 @@ Pair this with `wrangler tail ss-web --format pretty` running in a second shell 
 - [ ] `GET /book` → 200, contains Turnstile widget markup
 - [ ] `GET /contact` → 200
 - [ ] `GET /get-started` → 200
-- [ ] `GET /scorecard` → 200
+- [ ] `GET /scorecard` → 301 redirect to `/` (retired in PR #702/#703)
 - [ ] `GET /404-nonexistent` → 404 with prerendered 404 body
 - [ ] `GET /favicon.svg`, `/og-image.png`, `/scott-durgan.jpg`, `/robots.txt` → 200 from `[assets]` binding
 - [ ] `GET /sitemap-index.xml` → 200 (Astro sitemap integration)

--- a/migrations/0027_create_enrichment_runs.sql
+++ b/migrations/0027_create_enrichment_runs.sql
@@ -1,3 +1,10 @@
+-- HISTORICAL: This migration shares its 00NN prefix with another migration applied
+-- in the same timeframe. Wrangler tracks applied migrations by full filename so
+-- both apply correctly, but the prefix collision violates the "monotonic unique
+-- prefix" convention. Do NOT rename to fix — renaming applied migrations causes
+-- D1 to reapply them as new migrations in prod. Going forward, each migration
+-- must use a unique, monotonically-increasing 00NN prefix.
+
 -- Per-module enrichment-run state. Replaces the in-memory EnrichResult that
 -- workers/admin endpoints discarded after every call, leaving us with no way
 -- to see which modules ran for which entity (or why some — like Cactus

--- a/migrations/0027_harden_magic_links_context_and_milestones.sql
+++ b/migrations/0027_harden_magic_links_context_and_milestones.sql
@@ -1,3 +1,10 @@
+-- HISTORICAL: This migration shares its 00NN prefix with another migration applied
+-- in the same timeframe. Wrangler tracks applied migrations by full filename so
+-- both apply correctly, but the prefix collision violates the "monotonic unique
+-- prefix" convention. Do NOT rename to fix — renaming applied migrations causes
+-- D1 to reapply them as new migrations in prod. Going forward, each migration
+-- must use a unique, monotonically-increasing 00NN prefix.
+
 -- Migration 0027: Harden magic_links, context, and milestones
 --
 -- Fixes three integrity gaps left by earlier incremental migrations:

--- a/migrations/0028_create_outreach_events.sql
+++ b/migrations/0028_create_outreach_events.sql
@@ -1,3 +1,10 @@
+-- HISTORICAL: This migration shares its 00NN prefix with another migration applied
+-- in the same timeframe. Wrangler tracks applied migrations by full filename so
+-- both apply correctly, but the prefix collision violates the "monotonic unique
+-- prefix" convention. Do NOT rename to fix — renaming applied migrations causes
+-- D1 to reapply them as new migrations in prod. Going forward, each migration
+-- must use a unique, monotonically-increasing 00NN prefix.
+
 -- Outreach attribution telemetry. Captures per-message lifecycle events
 -- (sent / open / click / bounce / reply) so we can answer the most basic
 -- ROI question for lead-gen: which signals turn into engagements, and at

--- a/migrations/0028_originating_signal_attribution.sql
+++ b/migrations/0028_originating_signal_attribution.sql
@@ -1,3 +1,10 @@
+-- HISTORICAL: This migration shares its 00NN prefix with another migration applied
+-- in the same timeframe. Wrangler tracks applied migrations by full filename so
+-- both apply correctly, but the prefix collision violates the "monotonic unique
+-- prefix" convention. Do NOT rename to fix — renaming applied migrations causes
+-- D1 to reapply them as new migrations in prod. Going forward, each migration
+-- must use a unique, monotonically-increasing 00NN prefix.
+
 -- Originating-signal attribution on lifecycle artifacts (#589).
 --
 -- Why: signals (rows in `context` with type='signal') are the leading indicator

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "globals": "^17.6.0",
         "husky": "^9.1.0",
         "lint-staged": "^15.4.0",
-        "pdf-lib": "^1.17.1",
         "prettier": "^3.4.0",
         "prettier-plugin-astro": "^0.14.1",
         "tailwindcss": "^4.2.2",
@@ -43,11 +42,13 @@
       }
     },
     "node_modules/@astrojs/check": {
-      "version": "0.9.8",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/language-server": "^2.16.5",
+        "@astrojs/language-server": "^2.16.7",
         "chokidar": "^4.0.3",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
@@ -56,7 +57,7 @@
         "astro-check": "bin/astro-check.js"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@astrojs/cloudflare": {
@@ -92,7 +93,9 @@
       }
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.16.6",
+      "version": "2.16.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.7.tgz",
+      "integrity": "sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -104,7 +107,7 @@
         "@volar/language-server": "~2.4.28",
         "@volar/language-service": "~2.4.28",
         "muggle-string": "^0.4.1",
-        "tinyglobby": "^0.2.15",
+        "tinyglobby": "^0.2.16",
         "volar-service-css": "0.0.70",
         "volar-service-emmet": "0.0.70",
         "volar-service-html": "0.0.70",
@@ -207,6 +210,8 @@
     },
     "node_modules/@astrojs/yaml2ts": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -435,6 +440,8 @@
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -443,6 +450,8 @@
     },
     "node_modules/@emmetio/css-abbreviation": {
       "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -451,6 +460,8 @@
     },
     "node_modules/@emmetio/css-parser": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -460,6 +471,8 @@
     },
     "node_modules/@emmetio/html-matcher": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -468,16 +481,22 @@
     },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader-utils": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1665,22 +1684,6 @@
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@pdf-lib/standard-fonts": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^1.0.6"
-      }
-    },
-    "node_modules/@pdf-lib/upng": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^1.0.10"
-      }
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -3216,6 +3219,8 @@
     },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3231,6 +3236,8 @@
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3239,6 +3246,8 @@
     },
     "node_modules/@volar/language-server": {
       "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3255,6 +3264,8 @@
     },
     "node_modules/@volar/language-service": {
       "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3266,11 +3277,15 @@
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3281,6 +3296,8 @@
     },
     "node_modules/@vscode/emmet-helper": {
       "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3293,6 +3310,8 @@
     },
     "node_modules/@vscode/l10n": {
       "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4251,6 +4270,8 @@
     },
     "node_modules/emmet": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -4780,7 +4801,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5429,6 +5452,8 @@
     },
     "node_modules/jsonc-parser": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6786,6 +6811,8 @@
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7068,11 +7095,6 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -7117,6 +7139,8 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
     },
@@ -7152,22 +7176,6 @@
         "node": ">= 14.16"
       }
     },
-    "node_modules/pdf-lib": {
-      "version": "1.17.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pdf-lib/standard-fonts": "^1.0.0",
-        "@pdf-lib/upng": "^1.0.1",
-        "pako": "^1.0.11",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/pdf-lib/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -7200,7 +7208,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7517,6 +7527,8 @@
     },
     "node_modules/request-light": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7530,6 +7542,8 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8247,6 +8261,8 @@
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8264,6 +8280,8 @@
     },
     "node_modules/typescript-auto-import-cache": {
       "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8891,6 +8909,8 @@
     },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8909,6 +8929,8 @@
     },
     "node_modules/volar-service-emmet": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8928,6 +8950,8 @@
     },
     "node_modules/volar-service-html": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8946,6 +8970,8 @@
     },
     "node_modules/volar-service-prettier": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8966,6 +8992,8 @@
     },
     "node_modules/volar-service-typescript": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8987,6 +9015,8 @@
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9003,6 +9033,8 @@
     },
     "node_modules/volar-service-yaml": {
       "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9020,6 +9052,8 @@
     },
     "node_modules/vscode-css-languageservice": {
       "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9031,6 +9065,8 @@
     },
     "node_modules/vscode-html-languageservice": {
       "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9042,6 +9078,8 @@
     },
     "node_modules/vscode-json-languageservice": {
       "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9057,11 +9095,15 @@
     },
     "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9070,6 +9112,8 @@
     },
     "node_modules/vscode-languageserver": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9081,6 +9125,8 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9090,21 +9136,29 @@
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9736,6 +9790,8 @@
     },
     "node_modules/yaml-language-server": {
       "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9756,7 +9812,9 @@
       }
     },
     "node_modules/yaml-language-server/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9772,6 +9830,8 @@
     },
     "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -9785,16 +9845,22 @@
     },
     "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "globals": "^17.6.0",
     "husky": "^9.1.0",
     "lint-staged": "^15.4.0",
-    "pdf-lib": "^1.17.1",
     "prettier": "^3.4.0",
     "prettier-plugin-astro": "^0.14.1",
     "tailwindcss": "^4.2.2",

--- a/src/lib/enrichment/dispatch.ts
+++ b/src/lib/enrichment/dispatch.ts
@@ -139,7 +139,7 @@ export async function dispatchEnrichmentWorkflow(
  * treat it as non-prod and log a warning.
  */
 function isProductionEnvironment(): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ua = (globalThis as any).navigator?.userAgent
+  const nav = (globalThis as { navigator?: { userAgent?: string } }).navigator
+  const ua = nav?.userAgent
   return typeof ua === 'string' && ua === 'Cloudflare-Workers'
 }


### PR DESCRIPTION
## Summary

Bundle of 8 small, independent cleanups to lift dimension grades from B to A across Dependencies, Architecture, Code Quality, and Documentation.

## Fixes

### Dependencies → A

1. **Remove unused `pdf-lib`.** Declared in `dependencies` (`^1.17.1`) with zero imports across `src/` and `workers/`. Codebase uses `@formepdf/core` and `@formepdf/react` exclusively for PDFs. `npm uninstall pdf-lib`; build still succeeds.
2. **`npm audit fix` for postcss moderate.** Clears the postcss `<8.5.10` XSS variant in the `@astrojs/check` → `@astrojs/language-server` → `volar-service-yaml` → `postcss` chain. Non-force form leaves the breaking-change `yaml` chain as-is. `npm audit` no longer reports a postcss advisory.

### Architecture → A

3. **`workers/scan-workflow/` shell directory.** Already removed at HEAD of `chore/path-to-a-cleanup` (off `origin/main` at `fa9024f`). No-op for this PR; calling out so the dimension grade lifts cleanly. The only stale reference is a comment in `workers/enrichment-workflow/wrangler.toml` line 4 citing `ss-scan-workflow` as historical context — left in place since it's genuinely historical and removing it would erase the architectural-rationale paper trail.
4. **Document 0027/0028 migration prefix collisions.** Prepended a HISTORICAL comment block to all four affected files (`migrations/0027_create_enrichment_runs.sql`, `migrations/0027_harden_magic_links_context_and_milestones.sql`, `migrations/0028_create_outreach_events.sql`, `migrations/0028_originating_signal_attribution.sql`) explaining the collision, why renaming would break D1 idempotency in prod, and the monotonic-prefix convention going forward.

### Code Quality → A

5. **Replace `any` cast in `src/lib/enrichment/dispatch.ts:142`.** Was `(globalThis as any).navigator?.userAgent` with an `eslint-disable-next-line`. Replaced with a scoped typed cast: `(globalThis as { navigator?: { userAgent?: string } }).navigator`. Call-site semantics preserved; eslint-disable removed.

### Documentation → A

6. **ADR index pointer to `decision-stack.md`.** Added a blockquote near the top of `docs/adr/index.md` directing readers to the substantive decision corpus (43+ decisions across 6 go-to-market layers). Existing ADR list intact.
7. **Annotate retired `/scorecard` route in design docs.** Updated route tables in `docs/design/brief.md`, `docs/design/contributions/round-1/interaction-designer.md`, `docs/design/contributions/round-2/interaction-designer.md` from "Exists" to "Retired (301 → /) — public route retired in PR #702/#703".
8. **Final sweep across `docs/`.** Caught and annotated three additional files: `docs/design/contributions/round-3/interaction-designer.md` (same route table pattern); `docs/design/operations-health-scorecard.md` (retirement banner at top of the spec); `docs/handoffs/workers-migration-validation.md` line 13 (`GET /scorecard → 200` corrected to `→ 301 redirect to /`). ADR text in `0002-outside-view-unified-diagnostic.md` and `decision-stack.md`, plus `audits/` and `style/UI-PATTERNS.md` history left intact — those are historical record, not active references.

## Verification

All green on `chore/path-to-a-cleanup` worktree:

- `npm run lint` — 0 errors, 66 pre-existing warnings
- `npm run typecheck` — 0 errors, 0 warnings, 14 hints
- `npm run test` — 1758 passed, 2 skipped (after `npm run build`)
- `npm run build` — clean

No `--no-verify` or `eslint-disable` was used to bypass anything.

## Test plan

- [ ] CI passes the required `Typecheck, Lint, Format, Test` check
- [ ] Confirm `npm audit` no longer reports postcss-related advisories
- [ ] Spot-check one migration file to confirm the HISTORICAL block reads cleanly above the existing rationale comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)