### PR TITLE
fix(lead-gen): canonicalize vertical heuristic headings (#747)

### DIFF
--- a/src/lead-gen/prompts/new-business-prompt.ts
+++ b/src/lead-gen/prompts/new-business-prompt.ts
@@ -66,11 +66,11 @@ Use "not_recommended" when the business is disqualified or clearly outside our t
 
 Business names often contain industry clues. Use these patterns:
 
-- **Home services:** plumbing, plumber, HVAC, heating, cooling, air, electric, electrical, pest, landscape, lawn, cleaning, maid, roofing, painting, pool, garage, handyman
-- **Professional services:** law, legal, attorney, CPA, accounting, tax, bookkeeping, insurance, realty, real estate, financial, advisory, consulting, architect, engineering, marketing, design
-- **Contractor/trades:** construction, contracting, remodel, concrete, framing, drywall, flooring, tile, cabinet, countertop, excavation, demolition, welding, fabrication
-- **Retail/salon/spa:** salon, spa, barber, beauty, nail, boutique, shop, store, fitness, gym, studio
-- **Restaurant/food:** restaurant, cafe, bistro, grill, kitchen, catering, bakery, pizzeria, taco, sushi, bar
+- **home_services:** plumbing, plumber, HVAC, heating, cooling, air, electric, electrical, pest, landscape, lawn, cleaning, maid, roofing, painting, pool, garage, handyman
+- **professional_services:** law, legal, attorney, CPA, accounting, tax, bookkeeping, insurance, realty, real estate, financial, advisory, consulting, architect, engineering, marketing, design
+- **contractor_trades:** construction, contracting, remodel, concrete, framing, drywall, flooring, tile, cabinet, countertop, excavation, demolition, welding, fabrication
+- **retail_salon:** salon, spa, barber, beauty, nail, boutique, shop, store, fitness, gym, studio
+- **restaurant_food:** restaurant, cafe, bistro, grill, kitchen, catering, bakery, pizzeria, taco, sushi, bar
 
 When the name is ambiguous (e.g., "Copper State Holdings LLC"), use entity type, address, permit type, and additional_data to infer vertical. If still unclear, use "other."
 

--- a/tests/lead-gen-vertical-headings.test.ts
+++ b/tests/lead-gen-vertical-headings.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { VERTICALS } from '../src/portal/assessments/extraction-schema'
+
+const newBusinessPrompt = readFileSync(
+  resolve('src/lead-gen/prompts/new-business-prompt.ts'),
+  'utf8'
+)
+
+describe('new-business prompt vertical heading canonicalization (#747)', () => {
+  it('uses canonical enum names as heuristic section headings', () => {
+    const heuristicHeadings = [
+      'home_services',
+      'professional_services',
+      'contractor_trades',
+      'retail_salon',
+      'restaurant_food',
+    ]
+    for (const heading of heuristicHeadings) {
+      expect(newBusinessPrompt).toContain(`- **${heading}:**`)
+    }
+  })
+
+  it('does not emit the deprecated retail_food sibling that Haiku invented', () => {
+    expect(newBusinessPrompt).not.toContain('retail_food')
+  })
+
+  it('does not use freeform spaced/slashed heading variants', () => {
+    expect(newBusinessPrompt).not.toMatch(/- \*\*Home services:/)
+    expect(newBusinessPrompt).not.toMatch(/- \*\*Professional services:/)
+    expect(newBusinessPrompt).not.toMatch(/- \*\*Contractor\/trades:/)
+    expect(newBusinessPrompt).not.toMatch(/- \*\*Retail\/salon\/spa:/)
+    expect(newBusinessPrompt).not.toMatch(/- \*\*Restaurant\/food:/)
+  })
+
+  it('keeps every canonical vertical referenced somewhere in the prompt', () => {
+    for (const vertical of VERTICALS) {
+      expect(newBusinessPrompt).toContain(vertical)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Aligns all five vertical heuristic headings in `new-business-prompt.ts` to canonical enum names so Haiku's emitted `vertical_match` value matches the validator. Closes #747.
- Adds a source-level guard test (`tests/lead-gen-vertical-headings.test.ts`) asserting canonical headings, absence of the invented `retail_food` sibling, absence of freeform variants, and that every canonical vertical is referenced somewhere in the prompt.

## Why this is the right shape
The bug surfaced as Haiku emitting `retail_food` (parallel to `retail_salon`) and failing validation. The proximate fix is one line; the root cause is that five of the six heuristic headings used freeform names while the model is required to output canonical enum values. Aligning all five forecloses the same drift on the other four headings.

## Test plan
- [x] `npm run verify` passes
- [x] Test file run isolated: 4 passed
- [x] Adjacent prompt-source tests still pass: `lead-gen-statewide`, `lead-gen-revenue-gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)