### PR TITLE
fix(dedup): drop area from slug, broaden fuzzy-match scope (#751 bugs 2 & 3)

### DIFF
--- a/src/lib/db/entities.ts
+++ b/src/lib/db/entities.ts
@@ -291,16 +291,22 @@ interface FuzzyMatchCandidate {
   score: number
 }
 
-async function findBestFuzzyAreaMatch(
+/**
+ * Find the highest-scoring Jaro-Winkler match for `name` across the org's
+ * existing entities. Scope is org-wide as of 2026-05-18 (#751 bug 3) —
+ * previously scoped `WHERE area = ?`, which silently disabled fuzzy
+ * matching for area-less ingests (the common case post-bug-1, since
+ * `entities.area` was being silently dropped at INSERT).
+ */
+async function findBestFuzzyMatch(
   db: D1Database,
   orgId: string,
   name: string,
-  area: string,
   threshold: number
 ): Promise<FuzzyMatchCandidate | null> {
   const candidates = await db
-    .prepare(`SELECT * FROM entities WHERE org_id = ? AND area = ?`)
-    .bind(orgId, area)
+    .prepare(`SELECT * FROM entities WHERE org_id = ?`)
+    .bind(orgId)
     .all<Entity>()
 
   const target = normalizeBusinessName(name)
@@ -321,18 +327,16 @@ async function maybeLogFuzzyDuplicate(
   data: CreateEntityData,
   slug: string
 ): Promise<void> {
-  if (!data.area) return
-
   const settings = await getPipelineSettings(db, orgId, 'new_business')
   const threshold = settings.dedup_fuzzy_threshold
-  const bestMatch = await findBestFuzzyAreaMatch(db, orgId, data.name, data.area, threshold)
+  const bestMatch = await findBestFuzzyMatch(db, orgId, data.name, threshold)
   if (!bestMatch) return
 
   await appendCandidateMergeLog(db, orgId, {
     existingEntityId: bestMatch.entity.id,
     candidateName: data.name,
     candidateSlug: slug,
-    candidateArea: data.area,
+    candidateArea: data.area ?? null,
     matchedName: bestMatch.entity.name,
     matchedArea: bestMatch.entity.area,
     sourcePipeline: data.source_pipeline ?? null,

--- a/src/lib/entities/slug.ts
+++ b/src/lib/entities/slug.ts
@@ -2,12 +2,23 @@
  * Slug computation for entity dedup.
  *
  * Normalizes business names into URL-safe slugs for UNIQUE(org_id, slug)
- * dedup. When area is provided, it's appended for location disambiguation
- * (e.g., two PIRTEK franchises in different cities).
+ * dedup. Slug is name-only as of 2026-05-18 (#751 bug 2).
  *
- * Known limitation: genuinely different name variants for the same business
- * (e.g., "AZ Comfort Solutions" vs "Arizona Comfort Solutions") will create
- * separate entities. Handle with admin merge action at the UI layer.
+ * History. Pre-2026-05-18 the slug included the area as a disambiguator
+ * ("pirtek-goodyear-az"). That worked when geography was Phoenix-only
+ * and area strings were stable. After ADR 0003 made reach statewide,
+ * the area in the slug stopped being a meaningful discriminator AND
+ * SerpAPI started returning drifting location strings for the same
+ * business ("Phoenix, AZ" vs "Phoenix, AZ, Estados Unidos" vs "AZ"),
+ * which created N entities for the same business across cron runs.
+ * Slug is now name-only; genuine collisions (two different "Joe's
+ * Plumbing" businesses in AZ) get caught by the fuzzy-match logger
+ * and resolved by the admin Merge action.
+ *
+ * Known limitation: genuinely different name variants for the same
+ * business (e.g., "AZ Comfort Solutions" vs "Arizona Comfort Solutions")
+ * will still produce different slugs. The Jaro-Winkler fuzzy-match
+ * logger catches these as `candidate_merge_log` rows for admin review.
  */
 
 /** Common business suffixes stripped during normalization. */
@@ -18,13 +29,17 @@ const SUFFIX_PATTERN =
 const PAREN_PATTERN = /\s*\(.*?\)\s*/g
 
 /**
- * Compute a normalized slug from a business name and optional area.
+ * Compute a normalized slug from a business name.
+ *
+ * The `area` parameter is accepted for backwards compatibility with
+ * existing callers but no longer influences the slug. See file-level
+ * doc comment for history.
  *
  * Examples:
- *   computeSlug("PIRTEK (Goodyear, AZ – Franchise Location)", "Goodyear, AZ")
- *     → "pirtek-goodyear-az"
+ *   computeSlug("PIRTEK (Goodyear, AZ – Franchise Location)")
+ *     → "pirtek"
  *   computeSlug("ProGuard Roofing LLC", "Phoenix, AZ")
- *     → "proguard-roofing-phoenix-az"
+ *     → "proguard-roofing"
  *   computeSlug("Smith & Sons Plumbing")
  *     → "smith-sons-plumbing"
  */
@@ -38,27 +53,8 @@ export function normalizeBusinessName(name: string): string {
   return s.trim().replace(/\s+/g, ' ').replace(/-+/g, '-')
 }
 
-function normalizeArea(area: string): string {
-  return area
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, '')
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-}
-
-export function computeSlug(name: string, area?: string | null): string {
-  let s = normalizeBusinessName(name).replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
-
-  if (area) {
-    const a = normalizeArea(area)
-    if (a) {
-      s = `${s}-${a}`
-    }
-  }
-
-  return s
+export function computeSlug(name: string, _area?: string | null): string {
+  return normalizeBusinessName(name).replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
 }
 
 export function jaroWinklerSimilarity(a: string, b: string): number {

--- a/tests/entities-fuzzy-dedup-log.test.ts
+++ b/tests/entities-fuzzy-dedup-log.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createTestD1,
+  discoverNumericMigrations,
+  runMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import { findOrCreateEntity } from '../src/lib/db/entities'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+const ORG = 'org-test'
+
+async function setup() {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  await db
+    .prepare(`INSERT INTO organizations (id, name, slug) VALUES (?, ?, ?)`)
+    .bind(ORG, 'Test Org', 'test-org')
+    .run()
+  return db
+}
+
+describe('candidate_merge_log fuzzy dedup logging (#751 bugs 2 & 3)', () => {
+  it('logs an org-wide near-match even when both entities have no area', async () => {
+    const db = await setup()
+
+    // First ingest: clean business
+    const first = await findOrCreateEntity(db, ORG, {
+      name: 'Sonoran Desert Plumbing',
+      source_pipeline: 'job_monitor',
+    })
+    expect(first.status).toBe('created')
+
+    // Second ingest: typo'd version of the same name. Slug differs but
+    // Jaro-Winkler scores well above the 0.92 default threshold. Area
+    // is null on both — pre-fix this would have silently bailed out
+    // via `if (!data.area) return`.
+    const second = await findOrCreateEntity(db, ORG, {
+      name: 'Sonaran Desert Plumbing',
+      source_pipeline: 'new_business',
+    })
+    expect(second.status).toBe('created')
+
+    const rows = await db
+      .prepare(`SELECT * FROM candidate_merge_log WHERE org_id = ?`)
+      .bind(ORG)
+      .all<{
+        candidate_name: string
+        matched_name: string
+        score: number
+        reason: string
+        source_pipeline: string
+      }>()
+    expect(rows.results.length).toBe(1)
+    const row = rows.results[0]
+    expect(row.candidate_name).toBe('Sonaran Desert Plumbing')
+    expect(row.matched_name).toBe('Sonoran Desert Plumbing')
+    expect(row.reason).toBe('slug_fuzzy_match')
+    expect(row.score).toBeGreaterThan(0.92)
+  })
+
+  it('does not log when no candidate clears the fuzzy threshold', async () => {
+    const db = await setup()
+
+    await findOrCreateEntity(db, ORG, {
+      name: 'Sonoran Electric LLC',
+      source_pipeline: 'job_monitor',
+    })
+    await findOrCreateEntity(db, ORG, {
+      name: 'High Desert Veterinary Group',
+      source_pipeline: 'job_monitor',
+    })
+
+    const rows = await db
+      .prepare(`SELECT COUNT(*) AS n FROM candidate_merge_log WHERE org_id = ?`)
+      .bind(ORG)
+      .first<{ n: number }>()
+    expect(rows?.n).toBe(0)
+  })
+
+  it('exact-name re-ingest hits the slug UNIQUE check, not the fuzzy logger', async () => {
+    // Same business, two slightly different area strings from SerpAPI.
+    // Pre-#751: each created a new entity (slug included area). Post-fix:
+    // slug is name-only, second call returns the first entity.
+    const db = await setup()
+
+    const first = await findOrCreateEntity(db, ORG, {
+      name: 'Old Town Towing',
+      area: 'Phoenix, AZ',
+      source_pipeline: 'job_monitor',
+    })
+    expect(first.status).toBe('created')
+
+    const second = await findOrCreateEntity(db, ORG, {
+      name: 'Old Town Towing',
+      area: 'Phoenix, AZ, United States',
+      source_pipeline: 'job_monitor',
+    })
+    expect(second.status).toBe('found')
+    expect(second.entity.id).toBe(first.entity.id)
+
+    // No fuzzy-log row: the slug check matched directly.
+    const rows = await db
+      .prepare(`SELECT COUNT(*) AS n FROM candidate_merge_log WHERE org_id = ?`)
+      .bind(ORG)
+      .first<{ n: number }>()
+    expect(rows?.n).toBe(0)
+  })
+})

--- a/tests/lead-gen-dedup.test.ts
+++ b/tests/lead-gen-dedup.test.ts
@@ -3,8 +3,26 @@ import { computeSlug, jaroWinklerSimilarity, normalizeBusinessName } from '../sr
 
 describe('lead-gen dedup normalization', () => {
   it('strips common business suffixes from slug normalization', () => {
-    expect(computeSlug('ProGuard Roofing LLC', 'Phoenix, AZ')).toBe('proguard-roofing-phoenix-az')
-    expect(computeSlug('Acme Electric Co.', 'Mesa, AZ')).toBe('acme-electric-mesa-az')
+    expect(computeSlug('ProGuard Roofing LLC')).toBe('proguard-roofing')
+    expect(computeSlug('Acme Electric Co.')).toBe('acme-electric')
+  })
+
+  // Regression for #751 bug 2 (SerpAPI location-string drift):
+  // The same business at the same address but with a slightly different
+  // location string from SerpAPI must produce the same slug — otherwise
+  // every cron run creates a new entity for the same business.
+  it('produces a single slug for one business regardless of area variants', () => {
+    const variants = [
+      computeSlug('Old Town Towing', 'Phoenix, AZ'),
+      computeSlug('Old Town Towing', 'Phoenix, AZ, United States'),
+      computeSlug('Old Town Towing', 'Phoenix, AZ, Estados Unidos'),
+      computeSlug('Old Town Towing', 'AZ'),
+      computeSlug('Old Town Towing', null),
+      computeSlug('Old Town Towing'),
+    ]
+    for (const slug of variants) {
+      expect(slug).toBe('old-town-towing')
+    }
   })
 
   it('normalizes names for fuzzy comparison', () => {


### PR DESCRIPTION
## Summary
Closes the dedup-logging chain investigation. With Bug 1 already fixed in PR #783 and Bugs 2 & 3 fixed here, `candidate_merge_log` should start accumulating real near-misses; the original calibration step in #751 becomes runnable.

## Two fixes

### Bug 2 — SerpAPI location-string instability
`computeSlug(name, area)` appended a normalized area suffix to the slug. SerpAPI returned drifting location strings for the same business: "Phoenix, AZ" → "Phoenix, AZ, United States" → "Phoenix, AZ, Estados Unidos" → "AZ". Each produced a different slug; the slug UNIQUE check missed; multiple entities for the same business accumulated.

**Fix:** slug is name-only. The `area` parameter is kept on `computeSlug` for backward compat but ignored.

### Bug 3 — fuzzy-match scope was area-required
`findBestFuzzyAreaMatch` filtered `WHERE area = ?` and `maybeLogFuzzyDuplicate` bailed on missing area. Combined with the pre-#783 silent-area-drop, fuzzy logging ran for effectively 0% of post-2026-04-03 ingests.

**Fix:** rename `findBestFuzzyAreaMatch` → `findBestFuzzyMatch`, drop the area filter, drop the `if (!data.area) return` guard. Scope is now org-wide.

## Tests
- `tests/lead-gen-dedup.test.ts` — new regression: "single slug per business regardless of area variant" (6 area variants for "Old Town Towing" all produce `old-town-towing`)
- `tests/entities-fuzzy-dedup-log.test.ts` — three new behavioral tests using the D1 test harness:
  1. Near-match with no area on either entity logs to `candidate_merge_log`
  2. Below-threshold names do not log
  3. Exact-name re-ingest with drifting area hits the slug check, not the fuzzy logger (confirms Bug 2 fix end-to-end)

## What this does NOT do
- No backfill of legacy slugs (271 entities with area-bearing slugs). The fuzzy-match logger will surface them as Captain reviews `candidate_merge_log` over time.
- No threshold calibration. That was the original #751 premise; it's now runnable after this PR — followup, not in this scope.

## Test plan
- [x] `npm run verify` passes
- [x] 12 dedup tests pass across the three files
- [x] Old slug expectations updated to the new name-only form

🤖 Generated with [Claude Code](https://claude.com/claude-code)