### PR TITLE
feat(observability): integrate Sentry on Cloudflare Workers (gated on SENTRY_DSN)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/sitemap": "^3.7.2",
         "@formepdf/core": "^0.8.2",
         "@formepdf/react": "^0.8.2",
+        "@sentry/cloudflare": "^10.51.0",
         "@venturecrane/tokens": "0.0.2-alpha.0",
         "astro": "^6.1.7",
         "date-fns": "^4.1.0",
@@ -1653,6 +1654,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -2063,6 +2073,36 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/cloudflare": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.51.0.tgz",
+      "integrity": "sha512-oDv2i70q25QPG9zN2GbdtkAjxBdvwHjZL+2aAuilDsagz+jUMq89EXrdh3RPdqnSlaTOqMJovIRDJVbTvpOCsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@astrojs/sitemap": "^3.7.2",
     "@formepdf/core": "^0.8.2",
     "@formepdf/react": "^0.8.2",
+    "@sentry/cloudflare": "^10.51.0",
     "@venturecrane/tokens": "0.0.2-alpha.0",
     "astro": "^6.1.7",
     "date-fns": "^4.1.0",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -124,6 +124,13 @@ declare namespace Cloudflare {
      */
     ENABLE_PUBLIC_PATTERNS?: string
     /**
+     * Sentry DSN for Workers-side error monitoring. Optional — when unset,
+     * the integration is a complete no-op (no SDK init, zero overhead).
+     * Provisioned via `wrangler secret put SENTRY_DSN`. See
+     * src/lib/observability/sentry.ts.
+     */
+    SENTRY_DSN?: string
+    /**
      * Service binding to the `ss-enrichment-workflow` Worker (#631). Hosts
      * the EnrichmentWorkflow class for entity enrichment. Dispatched from
      * lead-gen workers and admin endpoints by POSTing to the binding's

--- a/src/lib/observability/sentry.ts
+++ b/src/lib/observability/sentry.ts
@@ -1,0 +1,47 @@
+import * as Sentry from '@sentry/cloudflare'
+import type { APIContext } from 'astro'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Workers-side Sentry integration. Wraps the Astro middleware request
+ * handler with Sentry instrumentation when `SENTRY_DSN` is set; no-ops
+ * otherwise.
+ *
+ * Why middleware-level wrapping (and not `withSentry` on the exported
+ * fetch handler): the @astrojs/cloudflare adapter writes the Worker
+ * entry at build time — there is no source-controlled handler to wrap.
+ * `wrapRequestHandler` is the official @sentry/cloudflare path for
+ * exactly this case (it's how the SvelteKit-on-Cloudflare integration
+ * initialises Sentry from a per-request hook). See the Sentry SDK
+ * README for `@sentry/cloudflare`.
+ *
+ * No-op behaviour: when `SENTRY_DSN` is unset, `withSentryRequestHandler`
+ * returns the bare handler result. The Sentry SDK is imported but never
+ * initialised, so no transport opens and no global handlers are wired.
+ */
+
+function buildOptions(dsn: string): Sentry.CloudflareOptions {
+  return {
+    dsn,
+    environment: env.APP_BASE_URL?.includes('smd.services') ? 'production' : 'development',
+    tracesSampleRate: 0.1,
+    sendDefaultPii: false,
+  }
+}
+
+export async function withSentryRequestHandler(
+  context: APIContext,
+  handler: () => Promise<Response>
+): Promise<Response> {
+  const dsn = env.SENTRY_DSN
+  if (!dsn) return handler()
+
+  return Sentry.wrapRequestHandler(
+    {
+      options: buildOptions(dsn),
+      request: context.request,
+      context: context.locals.cfContext,
+    },
+    handler
+  )
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ import {
   buildSessionCookie,
   buildClearSessionCookie,
 } from './lib/auth/session'
+import { withSentryRequestHandler } from './lib/observability/sentry'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -171,7 +172,7 @@ function applySessionCookie(
   }
 }
 
-export const onRequest = defineMiddleware(async (context, next: NextFn) => {
+async function handleRequest(context: APIContext, next: NextFn): Promise<Response> {
   const { pathname } = context.url
   const hostname = context.url.hostname
 
@@ -190,4 +191,8 @@ export const onRequest = defineMiddleware(async (context, next: NextFn) => {
   const response = await next()
   if (token) applySessionCookie(response, context, token, hostname)
   return response
+}
+
+export const onRequest = defineMiddleware(async (context: APIContext, next: NextFn) => {
+  return withSentryRequestHandler(context, () => handleRequest(context, next))
 })

--- a/tests/sentry-gating.test.ts
+++ b/tests/sentry-gating.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { APIContext } from 'astro'
+import { env as testEnv } from 'cloudflare:workers'
+
+const { wrapSpy } = vi.hoisted(() => ({
+  wrapSpy: vi.fn(async (_opts: unknown, h: () => Promise<Response>) => h()),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+  wrapRequestHandler: wrapSpy,
+}))
+
+import { withSentryRequestHandler } from '../src/lib/observability/sentry'
+
+function resetEnv(): void {
+  for (const key of Object.keys(testEnv)) delete testEnv[key as keyof typeof testEnv]
+}
+
+function makeApiContext(): APIContext {
+  return {
+    request: new Request('https://smd.services/'),
+    locals: { cfContext: undefined, session: null },
+  } as unknown as APIContext
+}
+
+describe('observability/sentry: gating', () => {
+  beforeEach(() => {
+    resetEnv()
+    wrapSpy.mockClear()
+  })
+
+  afterEach(() => {
+    resetEnv()
+  })
+
+  it('returns the bare handler result when SENTRY_DSN is unset (no-op)', async () => {
+    const ctx = makeApiContext()
+    const handler = vi.fn<() => Promise<Response>>().mockResolvedValue(new Response('ok'))
+
+    const response = await withSentryRequestHandler(ctx, handler)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(wrapSpy).not.toHaveBeenCalled()
+    expect(await response.text()).toBe('ok')
+  })
+
+  it('delegates to wrapRequestHandler when SENTRY_DSN is set', async () => {
+    Object.assign(testEnv, { SENTRY_DSN: 'https://example@o0.ingest.sentry.io/0' })
+    const ctx = makeApiContext()
+    const handler = vi.fn<() => Promise<Response>>().mockResolvedValue(new Response('wrapped'))
+
+    const response = await withSentryRequestHandler(ctx, handler)
+
+    expect(wrapSpy).toHaveBeenCalledTimes(1)
+    const [opts] = wrapSpy.mock.calls[0]
+    expect((opts as { options: { dsn: string } }).options.dsn).toBe(
+      'https://example@o0.ingest.sentry.io/0'
+    )
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(await response.text()).toBe('wrapped')
+  })
+})
+
+describe('observability/sentry: source-level guarantees', () => {
+  const source = readFileSync(resolve('src/lib/observability/sentry.ts'), 'utf-8')
+
+  it('imports from @sentry/cloudflare (Workers SDK, not @sentry/astro)', () => {
+    expect(source).toContain("from '@sentry/cloudflare'")
+    expect(source).not.toContain('@sentry/astro')
+  })
+
+  it('reads DSN from env, never hardcodes a fallback', () => {
+    expect(source).toContain('env.SENTRY_DSN')
+    expect(source).not.toMatch(/dsn:\s*['"]https:\/\//i)
+  })
+
+  it('gates wrapRequestHandler call on DSN presence', () => {
+    expect(source).toMatch(/if\s*\(\s*!dsn\s*\)/)
+  })
+})
+
+describe('middleware: wires Sentry wrapper', () => {
+  const source = readFileSync(resolve('src/middleware.ts'), 'utf-8')
+
+  it('imports withSentryRequestHandler', () => {
+    expect(source).toContain('withSentryRequestHandler')
+  })
+
+  it('wraps the handler in onRequest', () => {
+    expect(source).toContain('withSentryRequestHandler(context')
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -138,6 +138,9 @@ name = "ss-web-staging"
 # STRIPE_API_KEY          — Stripe invoicing
 # STRIPE_WEBHOOK_SECRET   — Stripe webhook verification
 # PROXYCURL_API_KEY       — LinkedIn company data (optional, Tier 4 dossier)
+# SENTRY_DSN               — Workers-side Sentry error monitoring (optional —
+#                            integration is a no-op when unset; see
+#                            src/lib/observability/sentry.ts)
 #
 # Booking system (Calendly replacement) — added in migration 0011 era:
 # GOOGLE_CLIENT_ID         — Google Cloud OAuth 2.0 client ID


### PR DESCRIPTION
## Summary

Adds Workers-side error monitoring via `@sentry/cloudflare`, wired into `src/middleware.ts` using the `wrapRequestHandler` pattern. **PR is a no-op until `SENTRY_DSN` is provisioned** — when the secret is unset, the wrap call is skipped so the Sentry SDK is never initialised. Lifts Golden Path observability from B to A: the Cloudflare `[observability]` binding already captures duration metrics and uncaught exceptions; this adds aggregated stack traces and error rates.

## Context7 research

Consulted the official Sentry docs (`/getsentry/sentry-docs`) and JS SDK repo (`/getsentry/sentry-javascript`) for the current `@sentry/cloudflare` integration pattern.

Relevant sections:
- `packages/cloudflare/README.md` (`/getsentry/sentry-javascript`) — documents two integration patterns: `withSentry` for raw exported `fetch` handlers, and `wrapRequestHandler` for per-request init from a framework hook. The README's SvelteKit example uses `wrapRequestHandler` from `event.platform.env.SENTRY_DSN`.
- `docs/platforms/javascript/guides/cloudflare/frameworks/astro.mdx` — the canonical install pattern for Astro is `@sentry/astro` + `@sentry/cloudflare`. The `@sentry/astro` integration auto-detects the Cloudflare adapter and wraps the Worker entry, but it also installs **client-side** instrumentation (`sentry.client.config.ts` + browser SDK injection).

## Integration choice and rationale

**Used `@sentry/cloudflare` alone, init via `wrapRequestHandler` in Astro middleware.**

The task brief is explicit: "no client-side Sentry on the marketing pages — Workers-side coverage only at this stage." The `@sentry/astro` integration would violate that by adding browser SDK injection. `@sentry/cloudflare` directly is the right fit for Workers-only coverage.

The middleware-level `wrapRequestHandler` pattern (vs `withSentry` on the exported fetch handler) is the right wrapper for this app because the `@astrojs/cloudflare` v13 adapter writes the Worker entry at build time — there is no source-controlled handler to wrap. `wrapRequestHandler` is the official Sentry path for exactly this case (it's what the SvelteKit-on-Cloudflare integration uses internally). `nodejs_compat` is already enabled in `wrangler.toml`, so AsyncLocalStorage is available as the SDK requires.

## What changed

- `package.json` — adds `@sentry/cloudflare@^10.51.0`
- `src/env.d.ts` — adds `SENTRY_DSN?: string` to `Cloudflare.Env`
- `src/lib/observability/sentry.ts` — new module: `withSentryRequestHandler(context, handler)` no-ops when DSN unset, otherwise calls `Sentry.wrapRequestHandler` with environment + 10% trace sample rate
- `src/middleware.ts` — extracts the existing onRequest body into `handleRequest()` and wraps the call site with `withSentryRequestHandler`. Net delta: +1 line wrapping the handler invocation, structural refactor of the body into a named function. No semantics change.
- `wrangler.toml` — adds `SENTRY_DSN` to the documented secrets list (it is a secret, not a `[vars]` entry)
- `tests/sentry-gating.test.ts` — 7 tests covering the no-op path, the wrapped path, and source-level invariants (no `@sentry/astro` import, no hardcoded DSN fallback, gate present, middleware wires the wrapper)

## Verification

- `npm run lint` — 0 errors (3 errors I introduced were fixed; net lint delta on `middleware.ts` is **−1 warning** vs baseline because the body refactor eliminated one `Unsafe assignment` site)
- `npm run typecheck` — 0 errors, 0 warnings
- `npm run test` — 1766 passed, 2 skipped (pre-existing skips), 1 sentry test file with 7 passing
- `npm run build` — clean (the two pre-existing vite circular-dep warnings are unrelated to this PR)
- Local smoke (no DSN): `npm run dev` boots cleanly — Astro v6.1.7 ready in ~1.9s, no Sentry init noise

## Captain follow-up

After merge, Captain provisions:
1. Create Sentry project at sentry.io under SMDurgan LLC org, named `ss-web`
2. Copy the DSN
3. Add to Worker secrets: `echo $SENTRY_DSN | npx wrangler secret put SENTRY_DSN`
   (or via Infisical → wrangler secret bulk path documented in CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)