### PR TITLE
feat(admin): entity detail page redesign — two-column decision surface

### DIFF
--- a/docs/plans/entity-detail-redesign-v1.md
+++ b/docs/plans/entity-detail-redesign-v1.md
@@ -1,0 +1,666 @@
+# Entity Detail Page Redesign — Two-Column Decision Surface (v1)
+
+> **Status:** Plan approved 2026-05-07. Implementation handoff to Codex.
+> **Mockup:** Approved static HTML at `/tmp/ss-entity-detail-mockup.html`
+> (Captain's local machine — visual ground truth for Plainspoken Sign Shop
+> conformance and Option B layout). Codex should run the static mockup
+> locally for visual reference.
+> **Related:** ADR 0003 (lead-gen pivot, wrong-actor pipeline), PR #745
+> (entity-row-view composer + actor_role plumbing), PR #746 (validator
+> enum alignment).
+
+## Context
+
+The production `/admin/entities/[id]` page has structural problems Captain
+audited on 2026-05-07: three renders of the outreach draft, two of the
+intelligence brief, two stale runs of `review_synthesis` / `review_analysis`,
+no first-class identity check after the ADR 0003 wrong-actor pivot, AI-
+generated "Outreach Hooks" that read as Pattern A claims, and a stale
+"Phoenix area" outreach draft from before the AZ-wide pivot. Decision controls
+(Promote / Dismiss) sit at the top while the evidence supporting that decision
+is scattered across three competing layouts (Context Timeline, Enrichment
+Status table, Dossier Summary).
+
+Captain's job on this page is to decide in under 90 seconds: promote a real
+opportunity, dismiss a false positive, or merge a duplicate. The current
+layout fights that job.
+
+A team of three Phase-1 agents (internal map, external research, JTBD
+strategy) recommended a two-column "evidence + sticky decision rail" layout
+(Option B). A high-fidelity static mockup rendering Scottsdale Icon Dental's
+real data in the SMD Plainspoken Sign Shop visual language was approved by
+Captain on 2026-05-07. This plan implements that design.
+
+**Intended outcome:** the redesigned page renders in the existing admin chrome,
+deduplicates AI artifacts at the data layer, surfaces ADR 0003 fields
+(`actor_role`, structural flags, candidate-merge-log hits) above the fold,
+replaces the 2-button decision with a 3-disposition rail (Promote / Dismiss
+with reason taxonomy / Merge), structurally suppresses Pattern A surfaces
+(dossier "Outreach Hooks") at Signal stage, and degrades gracefully on mobile
+without a separate redesign.
+
+**Captain decisions baked in:**
+
+- Promote unconditionally — no contact / enrichment prerequisite.
+- Hold disposition deferred to a follow-on PR. v1 ships 3 buttons, not 4.
+- Merge in v1 = wire existing `/api/admin/entities/[id]/merge.ts` for
+  Signal-stage entities only (see WS-6 for the gap that constrains the
+  scope to Signal). The original draft of this plan punted to "anchor-link
+  only" before realizing the merge endpoint already exists and works for
+  the Signal-stage use case.
+- Desktop-primary, mobile-tolerant. Single-column stack below the `lg`
+  Tailwind breakpoint (1024px), sticky bottom action bar for the decision
+  rail at narrow widths.
+
+## Out of scope (explicit)
+
+These were considered and deferred to keep v1 tight. Each becomes its own
+follow-on issue, not "we'll get to it."
+
+- **Hold disposition** — needs `entities.snoozed_until` column, queue filter,
+  re-surface mechanism. Separate PR.
+- **Extending `mergeEntities()` to cover meetings / quotes / engagements /
+  invoices.** The existing implementation at `src/lib/db/entities-extra.ts:57`
+  moves `context` and `contacts` rows but those four related tables are
+  not touched. For v1 the Merge button is enabled only on Signal-stage
+  entities (where these tables are typically empty), so the gap doesn't
+  bite. Extending mergeEntities for later-stage merges is a separate PR
+  with per-table migration tests.
+- **Pattern A validator extension to dossier markdown** — at Signal stage v1
+  simply does not render the dossier "Outreach Hooks" section at all. Post-
+  Promote rendering with classifier verdict is a follow-on.
+- **Stale-draft regeneration endpoint** — the existing per-module
+  `/api/admin/entities/[id]/enrichment/outreach_draft/retry` already
+  regenerates. v1 wires "Discard" + "Regenerate on Promote" but does not
+  introduce a new endpoint for regeneration.
+- **EntityListRow / list page changes** — already updated in PR #745 with the
+  row-view composer. Detail page reuses those derivations.
+- **Removal of `EntityDossierSummary.astro` / `EntityStageActions.astro`
+  source files** — `[id].astro` stops importing them, but the files stay
+  orphaned for now. Cleanup is a follow-on once nothing else imports them.
+- **Mobile-optimized layouts beyond degradation** — single-column stack +
+  sticky bottom bar is enough. No separate phone-first design.
+
+## Workstreams
+
+Eleven workstreams across five phases. Phases sequential because of view-model
+and component dependencies; workstreams within a phase are parallelizable.
+
+### Phase 1 — View-model layer (one PR)
+
+**WS-1. Read-side query for `candidate_merge_log`.** File:
+`src/lib/db/candidate-merge-log.ts` (currently has only the append query).
+Add `getCandidateMergesForEntity(db, orgId, entityId): Promise<CandidateMergeRow[]>`
+that selects rows where `existing_entity_id = ? AND review_status = 'pending'`
+ordered by `score DESC, created_at DESC`. Return shape: `id, candidateName,
+candidateAddress, score, reason, sourcePipeline, createdAt`. Used by the
+Merge dropdown in the decision rail.
+
+**WS-2. Extend `LOST_REASONS` with Signal-stage codes.** File:
+`src/lib/db/lost-reasons.ts`. Add five codes:
+
+- `wrong-actor` — "Wrong actor (contractor / vendor / staffing agency, not the operating business)"
+- `out-of-buy-box` — "Outside buy box (chain franchise / enterprise / government / non-profit / holding LLC)"
+- `out-of-geography` — "Outside Arizona"
+- `no-signal` — "Insufficient signal to qualify"
+- `duplicate` — "Duplicate of another entity"
+
+Update the `LostReasonCode` union and the `LOST_REASONS` array. The
+`isLostReasonCode` validator picks up the additions automatically. Existing
+post-engagement codes still apply at later stages.
+
+**Chip styling for the 5 new codes:** all five fall through to the existing
+default branch in `lostReasonChipClass` (`bg-[color:var(--ss-color-border-subtle)]
+text-[color:var(--ss-color-text-secondary)]`). Do **not** invent new color
+families. Rationale: the existing 7 codes already use 7 distinct colors and
+adding 5 more would degrade scanability on the entities list and the lost
+tab. Structural disqualifications (the new codes) intentionally read as
+"neutral / structural" rather than "warm / cool" — the chip is for record-
+keeping, not visual urgency. This change ships as part of WS-2 with a
+screenshot of the entities list at the `stage=lost` filter included in the
+PR description for visual review.
+
+**WS-3. Compose decision evidence in `entity-detail-page.ts`.** File:
+`src/lib/admin/entity-detail-page.ts`. Extend `EntityDetailPageResult` and
+`loadEntityDetailPage` with three new derived bundles:
+
+```ts
+export interface EntityDetailPageResult {
+  // ...existing fields...
+  decisionEvidence: {
+    actorRole: 'business' | 'contractor' | 'unknown'
+    actorRoleConfidence: 'high' | 'medium' | 'low'
+    signalEvidence: string | null // reuse composeSignalEvidence
+    enrichmentSummary: string | null // first sentence from latest enrichment, sourced
+    structuralFlags: string[] // e.g. ['Single-tenant suite', 'Arizona']
+    missingForOutreach: Array<{
+      key: 'contact' | 'website' | 'public-web-signal'
+      label: string
+      reason: string // the cited reason ("Google Places no_match", etc.)
+    }>
+    staleDraftWarning: {
+      isStale: boolean
+      reason: string | null // e.g. "Generated 2026-05-07 — pre-statewide pivot"
+    }
+  }
+  mergeCandidates: CandidateMergeRow[]
+  deduplicatedTimeline: ContextEntry[] // see WS-4
+}
+```
+
+**Source of `actor_role`.** `actor_role` is written by the new-business
+worker into the `metadata` JSON of the original ingest context entry — see
+`workers/new-business/src/index.ts:65` where
+`{ actor_role: permit.actor_role, ... }` is bound into the signal-creation
+metadata, and the four soda.ts call sites (`soda.ts:256`, `soda.ts:303`,
+`soda.ts:350`, `soda.ts:396`) that produce the value. The existing parser
+at `src/lib/db/entity-signal-metadata.ts:21` (`parseSignalMetadataRow`)
+reads other fields from this same metadata JSON but does NOT currently
+extract `actor_role`. Pre-pivot entities have no `actor_role` key.
+
+**WS-3a (additive to WS-3). Extend `EntitySignalMetadata`.** Add two fields
+to the interface at `entity-signal-metadata.ts:5-14`:
+
+```ts
+actor_role: 'business' | 'contractor' | 'unknown' | null
+actor_role_confidence: 'high' | 'medium' | 'low' | null
+```
+
+Update `parseSignalMetadataRow` to extract them — `actor_role` from the
+top-level metadata key, `actor_role_confidence` from a sibling key (write
+path may need a small workers-side update if confidence isn't currently
+persisted; if not, default to `'high'` when role is `'business'` or
+`'contractor'`, and `'low'` when role is `'unknown'` or absent). Update
+`buildEmptyMetadata` to set both to `null`. This makes `actor_role`
+available to **both** the list view (`EntityRowView` already consumes
+`EntitySignalMetadata`) and the detail page through one parser, single
+source of truth, no second fetch path. The list view automatically gains
+the `actor_role` chip when rows render it (deferrable — list-view chip
+rendering is out of v1 scope, but the data is now there).
+
+Implementation helpers in WS-3 (all new, exported for testing):
+
+- `resolveActorRole(metadata: EntitySignalMetadata): { role, confidence }` —
+  reads the now-populated `metadata.actor_role` and `metadata.actor_role_confidence`.
+  When `actor_role` is null (pre-#745 entities), returns
+  `{ role: 'unknown', confidence: 'low' }`.
+- `composeMissingForOutreach(entity, contextEntries, contacts, enrichmentRuns)` —
+  derives the three-item list. Each item only appears when actually missing.
+- `detectStaleDraft(outreachEntry, entity)` — returns true when
+  `outreachEntry.created_at < ADR_0003_DEPLOY_DATE` (constant: `'2026-05-07T00:00:00Z'`)
+  OR draft body matches `/Phoenix\s+(area|metro)/i`. The body-pattern check is
+  belt-and-suspenders; once the date threshold ages out (~30 days post-merge),
+  it becomes the only check.
+- `composeEnrichmentSummary(reviewSynthEntry, websiteMeta, intelligenceBriefEntry)` —
+  picks the most-sourced single sentence available. Priority: review_synthesis
+  one-line summary, then deep_website summary, then first paragraph of
+  intelligence_brief (stripped of "Engagement Hypotheses" / "Outreach Hooks"
+  markdown sections). Never invents.
+
+**WS-4. Deduplicate the timeline in the view-model.** File:
+`src/lib/admin/entity-detail-page.ts` — add `composeDeduplicatedTimeline()`.
+Rules:
+
+- Drop ALL `outreach_draft` entries from the timeline (they're surfaced via
+  `staleDraftWarning` + diagnostics drawer; never in the timeline body).
+- Drop ALL `intelligence_brief`-source entries from the timeline (surfaced
+  via `enrichmentSummary` derivation + diagnostics drawer).
+- For `review_synthesis` and `review_analysis` sources, keep only the most
+  recent entry per source.
+- For all other context types, keep all entries (notes, stage_change, etc.).
+- Preserve reverse-chronological order.
+
+The `dossierBrief` and `outreachEntry` fields stay populated on the result
+for the diagnostics drawer, but they no longer appear in `filteredEntries` /
+`deduplicatedTimeline`.
+
+### Phase 2 — Components (one PR, five new files)
+
+All five components match the existing admin convention: `.astro`,
+PascalCase, ARIA roles, Tailwind v4 utilities backed by `@venturecrane/tokens`,
+no rounded corners, no shadows. Visual reference is the approved mockup —
+match the mockup precisely.
+
+**WS-5. `EntityIdentityStrip.astro`.** Above-the-fold identity panel.
+
+```ts
+interface Props {
+  entity: Entity // .name, .vertical, .area, .stage
+  actorRole: 'business' | 'contractor' | 'unknown'
+  actorRoleConfidence: 'high' | 'medium' | 'low'
+  signalEvidence: string | null // pre-composed line
+  signalSourceLabel: string | null // for the eyebrow
+  daysInStage: number
+  structuralFlags: string[]
+}
+```
+
+Render: 3px ink-bordered card. Eyebrow ("Signal · scottsdale_license", Archivo
+Narrow 12px uppercase). Entity name (Archivo display 36px, weight 900,
+letter-spacing -0.02em, uppercase). Chip row: actor_role chip first
+(green/red/amber per role), vertical chip, then up to 3 structural flag
+chips, then stage chip. Signal evidence line in JetBrains Mono 15px.
+Meta line ("Filed today · 0 days in Signal · actor_role: business (high
+confidence)") in 14px secondary text. Chips follow Pattern 01 — 0 radius,
+1px border, Archivo Narrow uppercase.
+
+**WS-6. `EntityDecisionRail.astro`.** Sticky right-rail card with 3
+dispositions. Mobile becomes fixed bottom bar at the `lg` breakpoint.
+
+```ts
+interface Props {
+  entityId: string
+  entityStage: EntityStage
+  mergeCandidates: CandidateMergeRow[]
+  staleDraft: { isStale: boolean; reason: string | null }
+  outreachEntry: ContextEntry | undefined // for the diagnostics-drawer link
+}
+```
+
+Render: 3px ink-bordered card. Eyebrow "DISPOSITION".
+
+- **Promote** — primary button (burnt orange). `<form method="POST"
+action="/api/admin/entities/[id]/stage">` with hidden `stage=prospect`,
+  `reason="Promoted to prospect by admin."`. Reuses existing endpoint.
+- **Dismiss…** — `<details>` dropdown. Opens to a list of 12 reasons
+  (the 5 new structural codes from WS-2 + 7 existing). Each is a
+  `<form method="POST" action="/api/admin/entities/[id]/stage">` with
+  `stage=lost`, `lost_reason=<code>`, `reason="<label> by admin."`.
+  Optional `lost_detail` textarea per existing pattern in
+  `EntityStageActions.astro:104-140`. Visually group structural codes (top)
+  vs. post-engagement codes (bottom) with an `<optgroup>`-style separator.
+- **Merge into…** — `<details>` dropdown. Wires the existing
+  `/api/admin/entities/[targetId]/merge.ts` endpoint at
+  `src/pages/api/admin/entities/[id]/merge.ts:14`, which calls
+  `mergeEntities()` from `src/lib/db/entities-extra.ts:57`. Lists
+  `mergeCandidates` with candidate name + address + score. Each row is a
+  `<form method="POST" action="/api/admin/entities/<candidate.targetId>/merge">`
+  with hidden `source_id=<this entity's id>` — so this entity becomes the
+  source (deleted), the candidate becomes the target (kept). Endpoint
+  redirects to the target's detail page on success.
+
+  **Constraint: enabled at Signal stage only.** `mergeEntities()` moves
+  `context` and `contacts` rows but does NOT move `meetings`, `quotes`,
+  `engagements`, or `invoices`. Signal-stage entities typically have none
+  of those, so the gap doesn't bite. For all other stages, render the
+  Merge button as **disabled** with tooltip "Merge available at Signal
+  stage only — extending mergeEntities is a follow-on." Wire this stage
+  check (`entityStage === 'signal'`).
+
+  **Empty state** when `mergeCandidates.length === 0`: render the dropdown
+  trigger normally but display "No candidates from candidate_merge_log"
+  inside.
+
+Below the buttons, a divider, then "Outreach status" section. When
+`staleDraft.isStale`: render the amber-bordered warning per the mockup with
+"View draft" (links to diagnostics drawer anchor) + "Discard now" (POSTs to
+the small new endpoint from WS-7). When `entityStage !== 'signal'` and an
+outreach entry exists with no staleness: render a 1-line "Latest draft
+generated <relative time>" link. At Signal stage with no draft: render
+"Will be generated post-Promote and validated against Pattern A doctrine."
+
+**Sticky vs. fixed positioning at the breakpoint.** The rail's positioning
+lives entirely in the rail component, not split between the component and
+the page's inline style block. Use Tailwind v4 responsive utilities at the
+`lg:` breakpoint (Tailwind default 1024px):
+`lg:sticky lg:top-20 max-lg:fixed max-lg:bottom-0 max-lg:left-0 max-lg:right-0
+max-lg:border-t-[3px] max-lg:border-[color:var(--ss-color-text-primary)]
+max-lg:bg-[color:var(--ss-color-background)] max-lg:px-4 max-lg:py-3 max-lg:z-40`.
+At `lg` and above the rail sticks at top:5rem inside its grid column; below
+`lg` the rail detaches into a fixed bottom bar. The breakpoint is exactly
+1024px (Tailwind default), not 1100px — the mockup's 1100 was arbitrary.
+
+Below `lg` the rail collapses to 3 buttons side-by-side (Promote / Dismiss /
+Merge), each `flex-1`. The stale-draft section is hidden on the bottom bar
+itself (it moves into the body content area above the bar to avoid
+crowding). Disposition `<details>` dropdowns at this breakpoint open
+upward (`max-lg:[&_>summary+*]:bottom-full max-lg:[&_>summary+*]:top-auto`)
+so they don't appear below the screen edge.
+
+Page-side: WS-11 must add `lg:pb-0 max-lg:pb-20` to the `<main>` element so
+content isn't occluded by the fixed bar. The 5rem (80px) bottom padding
+matches the bar height including the 3px ink top border.
+
+**WS-7. Discard-stale-draft endpoint (small).** New file:
+`src/pages/api/admin/entities/[id]/outreach-draft/discard.ts`. POST with no
+body. Updates the latest `outreach_draft` context entry's `metadata.superseded =
+true`. Used by the rail's "Discard now" link. Idempotent — multiple discards
+on the same already-superseded entry are no-ops. The "Discard" affordance
+exists because Captain may want to clear the stale Phoenix-area draft before
+deciding; it doesn't change the disposition logic.
+
+**Auth:** reuses the existing admin-session middleware applied to
+`/api/admin/*` routes. Verify session in handler exactly the same way as
+`src/pages/api/admin/entities/[id]/stage.ts:46-51`
+(`if (!session || session.role !== 'admin') return 401`). No additional
+CSRF wiring required — same as every other admin POST in the project.
+
+(Author's note: this is the smallest possible new endpoint. If a metadata
+write through the existing `/api/admin/entities/[id]/context` endpoint is
+preferred, that endpoint appends rather than updates, so a tiny dedicated
+route is cleaner.)
+
+**WS-8. `EntityMissingPanel.astro`.** Amber-rule warning block listing the
+gaps that prevent credible outreach.
+
+```ts
+interface Props {
+  items: Array<{ key: string; label: string; reason: string }>
+}
+```
+
+Render: amber left-border (3px solid `--ss-color-warning`), warning eyebrow
+("MISSING FOR CREDIBLE OUTREACH"), bullet list. Each bullet renders as
+"<strong>{label}</strong> — {reason}". When `items.length === 0`, render
+nothing (component returns null).
+
+**WS-9. `EntityEnrichmentSummary.astro`.** Single-paragraph factual summary +
+4-cell facts grid.
+
+```ts
+interface Props {
+  summary: string | null // composed by WS-3 helper
+  source: string // e.g. "scottsdale_license"
+  signalDate: string // ISO
+  address: string | null
+  vertical: string | null
+  generatedAt: string // for the eyebrow aside
+}
+```
+
+Render: block title "ENRICHMENT SUMMARY" eyebrow, aside with relative time +
+source-of-summary attribution ("2 hours ago · review_synthesis"), one
+paragraph in body text (16px, 1.55 line-height), 2-column dl grid with
+Archivo Narrow eyebrow keys + JetBrains Mono values. Render an empty-state
+sentence when `summary === null`: "Enrichment in progress — summary will
+appear once review or website signals resolve."
+
+**WS-10. `EntityDiagnosticsDrawer.astro`.** Collapsed `<details>` containing
+operational data: 13-module status table (extracted from existing
+`EnrichmentStatusPanel.astro`) + raw `intelligence_brief` markdown.
+
+```ts
+interface Props {
+  entityId: string
+  intelligenceBriefEntry: ContextEntry | undefined
+}
+```
+
+Render: `<details>` with summary "ENRICHMENT DIAGNOSTICS (13 MODULES)" using
+Archivo Narrow eyebrow style. When open: existing `EnrichmentStatusPanel`
+table (or its inline equivalent — decide whether to compose or inline; the
+existing component is reusable). Below the table, a horizontal hairline
+divider, then "RAW INTELLIGENCE BRIEF" eyebrow and the brief's markdown
+rendered via `renderSimpleMarkdown` (already exists in
+`entity-detail-page.ts:108`). The brief contains the dossier "Outreach
+Hooks" Pattern A surface — that's acceptable HERE because diagnostics is
+operational data for retry/debugging, not decision-supportive UI. Add a
+small visible note above the markdown: "Raw model output for retry /
+debugging — not for outreach use." The markdown is not surfaced anywhere
+else on the page.
+
+### Phase 3 — Page integration (one PR)
+
+**WS-11. Rewrite `src/pages/admin/entities/[id].astro`.** This is the
+biggest workstream — most existing code is replaced.
+
+- Imports: drop `EntityStageActions`, `EntityDossierSummary`. Add the five
+  new components from Phase 2 + `EntityContactsPanel` (kept) +
+  `EntityTimelineEntry` (kept) + `LogReplyDialog` (kept) +
+  `EntitySendBookingDialog` (kept) + `AdminFlashNotice` (kept).
+- Layout: AdminLayout with `maxWidth="max-w-6xl"` (was `max-w-5xl`; the new
+  layout needs the wider container). Verified at
+  `src/layouts/AdminLayout.astro:13` — the `maxWidth` prop type is
+  `'max-w-5xl' | 'max-w-6xl'`, so this is a supported value, not a
+  freeform string.
+- Above-the-fold (full width): flash notices + back link.
+- Two-column grid: `lg:grid lg:grid-cols-[1fr_22rem] lg:gap-stack`. Below
+  `lg` the layout is implicit single column (no grid required).
+- **Left column (evidence) order:** EntityIdentityStrip, EntityMissingPanel,
+  EntityEnrichmentSummary, "Pain observations" block (existing data
+  surface, see WS-12), EntityContactsPanel, "Timeline" block (existing
+  EntityTimelineEntry components fed by `deduplicatedTimeline`),
+  EntityDiagnosticsDrawer.
+- **Right column (decision):** EntityDecisionRail. Positioning lives in
+  the rail itself — see WS-6 for the exact Tailwind utility chain.
+- Below-the-fold full-width sections (kept as-is): Meetings, Engagements,
+  Quotes, Invoices `<details>` collapsibles. These render only when their
+  arrays are non-empty (existing condition).
+- The "Add a note" form moves out of body real estate to a small
+  `<details>` collapsible above the timeline list with summary "+ Add note",
+  containing the existing form. Captain can still add notes; they're just
+  no longer competing with decision evidence at the top of the page.
+
+**WS-12. "Pain observations" block.** Currently absent — the existing page
+renders review_synthesis content via the dossier. New block reuses
+`reviewMeta.top_themes`, `reviewMeta.operational_problems`, and signals from
+job-monitor metadata if present (file `src/lead-gen/schemas/job-signal.ts`).
+At Signal stage with no review/job data, render the empty-state sentence:
+"No public review or job-post signal yet. License filed today; nothing has
+been written about this practice externally. Expect this to fill in over 30–60
+days as the practice opens." (See mockup.) Implement inline in `[id].astro`
+or as a thin component `EntityPainObservations.astro` — implementer's call.
+
+### Phase 4 — Tests (same PR as Phase 2/3 ideally)
+
+**WS-13. View-model unit tests.** New file:
+`tests/entity-detail-decision-evidence.test.ts`. Cases:
+
+- `composeDeduplicatedTimeline` strips outreach_draft, intelligence_brief,
+  keeps latest review_synthesis only, keeps notes / stage_change.
+- `composeMissingForOutreach` returns `contact` when contacts.length === 0,
+  `website` when entity.website is null AND no enrichment website resolved,
+  `public-web-signal` when no review_analysis or job-monitor signal.
+- `detectStaleDraft` returns true for created_at < ADR_0003_DEPLOY_DATE,
+  false for newer drafts, true for any draft containing "Phoenix area".
+- `resolveActorRole` returns `{role: 'unknown', confidence: 'low'}` when
+  metadata field is missing.
+- `composeEnrichmentSummary` priority: review_synthesis → deep_website →
+  intelligence_brief first paragraph (stripped of Hypotheses / Hooks).
+
+**WS-14. Render test.** New file:
+`tests/entity-detail-page-render.test.ts`. Astro container API or SSR-render
+test asserting:
+
+- Signal-stage entity: `outreach_draft` body content does NOT appear in the
+  page HTML **outside the `EntityDiagnosticsDrawer` `<details>` block**.
+  The diagnostics drawer's collapsed `<details>` markup contains the raw
+  intelligence-brief markdown (which may include Pattern A "Outreach
+  Hooks") — that's intentional per WS-10. The assertion scopes against the
+  body region, not the operational drawer. Practical implementation: parse
+  the rendered HTML and assert the substring is absent in
+  `document.querySelector('main').innerHTML.replace(/<details[^>]*data-diagnostics[^>]*>[\s\S]*?<\/details>/, '')`,
+  or use `data-test="decision-evidence"` wrappers on the body sections and
+  assert against those only.
+- `intelligence_brief` body content does NOT appear outside the diagnostics
+  drawer (same scoping).
+- Identity strip renders the `actor_role` chip text.
+- Decision rail has exactly 3 buttons: Promote, Dismiss…, Merge into….
+- New `LOST_REASONS` codes render as options in the Dismiss dropdown.
+- Pain Observations renders empty state when no review data.
+- Merge button is **disabled** when `entityStage !== 'signal'` (per WS-6
+  constraint).
+
+**WS-15. Update existing tests.** Grep for tests touching `[id].astro`,
+`EntityDossierSummary`, `EntityStageActions`, `dossierBrief`,
+`outreachEntry`, and `outreachAngle` and update assertions to match the new
+shape. The forbidden-strings test (`tests/forbidden-strings.test.ts`) gets a
+new entry catching any reintroduction of "outreach_angle" or
+"Pre-dossier draft" in source files.
+
+### Phase 5 — Verify
+
+1. `npm run lint && npm run typecheck && npm run test`
+2. `npm run dev` → navigate to
+   `admin.localhost:4321/admin/entities/<id>` for an existing Signal-stage
+   entity (Scottsdale Icon Dental, ID
+   `cba10031-5e26-42b9-8872-3d03bba60f45`).
+3. Visual confirmation against the approved mockup.
+4. Promote → confirms transition to Prospect, redirect, flash notice.
+5. Dismiss with `wrong-actor` → confirms `lost_reason` persisted in
+   stage_change metadata.
+6. Merge dropdown → confirms candidates surface (or empty state if none).
+7. Discard stale draft → confirms metadata mutation.
+8. Resize browser to 800px → decision rail moves to bottom bar; chip row
+   wraps; timeline grid stacks; main element has 5rem bottom padding.
+9. `npm run verify` — all green.
+
+## Critical files
+
+| File                                                          | Action                                                                                |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `src/pages/admin/entities/[id].astro`                         | Rewrite (compose new components, new layout)                                          |
+| `src/lib/db/entity-signal-metadata.ts`                        | Extend interface + parser to extract `actor_role` and `actor_role_confidence` (WS-3a) |
+| `src/lib/admin/entity-detail-page.ts`                         | Add 5 helpers + extend result type                                                    |
+| `src/lib/db/candidate-merge-log.ts`                           | Add `getCandidateMergesForEntity()` reader                                            |
+| `src/lib/db/lost-reasons.ts`                                  | Add 5 new codes + chip class entries                                                  |
+| `src/components/admin/EntityIdentityStrip.astro`              | NEW                                                                                   |
+| `src/components/admin/EntityDecisionRail.astro`               | NEW                                                                                   |
+| `src/components/admin/EntityMissingPanel.astro`               | NEW                                                                                   |
+| `src/components/admin/EntityEnrichmentSummary.astro`          | NEW                                                                                   |
+| `src/components/admin/EntityDiagnosticsDrawer.astro`          | NEW                                                                                   |
+| `src/components/admin/EntityPainObservations.astro`           | NEW (optional — may inline)                                                           |
+| `src/pages/api/admin/entities/[id]/outreach-draft/discard.ts` | NEW (small endpoint)                                                                  |
+| `tests/entity-detail-decision-evidence.test.ts`               | NEW                                                                                   |
+| `tests/entity-detail-page-render.test.ts`                     | NEW                                                                                   |
+| `tests/forbidden-strings.test.ts`                             | Extend banlist                                                                        |
+
+## Reusable utilities
+
+Reuse before reimplementing.
+
+- `composeSignalEvidence()` from `src/lib/admin/entity-row-view.ts:106` —
+  same composer for the identity strip's evidence line.
+- `EntitySignalMetadata` type from `src/lib/db/entity-signal-metadata.ts` —
+  extended in WS-3a to include `actor_role`, `actor_role_confidence`.
+- `LOST_REASONS` registry from `src/lib/db/lost-reasons.ts` — extend, don't
+  parallel-implement.
+- `lostReasonChipClass()` from `src/lib/db/lost-reasons.ts` — fall through
+  to default branch for the 5 new codes (no new color families).
+- `appendCandidateMergeLog()` exists at
+  `src/lib/db/candidate-merge-log.ts:17` — pair the new reader with it,
+  same file.
+- `mergeEntities()` from `src/lib/db/entities-extra.ts:57` — wire to the
+  decision rail's Merge dropdown for Signal-stage entities only.
+- `renderSimpleMarkdown()` from `src/lib/admin/entity-detail-page.ts:108` —
+  reuse in the diagnostics drawer.
+- `relativeTime()` from `src/lib/admin/relative-time.ts` — already used in
+  the existing `EntityStageActions`.
+- `parseMetadata()` from `src/lib/admin/entity-detail-page.ts:91`.
+- Existing `EnrichmentStatusPanel.astro` component — compose into the
+  diagnostics drawer rather than reimplement the 13-row table.
+- AdminLayout chrome (header, breadcrumb, nav) is unchanged.
+- `@venturecrane/tokens/ss.css` — all design tokens are token-driven; no
+  new hex values, no new font sizes outside the type scale.
+
+## Visual conformance
+
+All new components MUST honor the SMD design system (Plainspoken Sign Shop):
+
+- Cream `#f5f0e3` paper, ink `#1a1512` text, single accent burnt orange
+  `#c5501e`. No new colors.
+- **No rounded corners.** All new elements use `--ss-radius-*` tokens which
+  are 0. Do not introduce literal `rounded-*` Tailwind classes.
+- **No drop shadows.** Hairline borders (`--ss-color-border`) and 3px ink
+  rules (`border-[3px] border-[color:var(--ss-color-text-primary)]`) carry
+  the page.
+- Typography: Archivo display, Archivo Narrow for eyebrows / tags / labels,
+  JetBrains Mono for IDs / signal evidence / fact values.
+- Spacing tokens: section 48 / card 32 / stack 16 / row 12 px. No literal
+  spacing values outside the scale.
+- Material Symbols Outlined for icons, axis 400/24/0/0.
+- Pattern 01 (status display by context) for chips. Pattern 02 (redundancy
+  ban) is the load-bearing rationale for this entire redesign — every fact
+  on the page should appear once.
+
+The approved mockup is the visual ground truth. When in doubt, match the
+mockup.
+
+## Risks + mitigations
+
+- **`actor_role` write-path coverage.** Confirmed: written by the
+  new-business worker into context.metadata at four call sites in
+  `workers/new-business/src/soda.ts`. NOT written by job-monitor or
+  review-mining workers (those have their own `posting_actor_role` field
+  for the staffing-agency filter; not the same field). Detail page
+  identity strip will therefore render "Business" / "Contractor" chips
+  for new-business-pipeline entities only; entities from job_monitor /
+  review_mining pipelines will fall through to the amber "Unknown" chip.
+  This is acceptable for v1 — the wrong-actor problem ADR 0003 solves is
+  scoped to the new-business pipeline.
+- **`actor_role` missing on pre-#745 entities.** Identity strip falls back
+  to amber "Unknown" chip with confidence: low. WS-3 helper handles the
+  null case; do not throw. WS-3a's parser update extends
+  `EntitySignalMetadata` so this is resolved at the data layer.
+- **Stale-draft body-text heuristic false positives.** `Phoenix area` /
+  `Phoenix metro` might legitimately appear in a draft for a Phoenix-located
+  prospect post-pivot. Mitigation: the date threshold check is the primary;
+  body text is secondary. Drop body check 30 days post-merge.
+- **Mobile sticky bottom bar occluding content.** Decision rail at <`lg` is
+  `position: fixed; bottom: 0`; main element gets `padding-bottom: 5rem`
+  matching the bar height. Test at 800px viewport before merge.
+- **`EntityStageActions` still imported elsewhere.** Grep before removing
+  — confirmed only `[id].astro` imports it on 2026-05-07, but reverify
+  pre-merge.
+- **Dismiss reasons proliferation.** 12 reasons (7 + 5) in a single dropdown
+  may overwhelm. Mitigation: visually group structural (top) vs.
+  post-engagement (bottom) with a small `<optgroup>`-style separator.
+- **Diagnostics drawer rendering the dossier markdown re-introduces the
+  Pattern A surface.** That's intentional — diagnostics is operational, not
+  decision-supportive. The visible "Raw model output for retry / debugging
+  — not for outreach use" note above the markdown clarifies it.
+
+## Verification (end-to-end)
+
+After all phases land:
+
+1. `npm run lint && npm run typecheck && npm run test` — green.
+2. `npm run dev` then `open http://admin.localhost:4321/admin/entities/cba10031-5e26-42b9-8872-3d03bba60f45`
+   (Scottsdale Icon Dental).
+3. Identity strip: green BUSINESS chip first, then HEALTHCARE, structural
+   flags, SIGNAL stage chip. Signal evidence line in mono. Days-in-stage = 0. Side-by-side with the approved mockup — visual parity.
+4. Missing panel: lists Contact email, Website, Public-web signal with
+   reasons.
+5. Enrichment summary: one paragraph, facts grid populated.
+6. Pain observations: empty-state sentence (newly licensed, no review data).
+7. Contacts: 0 with empty state and "Add contact manually" link.
+8. Timeline: ≤5 events, no outreach_draft entry, no intelligence_brief
+   entry. Note-add `<details>` collapsible above the list works.
+9. Diagnostics drawer: collapsed by default. Click reveals 13-module status
+   table + raw intelligence brief.
+10. Decision rail: Promote (primary burnt orange), Dismiss…, Merge into….
+    Promote posts to existing endpoint, redirects, flash notice.
+11. Dismiss with `wrong-actor` → entity.stage = lost, lost_reason persisted
+    in stage_change metadata. Verify in D1 console.
+12. Merge dropdown: empty state for this entity (no candidate_merge_log
+    rows). For an entity with pending merge candidates, candidates surface
+    correctly and link to target's detail page.
+13. Stale draft warning: rendered (this entity has a pre-pivot draft).
+    "View draft" anchors to diagnostics drawer; "Discard now" POSTs to the
+    new discard endpoint and reloads with the warning gone.
+14. Resize browser to 800px: rail moves to fixed bottom bar; main has
+    bottom padding; chip row wraps; timeline grid stacks; everything
+    readable.
+15. `npm run verify` — green.
+
+## Handoff to Codex
+
+This plan is self-contained and references only canonical files. Codex
+should:
+
+1. Read this plan in full.
+2. Read the approved mockup HTML for visual ground truth (Captain will
+   share it directly — it's not committed to the repo).
+3. Read `src/lib/admin/entity-row-view.ts` (PR #745 reference for the
+   composer pattern).
+4. Read the SMD design spec via `crane_doc('ss', 'design-spec.md')` for
+   tokens.
+5. Implement Phase 1 (view-model) in a single PR. Verify with WS-13 tests.
+6. Implement Phase 2 (components) + Phase 3 (page integration) in a second
+   PR. Visual verify against the mockup at desktop and 800px widths. Phase
+   4 tests land in the same PR.
+7. Run `npm run verify` before requesting review.
+
+Captain reviews each PR. Open follow-on issues for: Hold disposition, full
+merge logic, dossier-hooks Pattern A validator, and `EntityDossierSummary`
+/ `EntityStageActions` source-file removal.

--- a/src/components/admin/EntityContactRow.astro
+++ b/src/components/admin/EntityContactRow.astro
@@ -1,118 +1,97 @@
 ---
-/**
- * Single contact row, extracted from EntityContactsPanel.astro to keep
- * the parent's map callback under the 75-line function ceiling.
- */
 import type { Contact } from '../../lib/db/contacts'
 
 interface Props {
   contact: Contact
 }
 
-const { contact: c } = Astro.props
+const { contact } = Astro.props
+const inputClass =
+  'mt-1 w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]'
+const labelClass =
+  'text-[12px] font-medium uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]'
 ---
 
-<div class="px-6 py-3 space-y-row">
-  <div class="flex items-start justify-between gap-stack">
-    <div class="flex-1 min-w-0">
-      <div class="flex items-center gap-2 flex-wrap">
-        <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">{c.name}</span>
+<div class="py-4">
+  <div class="flex items-start justify-between gap-4">
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-sm font-semibold text-[color:var(--ss-color-text-primary)]"
+          >{contact.name}</span
+        >
         {
-          c.title && (
-            <span class="text-xs text-[color:var(--ss-color-text-secondary)]">{c.title}</span>
+          contact.title && (
+            <span class="text-sm text-[color:var(--ss-color-text-secondary)]">{contact.title}</span>
           )
         }
         {
-          c.role && (
-            <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
-              {c.role}
+          contact.role && (
+            <span class="border border-[color:var(--ss-color-border)] px-2 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+              {contact.role}
             </span>
           )
         }
       </div>
-      <div class="text-xs text-[color:var(--ss-color-text-muted)] flex flex-wrap gap-x-3 mt-0.5">
-        {c.email && <span>{c.email}</span>}
-        {c.phone && <span>{c.phone}</span>}
+      <div
+        class="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[13px] text-[color:var(--ss-color-text-muted)]"
+      >
+        {contact.email && <span>{contact.email}</span>}
+        {contact.phone && <span>{contact.phone}</span>}
       </div>
     </div>
-    <div class="flex-shrink-0 flex items-center gap-2">
+
+    <div class="flex shrink-0 items-start gap-3">
       <details class="relative">
         <summary
-          class="cursor-pointer text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
+          class="cursor-pointer font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4"
         >
           Edit
         </summary>
         <form
           method="POST"
-          action={`/api/admin/contacts/${c.id}`}
-          class="space-y-row mt-2 p-3 border border-[color:var(--ss-color-border)] rounded bg-[color:var(--ss-color-background)]"
+          action={`/api/admin/contacts/${contact.id}`}
+          class="absolute right-0 top-full z-20 mt-3 w-[min(26rem,calc(100vw-2rem))] border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-4 py-4"
         >
-          <div class="grid grid-cols-2 gap-2">
-            <label class="text-xs text-[color:var(--ss-color-text-secondary)] col-span-2">
+          <div class="grid gap-3 sm:grid-cols-2">
+            <label class={`${labelClass} sm:col-span-2`}>
               Name *
-              <input
-                type="text"
-                name="name"
-                required
-                value={c.name}
-                class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
-              />
+              <input type="text" name="name" required value={contact.name} class={inputClass} />
             </label>
-            <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+            <label class={labelClass}>
               Email
-              <input
-                type="email"
-                name="email"
-                value={c.email ?? ''}
-                class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
-              />
+              <input type="email" name="email" value={contact.email ?? ''} class={inputClass} />
             </label>
-            <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+            <label class={labelClass}>
               Phone
-              <input
-                type="text"
-                name="phone"
-                value={c.phone ?? ''}
-                class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
-              />
+              <input type="text" name="phone" value={contact.phone ?? ''} class={inputClass} />
             </label>
-            <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+            <label class={labelClass}>
               Title
-              <input
-                type="text"
-                name="title"
-                value={c.title ?? ''}
-                class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
-              />
+              <input type="text" name="title" value={contact.title ?? ''} class={inputClass} />
             </label>
-            <label class="text-xs text-[color:var(--ss-color-text-secondary)]">
+            <label class={labelClass}>
               Role
-              <input
-                type="text"
-                name="role"
-                value={c.role ?? ''}
-                class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-2 py-1 text-sm"
-              />
+              <input type="text" name="role" value={contact.role ?? ''} class={inputClass} />
             </label>
           </div>
-          <div class="flex justify-end">
+          <div class="mt-4 flex justify-end">
             <button
               type="submit"
-              class="text-xs px-3 py-1 bg-[color:var(--ss-color-primary)] text-white hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
+              class="border border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] px-4 py-2 font-['Archivo'] text-sm font-semibold uppercase tracking-[0.04em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)] hover:border-[color:var(--ss-color-primary-hover)]"
             >
               Save
             </button>
           </div>
         </form>
       </details>
-      <form method="POST" action={`/api/admin/contacts/${c.id}`}>
+      <form method="POST" action={`/api/admin/contacts/${contact.id}`}>
         <input type="hidden" name="_method" value="DELETE" />
         <button
           type="submit"
-          class="text-xs px-2 py-1 border border-[color:var(--ss-color-error)] text-[color:var(--ss-color-error)] hover:bg-[color:var(--ss-color-background)] transition-colors"
+          class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-error)] underline underline-offset-4"
           onclick="return confirm('Delete this contact? Engagement role assignments referencing it will block deletion.')"
         >
-          Del
+          Delete
         </button>
       </form>
     </div>

--- a/src/components/admin/EntityContactsPanel.astro
+++ b/src/components/admin/EntityContactsPanel.astro
@@ -1,15 +1,4 @@
 ---
-/**
- * Contacts panel for the admin entity detail page (PRD CM-3, US-003).
- *
- * Replaces the read-only contacts list with a CRUD panel:
- *   - Inline list with per-row edit/delete affordances
- *   - "Add contact" form (name, email, phone, title, role)
- *
- * `role` here is the contact's free-text job role on the contact record,
- * not the per-engagement role assignment (owner / decision_maker /
- * champion). Engagement-role assignment lives on the engagement detail page.
- */
 import type { Contact } from '../../lib/db/contacts'
 import EntityContactRow from './EntityContactRow.astro'
 
@@ -19,95 +8,163 @@ interface Props {
 }
 
 const { entityId, contacts } = Astro.props
+
+const labelClass =
+  'text-[12px] font-medium uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]'
+const inputClass =
+  'mt-1 w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]'
 ---
 
-<div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)]">
-  <div class="px-6 py-4 border-b border-[color:var(--ss-color-border-subtle)]">
-    <h2 class="font-medium text-[color:var(--ss-color-text-primary)]">
+<section class="border-b border-[color:var(--ss-color-border)] py-8" data-test="contacts-panel">
+  <div class="mb-4 flex items-baseline justify-between gap-4">
+    <h2
+      class="font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)]"
+    >
       Contacts ({contacts.length})
     </h2>
