### PR TITLE
feat(intake): V2 multi-turn /book conversation

### DIFF
--- a/src/components/booking/UnifiedIntake.astro
+++ b/src/components/booking/UnifiedIntake.astro
@@ -243,37 +243,68 @@ const { values } = Astro.props
     </div>
   </form>
 
-  <!-- Post-Send response: either an AI reply (with-message) or a brief
-       acknowledgement (empty-message). Either way, the booking offer
-       reveals beneath. -->
-  <div id="ui-response-slot" hidden aria-live="polite" class="mt-8">
-    <h3
-      id="ui-response-header"
-      hidden
-      class="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ss-color-text-secondary)]"
+  <!-- Post-Send conversation thread. Grows as the prospect and the AI
+       trade turns. Each turn renders as its own styled block. The empty
+       acknowledgement renders here when the prospect submitted with no
+       textarea content. -->
+  <div id="ui-thread" hidden aria-live="polite" class="mt-8 space-y-4"></div>
+
+  <p id="ui-empty-ack" hidden class="mt-6 text-base text-[color:var(--ss-color-text-primary)]">
+    Got it.
+  </p>
+
+  <!-- Reply input. Visible while the conversation is in progress and the
+       turn cap has not been reached. -->
+  <div id="ui-reply-section" hidden class="mt-6">
+    <label
+      for="ui-reply-text"
+      class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
     >
-      We hear you
-    </h3>
+      Reply
+    </label>
+    <textarea
+      id="ui-reply-text"
+      rows="3"
+      class="mt-1 block w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/20 bg-white px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)] shadow-sm transition-colors placeholder:text-[color:var(--ss-color-text-secondary)]/50 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed read-only:cursor-not-allowed read-only:bg-[color:var(--ss-color-text-secondary)]/5"
+    ></textarea>
     <div
-      id="ui-response-content"
+      id="ui-reply-error"
       hidden
-      class="whitespace-pre-wrap rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/20 bg-white px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)] shadow-sm"
+      class="mt-2 rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-error)]/5 px-4 py-3 text-sm text-[color:var(--ss-color-error)]"
     >
     </div>
-    <p id="ui-empty-ack" hidden class="text-base text-[color:var(--ss-color-text-primary)]">
-      Got it.
-    </p>
-    <div id="ui-booking-offer" hidden class="mt-6">
-      <p id="ui-booking-prompt" class="text-base text-[color:var(--ss-color-text-secondary)]"></p>
+    <div class="mt-3 flex justify-end">
       <button
-        id="ui-pick-time-btn"
+        id="ui-reply-send-btn"
         type="button"
-        data-ev="intake-pick-time"
-        class="mt-3 inline-flex items-center justify-center rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-base font-semibold text-white shadow-sm transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40"
+        data-ev="intake-reply-send"
+        class="inline-flex items-center justify-center rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-base font-semibold text-white shadow-sm transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        Pick a time to talk
+        Send
       </button>
     </div>
+  </div>
+
+  <!-- Surfaced when the conversation hits the turn cap. Replaces the
+       reply input. -->
+  <p id="ui-turn-cap-msg" hidden class="mt-6 text-base text-[color:var(--ss-color-text-secondary)]">
+    We've covered a lot. The natural next step is a real conversation.
+  </p>
+
+  <!-- Booking offer. Always visible after the first Send so the prospect
+       can move to a real conversation at any turn. -->
+  <div id="ui-booking-offer" hidden class="mt-6">
+    <p id="ui-booking-prompt" class="text-base text-[color:var(--ss-color-text-secondary)]">
+      Want to keep the conversation going?
+    </p>
+    <button
+      id="ui-pick-time-btn"
+      type="button"
+      data-ev="intake-pick-time"
+      class="mt-3 inline-flex items-center justify-center rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-base font-semibold text-white shadow-sm transition-all hover:opacity-90 focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40"
+    >
+      Pick a time to talk
+    </button>
   </div>
 </section>
 
@@ -297,215 +328,6 @@ const { values } = Astro.props
   }
 </style>
 
-<script is:inline>
-  ;(() => {
-    const SR = window.SpeechRecognition || window.webkitSpeechRecognition
-    const shell = document.getElementById('unified-intake')
-    const form = document.getElementById('unified-intake-form')
-    const textInput = document.getElementById('ui-message')
-    const micBtn = document.getElementById('ui-mic-btn')
-    const sendBtn = document.getElementById('ui-send-btn')
-    const errorDiv = document.getElementById('ui-error')
-    const voiceUnsupported = document.getElementById('ui-voice-unsupported')
-    const permissionError = document.getElementById('ui-voice-permission-error')
-    const responseSlot = document.getElementById('ui-response-slot')
-    const responseHeader = document.getElementById('ui-response-header')
-    const responseContent = document.getElementById('ui-response-content')
-    const emptyAck = document.getElementById('ui-empty-ack')
-    const bookingOffer = document.getElementById('ui-booking-offer')
-    const bookingPrompt = document.getElementById('ui-booking-prompt')
-    const pickTimeBtn = document.getElementById('ui-pick-time-btn')
-
-    let recognition = null
-    const supportsVoice = !!SR
-    if (!supportsVoice) {
-      micBtn.hidden = true
-      voiceUnsupported.hidden = false
-    } else {
-      recognition = new SR()
-      recognition.lang = 'en-US'
-      recognition.interimResults = false
-      recognition.continuous = false
-      recognition.maxAlternatives = 1
-
-      recognition.onresult = (e) => {
-        let finalText = ''
-        for (let i = e.resultIndex; i < e.results.length; i++) {
-          if (e.results[i].isFinal) finalText += e.results[i][0].transcript
-        }
-        if (finalText) {
-          const current = textInput.value
-          const needsSpace = current.length > 0 && !/\s$/.test(current)
-          textInput.value = current + (needsSpace ? ' ' : '') + finalText
-        }
-      }
-      recognition.onerror = (e) => {
-        if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
-          permissionError.hidden = false
-        } else if (e.error === 'no-speech' || e.error === 'aborted') {
-          // benign
-        } else {
-          console.error('[unified-intake] recognition error', e.error)
-        }
-        setListening(false)
-      }
-      recognition.onend = () => {
-        if (shell.dataset.state === 'listening') setListening(false)
-      }
-    }
-
-    function setListening(on) {
-      shell.dataset.state = on ? 'listening' : 'idle'
-      textInput.readOnly = on
-    }
-
-    function stopRecognitionIfActive() {
-      if (recognition && shell.dataset.state === 'listening') {
-        try {
-          recognition.stop()
-        } catch (err) {
-          // benign — recognition may already be stopping
-        }
-      }
-    }
-
-    function hidePostSendUi() {
-      responseSlot.hidden = true
-      responseHeader.hidden = true
-      responseContent.hidden = true
-      responseContent.textContent = ''
-      emptyAck.hidden = true
-      bookingOffer.hidden = true
-      bookingPrompt.textContent = ''
-    }
-
-    if (supportsVoice && micBtn) {
-      micBtn.addEventListener('click', () => {
-        if (shell.dataset.state === 'listening') {
-          recognition.stop()
-          return
-        }
-        if (shell.dataset.state !== 'idle') return
-        permissionError.hidden = true
-        setListening(true)
-        try {
-          recognition.start()
-        } catch (err) {
-          console.error('[unified-intake] start() failed', err)
-          setListening(false)
-        }
-      })
-    }
-
-    // Captured at script-execute time. The page-level handler reads this off
-    // the unified-send detail and sends it as `rendered_at` to the server,
-    // which rejects submissions under 2s old as bot-driven.
-    const renderedAt = Date.now()
-
-    function readFormData() {
-      const fd = new FormData(form)
-      return {
-        name: String(fd.get('name') ?? '').trim(),
-        email: String(fd.get('email') ?? '').trim(),
-        business_name: String(fd.get('business_name') ?? '').trim(),
-        phone: String(fd.get('phone') ?? '').trim(),
-        website: String(fd.get('website') ?? '').trim() || null,
-        message: String(fd.get('message') ?? '').trim(),
-        rendered_at: renderedAt,
-      }
-    }
-
-    // Listen on the form, not the button. type="submit" routes button click
-    // and Enter-in-field through the same path, and gives Chrome the submit
-    // event it needs to register form values for future-visit autofill.
-    form.addEventListener('submit', (e) => {
-      e.preventDefault()
-      if (sendBtn.disabled) return
-      const data = readFormData()
-      shell.dispatchEvent(new CustomEvent('unified-send', { detail: data, bubbles: true }))
-    })
-
-    pickTimeBtn.addEventListener('click', () => {
-      shell.dispatchEvent(new CustomEvent('unified-pick-time', { bubbles: true }))
-    })
-
-    // Page-side state controls. The page calls these via dispatchEvent on #unified-intake.
-    shell.addEventListener('unified-set-state', (e) => {
-      const next = e.detail?.state
-      if (!next) return
-      const prev = shell.dataset.state
-      // Halt any active speech recognition before locking the form so
-      // late-arriving onresult cannot mutate textarea content the server
-      // already saw.
-      if (next !== 'idle' && next !== 'listening' && prev === 'listening') {
-        stopRecognitionIfActive()
-      }
-      shell.dataset.state = next
-      const fields = form.querySelectorAll('input, textarea')
-      const locked = next === 'send_thinking' || next === 'send_done' || next === 'booked'
-      fields.forEach((f) => {
-        f.readOnly = locked
-      })
-      if (next === 'send_thinking') {
-        sendBtn.disabled = true
-        sendBtn.textContent = 'Sending...'
-      } else if (next === 'send_done') {
-        sendBtn.disabled = true
-        sendBtn.hidden = true
-        if (supportsVoice) micBtn.hidden = true
-      } else if (next === 'booked') {
-        sendBtn.disabled = true
-        sendBtn.hidden = true
-        if (supportsVoice) micBtn.hidden = true
-        // Page-level confirmation panel takes over rendering.
-      } else if (next === 'idle') {
-        sendBtn.disabled = false
-        sendBtn.hidden = false
-        sendBtn.textContent = 'Get in touch'
-        if (supportsVoice) {
-          micBtn.hidden = false
-          micBtn.disabled = false
-        }
-        // Recovery from a failed Send: scrub any post-send UI so a
-        // stale booking offer can't appear above a still-editable form.
-        hidePostSendUi()
-      }
-    })
-
-    shell.addEventListener('unified-show-error', (e) => {
-      const msg = e.detail?.message || 'Something went wrong. Please try again.'
-      errorDiv.textContent = msg
-      errorDiv.hidden = false
-    })
-
-    shell.addEventListener('unified-clear-error', () => {
-      errorDiv.hidden = true
-      errorDiv.textContent = ''
-    })
-
-    // Two-mode response handler. With-message: render AI reply. Empty-message:
-    // brief acknowledgement. In both, reveal the booking offer below as the
-    // sequential next step.
-    //
-    // Note: no scrollIntoView here. The booking offer is offered passively;
-    // scroll fires only when the user clicks Pick-a-time (page-side), so we
-    // never jump the page while the prospect is mid-read.
-    shell.addEventListener('unified-show-ai-reply', (e) => {
-      const reply = (e.detail?.reply || '').trim()
-      responseSlot.hidden = false
-      if (reply) {
-        responseHeader.hidden = false
-        responseContent.textContent = reply
-        responseContent.hidden = false
-        emptyAck.hidden = true
-        bookingPrompt.textContent = 'Want to keep the conversation going?'
-      } else {
-        responseHeader.hidden = true
-        responseContent.hidden = true
-        emptyAck.hidden = false
-        bookingPrompt.textContent = 'Ready to talk?'
-      }
-      bookingOffer.hidden = false
-    })
-  })()
+<script>
+  import '../../scripts/unified-intake.ts'
 </script>

--- a/src/lib/booking/conversation-token.ts
+++ b/src/lib/booking/conversation-token.ts
@@ -19,6 +19,14 @@
  * Mirrors the encoding and crypto posture of `src/lib/booking/signed-link.ts`
  * (HMAC-SHA256, base64url, constant-time verify via crypto.subtle).
  *
+ * Cookie scope is `Path=/`. This is intentional. The cookie needs to be
+ * reachable by /api/intake/continue today and by any future intake-related
+ * endpoints (e.g. a passive /api/intake/state hydration route under
+ * discussion). Scoping to /api/intake/ would block any non-API page from
+ * doing a lightweight presence check before fetching, and gives no real
+ * security benefit since the cookie is `HttpOnly` and HMAC-bound to a
+ * specific (entity_id, conversation_id) pair.
+ *
  * Encoding:
  *   `<base64url(json-payload)>.<base64url(hmac)>`
  *

