### PR TITLE
feat(portal): AI Employee dashboard landing route (#868)

### DIFF
--- a/src/lib/portal/product-access.ts
+++ b/src/lib/portal/product-access.ts
@@ -1,0 +1,114 @@
+/**
+ * Product access helpers for the customer-first portal.
+ *
+ * Two layers govern whether a portal user can use a given product on a
+ * given entity:
+ *
+ *   1. `subscriptions(entity_id, product_slug)` — does this customer
+ *      have an active subscription to the product? Status lifecycle:
+ *      provisioning → active → paused → cancelled.
+ *
+ *   2. `product_roles(user_id, entity_id, product_slug, role)` — is
+ *      this specific user granted a role inside the product? AI
+ *      Employee vocabulary: `principal | operator | compliance`.
+ *      Future products bring their own vocabularies.
+ *
+ * Both layers must pass for the product surface to render. Anything
+ * less degrades to the appropriate empty state per
+ * docs/style/empty-state-pattern.md (no fabrication).
+ */
+
+export interface SubscriptionRow {
+  id: string
+  org_id: string
+  entity_id: string
+  product_slug: string
+  status: string
+  started_at: string
+  ended_at: string | null
+  settings_json: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ProductRoleRow {
+  id: string
+  org_id: string
+  user_id: string
+  entity_id: string
+  product_slug: string
+  role: string
+  granted_by: string | null
+  granted_at: string
+  revoked_at: string | null
+}
+
+export interface ProductAccess {
+  subscription: SubscriptionRow
+  roles: string[]
+}
+
+/**
+ * Return the customer's active subscription for a given product slug, or
+ * null if no row exists or the row is cancelled. `provisioning`,
+ * `active`, and `paused` are all returned — the caller decides which
+ * statuses unlock which UI states.
+ */
+export async function getProductSubscription(
+  db: D1Database,
+  entityId: string,
+  productSlug: string
+): Promise<SubscriptionRow | null> {
+  return await db
+    .prepare(
+      `SELECT * FROM subscriptions
+        WHERE entity_id = ? AND product_slug = ?
+          AND status IN ('provisioning', 'active', 'paused')`
+    )
+    .bind(entityId, productSlug)
+    .first<SubscriptionRow>()
+}
+
+/**
+ * Return the list of active (non-revoked) roles this user holds on this
+ * (entity, product) tuple. Empty array means the user has no access
+ * inside the product even if the customer has a subscription.
+ */
+export async function listProductRoles(
+  db: D1Database,
+  userId: string,
+  entityId: string,
+  productSlug: string
+): Promise<string[]> {
+  const result = await db
+    .prepare(
+      `SELECT role FROM product_roles
+        WHERE user_id = ? AND entity_id = ? AND product_slug = ?
+          AND revoked_at IS NULL
+        ORDER BY granted_at ASC`
+    )
+    .bind(userId, entityId, productSlug)
+    .all<{ role: string }>()
+  return (result.results ?? []).map((r) => r.role)
+}
+
+/**
+ * Combined check: does this user have access to this product on this
+ * customer? Returns the subscription + role list when both layers pass.
+ * Returns null when either the subscription is missing/cancelled or the
+ * user has no roles granted.
+ */
+export async function resolveProductAccess(
+  db: D1Database,
+  userId: string,
+  entityId: string,
+  productSlug: string
+): Promise<ProductAccess | null> {
+  const subscription = await getProductSubscription(db, entityId, productSlug)
+  if (!subscription) return null
+
+  const roles = await listProductRoles(db, userId, entityId, productSlug)
+  if (roles.length === 0) return null
+
+  return { subscription, roles }
+}

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -1,0 +1,222 @@
+---
+import '../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../lib/config/brand'
+import { getPortalClient } from '../../../../lib/portal/session'
+import {
+  getProductSubscription,
+  listProductRoles,
+  type ProductAccess,
+} from '../../../../lib/portal/product-access'
+import PortalHeader from '../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee dashboard — landing page.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee
+ *
+ * Access model (per PR #904 substrate, PR #906 Clerk rewire):
+ *   1. Clerk session required (gated by middleware)
+ *   2. Local users row linked to a Clerk org with a matching local
+ *      entity (resolved by getPortalClient)
+ *   3. Active subscription on (entity, 'ai-employee') in the
+ *      subscriptions table
+ *   4. At least one role granted on (user, entity, 'ai-employee') in
+ *      product_roles — vocabulary: principal | operator | compliance
+ *
+ * Anything less degrades to the appropriate empty state per
+ * docs/style/empty-state-pattern.md. No fabrication.
+ *
+ * This page is the routing entry point. Internal product surfaces
+ * (Today, Drafts, Matters, Audit, Settings) live under
+ * /portal/products/ai-employee/* and are introduced by subsequent PRs
+ * (#869 drafts, #871 matters, #872 calendar, #873 audit, #874
+ * settings, etc.).
+ */
+
+const PRODUCT_SLUG = 'ai-employee'
+
+const portalData = await getPortalClient(env.DB, Astro.locals)
+if (!portalData) {
+  return Astro.redirect('/auth/portal-sign-in')
+}
+if (!portalData.client) {
+  return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
+}
+
+const { user, client } = portalData
+
+// Surface state derived in priority order. We render exactly one state.
+//   no_subscription   — customer has no AI Employee subscription on file
+//   provisioning      — subscription exists but the per-customer Hermes
+//                       Machine + D1 are still being set up
+//   paused            — subscription is paused (audit-only access)
+//   no_role           — subscription is active but the user has no role
+//                       granted; principal needs to grant access
+//   active            — subscription active + at least one role; render
+//                       the dashboard
+type SurfaceState = 'no_subscription' | 'provisioning' | 'paused' | 'no_role' | 'active'
+
+let surfaceState: SurfaceState
+let access: ProductAccess | null = null
+
+const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
+if (!subscription) {
+  surfaceState = 'no_subscription'
+} else if (subscription.status === 'provisioning') {
+  surfaceState = 'provisioning'
+} else if (subscription.status === 'paused') {
+  surfaceState = 'paused'
+} else {
+  const roles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
+  if (roles.length === 0) {
+    surfaceState = 'no_role'
+  } else {
+    surfaceState = 'active'
+    access = { subscription, roles }
+  }
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal"
+        crumbLabel="Home"
+        tag="Product"
+        h1="AI Employee"
+        meta={null}
+      />
+
+      {
+        surfaceState === 'no_subscription' && (
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Not subscribed
+            </p>
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+              Your account doesn't include the AI Employee product. Contact us if you'd like to talk
+              about adding it.
+            </p>
+          </div>
+        )
+      }
+
+      {
+        surfaceState === 'provisioning' && (
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Setup in progress
+            </p>
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+              Your AI Employee is being configured. We'll reach out once it's ready to review.
+            </p>
+          </div>
+        )
+      }
+
+      {
+        surfaceState === 'paused' && (
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Paused
+            </p>
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+              Your AI Employee subscription is paused. Audit history remains accessible; new drafts
+              are suspended until the subscription resumes.
+            </p>
+          </div>
+        )
+      }
+
+      {
+        surfaceState === 'no_role' && (
+          <div class="mt-10 border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+            <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+              Access pending
+            </p>
+            <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+              The AI Employee is set up for your firm, but you haven't been granted a role yet.
+              Contact your firm's principal to be added.
+            </p>
+          </div>
+        )
+      }
+
+      {
+        surfaceState === 'active' && (
+          <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
+            <div class="flex flex-col gap-8 min-w-0">
+              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  <span>Today</span>
+                  <span class="text-[color:var(--ss-color-primary)]">§ 01</span>
+                </div>
+                <div class="px-5 md:px-7 py-6">
+                  <p class="text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
+                    Your AI Employee dashboard is ready. Activity, drafts, and matters appear here
+                    once the agent has been working with your firm.
+                  </p>
+                </div>
+              </section>
+            </div>
+
+            <aside class="flex flex-col gap-8 min-w-0">
+              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  <span>Your roles</span>
+                  <span class="text-[color:var(--ss-color-primary)]">§ 02</span>
+                </div>
+                <div class="px-5 md:px-7 py-6">
+                  <ul
+                    class="space-y-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)]"
+                    role="list"
+                  >
+                    {access?.roles.map((role) => (
+                      <li>· {role}</li>
+                    ))}
+                  </ul>
+                </div>
+              </section>
+            </aside>
+          </div>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -348,6 +348,15 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // a repeating card — a different primitive than `PortalListItem`. Track
   // as a follow-up if milestone rail drifts or gains a second use.
   resolve('src/pages/portal/engagement/index.astro'),
+  // `products/ai-employee/index.astro` is the AI Employee dashboard
+  // landing (one customer per render), not a list of products. The
+  // small `.map(roles, …)` inside the sidebar renders a bullet list of
+  // granted role names (principal / operator / compliance) — text
+  // items inside a chrome card, not a list-row card surface. Drafts
+  // (#869) and Matters (#871) list views will live under
+  // /portal/products/ai-employee/drafts/index.astro and matters/index.astro
+  // and WILL use PortalListItem.
+  resolve('src/pages/portal/products/ai-employee/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */


### PR DESCRIPTION
## Summary

First slice of the AI Employee product surface inside the customer-first portal. Routes the URL, gates access against the substrate from PR #904 + Clerk identity from PR #906, renders one of five explicit access states, and provides the layout shell future sub-pages will inherit. Closes the routing AC of issue #868; the sub-surfaces (#869 drafts, #871 matters, #872 calendar, #873 audit, #874 settings) land in follow-on PRs.

## URL

`portal.smd.services/portal/products/ai-employee`

## Access model

Composes PR #904 substrate + PR #906 Clerk rewire:

1. Clerk session required (middleware gate)
2. Local `users` + `entities` row resolved via `getPortalClient`
3. Active `subscription` on `(entity, 'ai-employee')`
4. At least one role granted in `product_roles` (principal | operator | compliance)

## Surface states

Rendered in priority order; exactly one shows on any given request:

| State | Trigger | What the user sees |
|---|---|---|
| `no_subscription` | Customer has no AI Employee subscription | "Not subscribed" — contact us to add |
| `provisioning` | Subscription row exists, status = `provisioning` | "Setup in progress" — we'll reach out when ready |
| `paused` | Subscription status = `paused` | "Paused" — audit history accessible, new drafts suspended |
| `no_role` | Subscription active, but user has zero rows in `product_roles` | "Access pending" — contact firm principal |
| `active` | Subscription active + ≥1 role | Dashboard placeholder + granted-roles sidebar |

All empty states follow `docs/style/empty-state-pattern.md`. No fabrication.

## New helper

`src/lib/portal/product-access.ts` — `getProductSubscription`, `listProductRoles`, `resolveProductAccess`. Product-agnostic; future subscription products use the same primitives with their own `product_slug`.

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `npm run build` — completes
- `npx vitest run` — 1932 / 1932 pass

## Not in this PR

- PortalTabs gets a conditional "AI Employee" tab when the subscription is active (small follow-on once we confirm the route renders)
- Internal sub-nav (Today / Drafts / Matters / Audit / Settings)
- Drafts list (#869), Matters list (#871), Audit log viewer (#873), Calendar (#872), Settings (#874)
- Proxy to the per-customer Hermes Machine for live data on the `active` state

## Test plan

- [x] Local typecheck passes
- [x] Local build succeeds
- [x] Full test suite (1932 tests) passes
- [ ] CI passes
- [ ] After merge: deploy and confirm each surface state renders with seeded fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)