### PR TITLE
fix(book): restore post-Send AI reply / booking CTA on /book

### DIFF
--- a/src/scripts/book.ts
+++ b/src/scripts/book.ts
@@ -74,7 +74,9 @@ function dispatchClearError(root: HTMLElement): void {
 }
 
 function dispatchAiReply(root: HTMLElement, reply: string | null): void {
-  root.dispatchEvent(new CustomEvent('unified-ai-reply', { detail: { reply }, bubbles: false }))
+  root.dispatchEvent(
+    new CustomEvent('unified-show-ai-reply', { detail: { reply }, bubbles: false })
+  )
 }
 
 function showConfirmation(els: BookElements, body: BookingResponse, state: BookState): void {

--- a/tests/booking/unified-intake-event-contract.test.ts
+++ b/tests/booking/unified-intake-event-contract.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression guard: every `unified-*` CustomEvent dispatched in one of the
+ * two collaborating files must be listened for in the other.
+ *
+ * /book splits its UI into UnifiedIntake.astro (component) and
+ * src/scripts/book.ts (page-level controller). They communicate over
+ * CustomEvents on the `#unified-intake` element. If a dispatch and its
+ * matching listener disagree on the event name, the listener silently
+ * never fires — that breaks the post-Send AI reply / "Pick a time to
+ * talk" CTA without any error or test signal.
+ *
+ * This regression actually shipped: PR #722 extracted book.ts out of
+ * book.astro and renamed `unified-show-ai-reply` to `unified-ai-reply`
+ * in the dispatcher only, leaving the listener stranded.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const BOOK_TS = resolve('src/scripts/book.ts')
+const UNIFIED_INTAKE_ASTRO = resolve('src/components/booking/UnifiedIntake.astro')
+
+const DISPATCH_RE = /dispatchEvent\(\s*new\s+CustomEvent\(\s*['"](unified-[a-z-]+)['"]/g
+const LISTEN_RE = /addEventListener\(\s*['"](unified-[a-z-]+)['"]/g
+
+function extractEventNames(source: string, regex: RegExp): Set<string> {
+  const names = new Set<string>()
+  for (const match of source.matchAll(regex)) {
+    names.add(match[1])
+  }
+  return names
+}
+
+describe('UnifiedIntake event contract', () => {
+  const bookTs = readFileSync(BOOK_TS, 'utf8')
+  const unifiedIntake = readFileSync(UNIFIED_INTAKE_ASTRO, 'utf8')
+
+  const bookDispatches = extractEventNames(bookTs, DISPATCH_RE)
+  const bookListens = extractEventNames(bookTs, LISTEN_RE)
+  const intakeDispatches = extractEventNames(unifiedIntake, DISPATCH_RE)
+  const intakeListens = extractEventNames(unifiedIntake, LISTEN_RE)
+
+  it('every event book.ts dispatches is listened for in UnifiedIntake.astro', () => {
+    for (const name of bookDispatches) {
+      expect(
+        intakeListens,
+        `book.ts dispatches "${name}" but UnifiedIntake.astro never listens`
+      ).toContain(name)
+    }
+  })
+
+  it('every event UnifiedIntake.astro dispatches is listened for in book.ts', () => {
+    for (const name of intakeDispatches) {
+      expect(
+        bookListens,
+        `UnifiedIntake.astro dispatches "${name}" but book.ts never listens`
+      ).toContain(name)
+    }
+  })
+
+  it('extracts a non-empty set on both sides (sanity)', () => {
+    expect(bookDispatches.size).toBeGreaterThan(0)
+    expect(intakeListens.size).toBeGreaterThan(0)
+    expect(intakeDispatches.size).toBeGreaterThan(0)
+    expect(bookListens.size).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Captain reported that submitting the /book intake form left the form silent — no AI reply, no acknowledgement, no "Pick a time to talk" CTA. Source-code root-cause: PR #722's lint refactor (`9748afc`) extracted `book.ts` out of `book.astro` and renamed the AI-reply CustomEvent in the dispatcher only, leaving `UnifiedIntake.astro:493`'s listener stranded on the old name.
- One-line fix in `src/scripts/book.ts`: rename dispatched event back to `unified-show-ai-reply`.
- New regression test `tests/booking/unified-intake-event-contract.test.ts`: source-level guard asserting every `unified-*` CustomEvent dispatched in one of the two files is listened for in the other. Catches drift across all six events, not just this one.

## Repro (from main, pre-fix)

1. Visit /book.
2. Fill all required fields, submit.
3. Server returns 200, but on the page:
   - Send button hides (state goes to `send_done`).
   - No "We hear you" / "Got it." response slot opens.
   - No "Pick a time to talk" booking CTA appears.
4. Captain's screenshots match this exact state — form filled, no acknowledgement, no path forward.

Captain only saw the team@smd.services notification land, because that path runs server-side and is unaffected. The on-page response is the only acknowledgement the prospect was supposed to see, and it was hidden by an event-name typo introduced in the lint refactor.

## Out of scope

This PR fixes the regression. There is a separate, pre-existing design gap: `/api/intake/send` never sends a confirmation email to the submitter (only to team@smd.services). That is not a regression — `/api/intake/send` shipped that way in #680. Filing a follow-on issue separately for Captain to prioritize.

## Test plan

- [x] `npx vitest run tests/booking/` — 106 passed (including the new 3-test contract suite).
- [x] `npx eslint src/scripts/book.ts tests/booking/unified-intake-event-contract.test.ts` — clean.
- [x] `npx astro check` — 0 errors after `npm install` (the @sentry/cloudflare error was a stale-deps artifact in the worktree, not a regression introduced here).
- [ ] Smoke test on preview deploy: submit /book intake with text, verify AI reply renders + "Pick a time to talk" appears.
- [ ] Smoke test on preview deploy: submit /book intake with empty textarea, verify "Got it." ack renders + "Pick a time to talk" appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)