--- a/src/lib/booking/conversation-token.ts
+++ b/src/lib/booking/conversation-token.ts
@@ -1,0 +1,198 @@
+/**
+ * Signed conversation tokens for the V2 multi-turn intake (`/book` Send +
+ * follow-up turns).
+ *
+ * The first POST to /api/intake/send creates an entity, generates a fresh
+ * conversation_id, and returns this token in an HttpOnly cookie. Every
+ * subsequent POST to /api/intake/continue includes the cookie; the server
+ * verifies the HMAC, extracts (entity_id, conversation_id), and loads the
+ * conversation history from the context table.
+ *
+ * Threat model:
+ *   - The cookie binds conversation_id to entity_id server-side. A client
+ *     cannot forge a cookie pointing at someone else's entity without the
+ *     signing key.
+ *   - The token has a TTL (default 1 hour). After expiry the conversation
+ *     is over from the server's perspective; the prospect would need to
+ *     submit a fresh /api/intake/send to start a new conversation.
+ *
+ * Mirrors the encoding and crypto posture of `src/lib/booking/signed-link.ts`
+ * (HMAC-SHA256, base64url, constant-time verify via crypto.subtle).
+ *
+ * Encoding:
+ *   `<base64url(json-payload)>.<base64url(hmac)>`
+ *
+ * Payload fields:
+ *   v               — schema version (currently 1)
+ *   conversation_id — UUID for this conversation
+ *   entity_id       — entity created/found on first Send
+ *   exp             — Unix seconds; token invalid after this time
+ */
+import { env } from 'cloudflare:workers'
+
+const ALGORITHM: HmacImportParams = { name: 'HMAC', hash: 'SHA-256' }
+const ENCODER = new TextEncoder()
+const SCHEMA_VERSION = 1
+
+/** 1 hour matches the typical intake conversation duration. */
+export const DEFAULT_CONVERSATION_TTL_SECONDS = 60 * 60
+
+/** Cookie name for the conversation token. */
+export const CONVERSATION_COOKIE_NAME = 'ss_intake_conv'
+
+export interface ConversationTokenPayload {
+  v: number
+  conversation_id: string
+  entity_id: string
+  exp: number
+}
+
+export interface SignConversationTokenInput {
+  conversation_id: string
+  entity_id: string
+  /** Override the default TTL (seconds). */
+  ttl_seconds?: number
+}
+
+export type VerifyConversationTokenResult =
+  | { ok: true; payload: ConversationTokenPayload }
+  | { ok: false; error: 'malformed' | 'bad_signature' | 'expired' | 'unknown_version' }
+
+export async function signConversationToken(input: SignConversationTokenInput): Promise<string> {
+  const key = await importSigningKey()
+  const ttl = input.ttl_seconds ?? DEFAULT_CONVERSATION_TTL_SECONDS
+  const exp = Math.floor(Date.now() / 1000) + ttl
+
+  const payload: ConversationTokenPayload = {
+    v: SCHEMA_VERSION,
+    conversation_id: input.conversation_id,
+    entity_id: input.entity_id,
+    exp,
+  }
+
+  const payloadB64 = base64UrlEncode(ENCODER.encode(JSON.stringify(payload)))
+  const sigBuf = await crypto.subtle.sign(ALGORITHM, key, ENCODER.encode(payloadB64))
+  const sigB64 = base64UrlEncode(new Uint8Array(sigBuf))
+  return `${payloadB64}.${sigB64}`
+}
+
+export async function verifyConversationToken(
+  token: string
+): Promise<VerifyConversationTokenResult> {
+  if (typeof token !== 'string' || token.length === 0) {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const dot = token.indexOf('.')
+  if (dot <= 0 || dot === token.length - 1) {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const payloadB64 = token.slice(0, dot)
+  const sigB64 = token.slice(dot + 1)
+
+  let sigBytes: Uint8Array
+  try {
+    sigBytes = base64UrlDecode(sigB64)
+  } catch {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const key = await importSigningKey()
+  const valid = await crypto.subtle.verify(
+    ALGORITHM,
+    key,
+    sigBytes as unknown as ArrayBuffer,
+    ENCODER.encode(payloadB64)
+  )
+  if (!valid) return { ok: false, error: 'bad_signature' }
+
+  let payload: ConversationTokenPayload
+  try {
+    const json = new TextDecoder().decode(base64UrlDecode(payloadB64))
+    payload = JSON.parse(json) as ConversationTokenPayload
+  } catch {
+    return { ok: false, error: 'malformed' }
+  }
+
+  if (payload.v !== SCHEMA_VERSION) {
+    return { ok: false, error: 'unknown_version' }
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  if (typeof payload.exp !== 'number' || payload.exp < now) {
+    return { ok: false, error: 'expired' }
+  }
+
+  if (!payload.entity_id || !payload.conversation_id) {
+    return { ok: false, error: 'malformed' }
+  }
+
+  return { ok: true, payload }
+}
+
+/**
+ * Build a Set-Cookie header value carrying the signed token.
+ * Caller is responsible for adding the header to the Response.
+ */
+export function buildConversationCookieHeader(
+  token: string,
+  ttlSeconds: number,
+  secure = true
+): string {
+  const parts = [
+    `${CONVERSATION_COOKIE_NAME}=${token}`,
+    'HttpOnly',
+    'SameSite=Lax',
+    'Path=/',
+    `Max-Age=${ttlSeconds}`,
+  ]
+  if (secure) parts.push('Secure')
+  return parts.join('; ')
+}
+
+/**
+ * Parse the token out of a request's Cookie header. Returns null if absent.
+ */
+export function readConversationCookie(request: Request): string | null {
+  const header = request.headers.get('cookie')
+  if (!header) return null
+  for (const part of header.split(';')) {
+    const trimmed = part.trim()
+    const eq = trimmed.indexOf('=')
+    if (eq < 0) continue
+    const name = trimmed.slice(0, eq)
+    if (name === CONVERSATION_COOKIE_NAME) {
+      return trimmed.slice(eq + 1)
+    }
+  }
+  return null
+}
+
+async function importSigningKey(): Promise<CryptoKey> {
+  const raw = env.BOOKING_ENCRYPTION_KEY
+  if (!raw || typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error(
+      'BOOKING_ENCRYPTION_KEY is not configured. Set it in wrangler env before issuing conversation tokens.'
+    )
+  }
+  const keyBytes = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0))
+  return crypto.subtle.importKey('raw', keyBytes, ALGORITHM, false, ['sign', 'verify'])
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  const b64 = btoa(bin)
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/')
+  const padLen = (4 - (padded.length % 4)) % 4
+  const b64 = padded + '='.repeat(padLen)
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}

--- a/src/lib/claude/conversation.ts
+++ b/src/lib/claude/conversation.ts
@@ -219,3 +219,42 @@ export async function generateConversationReply(
 
   return textBlock.text.trim()
 }
+
+/**
+ * Defense-in-depth observability for Claude replies on the V2 intake.
+ *
+ * The system prompt forbids ending a turn on anything but a question. If the
+ * model drifts and ends on a statement, the UX dead-ends silently — the user
+ * sees a paragraph with no obvious next step, and the conversation stalls.
+ *
+ * This helper does NOT modify the reply or block the response. It logs a
+ * structured warning so we can observe drift in production. Wrapped in
+ * try/catch so any bug in the helper itself cannot take down the endpoint
+ * it is meant to protect.
+ *
+ * Future work: wire warnings into a notifications surface so they become
+ * actionable rather than log lines that nobody reads.
+ */
+export function postProcessReply(
+  reply: string,
+  context: { endpoint: string; entityId?: string; conversationId?: string; turn?: number }
+): void {
+  try {
+    const trimmed = reply.trimEnd()
+    if (trimmed.length === 0) return
+    const lastChar = trimmed[trimmed.length - 1]
+    if (lastChar !== '?') {
+      console.warn('[conversation.postProcessReply] reply did not end on a question', {
+        endpoint: context.endpoint,
+        entity_id: context.entityId,
+        conversation_id: context.conversationId,
+        turn: context.turn,
+        last_char: lastChar,
+        reply_tail: trimmed.slice(-80),
+      })
+    }
+  } catch (err) {
+    // Helper bugs cannot impact the endpoint. Best-effort log and swallow.
+    console.error('[conversation.postProcessReply] internal error:', err)
+  }
+}

--- a/src/lib/claude/conversation.ts
+++ b/src/lib/claude/conversation.ts
@@ -1,15 +1,19 @@
 /**
- * Claude API client for the voice-intake conversation agent (`/talk`).
+ * Claude API client for the multi-turn intake conversation agent
+ * (`/api/intake/send` initial turn + `/api/intake/continue` follow-ups).
  *
  * Uses raw fetch against the Anthropic Messages API — no SDK dependency.
  * Mirrors the pattern in `src/lib/claude/extract.ts` for fetch posture,
  * error handling, and constants.
  *
- * The agent is the warm, structured listener for the prospect-facing
- * voice intake. The system prompt encodes the doctrine: curious-not-clever,
- * past-behavior questions, OARS, hard bans on AI vocabulary and validation
- * theater, no solutioning during intake, never claim insight into the
- * prospect's business.
+ * V2 doctrine (replaces the V1 "warm structured listener" framing):
+ *   The agent is a working tool that asks one specific operational
+ *   question per turn to coax useful signal out of the prospect — volume,
+ *   current state, what they've tried, where the breakdown is. Warmth
+ *   comes from the specificity of the question, not from acknowledgement
+ *   language. Two outcomes are wins: the prospect picks a time to talk,
+ *   or they share enough context to inform a follow-up. They are not
+ *   required to answer the question.
  */
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages'
@@ -37,84 +41,116 @@ export interface ConversationTurn {
 }
 
 /**
- * The system prompt is the agent's sole behavior contract. The doctrine
- * encoded here comes from research on clinical history-taking, motivational
- * interviewing, The Mom Test, and a corpus of real user complaints about
- * AI sales agents. Every banned phrase is sourced from real user reports.
+ * The system prompt is the agent's sole behavior contract. Changes are
+ * P0 — they affect every prospect conversation. Treat with the same care
+ * as user-facing copy.
  *
- * Changes to this prompt are P0 — they directly affect every prospect
- * conversation. Treat with the same care as user-facing copy.
+ * V2 doctrine. The agent is a working tool that produces signal for the
+ * assessment by asking specific operational questions. Reflection
+ * sentences and "we hear you" framing are forbidden — the question
+ * itself shows the agent read what the prospect said. Universal
+ * observations about businesses ("X gets harder as you grow",
+ * "Y leaves a mark") are forbidden — the agent doesn't have wisdom; it
+ * has questions. Two outcomes are wins: the prospect books, or they
+ * share useful context. They are not obligated to answer.
  */
-export const CONVERSATION_SYSTEM_PROMPT = `You are a conversational AI agent for SMD Services, an operations consultancy serving Phoenix-area small businesses (10-25 employees). Your one job is to help the prospect think out loud about their business, in their own words.
+export const CONVERSATION_SYSTEM_PROMPT = `You are a conversational AI for SMD Services, an operations consultancy working with growing businesses in the Phoenix area. Your one job is to coax useful operational information out of the prospect by asking one specific question per turn. The signal you collect informs the assessment call or the follow-up reach-out our team makes when the prospect is ready.
 
-You are not selling. You are not diagnosing. You are listening. If a prospect asks whether you're an AI, answer plainly: yes. Otherwise, do not preempt that disclosure. Just ask the next question naturally.
+The page running this conversation always shows a "Pick a time to talk" button below your reply. The prospect can keep typing or pick a time at any point. Both outcomes are wins. You are not selling. You are not closing. You are not gating anything.
+
+If the prospect asks whether you're an AI, answer plainly: yes. Otherwise, do not preempt that disclosure.
 
 ## Your stance
 
-You are curious. You are prepared. You are a collaborator, never an expert on their business. They are the expert. You assume nothing about what their work looks like day-to-day. When they say something you don't understand, you ask. When they say something interesting, you reflect it back in their own language and ask them to say more.
+You are curious about specifics. You are not warm-on-the-outside. You do not perform empathy. You assume nothing about what their work looks like day-to-day. They are the expert on their own business. The shape of warmth here is asking a question that respects their time and intelligence.
 
-You are not here to sell. You are not here to diagnose. You are not here to suggest solutions. Anyone on our team who tries to pitch during intake has missed the point. So do you.
+You are not here to sell. You are not here to diagnose. You are not here to suggest solutions. The assessment call is where solutions come up. This conversation is where the picture gets clearer.
 
 ## What to do on each turn
 
-The prospect has just sent you something about their business. The page invited them to cover three things: where the business is now (situation), where they're trying to take it (direction), and what's in the way (obstacle). Most will cover one or two of those. Some will cover all three. Some will only name what they do.
+Read what the prospect just sent and the prior conversation. Pick the most useful gap and ask one specific operational question that fills it.
 
-Your turn 1 job:
-1. Read what they sent.
-2. Identify the most useful gap from the situation/direction/obstacle triplet. If they named pain but no direction, ask about direction. If they named direction but no obstacle, ask what's in the way. If they only named what they do, ask what they're trying to build.
-3. Reply with a brief reflection in their own language, then one focused follow-up question.
+Useful gaps to fill, in rough priority:
 
-If the conversation continues past turn 1, keep listening. Ask about past behavior, not hypotheticals. Reflect more than you ask.
+- Volume: how big is the team, how many crews, jobs per week, customers, accounts, transactions.
+- Current state: what's running the work today, who handles it, what tools or systems are in place, what's manual.
+- Past attempts: what they've already tried, what worked, what fell apart, what they DIY'd.
+- Objective: what they're trying to figure out, fix, build, or improve next.
+- Breakdown: where the slowdown or friction shows up most, when it started.
 
-Do not promise next steps. Do not say a consultant will follow up or that anyone from our team will contact the prospect. Do not write a closing summary or "read back" what you've heard. Just keep asking good questions for as long as the prospect is engaged.
+Pick the gap that produces the most useful signal given what they've already shared.
+
+Skip reflection. Do not start your turn by paraphrasing or summarizing what they said. The question itself shows you read it.
+
+Skip openers like "Got it", "Great", "Thanks for sharing", "I see", "Sure" when you are asking a substantive question. Go straight to the question.
+
+If they shared almost nothing or appear to be testing the form, keep your reply small and open the door without manufacturing context. A short "Got it" plus a low-pressure question about what they'd actually want to talk about is the right shape there.
+
+Do not write a closing summary or "read back" what you've heard. Do not promise that anyone from the team will follow up.
 
 ## How to ask
 
-- One question at a time. Never stack two questions in one turn.
-- Past behavior, never hypotheticals. Ask "walk me through the last time..." Do not ask "would you find it useful if..."
-- Funnel: open questions first, narrowing questions later, closed yes/no questions only at the very end if at all.
-- OARS: Open questions, Affirmations, Reflective listening, Summaries. Each turn should do at least one of these. The best turns reflect first, then ask.
+- One specific operational question per turn. A paired ask is fine when the parts are tightly related (e.g., "how big is the team and what's the next thing you're trying to figure out"). Do not stack three or more.
+- Past behavior, never hypotheticals. Ask "what's running the schedule today" not "would a tool help".
+- Specific, not abstract. "How many crews" beats "what does the team look like". "What were you trying to fix when you bought it" beats "what was the experience like".
+- Funnel: open questions first, narrowing later. By turn three or four, narrow toward concrete details.
+- The conversation is generous. Most prospects will share two to five turns before they pick a time or stop. Don't try to wrap up early.
 
 ## How to write
 
 - Short. Default 6 to 12 words per sentence. Hard cap 25.
-- Plain. The way a thoughtful neighbor talks, not a brochure.
-- Two short paragraphs maximum per turn. Often one is enough.
+- Plain. The way a smart neighbor texts back, not a brochure.
+- Two short paragraphs maximum per turn. One is almost always enough.
 - No em dashes. Use periods. Use commas.
-- No headers, no bullets, no markdown. This is a conversation.
-- One question per turn, placed at the end.
+- No headers, no bullets, no markdown.
+- End on the question.
 
 ## Banned words and phrases (do not use, ever)
 
-Validation phrases: "I understand exactly", "great question", "I hear you", "absolutely", "totally", "for sure", "makes complete sense", "what a great point".
+Validation phrases: "we hear you", "I hear you", "I understand", "absolutely", "totally", "for sure", "makes complete sense", "what a great point", "great question", "thanks for sharing", "thanks for reaching out", "I appreciate you".
 
 AI vocabulary: delve, embark, robust, holistic, seamless, leverage, synergy, pivotal, intricate, navigate, unlock, journey, realm, underscore, tapestry, streamline, comprehensive, ecosystem, dynamic, empower, foster, facilitate, elevate.
 
 Em dashes. Replace with a period or a comma.
 
-Solutioning language during intake: "we could", "you should", "have you tried", "what you need is", "the answer is".
+Solutioning language: "we could", "you should", "have you tried as a solution", "what you need is", "the answer is".
 
-Before you send a turn, scan it for these. If you find any, rewrite.
+Promise language: do not say a consultant will follow up, that anyone from our team will contact them, or that you'll route their information anywhere.
+
+Universal observations about businesses: do not write sentences like "scheduling gets heavier as the team grows", "bad implementations leave a mark", "spreadsheets only get you so far". The agent has no wisdom about businesses in general. Stay specific to what this prospect actually said.
+
+Before you send a turn, scan it for these patterns. If you find any, rewrite.
 
 ## Sample turns showing the right shape
 
-Prospect: "We do HVAC, mostly residential, been around about twelve years now."
-You: "Twelve years is a long run in residential HVAC. What does the business look like today, in terms of crews and the kind of work you're taking on?"
+Prospect (turn 1): "We do HVAC, mostly residential, been around about twelve years."
+You: "How big is the team today, and what's the next thing you're working to figure out?"
 
-Prospect: "Honestly the scheduling is killing me. I'm doing it all in my head and on text messages."
-You: "That sounds like a lot to hold. Walk me through yesterday. How did the schedule come together for today's jobs?"
+Prospect (turn 1): "Honestly the scheduling is killing me. I'm doing it all in my head and on text messages."
+You: "How many crews are you running, and what's holding the schedule together right now besides the texts?"
 
-Prospect: "We tried a software thing last year, it was a disaster."
-You: "Sorry to hear that. What part of it didn't fit how your team actually works?"
+Prospect (turn 1): "We tried a software thing last year, it was a disaster."
+You: "What were you trying to fix when you bought it, and what's running things now?"
+
+Prospect (turn 1): "Just looking around right now, not sure what we need yet."
+You: "What are the top two or three things you're trying to figure out next in the business?"
+
+Prospect (turn 1): "this is a form test"
+You: "Got it, just a check. Anything we can actually help with while you're here?"
+
+Prospect (turn 3, after sharing HVAC + four crews + slow follow-up costing them work):
+"Yeah, I'd say one job a week we lose because nobody calls back fast enough."
+You: "Which part of follow-up is the slowdown for you right now?"
 
 ## Hard rules
 
 - Never pitch a solution. Not even a small one.
-- Never judge how they're running things. Affirm them.
-- Never claim to understand their business. Ask.
+- Never judge how they're running things.
+- Never claim to understand their business. Ask about it.
 - Never invent facts about them. If they haven't said it, you don't know it.
-- Never promise next steps. Don't tell the prospect that a consultant will contact them, that anyone from our team will follow up, or that you'll route their information anywhere.
-- Never use the banned words above.
+- Never promise next steps.
+- Never use the banned words and phrases above.
+- Never make a universal observation about businesses, growth, owners, or operations.
 - Never write more than two short paragraphs per turn.
 - Always end on a question.`
 

--- a/src/lib/db/intake-conversations.ts
+++ b/src/lib/db/intake-conversations.ts
@@ -1,0 +1,162 @@
+/**
+ * Intake conversation persistence — V2 multi-turn intake (`/book` Send +
+ * follow-up turns).
+ *
+ * Design: messages are stored in the existing `context` table as
+ * `type='intake'` rows with V2-specific sources and `conversation_id` +
+ * `turn` + `role` in metadata. No new schema. Filter and reconstruct
+ * happens app-side on the small per-conversation N (capped at MAX_TURNS
+ * × 2 entries).
+ *
+ * Sources (per V2):
+ *   - `website_intake_v2_user`      — a user message for a given turn
+ *   - `website_intake_v2_ai`        — the AI's reply for that turn
+ *
+ * The existing intake-core context entry (`source='website_intake_send'`)
+ * is preserved as the canonical "first contact" record for admin viewing.
+ * V2 stores its own user-turn-1 entry so conversation history is uniform
+ * (a small duplication, deliberately accepted to keep the admin record
+ * untouched).
+ */
+
+import { appendContext, listContext } from './context'
+import type { ContextEntry } from './context'
+import type { ConversationTurn } from '../claude/conversation'
+
+export const MAX_TURNS = 20
+export const V2_USER_SOURCE = 'website_intake_v2_user'
+export const V2_AI_SOURCE = 'website_intake_v2_ai'
+const V2_SOURCES = new Set([V2_USER_SOURCE, V2_AI_SOURCE])
+
+interface V2Metadata {
+  conversation_id: string
+  turn: number
+  role: 'user' | 'assistant'
+}
+
+function parseV2Metadata(raw: string | null): V2Metadata | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const conversation_id = parsed?.conversation_id
+    const turn = parsed?.turn
+    const role = parsed?.role
+    if (
+      typeof conversation_id !== 'string' ||
+      typeof turn !== 'number' ||
+      (role !== 'user' && role !== 'assistant')
+    ) {
+      return null
+    }
+    return { conversation_id, turn, role }
+  } catch {
+    return null
+  }
+}
+
+interface OrderedEntry {
+  entry: ContextEntry
+  meta: V2Metadata
+}
+
+async function listV2Entries(
+  db: D1Database,
+  entityId: string,
+  conversationId: string
+): Promise<OrderedEntry[]> {
+  const all = await listContext(db, entityId, { type: 'intake' })
+  const ordered: OrderedEntry[] = []
+  for (const entry of all) {
+    if (!V2_SOURCES.has(entry.source)) continue
+    const meta = parseV2Metadata(entry.metadata)
+    if (!meta) continue
+    if (meta.conversation_id !== conversationId) continue
+    ordered.push({ entry, meta })
+  }
+  ordered.sort((a, b) => {
+    if (a.meta.turn !== b.meta.turn) return a.meta.turn - b.meta.turn
+    // user before assistant within the same turn
+    if (a.meta.role === b.meta.role) return 0
+    return a.meta.role === 'user' ? -1 : 1
+  })
+  return ordered
+}
+
+/**
+ * Load conversation history as ConversationTurn[] for sending to Claude.
+ * Returns turns in chronological order, alternating user / assistant.
+ */
+export async function loadConversationHistory(
+  db: D1Database,
+  entityId: string,
+  conversationId: string
+): Promise<ConversationTurn[]> {
+  const ordered = await listV2Entries(db, entityId, conversationId)
+  return ordered.map(({ entry, meta }) => ({
+    role: meta.role,
+    content: entry.content,
+  }))
+}
+
+/**
+ * Count how many user turns have been recorded for the conversation.
+ * Used to enforce MAX_TURNS and to compute the next turn number.
+ */
+export async function countUserTurns(
+  db: D1Database,
+  entityId: string,
+  conversationId: string
+): Promise<number> {
+  const ordered = await listV2Entries(db, entityId, conversationId)
+  return ordered.filter((e) => e.meta.role === 'user').length
+}
+
+/**
+ * Persist a user turn. `turn` is 1-indexed; for follow-ups it must equal
+ * `prior user turns + 1`.
+ */
+export async function appendUserTurn(
+  db: D1Database,
+  orgId: string,
+  params: { entityId: string; conversationId: string; turn: number; content: string }
+): Promise<void> {
+  await appendContext(db, orgId, {
+    entity_id: params.entityId,
+    type: 'intake',
+    content: params.content,
+    source: V2_USER_SOURCE,
+    metadata: {
+      conversation_id: params.conversationId,
+      turn: params.turn,
+      role: 'user',
+    },
+  })
+}
+
+/**
+ * Persist an AI assistant turn. `turn` matches the user turn it replies to.
+ */
+export async function appendAssistantTurn(
+  db: D1Database,
+  orgId: string,
+  params: {
+    entityId: string
+    conversationId: string
+    turn: number
+    content: string
+    model?: string
+  }
+): Promise<void> {
+  await appendContext(db, orgId, {
+    entity_id: params.entityId,
+    type: 'intake',
+    content: params.content,
+    source: V2_AI_SOURCE,
+    metadata: {
+      conversation_id: params.conversationId,
+      turn: params.turn,
+      role: 'assistant',
+      model: params.model ?? 'claude',
+    },
+  })
+}

--- a/src/pages/api/intake/continue.ts
+++ b/src/pages/api/intake/continue.ts
@@ -1,0 +1,222 @@
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import { ORG_ID } from '../../../lib/constants'
+import { rateLimitByIp } from '../../../lib/booking/rate-limit'
+import { generateConversationReply, ConversationApiError } from '../../../lib/claude/conversation'
+import {
+  appendUserTurn,
+  appendAssistantTurn,
+  countUserTurns,
+  loadConversationHistory,
+  MAX_TURNS,
+} from '../../../lib/db/intake-conversations'
+import {
+  verifyConversationToken,
+  readConversationCookie,
+  signConversationToken,
+  buildConversationCookieHeader,
+  DEFAULT_CONVERSATION_TTL_SECONDS,
+} from '../../../lib/booking/conversation-token'
+
+/**
+ * POST /api/intake/continue
+ *
+ * Follow-up turn in a multi-turn intake conversation. The first turn is
+ * established by `/api/intake/send`, which issues the signed
+ * `ss_intake_conv` cookie. Each `/continue` POST verifies the cookie,
+ * loads the conversation history, calls Claude with the full history,
+ * persists the new user/assistant pair, and returns the AI reply.
+ *
+ * Request body:
+ *   { message: string }    — the prospect's next message (1..MAX_MESSAGE_CHARS)
+ *
+ * Response:
+ *   200 { ok, ai_reply, turn, can_continue }
+ *   401 { error: 'session_expired' | 'unauthorized' }
+ *   400 { error: 'validation_failed', message }
+ *   429 { error: 'rate_limited' }
+ *   503 { error: 'ai_unavailable' }      — Claude call failed; user turn was still persisted
+ *
+ * `can_continue` is false when the conversation has reached MAX_TURNS,
+ * signaling the UI to surface the booking CTA as the next step.
+ *
+ * Cookie is rotated on every successful turn so the TTL slides forward
+ * with active engagement.
+ */
+
+const MAX_MESSAGE_CHARS = 5000
+/** /continue is generous because each conversation can produce up to MAX_TURNS hits per user. */
+const RATE_LIMIT_PER_HOUR = 60
+
+interface ValidatedContinueBody {
+  messageRaw: string
+}
+
+function validateContinueBody(body: Record<string, unknown>): ValidatedContinueBody | Response {
+  const message = typeof body.message === 'string' ? body.message.trim() : ''
+  if (!message) {
+    return jsonResponse(400, {
+      error: 'validation_failed',
+      message: 'Message is required.',
+    })
+  }
+  if (message.length > MAX_MESSAGE_CHARS) {
+    return jsonResponse(400, {
+      error: 'validation_failed',
+      message: `Your message is too long (max ${MAX_MESSAGE_CHARS} characters).`,
+    })
+  }
+  return { messageRaw: message }
+}
+
+async function authConversationCookie(
+  request: Request
+): Promise<{ conversationId: string; entityId: string } | Response> {
+  const token = readConversationCookie(request)
+  if (!token) {
+    return jsonResponse(401, { error: 'unauthorized', message: 'No conversation in progress.' })
+  }
+  const verify = await verifyConversationToken(token)
+  if (!verify.ok) {
+    const which = verify.error === 'expired' ? 'session_expired' : 'unauthorized'
+    return jsonResponse(401, { error: which })
+  }
+  return { conversationId: verify.payload.conversation_id, entityId: verify.payload.entity_id }
+}
+
+async function callClaudeForTurn(
+  entityId: string,
+  conversationId: string,
+  userMessage: string
+): Promise<{ aiReply: string } | Response> {
+  const apiKey = env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    console.error('[api/intake/continue] ANTHROPIC_API_KEY not configured')
+    return jsonResponse(503, { error: 'ai_unavailable' })
+  }
+  const fullHistory = await loadConversationHistory(env.DB, entityId, conversationId)
+  // The just-persisted user turn sits at the end of fullHistory; Claude's
+  // messages[] expects the new user turn as the prompt and prior turns
+  // as history.
+  const historyForClaude = fullHistory.slice(0, -1)
+  try {
+    const aiReply = await generateConversationReply(apiKey, userMessage, historyForClaude)
+    return { aiReply }
+  } catch (err) {
+    if (err instanceof ConversationApiError) {
+      console.error('[api/intake/continue] Claude API error:', err.message, {
+        status: err.statusCode,
+        body: err.responseBody?.slice(0, 500),
+      })
+    } else {
+      console.error('[api/intake/continue] Unexpected Claude error:', err)
+    }
+    return jsonResponse(503, { error: 'ai_unavailable' })
+  }
+}
+
+async function handlePost({ request, clientAddress }: APIContext): Promise<Response> {
+  const auth = await authConversationCookie(request)
+  if (auth instanceof Response) return auth
+  const { conversationId, entityId } = auth
+
+  const rateResult = await rateLimitByIp(
+    env.BOOKING_CACHE,
+    'intake_continue',
+    clientAddress,
+    RATE_LIMIT_PER_HOUR
+  )
+  if (!rateResult.allowed) {
+    return jsonResponse(429, {
+      error: 'rate_limited',
+      message: 'Too many messages. Please wait a moment.',
+    })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON' })
+  }
+  const validated = validateContinueBody(body)
+  if (validated instanceof Response) return validated
+
+  const priorUserTurns = await countUserTurns(env.DB, entityId, conversationId)
+  if (priorUserTurns >= MAX_TURNS) {
+    return jsonResponse(200, {
+      ok: true,
+      ai_reply: null,
+      turn: priorUserTurns,
+      can_continue: false,
+      message: 'turn_cap_reached',
+    })
+  }
+  const turn = priorUserTurns + 1
+
+  // Persist user turn first so admin sees what they wrote even if
+  // Claude fails.
+  try {
+    await appendUserTurn(env.DB, ORG_ID, {
+      entityId,
+      conversationId,
+      turn,
+      content: validated.messageRaw,
+    })
+  } catch (err) {
+    console.error('[api/intake/continue] User turn append failed:', err)
+    return jsonResponse(500, { error: 'Internal server error' })
+  }
+
+  const claudeResult = await callClaudeForTurn(entityId, conversationId, validated.messageRaw)
+  if (claudeResult instanceof Response) return claudeResult
+  const { aiReply } = claudeResult
+
+  try {
+    await appendAssistantTurn(env.DB, ORG_ID, {
+      entityId,
+      conversationId,
+      turn,
+      content: aiReply,
+    })
+  } catch (err) {
+    console.error('[api/intake/continue] AI turn append failed:', err)
+    // Reply was generated; persistence loss is non-fatal for the response.
+  }
+
+  return buildContinueResponse({ conversationId, entityId, turn, aiReply })
+}
+
+async function buildContinueResponse(args: {
+  conversationId: string
+  entityId: string
+  turn: number
+  aiReply: string
+}): Promise<Response> {
+  const newToken = await signConversationToken({
+    conversation_id: args.conversationId,
+    entity_id: args.entityId,
+  })
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Set-Cookie': buildConversationCookieHeader(newToken, DEFAULT_CONVERSATION_TTL_SECONDS),
+  }
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      ai_reply: args.aiReply,
+      turn: args.turn,
+      can_continue: args.turn < MAX_TURNS,
+    }),
+    { status: 200, headers }
+  )
+}
+
+export const POST: APIRoute = (ctx) => handlePost(ctx)
+
+function jsonResponse(status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/pages/api/intake/continue.ts
+++ b/src/pages/api/intake/continue.ts
@@ -2,7 +2,11 @@ import type { APIContext, APIRoute } from 'astro'
 import { env } from 'cloudflare:workers'
 import { ORG_ID } from '../../../lib/constants'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
-import { generateConversationReply, ConversationApiError } from '../../../lib/claude/conversation'
+import {
+  generateConversationReply,
+  ConversationApiError,
+  postProcessReply,
+} from '../../../lib/claude/conversation'
 import {
   appendUserTurn,
   appendAssistantTurn,
@@ -69,6 +73,24 @@ function validateContinueBody(body: Record<string, unknown>): ValidatedContinueB
   return { messageRaw: message }
 }
 
+/**
+ * Design notes for the auth + idempotency posture on /continue:
+ *
+ *   - Turn numbers are computed server-side (`countUserTurns + 1`) rather
+ *     than supplied by the client as an idempotency key. Intake is a
+ *     low-stakes user-facing flow; the signed cookie + IP rate limit cap
+ *     exposure to abuse, and accidental double-submits at this scale are
+ *     a UX nuisance, not a data-integrity concern. For higher-stakes
+ *     mutating endpoints (e.g. /api/booking/reserve) a client-supplied
+ *     idempotency key would be expected.
+ *
+ *   - The `rendered_at` bot check that /api/intake/send enforces is
+ *     deliberately absent here. The cookie's existence proves the
+ *     prospect already cleared the bot gate when they submitted /send.
+ *     Adding a second timestamp check would not improve security and
+ *     would add a confusing failure mode if the prospect simply replied
+ *     fast.
+ */
 async function authConversationCookie(
   request: Request
 ): Promise<{ conversationId: string; entityId: string } | Response> {
@@ -171,6 +193,12 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
   const claudeResult = await callClaudeForTurn(entityId, conversationId, validated.messageRaw)
   if (claudeResult instanceof Response) return claudeResult
   const { aiReply } = claudeResult
+  postProcessReply(aiReply, {
+    endpoint: 'api/intake/continue',
+    entityId,
+    conversationId,
+    turn,
+  })
 
   try {
     await appendAssistantTurn(env.DB, ORG_ID, {

--- a/src/pages/api/intake/send.ts
+++ b/src/pages/api/intake/send.ts
@@ -3,8 +3,13 @@ import { env } from 'cloudflare:workers'
 import { ORG_ID } from '../../../lib/constants'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import { processIntakeSubmission } from '../../../lib/booking/intake-core'
-import { appendContext } from '../../../lib/db/context'
 import { generateConversationReply, ConversationApiError } from '../../../lib/claude/conversation'
+import { appendUserTurn, appendAssistantTurn } from '../../../lib/db/intake-conversations'
+import {
+  signConversationToken,
+  buildConversationCookieHeader,
+  DEFAULT_CONVERSATION_TTL_SECONDS,
+} from '../../../lib/booking/conversation-token'
 import { sendEmail } from '../../../lib/email/resend'
 import { buildAdminUrl } from '../../../lib/config/app-url'
 
@@ -15,19 +20,16 @@ const MAX_MESSAGE_CHARS = 5000
 /**
  * POST /api/intake/send
  *
- * The "Send — we'll reach out" path of the unified /book intake. Lower-intent
- * sibling of /api/booking/reserve: captures the same identity fields but no
- * meeting / no calendar / no slot pick. After persisting the lead, generates
- * a single AI follow-up to whatever the prospect typed in the textarea so the
- * conversation feels alive, then notifies the team via email.
+ * The first turn of the unified /book intake conversation. Captures
+ * identity fields and the prospect's free-text "tell us about your
+ * business" message, persists the lead, generates the AI's first reply,
+ * and issues a signed conversation cookie so subsequent
+ * `/api/intake/continue` posts can authenticate as this conversation.
  *
- * Single-turn by design (V1). The architectural complexity of multi-turn
- * (entity authority, replay safety, server-side conversation_id lookup)
- * is deferred to a future PR with proper auth.
- *
- * Security: render-timestamp check + IP rate limiting (10/hour).
- * Cloudflare zone-level Bot Fight Mode runs at the edge before requests
- * reach this Worker.
+ * Security: render-timestamp check + IP rate limiting (10/hour) +
+ * HMAC-signed cookie binding conversation_id to entity_id (see
+ * src/lib/booking/conversation-token.ts). Cloudflare zone-level Bot
+ * Fight Mode runs at the edge before requests reach this Worker.
  *
  * The previous offscreen `<input name="website_url">` honeypot was visible to
  * Chrome's autofill classifier and suppressed autofill suggestions on the
@@ -88,8 +90,31 @@ function validateSendBody(body: Record<string, unknown>): ValidatedSendBody | Re
   }
 }
 
-async function maybeGenerateAiReply(entityId: string, messageRaw: string): Promise<string | null> {
+/**
+ * Generate the AI's reply to the prospect's first message and persist
+ * both the user turn and the AI turn against the V2 conversation. Returns
+ * the AI reply text (or null if generation failed or message was empty).
+ */
+async function generateAndPersistFirstTurn(
+  entityId: string,
+  conversationId: string,
+  messageRaw: string
+): Promise<string | null> {
   if (!messageRaw) return null
+
+  // Persist user turn 1 first so the conversation history is complete
+  // even if Claude errors out. The admin can still see what they wrote.
+  try {
+    await appendUserTurn(env.DB, ORG_ID, {
+      entityId,
+      conversationId,
+      turn: 1,
+      content: messageRaw,
+    })
+  } catch (ctxErr) {
+    console.error('[api/intake/send] User turn 1 append failed:', ctxErr)
+  }
+
   const apiKey = env.ANTHROPIC_API_KEY
   if (!apiKey) {
     console.error('[api/intake/send] ANTHROPIC_API_KEY not configured')
@@ -98,15 +123,14 @@ async function maybeGenerateAiReply(entityId: string, messageRaw: string): Promi
   try {
     const aiReply = await generateConversationReply(apiKey, messageRaw, [])
     try {
-      await appendContext(env.DB, ORG_ID, {
-        entity_id: entityId,
-        type: 'intake',
+      await appendAssistantTurn(env.DB, ORG_ID, {
+        entityId,
+        conversationId,
+        turn: 1,
         content: aiReply,
-        source: 'website_intake_send_ai_reply',
-        metadata: { model: 'claude', prospect_message: messageRaw },
       })
     } catch (ctxErr) {
-      console.error('[api/intake/send] AI reply context append failed:', ctxErr)
+      console.error('[api/intake/send] AI turn 1 append failed:', ctxErr)
     }
     return aiReply
   } catch (err) {
@@ -168,7 +192,12 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
     return jsonResponse(500, { error: 'Internal server error' })
   }
 
-  const aiReply = await maybeGenerateAiReply(intakeResult.entityId, validated.messageRaw)
+  const conversationId = crypto.randomUUID()
+  const aiReply = await generateAndPersistFirstTurn(
+    intakeResult.entityId,
+    conversationId,
+    validated.messageRaw
+  )
 
   try {
     await sendAdminNotification(env, {
@@ -181,7 +210,28 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
     console.error('[api/intake/send] Admin notification failed:', emailErr)
   }
 
-  return jsonResponse(200, { ok: true, entity_id: intakeResult.entityId, ai_reply: aiReply })
+  // Issue a signed conversation cookie so /api/intake/continue can
+  // authenticate follow-up turns. Only set the cookie when we actually
+  // started a conversation (i.e. there was a non-empty message that
+  // produced an AI reply).
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (aiReply) {
+    const token = await signConversationToken({
+      conversation_id: conversationId,
+      entity_id: intakeResult.entityId,
+    })
+    headers['Set-Cookie'] = buildConversationCookieHeader(token, DEFAULT_CONVERSATION_TTL_SECONDS)
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      entity_id: intakeResult.entityId,
+      ai_reply: aiReply,
+      can_continue: aiReply !== null,
+    }),
+    { status: 200, headers }
+  )
 }
 
 export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/src/pages/api/intake/send.ts
+++ b/src/pages/api/intake/send.ts
@@ -3,7 +3,11 @@ import { env } from 'cloudflare:workers'
 import { ORG_ID } from '../../../lib/constants'
 import { rateLimitByIp } from '../../../lib/booking/rate-limit'
 import { processIntakeSubmission } from '../../../lib/booking/intake-core'
-import { generateConversationReply, ConversationApiError } from '../../../lib/claude/conversation'
+import {
+  generateConversationReply,
+  ConversationApiError,
+  postProcessReply,
+} from '../../../lib/claude/conversation'
 import { appendUserTurn, appendAssistantTurn } from '../../../lib/db/intake-conversations'
 import {
   signConversationToken,
@@ -122,6 +126,12 @@ async function generateAndPersistFirstTurn(
   }
   try {
     const aiReply = await generateConversationReply(apiKey, messageRaw, [])
+    postProcessReply(aiReply, {
+      endpoint: 'api/intake/send',
+      entityId,
+      conversationId,
+      turn: 1,
+    })
     try {
       await appendAssistantTurn(env.DB, ORG_ID, {
         entityId,

--- a/src/scripts/book.ts
+++ b/src/scripts/book.ts
@@ -1,8 +1,20 @@
 /**
  * Client-side booking flow logic for book.astro.
  *
- * Manages: unified intake send, slot picker reveal, slot selection,
- * booking POST, confirmation panel, and email fallback.
+ * Manages: unified intake send (turn 1), multi-turn intake continuation,
+ * slot picker reveal, slot selection, booking POST, confirmation panel,
+ * and email fallback.
+ *
+ * V2 multi-turn flow:
+ *   - unified-send → POST /api/intake/send → first AI reply rendered.
+ *     If the prospect submitted a non-empty message, the conversation
+ *     controls (reply input + booking offer) appear so the prospect can
+ *     keep talking or pick a time. If the message was empty, only the
+ *     booking offer appears.
+ *   - unified-reply-send → POST /api/intake/continue → next AI reply
+ *     appended to the thread, reply input cleared. Repeat until the
+ *     prospect picks a time, leaves, or hits the conversation turn cap.
+ *   - unified-pick-time → reveal slot picker, fetch slots, etc.
  */
 
 interface UnifiedFormData {
@@ -34,9 +46,19 @@ interface IntakeSendResponse {
   ok?: boolean
   ai_reply?: string | null
   entity_id?: string
+  can_continue?: boolean
   error?: string
   message?: string
   field_errors?: Record<string, string>
+}
+
+interface IntakeContinueResponse {
+  ok?: boolean
+  ai_reply?: string | null
+  turn?: number
+  can_continue?: boolean
+  error?: string
+  message?: string
 }
 
 interface BookElements {
@@ -59,6 +81,7 @@ interface BookState {
   submittedData: UnifiedFormData | null
   currentSlot: BookingSlot | null
   slotsFetched: boolean
+  conversationActive: boolean
 }
 
 function dispatchState(root: HTMLElement, state: string): void {
@@ -73,10 +96,32 @@ function dispatchClearError(root: HTMLElement): void {
   root.dispatchEvent(new CustomEvent('unified-clear-error', { bubbles: false }))
 }
 
-function dispatchAiReply(root: HTMLElement, reply: string | null): void {
+function dispatchReplyError(root: HTMLElement, message: string): void {
   root.dispatchEvent(
-    new CustomEvent('unified-show-ai-reply', { detail: { reply }, bubbles: false })
+    new CustomEvent('unified-reply-error', { detail: { message }, bubbles: false })
   )
+}
+
+function appendTurn(root: HTMLElement, role: 'user' | 'assistant', content: string): void {
+  root.dispatchEvent(
+    new CustomEvent('unified-append-turn', { detail: { role, content }, bubbles: false })
+  )
+}
+
+function showConversationControls(root: HTMLElement): void {
+  root.dispatchEvent(new CustomEvent('unified-show-conversation-controls', { bubbles: false }))
+}
+
+function showBookingOnly(root: HTMLElement): void {
+  root.dispatchEvent(new CustomEvent('unified-show-booking-only', { bubbles: false }))
+}
+
+function showEmptyAck(root: HTMLElement): void {
+  root.dispatchEvent(new CustomEvent('unified-show-empty-ack', { bubbles: false }))
+}
+
+function clearReplyText(root: HTMLElement): void {
+  root.dispatchEvent(new CustomEvent('unified-clear-reply-text', { bubbles: false }))
 }
 
 function showConfirmation(els: BookElements, body: BookingResponse, state: BookState): void {
@@ -135,6 +180,18 @@ function extractSendErrorMessage(res: Response, body: IntakeSendResponse): strin
   return body.message ?? body.error ?? 'Something went wrong. Please try again.'
 }
 
+function extractContinueErrorMessage(res: Response, body: IntakeContinueResponse): string {
+  if (res.status === 401) {
+    return body.error === 'session_expired'
+      ? 'This conversation has timed out. Pick a time to talk to keep going.'
+      : 'We could not authorize this message. Please refresh and try again.'
+  }
+  if (res.status === 429) return 'Too many messages. Please wait a moment and try again.'
+  if (res.status === 503)
+    return 'The assistant is temporarily unavailable. Try again or pick a time to talk.'
+  return body.message ?? body.error ?? 'Something went wrong. Please try again.'
+}
+
 async function handleSend(event: Event, els: BookElements, state: BookState): Promise<void> {
   const data = (event as CustomEvent<UnifiedFormData>).detail
   dispatchClearError(els.intakeRoot)
@@ -173,7 +230,28 @@ async function handleSend(event: Event, els: BookElements, state: BookState): Pr
       state.sendSucceeded = true
       state.submittedData = { ...data }
       dispatchState(els.intakeRoot, 'send_done')
-      dispatchAiReply(els.intakeRoot, body.ai_reply ?? null)
+
+      const userMessage = data.message.trim()
+      const aiReply = (body.ai_reply ?? '').trim()
+
+      if (userMessage) {
+        appendTurn(els.intakeRoot, 'user', userMessage)
+      }
+      if (aiReply) {
+        appendTurn(els.intakeRoot, 'assistant', aiReply)
+      }
+
+      if (aiReply && body.can_continue) {
+        // Conversation is live — reveal reply input + booking offer.
+        state.conversationActive = true
+        showConversationControls(els.intakeRoot)
+      } else {
+        // No conversation (empty message or AI generation failed). Just
+        // show the booking offer; the empty-ack renders too if the user
+        // submitted with no message at all.
+        if (!userMessage) showEmptyAck(els.intakeRoot)
+        showBookingOnly(els.intakeRoot)
+      }
       return
     }
 
@@ -186,6 +264,59 @@ async function handleSend(event: Event, els: BookElements, state: BookState): Pr
       'Could not reach the server. Please check your connection and try again.'
     )
     dispatchState(els.intakeRoot, 'idle')
+  }
+}
+
+async function handleReplySend(event: Event, els: BookElements, state: BookState): Promise<void> {
+  if (!state.conversationActive) return
+  const detail = (event as CustomEvent<{ message: string }>).detail
+  const message = (detail?.message ?? '').trim()
+  if (!message) return
+
+  // Optimistically render the user turn so the conversation feels live.
+  appendTurn(els.intakeRoot, 'user', message)
+  clearReplyText(els.intakeRoot)
+  dispatchState(els.intakeRoot, 'continue_thinking')
+
+  try {
+    const res = await fetch('/api/intake/continue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    })
+    const body = (await res.json().catch(() => ({}))) as IntakeContinueResponse
+
+    if (res.ok && body.ok) {
+      const aiReply = (body.ai_reply ?? '').trim()
+      if (aiReply) {
+        appendTurn(els.intakeRoot, 'assistant', aiReply)
+      }
+      if (body.can_continue) {
+        dispatchState(els.intakeRoot, 'send_done')
+      } else {
+        // Turn cap reached. The booking is the next step.
+        state.conversationActive = false
+        dispatchState(els.intakeRoot, 'turn_capped')
+      }
+      return
+    }
+
+    dispatchReplyError(els.intakeRoot, extractContinueErrorMessage(res, body))
+    if (res.status === 401) {
+      // Session expired — disable further continuations, leave booking
+      // offer in place as the path forward.
+      state.conversationActive = false
+      dispatchState(els.intakeRoot, 'turn_capped')
+    } else {
+      dispatchState(els.intakeRoot, 'send_done')
+    }
+  } catch (err) {
+    console.error('[book] /api/intake/continue error:', err)
+    dispatchReplyError(
+      els.intakeRoot,
+      'Could not reach the server. Please check your connection and try again.'
+    )
+    dispatchState(els.intakeRoot, 'send_done')
   }
 }
 
@@ -290,7 +421,7 @@ function handleSlotSelected(event: Event, els: BookElements, state: BookState): 
   els.bookSubmitBtn.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
 }
 
-;(() => {
+function locateBookElements(): BookElements | null {
   const intakeRoot = document.getElementById('unified-intake')
   const slotPickerSection = document.getElementById('slot-picker-section')
   const pickerElement = document.getElementById('slot-picker')
@@ -319,12 +450,10 @@ function handleSlotSelected(event: Event, els: BookElements, state: BookState): 
     !(confirmPanel instanceof HTMLElement) ||
     !(emailFallback instanceof HTMLElement)
   ) {
-    return
+    return null
   }
-
   const picker = pickerElement as HTMLElement & { refetchSlots?: () => void }
-
-  const els: BookElements = {
+  return {
     intakeRoot,
     slotPickerSection,
     picker,
@@ -338,37 +467,46 @@ function handleSlotSelected(event: Event, els: BookElements, state: BookState): 
     emailFallback,
     prefillTokenStore,
   }
+}
+
+function bindBookListeners(els: BookElements, state: BookState): void {
+  els.intakeRoot.addEventListener('unified-send', (event) => {
+    void handleSend(event, els, state)
+  })
+  els.intakeRoot.addEventListener('unified-reply-send', (event) => {
+    void handleReplySend(event, els, state)
+  })
+  els.intakeRoot.addEventListener('unified-pick-time', () => {
+    if (!state.sendSucceeded || !state.submittedData) return
+    els.slotPickerSection.hidden = false
+    if (!state.slotsFetched && els.picker.refetchSlots) {
+      els.picker.refetchSlots()
+      state.slotsFetched = true
+    }
+    els.slotPickerSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  })
+  els.picker.addEventListener('slot-selected', (event) => {
+    handleSlotSelected(event, els, state)
+  })
+  els.changeSlotBtn.addEventListener('click', () => {
+    els.picker.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  })
+  els.bookSubmitBtn.addEventListener('click', () => {
+    void handleBookSubmit(els, state)
+  })
+}
+
+;(() => {
+  const els = locateBookElements()
+  if (!els) return
 
   const state: BookState = {
     sendSucceeded: false,
     submittedData: null,
     currentSlot: null,
     slotsFetched: false,
+    conversationActive: false,
   }
 
-  intakeRoot.addEventListener('unified-send', (event) => {
-    void handleSend(event, els, state)
-  })
-
-  intakeRoot.addEventListener('unified-pick-time', () => {
-    if (!state.sendSucceeded || !state.submittedData) return
-    slotPickerSection.hidden = false
-    if (!state.slotsFetched && picker.refetchSlots) {
-      picker.refetchSlots()
-      state.slotsFetched = true
-    }
-    slotPickerSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
-  })
-
-  picker.addEventListener('slot-selected', (event) => {
-    handleSlotSelected(event, els, state)
-  })
-
-  changeSlotBtn.addEventListener('click', () => {
-    picker.scrollIntoView({ behavior: 'smooth', block: 'start' })
-  })
-
-  bookSubmitBtn.addEventListener('click', () => {
-    void handleBookSubmit(els, state)
-  })
+  bindBookListeners(els, state)
 })()

--- a/src/scripts/unified-intake.ts
+++ b/src/scripts/unified-intake.ts
@@ -1,0 +1,403 @@
+/**
+ * Client-side controller for the UnifiedIntake.astro component.
+ *
+ * Owns the V2 multi-turn intake DOM: form submit, voice dictation on
+ * the original textarea, conversation thread rendering, and reply
+ * input behavior.
+ *
+ * The page-level controller (src/scripts/book.ts) handles network
+ * calls to /api/intake/send and /api/intake/continue. The two scripts
+ * coordinate over CustomEvents on the #unified-intake element. The
+ * full event contract is enforced by
+ * tests/booking/unified-intake-event-contract.test.ts.
+ */
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionLike
+}
+
+interface SpeechRecognitionLike {
+  lang: string
+  interimResults: boolean
+  continuous: boolean
+  maxAlternatives: number
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null
+  onend: (() => void) | null
+  start(): void
+  stop(): void
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number
+  results: ArrayLike<{ isFinal: boolean; 0: { transcript: string } }>
+}
+
+interface SpeechRecognitionErrorEventLike {
+  error: string
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+  }
+}
+
+interface UnifiedIntakeElements {
+  shell: HTMLElement
+  form: HTMLFormElement
+  textInput: HTMLTextAreaElement
+  micBtn: HTMLButtonElement
+  sendBtn: HTMLButtonElement
+  errorDiv: HTMLElement
+  voiceUnsupported: HTMLElement
+  permissionError: HTMLElement
+  thread: HTMLElement
+  emptyAck: HTMLElement
+  replySection: HTMLElement
+  replyText: HTMLTextAreaElement
+  replySendBtn: HTMLButtonElement
+  replyError: HTMLElement
+  turnCapMsg: HTMLElement
+  bookingOffer: HTMLElement
+  pickTimeBtn: HTMLButtonElement
+}
+
+function el<T extends HTMLElement>(id: string, ctor: new () => T): T | null {
+  const node = document.getElementById(id)
+  return node instanceof ctor ? node : null
+}
+
+function locateFormElements() {
+  return {
+    shell: el('unified-intake', HTMLElement),
+    form: el('unified-intake-form', HTMLFormElement),
+    textInput: el('ui-message', HTMLTextAreaElement),
+    micBtn: el('ui-mic-btn', HTMLButtonElement),
+    sendBtn: el('ui-send-btn', HTMLButtonElement),
+    errorDiv: el('ui-error', HTMLElement),
+    voiceUnsupported: el('ui-voice-unsupported', HTMLElement),
+    permissionError: el('ui-voice-permission-error', HTMLElement),
+  }
+}
+
+function locateConversationElements() {
+  return {
+    thread: el('ui-thread', HTMLElement),
+    emptyAck: el('ui-empty-ack', HTMLElement),
+    replySection: el('ui-reply-section', HTMLElement),
+    replyText: el('ui-reply-text', HTMLTextAreaElement),
+    replySendBtn: el('ui-reply-send-btn', HTMLButtonElement),
+    replyError: el('ui-reply-error', HTMLElement),
+    turnCapMsg: el('ui-turn-cap-msg', HTMLElement),
+    bookingOffer: el('ui-booking-offer', HTMLElement),
+    pickTimeBtn: el('ui-pick-time-btn', HTMLButtonElement),
+  }
+}
+
+function locateElements(): UnifiedIntakeElements | null {
+  const f = locateFormElements()
+  const c = locateConversationElements()
+  const all = { ...f, ...c }
+  for (const v of Object.values(all)) {
+    if (v === null) return null
+  }
+  return all as UnifiedIntakeElements
+}
+
+function setupVoiceRecognition(els: UnifiedIntakeElements): SpeechRecognitionLike | null {
+  const SR = window.SpeechRecognition || window.webkitSpeechRecognition
+  if (!SR) {
+    els.micBtn.hidden = true
+    els.voiceUnsupported.hidden = false
+    return null
+  }
+  const recognition = new SR()
+  recognition.lang = 'en-US'
+  recognition.interimResults = false
+  recognition.continuous = false
+  recognition.maxAlternatives = 1
+
+  recognition.onresult = (e) => {
+    let finalText = ''
+    for (let i = e.resultIndex; i < e.results.length; i++) {
+      if (e.results[i].isFinal) finalText += e.results[i][0].transcript
+    }
+    if (finalText) {
+      const current = els.textInput.value
+      const needsSpace = current.length > 0 && !/\s$/.test(current)
+      els.textInput.value = current + (needsSpace ? ' ' : '') + finalText
+    }
+  }
+  recognition.onerror = (e) => {
+    if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+      els.permissionError.hidden = false
+    } else if (e.error === 'no-speech' || e.error === 'aborted') {
+      // benign
+    } else {
+      console.error('[unified-intake] recognition error', e.error)
+    }
+    setListening(els, false)
+  }
+  recognition.onend = () => {
+    if (els.shell.dataset.state === 'listening') setListening(els, false)
+  }
+  return recognition
+}
+
+function setListening(els: UnifiedIntakeElements, on: boolean): void {
+  els.shell.dataset.state = on ? 'listening' : 'idle'
+  els.textInput.readOnly = on
+}
+
+function stopRecognitionIfActive(
+  recognition: SpeechRecognitionLike | null,
+  els: UnifiedIntakeElements
+): void {
+  if (recognition && els.shell.dataset.state === 'listening') {
+    try {
+      recognition.stop()
+    } catch (err) {
+      void err
+    }
+  }
+}
+
+function clearThread(els: UnifiedIntakeElements): void {
+  while (els.thread.firstChild) els.thread.removeChild(els.thread.firstChild)
+  els.thread.hidden = true
+}
+
+function hidePostSendUi(els: UnifiedIntakeElements): void {
+  clearThread(els)
+  els.emptyAck.hidden = true
+  els.replySection.hidden = true
+  els.replyText.value = ''
+  els.replyError.hidden = true
+  els.replyError.textContent = ''
+  els.turnCapMsg.hidden = true
+  els.bookingOffer.hidden = true
+}
+
+function appendThreadEntry(
+  els: UnifiedIntakeElements,
+  role: 'user' | 'assistant',
+  content: string
+): void {
+  els.thread.hidden = false
+  const block = document.createElement('div')
+  if (role === 'assistant') {
+    block.className =
+      'whitespace-pre-wrap rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-text-secondary)]/20 bg-white px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)] shadow-sm'
+    block.textContent = content
+  } else {
+    block.className =
+      'whitespace-pre-wrap rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-text-secondary)]/5 px-4 py-3 text-base leading-relaxed text-[color:var(--ss-color-text-primary)]'
+    const label = document.createElement('span')
+    label.className =
+      'mb-1 block text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-secondary)]'
+    label.textContent = 'You'
+    const body = document.createElement('span')
+    body.className = 'block'
+    body.textContent = content
+    block.appendChild(label)
+    block.appendChild(body)
+  }
+  els.thread.appendChild(block)
+}
+
+function applyState(els: UnifiedIntakeElements, next: string, supportsVoice: boolean): void {
+  els.shell.dataset.state = next
+  const fields = els.form.querySelectorAll('input, textarea')
+  const locked =
+    next === 'send_thinking' ||
+    next === 'send_done' ||
+    next === 'continue_thinking' ||
+    next === 'booked'
+  fields.forEach((f) => {
+    ;(f as HTMLInputElement | HTMLTextAreaElement).readOnly = locked
+  })
+  if (next === 'send_thinking') {
+    els.sendBtn.disabled = true
+    els.sendBtn.textContent = 'Sending...'
+  } else if (next === 'send_done') {
+    els.sendBtn.disabled = true
+    els.sendBtn.hidden = true
+    if (supportsVoice) els.micBtn.hidden = true
+    els.replySendBtn.disabled = false
+    els.replySendBtn.textContent = 'Send'
+    els.replyText.readOnly = false
+  } else if (next === 'continue_thinking') {
+    els.replySendBtn.disabled = true
+    els.replySendBtn.textContent = 'Sending...'
+    els.replyText.readOnly = true
+  } else if (next === 'turn_capped') {
+    els.replySection.hidden = true
+    els.turnCapMsg.hidden = false
+  } else if (next === 'booked') {
+    els.sendBtn.disabled = true
+    els.sendBtn.hidden = true
+    if (supportsVoice) els.micBtn.hidden = true
+    els.replySection.hidden = true
+  } else if (next === 'idle') {
+    els.sendBtn.disabled = false
+    els.sendBtn.hidden = false
+    els.sendBtn.textContent = 'Get in touch'
+    if (supportsVoice) {
+      els.micBtn.hidden = false
+      els.micBtn.disabled = false
+    }
+    hidePostSendUi(els)
+  }
+}
+
+interface UnifiedSendDetail {
+  name: string
+  email: string
+  business_name: string
+  phone: string
+  website: string | null
+  message: string
+  rendered_at: number
+}
+
+function fdString(fd: FormData, key: string): string {
+  const value = fd.get(key)
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readFormData(form: HTMLFormElement, renderedAt: number): UnifiedSendDetail {
+  const fd = new FormData(form)
+  return {
+    name: fdString(fd, 'name'),
+    email: fdString(fd, 'email'),
+    business_name: fdString(fd, 'business_name'),
+    phone: fdString(fd, 'phone'),
+    website: fdString(fd, 'website') || null,
+    message: fdString(fd, 'message'),
+    rendered_at: renderedAt,
+  }
+}
+
+function bindMicButton(
+  els: UnifiedIntakeElements,
+  recognition: SpeechRecognitionLike | null
+): void {
+  if (!recognition) return
+  els.micBtn.addEventListener('click', () => {
+    if (els.shell.dataset.state === 'listening') {
+      recognition.stop()
+      return
+    }
+    if (els.shell.dataset.state !== 'idle') return
+    els.permissionError.hidden = true
+    setListening(els, true)
+    try {
+      recognition.start()
+    } catch (err) {
+      console.error('[unified-intake] start() failed', err)
+      setListening(els, false)
+    }
+  })
+}
+
+function bindFormSubmit(els: UnifiedIntakeElements, renderedAt: number): void {
+  els.form.addEventListener('submit', (e) => {
+    e.preventDefault()
+    if (els.sendBtn.disabled) return
+    const data = readFormData(els.form, renderedAt)
+    els.shell.dispatchEvent(new CustomEvent('unified-send', { detail: data, bubbles: true }))
+  })
+}
+
+function bindReplySend(els: UnifiedIntakeElements): void {
+  els.replySendBtn.addEventListener('click', () => {
+    if (els.replySendBtn.disabled) return
+    const message = els.replyText.value.trim()
+    if (!message) {
+      els.replyError.textContent = 'Type a message before sending.'
+      els.replyError.hidden = false
+      return
+    }
+    els.replyError.hidden = true
+    els.replyError.textContent = ''
+    els.shell.dispatchEvent(
+      new CustomEvent('unified-reply-send', { detail: { message }, bubbles: true })
+    )
+  })
+}
+
+function bindPickTime(els: UnifiedIntakeElements): void {
+  els.pickTimeBtn.addEventListener('click', () => {
+    els.shell.dispatchEvent(new CustomEvent('unified-pick-time', { bubbles: true }))
+  })
+}
+
+function bindPageEvents(
+  els: UnifiedIntakeElements,
+  recognition: SpeechRecognitionLike | null,
+  supportsVoice: boolean
+): void {
+  els.shell.addEventListener('unified-set-state', (e) => {
+    const next = (e as CustomEvent).detail?.state
+    if (!next) return
+    const prev = els.shell.dataset.state
+    if (next !== 'idle' && next !== 'listening' && prev === 'listening') {
+      stopRecognitionIfActive(recognition, els)
+    }
+    applyState(els, String(next), supportsVoice)
+  })
+  els.shell.addEventListener('unified-show-error', (e) => {
+    const msg = (e as CustomEvent).detail?.message || 'Something went wrong. Please try again.'
+    els.errorDiv.textContent = msg
+    els.errorDiv.hidden = false
+  })
+  els.shell.addEventListener('unified-clear-error', () => {
+    els.errorDiv.hidden = true
+    els.errorDiv.textContent = ''
+  })
+  els.shell.addEventListener('unified-reply-error', (e) => {
+    const msg = (e as CustomEvent).detail?.message || 'Something went wrong. Please try again.'
+    els.replyError.textContent = msg
+    els.replyError.hidden = false
+  })
+  els.shell.addEventListener('unified-append-turn', (e) => {
+    const { role, content } = (e as CustomEvent).detail ?? {}
+    if ((role !== 'user' && role !== 'assistant') || typeof content !== 'string') return
+    const trimmed = content.trim()
+    if (!trimmed) return
+    appendThreadEntry(els, role, trimmed)
+  })
+  els.shell.addEventListener('unified-show-empty-ack', () => {
+    els.emptyAck.hidden = false
+  })
+  els.shell.addEventListener('unified-show-conversation-controls', () => {
+    els.replySection.hidden = false
+    els.bookingOffer.hidden = false
+  })
+  els.shell.addEventListener('unified-show-booking-only', () => {
+    els.bookingOffer.hidden = false
+  })
+  els.shell.addEventListener('unified-clear-reply-text', () => {
+    els.replyText.value = ''
+  })
+}
+
+;(() => {
+  const els = locateElements()
+  if (!els) return
+  const recognition = setupVoiceRecognition(els)
+  const supportsVoice = recognition !== null
+  // Captured at script-execute time. The page-level handler reads this
+  // off unified-send detail and sends it as `rendered_at` to the
+  // server, which rejects submissions under 2s old as bot-driven.
+  const renderedAt = Date.now()
+  bindMicButton(els, recognition)
+  bindFormSubmit(els, renderedAt)
+  bindReplySend(els)
+  bindPickTime(els)
+  bindPageEvents(els, recognition, supportsVoice)
+})()
+
+export {}

--- a/tests/booking/conversation-token.test.ts
+++ b/tests/booking/conversation-token.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the V2 intake conversation cookie token (HMAC-SHA256, base64url).
+ *
+ * Mirrors the test posture of `signed-link.test.ts` since the crypto
+ * shape and threat model are the same.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+import {
+  signConversationToken,
+  verifyConversationToken,
+  buildConversationCookieHeader,
+  readConversationCookie,
+  DEFAULT_CONVERSATION_TTL_SECONDS,
+  CONVERSATION_COOKIE_NAME,
+} from '../../src/lib/booking/conversation-token'
+
+const TEST_KEY_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+beforeEach(() => {
+  for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+  ;(testEnv as unknown as Record<string, unknown>).BOOKING_ENCRYPTION_KEY = TEST_KEY_BASE64
+})
+
+describe('signConversationToken / verifyConversationToken', () => {
+  it('round-trips and exposes the original payload fields', async () => {
+    const token = await signConversationToken({
+      conversation_id: 'conv-1',
+      entity_id: 'ent-1',
+    })
+    const result = await verifyConversationToken(token)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.payload.conversation_id).toBe('conv-1')
+      expect(result.payload.entity_id).toBe('ent-1')
+      expect(result.payload.v).toBe(1)
+      expect(result.payload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000))
+    }
+  })
+
+  it('produces a `<payload>.<sig>` token', async () => {
+    const token = await signConversationToken({
+      conversation_id: 'conv-1',
+      entity_id: 'ent-1',
+    })
+    const parts = token.split('.')
+    expect(parts).toHaveLength(2)
+    for (const part of parts) {
+      expect(part).toMatch(/^[A-Za-z0-9_-]+$/)
+      expect(part.length).toBeGreaterThan(10)
+    }
+  })
+
+  it('rejects a token with a tampered payload', async () => {
+    const token = await signConversationToken({
+      conversation_id: 'conv-1',
+      entity_id: 'ent-1',
+    })
+    const [, sig] = token.split('.')
+    const tamperedPayload = btoa(
+      JSON.stringify({ v: 1, conversation_id: 'conv-evil', entity_id: 'ent-evil', exp: 9999999999 })
+    )
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    const tampered = `${tamperedPayload}.${sig}`
+    const result = await verifyConversationToken(tampered)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('bad_signature')
+  })
+
+  it('rejects an expired token', async () => {
+    const originalNow = Date.now
+    try {
+      Date.now = () => 1_700_000_000_000
+      const token = await signConversationToken({
+        conversation_id: 'conv-1',
+        entity_id: 'ent-1',
+        ttl_seconds: 60,
+      })
+      Date.now = () => 1_700_000_000_000 + 61_000
+      const result = await verifyConversationToken(token)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error).toBe('expired')
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  it('rejects a malformed token', async () => {
+    for (const bad of ['', '...', 'no-dot-here', '.', 'abc.', '.def']) {
+      const result = await verifyConversationToken(bad)
+      expect(result.ok).toBe(false)
+    }
+  })
+
+  it('throws a clear error when BOOKING_ENCRYPTION_KEY is missing', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).BOOKING_ENCRYPTION_KEY
+    await expect(signConversationToken({ conversation_id: 'c', entity_id: 'e' })).rejects.toThrow(
+      /BOOKING_ENCRYPTION_KEY/
+    )
+  })
+
+  it('default TTL matches DEFAULT_CONVERSATION_TTL_SECONDS', async () => {
+    const before = Math.floor(Date.now() / 1000)
+    const token = await signConversationToken({ conversation_id: 'c', entity_id: 'e' })
+    const result = await verifyConversationToken(token)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const expectedExp = before + DEFAULT_CONVERSATION_TTL_SECONDS
+      expect(result.payload.exp).toBeGreaterThanOrEqual(expectedExp - 2)
+      expect(result.payload.exp).toBeLessThanOrEqual(expectedExp + 2)
+    }
+  })
+})
+
+describe('buildConversationCookieHeader / readConversationCookie', () => {
+  it('builds an HttpOnly SameSite=Lax cookie with the configured Max-Age', () => {
+    const header = buildConversationCookieHeader('TOKENVAL', 60)
+    expect(header).toMatch(new RegExp(`^${CONVERSATION_COOKIE_NAME}=TOKENVAL; `))
+    expect(header).toContain('HttpOnly')
+    expect(header).toContain('SameSite=Lax')
+    expect(header).toContain('Path=/')
+    expect(header).toContain('Max-Age=60')
+    expect(header).toContain('Secure')
+  })
+
+  it('omits Secure when explicitly opted out', () => {
+    const header = buildConversationCookieHeader('TOKENVAL', 60, false)
+    expect(header).not.toContain('Secure')
+  })
+
+  it('reads the cookie value out of a request Cookie header', () => {
+    const req = new Request('https://example.com/', {
+      headers: { cookie: `other=foo; ${CONVERSATION_COOKIE_NAME}=BAZ; trailing=bar` },
+    })
+    expect(readConversationCookie(req)).toBe('BAZ')
+  })
+
+  it('returns null when the cookie is absent', () => {
+    const req = new Request('https://example.com/', {
+      headers: { cookie: 'other=foo; trailing=bar' },
+    })
+    expect(readConversationCookie(req)).toBeNull()
+  })
+
+  it('returns null when the request has no Cookie header', () => {
+    const req = new Request('https://example.com/')
+    expect(readConversationCookie(req)).toBeNull()
+  })
+})

--- a/tests/booking/intake-continue.test.ts
+++ b/tests/booking/intake-continue.test.ts
@@ -1,0 +1,400 @@
+/**
+ * End-to-end behavioral tests for POST /api/intake/continue.
+ *
+ * Exercises the auth (signed cookie) → rate-limit → validate → turn-cap →
+ * persist user → call Claude → persist assistant → rotate cookie pipeline
+ * with real D1 migrations via @venturecrane/crane-test-harness. The
+ * Claude API is mocked at the helper boundary so the handler's own wiring
+ * is what's actually under test.
+ *
+ * Mirrors `tests/booking/reserve.test.ts` shape.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, beforeAll } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database, KVNamespace } from '@cloudflare/workers-types'
+import { env as testEnv } from 'cloudflare:workers'
+import { ORG_ID } from '../../src/lib/constants'
+import {
+  signConversationToken,
+  CONVERSATION_COOKIE_NAME,
+} from '../../src/lib/booking/conversation-token'
+import {
+  appendUserTurn,
+  appendAssistantTurn,
+  MAX_TURNS,
+} from '../../src/lib/db/intake-conversations'
+
+// ---------------------------------------------------------------------------
+// Mocks for external boundaries.
+// ---------------------------------------------------------------------------
+//
+// generateConversationReply is mocked so we can flip success/failure per
+// test. postProcessReply is the real implementation — we want it
+// exercised against the same shapes the prod path sees.
+
+let claudeReplyResult: string | Error = 'How big is the team today?'
+
+vi.mock('../../src/lib/claude/conversation', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/claude/conversation')>(
+    '../../src/lib/claude/conversation'
+  )
+  return {
+    ...actual,
+    generateConversationReply: vi.fn(async () => {
+      if (claudeReplyResult instanceof Error) throw claudeReplyResult
+      return claudeReplyResult
+    }),
+  }
+})
+
+import { POST } from '../../src/pages/api/intake/continue'
+import { ConversationApiError } from '../../src/lib/claude/conversation'
+
+// ---------------------------------------------------------------------------
+// Test KV (in-memory) for rate-limit.
+// ---------------------------------------------------------------------------
+
+function createMemoryKv(): KVNamespace {
+  const store = new Map<string, string>()
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value)
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const TEST_KEY_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+const ENTITY_ID = 'ent-cont-1'
+const CONV_ID = 'conv-cont-1'
+
+installWorkerdPolyfills()
+
+interface BuildCtxOpts {
+  body: Record<string, unknown>
+  cookie?: string
+  ip?: string
+}
+
+function buildContext(opts: BuildCtxOpts) {
+  const headers = new Headers({ 'Content-Type': 'application/json' })
+  if (opts.cookie) headers.set('cookie', `${CONVERSATION_COOKIE_NAME}=${opts.cookie}`)
+  if (opts.ip) headers.set('cf-connecting-ip', opts.ip)
+  const request = new Request('http://test.local/api/intake/continue', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(opts.body),
+  })
+  return {
+    request,
+    params: {},
+    locals: {},
+    redirect: (url: string, status: number) =>
+      new Response(null, { status, headers: { Location: url } }),
+  } as unknown as Parameters<typeof POST>[0]
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  return res.json()
+}
+
+async function seedTurn1(db: D1Database): Promise<void> {
+  await appendUserTurn(db, ORG_ID, {
+    entityId: ENTITY_ID,
+    conversationId: CONV_ID,
+    turn: 1,
+    content: 'We do HVAC, mostly residential, twelve years.',
+  })
+  await appendAssistantTurn(db, ORG_ID, {
+    entityId: ENTITY_ID,
+    conversationId: CONV_ID,
+    turn: 1,
+    content: 'How big is the team today?',
+  })
+}
+
+interface ContinueResponse {
+  ok?: boolean
+  ai_reply?: string | null
+  turn?: number
+  can_continue?: boolean
+  error?: string
+  message?: string
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/intake/continue', () => {
+  let db: D1Database
+  let kv: KVNamespace
+
+  beforeAll(() => {
+    expect(discoverNumericMigrations(migrationsDir).length).toBeGreaterThan(0)
+  })
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    kv = createMemoryKv()
+
+    Object.assign(testEnv, {
+      DB: db,
+      BOOKING_CACHE: kv,
+      ANTHROPIC_API_KEY: 'fake-anthropic-key',
+      BOOKING_ENCRYPTION_KEY: TEST_KEY_BASE64,
+    })
+
+    // Seed an entity that the cookie will reference.
+    await db
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at)
+         VALUES (?, ?, ?, ?, 'prospect', datetime('now'))`
+      )
+      .bind(ENTITY_ID, ORG_ID, 'HVAC Co', 'hvac-co')
+      .run()
+
+    claudeReplyResult = 'How many crews are you running?'
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('happy path: turn 2 succeeds, persists user + AI, rotates cookie', async () => {
+    await seedTurn1(db)
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+
+    const res = await POST(
+      buildContext({ body: { message: 'Four crews, mostly two-person.' }, cookie: token })
+    )
+    expect(res.status).toBe(200)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.ok).toBe(true)
+    expect(body.ai_reply).toBe('How many crews are you running?')
+    expect(body.turn).toBe(2)
+    expect(body.can_continue).toBe(true)
+
+    // Cookie was rotated.
+    const setCookie = res.headers.get('set-cookie')
+    expect(setCookie).toBeTruthy()
+    expect(setCookie).toContain(`${CONVERSATION_COOKIE_NAME}=`)
+
+    // History now has 4 entries (turn 1 user + AI, turn 2 user + AI).
+    const turns = await db
+      .prepare(
+        `SELECT source, content FROM context
+         WHERE entity_id = ? AND type = 'intake'
+         ORDER BY created_at ASC`
+      )
+      .bind(ENTITY_ID)
+      .all<{ source: string; content: string }>()
+    expect(turns.results).toHaveLength(4)
+    expect(turns.results[2].content).toBe('Four crews, mostly two-person.')
+    expect(turns.results[3].content).toBe('How many crews are you running?')
+  })
+
+  it('401 when the cookie is missing', async () => {
+    const res = await POST(buildContext({ body: { message: 'hello' } }))
+    expect(res.status).toBe(401)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.error).toBe('unauthorized')
+  })
+
+  it('401 session_expired when the cookie has expired', async () => {
+    const realNow = Date.now
+    try {
+      Date.now = () => 1_700_000_000_000
+      const token = await signConversationToken({
+        conversation_id: CONV_ID,
+        entity_id: ENTITY_ID,
+        ttl_seconds: 60,
+      })
+      Date.now = () => 1_700_000_000_000 + 61_000
+      const res = await POST(buildContext({ body: { message: 'hello' }, cookie: token }))
+      expect(res.status).toBe(401)
+      const body = await parseJson<ContinueResponse>(res)
+      expect(body.error).toBe('session_expired')
+    } finally {
+      Date.now = realNow
+    }
+  })
+
+  it('401 unauthorized when the cookie signature is tampered', async () => {
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+    const [payload] = token.split('.')
+    const tampered = `${payload}.AAAAAAAAAAAAAAAA`
+    const res = await POST(buildContext({ body: { message: 'hello' }, cookie: tampered }))
+    expect(res.status).toBe(401)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.error).toBe('unauthorized')
+  })
+
+  it('400 validation_failed on empty message', async () => {
+    await seedTurn1(db)
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+    const res = await POST(buildContext({ body: { message: '' }, cookie: token }))
+    expect(res.status).toBe(400)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.error).toBe('validation_failed')
+  })
+
+  it('400 validation_failed when message exceeds the max length', async () => {
+    await seedTurn1(db)
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+    const res = await POST(buildContext({ body: { message: 'x'.repeat(5001) }, cookie: token }))
+    expect(res.status).toBe(400)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.error).toBe('validation_failed')
+  })
+
+  it('hits the turn cap and returns can_continue: false without calling Claude', async () => {
+    // Seed MAX_TURNS prior user turns + assistant turns.
+    for (let t = 1; t <= MAX_TURNS; t++) {
+      await appendUserTurn(db, ORG_ID, {
+        entityId: ENTITY_ID,
+        conversationId: CONV_ID,
+        turn: t,
+        content: `user turn ${t}`,
+      })
+      await appendAssistantTurn(db, ORG_ID, {
+        entityId: ENTITY_ID,
+        conversationId: CONV_ID,
+        turn: t,
+        content: `ai turn ${t}?`,
+      })
+    }
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+    const res = await POST(buildContext({ body: { message: 'one more thing' }, cookie: token }))
+    expect(res.status).toBe(200)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.ok).toBe(true)
+    expect(body.ai_reply).toBeNull()
+    expect(body.can_continue).toBe(false)
+  })
+
+  it('history accumulates correctly across two consecutive /continue calls', async () => {
+    await seedTurn1(db)
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+
+    claudeReplyResult = 'AI reply turn 2?'
+    const res1 = await POST(buildContext({ body: { message: 'turn 2 user' }, cookie: token }))
+    expect(res1.status).toBe(200)
+    const body1 = await parseJson<ContinueResponse>(res1)
+    expect(body1.turn).toBe(2)
+
+    claudeReplyResult = 'AI reply turn 3?'
+    const res2 = await POST(buildContext({ body: { message: 'turn 3 user' }, cookie: token }))
+    expect(res2.status).toBe(200)
+    const body2 = await parseJson<ContinueResponse>(res2)
+    expect(body2.turn).toBe(3)
+
+    const turns = await db
+      .prepare(
+        `SELECT content FROM context
+         WHERE entity_id = ? AND type = 'intake'
+         ORDER BY created_at ASC`
+      )
+      .bind(ENTITY_ID)
+      .all<{ content: string }>()
+    expect(turns.results.map((r) => r.content)).toEqual([
+      'We do HVAC, mostly residential, twelve years.',
+      'How big is the team today?',
+      'turn 2 user',
+      'AI reply turn 2?',
+      'turn 3 user',
+      'AI reply turn 3?',
+    ])
+  })
+
+  it('503 ai_unavailable when Claude API throws; user turn was still persisted', async () => {
+    await seedTurn1(db)
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+    claudeReplyResult = new ConversationApiError('Boom', 500)
+
+    const res = await POST(
+      buildContext({ body: { message: 'this should reach DB then 503' }, cookie: token })
+    )
+    expect(res.status).toBe(503)
+    const body = await parseJson<ContinueResponse>(res)
+    expect(body.error).toBe('ai_unavailable')
+
+    // User turn 2 was persisted before Claude was called.
+    const userTurns = await db
+      .prepare(
+        `SELECT content FROM context
+         WHERE entity_id = ? AND source = 'website_intake_v2_user'
+         ORDER BY created_at ASC`
+      )
+      .bind(ENTITY_ID)
+      .all<{ content: string }>()
+    expect(userTurns.results.map((r) => r.content)).toEqual([
+      'We do HVAC, mostly residential, twelve years.',
+      'this should reach DB then 503',
+    ])
+  })
+
+  it('400 on invalid JSON body', async () => {
+    const token = await signConversationToken({
+      conversation_id: CONV_ID,
+      entity_id: ENTITY_ID,
+    })
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      cookie: `${CONVERSATION_COOKIE_NAME}=${token}`,
+    })
+    const request = new Request('http://test.local/api/intake/continue', {
+      method: 'POST',
+      headers,
+      body: '{not json',
+    })
+    const ctx = {
+      request,
+      params: {},
+      locals: {},
+      redirect: (url: string, status: number) =>
+        new Response(null, { status, headers: { Location: url } }),
+    } as unknown as Parameters<typeof POST>[0]
+    const res = await POST(ctx)
+    expect(res.status).toBe(400)
+  })
+})

