### PR TITLE
feat(portal): install @clerk/astro and compose Clerk middleware

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -31,3 +31,13 @@ GOOGLE_PLACES_API_KEY=""
 OUTSCRAPER_API_KEY=""
 SERPAPI_API_KEY=""
 PROXYCURL_API_KEY=""
+
+# ---------- Clerk auth (portal.smd.services) ----------
+# Identity layer for the portal — users, organizations, memberships,
+# invitations, sessions. SMD Services Application in the shared Clerk
+# workspace. Pull from Infisical (path=/) for local dev:
+#   infisical secrets get PUBLIC_CLERK_PUBLISHABLE_KEY --env=dev --path=/ --plain
+#   infisical secrets get CLERK_SECRET_KEY --env=dev --path=/ --plain
+# Production deploys read from Workers secrets (synced via Infisical bulk).
+PUBLIC_CLERK_PUBLISHABLE_KEY=""
+CLERK_SECRET_KEY=""

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig, sessionDrivers } from 'astro/config'
 import cloudflare from '@astrojs/cloudflare'
 import tailwindcss from '@tailwindcss/vite'
 import sitemap from '@astrojs/sitemap'
+import clerk from '@clerk/astro'
 
 // SS uses its own session layer backed by the SESSIONS KV namespace (see
 // src/lib/auth/session.ts); we don't use Astro's built-in session API. Pin
@@ -9,6 +10,17 @@ import sitemap from '@astrojs/sitemap'
 // SESSION KV binding that we wouldn't populate or provision.
 // `imageService: 'passthrough'` avoids the Cloudflare Images binding — SS
 // doesn't use `astro:assets` components.
