### PR TITLE
feat(portal): substrate for Clerk auth + product subscription model

### DIFF
--- a/migrations/0038_portal_clerk_subscriptions_substrate.sql
+++ b/migrations/0038_portal_clerk_subscriptions_substrate.sql
@@ -1,0 +1,102 @@
+-- Portal substrate for Clerk auth + product subscription model
+-- ============================================================================
+--
+-- Adds the schema substrate the AI Employee dashboard (and future subscription
+-- products) needs to live inside portal.smd.services as product modules.
+--
+-- Decisions encoded here:
+--   * Clerk is the identity layer. `users.clerk_user_id` and
+--     `entities.clerk_org_id` are the bridge to local business state.
+--   * Subscriptions are product-agnostic. The same table tracks AI Employee
+--     and any future productized SKU.
+--   * Per-product roles (principal | operator | compliance for AI Employee)
+--     live in a polymorphic table keyed by (user, entity, product_slug).
+--     Clerk's `admin | basic_member` Organization role sits at a separate axis
+--     and is resolved from Clerk, not from this table.
+--
+-- Forward-only, additive. No drops. Existing magic-link auth keeps working
+-- through the migration. Removal of magic-link tables is deferred to a later
+-- migration once Clerk-backed login is verified in production.
+-- ============================================================================
+
+-- ---------- users.clerk_user_id ----------
+-- Bridge column to the Clerk user that owns this portal identity. Nullable
+-- during transition; backfilled by the Clerk-import flow. Unique when present.
+ALTER TABLE users ADD COLUMN clerk_user_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_clerk_user
+  ON users(clerk_user_id) WHERE clerk_user_id IS NOT NULL;
+
+-- ---------- entities.clerk_org_id ----------
+-- Bridge column to the Clerk Organization representing this customer. Nullable
+-- until the entity becomes a paying customer with portal access provisioned.
+-- A single entity maps to at most one Clerk Organization (1:1).
+ALTER TABLE entities ADD COLUMN clerk_org_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_entities_clerk_org
+  ON entities(clerk_org_id) WHERE clerk_org_id IS NOT NULL;
+
+-- ---------- subscriptions ----------
+-- Product-agnostic subscription ledger. One row per (entity, product) pair
+-- the customer has purchased. The `product_slug` is a stable identifier
+-- ('ai-employee' for the v1 SKU); future products add new slugs without
+-- schema changes.
+--
+-- `settings_json` holds per-product configuration the portal needs to render
+-- the product module (e.g., the AI Employee customer slug used to address
+-- the per-customer Hermes Machine). Substantive product state lives in the
+-- customer's per-customer D1 per ADR 0008, not here.
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  entity_id       TEXT NOT NULL REFERENCES entities(id),
+  product_slug    TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'provisioning' CHECK (status IN (
+    'provisioning', 'active', 'paused', 'cancelled'
+  )),
+  started_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  ended_at        TEXT,
+  settings_json   TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(entity_id, product_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_entity
+  ON subscriptions(entity_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_product_status
+  ON subscriptions(product_slug, status);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_org_product
+  ON subscriptions(org_id, product_slug);
+
+-- ---------- product_roles ----------
+-- Per-user, per-entity, per-product role assignment. For AI Employee, the
+-- `role` vocabulary is 'principal' | 'operator' | 'compliance' (set by the
+-- product, not constrained at the schema layer — future products may use
+-- different vocabularies).
+--
+-- Sits on a separate axis from Clerk's Organization membership role
+-- (admin | basic_member), which governs who can manage the org itself.
+-- Product roles govern what a user can do INSIDE a specific product they
+-- have access to.
+--
+-- Soft-delete via revoked_at preserves the audit trail. A user may have
+-- multiple roles within a single product on a single entity (the UNIQUE
+-- constraint permits row coexistence on different role values).
+CREATE TABLE IF NOT EXISTS product_roles (
+  id              TEXT PRIMARY KEY,
+  org_id          TEXT NOT NULL REFERENCES organizations(id),
+  user_id         TEXT NOT NULL REFERENCES users(id),
+  entity_id       TEXT NOT NULL REFERENCES entities(id),
+  product_slug    TEXT NOT NULL,
+  role            TEXT NOT NULL,
+  granted_by      TEXT REFERENCES users(id),
+  granted_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  revoked_at      TEXT,
+  UNIQUE(user_id, entity_id, product_slug, role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_product_roles_user_entity
+  ON product_roles(user_id, entity_id) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_product_roles_entity_product
+  ON product_roles(entity_id, product_slug) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_product_roles_org_product
+  ON product_roles(org_id, product_slug) WHERE revoked_at IS NULL;

--- a/migrations/rollbacks/0038_portal_clerk_subscriptions_substrate_down.sql
+++ b/migrations/rollbacks/0038_portal_clerk_subscriptions_substrate_down.sql
@@ -1,0 +1,27 @@
+-- Manual rollback for migration 0038. NOT auto-applied.
+-- See migrations/rollbacks/README.md.
+--
+-- DESTRUCTIVE: dropping `subscriptions` and `product_roles` removes all
+-- subscription state and product-role assignments. Only invoke after
+-- confirming no production data depends on these tables.
+--
+-- SQLite/D1 does not support DROP COLUMN directly on indexed columns; the
+-- `clerk_user_id` / `clerk_org_id` columns are left in place (they are
+-- nullable and harmless). The unique indexes are dropped explicitly so a
+-- re-apply of 0038 succeeds.
+
+DROP INDEX IF EXISTS idx_product_roles_org_product;
+DROP INDEX IF EXISTS idx_product_roles_entity_product;
+DROP INDEX IF EXISTS idx_product_roles_user_entity;
+DROP TABLE IF EXISTS product_roles;
+
+DROP INDEX IF EXISTS idx_subscriptions_org_product;
+DROP INDEX IF EXISTS idx_subscriptions_product_status;
+DROP INDEX IF EXISTS idx_subscriptions_entity;
+DROP TABLE IF EXISTS subscriptions;
+
+DROP INDEX IF EXISTS idx_entities_clerk_org;
+DROP INDEX IF EXISTS idx_users_clerk_user;
+-- Note: ALTER TABLE DROP COLUMN is not supported in legacy SQLite; the
+-- clerk_user_id and clerk_org_id columns remain. They are nullable with no
+-- writers after rollback, so they impose no runtime cost.


### PR DESCRIPTION
## Summary

First slice of the portal architecture work for the AI Employee dashboard (and future subscription products). Pure schema substrate — forward-only, additive, no drops, no behavioral change. Existing magic-link auth continues to work; this PR doesn't touch it.

## What lands

**Bridge columns to Clerk** (Clerk is the identity layer for portal.smd.services; SMD will get a new Clerk Application on the existing Hobby workspace):
- `users.clerk_user_id` — nullable, unique when present
- `entities.clerk_org_id` — nullable, unique when present, 1:1 mapping

**New tables:**
- `subscriptions` — product-agnostic ledger keyed by `(entity_id, product_slug)`. Status lifecycle `provisioning → active → paused → cancelled`. `settings_json` holds per-product config (e.g., the AI Employee customer slug used to address the per-customer Hermes Machine).
- `product_roles` — per-user, per-entity, per-product role assignment. AI Employee vocabulary is `principal | operator | compliance`; future products bring their own. Sits on a separate axis from Clerk's Organization membership role. Soft-delete via `revoked_at`.

**Rollback:** `migrations/rollbacks/0038_portal_clerk_subscriptions_substrate_down.sql` (not auto-applied per the rollbacks README convention).

## Decisions encoded

- **Customer-first portal.** Universal customer surfaces (invoices, documents, communications) stay shared. AI Employee and future subscription products appear as conditional product modules driven by `subscriptions`.
- **Clerk for identity, our D1 for business state.** Clerk owns users / organizations / memberships / invitations / sessions. We own subscriptions, product roles, engagements, invoices, audit.
- **No B2B SaaS add-on.** Per-product roles (the `principal | operator | compliance` distinction) live in `product_roles`, not in Clerk custom roles. Clerk's default `admin | basic_member` Organization role pair is what we use at the Clerk layer.
- **Hobby tier is enough for v1.** Organizations is included on Hobby; no Pro upgrade required to ship.

## Verified

- `npx wrangler d1 execute ss-console-db --local --file migrations/0038_portal_clerk_subscriptions_substrate.sql` applies cleanly
- All 2 tables, 2 bridge columns, and 8 indexes present after apply (verified via `sqlite_master`)
- No conflict with existing `users.password_hash` (already present from a prior migration)

## Follow-ons

This is PR 1 of 3 for the portal/dashboard substrate:

1. **This PR** — schema substrate
2. **Next** — Clerk integration: install `@clerk/astro`, middleware session validation on portal.smd.services, bridge `getPortalClient()` to resolve via Clerk user + active org → local entity. Includes a checklist for the SMD Services Clerk Application creation.
3. **After that** — #868 follow-through: Astro routes at `/portal/products/ai-employee/*`, layout shell, role gate using `product_roles`.

## Test plan

- [x] Migration applies on local D1 without errors
- [x] All expected tables/columns/indexes present after apply
- [ ] CI passes (typecheck, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)