### PR TITLE
fix(outreach): tighten draft prompt against 8 production rejection patterns

### DIFF
--- a/src/lib/claude/outreach.ts
+++ b/src/lib/claude/outreach.ts
@@ -57,11 +57,27 @@ The draft is used after public-source enrichment is assembled. It is not a diagn
 - Do not claim to know the recipient's business state, history, growth phase, internal experience, emotions, or thoughts unless the exact claim is present in the intelligence.
 - Do not say "systems," "streamline," "leverage," or "game-changer."
 - Subject line must be specific to this business. Not generic. Not clever. Specific.
-- Maximum 120 words for the email body. Subject line is separate.
+- **Strict 120-word maximum** for the email body. Subject line is separate from the count. Aim for ~100 words to leave headroom. Every word counts — articles, prepositions, sign-off. One word over fails validation.
 - Sign off as "-- The SMD Services team"
 
 ## Anti-fabrication rule (CRITICAL)
 Every specific detail in the email must trace to the intelligence gathered below. If you do not have evidence for a number, event, person's name, quote, or date, do not invent one. When the intelligence is thin, stay broad and factual rather than pretending we know their business.
+
+## Specific patterns to avoid (drawn from past validator rejections)
+
+Each of the following has caused a draft to fail in production. They are listed here because the abstract "no inference" rule keeps getting routed around. Treat these as hard rules, not suggestions.
+
+1. **Causal inference from observed data.** Facts in the intelligence (rating, review count, hiring text, license filing) are facts only. Do not speculate about *why* a fact is what it is. Forbidden phrasings include "suggests friction," "indicates struggle," "points to a challenge with," "reflects pressure on," "shows the need for." If you find yourself writing "X suggests Y," delete it.
+
+2. **Ownership claims about web presence or traction.** Review counts, ratings, Google listings, social profiles, and website pages are public facts about the business. Mention them as facts; do NOT characterize them as something the business "built," "earned," "established," "achieved," "developed," or "grew." "167 reviews on Google" is allowed. "Already built 167 reviews" is not.
+
+3. **Hedged state assumptions.** A new business license does NOT tell you whether the business is launching fresh, expanding from elsewhere, or relocating. Do not write "either expanding or launching," "either new or established," or any other binary guess. State only what the intelligence directly supports.
+
+4. **Multi-location claims from website copy.** Service-area lists ("we serve Phoenix, Tucson, Flagstaff"), location pages, or address lists on a website do NOT establish that the business operates at multiple addresses. Do not write "your locations in A and B," "your multi-state footprint," or "expanding the X footprint" from website content alone. Multiple operating addresses require explicit confirmation in the intelligence.
+
+5. **Inconsistent-address handling.** If the license address and the website address conflict (e.g. license in Scottsdale, website lists Phoenix), do NOT pick one and assert it as "your location." Avoid location-specific claims when the intelligence is inconsistent. Reference the business by name, not by location.
+
+6. **Growth-state language.** "Growing," "expanding," "scaling," "continues to grow," "footprint" all imply a trajectory the intelligence has not established. Use them only when the intelligence explicitly states the business is in that phase. A new license is not evidence of growth — it's evidence of a license.
 
 Output ONLY the subject line and email. No commentary, no markdown fences.`
 
@@ -191,6 +207,19 @@ const BANNED_DRAFT_PHRASES = [
   'connect dots',
   'you are feeling',
   'you are thinking',
+  // Added 2026-05-18 from production validator rejections in the prior 14
+  // days. Each phrase appeared verbatim in a draft that the Pattern A
+  // classifier flagged. Listed here so the mechanical pre-filter catches
+  // them before the Haiku call.
+  'either expanding',
+  'either launching',
+  'continues growing',
+  'continues to grow',
+  'suggests friction',
+  'suggests some friction',
+  'indicates struggle',
+  'already built a',
+  'already built an',
 ] as const
 
 function parseDraft(draft: string): { subject: string; body: string } {

--- a/tests/outreach-pattern-a.test.ts
+++ b/tests/outreach-pattern-a.test.ts
@@ -59,4 +59,42 @@ We came across your part-time shop coordinator opening and your recent customer 
 
     await expect(validateOutreachDraft('sk-test', INTELLIGENCE, draft)).resolves.toBeUndefined()
   })
+
+  // Regression coverage for 2026-05-18 prompt tightening. Each phrase below
+  // appeared verbatim in a real validator rejection in the prior 14 days
+  // (see docs/audits/lead-gen-pivot-validation-2026-05-08.md and
+  // enrichment_runs.error_message). The mechanical pre-filter should catch
+  // them before the Haiku classifier call.
+  const NEW_BANLIST_CASES: Array<{ phrase: string; label: string }> = [
+    { phrase: 'either expanding or launching fresh', label: 'either expanding' },
+    { phrase: 'either launching as a new business or relocating', label: 'either launching' },
+    { phrase: 'as the business continues growing', label: 'continues growing' },
+    { phrase: 'and continues to grow into the local market', label: 'continues to grow' },
+    {
+      phrase: 'suggests friction in how client interactions are handled',
+      label: 'suggests friction',
+    },
+    {
+      phrase: 'rating suggests some friction in customer experience',
+      label: 'suggests some friction',
+    },
+    { phrase: 'review volume indicates struggle with throughput', label: 'indicates struggle' },
+    { phrase: 'already built a verified Google presence', label: 'already built a' },
+    { phrase: 'already built an audience of loyal customers', label: 'already built an' },
+  ]
+
+  for (const { phrase, label } of NEW_BANLIST_CASES) {
+    it(`rejects mechanical violation: "${label}"`, async () => {
+      const fetchSpy = vi.fn()
+      vi.stubGlobal('fetch', fetchSpy)
+      const draft = `Subject for Desert Bloom
+
+${phrase} and that is why we are reaching out.`
+
+      await expect(validateOutreachDraft('sk-test', INTELLIGENCE, draft)).rejects.toThrow(
+        OutreachValidationError
+      )
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+  }
 })


### PR DESCRIPTION
## Summary
Reduces outreach_draft module failure rate by tightening the Sonnet generation prompt against the 8 real Pattern A patterns the Haiku validator caught in the prior 14 days. Validator was working correctly — the generator was over-eager to infer.

## Production data driving this
14 outreach_draft module failures last 14d (from `enrichment_runs.error_message`):
- **8 Pattern A inference violations:** "your 2.6 rating suggests friction in client interactions," "already built a verified Google presence with 167 client reviews," "either expanding or launching fresh," "expanding your senior care footprint," "as the business continues growing," etc.
- **5 mechanical:** 3 em dashes + 3 word-count overruns at 121–123 words against the 120 cap.
- **1 transient:** Anthropic 429 rate limit.

## What changed

### System prompt
New "Specific patterns to avoid" section with 6 concrete anti-patterns, each drawn from a real rejection:
1. Causal inference from observed data
2. Ownership claims about web presence/traction
3. Hedged state assumptions ("either X or Y")
4. Multi-location claims from website copy
5. Inconsistent-address handling
6. Growth-state language

Word-count guidance tightened: "Strict 120-word maximum. Aim for ~100 words. Every word counts. One word over fails validation."

### Mechanical pre-filter
9 additions to `BANNED_DRAFT_PHRASES` targeting the exact substrings the model used:
- `either expanding`, `either launching`
- `continues growing`, `continues to grow`
- `suggests friction`, `suggests some friction`, `indicates struggle`
- `already built a`, `already built an`

Each backed by a regression test using the existing test pattern.

## Test plan
- [x] `npm run verify` passes
- [x] 12 outreach-pattern-a tests pass (3 existing + 9 new banlist regressions)
- [x] 29 outreach-vertical-aware tests still pass (no vertical-block changes)

## Expected production effect
Pre-pivot rejection rate: ~21% (14/66 attempts). The 5 mechanical rejections should drop to near-zero (the model is consistently overshooting word count by 1–3 words; the explicit guidance should fix this). The 8 inference rejections should drop substantially since each pattern is now explicitly named. Net expected: outreach_draft success rate from 79% → 90%+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)