+//
+// Clerk integration:
+//   - Identity layer for portal.smd.services (users, orgs, memberships,
+//     invitations, sessions). Application "SMD Services" in the existing
+//     Clerk workspace; production instance bound to smd.services apex with
+//     auth subdomains at clerk./accounts./clkmail.smd.services.
+//   - Requires PUBLIC_CLERK_PUBLISHABLE_KEY at build time and
+//     CLERK_SECRET_KEY at runtime. Both live in Infisical (/ path); pulled
+//     into .dev.vars for local dev and into Workers secrets for deploys.
+//   - Coexists with the legacy magic-link auth in src/lib/auth/session.ts
+//     during the transition. Magic-link routes keep working unchanged.
 export default defineConfig({
   site: 'https://smd.services',
   output: 'server',
@@ -16,7 +28,7 @@ export default defineConfig({
     imageService: 'passthrough',
   }),
   session: { driver: sessionDrivers.lruCache() },
-  integrations: [sitemap()],
+  integrations: [clerk(), sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/cloudflare": "^13.1.10",
         "@astrojs/sitemap": "^3.7.2",
+        "@clerk/astro": "^3.2.6",
         "@formepdf/core": "^0.8.2",
         "@formepdf/react": "^0.8.2",
         "@sentry/cloudflare": "^10.51.0",
@@ -295,6 +296,85 @@
         "fast-string-width": "^1.1.0",
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clerk/astro": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@clerk/astro/-/astro-3.2.6.tgz",
+      "integrity": "sha512-EXh/Gtcj+kP99hUdMDUbnf31gv8to8cm2A3DN1Do8JSVBQI7538sFuC4AGiaO7JV46OzrLhvWQyF3RpiQHDtJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.4.11",
+        "@clerk/shared": "^4.12.2",
+        "nanoid": "5.1.6",
+        "nanostores": "1.0.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "astro": "^4.15.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@clerk/astro/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.11.tgz",
+      "integrity": "sha512-WT+4FrcMMofxe+irQYUkawoRWaHHXT9/wiRYhRbSb30cOPjN95ViydqPhAyp8ZWAHInHg4mILynQQRJH14SKZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.12.2",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.12.2.tgz",
+      "integrity": "sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -2239,6 +2319,12 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "dev": true,
@@ -2501,6 +2587,16 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
+      "integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -4863,6 +4959,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
@@ -5081,6 +5183,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "17.6.0",
@@ -5509,6 +5617,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -6927,6 +7044,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanostores": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.0.1.tgz",
+      "integrity": "sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -8034,9 +8166,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-replace-string": {
@@ -8321,8 +8462,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^13.1.10",
     "@astrojs/sitemap": "^3.7.2",
+    "@clerk/astro": "^3.2.6",
     "@formepdf/core": "^0.8.2",
     "@formepdf/react": "^0.8.2",
     "@sentry/cloudflare": "^10.51.0",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -140,6 +140,13 @@ declare namespace Cloudflare {
      * in prod (a missing binding in prod is a deploy ordering bug).
      */
     ENRICHMENT_WORKFLOW_SERVICE?: EnrichmentWorkflowServiceBinding
+    /**
+     * Clerk secret key (sk_test_* for dev, sk_live_* for prod). Used by
+     * @clerk/astro middleware to authenticate Clerk sessions on
+     * portal.smd.services. Pulled from Infisical at deploy time per the
+     * standard wrangler secret bulk pattern documented in CLAUDE.md.
+     */
+    CLERK_SECRET_KEY?: string
   }
 }
 
@@ -166,6 +173,12 @@ declare namespace App {
 interface ImportMetaEnv {
   readonly PUBLIC_GA4_MEASUREMENT_ID?: string
   readonly PUBLIC_GA4_INTERNAL_HOST_PATTERNS?: string
+  /**
+   * Clerk publishable key (pk_test_* for dev, pk_live_* for prod). Required
+   * at build time — @clerk/astro inlines it into the client bundle. Pulled
+   * from Infisical into .dev.vars locally and into Workers env at deploy.
+   */
+  readonly PUBLIC_CLERK_PUBLISHABLE_KEY?: string
 }
 
 interface ImportMeta {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
-import { defineMiddleware } from 'astro:middleware'
+import { defineMiddleware, sequence } from 'astro:middleware'
 import type { APIContext, MiddlewareNext } from 'astro'
+import { clerkMiddleware } from '@clerk/astro/server'
 import {
   parseSessionToken,
   validateSession,
@@ -193,6 +194,21 @@ async function handleRequest(context: APIContext, next: NextFn): Promise<Respons
   return response
 }
 
-export const onRequest = defineMiddleware(async (context: APIContext, next: NextFn) => {
+// Clerk + legacy magic-link middleware composed in sequence.
+//
+// clerkMiddleware reads the Clerk session cookie (set by @clerk/astro's
+// sign-in flow on auth.smd.services) and populates `Astro.locals.auth()`
+// for downstream handlers. It does NOT enforce auth on any route — that
+// remains the job of the legacy ssMiddleware below, which is being kept
+// untouched during the Clerk transition. Magic-link sessions continue to
+// flow through `context.locals.session` as before.
+//
+// The bridge from Clerk identity to local user/entity state (via
+// users.clerk_user_id and entities.clerk_org_id, added in PR #904) is
+// implemented in a follow-on PR alongside the AI Employee dashboard route
+// (#868).
+const ssMiddleware = defineMiddleware(async (context: APIContext, next: NextFn) => {
   return withSentryRequestHandler(context, () => handleRequest(context, next))
 })
+
+export const onRequest = sequence(clerkMiddleware(), ssMiddleware)


### PR DESCRIPTION
## Summary

Second slice of the portal architecture work. Adds Clerk as the identity layer for portal.smd.services, composed alongside the existing magic-link middleware via Astro's `sequence()`. Behavior change is intentionally minimal — Clerk session is now parsed and available on `locals.auth()`, but no route reads it yet. The bridge to local users/entities lands in PR 3 alongside the AI Employee dashboard route (#868).

## Clerk Application setup (done outside this PR)

- Created **SMD Services** Clerk Application in the existing Clerk workspace (Hobby tier — Organizations supported, 100 MROs/app, 50K MRU cap, custom domain included)
- **Production instance** bound to `smd.services` apex
- 5 CNAMEs verified at Cloudflare (`clerk.`, `accounts.`, `clkmail.`, `clk._domainkey.`, `clk2._domainkey.smd.services`), SSL provisioned automatically
- **Organizations enabled**, Membership required, org slugs on, Limited membership 25
- **Email + Password** primary; email verification on; magic-link demoted to recovery path
- 4 API keys pushed to Infisical at `/` path:
  - `PUBLIC_CLERK_PUBLISHABLE_KEY` (test + live)
  - `CLERK_SECRET_KEY` (test + live)

## What lands in code

- `npm i @clerk/astro` — dependency added
- `astro.config.mjs` — `clerk()` added to integrations
- `src/env.d.ts` — `CLERK_SECRET_KEY` typed on `Cloudflare.Env`, `PUBLIC_CLERK_PUBLISHABLE_KEY` typed on `ImportMetaEnv`
- `src/middleware.ts` — `clerkMiddleware()` composed with the existing `ssMiddleware` via `sequence()`. Clerk parses its session cookie and populates `locals.auth()` on every request. Enforcement still flows through the legacy magic-link middleware (untouched).
- `.dev.vars.example` — documents the dev-vars seeding pattern (pulled from Infisical at `--env=dev --path=/`)

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `npm run build` — completes successfully (Clerk integration compiles at build time, publishable key inlines from `.dev.vars`)

## Not in this PR (next up)

- Reading `locals.auth()` in routes (PR 3 — AI Employee dashboard at `/portal/products/ai-employee/*`)
- Bridge from Clerk identity to local `users`/`entities` rows via `clerk_user_id` and `clerk_org_id` (PR 3)
- Migration path for existing magic-link portal users to Clerk (future PR, no urgency — no live customers yet)
- Per-product role gate using `product_roles` (PR 3)

## Test plan

- [x] Local typecheck passes
- [x] Local build completes
- [ ] CI passes
- [ ] After merge: deploy to Workers and confirm Clerk session detection works in deployed environment (deploy is a separate step — needs prod keys synced to Workers via `wrangler secret bulk` from Infisical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)