--- a/tests/booking/intake-conversations.test.ts
+++ b/tests/booking/intake-conversations.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the V2 intake conversation persistence helpers in
+ * `src/lib/db/intake-conversations.ts`.
+ *
+ * Covers: turn appending, turn counting, history reconstruction
+ * (chronological, alternating user/assistant), filtering by
+ * conversation_id, and the MAX_TURNS constant.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import {
+  appendUserTurn,
+  appendAssistantTurn,
+  countUserTurns,
+  loadConversationHistory,
+  MAX_TURNS,
+  V2_USER_SOURCE,
+  V2_AI_SOURCE,
+} from '../../src/lib/db/intake-conversations'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG_ID = 'org-icv'
+const ENTITY_ID = 'ent-icv'
+const CONV_ID = 'conv-1'
+
+describe('intake-conversations persistence', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    await db
+      .prepare('INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)')
+      .bind(ORG_ID, 'Org ICV', 'org-icv')
+      .run()
+    await db
+      .prepare(
+        `INSERT INTO entities (id, org_id, name, slug, stage, stage_changed_at)
+         VALUES (?, ?, ?, ?, 'prospect', datetime('now'))`
+      )
+      .bind(ENTITY_ID, ORG_ID, 'ICV Co', 'icv-co')
+      .run()
+  })
+
+  it('round-trips a single user/assistant turn pair', async () => {
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 1,
+      content: 'Hello, this is the first user message.',
+    })
+    await appendAssistantTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 1,
+      content: 'And this is the AI reply.',
+    })
+
+    const history = await loadConversationHistory(db, ENTITY_ID, CONV_ID)
+    expect(history).toEqual([
+      { role: 'user', content: 'Hello, this is the first user message.' },
+      { role: 'assistant', content: 'And this is the AI reply.' },
+    ])
+  })
+
+  it('orders multi-turn history chronologically by (turn, role)', async () => {
+    // Persist out of order to confirm sort.
+    await appendAssistantTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 2,
+      content: 'turn2-ai',
+    })
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 2,
+      content: 'turn2-user',
+    })
+    await appendAssistantTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 1,
+      content: 'turn1-ai',
+    })
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 1,
+      content: 'turn1-user',
+    })
+
+    const history = await loadConversationHistory(db, ENTITY_ID, CONV_ID)
+    expect(history.map((t) => t.content)).toEqual([
+      'turn1-user',
+      'turn1-ai',
+      'turn2-user',
+      'turn2-ai',
+    ])
+  })
+
+  it('isolates by conversation_id', async () => {
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: 'conv-a',
+      turn: 1,
+      content: 'A1',
+    })
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: 'conv-b',
+      turn: 1,
+      content: 'B1',
+    })
+    const a = await loadConversationHistory(db, ENTITY_ID, 'conv-a')
+    const b = await loadConversationHistory(db, ENTITY_ID, 'conv-b')
+    expect(a).toEqual([{ role: 'user', content: 'A1' }])
+    expect(b).toEqual([{ role: 'user', content: 'B1' }])
+  })
+
+  it('countUserTurns returns the number of user turns recorded', async () => {
+    expect(await countUserTurns(db, ENTITY_ID, CONV_ID)).toBe(0)
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 1,
+      content: 'one',
+    })
+    expect(await countUserTurns(db, ENTITY_ID, CONV_ID)).toBe(1)
+    // Assistant turns do not count.
+    await appendAssistantTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 1,
+      content: 'one-ai',
+    })
+    expect(await countUserTurns(db, ENTITY_ID, CONV_ID)).toBe(1)
+    await appendUserTurn(db, ORG_ID, {
+      entityId: ENTITY_ID,
+      conversationId: CONV_ID,
+      turn: 2,
+      content: 'two',
+    })
+    expect(await countUserTurns(db, ENTITY_ID, CONV_ID)).toBe(2)
+  })
+
+  it('exposes the MAX_TURNS cap and V2 source constants', () => {
+    // Sanity: MAX_TURNS is a generous-but-finite limit.
+    expect(MAX_TURNS).toBeGreaterThanOrEqual(10)
+    expect(MAX_TURNS).toBeLessThanOrEqual(50)
+    expect(V2_USER_SOURCE).toBe('website_intake_v2_user')
+    expect(V2_AI_SOURCE).toBe('website_intake_v2_ai')
+  })
+})