-    <p class="text-xs text-[color:var(--ss-color-text-secondary)] mt-1">
-      People at this organization. Engagement-specific roles (owner / decision maker / champion) are
-      assigned per engagement.
-    </p>
+    <span class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+      People at this organization
+    </span>
   </div>
 
-  <div class="divide-y divide-[color:var(--ss-color-border-subtle)]">
-    {
-      contacts.length === 0 && (
-        <div class="px-6 py-8 text-center text-sm text-[color:var(--ss-color-text-muted)]">
-          No contacts on file.
+  {
+    contacts.length === 0 ? (
+      <div class="space-y-4">
+        <div class="flex items-center justify-between gap-4 border border-dashed border-[color:var(--ss-color-border)] px-5 py-4">
+          <span class="text-[15px] leading-6 text-[color:var(--ss-color-text-secondary)]">
+            No contacts on file. Discovery runs after Promote.
+          </span>
+          <span class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4">
+            + Add contact manually
+          </span>
         </div>
-      )
-    }
-    {contacts.map((c) => <EntityContactRow contact={c} />)}
-  </div>
-
-  <details class="border-t border-[color:var(--ss-color-border-subtle)]">
-    <summary
-      class="px-6 py-3 cursor-pointer text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
-    >
-      + Add contact
-    </summary>
-    <div class="px-6 pb-4">
-      <form method="POST" action={`/api/admin/entities/${entityId}/contacts`} class="space-y-row">
-        <div class="grid grid-cols-2 gap-2">
-          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)] col-span-2">
-            Name *
-            <input
-              type="text"
-              name="name"
-              required
-              placeholder="Jane Smith"
-              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
-            />
-          </label>
-          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
-            Email
-            <input
-              type="email"
-              name="email"
-              placeholder="jane@example.com"
-              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
-            />
-          </label>
-          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
-            Phone
-            <input
-              type="text"
-              name="phone"
-              placeholder="(555) 123-4567"
-              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
-            />
-          </label>
-          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
-            Title
-            <input
-              type="text"
-              name="title"
-              placeholder="Operations Manager"
-              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
-            />
-          </label>
-          <label class="text-xs font-medium text-[color:var(--ss-color-text-secondary)]">
-            Role
-            <input
-              type="text"
-              name="role"
-              placeholder="Free-form (e.g. owner, ops lead)"
-              class="mt-1 w-full border border-[color:var(--ss-color-border)] rounded px-3 py-1.5 text-sm"
-            />
-          </label>
+        <details>
+          <summary class="cursor-pointer font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4">
+            Add contact manually
+          </summary>
+          <div class="mt-4 border border-[color:var(--ss-color-border)] px-5 py-4">
+            <form
+              method="POST"
+              action={`/api/admin/entities/${entityId}/contacts`}
+              class="space-y-4"
+            >
+              <div class="grid gap-3 sm:grid-cols-2">
+                <label class={`${labelClass} sm:col-span-2`}>
+                  Name *
+                  <input
+                    type="text"
+                    name="name"
+                    required
+                    placeholder="Jane Smith"
+                    class={inputClass}
+                  />
+                </label>
+                <label class={labelClass}>
+                  Email
+                  <input
+                    type="email"
+                    name="email"
+                    placeholder="jane@example.com"
+                    class={inputClass}
+                  />
+                </label>
+                <label class={labelClass}>
+                  Phone
+                  <input type="text" name="phone" placeholder="(555) 123-4567" class={inputClass} />
+                </label>
+                <label class={labelClass}>
+                  Title
+                  <input
+                    type="text"
+                    name="title"
+                    placeholder="Operations Manager"
+                    class={inputClass}
+                  />
+                </label>
+                <label class={labelClass}>
+                  Role
+                  <input type="text" name="role" placeholder="owner, ops lead" class={inputClass} />
+                </label>
+              </div>
+              <div class="flex justify-end">
+                <button
+                  type="submit"
+                  class="border border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] px-4 py-2 font-['Archivo'] text-sm font-semibold uppercase tracking-[0.04em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)] hover:border-[color:var(--ss-color-primary-hover)]"
+                >
+                  Add contact
+                </button>
+              </div>
+            </form>
+          </div>
+        </details>
+      </div>
+    ) : (
+      <div class="space-y-4">
+        <div class="divide-y divide-[color:var(--ss-color-border-subtle)] border-y border-[color:var(--ss-color-border-subtle)]">
+          {contacts.map((contact) => (
+            <EntityContactRow contact={contact} />
+          ))}
         </div>
-        <div class="flex">
-          <button
-            type="submit"
-            class="ml-auto bg-[color:var(--ss-color-primary)] text-white text-xs px-3 py-1.5 hover:bg-[color:var(--ss-color-primary-hover)] transition-colors"
-          >
-            Add contact
-          </button>
-        </div>
-      </form>
-    </div>
-  </details>
-</div>
+        <details>
+          <summary class="cursor-pointer font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4">
+            + Add contact manually
+          </summary>
+          <div class="mt-4 border border-[color:var(--ss-color-border)] px-5 py-4">
+            <form
+              method="POST"
+              action={`/api/admin/entities/${entityId}/contacts`}
+              class="space-y-4"
+            >
+              <div class="grid gap-3 sm:grid-cols-2">
+                <label class={`${labelClass} sm:col-span-2`}>
+                  Name *
+                  <input
+                    type="text"
+                    name="name"
+                    required
+                    placeholder="Jane Smith"
+                    class={inputClass}
+                  />
+                </label>
+                <label class={labelClass}>
+                  Email
+                  <input
+                    type="email"
+                    name="email"
+                    placeholder="jane@example.com"
+                    class={inputClass}
+                  />
+                </label>
+                <label class={labelClass}>
+                  Phone
+                  <input type="text" name="phone" placeholder="(555) 123-4567" class={inputClass} />
+                </label>
+                <label class={labelClass}>
+                  Title
+                  <input
+                    type="text"
+                    name="title"
+                    placeholder="Operations Manager"
+                    class={inputClass}
+                  />
+                </label>
+                <label class={labelClass}>
+                  Role
+                  <input type="text" name="role" placeholder="owner, ops lead" class={inputClass} />
+                </label>
+              </div>
+              <div class="flex justify-end">
+                <button
+                  type="submit"
+                  class="border border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] px-4 py-2 font-['Archivo'] text-sm font-semibold uppercase tracking-[0.04em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)] hover:border-[color:var(--ss-color-primary-hover)]"
+                >
+                  Add contact
+                </button>
+              </div>
+            </form>
+          </div>
+        </details>
+      </div>
+    )
+  }
+</section>

