### PR TITLE
feat(portal): AI Employee user list (read-only, #883 slice 1)

### DIFF
--- a/src/pages/portal/products/ai-employee/settings/users.astro
+++ b/src/pages/portal/products/ai-employee/settings/users.astro
@@ -1,0 +1,252 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { getPortalClient } from '../../../../../lib/portal/session'
+import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — user management (read-only list).
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/settings/users
+ *
+ * First slice of #883. Lists every local user who has at least one
+ * non-revoked role in product_roles for this customer's AI Employee
+ * subscription. Renders name, email, granted roles, granted_at, and
+ * last_login_at.
+ *
+ * Access gate:
+ *   - Clerk session (middleware)
+ *   - Active AI Employee subscription on this customer
+ *   - Current user must hold the 'principal' role on (entity,
+ *     'ai-employee')
+ *
+ * Anyone else hitting this URL is redirected to the AI Employee
+ * landing page; the page's role-gate empty state explains why.
+ *
+ * Mutation actions (invite new member, change role, revoke role) land
+ * in follow-on PRs against #883. This slice intentionally ships no
+ * action UI — dead buttons would be worse than no buttons. A short
+ * note at the bottom tells principals to contact us for member
+ * changes until self-service controls land.
+ */
+
+const PRODUCT_SLUG = 'ai-employee'
+
+const portalData = await getPortalClient(env.DB, Astro.locals)
+if (!portalData) {
+  return Astro.redirect('/auth/portal-sign-in')
+}
+if (!portalData.client) {
+  return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
+}
+
+const { user, client } = portalData
+const orgId = user.org_id
+
+const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
+if (!subscription) {
+  return Astro.redirect('/portal/products/ai-employee')
+}
+
+const callerRoles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
+const isPrincipal = callerRoles.includes('principal')
+if (!isPrincipal) {
+  return Astro.redirect('/portal/products/ai-employee')
+}
+
+// Aggregate roles per user. A single user can hold multiple roles
+// (e.g., principal AND compliance); we group rows here so the UI
+// renders one row per person with a comma-joined role list.
+interface MemberRow {
+  id: string
+  email: string
+  name: string
+  last_login_at: string | null
+  earliest_granted_at: string
+  roles: string[]
+}
+
+const memberRowsRaw = await env.DB.prepare(
+  `SELECT u.id           AS id,
+          u.email        AS email,
+          u.name         AS name,
+          u.last_login_at AS last_login_at,
+          pr.role         AS role,
+          pr.granted_at   AS granted_at
+     FROM product_roles pr
+     JOIN users u ON u.id = pr.user_id
+    WHERE pr.entity_id = ?
+      AND pr.org_id = ?
+      AND pr.product_slug = ?
+      AND pr.revoked_at IS NULL
+    ORDER BY u.name, pr.granted_at ASC`
+)
+  .bind(client.id, orgId, PRODUCT_SLUG)
+  .all<{
+    id: string
+    email: string
+    name: string
+    last_login_at: string | null
+    role: string
+    granted_at: string
+  }>()
+
+const memberMap = new Map<string, MemberRow>()
+for (const row of memberRowsRaw.results ?? []) {
+  const existing = memberMap.get(row.id)
+  if (existing) {
+    existing.roles.push(row.role)
+    if (row.granted_at < existing.earliest_granted_at) {
+      existing.earliest_granted_at = row.granted_at
+    }
+  } else {
+    memberMap.set(row.id, {
+      id: row.id,
+      email: row.email,
+      name: row.name,
+      last_login_at: row.last_login_at,
+      earliest_granted_at: row.granted_at,
+      roles: [row.role],
+    })
+  }
+}
+const members = Array.from(memberMap.values())
+
+const ROLE_ORDER: Record<string, number> = { principal: 0, operator: 1, compliance: 2 }
+for (const m of members) {
+  m.roles.sort((a, b) => (ROLE_ORDER[a] ?? 99) - (ROLE_ORDER[b] ?? 99))
+}
+
+function formatLastLogin(iso: string | null): string {
+  if (!iso) return 'Never'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return 'Never'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function formatGrantedAt(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Users | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Settings"
+        h1="Users"
+        meta={`${members.length} ${members.length === 1 ? 'member' : 'members'}`}
+      />
+
+      <section class="mt-8">
+        <p
+          class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Granted access
+        </p>
+
+        {
+          members.length === 0 ? (
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                No members yet
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                Once you invite team members and grant them roles, they'll appear here.
+              </p>
+            </div>
+          ) : (
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
+              {/* Header row */}
+              <div class="hidden md:grid grid-cols-[2fr_2fr_1fr_1fr_140px] gap-4 px-5 py-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                <span>Name</span>
+                <span>Email</span>
+                <span>Roles</span>
+                <span>Last login</span>
+                <span class="text-right">Granted</span>
+              </div>
+              {members.map((m, idx) => (
+                <div
+                  class:list={[
+                    'px-5 py-4 md:py-3',
+                    idx > 0 ? 'border-t-[2px] border-[color:var(--ss-color-text-primary)]' : '',
+                    'md:grid md:grid-cols-[2fr_2fr_1fr_1fr_140px] md:gap-4 md:items-center',
+                  ]}
+                >
+                  <div class="md:hidden flex flex-col gap-1 mb-2">
+                    <span class="font-['Archivo'] text-base font-bold text-[color:var(--ss-color-text-primary)]">
+                      {m.name || m.email}
+                    </span>
+                    <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                      {m.email}
+                    </span>
+                  </div>
+                  <span class="hidden md:inline font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                    {m.name || m.email}
+                  </span>
+                  <span class="hidden md:inline text-sm text-[color:var(--ss-color-text-secondary)] truncate">
+                    {m.email}
+                  </span>
+                  <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)]">
+                    {m.roles.join(', ')}
+                  </span>
+                  <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                    {formatLastLogin(m.last_login_at)}
+                  </span>
+                  <span class="text-xs text-[color:var(--ss-color-text-muted)] md:text-right">
+                    Granted {formatGrantedAt(m.earliest_granted_at)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )
+        }
+
+        <p class="mt-6 text-sm text-[color:var(--ss-color-text-secondary)]">
+          To invite new members, change a role, or remove someone, contact us. Self-service controls
+          land in the next release.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

First slice of issue #883. Adds the read-only user list at `portal.smd.services/portal/products/ai-employee/settings/users`. Visible only to principals. The `no_role` empty state shipped in PR #907 told users to "contact your firm's principal" — this gives principals a place to see who has what.

## Access gate

- Clerk session (middleware)
- Active AI Employee subscription on the customer
- Current user holds the `principal` role on `(entity, 'ai-employee')`

Anything less → redirect to `/portal/products/ai-employee`. The landing page's role-gate empty state explains why.

## What renders

- Header chrome (PortalHeader + PortalTabs with AI Employee tab on)
- Breadcrumb: AI Employee → Settings → Users
- Read-only table: **Name | Email | Roles | Last login | Granted-date**
- Roles aggregated per user (one row per person, multiple roles sorted `principal → operator → compliance`)
- Empty state when no members granted yet
- Short note: contact us for member changes until self-service controls ship

## Not in this PR

The mutation actions land in follow-on slices against #883:

- Invite-new-member flow (Clerk Organization invitation API)
- Change-role / revoke-role mutations
- Audit-log entries on each mutation
- Listing Clerk Organization members who don't yet have a local `product_roles` row (so principals can grant role to existing org members)

This slice intentionally ships **no action UI** — dead buttons read worse than no buttons. The short footer note is the explicit empty-state fallback.

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1932 / 1932 pass

## Test plan

- [x] Local typecheck + prettier + tests
- [ ] CI passes
- [ ] After merge: seed a `principal` row, visit the URL, confirm the list renders; revoke the role, confirm redirect to landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)