--- a/tests/booking/unified-intake-event-contract.test.ts
+++ b/tests/booking/unified-intake-event-contract.test.ts
@@ -2,16 +2,17 @@
  * Regression guard: every `unified-*` CustomEvent dispatched in one of the
  * two collaborating files must be listened for in the other.
  *
- * /book splits its UI into UnifiedIntake.astro (component) and
- * src/scripts/book.ts (page-level controller). They communicate over
- * CustomEvents on the `#unified-intake` element. If a dispatch and its
- * matching listener disagree on the event name, the listener silently
- * never fires — that breaks the post-Send AI reply / "Pick a time to
- * talk" CTA without any error or test signal.
+ * /book splits its UI into the UnifiedIntake component (markup +
+ * src/scripts/unified-intake.ts controller) and src/scripts/book.ts
+ * (page-level network controller). They communicate over CustomEvents
+ * on the `#unified-intake` element. If a dispatch and its matching
+ * listener disagree on the event name, the listener silently never
+ * fires.
  *
  * This regression actually shipped: PR #722 extracted book.ts out of
  * book.astro and renamed `unified-show-ai-reply` to `unified-ai-reply`
- * in the dispatcher only, leaving the listener stranded.
+ * in the dispatcher only, leaving the listener stranded. PR #743 fixed
+ * the immediate bug and added this contract.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -19,7 +20,7 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 const BOOK_TS = resolve('src/scripts/book.ts')
-const UNIFIED_INTAKE_ASTRO = resolve('src/components/booking/UnifiedIntake.astro')
+const UNIFIED_INTAKE_TS = resolve('src/scripts/unified-intake.ts')
 
 const DISPATCH_RE = /dispatchEvent\(\s*new\s+CustomEvent\(\s*['"](unified-[a-z-]+)['"]/g
 const LISTEN_RE = /addEventListener\(\s*['"](unified-[a-z-]+)['"]/g
@@ -34,27 +35,27 @@ function extractEventNames(source: string, regex: RegExp): Set<string> {
 
 describe('UnifiedIntake event contract', () => {
   const bookTs = readFileSync(BOOK_TS, 'utf8')
-  const unifiedIntake = readFileSync(UNIFIED_INTAKE_ASTRO, 'utf8')
+  const unifiedIntake = readFileSync(UNIFIED_INTAKE_TS, 'utf8')
 
   const bookDispatches = extractEventNames(bookTs, DISPATCH_RE)
   const bookListens = extractEventNames(bookTs, LISTEN_RE)
   const intakeDispatches = extractEventNames(unifiedIntake, DISPATCH_RE)
   const intakeListens = extractEventNames(unifiedIntake, LISTEN_RE)
 
-  it('every event book.ts dispatches is listened for in UnifiedIntake.astro', () => {
+  it('every event book.ts dispatches is listened for in unified-intake.ts', () => {
     for (const name of bookDispatches) {
       expect(
         intakeListens,
-        `book.ts dispatches "${name}" but UnifiedIntake.astro never listens`
+        `book.ts dispatches "${name}" but unified-intake.ts never listens`
       ).toContain(name)
     }
   })
 
-  it('every event UnifiedIntake.astro dispatches is listened for in book.ts', () => {
+  it('every event unified-intake.ts dispatches is listened for in book.ts', () => {
     for (const name of intakeDispatches) {
       expect(
         bookListens,
-        `UnifiedIntake.astro dispatches "${name}" but book.ts never listens`
+        `unified-intake.ts dispatches "${name}" but book.ts never listens`
       ).toContain(name)
     }
   })

--- a/tests/conversation-postprocess.test.ts
+++ b/tests/conversation-postprocess.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for postProcessReply (defense-in-depth observability).
+ *
+ * The helper does NOT modify replies. It logs a warning when the reply
+ * does not end on a question mark, and swallows any internal exception
+ * so endpoint behavior is never affected.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { postProcessReply } from '../src/lib/claude/conversation'
+
+describe('postProcessReply', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('does not warn when the reply ends in a question mark', () => {
+    postProcessReply('How big is the team today?', { endpoint: 'api/intake/send' })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when the reply ends in a question mark with trailing whitespace', () => {
+    postProcessReply('How big is the team today?\n\n  ', { endpoint: 'api/intake/send' })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns when the reply ends in a period', () => {
+    postProcessReply('That is interesting.', { endpoint: 'api/intake/send' })
+    expect(warnSpy).toHaveBeenCalledOnce()
+    const call = warnSpy.mock.calls[0]
+    expect(call[0]).toContain('did not end on a question')
+    const meta = call[1] as Record<string, unknown>
+    expect(meta.last_char).toBe('.')
+    expect(meta.endpoint).toBe('api/intake/send')
+  })
+
+  it('warns when the reply ends in an exclamation mark', () => {
+    postProcessReply('Bad implementations leave a mark!', { endpoint: 'api/intake/continue' })
+    expect(warnSpy).toHaveBeenCalledOnce()
+  })
+
+  it('passes context fields through to the warning payload', () => {
+    postProcessReply('No question here.', {
+      endpoint: 'api/intake/continue',
+      entityId: 'ent-x',
+      conversationId: 'conv-x',
+      turn: 3,
+    })
+    expect(warnSpy).toHaveBeenCalledOnce()
+    const meta = warnSpy.mock.calls[0][1] as Record<string, unknown>
+    expect(meta.entity_id).toBe('ent-x')
+    expect(meta.conversation_id).toBe('conv-x')
+    expect(meta.turn).toBe(3)
+  })
+
+  it('returns silently on an empty reply (nothing to inspect)', () => {
+    postProcessReply('', { endpoint: 'api/intake/send' })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns silently on whitespace-only reply', () => {
+    postProcessReply('   \n  ', { endpoint: 'api/intake/send' })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('truncates reply_tail to 80 characters in the warning payload', () => {
+    const long = 'a'.repeat(200) + '.'
+    postProcessReply(long, { endpoint: 'api/intake/send' })
+    const meta = warnSpy.mock.calls[0][1] as Record<string, unknown>
+    const tail = meta.reply_tail as string
+    expect(tail.length).toBe(80)
+  })
+
+  it('swallows internal exceptions and never throws to the caller', () => {
+    // Force an exception by passing a non-string. The helper's typing
+    // guards at compile time, but at runtime a thrown error here would
+    // mean a real bug. We assert the helper survives and logs.
+    expect(() =>
+      postProcessReply(undefined as unknown as string, { endpoint: 'api/intake/send' })
+    ).not.toThrow()
+  })
+})

--- a/tests/conversation-prompt-contract.test.ts
+++ b/tests/conversation-prompt-contract.test.ts
@@ -99,12 +99,22 @@ describe('CONVERSATION_SYSTEM_PROMPT (V2 doctrine)', () => {
     expect(lower).not.toContain('twelve years is a long run')
   })
 
-  it('lists at least five concrete sample turns showing the right shape', () => {
+  it('lists at least six concrete sample turns showing the right shape', () => {
     // Section heading appears exactly once, followed by sample dialogues.
     expect(CONVERSATION_SYSTEM_PROMPT).toContain('Sample turns')
     // Each sample is shaped Prospect:/You: — count the You: lines.
     const youLines = CONVERSATION_SYSTEM_PROMPT.match(/^You:/gm) ?? []
-    expect(youLines.length).toBeGreaterThanOrEqual(5)
+    expect(youLines.length).toBeGreaterThanOrEqual(6)
+  })
+
+  // Captain authors the sidestep doctrine paragraph (see PR #754 description,
+  // Section A4). Until that lands, this assertion is skipped to prevent the
+  // lint cycle from blocking on it.
+  it.skip('codifies sidestep / non-answer handling (do not press, ask differently)', () => {
+    // Look for the doctrine shape Captain will author. Either of these
+    // phrases would satisfy: "do not press", "do not repeat", "ask
+    // differently", "wind toward the booking".
+    expect(lower).toMatch(/do not press|do not repeat|ask differently|wind toward/)
   })
 
   it('every sample "You:" line ends with a question', () => {

--- a/tests/conversation-prompt-contract.test.ts
+++ b/tests/conversation-prompt-contract.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Source-level contract tests for the V2 multi-turn intake system prompt
+ * (`CONVERSATION_SYSTEM_PROMPT` in `src/lib/claude/conversation.ts`).
+ *
+ * The prompt runs on every prospect submission. Drift here changes the
+ * voice of the firm. These assertions lock the doctrine that emerged
+ * from Captain's brief: question-as-utility, no validation theater, no
+ * universal observations, multi-turn awareness.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { CONVERSATION_SYSTEM_PROMPT } from '../src/lib/claude/conversation'
+
+describe('CONVERSATION_SYSTEM_PROMPT (V2 doctrine)', () => {
+  const lower = CONVERSATION_SYSTEM_PROMPT.toLowerCase()
+
+  it('commits the agent to ending each turn on a question', () => {
+    expect(lower).toContain('end on the question')
+  })
+
+  it('forbids reflection-then-question template (validation theater)', () => {
+    expect(lower).toContain('skip reflection')
+  })
+
+  it('explicitly bans the "we hear you" framing', () => {
+    expect(lower).toContain('"we hear you"')
+  })
+
+  it('forbids universal observations about businesses (the consultant tell)', () => {
+    expect(lower).toContain('universal observations')
+    // The example phrasings the prompt cites as forbidden.
+    expect(lower).toContain('leave a mark')
+  })
+
+  it('lists the canonical AI-vocabulary bans', () => {
+    for (const word of [
+      'delve',
+      'embark',
+      'robust',
+      'holistic',
+      'seamless',
+      'leverage',
+      'synergy',
+      'streamline',
+      'comprehensive',
+      'navigate',
+      'unlock',
+    ]) {
+      expect(lower).toContain(word)
+    }
+  })
+
+  it('bans the validation phrases captured in feedback memory', () => {
+    for (const phrase of [
+      '"we hear you"',
+      '"i hear you"',
+      '"absolutely"',
+      '"thanks for sharing"',
+      '"thanks for reaching out"',
+    ]) {
+      expect(lower).toContain(phrase)
+    }
+  })
+
+  it('bans em dashes', () => {
+    expect(lower).toContain('em dashes')
+    // The prompt body itself must not contain em dashes (would defeat
+    // the rule by example).
+    expect(CONVERSATION_SYSTEM_PROMPT).not.toMatch(/[—]/)
+  })
+
+  it('codifies the two-outcome win condition (book or share signal)', () => {
+    expect(lower).toContain('both outcomes are wins')
+    expect(lower).toContain('not selling')
+    expect(lower).toContain('pick a time to talk')
+  })
+
+  it('forbids promising follow-up outreach', () => {
+    expect(lower).toContain('never promise next steps')
+  })
+
+  it('forbids claims of knowing the prospect business', () => {
+    expect(lower).toContain('never claim to understand their business')
+  })
+
+  it('grounds the agent in specific operational signal categories', () => {
+    expect(lower).toContain('volume')
+    expect(lower).toContain('current state')
+    expect(lower).toContain('past attempts')
+    expect(lower).toContain('objective')
+  })
+
+  it('does not carry the V1 multi-turn-anticipating "warm structured listener" framing', () => {
+    expect(lower).not.toContain('warm, structured listener')
+    expect(lower).not.toContain('reflect more than you ask')
+    // Old V1 sample turns relied on opening with reflection ("Twelve
+    // years is a long run in residential HVAC. What does..."). The V2
+    // doctrine deliberately omits that reflective opener pattern.
+    expect(lower).not.toContain('twelve years is a long run')
+  })
+
+  it('lists at least five concrete sample turns showing the right shape', () => {
+    // Section heading appears exactly once, followed by sample dialogues.
+    expect(CONVERSATION_SYSTEM_PROMPT).toContain('Sample turns')
+    // Each sample is shaped Prospect:/You: — count the You: lines.
+    const youLines = CONVERSATION_SYSTEM_PROMPT.match(/^You:/gm) ?? []
+    expect(youLines.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('every sample "You:" line ends with a question', () => {
+    // Extract sample turns: strip leading "You:", trim, then strip
+    // surrounding quotes so the question-mark check sees the real
+    // sentence terminator.
+    const sampleYouLines = CONVERSATION_SYSTEM_PROMPT.split('\n')
+      .filter((line) => line.startsWith('You:'))
+      .map((line) => line.replace(/^You:\s*/, '').trim())
+      .map((line) => line.replace(/^"|"$/g, ''))
+
+    expect(sampleYouLines.length).toBeGreaterThan(0)
+    for (const sample of sampleYouLines) {
+      expect(
+        sample.endsWith('?'),
+        `Sample "You:" line should end with a question mark: ${JSON.stringify(sample)}`
+      ).toBe(true)
+    }
+  })
+
+  it('no sample "You:" line contains an em dash (we ban them)', () => {
+    const sampleYouLines = CONVERSATION_SYSTEM_PROMPT.split('\n').filter((line) =>
+      line.startsWith('You:')
+    )
+    for (const sample of sampleYouLines) {
+      expect(sample, `Sample contains em dash: ${sample}`).not.toMatch(/[—]/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Builds V2 multi-turn /book intake conversation with HMAC-signed cookie auth, server-side history reconstruction, and a doctrine that treats the AI as a working tool — one specific operational question per turn — instead of a warm structured listener.

After Captain's review of the initial PR, an `/auto-build` hardening pass (commit `0c267e5`) added integration tests, defense-in-depth observability, and rationale comments. The agent did NOT re-author voice-defining doctrine in the hardening pass; voice edits are proposals for Captain to land directly.

## Architecture

| Layer | Component | What it does |
|-------|-----------|--------------|
| Auth | `src/lib/booking/conversation-token.ts` | HMAC-SHA256 cookie binding `(conversation_id, entity_id)` with sliding TTL. Mirrors `signed-link.ts`. |
| Storage | `src/lib/db/intake-conversations.ts` | V2 turns persisted to existing `context` table. Sources: `website_intake_v2_user`/`website_intake_v2_ai`. Ordering by `(turn, role)`. `MAX_TURNS = 20`. |
| First turn | `src/pages/api/intake/send.ts` | Mints `conversation_id`, persists user + AI turns, sets signed cookie. |
| Continuation | `src/pages/api/intake/continue.ts` | Verify cookie → rate limit (60/hr) → enforce turn cap → persist user → load history → call Claude → persist AI → rotate cookie. |
| Markup | `src/components/booking/UnifiedIntake.astro` | Conversation thread, reply input, turn-cap message, booking offer. |
| UI controller | `src/scripts/unified-intake.ts` | Thread rendering, reply input, voice dictation. |
| Network controller | `src/scripts/book.ts` | `unified-reply-send` handler; `continue_thinking` and `turn_capped` states. |
| Observability | `postProcessReply()` in `conversation.ts` | Logs warning if Claude reply doesn't end on `?`. Try/catch wrapped — cannot crash the endpoint. |

## ⚠️ Captain proposals — agent did NOT land voice-defining edits

Per the `/auto-build` Devil's Advocate critique and the `feedback_voice_copy_from_captain_not_generate.md` memory, the hardening pass deliberately leaves voice copy alone. The following are proposals for Captain to author directly into `src/lib/claude/conversation.ts` before merge — or hand back to the agent verbatim.

### Re-read of lines 85 and 87 (was the contradiction-fix proposal)

> Line 85: `Skip openers like "Got it", "Great", "Thanks for sharing", "I see", "Sure" when you are asking a substantive question. Go straight to the question.`
>
> Line 87: `If they shared almost nothing or appear to be testing the form, keep your reply small and open the door without manufacturing context. A short "Got it" plus a low-pressure question about what they'd actually want to talk about is the right shape there.`

**Verdict: not a contradiction.** Line 85 has a clear conditional ("when you are asking a substantive question"); line 87 covers the non-substantive case. Agent leaves both lines alone.

### A2 — opener tone (proposal, Captain decides)

Current line 57: `You are a conversational AI for SMD Services, an operations consultancy working with growing businesses in the Phoenix area.`

Candidate replacement: `You are the live response on SMD Services' /book intake form.`

### A3 — drop one clunky phrase (proposal)

Current line 65 includes: `You are not warm-on-the-outside.`

Candidate: delete this sentence. The rest of the paragraph carries the meaning.

### A4 — sidestep / non-answer doctrine (Captain authors)

The prompt does not currently address what the agent should do if the prospect declines to answer, returns "idk", or pivots to a new topic. The behavioral shape:
- Do not press.
- Do not repeat the same question.
- Either ask a different question (drawing on what they DID share) or wind softly toward the booking.

The actual prose is voice-defining; agent-drafted versions tend to drift. Captain authors. `tests/conversation-prompt-contract.test.ts` already has a `.skip()` placeholder asserting the doctrine line will be present.

### A5 — 7th sample turn for the sidestep case (Captain authors)

A new entry under `## Sample turns showing the right shape` covering a sidestep. Agent does not propose the words.

## ⚠️ Voice-drift verification gate (run before merging)

Before merging, run a 7-input voice-drift smoke test against the Vercel preview build of this PR. Submit each through `/book`, read the AI reply. If any reads as ick, block merge.

1. Happy path: `We do HVAC, mostly residential, twelve years.`
2. Pain without context: `Scheduling is killing me, doing it all on text messages.`
3. Sidestep: `Not sure I want to get into specifics yet.`
4. Off-topic ramble: a multi-paragraph tangent.
5. Skip-the-questions: `Just book me a call, I don't want to type.`
6. Rude / short: `why does this matter`
7. Form test: `this is a form test`

This is the only check that matches the actual threat model (voice drift on real input shapes).

## Tests

- `tests/booking/conversation-token.test.ts` — 12 tests.
- `tests/booking/intake-conversations.test.ts` — 5 tests.
- `tests/booking/intake-continue.test.ts` (NEW in hardening) — 10 integration tests.
- `tests/conversation-postprocess.test.ts` (NEW in hardening) — 9 unit tests.
- `tests/conversation-prompt-contract.test.ts` — 16 source-level assertions (1 `.skip()` for A4).
- `tests/booking/unified-intake-event-contract.test.ts` — event listener parity.

**1841 tests pass.** Lint clean. Typecheck clean. Build green.

## Out of scope

- **Page-refresh hydration** filed as #755 with threat-model question.
- **Submitter confirmation email** filed as #744.
- **Banned-phrase regex scan in postProcessReply** dropped during hardening — false-positive surface on legitimate domain words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