--- a/src/components/admin/EntityDecisionRail.astro
+++ b/src/components/admin/EntityDecisionRail.astro
@@ -1,0 +1,472 @@
+---
+import type { ContextEntry } from '../../lib/db/context'
+import { LOST_REASONS, type LostReasonCode } from '../../lib/db/lost-reasons'
+import type { CandidateMergeRow } from '../../lib/db/candidate-merge-log'
+import type { EntityStage } from '../../lib/db/entities'
+import type { EntityDetailTransition } from '../../lib/admin/entity-detail-page'
+import { relativeTime } from '../../lib/admin/relative-time'
+
+interface SupersedeCandidate {
+  id: string
+  version: number
+  status: string
+}
+
+interface MeetingRef {
+  id: string
+}
+
+interface Props {
+  entityId: string
+  entityStage: EntityStage
+  mergeCandidates: CandidateMergeRow[]
+  staleDraft: { isStale: boolean; reason: string | null }
+  outreachEntry: ContextEntry | undefined
+  transitions: EntityDetailTransition[]
+  mostRecentDraftableMeeting: MeetingRef | null
+  outreachMailto: string | null
+  outreachContactEmail: string | null
+  showReEnrichButton: boolean
+  lastEnrichmentAt: string | null
+  hasOutreach: boolean
+  showNewQuoteButton: boolean
+  supersedeCandidates: SupersedeCandidate[]
+}
+
+const {
+  entityId,
+  entityStage,
+  mergeCandidates,
+  staleDraft,
+  outreachEntry,
+  transitions,
+  mostRecentDraftableMeeting,
+  outreachMailto,
+  outreachContactEmail,
+  showReEnrichButton,
+  lastEnrichmentAt,
+  hasOutreach,
+  showNewQuoteButton,
+  supersedeCandidates,
+} = Astro.props
+
+const structuralLostReasons = LOST_REASONS.slice(0, 5)
+const lifecycleLostReasons = LOST_REASONS.slice(5)
+const railButtonBase =
+  "flex w-full items-center justify-between border px-4 py-3 text-left font-['Archivo'] text-base font-semibold uppercase tracking-[0.04em] transition-colors"
+const railPrimaryButton = `${railButtonBase} border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] text-white hover:border-[color:var(--ss-color-primary-hover)] hover:bg-[color:var(--ss-color-primary-hover)]`
+const railSecondaryButton = `${railButtonBase} border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]`
+const railDisabledButton = `${railButtonBase} cursor-not-allowed border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-muted)]`
+const workflowButtonClass =
+  "flex w-full items-center justify-between border border-[color:var(--ss-color-text-primary)] px-3 py-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)] transition-colors hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]"
+const menuClass =
+  'absolute right-0 top-full z-30 mt-2 w-[min(22rem,calc(100vw-2rem))] border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-4 shadow-none max-lg:bottom-full max-lg:left-1/2 max-lg:right-auto max-lg:top-auto max-lg:mb-2 max-lg:mt-0 max-lg:w-[min(24rem,calc(100vw-2rem))] max-lg:-translate-x-1/2'
+
+const promoteTransition =
+  transitions.find((transition) => transition.stage !== 'lost') ?? transitions[0] ?? null
+const dismissTransition = transitions.find((transition) => transition.stage === 'lost') ?? null
+const mergeDisabled = entityStage !== 'signal'
+
+const hasWorkflowActions =
+  entityStage === 'prospect' ||
+  (entityStage === 'meetings' && !!mostRecentDraftableMeeting) ||
+  !!outreachMailto ||
+  showReEnrichButton ||
+  hasOutreach ||
+  showNewQuoteButton
+
+function lostDetailPlaceholder(code: LostReasonCode): string {
+  if (code === 'wrong-actor') return 'What made it the wrong actor?'
+  if (code === 'duplicate') return 'Link the kept entity or explain the duplicate.'
+  return 'Optional detail for the record'
+}
+---
+
+<aside
+  class="lg:sticky lg:top-20 max-lg:fixed max-lg:bottom-0 max-lg:left-0 max-lg:right-0 max-lg:z-40 max-lg:border-t-[3px] max-lg:border-[color:var(--ss-color-text-primary)] max-lg:bg-[color:var(--ss-color-background)] max-lg:px-4 max-lg:py-3"
+  data-test="decision-rail"
+>
+  <div
+    class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-6 py-6 max-lg:border-0 max-lg:px-0 max-lg:py-0"
+  >
+    <div
+      class="mb-4 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] max-lg:hidden"
+    >
+      Disposition
+    </div>
+
+    <div class="grid gap-2 max-lg:grid-cols-3">
+      {
+        entityStage === 'signal' ? (
+          <>
+            <form method="POST" action={`/api/admin/entities/${entityId}/stage`}>
+              <input type="hidden" name="stage" value="prospect" />
+              <input type="hidden" name="reason" value="Promoted to prospect by admin." />
+              <button type="submit" class={railPrimaryButton} data-rail-action="promote">
+                <span class="max-lg:hidden">Promote to Prospect</span>
+                <span class="lg:hidden">Promote</span>
+              </button>
+            </form>
+
+            <details class="relative">
+              <summary class={`list-none ${railSecondaryButton}`} data-rail-action="dismiss">
+                <span>Dismiss...</span>
+                <span aria-hidden="true">v</span>
+              </summary>
+              {dismissTransition && (
+                <div class={menuClass}>
+                  <form
+                    method="POST"
+                    action={dismissTransition.action ?? `/api/admin/entities/${entityId}/stage`}
+                    class="space-y-4"
+                  >
+                    <input type="hidden" name="stage" value="lost" />
+                    <input type="hidden" name="reason" value="Dismissed by admin." />
+                    <label class="block">
+                      <span class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                        Lost reason
+                      </span>
+                      <select
+                        name="lost_reason"
+                        required
+                        class="w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]"
+                      >
+                        <option value="" disabled selected>
+                          Select a reason...
+                        </option>
+                        <optgroup label="Structural disqualifications">
+                          {structuralLostReasons.map((reason) => (
+                            <option value={reason.value}>{reason.label}</option>
+                          ))}
+                        </optgroup>
+                        <optgroup label="Lifecycle reasons">
+                          {lifecycleLostReasons.map((reason) => (
+                            <option value={reason.value}>{reason.label}</option>
+                          ))}
+                        </optgroup>
+                      </select>
+                    </label>
+                    <label class="block">
+                      <span class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                        Detail (optional)
+                      </span>
+                      <textarea
+                        name="lost_detail"
+                        rows="3"
+                        placeholder={lostDetailPlaceholder('wrong-actor')}
+                        class="w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]"
+                      />
+                    </label>
+                    <div class="flex justify-end">
+                      <button type="submit" class={railSecondaryButton}>
+                        Dismiss
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              )}
+            </details>
+
+            <details class="relative">
+              <summary
+                class:list={[mergeDisabled ? railDisabledButton : railSecondaryButton, 'list-none']}
+                title={
+                  mergeDisabled
+                    ? 'Merge available at Signal stage only - extending mergeEntities is a follow-on.'
+                    : undefined
+                }
+              >
+                <span class="sr-only" data-rail-action="merge">
+                  Merge into...
+                </span>
+                <span>Merge into...</span>
+                <span aria-hidden="true">v</span>
+              </summary>
+              <div class={menuClass}>
+                {mergeCandidates.length === 0 ? (
+                  <p class="text-sm leading-6 text-[color:var(--ss-color-text-secondary)]">
+                    No candidates from candidate_merge_log.
+                  </p>
+                ) : (
+                  <div class="space-y-3">
+                    {mergeCandidates.map((candidate) => (
+                      <div class="border border-[color:var(--ss-color-border)] px-3 py-3">
+                        <div class="font-semibold text-[color:var(--ss-color-text-primary)]">
+                          {candidate.candidateName}
+                        </div>
+                        <div class="mt-1 text-sm leading-6 text-[color:var(--ss-color-text-secondary)]">
+                          {candidate.candidateAddress ?? 'Address unavailable'}
+                        </div>
+                        <div class="mt-1 font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+                          {candidate.reason}
+                          {candidate.score !== null ? ` - score ${candidate.score}` : ''}
+                        </div>
+                        {candidate.targetId ? (
+                          <form
+                            method="POST"
+                            action={`/api/admin/entities/${candidate.targetId}/merge`}
+                            class="mt-3"
+                          >
+                            <input type="hidden" name="source_id" value={entityId} />
+                            <button type="submit" class={workflowButtonClass}>
+                              Merge into candidate
+                            </button>
+                          </form>
+                        ) : (
+                          <p class="mt-3 text-[13px] leading-5 text-[color:var(--ss-color-text-muted)]">
+                            Candidate logged for review only. No target entity record exists yet.
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </details>
+          </>
+        ) : (
+          <>
+            {promoteTransition && (
+              <form
+                method="POST"
+                action={promoteTransition.action ?? `/api/admin/entities/${entityId}/stage`}
+              >
+                <input type="hidden" name="stage" value={promoteTransition.stage} />
+                <input type="hidden" name="reason" value={`${promoteTransition.label} by admin.`} />
+                <button
+                  type="submit"
+                  class={
+                    promoteTransition.variant === 'primary'
+                      ? railPrimaryButton
+                      : railSecondaryButton
+                  }
+                  data-rail-action="promote"
+                >
+                  <span>{promoteTransition.label}</span>
+                </button>
+              </form>
+            )}
+
+            {dismissTransition ? (
+              <details class="relative">
+                <summary class={`list-none ${railSecondaryButton}`} data-rail-action="dismiss">
+                  <span>{dismissTransition.label}</span>
+                  <span aria-hidden="true">v</span>
+                </summary>
+                <div class={menuClass}>
+                  <form
+                    method="POST"
+                    action={dismissTransition.action ?? `/api/admin/entities/${entityId}/stage`}
+                    class="space-y-4"
+                  >
+                    <input type="hidden" name="stage" value="lost" />
+                    <input
+                      type="hidden"
+                      name="reason"
+                      value={`${dismissTransition.label} by admin.`}
+                    />
+                    <label class="block">
+                      <span class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                        Lost reason
+                      </span>
+                      <select
+                        name="lost_reason"
+                        required
+                        class="w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]"
+                      >
+                        <option value="" disabled selected>
+                          Select a reason...
+                        </option>
+                        <optgroup label="Structural disqualifications">
+                          {structuralLostReasons.map((reason) => (
+                            <option value={reason.value}>{reason.label}</option>
+                          ))}
+                        </optgroup>
+                        <optgroup label="Lifecycle reasons">
+                          {lifecycleLostReasons.map((reason) => (
+                            <option value={reason.value}>{reason.label}</option>
+                          ))}
+                        </optgroup>
+                      </select>
+                    </label>
+                    <label class="block">
+                      <span class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                        Detail (optional)
+                      </span>
+                      <textarea
+                        name="lost_detail"
+                        rows="3"
+                        placeholder="Optional detail for the record"
+                        class="w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]"
+                      />
+                    </label>
+                    <div class="flex justify-end">
+                      <button type="submit" class={railSecondaryButton}>
+                        {dismissTransition.label}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </details>
+            ) : (
+              <button
+                type="button"
+                class={railDisabledButton}
+                title="Dismiss reasons apply from the Signal and prospect workflow."
+                disabled
+                data-rail-action="dismiss"
+              >
+                <span>Dismiss...</span>
+              </button>
+            )}
+
+            <button
+              type="button"
+              class={railDisabledButton}
+              title="Merge available at Signal stage only - extending mergeEntities is a follow-on."
+              disabled
+              data-rail-action="merge"
+            >
+              <span>Merge into...</span>
+            </button>
+          </>
+        )
+      }
+    </div>
+
+    {
+      hasWorkflowActions && (
+        <div class="mt-6 border-t border-[color:var(--ss-color-border)] pt-4 max-lg:hidden">
+          <div class="mb-3 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+            Workflow actions
+          </div>
+          <div class="space-y-2">
+            {entityStage === 'prospect' && (
+              <button type="button" id="send-booking-link-btn" class={workflowButtonClass}>
+                Send booking link
+              </button>
+            )}
+            {entityStage === 'meetings' && mostRecentDraftableMeeting && (
+              <form
+                method="POST"
+                action={`/api/admin/entities/${entityId}/meetings/${mostRecentDraftableMeeting.id}/draft-quote`}
+              >
+                <button type="submit" class={workflowButtonClass}>
+                  Draft proposal from meeting
+                </button>
+              </form>
+            )}
+            {outreachMailto && (
+              <a
+                href={outreachMailto}
+                class={workflowButtonClass}
+                title={`Open mail to ${outreachContactEmail ?? ''} with the draft pre-filled`}
+              >
+                Send outreach
+              </a>
+            )}
+            {showReEnrichButton && (
+              <form
+                method="POST"
+                action={`/api/admin/entities/${entityId}/dossier`}
+                id="re-enrich-form"
+              >
+                <button type="submit" id="re-enrich-btn" class={workflowButtonClass}>
+                  Re-enrich
+                </button>
+                {lastEnrichmentAt && (
+                  <div class="mt-1 font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+                    Last enriched {relativeTime(lastEnrichmentAt)}
+                  </div>
+                )}
+              </form>
+            )}
+            {entityStage === 'prospect' && hasOutreach && (
+              <button type="button" data-open-reply-dialog={entityId} class={workflowButtonClass}>
+                Log reply
+              </button>
+            )}
+            {showNewQuoteButton && (
+              <form
+                method="POST"
+                action={`/api/admin/entities/${entityId}/quotes`}
+                class="space-y-2"
+              >
+                {supersedeCandidates.length > 0 && (
+                  <label class="block">
+                    <span class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                      Supersede prior quote
+                    </span>
+                    <select
+                      name="parent_quote_id"
+                      class="w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]"
+                    >
+                      <option value="">No supersede link</option>
+                      {supersedeCandidates.map((quote) => (
+                        <option value={quote.id}>
+                          Supersede v{quote.version} ({quote.status})
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                <button type="submit" class={workflowButtonClass}>
+                  New quote
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      )
+    }
+
+    <div class="mt-6 border-t border-[color:var(--ss-color-border)] pt-4 max-lg:hidden">
+      <div
+        class="mb-3 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+      >
+        Outreach status
+      </div>
+
+      {
+        staleDraft.isStale ? (
+          <div class="border border-[color:var(--ss-color-warning)] border-l-[3px] px-3 py-3 text-sm leading-6 text-[color:var(--ss-color-text-secondary)]">
+            <strong class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-warning)]">
+              Draft is stale
+            </strong>
+            <span>
+              {staleDraft.reason} Will be regenerated when you Promote and validated against Pattern
+              A.
+            </span>
+            <div class="mt-2 flex gap-3">
+              <a
+                href="#entity-diagnostics-draft"
+                class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4"
+              >
+                View draft
+              </a>
+              <form method="POST" action={`/api/admin/entities/${entityId}/outreach-draft/discard`}>
+                <button
+                  type="submit"
+                  class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4"
+                >
+                  Discard now
+                </button>
+              </form>
+            </div>
+          </div>
+        ) : entityStage !== 'signal' && outreachEntry ? (
+          <a
+            href="#entity-diagnostics-draft"
+            class="text-sm leading-6 text-[color:var(--ss-color-text-secondary)] underline underline-offset-4"
+          >
+            Latest draft generated {relativeTime(outreachEntry.created_at)}.
+          </a>
+        ) : (
+          <p class="text-sm leading-6 text-[color:var(--ss-color-text-secondary)]">
+            Will be generated post-Promote and validated against Pattern A doctrine.
+          </p>
+        )
+      }
+    </div>
+  </div>
+</aside>

--- a/src/components/admin/EntityDiagnosticsDrawer.astro
+++ b/src/components/admin/EntityDiagnosticsDrawer.astro
@@ -1,0 +1,182 @@
+---
+import { MODULES } from '../../lib/enrichment/modules'
+import type { ModuleId } from '../../lib/enrichment/modules'
+import type { EnrichmentRun, RunStatus } from '../../lib/db/enrichment-runs'
+import type { ContextEntry } from '../../lib/db/context'
+import { renderSimpleMarkdown } from '../../lib/admin/entity-detail-page'
+import { relativeTime } from '../../lib/admin/relative-time'
+
+interface Props {
+  entityId: string
+  intelligenceBriefEntry: ContextEntry | undefined
+  outreachEntry: ContextEntry | undefined
+  enrichmentRuns: Map<EnrichmentRun['module'], EnrichmentRun>
+}
+
+const { entityId, intelligenceBriefEntry, outreachEntry, enrichmentRuns } = Astro.props
+
+type DisplayStatus = RunStatus | 'not_yet_run' | 'timed_out'
+
+const STALE_RUNNING_THRESHOLD_MS = 5 * 60 * 1000
+const now = Date.now()
+const statusPillBase =
+  "inline-block border px-2 py-0.5 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em]"
+
+function statusLabel(status: DisplayStatus): string {
+  if (status === 'not_yet_run') return 'not yet run'
+  if (status === 'timed_out') return 'timed out'
+  return status.replace(/_/g, ' ')
+}
+
+function statusClass(status: DisplayStatus): string {
+  switch (status) {
+    case 'succeeded':
+      return 'border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-complete)] text-white'
+    case 'no_data':
+      return 'border-[color:var(--ss-color-warning)] bg-[color:var(--ss-color-warning)] text-white'
+    case 'failed':
+    case 'timed_out':
+      return 'border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-error)] text-white'
+    case 'running':
+      return 'border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] text-white'
+    default:
+      return 'border-[color:var(--ss-color-text-muted)] bg-[color:var(--ss-color-text-muted)] text-white'
+  }
+}
+
+function deriveModuleStatus(
+  run: EnrichmentRun | undefined,
+  nowMs: number
+): { status: DisplayStatus; reason: string | null } {
+  let status: DisplayStatus = run?.status ?? 'not_yet_run'
+  let reason: string | null = run?.reason ?? null
+
+  if (run?.status === 'running' && run.started_at) {
+    const startedAtMs = new Date(run.started_at).getTime()
+    if (Number.isFinite(startedAtMs) && nowMs - startedAtMs > STALE_RUNNING_THRESHOLD_MS) {
+      status = 'timed_out'
+      reason = 'worker_terminated_mid_run'
+    }
+  }
+
+  return { status, reason }
+}
+
+const rows = MODULES.map((moduleDef) => {
+  const run = enrichmentRuns.get(moduleDef.id)
+  const { status, reason } = deriveModuleStatus(run, now)
+  const when = run?.completed_at ?? run?.started_at ?? null
+  return {
+    id: moduleDef.id as ModuleId,
+    displayName: moduleDef.displayName,
+    tier: moduleDef.tier,
+    status,
+    reason,
+    when,
+  }
+})
+---
+
+<details class="py-4" data-diagnostics id="entity-diagnostics">
+  <summary
+    class="cursor-pointer list-none font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+  >
+    Enrichment diagnostics (13 modules)
+  </summary>
+
+  <div class="mt-4 overflow-x-auto border-t border-[color:var(--ss-color-border)] pt-4">
+    <table class="w-full border-collapse text-sm">
+      <thead>
+        <tr class="border-b border-[color:var(--ss-color-border)] text-left">
+          <th
+            class="px-3 py-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Module
+          </th>
+          <th
+            class="px-3 py-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Status
+          </th>
+          <th
+            class="px-3 py-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Detail
+          </th>
+          <th class="px-3 py-2"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          rows.map((row) => (
+            <tr class="border-b border-[color:var(--ss-color-border-subtle)]">
+              <td class="px-3 py-2 align-top text-[color:var(--ss-color-text-primary)]">
+                {row.displayName}
+                <span class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+                  {' '}
+                  - tier {row.tier}
+                </span>
+              </td>
+              <td class="px-3 py-2 align-top">
+                <span class:list={[statusPillBase, statusClass(row.status)]}>
+                  {statusLabel(row.status)}
+                </span>
+              </td>
+              <td class="px-3 py-2 align-top text-[color:var(--ss-color-text-secondary)]">
+                <div>{row.reason ?? '-'}</div>
+                {row.when && (
+                  <div class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+                    {relativeTime(row.when)}
+                  </div>
+                )}
+              </td>
+              <td class="px-3 py-2 align-top text-right">
+                <form
+                  method="POST"
+                  action={`/api/admin/entities/${entityId}/enrichment/${row.id}/retry`}
+                >
+                  <button
+                    type="submit"
+                    class="border border-[color:var(--ss-color-primary)] px-2 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-primary)] transition-colors hover:bg-[color:var(--ss-color-primary)] hover:text-white"
+                  >
+                    {row.status === 'not_yet_run' ? 'Run' : 'Retry'}
+                  </button>
+                </form>
+              </td>
+            </tr>
+          ))
+        }
+      </tbody>
+    </table>
+
+    {
+      (outreachEntry || intelligenceBriefEntry) && (
+        <div class="mt-6 space-y-6 border-t border-[color:var(--ss-color-border)] pt-6">
+          <p class="text-[13px] leading-6 text-[color:var(--ss-color-text-secondary)]">
+            Raw model output for retry / debugging - not for outreach use.
+          </p>
+
+          {outreachEntry && (
+            <section id="entity-diagnostics-draft">
+              <div class="mb-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)]">
+                Raw outreach draft
+              </div>
+              <pre class="overflow-x-auto whitespace-pre-wrap border border-[color:var(--ss-color-border)] px-4 py-4 text-sm leading-6 text-[color:var(--ss-color-text-primary)]">
+                {outreachEntry.content}
+              </pre>
+            </section>
+          )}
+
+          {intelligenceBriefEntry && (
+            <section id="entity-diagnostics-brief">
+              <div class="mb-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)]">
+                Raw intelligence brief
+              </div>
+              <div set:html={renderSimpleMarkdown(intelligenceBriefEntry.content)} />
+            </section>
+          )}
+        </div>
+      )
+    }
+  </div>
+</details>

--- a/src/components/admin/EntityDossierSummary.astro
+++ b/src/components/admin/EntityDossierSummary.astro
@@ -175,7 +175,7 @@ const {
             Outreach Draft
             {!outreachFromDossier && (
               <span class="normal-case font-normal text-[color:var(--ss-color-text-muted)] ml-2">
-                Pre-dossier draft
+                Draft source: pre-dossier
               </span>
             )}
           </div>

--- a/src/components/admin/EntityEnrichmentSummary.astro
+++ b/src/components/admin/EntityEnrichmentSummary.astro
@@ -1,0 +1,87 @@
+---
+import { relativeTime } from '../../lib/admin/relative-time'
+
+interface Props {
+  summary: string | null
+  summarySource: string | null
+  signalSource: string
+  signalDate: string | null
+  address: string | null
+  vertical: string | null
+  generatedAt: string | null
+}
+
+const { summary, summarySource, signalSource, signalDate, address, vertical, generatedAt } =
+  Astro.props
+
+function formatIsoDate(iso: string | null): string {
+  if (!iso) return '-'
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) return iso
+  return parsed.toISOString().slice(0, 10)
+}
+
+const verticalLabel = vertical?.replace(/_/g, ' ') ?? '-'
+const aside = generatedAt
+  ? `${relativeTime(generatedAt)}${summarySource ? ` - ${summarySource}` : ''}`
+  : (summarySource ?? 'pending')
+---
+
+<section class="border-b border-[color:var(--ss-color-border)] py-8" data-test="enrichment-summary">
+  <div class="mb-4 flex items-baseline justify-between gap-4">
+    <h2
+      class="font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)]"
+    >
+      Enrichment summary
+    </h2>
+    <span class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+      {aside}
+    </span>
+  </div>
+
+  {
+    summary ? (
+      <div class="space-y-4 text-base leading-7 text-[color:var(--ss-color-text-primary)]">
+        <p>{summary}</p>
+        <dl class="grid grid-cols-1 gap-x-5 gap-y-3 text-sm sm:grid-cols-2">
+          <div>
+            <dt class="mb-0.5 font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+              Source
+            </dt>
+            <dd class="font-['JetBrains_Mono'] text-[13px] text-[color:var(--ss-color-text-primary)]">
+              {signalSource}
+            </dd>
+          </div>
+          <div>
+            <dt class="mb-0.5 font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+              Signal date
+            </dt>
+            <dd class="font-['JetBrains_Mono'] text-[13px] text-[color:var(--ss-color-text-primary)]">
+              {formatIsoDate(signalDate)}
+            </dd>
+          </div>
+          <div>
+            <dt class="mb-0.5 font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+              Address
+            </dt>
+            <dd class="font-['JetBrains_Mono'] text-[13px] text-[color:var(--ss-color-text-primary)]">
+              {address ?? '-'}
+            </dd>
+          </div>
+          <div>
+            <dt class="mb-0.5 font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+              Vertical
+            </dt>
+            <dd class="font-['JetBrains_Mono'] text-[13px] text-[color:var(--ss-color-text-primary)]">
+              {verticalLabel}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    ) : (
+      <p class="text-[15px] italic leading-6 text-[color:var(--ss-color-text-secondary)]">
+        Enrichment in progress - summary will appear once review or website signals resolve.
+      </p>
+    )
+  }
+</section>

--- a/src/components/admin/EntityIdentityStrip.astro
+++ b/src/components/admin/EntityIdentityStrip.astro
@@ -1,0 +1,127 @@
+---
+import { ENTITY_STAGES, type Entity } from '../../lib/db/entities'
+
+interface Props {
+  entity: Entity
+  actorRole: 'business' | 'contractor' | 'unknown'
+  actorRoleConfidence: 'high' | 'medium' | 'low'
+  signalEvidence: string | null
+  signalSourceLabel: string | null
+  daysInStage: number
+  structuralFlags: string[]
+}
+
+const {
+  entity,
+  actorRole,
+  actorRoleConfidence,
+  signalEvidence,
+  signalSourceLabel,
+  daysInStage,
+  structuralFlags,
+} = Astro.props
+
+const stageLabel =
+  ENTITY_STAGES.find((stage) => stage.value === entity.stage)?.label ?? entity.stage
+const verticalLabel = entity.vertical?.replace(/_/g, ' ') ?? null
+
+function actorRoleTone(role: Props['actorRole']): string {
+  switch (role) {
+    case 'business':
+      return 'border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-complete)] text-white'
+    case 'contractor':
+      return 'border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-error)] text-white'
+    default:
+      return 'border-[color:var(--ss-color-warning)] bg-[color:var(--ss-color-warning)] text-white'
+  }
+}
+
+function actorRoleIcon(role: Props['actorRole']): string {
+  switch (role) {
+    case 'business':
+      return 'verified'
+    case 'contractor':
+      return 'construction'
+    default:
+      return 'help'
+  }
+}
+
+function formatRole(role: Props['actorRole']): string {
+  if (role === 'business') return 'Business'
+  if (role === 'contractor') return 'Contractor'
+  return 'Unknown'
+}
+
+function stageAgeLabel(days: number): string {
+  if (days <= 0) return 'Filed today'
+  if (days === 1) return 'Filed yesterday'
+  return `Filed ${days} days ago`
+}
+
+const chipClass =
+  "inline-flex items-center gap-1 border px-2.5 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em]"
+---
+
+<section
+  class="border-[3px] border-[color:var(--ss-color-text-primary)] px-7 py-6"
+  data-test="identity-strip"
+>
+  <div
+    class="mb-2 font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]"
+  >
+    Signal | {signalSourceLabel ?? entity.source_pipeline ?? 'unknown_source'}
+  </div>
+  <h1
+    class="mb-3 font-['Archivo'] text-4xl font-black uppercase leading-[1.05] tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+  >
+    {entity.name}
+  </h1>
+  <div class="mb-5 flex flex-wrap gap-2">
+    <span class:list={[chipClass, actorRoleTone(actorRole)]}>
+      <span class="material-symbols-outlined text-[16px]" aria-hidden="true">
+        {actorRoleIcon(actorRole)}
+      </span>
+      {formatRole(actorRole)}
+    </span>
+    {
+      verticalLabel && (
+        <span
+          class={`${chipClass} border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] capitalize`}
+        >
+          {verticalLabel}
+        </span>
+      )
+    }
+    {
+      structuralFlags
+        .slice(0, 3)
+        .map((flag) => (
+          <span
+            class={`${chipClass} border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-secondary)]`}
+          >
+            {flag}
+          </span>
+        ))
+    }
+    <span
+      class={`${chipClass} border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)]`}
+    >
+      {stageLabel}
+    </span>
+  </div>
+  {
+    signalEvidence && (
+      <div class="font-['JetBrains_Mono'] text-[15px] font-medium leading-6 text-[color:var(--ss-color-text-primary)]">
+        {signalEvidence}
+      </div>
+    )
+  }
+  <div class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
+    <span>{stageAgeLabel(daysInStage)}</span>
+    <span class="px-2 text-[color:var(--ss-color-text-muted)]">|</span>
+    <span>{daysInStage} {daysInStage === 1 ? 'day' : 'days'} in {stageLabel}</span>
+    <span class="px-2 text-[color:var(--ss-color-text-muted)]">|</span>
+    <span>actor_role: {actorRole} ({actorRoleConfidence} confidence)</span>
+  </div>
+</section>

--- a/src/components/admin/EntityMissingPanel.astro
+++ b/src/components/admin/EntityMissingPanel.astro
@@ -1,0 +1,48 @@
+---
+interface MissingItem {
+  key: string
+  label: string
+  reason: string
+}
+
+interface Props {
+  items: MissingItem[]
+}
+
+const { items } = Astro.props
+
+if (items.length === 0) {
+  return null
+}
+---
+
+<section class="border-b border-[color:var(--ss-color-border)] py-8">
+  <div
+    class="border-l-[3px] border-[color:var(--ss-color-warning)] px-5 py-4"
+    data-test="missing-panel"
+  >
+    <div
+      class="mb-2 font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-warning)]"
+    >
+      Missing for credible outreach
+    </div>
+    <ul class="space-y-1 text-[15px] leading-6 text-[color:var(--ss-color-text-secondary)]">
+      {
+        items.map((item) => (
+          <li class="flex items-start gap-2">
+            <span class="font-bold text-[color:var(--ss-color-warning)]" aria-hidden="true">
+              -
+            </span>
+            <span>
+              <strong class="font-semibold text-[color:var(--ss-color-text-primary)]">
+                {item.label}
+              </strong>
+              {' - '}
+              {item.reason}
+            </span>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+</section>

--- a/src/components/admin/EntityPainObservations.astro
+++ b/src/components/admin/EntityPainObservations.astro
@@ -1,0 +1,101 @@
+---
+interface ReviewMeta {
+  top_themes?: string[]
+  operational_problems?: Array<{ problem: string; confidence: string; evidence: string }>
+}
+
+interface JobSignalMeta {
+  top_problems?: string[]
+  evidence?: string
+}
+
+interface Props {
+  reviewMeta: ReviewMeta | null
+  jobSignalMeta: JobSignalMeta | null
+}
+
+const { reviewMeta, jobSignalMeta } = Astro.props
+
+const reviewProblems = reviewMeta?.operational_problems ?? []
+const reviewThemes = reviewMeta?.top_themes ?? []
+const jobProblems = jobSignalMeta?.top_problems ?? []
+const hasObservations =
+  reviewProblems.length > 0 ||
+  reviewThemes.length > 0 ||
+  jobProblems.length > 0 ||
+  !!jobSignalMeta?.evidence
+
+function humanizeProblem(problem: string): string {
+  return problem.replace(/_/g, ' ')
+}
+---
+
+<section class="border-b border-[color:var(--ss-color-border)] py-8" data-test="pain-observations">
+  <div class="mb-4 flex items-baseline justify-between gap-4">
+    <h2
+      class="font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)]"
+    >
+      Pain observations
+    </h2>
+    <span class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+      From public web
+    </span>
+  </div>
+
+  {
+    hasObservations ? (
+      <div class="space-y-4 text-[15px] leading-6 text-[color:var(--ss-color-text-primary)]">
+        {reviewProblems.length > 0 && (
+          <ul class="space-y-2">
+            {reviewProblems.map((problem) => (
+              <li class="border-l border-[color:var(--ss-color-border)] pl-4">
+                <div class="font-semibold">{humanizeProblem(problem.problem)}</div>
+                <p class="text-[color:var(--ss-color-text-secondary)]">
+                  {problem.evidence}
+                  <span class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]">
+                    {' '}
+                    ({problem.confidence})
+                  </span>
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {reviewThemes.length > 0 && (
+          <div>
+            <div class="mb-2 font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+              Recurring themes
+            </div>
+            <ul class="space-y-1 text-[color:var(--ss-color-text-secondary)]">
+              {reviewThemes.map((theme) => (
+                <li>- {theme}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {reviewProblems.length === 0 && jobProblems.length > 0 && jobSignalMeta?.evidence && (
+          <div class="space-y-2">
+            <div class="font-['Archivo_Narrow'] text-[12px] font-semibold uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+              Job-post signal
+            </div>
+            <p>{jobSignalMeta.evidence}</p>
+            <div class="flex flex-wrap gap-2">
+              {jobProblems.map((problem) => (
+                <span class="border border-[color:var(--ss-color-border)] px-2 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                  {humanizeProblem(problem)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    ) : (
+      <p class="text-[15px] italic leading-6 text-[color:var(--ss-color-text-secondary)]">
+        No public review or job-post signal yet. License filed today; nothing has been written about
+        this practice externally. Expect this to fill in over 30-60 days as the practice opens.
+      </p>
+    )
+  }
+</section>

--- a/src/components/admin/EntityTimelineEntry.astro
+++ b/src/components/admin/EntityTimelineEntry.astro
@@ -1,11 +1,6 @@
 ---
-/**
- * Single timeline entry for the entity detail page.
- * Extracted from src/pages/admin/entities/[id].astro to keep that page
- * under the 500 code-line ceiling.
- */
-import { contextTypeBadge, formatDateTime, parseMetadata } from '../../lib/admin/entity-detail-page'
-import { CONTEXT_TYPES } from '../../lib/db/context'
+import { parseMetadata } from '../../lib/admin/entity-detail-page'
+import { relativeTime } from '../../lib/admin/relative-time'
 import type { ContextEntry } from '../../lib/db/context'
 
 interface Props {
@@ -13,96 +8,88 @@ interface Props {
   openByDefault: boolean
 }
 
-const { entry, openByDefault } = Astro.props
+const { entry } = Astro.props
 const meta = parseMetadata(entry.metadata)
-const problems = meta?.top_problems as string[] | undefined
-const isLong = entry.content.length > 500
 const isReplyLog = entry.type === 'note' && entry.source === 'reply_log'
-const replySentiment = isReplyLog ? (meta?.sentiment as string | undefined) : undefined
-const replyNextAction = isReplyLog ? (meta?.next_action as string | undefined) : undefined
+
+function formatStage(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null
+  return value.replace(/_/g, ' ')
+}
+
+function entryHeadline(current: ContextEntry, _metadata: Record<string, unknown> | null): string {
+  if (current.type === 'enrichment') return 'Enrichment run completed'
+  if (current.type === 'signal') return 'Pipeline signal qualified'
+  if (current.type === 'stage_change') return 'Stage changed'
+  if (isReplyLog) return 'Reply logged'
+  if (current.type === 'note') return 'Note added'
+  return current.type.replace(/_/g, ' ')
+}
+
+function signalDetail(
+  current: ContextEntry,
+  metadata: Record<string, unknown> | null
+): string | null {
+  const parts = [
+    current.source,
+    typeof metadata?.vertical === 'string' ? `vertical: ${metadata.vertical}` : null,
+    typeof metadata?.outreach_timing === 'string' ? `timing: ${metadata.outreach_timing}` : null,
+  ].filter((part): part is string => !!part)
+  return parts.length > 0 ? parts.join(' | ') : null
+}
+
+function enrichmentDetail(
+  current: ContextEntry,
+  metadata: Record<string, unknown> | null
+): string | null {
+  const succeeded = typeof metadata?.succeeded === 'number' ? metadata.succeeded : null
+  const noData = typeof metadata?.no_data === 'number' ? metadata.no_data : null
+  const skipped = typeof metadata?.skipped === 'number' ? metadata.skipped : null
+  const parts = [
+    current.source ? `${current.source}` : null,
+    succeeded !== null ? `${succeeded} succeeded` : null,
+    noData !== null ? `${noData} no_data` : null,
+    skipped !== null ? `${skipped} skipped` : null,
+  ].filter((part): part is string => !!part)
+  return parts.length > 0 ? parts.join(' | ') : null
+}
+
+function stageChangeDetail(metadata: Record<string, unknown> | null): string | null {
+  const from = formatStage(metadata?.from)
+  const to = formatStage(metadata?.to)
+  const reason = typeof metadata?.reason === 'string' ? metadata.reason : null
+  const parts = [from && to ? `${from} to ${to}` : null, reason].filter(
+    (part): part is string => !!part
+  )
+  return parts.length > 0 ? parts.join(' | ') : null
+}
+
+function replyLogDetail(metadata: Record<string, unknown> | null): string | null {
+  const sentiment = formatStage(metadata?.sentiment)
+  const nextAction = formatStage(metadata?.next_action)
+  const parts = [sentiment, nextAction ? `next: ${nextAction}` : null].filter(
+    (part): part is string => !!part
+  )
+  return parts.length > 0 ? parts.join(' | ') : null
+}
+
+function entryDetail(current: ContextEntry, metadata: Record<string, unknown> | null): string {
+  if (current.type === 'signal') return signalDetail(current, metadata) ?? current.content
+  if (current.type === 'enrichment') return enrichmentDetail(current, metadata) ?? current.content
+  if (current.type === 'stage_change') return stageChangeDetail(metadata) ?? current.content
+  if (isReplyLog) return replyLogDetail(metadata) ?? current.content
+  return current.content
+}
 ---
 
-<details
-  open={openByDefault}
-  class={`group bg-surface rounded-[var(--ss-radius-card)] border px-4 py-3 ${
-    isReplyLog
-      ? 'border-l-4 border-l-teal-500 border-[color:var(--ss-color-border)]'
-      : 'border-[color:var(--ss-color-border)]'
-  }`}
+<li
+  class="grid gap-3 border-t border-[color:var(--ss-color-border-subtle)] py-3 text-[15px] leading-6 first:border-t-0 first:pt-0 md:grid-cols-[8rem_1fr]"
 >
-  <summary
-    class="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex-wrap"
-  >
-    {
-      isReplyLog ? (
-        <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary font-semibold">
-          Reply
-        </span>
-      ) : (
-        <span class={`text-xs px-2 py-0.5 rounded ${contextTypeBadge(entry.type)}`}>
-          {CONTEXT_TYPES.find((t) => t.value === entry.type)?.label ?? entry.type}
-        </span>
-      )
-    }
-    <span class="text-xs text-[color:var(--ss-color-text-muted)]">{entry.source}</span>
-    <span class="text-xs text-[color:var(--ss-color-text-muted)]"
-      >{formatDateTime(entry.created_at)}</span
-    >
-    {
-      replySentiment && (
-        <span class="text-xs px-1.5 py-0.5 rounded bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] capitalize">
-          {replySentiment.replace(/_/g, ' ')}
-        </span>
-      )
-    }
-    {
-      replyNextAction && (
-        <span class="text-xs text-[color:var(--ss-color-text-secondary)]">
-          Next: <span class="capitalize">{replyNextAction.replace(/_/g, ' ')}</span>
-        </span>
-      )
-    }
-    <svg
-      class="ml-auto h-3.5 w-3.5 shrink-0 text-[color:var(--ss-color-text-muted)] transition-transform group-open:rotate-180"
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
-        clip-rule="evenodd"></path>
-    </svg>
-    <span class="sr-only">Toggle entry</span>
-  </summary>
-
-  <div class="mt-1.5">
-    {
-      problems && problems.length > 0 && (
-        <div class="flex gap-1 mb-1.5 flex-wrap">
-          {problems.map((p: string) => (
-            <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
-              {p.replace(/_/g, ' ')}
-            </span>
-          ))}
-        </div>
-      )
-    }
-    <div
-      class={`text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap${isLong ? ' js-truncated' : ''}`}
-      data-long={isLong ? 'true' : 'false'}
-    >
-      {entry.content}
-    </div>
-    {
-      isLong && (
-        <button
-          type="button"
-          class="js-toggle-long text-xs mt-2 text-[color:var(--ss-color-primary)] hover:underline cursor-pointer"
-        >
-          Show more
-        </button>
-      )
-    }
-  </div>
-</details>
+  <span class="font-['JetBrains_Mono'] text-[13px] text-[color:var(--ss-color-text-secondary)]">
+    {relativeTime(entry.created_at)}
+  </span>
+  <span class="text-[color:var(--ss-color-text-primary)]">
+    <strong class="font-semibold">{entryHeadline(entry, meta)}</strong>
+    <span class="text-[color:var(--ss-color-text-secondary)]"> | {entryDetail(entry, meta)}</span>
+  </span>
+</li>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -11,9 +11,10 @@ interface Props {
   title: string
   breadcrumbs?: BreadcrumbItem[]
   maxWidth?: 'max-w-5xl' | 'max-w-6xl'
+  mainClass?: string
 }
 
-const { title, breadcrumbs = [], maxWidth = 'max-w-5xl' } = Astro.props
+const { title, breadcrumbs = [], maxWidth = 'max-w-5xl', mainClass = '' } = Astro.props
 const session = Astro.locals.session!
 const pathname = Astro.url.pathname
 
@@ -164,7 +165,7 @@ const navItems = [
       </div>
     </header>
 
-    <main id="main" role="main" class={`${maxWidth} mx-auto px-4 py-8`}>
+    <main id="main" role="main" class={`${maxWidth} mx-auto px-4 py-8 ${mainClass}`}>
       {
         breadcrumbs.length > 0 && (
           <nav aria-label="Breadcrumb" class="mb-4">

--- a/src/lib/admin/entity-detail-client.ts
+++ b/src/lib/admin/entity-detail-client.ts
@@ -104,29 +104,15 @@ function setupReEnrichForm(): void {
   }
 }
 
-function setupCopyOutreach(): void {
-  const copyBtn = document.getElementById('copy-outreach-btn') as HTMLButtonElement | null
-  const outreachEl = document.getElementById('outreach-content')
-  if (!copyBtn || !outreachEl) return
-  copyBtn.addEventListener('click', () => {
-    void navigator.clipboard.writeText(outreachEl.textContent ?? '').then(() => {
-      copyBtn.textContent = 'Copied!'
-      window.setTimeout(() => {
-        copyBtn.textContent = 'Copy'
-      }, 2000)
-    })
-  })
-}
+function setupDiagnosticsHash(): void {
+  const syncHash = () => {
+    if (!window.location.hash.startsWith('#entity-diagnostics')) return
+    const diagnostics = document.querySelector<HTMLDetailsElement>('[data-diagnostics]')
+    diagnostics?.setAttribute('open', 'true')
+  }
 
-function setupToggleLong(): void {
-  document.querySelectorAll<HTMLButtonElement>('.js-toggle-long').forEach((toggle) => {
-    toggle.addEventListener('click', () => {
-      const body = toggle.previousElementSibling as HTMLElement | null
-      if (!body || !body.classList.contains('js-truncated')) return
-      const expanded = body.classList.toggle('is-expanded')
-      toggle.textContent = expanded ? 'Show less' : 'Show more'
-    })
-  })
+  syncHash()
+  window.addEventListener('hashchange', syncHash)
 }
 
 function setupSendBookingLink(): void {
@@ -166,7 +152,6 @@ function setupSendBookingLink(): void {
 
 export function initEntityDetailPage(): void {
   setupReEnrichForm()
-  setupCopyOutreach()
-  setupToggleLong()
+  setupDiagnosticsHash()
   setupSendBookingLink()
 }

--- a/src/lib/admin/entity-detail-decision-evidence.ts
+++ b/src/lib/admin/entity-detail-decision-evidence.ts
@@ -1,0 +1,285 @@
+import type { Entity, EntitySignalMetadata } from '../db/entities'
+import type { ContextEntry } from '../db/context'
+import type { Contact } from '../db/contacts'
+import type { EnrichmentRun } from '../db/enrichment-runs'
+
+type ActorRole = NonNullable<EntitySignalMetadata['actor_role']>
+type ActorRoleConfidence = NonNullable<EntitySignalMetadata['actor_role_confidence']>
+
+export type MissingForOutreachItem = {
+  key: 'contact' | 'website' | 'public-web-signal'
+  label: string
+  reason: string
+}
+
+export interface DecisionEvidence {
+  actorRole: ActorRole
+  actorRoleConfidence: ActorRoleConfidence
+  signalEvidence: string | null
+  enrichmentSummary: string | null
+  structuralFlags: string[]
+  missingForOutreach: MissingForOutreachItem[]
+  staleDraftWarning: {
+    isStale: boolean
+    reason: string | null
+  }
+}
+
+export const ADR_0003_DEPLOY_DATE = '2026-05-07T00:00:00Z'
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatSignalDate(raw: string | null): string | null {
+  if (!raw) return null
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) return raw
+  return parsed.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export function composeSignalEvidence(
+  metadata: EntitySignalMetadata | null | undefined,
+  entityName?: string
+): string | null {
+  if (!metadata) return null
+  const subject = metadata.signal_subject?.trim()
+  const normalizedEntityName = entityName?.trim().toLowerCase()
+  const normalizedSubject = subject?.toLowerCase()
+  const subjectPart =
+    normalizedEntityName && normalizedSubject === normalizedEntityName ? null : (subject ?? null)
+
+  const parts = [
+    metadata.signal_source_label,
+    subjectPart,
+    metadata.signal_location,
+    formatSignalDate(metadata.signal_date),
+  ].filter((part): part is string => !!part)
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
+export function resolveActorRole(metadata: EntitySignalMetadata | null | undefined): {
+  role: ActorRole
+  confidence: ActorRoleConfidence
+} {
+  return {
+    role: metadata?.actor_role ?? 'unknown',
+    confidence: metadata?.actor_role_confidence ?? 'low',
+  }
+}
+
+function composeStructuralFlags(
+  entity: Entity,
+  metadata: EntitySignalMetadata | null | undefined
+): string[] {
+  const flags = new Set<string>()
+  const address = metadata?.signal_address ?? ''
+  if (/\b(ste|suite|unit)\b/i.test(address)) {
+    flags.add('Single-tenant suite')
+  }
+
+  const geographyText = [address, metadata?.signal_location, entity.area].filter(Boolean).join(' ')
+  if (/\b(arizona|az)\b/i.test(geographyText)) {
+    flags.add('Arizona')
+  }
+
+  return [...flags]
+}
+
+function firstSentence(text: string | null | undefined): string | null {
+  if (!text) return null
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^##\s+/.test(line))
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/^[-*]\s+/, '')
+    const match = line.match(/.+?[.!?](?=\s|$)/)
+    if (match) return match[0].trim()
+    if (line.length > 0) return line
+  }
+
+  return null
+}
+
+function firstParagraphFromBrief(content: string | null | undefined): string | null {
+  if (!content) return null
+
+  const lines = content.split('\n')
+  const paragraph: string[] = []
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) {
+      if (paragraph.length > 0) break
+      continue
+    }
+    if (/^##\s+(Engagement Hypotheses|Outreach Hooks)\b/i.test(line)) break
+    if (/^##\s+/.test(line)) continue
+    if (/^[-*]\s+/.test(line)) {
+      if (paragraph.length > 0) break
+      continue
+    }
+    paragraph.push(line)
+  }
+
+  const value = paragraph.join(' ').trim()
+  return value || null
+}
+
+export function composeEnrichmentSummary(
+  reviewSynthEntry: ContextEntry | undefined,
+  deepWebsiteEntry: ContextEntry | undefined,
+  intelligenceBriefEntry: ContextEntry | undefined
+): string | null {
+  return (
+    firstSentence(reviewSynthEntry?.content) ??
+    firstSentence(deepWebsiteEntry?.content) ??
+    firstParagraphFromBrief(intelligenceBriefEntry?.content)
+  )
+}
+
+function buildWebsiteMissingReason(
+  entity: Entity,
+  enrichmentRuns: Map<string, EnrichmentRun>
+): string {
+  const reasons: string[] = []
+  const placesReason = enrichmentRuns.get('google_places')?.reason
+  if (placesReason) reasons.push(`Google Places ${placesReason}`)
+
+  const outscraperReason = enrichmentRuns.get('outscraper')?.reason
+  if (!placesReason && outscraperReason === 'no_match') {
+    reasons.push('Outscraper no_match')
+  }
+
+  if (entity.source_pipeline === 'new_business') {
+    reasons.push('license filing did not include URL')
+  }
+
+  if (reasons.length === 0) return 'not resolved.'
+  return `not resolved (${reasons.join('; ')})`
+}
+
+export function composeMissingForOutreach(
+  entity: Entity,
+  contextEntries: ContextEntry[],
+  contacts: Contact[],
+  enrichmentRuns: Map<string, EnrichmentRun>
+): MissingForOutreachItem[] {
+  const missing: MissingForOutreachItem[] = []
+  const hasEmailContact = contacts.some((contact) => !!contact.email?.trim())
+  if (!hasEmailContact) {
+    missing.push({
+      key: 'contact',
+      label: 'Contact email',
+      reason: 'none on file. Promote will trigger contact discovery.',
+    })
+  }
+
+  if (!entity.website?.trim()) {
+    missing.push({
+      key: 'website',
+      label: 'Website',
+      reason: buildWebsiteMissingReason(entity, enrichmentRuns),
+    })
+  }
+
+  const hasPublicWebSignal = contextEntries.some(
+    (entry) => entry.source === 'review_analysis' || entry.source === 'job_monitor'
+  )
+  if (!hasPublicWebSignal) {
+    const reviewReason = enrichmentRuns.get('review_analysis')?.reason
+    missing.push({
+      key: 'public-web-signal',
+      label: 'Public-web signal',
+      reason:
+        entity.source_pipeline === 'new_business'
+          ? 'too new for reviews or job posts. License-only enrichment.'
+          : reviewReason
+            ? `no public review or job-post signal yet (${reviewReason}).`
+            : 'no public review or job-post signal yet.',
+    })
+  }
+
+  return missing
+}
+
+export function detectStaleDraft(outreachEntry: ContextEntry | undefined): {
+  isStale: boolean
+  reason: string | null
+} {
+  if (!outreachEntry) return { isStale: false, reason: null }
+
+  const reasons: string[] = []
+  if (new Date(outreachEntry.created_at).getTime() < Date.parse(ADR_0003_DEPLOY_DATE)) {
+    reasons.push(`Generated ${formatDate(outreachEntry.created_at)} - pre-statewide pivot`)
+  }
+
+  const phoenixPhrase = outreachEntry.content.match(/Phoenix\s+(area|metro)/i)?.[0]
+  if (phoenixPhrase) {
+    reasons.push(`References "${phoenixPhrase}"`)
+  }
+
+  return {
+    isStale: reasons.length > 0,
+    reason: reasons.length > 0 ? `${reasons.join('. ')}.` : null,
+  }
+}
+
+export function composeDeduplicatedTimeline(contextEntries: ContextEntry[]): ContextEntry[] {
+  const out: ContextEntry[] = []
+  const latestBySource = new Set<string>()
+
+  for (const entry of [...contextEntries].reverse()) {
+    if (entry.type === 'outreach_draft') continue
+    if (entry.source === 'intelligence_brief') continue
+    if (entry.source === 'review_synthesis' || entry.source === 'review_analysis') {
+      if (latestBySource.has(entry.source)) continue
+      latestBySource.add(entry.source)
+    }
+    out.push(entry)
+  }
+
+  return out
+}
+
+export function buildDecisionEvidence(args: {
+  entity: Entity
+  signalMetadata: EntitySignalMetadata | null
+  contextEntries: ContextEntry[]
+  contacts: Contact[]
+  reviewSynthEntry: ContextEntry | undefined
+  deepWebsiteEntry: ContextEntry | undefined
+  intelligenceBriefEntry: ContextEntry | undefined
+  outreachEntry: ContextEntry | undefined
+  enrichmentRuns: Map<string, EnrichmentRun>
+}): DecisionEvidence {
+  const actorRole = resolveActorRole(args.signalMetadata)
+  return {
+    actorRole: actorRole.role,
+    actorRoleConfidence: actorRole.confidence,
+    signalEvidence: composeSignalEvidence(args.signalMetadata, args.entity.name),
+    enrichmentSummary: composeEnrichmentSummary(
+      args.reviewSynthEntry,
+      args.deepWebsiteEntry,
+      args.intelligenceBriefEntry
+    ),
+    structuralFlags: composeStructuralFlags(args.entity, args.signalMetadata),
+    missingForOutreach: composeMissingForOutreach(
+      args.entity,
+      args.contextEntries,
+      args.contacts,
+      args.enrichmentRuns
+    ),
+    staleDraftWarning: detectStaleDraft(args.outreachEntry),
+  }
+}

--- a/src/lib/admin/entity-detail-page.ts
+++ b/src/lib/admin/entity-detail-page.ts
@@ -1,12 +1,29 @@
 import { hasOpenQuoteForEntity, listQuotes } from '../db/quotes'
-import { getEntity } from '../db/entities'
+import { getEntity, getSignalMetadataForEntities, type EntitySignalMetadata } from '../db/entities'
 import type { EntityStage } from '../db/entities'
 import { listContext } from '../db/context'
 import { listContacts } from '../db/contacts'
 import { listMeetings } from '../db/meetings'
 import { listEngagements } from '../db/engagements'
 import { listInvoices } from '../db/invoices'
+import { latestRunByModule } from '../db/enrichment-runs'
+import type { EnrichmentRun } from '../db/enrichment-runs'
+import { getCandidateMergesForEntity } from '../db/candidate-merge-log'
+import type { CandidateMergeRow } from '../db/candidate-merge-log'
 import { findDraftableMeeting } from '../../lib/entities/draftable-meeting'
+import {
+  buildDecisionEvidence,
+  composeDeduplicatedTimeline,
+  type DecisionEvidence,
+} from './entity-detail-decision-evidence'
+export {
+  ADR_0003_DEPLOY_DATE,
+  composeDeduplicatedTimeline,
+  composeEnrichmentSummary,
+  composeMissingForOutreach,
+  detectStaleDraft,
+  resolveActorRole,
+} from './entity-detail-decision-evidence'
 
 type Database = Parameters<typeof getEntity>[0]
 type EntityRecord = Exclude<Awaited<ReturnType<typeof getEntity>>, null>
@@ -163,6 +180,7 @@ type Quote = Awaited<ReturnType<typeof listQuotes>>[number]
 
 export interface EntityDetailPageResult {
   entity: EntityRecord
+  signalMetadata: EntitySignalMetadata | null
   contextEntries: ContextEntry[]
   contacts: Contact[]
   meetings: Awaited<ReturnType<typeof listMeetings>>
@@ -172,6 +190,7 @@ export interface EntityDetailPageResult {
   mostRecentDraftableMeeting: ReturnType<typeof findDraftableMeeting>
   hasOutreach: boolean
   filteredEntries: ContextEntry[]
+  deduplicatedTimeline: ContextEntry[]
   typeFilter: string
   typeCounts: Record<string, number>
   currentLostReason: { code: string; detail: string | null } | null
@@ -188,6 +207,8 @@ export interface EntityDetailPageResult {
   showNewQuoteButton: boolean
   supersedeCandidates: Quote[]
   transitions: EntityDetailTransition[]
+  decisionEvidence: DecisionEvidence
+  mergeCandidates: CandidateMergeRow[]
   dossierBrief: ContextEntry | undefined
   outreachEntry: ContextEntry | undefined
   outreachContact: Contact | null
@@ -297,6 +318,7 @@ function resolveContextDerivedFields(
   typeFilter: string
 ): {
   filteredEntries: ContextEntry[]
+  deduplicatedTimeline: ContextEntry[]
   typeCounts: Record<string, number>
   dossierBrief: ContextEntry | undefined
   outreachEntry: ContextEntry | undefined
@@ -305,14 +327,15 @@ function resolveContextDerivedFields(
   competitorEntry: ContextEntry | undefined
   lastEnrichmentAt: string | null
 } {
-  const timelineEntries = [...contextEntries].reverse()
+  const deduplicatedTimeline = composeDeduplicatedTimeline(contextEntries)
   const filteredEntries = typeFilter
-    ? timelineEntries.filter((e) => e.type === typeFilter)
-    : timelineEntries
+    ? deduplicatedTimeline.filter((e) => e.type === typeFilter)
+    : deduplicatedTimeline
   const typeCounts: Record<string, number> = {}
   for (const entry of contextEntries) typeCounts[entry.type] = (typeCounts[entry.type] ?? 0) + 1
   return {
     filteredEntries,
+    deduplicatedTimeline,
     typeCounts,
     dossierBrief: contextEntries.filter((e) => e.source === 'intelligence_brief').pop(),
     outreachEntry: contextEntries.filter((e) => e.type === 'outreach_draft').pop(),
@@ -328,6 +351,111 @@ function resolveContextDerivedFields(
   }
 }
 
+async function loadEntityDetailDependencies(
+  params: Parameters<typeof loadEntityDetailPage>[0]
+): Promise<{
+  contextEntries: ContextEntry[]
+  contacts: Contact[]
+  meetings: Awaited<ReturnType<typeof listMeetings>>
+  engagements: Awaited<ReturnType<typeof listEngagements>>
+  quotes: Quote[]
+  invoices: Awaited<ReturnType<typeof listInvoices>>
+  signalMetadata: EntitySignalMetadata | null
+  enrichmentRuns: Map<EnrichmentRun['module'], EnrichmentRun>
+  mergeCandidates: CandidateMergeRow[]
+}> {
+  const [
+    contextEntries,
+    contacts,
+    meetings,
+    engagements,
+    quotes,
+    invoices,
+    signalMetadataMap,
+    enrichmentRuns,
+    mergeCandidates,
+  ] = await Promise.all([
+    listContext(params.db, params.entityId),
+    listContacts(params.db, params.orgId, params.entityId),
+    listMeetings(params.db, params.orgId, params.entityId),
+    listEngagements(params.db, params.orgId, params.entityId),
+    listQuotes(params.db, params.orgId, params.entityId),
+    listInvoices(params.db, params.orgId, { entityId: params.entityId }),
+    getSignalMetadataForEntities(params.db, params.orgId, [params.entityId]),
+    latestRunByModule(params.db, params.entityId),
+    getCandidateMergesForEntity(params.db, params.orgId, params.entityId),
+  ])
+
+  return {
+    contextEntries,
+    contacts,
+    meetings,
+    engagements,
+    quotes,
+    invoices,
+    signalMetadata: signalMetadataMap.get(params.entityId) ?? null,
+    enrichmentRuns,
+    mergeCandidates,
+  }
+}
+
+interface DetailPresentationState {
+  currentLostReason: EntityDetailPageResult['currentLostReason']
+  outreachContact: Contact | null
+  outreachMailto: string | null
+  outreachFromDossier: unknown
+  showReEnrichButton: boolean
+  reviewMeta: EntityDetailPageResult['reviewMeta']
+  websiteMeta: EntityDetailPageResult['websiteMeta']
+  competitorMeta: EntityDetailPageResult['competitorMeta']
+  transitions: EntityDetailTransition[]
+}
+
+function resolveDetailPresentationState(args: {
+  entity: EntityRecord
+  contextEntries: ContextEntry[]
+  contacts: Contact[]
+  outreachEntry: ContextEntry | undefined
+  reviewSynthEntry: ContextEntry | undefined
+  deepWebsiteEntry: ContextEntry | undefined
+  competitorEntry: ContextEntry | undefined
+}): DetailPresentationState {
+  const currentLostReason = resolveLostReason(args.entity, args.contextEntries)
+  const outreachMeta = parseMetadata(args.outreachEntry?.metadata ?? null)
+  const outreachContact = args.contacts.find((c) => c.email && c.email.trim().length > 0) ?? null
+  const outreachMailto = resolveOutreachMailto(
+    args.outreachEntry,
+    outreachContact,
+    args.entity.name
+  )
+  const showReEnrichButton = RE_ENRICH_STAGES.includes(args.entity.stage)
+  const reviewMeta = parseMetadata(
+    args.reviewSynthEntry?.metadata ?? null
+  ) as EntityDetailPageResult['reviewMeta']
+  const websiteMeta = parseMetadata(
+    args.deepWebsiteEntry?.metadata ?? null
+  ) as EntityDetailPageResult['websiteMeta']
+  const competitorMeta = parseMetadata(
+    args.competitorEntry?.metadata ?? null
+  ) as EntityDetailPageResult['competitorMeta']
+  const transitions = ENTITY_DETAIL_TRANSITIONS[args.entity.stage].map((t) => ({
+    ...t,
+    action: t.action ?? `/api/admin/entities/${args.entity.id}/stage`,
+  }))
+
+  return {
+    currentLostReason,
+    outreachContact,
+    outreachMailto,
+    outreachFromDossier: outreachMeta?.trigger === 'dossier',
+    showReEnrichButton,
+    reviewMeta,
+    websiteMeta,
+    competitorMeta,
+    transitions,
+  }
+}
+
 export async function loadEntityDetailPage(params: {
   db: Database
   orgId: string
@@ -336,69 +464,63 @@ export async function loadEntityDetailPage(params: {
 }): Promise<EntityDetailPageResult> {
   const entity = await getEntity(params.db, params.orgId, params.entityId)
   if (!entity) return null as never
-
-  const [contextEntries, contacts, meetings, engagements, quotes, invoices] = await Promise.all([
-    listContext(params.db, params.entityId),
-    listContacts(params.db, params.orgId, params.entityId),
-    listMeetings(params.db, params.orgId, params.entityId),
-    listEngagements(params.db, params.orgId, params.entityId),
-    listQuotes(params.db, params.orgId, params.entityId),
-    listInvoices(params.db, params.orgId, { entityId: params.entityId }),
-  ])
-
+  const data = await loadEntityDetailDependencies(params)
   const urlParams = extractUrlParams(params.url)
-  const ctx = resolveContextDerivedFields(contextEntries, urlParams.typeFilter)
-
-  const currentLostReason = resolveLostReason(entity, contextEntries)
-  const outreachMeta = parseMetadata(ctx.outreachEntry?.metadata ?? null)
-  const outreachContact = contacts.find((c) => c.email && c.email.trim().length > 0) ?? null
-  const outreachMailto = resolveOutreachMailto(ctx.outreachEntry, outreachContact, entity.name)
-
+  const ctx = resolveContextDerivedFields(data.contextEntries, urlParams.typeFilter)
+  const decisionEvidence: DecisionEvidence = buildDecisionEvidence({
+    entity,
+    signalMetadata: data.signalMetadata,
+    contextEntries: data.contextEntries,
+    contacts: data.contacts,
+    reviewSynthEntry: ctx.reviewSynthEntry,
+    deepWebsiteEntry: ctx.deepWebsiteEntry,
+    intelligenceBriefEntry: ctx.dossierBrief,
+    outreachEntry: ctx.outreachEntry,
+    enrichmentRuns: data.enrichmentRuns,
+  })
+  const detailState = resolveDetailPresentationState({
+    entity,
+    contextEntries: data.contextEntries,
+    contacts: data.contacts,
+    outreachEntry: ctx.outreachEntry,
+    reviewSynthEntry: ctx.reviewSynthEntry,
+    deepWebsiteEntry: ctx.deepWebsiteEntry,
+    competitorEntry: ctx.competitorEntry,
+  })
   const hasOpenQuote = await hasOpenQuoteForEntity(params.db, params.orgId, params.entityId)
-  const quoteFlags = resolveQuoteFlags(entity, quotes, meetings, hasOpenQuote)
-  const showReEnrichButton = RE_ENRICH_STAGES.includes(entity.stage)
-  const reviewMeta = parseMetadata(
-    ctx.reviewSynthEntry?.metadata ?? null
-  ) as EntityDetailPageResult['reviewMeta']
-  const websiteMeta = parseMetadata(
-    ctx.deepWebsiteEntry?.metadata ?? null
-  ) as EntityDetailPageResult['websiteMeta']
-  const competitorMeta = parseMetadata(
-    ctx.competitorEntry?.metadata ?? null
-  ) as EntityDetailPageResult['competitorMeta']
-  const transitions = ENTITY_DETAIL_TRANSITIONS[entity.stage].map((t) => ({
-    ...t,
-    action: t.action ?? `/api/admin/entities/${entity.id}/stage`,
-  }))
-
+  const quoteFlags = resolveQuoteFlags(entity, data.quotes, data.meetings, hasOpenQuote)
   return {
     entity,
-    contextEntries,
-    contacts,
-    meetings,
-    engagements,
-    quotes,
-    invoices,
-    mostRecentDraftableMeeting: findDraftableMeeting(meetings, quotes),
-    hasOutreach: contextEntries.some((e) => e.type === 'outreach_draft'),
+    signalMetadata: data.signalMetadata,
+    contextEntries: data.contextEntries,
+    contacts: data.contacts,
+    meetings: data.meetings,
+    engagements: data.engagements,
+    quotes: data.quotes,
+    invoices: data.invoices,
+    mostRecentDraftableMeeting: findDraftableMeeting(data.meetings, data.quotes),
+    hasOutreach: data.contextEntries.some((e) => e.type === 'outreach_draft'),
     filteredEntries: ctx.filteredEntries,
+    deduplicatedTimeline: ctx.deduplicatedTimeline,
     typeCounts: ctx.typeCounts,
-    currentLostReason,
+    currentLostReason: detailState.currentLostReason,
     ...urlParams,
-    showReEnrichButton,
+    showReEnrichButton: detailState.showReEnrichButton,
     showNewQuoteButton: quoteFlags.showNewQuoteButton,
     supersedeCandidates: quoteFlags.supersedeCandidates,
-    transitions,
+    transitions: detailState.transitions,
+    decisionEvidence,
+    mergeCandidates: data.mergeCandidates,
     dossierBrief: ctx.dossierBrief,
     outreachEntry: ctx.outreachEntry,
-    outreachContact,
-    outreachMailto,
-    outreachFromDossier: outreachMeta?.trigger === 'dossier',
+    outreachContact: detailState.outreachContact,
+    outreachMailto: detailState.outreachMailto,
+    outreachFromDossier: detailState.outreachFromDossier,
     hasDossier: !!ctx.dossierBrief,
     lastEnrichmentAt: ctx.lastEnrichmentAt,
     latestSentQuoteAt: quoteFlags.latestSentQuoteAt,
-    reviewMeta,
-    websiteMeta,
-    competitorMeta,
+    reviewMeta: detailState.reviewMeta,
+    websiteMeta: detailState.websiteMeta,
+    competitorMeta: detailState.competitorMeta,
   }
 }

--- a/src/lib/admin/entity-detail-page.ts
+++ b/src/lib/admin/entity-detail-page.ts
@@ -187,6 +187,7 @@ export interface EntityDetailPageResult {
   engagements: Awaited<ReturnType<typeof listEngagements>>
   quotes: Quote[]
   invoices: Awaited<ReturnType<typeof listInvoices>>
+  enrichmentRuns: Map<EnrichmentRun['module'], EnrichmentRun>
   mostRecentDraftableMeeting: ReturnType<typeof findDraftableMeeting>
   hasOutreach: boolean
   filteredEntries: ContextEntry[]
@@ -498,6 +499,7 @@ export async function loadEntityDetailPage(params: {
     engagements: data.engagements,
     quotes: data.quotes,
     invoices: data.invoices,
+    enrichmentRuns: data.enrichmentRuns,
     mostRecentDraftableMeeting: findDraftableMeeting(data.meetings, data.quotes),
     hasOutreach: data.contextEntries.some((e) => e.type === 'outreach_draft'),
     filteredEntries: ctx.filteredEntries,

--- a/src/lib/db/candidate-merge-log.ts
+++ b/src/lib/db/candidate-merge-log.ts
@@ -14,6 +14,17 @@ export interface CandidateMergeLogData {
   metadata?: Record<string, unknown> | null
 }
 
+export interface CandidateMergeRow {
+  id: string
+  targetId: string | null
+  candidateName: string
+  candidateAddress: string | null
+  score: number | null
+  reason: string
+  sourcePipeline: string | null
+  createdAt: string
+}
+
 export async function appendCandidateMergeLog(
   db: D1Database,
   orgId: string,
@@ -47,4 +58,32 @@ export async function appendCandidateMergeLog(
       new Date().toISOString()
     )
     .run()
+}
+
+export async function getCandidateMergesForEntity(
+  db: D1Database,
+  orgId: string,
+  entityId: string
+): Promise<CandidateMergeRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT
+         id,
+         existing_entity_id AS targetId,
+         candidate_name AS candidateName,
+         candidate_address AS candidateAddress,
+         score,
+         reason,
+         source_pipeline AS sourcePipeline,
+         created_at AS createdAt
+       FROM candidate_merge_log
+       WHERE org_id = ?
+         AND existing_entity_id = ?
+         AND review_status = 'pending'
+       ORDER BY score DESC, created_at DESC`
+    )
+    .bind(orgId, entityId)
+    .all<CandidateMergeRow>()
+
+  return rows.results
 }

--- a/src/lib/db/candidate-merge-log.ts
+++ b/src/lib/db/candidate-merge-log.ts
@@ -68,19 +68,36 @@ export async function getCandidateMergesForEntity(
   const rows = await db
     .prepare(
       `SELECT
-         id,
-         existing_entity_id AS targetId,
-         candidate_name AS candidateName,
-         candidate_address AS candidateAddress,
-         score,
-         reason,
-         source_pipeline AS sourcePipeline,
-         created_at AS createdAt
-       FROM candidate_merge_log
-       WHERE org_id = ?
-         AND existing_entity_id = ?
+         cml.id,
+         (
+           SELECT e.id
+           FROM entities e
+           WHERE e.org_id = cml.org_id
+             AND e.id != cml.existing_entity_id
+             AND (
+               (cml.candidate_slug IS NOT NULL AND e.slug = cml.candidate_slug)
+               OR (
+                 e.name = cml.candidate_name
+                 AND (
+                   cml.candidate_area IS NULL
+                   OR e.area = cml.candidate_area
+                 )
+               )
+             )
+           ORDER BY e.updated_at DESC
+           LIMIT 1
+         ) AS targetId,
+         cml.candidate_name AS candidateName,
+         COALESCE(cml.candidate_address, cml.candidate_area) AS candidateAddress,
+         cml.score,
+         cml.reason,
+         cml.source_pipeline AS sourcePipeline,
+         cml.created_at AS createdAt
+       FROM candidate_merge_log cml
+       WHERE cml.org_id = ?
+         AND cml.existing_entity_id = ?
          AND review_status = 'pending'
-       ORDER BY score DESC, created_at DESC`
+       ORDER BY cml.score DESC, cml.created_at DESC`
     )
     .bind(orgId, entityId)
     .all<CandidateMergeRow>()

--- a/src/lib/db/entity-signal-metadata.ts
+++ b/src/lib/db/entity-signal-metadata.ts
@@ -9,13 +9,39 @@ export interface EntitySignalMetadata {
   signal_subject: string | null
   signal_location: string | null
   signal_date: string | null
+  signal_address: string | null
+  actor_role: 'business' | 'contractor' | 'unknown' | null
+  actor_role_confidence: 'high' | 'medium' | 'low' | null
   enrichment_summary: string | null
   last_activity_at: string | null
 }
 
+type ActorRole = NonNullable<EntitySignalMetadata['actor_role']>
+type ActorRoleConfidence = NonNullable<EntitySignalMetadata['actor_role_confidence']>
+
 function parseStringMeta(meta: Record<string, unknown>, key: string): string | null {
   const value = meta[key]
   return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function parseActorRole(meta: Record<string, unknown>): ActorRole | null {
+  const value = meta.actor_role
+  return value === 'business' || value === 'contractor' || value === 'unknown' ? value : null
+}
+
+function defaultActorRoleConfidence(role: ActorRole | null): ActorRoleConfidence | null {
+  if (role === 'business' || role === 'contractor') return 'high'
+  if (role === 'unknown') return 'low'
+  return null
+}
+
+function parseActorRoleConfidence(
+  meta: Record<string, unknown>,
+  role: ActorRole | null
+): ActorRoleConfidence | null {
+  const value = meta.actor_role_confidence
+  if (value === 'high' || value === 'medium' || value === 'low') return value
+  return defaultActorRoleConfidence(role)
 }
 
 function parseSignalMetadataRow(row: {
@@ -27,6 +53,9 @@ function parseSignalMetadataRow(row: {
   let signalSubject: string | null = null
   let signalLocation: string | null = null
   let signalDate: string | null = null
+  let signalAddress: string | null = null
+  let actorRole: ActorRole | null = null
+  let actorRoleConfidence: ActorRoleConfidence | null = null
   if (row.metadata) {
     try {
       const meta = JSON.parse(row.metadata) as Record<string, unknown>
@@ -40,6 +69,9 @@ function parseSignalMetadataRow(row: {
       signalSubject = parseStringMeta(meta, 'signal_subject')
       signalLocation = parseStringMeta(meta, 'signal_location')
       signalDate = parseStringMeta(meta, 'signal_date') ?? parseStringMeta(meta, 'date_found')
+      signalAddress = parseStringMeta(meta, 'signal_address')
+      actorRole = parseActorRole(meta)
+      actorRoleConfidence = parseActorRoleConfidence(meta, actorRole)
     } catch {
       // Malformed JSON - treat as missing metadata.
     }
@@ -51,6 +83,9 @@ function parseSignalMetadataRow(row: {
     signal_subject: signalSubject,
     signal_location: signalLocation,
     signal_date: signalDate,
+    signal_address: signalAddress,
+    actor_role: actorRole,
+    actor_role_confidence: actorRoleConfidence,
     enrichment_summary: null,
     last_activity_at: null,
   }
@@ -80,6 +115,9 @@ function buildEmptyMetadata(entityId: string): EntitySignalMetadata {
     signal_subject: null,
     signal_location: null,
     signal_date: null,
+    signal_address: null,
+    actor_role: null,
+    actor_role_confidence: null,
     enrichment_summary: null,
     last_activity_at: null,
   }

--- a/src/lib/db/lost-reasons.ts
+++ b/src/lib/db/lost-reasons.ts
@@ -23,6 +23,11 @@
  */
 
 export type LostReasonCode =
+  | 'wrong-actor'
+  | 'out-of-buy-box'
+  | 'out-of-geography'
+  | 'no-signal'
+  | 'duplicate'
   | 'not-a-fit'
   | 'no-budget'
   | 'no-response'
@@ -39,6 +44,32 @@ export interface LostReasonDef {
 }
 
 export const LOST_REASONS: LostReasonDef[] = [
+  {
+    value: 'wrong-actor',
+    label: 'Wrong actor',
+    description: 'Contractor, vendor, or staffing intermediary - not the operating business.',
+  },
+  {
+    value: 'out-of-buy-box',
+    label: 'Outside buy box',
+    description:
+      'Structurally outside fit - chain, enterprise, government, non-profit, or holding LLC.',
+  },
+  {
+    value: 'out-of-geography',
+    label: 'Outside Arizona',
+    description: 'Not an Arizona business.',
+  },
+  {
+    value: 'no-signal',
+    label: 'Insufficient signal',
+    description: 'Not enough evidence to qualify credibly.',
+  },
+  {
+    value: 'duplicate',
+    label: 'Duplicate',
+    description: 'Duplicate of another tracked entity.',
+  },
   {
     value: 'not-a-fit',
     label: 'Not a fit',

--- a/src/pages/admin/entities/[id].astro
+++ b/src/pages/admin/entities/[id].astro
@@ -1,29 +1,23 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro'
 import AdminFlashNotice from '../../../components/admin/AdminFlashNotice.astro'
-import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
-import EnrichmentStatusPanel from '../../../components/admin/EnrichmentStatusPanel.astro'
-import EntityTimelineEntry from '../../../components/admin/EntityTimelineEntry.astro'
-import EntitySendBookingDialog from '../../../components/admin/EntitySendBookingDialog.astro'
-import EntityStageActions from '../../../components/admin/EntityStageActions.astro'
-import EntityDossierSummary from '../../../components/admin/EntityDossierSummary.astro'
 import EntityContactsPanel from '../../../components/admin/EntityContactsPanel.astro'
+import EntityDecisionRail from '../../../components/admin/EntityDecisionRail.astro'
+import EntityDiagnosticsDrawer from '../../../components/admin/EntityDiagnosticsDrawer.astro'
+import EntityEnrichmentSummary from '../../../components/admin/EntityEnrichmentSummary.astro'
+import EntityIdentityStrip from '../../../components/admin/EntityIdentityStrip.astro'
+import EntityMissingPanel from '../../../components/admin/EntityMissingPanel.astro'
+import EntityPainObservations from '../../../components/admin/EntityPainObservations.astro'
+import EntitySendBookingDialog from '../../../components/admin/EntitySendBookingDialog.astro'
+import EntityTimelineEntry from '../../../components/admin/EntityTimelineEntry.astro'
+import LogReplyDialog from '../../../components/admin/LogReplyDialog.astro'
 import { statusBadgeClass } from '../../../lib/ui/status-badge'
-import { pipelineBadgeClass } from '../../../lib/ui/pipeline-badge'
-import { adminActionButtonClass } from '../../../lib/ui/admin-action-button'
-import { relativeTime } from '../../../lib/admin/relative-time'
+import { ENTITY_STAGES, type EntityStage } from '../../../lib/db/entities'
 import {
-  contextTypeBadge,
   formatDate,
-  isOverdue,
   loadEntityDetailPage,
+  parseMetadata,
 } from '../../../lib/admin/entity-detail-page'
-import { PIPELINE_LABELS } from '../../../lead-gen/schemas/lead-scoring-schema'
-import type { PipelineId } from '../../../lead-gen/schemas/lead-scoring-schema'
-import { ENTITY_STAGES } from '../../../lib/db/entities'
-import { lostReasonLabel, lostReasonChipClass } from '../../../lib/db/lost-reasons'
-import { CONTEXT_TYPES } from '../../../lib/db/context'
-import type { ContextEntry } from '../../../lib/db/context'
 import { env } from 'cloudflare:workers'
 
 const session = Astro.locals.session!
@@ -38,18 +32,16 @@ if (!pageData) return Astro.redirect('/admin/entities?error=not_found')
 
 const {
   entity,
+  signalMetadata,
   contextEntries,
   contacts,
   meetings,
   engagements,
   quotes,
   invoices,
+  enrichmentRuns,
   mostRecentDraftableMeeting,
-  hasOutreach,
-  filteredEntries,
-  typeFilter,
-  typeCounts,
-  currentLostReason,
+  deduplicatedTimeline,
   promoted,
   noteAdded,
   replyLogged,
@@ -63,187 +55,259 @@ const {
   showNewQuoteButton,
   supersedeCandidates,
   transitions,
+  decisionEvidence,
+  mergeCandidates,
   dossierBrief,
   outreachEntry,
   outreachContact,
   outreachMailto,
-  outreachFromDossier,
-  hasDossier,
+  hasOutreach,
   lastEnrichmentAt,
-  latestSentQuoteAt,
   reviewMeta,
-  websiteMeta,
-  competitorMeta,
 } = pageData
+
+const merged = Astro.url.searchParams.get('merged')
+const draftDiscarded = Astro.url.searchParams.get('draft_discarded')
+
+const signalSourceLabel =
+  signalMetadata?.signal_source_label ?? entity.source_pipeline ?? 'unknown_source'
+const signalAddress =
+  signalMetadata?.signal_address ?? signalMetadata?.signal_location ?? entity.area ?? null
+const signalDate = signalMetadata?.signal_date ?? entity.created_at
+const stageAnchorDate = entity.stage_changed_at ?? entity.created_at
+const stageAgeMs = Date.now() - new Date(stageAnchorDate).getTime()
+const daysInStage = Math.max(0, Math.floor(stageAgeMs / (24 * 60 * 60 * 1000)))
+const stageLabel =
+  ENTITY_STAGES.find((stage) => stage.value === entity.stage)?.label ?? entity.stage
+
+const reviewSynthesisEntry = [...contextEntries]
+  .reverse()
+  .find((entry) => entry.source === 'review_synthesis')
+const deepWebsiteEntry = [...contextEntries]
+  .reverse()
+  .find((entry) => entry.source === 'deep_website')
+const summaryGeneratedAt =
+  reviewSynthesisEntry?.created_at ??
+  deepWebsiteEntry?.created_at ??
+  dossierBrief?.created_at ??
+  null
+const summarySource =
+  reviewSynthesisEntry?.source ?? deepWebsiteEntry?.source ?? dossierBrief?.source ?? null
+
+const latestJobSignalEntry =
+  [...contextEntries]
+    .reverse()
+    .find((entry) => entry.type === 'signal' && entry.source === 'job_monitor') ?? undefined
+const jobSignalMeta = parseMetadata(latestJobSignalEntry?.metadata ?? null) as {
+  top_problems?: string[]
+  evidence?: string
+} | null
+
+const mobileDraftWarning = decisionEvidence.staleDraftWarning.isStale
+
+function emptyCountLabel(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+function renderCollapsedSectionTitle(stage: EntityStage, count: number): string {
+  const base = ENTITY_STAGES.find((item) => item.value === stage)?.label ?? stage
+  return `${base} (${count})`
+}
 ---
 
 <AdminLayout
-  title={`${entity.name} — SMD Services`}
+  title={`${entity.name} | SMD Services`}
   breadcrumbs={[
     { label: 'Dashboard', href: '/admin' },
     { label: 'Entities', href: `/admin/entities?stage=${entity.stage}` },
     { label: entity.name },
   ]}
+  mainClass="pb-20 lg:pb-8"
+  maxWidth="max-w-6xl"
 >
-  {
-    /* H19 — back-link to the stage list. Breadcrumbs cover this in
-      principle but reduce to a small text trail; an inline back link
-      gives the operator a one-click escape hatch from a deep detail
-      page back to the work queue they came from. */
-  }
-  <a
-    href={`/admin/entities?stage=${entity.stage}`}
-    class="inline-flex items-center gap-1 text-xs text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-primary)] mb-3"
-  >
-    <span aria-hidden="true">←</span>
-    <span>
-      Back to {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage} list
-    </span>
-  </a>
   {promoted && <AdminFlashNotice message={`${entity.name} promoted to prospect.`} />}
   {noteAdded && <AdminFlashNotice message={`Note added to ${entity.name}.`} />}
   {replyLogged && <AdminFlashNotice message={`Reply logged on ${entity.name}.`} />}
-  {
-    stageUpdated && (
-      <AdminFlashNotice
-        message={`${entity.name} moved to ${ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}.`}
-      />
-    )
-  }
+  {stageUpdated && <AdminFlashNotice message={`${entity.name} moved to ${stageLabel}.`} />}
+  {merged && <AdminFlashNotice message="Entity merge completed." />}
+  {draftDiscarded && <AdminFlashNotice message="Stale outreach draft discarded." />}
   {
     dossierGenerated === 'queued' && (
       <AdminFlashNotice
         kind="warning"
-        message={`Re-enrichment queued for ${entity.name}. The pipeline runs in the background. Refresh in about 30 seconds to see updated reviews, synthesis, news, and outreach draft.`}
+        message={`Re-enrichment queued for ${entity.name}. Refresh in about 30 seconds for updated signals.`}
       />
     )
   }
-  {
-    dossierGenerated === '1' && (
-      <AdminFlashNotice
-        message={`Re-enriched ${entity.name}. Refreshed reviews, synthesis, news, and outreach draft. See timeline below.`}
-      />
-    )
-  }
+  {dossierGenerated === '1' && <AdminFlashNotice message={`Re-enriched ${entity.name}.`} />}
   {contactAdded && <AdminFlashNotice message="Contact added." />}
   {contactUpdated && <AdminFlashNotice message="Contact updated." />}
   {contactDeleted && <AdminFlashNotice message="Contact deleted." />}
   {error && <AdminFlashNotice kind="error" message={decodeURIComponent(error)} />}
 
-  {/* Entity Summary */}
-  <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card mb-6"
+  <a
+    href={`/admin/entities?stage=${entity.stage}`}
+    class="mb-6 inline-flex items-center gap-1 text-sm text-[color:var(--ss-color-text-secondary)] transition-colors hover:text-[color:var(--ss-color-primary)]"
   >
-    <div class="flex items-start justify-between gap-stack">
-      <div>
-        <div class="flex items-center gap-row mb-2">
-          <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
-            {entity.name}
-          </h2>
-          <span class={statusBadgeClass(entity.stage)}>
-            {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage}
-          </span>
-          {
-            currentLostReason && (
-              <span
-                class={`text-xs px-2 py-0.5 rounded ${lostReasonChipClass(currentLostReason.code)}`}
-                title={currentLostReason.detail ?? undefined}
-              >
-                {lostReasonLabel(currentLostReason.code) ?? currentLostReason.code}
-              </span>
-            )
-          }
-          {
-            entity.tier && (
-              <span class="text-xs px-2 py-0.5 rounded bg-border-subtle text-text-secondary">
-                {entity.tier}
-              </span>
-            )
-          }
-        </div>
+    <span>Back to {stageLabel} list</span>
+  </a>
 
-        <div
-          class="flex items-center gap-stack text-sm text-[color:var(--ss-color-text-secondary)] mb-2 flex-wrap"
-        >
-          {entity.vertical && <span class="capitalize">{entity.vertical.replace(/_/g, ' ')}</span>}
-          {entity.area && <span>{entity.area}</span>}
-        </div>
+  <LogReplyDialog entityId={entity.id} entityName={entity.name} />
+  {entity.stage === 'prospect' && <EntitySendBookingDialog entityId={entity.id} />}
 
-        <div class="flex items-center gap-row text-xs text-[color:var(--ss-color-text-muted)]">
-          {
-            entity.source_pipeline && (
-              <span class={pipelineBadgeClass(entity.source_pipeline)}>
-                {PIPELINE_LABELS[entity.source_pipeline as PipelineId] ?? entity.source_pipeline}
-              </span>
-            )
-          }
-          {
-            entity.stage === 'signal' || entity.stage === 'lost' ? (
-              <span>
-                {entity.stage === 'lost'
-                  ? `Lost ${formatDate(entity.stage_changed_at)}`
-                  : `Created ${formatDate(entity.created_at)}`}
-              </span>
-            ) : (
-              <span>
-                {ENTITY_STAGES.find((s) => s.value === entity.stage)?.label ?? entity.stage} since{' '}
-                {formatDate(entity.stage_changed_at)}
-              </span>
-            )
-          }
-          {
-            entity.stage === 'proposing' && latestSentQuoteAt && (
-              <span title={`Quote sent ${formatDate(latestSentQuoteAt)}`}>
-                Quote sent {relativeTime(latestSentQuoteAt)}
-              </span>
-            )
-          }
-          {entity.phone && <span>{entity.phone}</span>}
-          {
-            entity.website && (
-              <a
-                href={
-                  entity.website.startsWith('http') ? entity.website : `https://${entity.website}`
-                }
-                target="_blank"
-                class="text-primary hover:underline"
-              >
-                {entity.website}
-              </a>
-            )
-          }
-        </div>
+  <div data-test="decision-evidence">
+    <div class="lg:grid lg:grid-cols-[1fr_22rem] lg:gap-8">
+      <section class="min-w-0">
+        <EntityIdentityStrip
+          entity={entity}
+          actorRole={decisionEvidence.actorRole}
+          actorRoleConfidence={decisionEvidence.actorRoleConfidence}
+          signalEvidence={decisionEvidence.signalEvidence}
+          signalSourceLabel={signalSourceLabel}
+          daysInStage={daysInStage}
+          structuralFlags={decisionEvidence.structuralFlags}
+        />
 
         {
-          entity.next_action && (
-            <div
-              class={`mt-3 px-3 py-2 rounded text-sm bg-surface border ${
-                isOverdue(entity.next_action_at) ? 'border-error' : 'border-border'
-              }`}
-            >
-              <span
-                class={`font-medium ${
-                  isOverdue(entity.next_action_at) ? 'text-error' : 'text-text-primary'
-                }`}
-              >
-                {isOverdue(entity.next_action_at) ? 'Overdue:' : 'Next:'}
-              </span>
-              <span class={isOverdue(entity.next_action_at) ? 'text-error' : 'text-text-secondary'}>
-                {' '}
-                {entity.next_action}
-                {entity.next_action_at && ` — ${formatDate(entity.next_action_at)}`}
-              </span>
-            </div>
+          mobileDraftWarning && (
+            <section class="border-b border-[color:var(--ss-color-border)] py-8 lg:hidden">
+              <div class="border border-[color:var(--ss-color-warning)] border-l-[3px] px-4 py-4 text-sm leading-6 text-[color:var(--ss-color-text-secondary)]">
+                <strong class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-warning)]">
+                  Draft is stale
+                </strong>
+                <span>
+                  {decisionEvidence.staleDraftWarning.reason} Will be regenerated when you Promote
+                  and validated against Pattern A.
+                </span>
+                <div class="mt-3 flex gap-3">
+                  <a
+                    href="#entity-diagnostics-draft"
+                    class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4"
+                  >
+                    View draft
+                  </a>
+                  <form
+                    method="POST"
+                    action={`/api/admin/entities/${entity.id}/outreach-draft/discard`}
+                  >
+                    <button
+                      type="submit"
+                      class="font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4"
+                    >
+                      Discard now
+                    </button>
+                  </form>
+                </div>
+              </div>
+            </section>
           )
         }
-      </div>
 
-      {/* Stage transition buttons */}
-      <EntityStageActions
+        <EntityMissingPanel items={decisionEvidence.missingForOutreach} />
+
+        <EntityEnrichmentSummary
+          summary={decisionEvidence.enrichmentSummary}
+          summarySource={summarySource}
+          signalSource={signalSourceLabel}
+          signalDate={signalDate}
+          address={signalAddress}
+          vertical={entity.vertical}
+          generatedAt={summaryGeneratedAt}
+        />
+
+        <EntityPainObservations reviewMeta={reviewMeta} jobSignalMeta={jobSignalMeta} />
+
+        <EntityContactsPanel entityId={entity.id} contacts={contacts} />
+
+        <section class="border-b border-[color:var(--ss-color-border)] py-8">
+          <div class="mb-4 flex items-baseline justify-between gap-4">
+            <h2
+              class="font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)]"
+            >
+              Timeline
+            </h2>
+            <span
+              class="font-['JetBrains_Mono'] text-[12px] text-[color:var(--ss-color-text-muted)]"
+            >
+              {emptyCountLabel(deduplicatedTimeline.length, 'event', 'events')} | deduped
+            </span>
+          </div>
+
+          <details class="mb-6">
+            <summary
+              class="cursor-pointer font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] underline underline-offset-4"
+            >
+              + Add note
+            </summary>
+            <div class="mt-4 border border-[color:var(--ss-color-border)] px-5 py-4">
+              <form
+                method="POST"
+                action={`/api/admin/entities/${entity.id}/context`}
+                class="space-y-4"
+              >
+                <input type="hidden" name="type" value="note" />
+                <label class="block">
+                  <span
+                    class="mb-1 block font-['Archivo_Narrow'] text-[12px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]"
+                  >
+                    Note
+                  </span>
+                  <textarea
+                    name="content"
+                    rows="4"
+                    placeholder="Add a note..."
+                    class="w-full border border-[color:var(--ss-color-border)] bg-[color:var(--ss-color-background)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)]"
+                  ></textarea>
+                </label>
+                <div class="flex justify-end gap-3">
+                  <button
+                    type="reset"
+                    class="border border-[color:var(--ss-color-text-primary)] px-4 py-2 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-primary)] transition-colors hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]"
+                  >
+                    Clear
+                  </button>
+                  <button
+                    type="submit"
+                    class="border border-[color:var(--ss-color-primary)] bg-[color:var(--ss-color-primary)] px-4 py-2 font-['Archivo'] text-sm font-semibold uppercase tracking-[0.04em] text-white transition-colors hover:bg-[color:var(--ss-color-primary-hover)] hover:border-[color:var(--ss-color-primary-hover)]"
+                  >
+                    Add note
+                  </button>
+                </div>
+              </form>
+            </div>
+          </details>
+
+          {
+            deduplicatedTimeline.length === 0 ? (
+              <p class="text-[15px] italic leading-6 text-[color:var(--ss-color-text-secondary)]">
+                No context entries yet.
+              </p>
+            ) : (
+              <ul class="list-none">
+                {deduplicatedTimeline.map((entry, idx) => (
+                  <EntityTimelineEntry entry={entry} openByDefault={idx < 3} />
+                ))}
+              </ul>
+            )
+          }
+        </section>
+
+        <EntityDiagnosticsDrawer
+          entityId={entity.id}
+          intelligenceBriefEntry={dossierBrief}
+          outreachEntry={outreachEntry}
+          enrichmentRuns={enrichmentRuns}
+        />
+      </section>
+
+      <EntityDecisionRail
         entityId={entity.id}
         entityStage={entity.stage}
+        mergeCandidates={mergeCandidates}
+        staleDraft={decisionEvidence.staleDraftWarning}
+        outreachEntry={outreachEntry}
         transitions={transitions}
-        mostRecentDraftableMeeting={mostRecentDraftableMeeting ?? null}
+        mostRecentDraftableMeeting={mostRecentDraftableMeeting}
         outreachMailto={outreachMailto}
         outreachContactEmail={outreachContact?.email ?? null}
         showReEnrichButton={showReEnrichButton}
@@ -253,244 +317,134 @@ const {
         supersedeCandidates={supersedeCandidates}
       />
     </div>
-  </div>
 
-  <LogReplyDialog entityId={entity.id} entityName={entity.name} />
-
-  {entity.stage === 'prospect' && <EntitySendBookingDialog entityId={entity.id} />}
-
-  {
-    /* Add Note — `rows="4"` and a non-resize textarea give the operator
-      enough room to draft a real note (the prior `rows="2"` was a single-
-      line nudge that fought against any actual writing). The Clear button
-      resets the textarea without submitting; the form's native reset
-      handles the clearing logic. */
-  }
-  <div
-    class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack mb-6"
-  >
-    <form method="POST" action={`/api/admin/entities/${entity.id}/context`} class="flex gap-row">
-      <input type="hidden" name="type" value="note" />
-      <textarea
-        name="content"
-        placeholder="Add a note..."
-        rows="4"
-        class="flex-1 text-sm border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] px-3 py-2 resize-y focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-      ></textarea>
-      <div class="flex flex-col gap-2 self-end">
-        <button type="submit" class={adminActionButtonClass('ghost')}>Add Note</button>
-        <button type="reset" class={adminActionButtonClass('ghost')}> Clear </button>
-      </div>
-    </form>
-  </div>
-
-  {/* Context Timeline */}
-  <div class="mb-6">
-    <div class="flex items-center justify-between mb-3">
-      <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
-        Context Timeline
-        <span class="text-sm font-normal text-[color:var(--ss-color-text-muted)]"
-          >({contextEntries.length})</span
-        >
-      </h3>
-    </div>
-
-    {/* Type filter pills */}
-    <div class="flex gap-1 mb-4 flex-wrap">
-      <a
-        href={`/admin/entities/${entity.id}`}
-        class={`text-xs px-2.5 py-1 rounded-full transition-colors ${!typeFilter ? 'bg-surface-inverse text-white' : 'bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] hover:bg-[color:var(--ss-color-border)]'}`}
-      >
-        All ({contextEntries.length})
-      </a>
+    <div class="mt-8 space-y-4">
       {
-        Object.entries(typeCounts).map(([type, count]) => (
-          <a
-            href={`/admin/entities/${entity.id}?type=${type}`}
-            class={`text-xs px-2.5 py-1 rounded-full transition-colors ${typeFilter === type ? 'bg-surface-inverse text-white' : contextTypeBadge(type) + ' hover:opacity-80'}`}
-          >
-            {CONTEXT_TYPES.find((t) => t.value === type)?.label ?? type} ({count})
-          </a>
-        ))
+        meetings.length > 0 && (
+          <details open class="border border-[color:var(--ss-color-border)]">
+            <summary class="cursor-pointer px-6 py-4 font-medium text-[color:var(--ss-color-text-primary)]">
+              {renderCollapsedSectionTitle('meetings', meetings.length)}
+            </summary>
+            <div class="px-6 pb-4">
+              {meetings.map((meeting) => (
+                <a
+                  href={`/admin/entities/${entity.id}/meetings/${meeting.id}`}
+                  class="flex items-center gap-2 border-t border-[color:var(--ss-color-border-subtle)] px-0 py-3 first:border-t-0 first:pt-0 hover:text-[color:var(--ss-color-primary)]"
+                >
+                  <span class={statusBadgeClass(meeting.status)}>{meeting.status}</span>
+                  {meeting.meeting_type && (
+                    <span class="border border-[color:var(--ss-color-border)] px-2 py-1 font-['Archivo_Narrow'] text-[11px] font-bold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)]">
+                      {meeting.meeting_type}
+                    </span>
+                  )}
+                  {meeting.scheduled_at && (
+                    <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                      {formatDate(meeting.scheduled_at)}
+                    </span>
+                  )}
+                  {meeting.duration_minutes && (
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                      {meeting.duration_minutes} min
+                    </span>
+                  )}
+                </a>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        engagements.length > 0 && (
+          <details class="border border-[color:var(--ss-color-border)]">
+            <summary class="cursor-pointer px-6 py-4 font-medium text-[color:var(--ss-color-text-primary)]">
+              {renderCollapsedSectionTitle('engaged', engagements.length)}
+            </summary>
+            <div class="px-6 pb-4">
+              {engagements.map((engagement) => (
+                <a
+                  href={`/admin/engagements/${engagement.id}`}
+                  class="flex items-center gap-2 border-t border-[color:var(--ss-color-border-subtle)] px-0 py-3 first:border-t-0 first:pt-0 hover:text-[color:var(--ss-color-primary)]"
+                >
+                  <span class={statusBadgeClass(engagement.status)}>{engagement.status}</span>
+                  {engagement.start_date && (
+                    <span class="text-sm text-[color:var(--ss-color-text-primary)]">
+                      {formatDate(engagement.start_date)}
+                    </span>
+                  )}
+                  {engagement.estimated_hours && (
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                      {engagement.actual_hours}/{engagement.estimated_hours} hrs
+                    </span>
+                  )}
+                </a>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        quotes.length > 0 && (
+          <details class="border border-[color:var(--ss-color-border)]">
+            <summary class="cursor-pointer px-6 py-4 font-medium text-[color:var(--ss-color-text-primary)]">
+              Quotes ({quotes.length})
+            </summary>
+            <div class="px-6 pb-4">
+              {quotes.map((quote) => (
+                <a
+                  href={`/admin/entities/${entity.id}/quotes/${quote.id}`}
+                  class="flex items-center gap-2 border-t border-[color:var(--ss-color-border-subtle)] px-0 py-3 first:border-t-0 first:pt-0 hover:text-[color:var(--ss-color-primary)]"
+                >
+                  <span class={statusBadgeClass(quote.status)}>{quote.status}</span>
+                  <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                    ${quote.total_price.toLocaleString()}
+                  </span>
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                    {quote.total_hours} hrs
+                  </span>
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                    v{quote.version}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </details>
+        )
+      }
+
+      {
+        invoices.length > 0 && (
+          <details class="border border-[color:var(--ss-color-border)]">
+            <summary class="cursor-pointer px-6 py-4 font-medium text-[color:var(--ss-color-text-primary)]">
+              Invoices ({invoices.length})
+            </summary>
+            <div class="px-6 pb-4">
+              {invoices.map((invoice) => (
+                <div class="flex items-center justify-between gap-4 border-t border-[color:var(--ss-color-border-subtle)] py-3 first:border-t-0 first:pt-0">
+                  <div class="flex items-center gap-2">
+                    <span class={statusBadgeClass(invoice.status)}>{invoice.status}</span>
+                    <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
+                      ${invoice.amount.toLocaleString()}
+                    </span>
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                      {invoice.type}
+                    </span>
+                    {invoice.due_date && (
+                      <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                        Due {formatDate(invoice.due_date)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )
       }
     </div>
-
-    {/* Timeline entries */}
-    {
-      filteredEntries.length === 0 ? (
-        <div class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-stack">
-          <p class="text-[color:var(--ss-color-text-secondary)] text-sm">No context entries yet.</p>
-        </div>
-      ) : (
-        <div class="space-y-row">
-          {filteredEntries.map((entry: ContextEntry, idx: number) => (
-            <EntityTimelineEntry entry={entry} openByDefault={idx < 3} />
-          ))}
-        </div>
-      )
-    }
   </div>
 
-  {/* Enrichment status — debug surface for the runs table */}
-  <EnrichmentStatusPanel entityId={entityId} />
-
-  {/* Dossier Summary */}
-  {
-    hasDossier && (
-      <EntityDossierSummary
-        dossierBrief={dossierBrief}
-        reviewMeta={reviewMeta}
-        websiteMeta={websiteMeta}
-        competitorMeta={competitorMeta}
-        outreachEntry={outreachEntry}
-        outreachFromDossier={outreachFromDossier}
-      />
-    )
-  }
-
-  {/* Related Data Panels */}
-  <div class="mb-4">
-    <EntityContactsPanel entityId={entity.id} contacts={contacts} />
-  </div>
-
-  {
-    meetings.length > 0 && (
-      <details
-        class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4"
-        open
-      >
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
-          Meetings ({meetings.length})
-        </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
-          {meetings.map((m) => (
-            <a
-              href={`/admin/entities/${entity.id}/meetings/${m.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-[color:var(--ss-color-background)] -mx-2 px-2 rounded transition-colors"
-            >
-              <span class={statusBadgeClass(m.status)}>{m.status}</span>
-              {m.meeting_type && (
-                <span class="text-xs bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-secondary)] px-1.5 py-0.5 rounded">
-                  {m.meeting_type}
-                </span>
-              )}
-              {m.scheduled_at && (
-                <span class="text-sm text-[color:var(--ss-color-text-primary)]">
-                  {formatDate(m.scheduled_at)}
-                </span>
-              )}
-              {m.duration_minutes && (
-                <span class="text-xs text-[color:var(--ss-color-text-muted)]">
-                  {m.duration_minutes} min
-                </span>
-              )}
-            </a>
-          ))}
-        </div>
-      </details>
-    )
-  }
-
-  {
-    engagements.length > 0 && (
-      <details class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
-          Engagements ({engagements.length})
-        </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
-          {engagements.map((e) => (
-            <a
-              href={`/admin/engagements/${e.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-[color:var(--ss-color-background)] -mx-2 px-2 rounded transition-colors"
-            >
-              <span class={statusBadgeClass(e.status)}>{e.status}</span>
-              {e.start_date && (
-                <span class="text-sm text-[color:var(--ss-color-text-primary)]">
-                  {formatDate(e.start_date)}
-                </span>
-              )}
-              {e.estimated_hours && (
-                <span class="text-xs text-[color:var(--ss-color-text-muted)]">
-                  {e.actual_hours}/{e.estimated_hours} hrs
-                </span>
-              )}
-            </a>
-          ))}
-        </div>
-      </details>
-    )
-  }
-
-  {
-    quotes.length > 0 && (
-      <details class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
-          Quotes ({quotes.length})
-        </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
-          {quotes.map((q) => (
-            <a
-              href={`/admin/entities/${entity.id}/quotes/${q.id}`}
-              class="py-2 flex items-center gap-2 hover:bg-[color:var(--ss-color-background)] -mx-2 px-2 rounded transition-colors"
-            >
-              <span class={statusBadgeClass(q.status)}>{q.status}</span>
-              <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
-                ${q.total_price.toLocaleString()}
-              </span>
-              <span class="text-xs text-[color:var(--ss-color-text-muted)]">
-                {q.total_hours} hrs
-              </span>
-              <span class="text-xs text-[color:var(--ss-color-text-muted)]">v{q.version}</span>
-            </a>
-          ))}
-        </div>
-      </details>
-    )
-  }
-
-  {
-    invoices.length > 0 && (
-      <details class="bg-surface rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] mb-4">
-        <summary class="px-6 py-4 cursor-pointer font-medium text-[color:var(--ss-color-text-primary)]">
-          Invoices ({invoices.length})
-        </summary>
-        <div class="px-6 pb-4 divide-y divide-[color:var(--ss-color-border-subtle)]">
-          {invoices.map((inv) => (
-            <div class="py-2 flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <span class={statusBadgeClass(inv.status)}>{inv.status}</span>
-                <span class="text-sm font-medium text-[color:var(--ss-color-text-primary)]">
-                  ${inv.amount.toLocaleString()}
-                </span>
-                <span class="text-xs text-[color:var(--ss-color-text-muted)]">{inv.type}</span>
-                {inv.due_date && (
-                  <span class="text-xs text-[color:var(--ss-color-text-muted)]">
-                    Due {formatDate(inv.due_date)}
-                  </span>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      </details>
-    )
-  }
-  <style>
-    /* Timeline long-entry truncation: visible by default, expands on toggle. */
-    .js-truncated {
-      display: -webkit-box;
-      -webkit-line-clamp: 6;
-      line-clamp: 6;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-    .js-truncated.is-expanded {
-      display: block;
-      -webkit-line-clamp: unset;
-      line-clamp: unset;
-      overflow: visible;
-    }
-  </style>
   <script>
     import { initEntityDetailPage } from '../../../lib/admin/entity-detail-client'
 

--- a/src/pages/api/admin/entities/[id]/outreach-draft/discard.ts
+++ b/src/pages/api/admin/entities/[id]/outreach-draft/discard.ts
@@ -1,0 +1,63 @@
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+
+interface OutreachDraftRow {
+  id: string
+  metadata: string | null
+}
+
+function parseMetadata(raw: string | null): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+async function handlePost({ params, locals, redirect }: APIContext): Promise<Response> {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const entityId = params.id
+  if (!entityId) return redirect('/admin/entities?error=missing', 302)
+
+  try {
+    const latestDraft = await env.DB.prepare(
+      `SELECT id, metadata
+       FROM context
+       WHERE org_id = ?
+         AND entity_id = ?
+         AND type = 'outreach_draft'
+       ORDER BY created_at DESC
+       LIMIT 1`
+    )
+      .bind(session.orgId, entityId)
+      .first<OutreachDraftRow>()
+
+    if (!latestDraft) {
+      return redirect(`/admin/entities/${entityId}?draft_discarded=1#entity-diagnostics`, 302)
+    }
+
+    const metadata = parseMetadata(latestDraft.metadata)
+    metadata.superseded = true
+
+    await env.DB.prepare(`UPDATE context SET metadata = ? WHERE id = ? AND org_id = ?`)
+      .bind(JSON.stringify(metadata), latestDraft.id, session.orgId)
+      .run()
+
+    return redirect(`/admin/entities/${entityId}?draft_discarded=1#entity-diagnostics`, 302)
+  } catch (error) {
+    console.error('[api/admin/entities/outreach-draft/discard] Error:', error)
+    const message = error instanceof Error ? error.message : 'server'
+    return redirect(`/admin/entities/${entityId}?error=${encodeURIComponent(message)}`, 302)
+  }
+}
+
+export const POST: APIRoute = (ctx) => handlePost(ctx)

--- a/tests/entities-signal-metadata.test.ts
+++ b/tests/entities-signal-metadata.test.ts
@@ -58,6 +58,8 @@ describe('getSignalMetadataForEntities', () => {
         signal_subject: 'HVAC contractor',
         signal_location: 'Phoenix, AZ',
         signal_date: '2026-05-07',
+        signal_address: '123 Main St, Phoenix, AZ 85001',
+        actor_role: 'business',
       },
     })
 
@@ -69,6 +71,9 @@ describe('getSignalMetadataForEntities', () => {
     expect(meta!.signal_subject).toBe('HVAC contractor')
     expect(meta!.signal_location).toBe('Phoenix, AZ')
     expect(meta!.signal_date).toBe('2026-05-07')
+    expect(meta!.signal_address).toBe('123 Main St, Phoenix, AZ 85001')
+    expect(meta!.actor_role).toBe('business')
+    expect(meta!.actor_role_confidence).toBe('high')
     expect(meta!.last_activity_at).toBeTruthy()
   })
 
@@ -124,6 +129,9 @@ describe('getSignalMetadataForEntities', () => {
     expect(meta!.top_problems).toBeNull()
     expect(meta!.signal_source_label).toBeNull()
     expect(meta!.signal_subject).toBeNull()
+    expect(meta!.signal_address).toBeNull()
+    expect(meta!.actor_role).toBeNull()
+    expect(meta!.actor_role_confidence).toBeNull()
     expect(meta!.last_activity_at).toBeTruthy()
   })
 
@@ -175,6 +183,25 @@ describe('getSignalMetadataForEntities', () => {
     const meta = result.get(entity.id)
     expect(meta!.top_problems).toBeNull()
     expect(meta!.signal_source_label).toBeNull()
+  })
+
+  it('defaults actor_role_confidence when role is present but confidence is missing', async () => {
+    const entity = await createEntity(db, ORG_ID, { name: 'Contractor Filed Biz' })
+
+    await appendContext(db, ORG_ID, {
+      entity_id: entity.id,
+      type: 'signal',
+      content: 'Contractor-owned permit',
+      source: 'new_business',
+      metadata: {
+        actor_role: 'contractor',
+        signal_source_label: 'Commercial permit',
+      },
+    })
+
+    const result = await getSignalMetadataForEntities(db, ORG_ID, [entity.id])
+    expect(result.get(entity.id)?.actor_role).toBe('contractor')
+    expect(result.get(entity.id)?.actor_role_confidence).toBe('high')
   })
 
   it('scopes by org_id — does not leak metadata across orgs', async () => {

--- a/tests/entity-detail-decision-evidence.test.ts
+++ b/tests/entity-detail-decision-evidence.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ADR_0003_DEPLOY_DATE,
+  composeDeduplicatedTimeline,
+  composeEnrichmentSummary,
+  composeMissingForOutreach,
+  detectStaleDraft,
+  resolveActorRole,
+} from '../src/lib/admin/entity-detail-decision-evidence'
+import type { Entity } from '../src/lib/db/entities'
+import type { ContextEntry } from '../src/lib/db/context'
+import type { Contact } from '../src/lib/db/contacts'
+import type { EnrichmentRun } from '../src/lib/db/enrichment-runs'
+
+const baseEntity: Entity = {
+  id: 'entity-1',
+  org_id: 'org-1',
+  name: 'Scottsdale Icon Dental',
+  slug: 'scottsdale-icon-dental-scottsdale',
+  phone: null,
+  website: null,
+  stage: 'signal',
+  stage_changed_at: '2026-05-07T12:00:00Z',
+  pain_score: null,
+  vertical: 'professional_services',
+  area: 'Scottsdale, AZ',
+  employee_count: null,
+  tier: null,
+  summary: null,
+  next_action: null,
+  next_action_at: null,
+  source_pipeline: 'new_business',
+  created_at: '2026-05-07T12:00:00Z',
+  updated_at: '2026-05-07T12:00:00Z',
+}
+
+function makeContextEntry(
+  overrides: Partial<ContextEntry> &
+    Pick<ContextEntry, 'id' | 'type' | 'content' | 'source' | 'created_at'>
+): ContextEntry {
+  return {
+    entity_id: 'entity-1',
+    org_id: 'org-1',
+    source_ref: null,
+    content_size: null,
+    metadata: null,
+    engagement_id: null,
+    ...overrides,
+  }
+}
+
+function makeRun(module: string, reason: string | null): EnrichmentRun {
+  return {
+    id: `${module}-run`,
+    org_id: 'org-1',
+    entity_id: 'entity-1',
+    module: module as EnrichmentRun['module'],
+    status: reason ? 'no_data' : 'succeeded',
+    reason,
+    error_message: null,
+    input_fingerprint: null,
+    started_at: '2026-05-07T09:00:00Z',
+    completed_at: '2026-05-07T09:01:00Z',
+    duration_ms: 1000,
+    triggered_by: 'test',
+    mode: 'full',
+    context_entry_id: null,
+  }
+}
+
+describe('entity detail decision evidence helpers', () => {
+  it('composeDeduplicatedTimeline strips duplicate AI artifacts and keeps operator events', () => {
+    const timeline = composeDeduplicatedTimeline([
+      makeContextEntry({
+        id: '1',
+        type: 'note',
+        source: 'admin',
+        content: 'Older note',
+        created_at: '2026-05-07T08:00:00Z',
+      }),
+      makeContextEntry({
+        id: '2',
+        type: 'enrichment',
+        source: 'review_synthesis',
+        content: 'Older synthesis',
+        created_at: '2026-05-07T09:00:00Z',
+      }),
+      makeContextEntry({
+        id: '3',
+        type: 'outreach_draft',
+        source: 'outreach_draft',
+        content: 'Draft body',
+        created_at: '2026-05-07T09:30:00Z',
+      }),
+      makeContextEntry({
+        id: '4',
+        type: 'enrichment',
+        source: 'review_analysis',
+        content: 'Older analysis',
+        created_at: '2026-05-07T10:00:00Z',
+      }),
+      makeContextEntry({
+        id: '5',
+        type: 'enrichment',
+        source: 'review_analysis',
+        content: 'Latest analysis',
+        created_at: '2026-05-07T11:00:00Z',
+      }),
+      makeContextEntry({
+        id: '6',
+        type: 'enrichment',
+        source: 'review_synthesis',
+        content: 'Latest synthesis',
+        created_at: '2026-05-07T12:00:00Z',
+      }),
+      makeContextEntry({
+        id: '7',
+        type: 'enrichment',
+        source: 'intelligence_brief',
+        content: 'Brief body',
+        created_at: '2026-05-07T13:00:00Z',
+      }),
+      makeContextEntry({
+        id: '8',
+        type: 'stage_change',
+        source: 'admin',
+        content: 'Promoted',
+        created_at: '2026-05-07T14:00:00Z',
+      }),
+    ])
+
+    expect(timeline.map((entry) => entry.id)).toEqual(['8', '6', '5', '1'])
+  })
+
+  it('composeMissingForOutreach cites missing contact, website, and public web signal', () => {
+    const missing = composeMissingForOutreach(
+      baseEntity,
+      [
+        makeContextEntry({
+          id: 'signal',
+          type: 'signal',
+          source: 'new_business',
+          content: 'License signal',
+          created_at: '2026-05-07T08:00:00Z',
+        }),
+      ],
+      [] as Contact[],
+      new Map<string, EnrichmentRun>([['google_places', makeRun('google_places', 'no_match')]])
+    )
+
+    expect(missing.map((item) => item.key)).toEqual(['contact', 'website', 'public-web-signal'])
+    expect(missing.find((item) => item.key === 'website')?.reason).toContain(
+      'Google Places no_match'
+    )
+  })
+
+  it('detectStaleDraft flags drafts before ADR 0003 and Phoenix-area copy', () => {
+    const beforePivot = detectStaleDraft(
+      makeContextEntry({
+        id: 'draft-1',
+        type: 'outreach_draft',
+        source: 'outreach_draft',
+        content: 'Hi there.',
+        created_at: '2026-05-06T23:59:59Z',
+      })
+    )
+    expect(beforePivot.isStale).toBe(true)
+    expect(beforePivot.reason).toContain('pre-statewide pivot')
+
+    const phoenixDraft = detectStaleDraft(
+      makeContextEntry({
+        id: 'draft-2',
+        type: 'outreach_draft',
+        source: 'outreach_draft',
+        content: 'We work with Phoenix area businesses.',
+        created_at: ADR_0003_DEPLOY_DATE,
+      })
+    )
+    expect(phoenixDraft.isStale).toBe(true)
+    expect(phoenixDraft.reason).toContain('Phoenix area')
+
+    const fresh = detectStaleDraft(
+      makeContextEntry({
+        id: 'draft-3',
+        type: 'outreach_draft',
+        source: 'outreach_draft',
+        content: 'We should talk.',
+        created_at: '2026-05-08T08:00:00Z',
+      })
+    )
+    expect(fresh).toEqual({ isStale: false, reason: null })
+  })
+
+  it('resolveActorRole falls back to unknown/low when metadata is absent', () => {
+    expect(resolveActorRole(null)).toEqual({ role: 'unknown', confidence: 'low' })
+  })
+
+  it('composeEnrichmentSummary prioritizes review synthesis, then deep website, then brief', () => {
+    const reviewSummary = composeEnrichmentSummary(
+      makeContextEntry({
+        id: 'review',
+        type: 'enrichment',
+        source: 'review_synthesis',
+        content: 'Newest review summary. Another sentence.',
+        created_at: '2026-05-07T12:00:00Z',
+      }),
+      makeContextEntry({
+        id: 'website',
+        type: 'enrichment',
+        source: 'deep_website',
+        content: 'Deep website fallback.',
+        created_at: '2026-05-07T11:00:00Z',
+      }),
+      makeContextEntry({
+        id: 'brief',
+        type: 'enrichment',
+        source: 'intelligence_brief',
+        content: 'Brief fallback paragraph.\n\n## Outreach Hooks\n- Should not appear',
+        created_at: '2026-05-07T10:00:00Z',
+      })
+    )
+    expect(reviewSummary).toBe('Newest review summary.')
+
+    const websiteSummary = composeEnrichmentSummary(
+      undefined,
+      makeContextEntry({
+        id: 'website-only',
+        type: 'enrichment',
+        source: 'deep_website',
+        content: 'Website fallback sentence. Another one.',
+        created_at: '2026-05-07T11:00:00Z',
+      }),
+      undefined
+    )
+    expect(websiteSummary).toBe('Website fallback sentence.')
+
+    const briefSummary = composeEnrichmentSummary(
+      undefined,
+      undefined,
+      makeContextEntry({
+        id: 'brief-only',
+        type: 'enrichment',
+        source: 'intelligence_brief',
+        content:
+          'Newly licensed dental practice operating from Suite 225 in Scottsdale.\n\n## Engagement Hypotheses\n- Ignore this',
+        created_at: '2026-05-07T10:00:00Z',
+      })
+    )
+    expect(briefSummary).toBe(
+      'Newly licensed dental practice operating from Suite 225 in Scottsdale.'
+    )
+  })
+})

--- a/tests/entity-detail-page-render.test.ts
+++ b/tests/entity-detail-page-render.test.ts
@@ -1,0 +1,343 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+
+vi.mock('cloudflare:workers', () => ({
+  env: { DB: {} },
+}))
+
+vi.mock('../src/lib/admin/entity-detail-page', async () => {
+  const actual = await vi.importActual<typeof import('../src/lib/admin/entity-detail-page')>(
+    '../src/lib/admin/entity-detail-page'
+  )
+  return {
+    ...actual,
+    loadEntityDetailPage: vi.fn(),
+  }
+})
+
+import { loadEntityDetailPage } from '../src/lib/admin/entity-detail-page'
+
+const mockedLoadEntityDetailPage = vi.mocked(loadEntityDetailPage)
+
+const DRAFT_TEXT =
+  'Phoenix area practice with a pre-dossier draft that claims you built something solid from day one.'
+const BRIEF_TEXT = `Newly licensed dental practice operating from Suite 225 in Scottsdale.
+
+## Engagement Hypotheses
+- Setup support
+
+## Outreach Hooks
+- you built something solid from day one`
+
+function createMockPageData(stage: 'signal' | 'prospect' = 'signal') {
+  const now = '2026-05-07T19:00:00.000Z'
+  const signalEntry = {
+    id: 'ctx-signal',
+    entity_id: 'entity-1',
+    org_id: 'org_1',
+    type: 'signal',
+    content: 'Signal from scottsdale_license.',
+    source: 'scottsdale_license',
+    source_ref: null,
+    content_size: 24,
+    metadata: JSON.stringify({
+      vertical: 'healthcare',
+      outreach_timing: 'immediate',
+    }),
+    engagement_id: null,
+    created_at: now,
+  }
+  const enrichmentEntry = {
+    id: 'ctx-enrichment',
+    entity_id: 'entity-1',
+    org_id: 'org_1',
+    type: 'enrichment',
+    content: 'Enrichment pipeline finished.',
+    source: 'enrichment_orchestrator',
+    source_ref: null,
+    content_size: 29,
+    metadata: JSON.stringify({
+      succeeded: 4,
+      no_data: 6,
+      skipped: 3,
+    }),
+    engagement_id: null,
+    created_at: now,
+  }
+  const briefEntry = {
+    id: 'ctx-brief',
+    entity_id: 'entity-1',
+    org_id: 'org_1',
+    type: 'enrichment',
+    content: BRIEF_TEXT,
+    source: 'intelligence_brief',
+    source_ref: null,
+    content_size: BRIEF_TEXT.length,
+    metadata: null,
+    engagement_id: null,
+    created_at: now,
+  }
+  const outreachEntry = {
+    id: 'ctx-draft',
+    entity_id: 'entity-1',
+    org_id: 'org_1',
+    type: 'outreach_draft',
+    content: DRAFT_TEXT,
+    source: 'outreach_draft',
+    source_ref: null,
+    content_size: DRAFT_TEXT.length,
+    metadata: JSON.stringify({ trigger: 'dossier' }),
+    engagement_id: null,
+    created_at: '2026-05-06T18:00:00.000Z',
+  }
+
+  const transitions =
+    stage === 'signal'
+      ? [
+          {
+            label: 'Promote',
+            stage: 'prospect',
+            variant: 'primary' as const,
+            action: '/api/admin/entities/entity-1/stage',
+          },
+          {
+            label: 'Dismiss',
+            stage: 'lost',
+            variant: 'destructive' as const,
+            action: '/api/admin/entities/entity-1/stage',
+          },
+        ]
+      : [
+          {
+            label: 'Mark as Proposing',
+            stage: 'proposing',
+            variant: 'primary' as const,
+            action: '/api/admin/entities/entity-1/stage',
+          },
+          {
+            label: 'Lost',
+            stage: 'lost',
+            variant: 'destructive' as const,
+            action: '/api/admin/entities/entity-1/stage',
+          },
+        ]
+
+  return {
+    entity: {
+      id: 'entity-1',
+      org_id: 'org_1',
+      name: 'Scottsdale Icon Dental',
+      slug: 'scottsdale-icon-dental',
+      phone: null,
+      website: null,
+      stage,
+      stage_changed_at: '2026-05-07T18:00:00.000Z',
+      pain_score: null,
+      vertical: 'healthcare',
+      area: 'Scottsdale, AZ',
+      employee_count: null,
+      tier: null,
+      summary: null,
+      next_action: null,
+      next_action_at: null,
+      source_pipeline: 'new_business',
+      created_at: '2026-05-07T18:00:00.000Z',
+      updated_at: '2026-05-07T19:00:00.000Z',
+    },
+    signalMetadata: {
+      entity_id: 'entity-1',
+      top_problems: null,
+      signal_source_label: 'scottsdale_license',
+      signal_subject: 'Scottsdale Icon Dental',
+      signal_location: 'Suite 225, Scottsdale AZ',
+      signal_date: '2026-05-07T18:00:00.000Z',
+      signal_address: 'Suite 225, Scottsdale AZ',
+      actor_role: 'business',
+      actor_role_confidence: 'high',
+      enrichment_summary: null,
+      last_activity_at: null,
+    },
+    contextEntries: [signalEntry, enrichmentEntry, briefEntry, outreachEntry],
+    contacts: [],
+    meetings: [],
+    engagements: [],
+    quotes: [],
+    invoices: [],
+    enrichmentRuns: new Map([
+      [
+        'google_places',
+        {
+          id: 'run-1',
+          entity_id: 'entity-1',
+          module: 'google_places',
+          status: 'no_data',
+          reason: 'no_match',
+          error_message: null,
+          started_at: now,
+          completed_at: now,
+          triggered_by: 'cron:test',
+        },
+      ],
+      [
+        'review_synthesis',
+        {
+          id: 'run-2',
+          entity_id: 'entity-1',
+          module: 'review_synthesis',
+          status: 'succeeded',
+          reason: null,
+          error_message: null,
+          started_at: now,
+          completed_at: now,
+          triggered_by: 'cron:test',
+        },
+      ],
+    ]),
+    mostRecentDraftableMeeting: null,
+    hasOutreach: true,
+    filteredEntries: [enrichmentEntry, signalEntry],
+    deduplicatedTimeline: [enrichmentEntry, signalEntry],
+    typeFilter: '',
+    typeCounts: {
+      signal: 1,
+      enrichment: 2,
+      outreach_draft: 1,
+    },
+    currentLostReason: null,
+    promoted: null,
+    noteAdded: null,
+    replyLogged: null,
+    stageUpdated: null,
+    dossierGenerated: null,
+    contactAdded: null,
+    contactUpdated: null,
+    contactDeleted: null,
+    error: null,
+    showReEnrichButton: false,
+    showNewQuoteButton: false,
+    supersedeCandidates: [],
+    transitions,
+    decisionEvidence: {
+      actorRole: 'business',
+      actorRoleConfidence: 'high',
+      signalEvidence: 'Scottsdale business license | 2026-05-07 | Suite 225, Scottsdale AZ',
+      enrichmentSummary:
+        'Newly licensed dental practice operating from Suite 225 in a Scottsdale professional building.',
+      structuralFlags: ['Single-tenant suite', 'Arizona'],
+      missingForOutreach: [
+        {
+          key: 'contact',
+          label: 'Contact email',
+          reason: 'none on file. Promote will trigger contact discovery.',
+        },
+      ],
+      staleDraftWarning: {
+        isStale: true,
+        reason: 'Generated May 6, 2026 - pre-statewide pivot. References "Phoenix area".',
+      },
+    },
+    mergeCandidates: [
+      {
+        id: 'merge-1',
+        targetId: 'entity-dup',
+        candidateName: 'Scottsdale Icon Dental PLLC',
+        candidateAddress: 'Suite 225, Scottsdale AZ',
+        score: 0.93,
+        reason: 'slug_fuzzy_match',
+        sourcePipeline: 'new_business',
+        createdAt: now,
+      },
+    ],
+    dossierBrief: briefEntry,
+    outreachEntry,
+    outreachContact: null,
+    outreachMailto: null,
+    outreachFromDossier: true,
+    hasDossier: true,
+    lastEnrichmentAt: now,
+    latestSentQuoteAt: null,
+    reviewMeta: null,
+    websiteMeta: null,
+    competitorMeta: null,
+  }
+}
+
+async function renderEntityPage(stage: 'signal' | 'prospect' = 'signal'): Promise<string> {
+  mockedLoadEntityDetailPage.mockResolvedValue(createMockPageData(stage) as never)
+  const { default: EntityPage } = await import('../src/pages/admin/entities/[id].astro')
+  const container = await AstroContainer.create()
+  return container.renderToString(EntityPage, {
+    request: new Request('https://admin.localhost:4321/admin/entities/entity-1'),
+    params: { id: 'entity-1' },
+    locals: {
+      session: { orgId: 'org_1', role: 'admin', email: 'ops@example.com' },
+    } as App.Locals,
+    partial: false,
+  })
+}
+
+function removeDiagnostics(html: string): string {
+  return html.replace(/<details[^>]*data-diagnostics[\s\S]*?<\/details>/, '')
+}
+
+function actionCount(railHtml: string): number {
+  return (railHtml.match(/data-rail-action="/g) ?? []).length
+}
+
+function railHtml(html: string): string {
+  const match = html.match(/<aside[^>]*data-test="decision-rail"[\s\S]*?<\/aside>/)
+  return match?.[0] ?? ''
+}
+
+describe('entity detail page render', () => {
+  beforeEach(() => {
+    mockedLoadEntityDetailPage.mockReset()
+  })
+
+  it('keeps outreach draft and intelligence brief content inside diagnostics only', async () => {
+    const html = await renderEntityPage('signal')
+    const bodyWithoutDiagnostics = removeDiagnostics(html)
+
+    expect(bodyWithoutDiagnostics).not.toContain(DRAFT_TEXT)
+    expect(bodyWithoutDiagnostics).not.toContain('Outreach Hooks')
+    expect(html).toContain('Raw outreach draft')
+    expect(html).toContain('Raw intelligence brief')
+  })
+
+  it('renders the actor role chip and the three signal-stage rail actions', async () => {
+    const html = await renderEntityPage('signal')
+    const rail = railHtml(html)
+
+    expect(html).toContain('data-test="identity-strip"')
+    expect(html).toContain('Business')
+    expect(actionCount(rail)).toBe(3)
+    expect(rail).toContain('data-rail-action="promote"')
+    expect(rail).toContain('data-rail-action="dismiss"')
+    expect(rail).toContain('data-rail-action="merge"')
+  })
+
+  it('renders the new structural dismiss reasons and the pain empty state', async () => {
+    const html = await renderEntityPage('signal')
+    const normalizedHtml = html.replace(/\s+/g, ' ')
+
+    expect(html).toContain('Wrong actor')
+    expect(html).toContain('Outside buy box')
+    expect(html).toContain('Outside Arizona')
+    expect(html).toContain('Insufficient signal')
+    expect(html).toContain('Duplicate')
+    expect(normalizedHtml).toContain(
+      'No public review or job-post signal yet. License filed today; nothing has been written about this practice externally. Expect this to fill in over 30-60 days as the practice opens.'
+    )
+  })
+
+  it('disables merge outside the signal stage', async () => {
+    const html = await renderEntityPage('prospect')
+    const rail = railHtml(html)
+
+    expect(rail).toContain('data-rail-action="merge"')
+    expect(rail).toContain('disabled')
+    expect(rail).toContain(
+      'Merge available at Signal stage only - extending mergeEntities is a follow-on.'
+    )
+  })
+})

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -136,6 +136,14 @@ const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp | string }> = [
     pattern: /['"]Engagement work['"]/,
   },
   {
+    label: 'Entity detail regression: do not reintroduce outreach_angle',
+    pattern: /\boutreach_angle\b/,
+  },
+  {
+    label: 'Entity detail regression: do not reintroduce pre-dossier draft copy',
+    pattern: /Pre-dossier draft/,
+  },
+  {
     label: 'Pattern B: hardcoded "Scott" fallback in portal render paths',
     // Match ?? 'Scott' or : 'Scott' (ternary / nullish) in portal pages and components.
     // Does not flag 'Scott' in test fixtures, variable names, or email author strings.

--- a/tests/lost-reason.test.ts
+++ b/tests/lost-reason.test.ts
@@ -46,16 +46,21 @@ describe('structured lost reason', () => {
   })
 
   describe('taxonomy module', () => {
-    it('exposes the seven canonical codes', () => {
+    it('exposes the full canonical code set', () => {
       const codes = LOST_REASONS.map((r) => r.value).sort()
       expect(codes).toEqual(
         [
           'declined-quote',
+          'duplicate',
           'no-budget',
           'no-response',
+          'no-signal',
           'not-a-fit',
           'other',
+          'out-of-buy-box',
+          'out-of-geography',
           'unreachable',
+          'wrong-actor',
           'wrong-contact',
         ].sort()
       )

--- a/tests/lost-reasons.test.ts
+++ b/tests/lost-reasons.test.ts
@@ -8,16 +8,21 @@ describe('lost-reasons: canonical enum (shared with #477)', () => {
     expect(existsSync(resolve('src/lib/db/lost-reasons.ts'))).toBe(true)
   })
 
-  it('exports the seven canonical values from issue #477', () => {
+  it('exports the current canonical values from issue #477 and the entity-detail redesign', () => {
     const values = LOST_REASONS.map((r) => r.value).sort()
     expect(values).toEqual(
       [
         'declined-quote',
+        'duplicate',
         'no-budget',
         'no-response',
+        'no-signal',
         'not-a-fit',
         'other',
+        'out-of-buy-box',
+        'out-of-geography',
         'unreachable',
+        'wrong-actor',
         'wrong-contact',
       ].sort()
     )

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,72 +1,82 @@
-import { defineConfig } from 'vitest/config'
+import { getViteConfig } from 'astro/config'
 import { resolve } from 'node:path'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      // `cloudflare:workers` is a runtime-only module; Node can't resolve it.
-      // Tests that import route handlers (which now pull `env` from it via
-      // the adapter v13 pattern) get a mutable stub they can populate with
-      // mock bindings. See tests/_stubs/cloudflare-workers.ts.
-      'cloudflare:workers': resolve(__dirname, 'tests/_stubs/cloudflare-workers.ts'),
-    },
-  },
-  test: {
-    // Exclude git worktrees from test discovery. Worktrees under
-    // `.claude/worktrees/*` and `.worktrees/*` are checkouts of other
-    // feature branches — their test expectations drift relative to main
-    // and cause spurious failures during `npm run verify`. Tests that
-    // belong to this branch live in `tests/`; anything inside a worktree
-    // dir belongs to whatever branch is checked out there.
-    exclude: ['**/node_modules/**', '**/dist/**', '.claude/worktrees/**', '.worktrees/**'],
-    // The crane-test-harness package imports from `node:sqlite`. The
-    // vitest 1.x + vite 6 combo trips on bare `node:` imports inside
-    // transformed-then-loaded modules, so we externalize the harness
-    // entirely — vitest loads it via plain Node require/import without
-    // running it through Vite's import-analysis pipeline. The harness
-    // ships pre-compiled JS in dist/, so this is correct anyway.
-    server: {
-      deps: {
-        external: ['@venturecrane/crane-test-harness', /node:/],
+export default getViteConfig(
+  {
+    resolve: {
+      alias: {
+        // `cloudflare:workers` is a runtime-only module; Node can't resolve it.
+        // Tests that import route handlers (which now pull `env` from it via
+        // the adapter v13 pattern) get a mutable stub they can populate with
+        // mock bindings. See tests/_stubs/cloudflare-workers.ts.
+        'cloudflare:workers': resolve(__dirname, 'tests/_stubs/cloudflare-workers.ts'),
       },
     },
-    coverage: {
-      provider: 'v8',
-      // Thresholds are set at the 2026-04-16 baseline (rounded down 1-2 pts)
-      // to act as a regression guardrail, not an aspirational target.
-      // Branches/functions are the meaningful signals; lines/statements are
-      // dragged down by .astro templates which v8 instruments but cannot
-      // exercise in a unit-test environment.
-      //
-      // To raise thresholds: run `npm run test:coverage`, note new numbers,
-      // bump here, and open a PR. Never set a threshold you can't currently
-      // meet.
-      thresholds: {
-        lines: 22,
-        branches: 67,
-        functions: 52,
-        statements: 22,
+    test: {
+      // Exclude git worktrees from test discovery. Worktrees under
+      // `.claude/worktrees/*` and `.worktrees/*` are checkouts of other
+      // feature branches — their test expectations drift relative to main
+      // and cause spurious failures during `npm run verify`. Tests that
+      // belong to this branch live in `tests/`; anything inside a worktree
+      // dir belongs to whatever branch is checked out there.
+      exclude: ['**/node_modules/**', '**/dist/**', '.claude/worktrees/**', '.worktrees/**'],
+      // The crane-test-harness package imports from `node:sqlite`. The
+      // vitest 1.x + vite 6 combo trips on bare `node:` imports inside
+      // transformed-then-loaded modules, so we externalize the harness
+      // entirely — vitest loads it via plain Node require/import without
+      // running it through Vite's import-analysis pipeline. The harness
+      // ships pre-compiled JS in dist/, so this is correct anyway.
+      server: {
+        deps: {
+          external: ['@venturecrane/crane-test-harness', /node:/],
+        },
       },
-      exclude: [
-        // Test files themselves
-        'tests/**',
-        '**/*.test.ts',
-        '**/*.spec.ts',
-        // Astro page templates — v8 instruments them but unit tests cannot
+      coverage: {
+        provider: 'v8',
+        // Thresholds are set at the 2026-04-16 baseline (rounded down 1-2 pts)
+        // to act as a regression guardrail, not an aspirational target.
+        // Branches/functions are the meaningful signals; lines/statements are
+        // dragged down by .astro templates which v8 instruments but cannot
         // exercise their request/response lifecycle, leading to misleading
         // zero-coverage numbers.
-        'src/pages/**/*.astro',
-        'src/components/**/*.astro',
-        // Generated and build artifacts
-        '.astro/**',
-        'dist/**',
-        // DB migrations — SQL-only, nothing to instrument
-        'migrations/**',
-        // Config files
-        '*.config.*',
-        '.claude/worktrees/**',
-        '.worktrees/**',
-      ],
+        //
+        // To raise thresholds: run `npm run test:coverage`, note new numbers,
+        // bump here, and open a PR. Never set a threshold you can't currently
+        // meet.
+        thresholds: {
+          lines: 22,
+          branches: 67,
+          functions: 52,
+          statements: 22,
+        },
+        exclude: [
+          // Test files themselves
+          'tests/**',
+          '**/*.test.ts',
+          '**/*.spec.ts',
+          // Astro page templates — v8 instruments them but unit tests cannot
+          // exercise their request/response lifecycle, leading to misleading
+          // zero-coverage numbers.
+          'src/pages/**/*.astro',
+          'src/components/**/*.astro',
+          // Generated and build artifacts
+          '.astro/**',
+          'dist/**',
+          // DB migrations — SQL-only, nothing to instrument
+          'migrations/**',
+          // Config files
+          '*.config.*',
+          '.claude/worktrees/**',
+          '.worktrees/**',
+        ],
+      },
     },
   },
-})
+  {
+    // Keep Astro's Vite pipeline for `.astro` imports in Vitest, but avoid
+    // loading the full Cloudflare adapter stack from `astro.config.mjs`.
+    configFile: false,
+    output: 'server',
+    site: 'https://smd.services',
+  }
+)


### PR DESCRIPTION
Closes #757.

Implements the entity detail redesign per [docs/plans/entity-detail-redesign-v1.md](https://github.com/venturecrane/ss-console/blob/feat/entity-detail-decision-surface/docs/plans/entity-detail-redesign-v1.md). Plan doc PR (#756) lands separately; once merged, this PR's diff against main collapses to just the two implementation commits.

## Summary

- Rebuilds `/admin/entities/[id]` as a two-column "evidence + sticky decision rail" surface (Option B). Eliminates the 3× outreach-draft / 2× intelligence-brief duplications at the data layer.
- Surfaces ADR 0003 fields (`actor_role`, structural flags, candidate_merge_log hits) above the fold via the new `EntityIdentityStrip`.
- Replaces 2-button Promote/Dismiss with 3-disposition rail (Promote / Dismiss-with-12-reason-taxonomy / Merge), with Merge enabled at Signal stage only.
- Structurally suppresses Pattern A surfaces at Signal stage (dossier "Outreach Hooks" no longer rendered in body — diagnostics drawer only).
- Stale-draft detection (Phoenix-area heuristic + ADR 0003 deploy-date threshold) with discard affordance.
- Mobile: collapses to single column with fixed bottom action bar at `<lg` (1024px Tailwind default).

## Commits in this PR

- `051b973` — Phase 1: view-model layer (5 helpers, extended types, dedup, candidate_merge_log reader, lost-reasons taxonomy extension, unit tests)
- `1d5ceb9` — Phase 2: components + page integration + render tests (5 new components + EntityPainObservations, [id].astro rewrite, discard endpoint, mobile padding hook)

## What landed

**View-model**
- `src/lib/admin/entity-detail-decision-evidence.ts` (new) — composers
- `src/lib/admin/entity-detail-page.ts` — extended result type
- `src/lib/db/candidate-merge-log.ts` — read-side query
- `src/lib/db/entity-signal-metadata.ts` — extracts `actor_role` + `actor_role_confidence`
- `src/lib/db/lost-reasons.ts` — 5 new structural codes (wrong-actor, out-of-buy-box, out-of-geography, no-signal, duplicate)

**Components** (all new under `src/components/admin/`)
- `EntityIdentityStrip.astro`
- `EntityDecisionRail.astro`
- `EntityMissingPanel.astro`
- `EntityEnrichmentSummary.astro`
- `EntityDiagnosticsDrawer.astro`
- `EntityPainObservations.astro` (optional per plan)

**Page + endpoint**
- `src/pages/admin/entities/[id].astro` rewritten to compose the new components
- `src/pages/api/admin/entities/[id]/outreach-draft/discard.ts` (new endpoint)
- `src/layouts/AdminLayout.astro` — mobile bottom-padding hook

**Tests**
- `tests/entity-detail-decision-evidence.test.ts` (WS-13)
- `tests/entity-detail-page-render.test.ts` (WS-14)
- `tests/forbidden-strings.test.ts` extended (WS-15)

## Test plan

- [x] `npm run verify` green (Codex)
- [x] Visual parity check against `/tmp/ss-entity-detail-mockup.html` at desktop (Codex, headless Chrome)
- [x] Visual check at 800px viewport — rail moves to fixed bottom bar, main has 80px (5rem) bottom padding (Codex)
- [ ] Captain hands-on review: open Scottsdale Icon Dental (`cba10031-5e26-42b9-8872-3d03bba60f45`) on `admin.localhost:4321` and walk the decision rail
- [ ] Promote → confirm transition + flash
- [ ] Dismiss with new `wrong-actor` code → confirm `lost_reason` persisted in stage_change metadata
- [ ] Merge dropdown — empty state confirmed; for an entity with pending candidate_merge_log rows, candidates surface
- [ ] Discard stale draft → confirm metadata mutation + warning disappears
- [ ] Resize to 800px in browser dev tools → confirm bottom-bar layout
- [ ] Side-by-side with the mockup

## Out of scope (follow-ons)

- #758 — Hold disposition
- #759 — Extend `mergeEntities()` to cover meetings/quotes/engagements/invoices
- #760 — Pattern A validator extension to dossier markdown post-Promote
- #761 — Remove orphaned `EntityDossierSummary.astro` / `EntityStageActions.astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)