### PR TITLE
feat(portal): conditional AI Employee tab in PortalTabs

### DIFF
--- a/src/components/portal/PortalTabs.astro
+++ b/src/components/portal/PortalTabs.astro
@@ -27,9 +27,17 @@
 
 interface Props {
   pathname: string
+  /**
+   * When true, render an additional "AI Employee" tab pointing at the
+   * product surface at /portal/products/ai-employee. Set by portal
+   * pages that detected an active (or provisioning/paused) subscription
+   * via getProductSubscription. Defaults to false so existing pages
+   * that don't yet pass the prop keep their current 4-tab layout.
+   */
+  aiEmployeeActive?: boolean
 }
 
-const { pathname } = Astro.props
+const { pathname, aiEmployeeActive = false } = Astro.props
 
 interface TabDef {
   href: string
@@ -38,7 +46,7 @@ interface TabDef {
   matchPrefix: string
 }
 
-const tabs: TabDef[] = [
+const baseTabs: TabDef[] = [
   {
     href: '/portal/quotes',
     label: 'Proposals',
@@ -64,6 +72,18 @@ const tabs: TabDef[] = [
     matchPrefix: '/portal/engagement',
   },
 ]
+
+const tabs: TabDef[] = aiEmployeeActive
+  ? [
+      ...baseTabs,
+      {
+        href: '/portal/products/ai-employee',
+        label: 'AI Employee',
+        anchor: '05',
+        matchPrefix: '/portal/products/ai-employee',
+      },
+    ]
+  : baseTabs
 
 function isActive(tab: TabDef, path: string): boolean {
   if (path === '/portal' || path === '/portal/') return false

--- a/src/pages/portal/documents/index.astro
+++ b/src/pages/portal/documents/index.astro
@@ -5,6 +5,7 @@ import { BRAND_NAME } from '../../../lib/config/brand'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listDocuments } from '../../../lib/storage/r2'
 import { getPortalClient } from '../../../lib/portal/session'
+import { getProductSubscription } from '../../../lib/portal/product-access'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
@@ -29,6 +30,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const clientId = portalData.client.id
 const clientName = portalData.client.name
@@ -162,7 +170,7 @@ function kindFor(doc: DocumentEntry): string {
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/engagement/index.astro
+++ b/src/pages/portal/engagement/index.astro
@@ -8,6 +8,7 @@ import {
   type Tone,
 } from '../../../lib/portal/status'
 import { getPortalClient } from '../../../lib/portal/session'
+import { getProductSubscription } from '../../../lib/portal/product-access'
 import { listEngagements } from '../../../lib/db/engagements'
 import { listMilestones } from '../../../lib/db/milestones'
 import type { Milestone } from '../../../lib/db/milestones'
@@ -35,6 +36,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const entityId = portalData.client.id
 const clientName = portalData.client.name
@@ -115,7 +123,7 @@ const currentMilestoneLabel = engagement ? resolveEngagementLabel(engagement.sta
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/index.astro
+++ b/src/pages/portal/index.astro
@@ -3,6 +3,7 @@ import '../../styles/global.css'
 import { SignOutButton } from '@clerk/astro/components'
 import { BRAND_NAME } from '../../lib/config/brand'
 import { getPortalClient } from '../../lib/portal/session'
+import { getProductSubscription } from '../../lib/portal/product-access'
 import PortalHeader from '../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../components/portal/PortalTabs.astro'
 import SkipToMain from '../../components/SkipToMain.astro'
@@ -29,6 +30,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const { client } = portalData
 
@@ -316,7 +324,7 @@ const touchpointText: string | null = (() => {
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/invoices/[id].astro
+++ b/src/pages/portal/invoices/[id].astro
@@ -3,6 +3,7 @@ import '../../../styles/global.css'
 import { SignOutButton } from '@clerk/astro/components'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
+import { getProductSubscription } from '../../../lib/portal/product-access'
 import { getInvoiceForEntity, listLineItemsForInvoice } from '../../../lib/db/invoices'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../components/portal/PortalTabs.astro'
@@ -43,6 +44,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const { client } = portalData
 
@@ -226,7 +234,7 @@ const consultantFirstName: string | null = consultantName
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/invoices/index.astro
+++ b/src/pages/portal/invoices/index.astro
@@ -3,6 +3,7 @@ import '../../../styles/global.css'
 import { SignOutButton } from '@clerk/astro/components'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
+import { getProductSubscription } from '../../../lib/portal/product-access'
 import { listInvoicesForEntity } from '../../../lib/db/invoices'
 import type { Invoice } from '../../../lib/db/invoices'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
@@ -31,6 +32,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const entityId = portalData.client.id
 const clientName = portalData.client.name
@@ -97,7 +105,7 @@ const totalCents = invoices.reduce((sum, i) => sum + Math.round(i.amount * 100),
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -112,7 +112,7 @@ if (!subscription) {
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={subscription !== null} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/quotes/[id].astro
+++ b/src/pages/portal/quotes/[id].astro
@@ -10,6 +10,7 @@ import ConsultantBlock from '../../../components/portal/ConsultantBlock.astro'
 import QuoteProposalSections from '../../../components/portal/QuoteProposalSections.astro'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
+import { getProductSubscription } from '../../../lib/portal/product-access'
 import { getQuoteForEntity, parseSchedule, parseDeliverables } from '../../../lib/db/quotes'
 import type { ScheduleRow, DeliverableRow } from '../../../lib/db/quotes'
 import { getSOWStateForQuote } from '../../../lib/sow/service'
@@ -43,6 +44,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const { client } = portalData
 const orgId = portalData.user.org_id
@@ -184,7 +192,7 @@ const consultantPhone = engagement?.consultant_phone ?? null
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-[1120px] mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead

--- a/src/pages/portal/quotes/index.astro
+++ b/src/pages/portal/quotes/index.astro
@@ -3,6 +3,7 @@ import '../../../styles/global.css'
 import { SignOutButton } from '@clerk/astro/components'
 import { BRAND_NAME } from '../../../lib/config/brand'
 import { getPortalClient } from '../../../lib/portal/session'
+import { getProductSubscription } from '../../../lib/portal/product-access'
 import { listQuotesForEntity } from '../../../lib/db/quotes'
 import type { Quote } from '../../../lib/db/quotes'
 import PortalHeader from '../../../components/portal/PortalHeader.astro'
@@ -28,6 +29,13 @@ if (!portalData) {
 if (!portalData.client) {
   return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
 }
+
+const aiEmployeeSubscription = await getProductSubscription(
+  env.DB,
+  portalData.client.id,
+  'ai-employee'
+)
+const aiEmployeeActive = aiEmployeeSubscription !== null
 
 const { client } = portalData
 const quotes = await listQuotesForEntity(env.DB, portalData.user.org_id, client.id)
@@ -92,7 +100,7 @@ const eyebrowText = eyebrowParts.join(' · ').toUpperCase()
       </SignOutButton>
     </PortalHeader>
 
-    <PortalTabs pathname={Astro.url.pathname} />
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={aiEmployeeActive} />
 
     <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
       <PortalPageHead


### PR DESCRIPTION
## Summary

Wires the AI Employee landing route (from PR #907) into the persistent portal navigation. The 5th tab "AI Employee" appears in the standard portal tabs (`Proposals / Invoices / Documents / Progress / AI Employee`) when the customer has a subscription on `(entity, 'ai-employee')` with status `provisioning | active | paused`. Cancelled or absent → no tab.

Closes the navigation loop opened by PR #907.

## Approach

`PortalTabs.astro` gains an optional `aiEmployeeActive?: boolean` prop, defaulting to `false`. Each portal page calls `getProductSubscription` (from PR #907) and passes the boolean. Single product, single bool — minimal change. Once we ship a second subscription product, we'll refactor to `productTabs[]`.

Files touched:
- `PortalTabs.astro` — prop + 5th tab definition
- 7 portal pages (home, invoices index/detail, quotes index/detail, engagement, documents) — subscription lookup + prop pass-through
- AI Employee landing page — passes the prop so the tab stays visible while inside the section

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1932 / 1932 pass

## Test plan

- [x] Local typecheck + prettier + tests
- [ ] CI passes
- [ ] After merge: seed a subscription row, confirm the tab appears on portal pages, verify navigation lands on /portal/products/ai-employee

🤖 Generated with [Claude Code](https://claude.com/claude-code)