### PR TITLE
feat(portal): AI Employee role grant/revoke (#883 slice 2)

### DIFF
--- a/src/lib/portal/product-roles-mutations.ts
+++ b/src/lib/portal/product-roles-mutations.ts
@@ -1,0 +1,93 @@
+/**
+ * Mutations on the product_roles table. Shared between the user-list
+ * page's form actions and any future API-driven role management.
+ *
+ * Authorization is the caller's responsibility — these helpers do NOT
+ * verify that the actor holds the `principal` role. The action route
+ * checks that before invoking.
+ *
+ * Both helpers are idempotent. Granting a role that is already active
+ * is a no-op (returns false). Revoking a role that is already revoked
+ * (or never existed) is a no-op (returns false). A successful change
+ * returns true.
+ */
+
+const ALLOWED_AI_EMPLOYEE_ROLES = ['principal', 'operator', 'compliance'] as const
+export type AIEmployeeRole = (typeof ALLOWED_AI_EMPLOYEE_ROLES)[number]
+
+export function isAIEmployeeRole(value: unknown): value is AIEmployeeRole {
+  return (
+    typeof value === 'string' && (ALLOWED_AI_EMPLOYEE_ROLES as readonly string[]).includes(value)
+  )
+}
+
+export interface GrantArgs {
+  orgId: string
+  userId: string
+  entityId: string
+  productSlug: string
+  role: string
+  grantedBy: string
+}
+
+export interface RevokeArgs {
+  userId: string
+  entityId: string
+  productSlug: string
+  role: string
+}
+
+/**
+ * Insert a fresh product_roles row, or restore one that was previously
+ * revoked. If an active row already exists, returns false (no-op).
+ *
+ * The active vs. revoked check is the indexed predicate
+ * `revoked_at IS NULL`. Restoring a previously revoked grant inserts
+ * a new row rather than mutating the prior one — preserves audit
+ * history of when each grant was created and revoked.
+ */
+export async function grantProductRole(db: D1Database, args: GrantArgs): Promise<boolean> {
+  const existing = await db
+    .prepare(
+      `SELECT id FROM product_roles
+        WHERE user_id = ? AND entity_id = ? AND product_slug = ? AND role = ?
+          AND revoked_at IS NULL`
+    )
+    .bind(args.userId, args.entityId, args.productSlug, args.role)
+    .first<{ id: string }>()
+
+  if (existing) return false
+
+  const id = crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO product_roles
+         (id, org_id, user_id, entity_id, product_slug, role, granted_by, granted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+    )
+    .bind(id, args.orgId, args.userId, args.entityId, args.productSlug, args.role, args.grantedBy)
+    .run()
+  return true
+}
+
+/**
+ * Soft-delete the active product_roles row for the given tuple by
+ * setting `revoked_at`. Returns false if no active row exists.
+ *
+ * Multiple historical rows for the same tuple are possible (each
+ * grant/revoke cycle inserts a new row). This helper only acts on
+ * the currently-active grant — the predicate `revoked_at IS NULL`
+ * matches exactly one row per the UNIQUE constraint shape.
+ */
+export async function revokeProductRole(db: D1Database, args: RevokeArgs): Promise<boolean> {
+  const result = await db
+    .prepare(
+      `UPDATE product_roles
+          SET revoked_at = datetime('now')
+        WHERE user_id = ? AND entity_id = ? AND product_slug = ? AND role = ?
+          AND revoked_at IS NULL`
+    )
+    .bind(args.userId, args.entityId, args.productSlug, args.role)
+    .run()
+  return (result.meta?.changes ?? 0) > 0
+}

--- a/src/pages/api/portal/products/ai-employee/role-action.ts
+++ b/src/pages/api/portal/products/ai-employee/role-action.ts
@@ -5,7 +5,10 @@ import {
   grantProductRole,
   revokeProductRole,
   isAIEmployeeRole,
+  type AIEmployeeRole,
 } from '../../../../../lib/portal/product-roles-mutations'
+import type { PortalUserRow } from '../../../../../lib/auth/clerk-bridge'
+import type { Entity } from '../../../../../lib/db/entities'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -26,10 +29,9 @@ import { env } from 'cloudflare:workers'
  *
  * Self-protection: a principal cannot revoke their own last principal
  * role (would lock the customer out of self-service management).
- * Revoking a non-last principal grant from yourself is allowed.
  *
  * Returns a 303 redirect back to the user-list page with a `status`
- * query param so the page can surface a toast.
+ * query param so the page can surface a banner.
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -43,107 +45,121 @@ function redirectWithStatus(status: string): Response {
   })
 }
 
-export const POST: APIRoute = async ({ request, locals }) => {
+function jsonError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+interface AuthorizedContext {
+  user: PortalUserRow
+  client: Entity
+  orgId: string
+}
+
+/**
+ * Resolve portal context and enforce principal-on-AI-Employee
+ * authorization. Returns a Response on failure (for the caller to
+ * return directly) or the authorized context on success.
+ */
+async function authorize(locals: App.Locals): Promise<Response | AuthorizedContext> {
   const portalData = await getPortalClient(env.DB, locals)
-  if (!portalData) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
-  if (!portalData.client) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  if (!portalData) return jsonError(401, 'Unauthorized')
+  if (!portalData.client) return jsonError(403, 'Forbidden')
 
   const { user, client } = portalData
-  const orgId = user.org_id
-
-  // Caller must hold the principal role on this entity / product.
   const callerRoles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
-  if (!callerRoles.includes('principal')) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  if (!callerRoles.includes('principal')) return jsonError(403, 'Forbidden')
 
-  // Subscription must exist before any role changes (status filter inside
-  // getProductSubscription is provisioning|active|paused — all acceptable
-  // for the principal to manage members).
   const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
-  if (!subscription) {
-    return new Response(JSON.stringify({ error: 'No active subscription' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  if (!subscription) return jsonError(404, 'No active subscription')
 
-  const formData = await request.formData()
+  return { user, client, orgId: user.org_id }
+}
+
+interface ParsedAction {
+  kind: 'grant' | 'revoke'
+  targetUserId: string
+  role: AIEmployeeRole
+}
+
+function parseForm(formData: FormData): ParsedAction | string {
   const action = formData.get('action')
   const targetUserId = formData.get('userId')
   const role = formData.get('role')
+  if (action !== 'grant' && action !== 'revoke') return 'invalid_action'
+  if (typeof targetUserId !== 'string' || targetUserId === '') return 'invalid_user'
+  if (!isAIEmployeeRole(role)) return 'invalid_role'
+  return { kind: action, targetUserId, role }
+}
 
-  if (action !== 'grant' && action !== 'revoke') {
-    return redirectWithStatus('invalid_action')
-  }
-  if (typeof targetUserId !== 'string' || targetUserId === '') {
-    return redirectWithStatus('invalid_user')
-  }
-  if (!isAIEmployeeRole(role)) {
-    return redirectWithStatus('invalid_role')
-  }
-
-  // Target user must actually exist in our local users table. We don't
-  // validate Clerk-side org membership here — that's enforced upstream
-  // (the user-list page only renders members who already have at least
-  // one product_roles row, and granting a role to a Clerk-org outsider
-  // would silently no-op when they next sign in since the local user
-  // row wouldn't be JIT-created until they authenticate).
-  const targetUser = await env.DB.prepare('SELECT id FROM users WHERE id = ? AND org_id = ?')
-    .bind(targetUserId, orgId)
+async function targetUserExists(userId: string, orgId: string): Promise<boolean> {
+  const row = await env.DB.prepare('SELECT id FROM users WHERE id = ? AND org_id = ?')
+    .bind(userId, orgId)
     .first<{ id: string }>()
-  if (!targetUser) {
+  return row !== null
+}
+
+/**
+ * Self-protection check: when a principal tries to revoke their own
+ * `principal` role, ensure another active principal exists on the same
+ * (entity, product) tuple. Returns true if the revoke is safe to
+ * proceed, false if it would lock the customer out.
+ */
+async function isSafeSelfPrincipalRevoke(
+  ctx: AuthorizedContext,
+  parsed: ParsedAction
+): Promise<boolean> {
+  if (parsed.role !== 'principal' || parsed.targetUserId !== ctx.user.id) return true
+  const row = await env.DB.prepare(
+    `SELECT COUNT(*) AS n FROM product_roles
+      WHERE entity_id = ? AND product_slug = ? AND role = 'principal'
+        AND user_id != ?
+        AND revoked_at IS NULL`
+  )
+    .bind(ctx.client.id, PRODUCT_SLUG, ctx.user.id)
+    .first<{ n: number }>()
+  return (row?.n ?? 0) > 0
+}
+
+async function handleRevoke(ctx: AuthorizedContext, parsed: ParsedAction): Promise<Response> {
+  if (!(await isSafeSelfPrincipalRevoke(ctx, parsed))) {
+    return redirectWithStatus('cannot_revoke_last_principal')
+  }
+  const changed = await revokeProductRole(env.DB, {
+    userId: parsed.targetUserId,
+    entityId: ctx.client.id,
+    productSlug: PRODUCT_SLUG,
+    role: parsed.role,
+  })
+  return redirectWithStatus(changed ? 'revoked' : 'no_change')
+}
+
+async function handleGrant(ctx: AuthorizedContext, parsed: ParsedAction): Promise<Response> {
+  const changed = await grantProductRole(env.DB, {
+    orgId: ctx.orgId,
+    userId: parsed.targetUserId,
+    entityId: ctx.client.id,
+    productSlug: PRODUCT_SLUG,
+    role: parsed.role,
+    grantedBy: ctx.user.id,
+  })
+  return redirectWithStatus(changed ? 'granted' : 'no_change')
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const ctxOrResponse = await authorize(locals)
+  if (ctxOrResponse instanceof Response) return ctxOrResponse
+  const ctx = ctxOrResponse
+
+  const formData = await request.formData()
+  const parsed = parseForm(formData)
+  if (typeof parsed === 'string') return redirectWithStatus(parsed)
+
+  if (!(await targetUserExists(parsed.targetUserId, ctx.orgId))) {
     return redirectWithStatus('user_not_found')
   }
 
-  if (action === 'revoke') {
-    // Self-protection: cannot revoke the last principal grant on this
-    // entity (would lock the customer out). Count other active
-    // principals before allowing.
-    if (role === 'principal' && targetUserId === user.id) {
-      const otherPrincipals = await env.DB.prepare(
-        `SELECT COUNT(*) AS n FROM product_roles
-          WHERE entity_id = ? AND product_slug = ? AND role = 'principal'
-            AND user_id != ?
-            AND revoked_at IS NULL`
-      )
-        .bind(client.id, PRODUCT_SLUG, user.id)
-        .first<{ n: number }>()
-      if (!otherPrincipals || otherPrincipals.n === 0) {
-        return redirectWithStatus('cannot_revoke_last_principal')
-      }
-    }
-
-    const changed = await revokeProductRole(env.DB, {
-      userId: targetUserId,
-      entityId: client.id,
-      productSlug: PRODUCT_SLUG,
-      role,
-    })
-    return redirectWithStatus(changed ? 'revoked' : 'no_change')
-  }
-
-  // action === 'grant'
-  const changed = await grantProductRole(env.DB, {
-    orgId,
-    userId: targetUserId,
-    entityId: client.id,
-    productSlug: PRODUCT_SLUG,
-    role,
-    grantedBy: user.id,
-  })
-  return redirectWithStatus(changed ? 'granted' : 'no_change')
+  return parsed.kind === 'revoke' ? handleRevoke(ctx, parsed) : handleGrant(ctx, parsed)
 }

--- a/src/pages/api/portal/products/ai-employee/role-action.ts
+++ b/src/pages/api/portal/products/ai-employee/role-action.ts
@@ -1,0 +1,149 @@
+import type { APIRoute } from 'astro'
+import { getPortalClient } from '../../../../../lib/portal/session'
+import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
+import {
+  grantProductRole,
+  revokeProductRole,
+  isAIEmployeeRole,
+} from '../../../../../lib/portal/product-roles-mutations'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/portal/products/ai-employee/role-action
+ *
+ * Action endpoint for granting and revoking AI Employee product roles.
+ * Driven by HTML <form method="POST"> submissions from the user-list
+ * page; no JSON / fetch logic. Form fields:
+ *
+ *   action:  'grant' | 'revoke'  — which mutation to run
+ *   userId:  TEXT                — target user's local users.id
+ *   role:    'principal' | 'operator' | 'compliance'
+ *
+ * Authorization:
+ *   - Clerk session required (middleware enforces)
+ *   - The caller must hold the `principal` role on the active entity's
+ *     AI Employee subscription
+ *
+ * Self-protection: a principal cannot revoke their own last principal
+ * role (would lock the customer out of self-service management).
+ * Revoking a non-last principal grant from yourself is allowed.
+ *
+ * Returns a 303 redirect back to the user-list page with a `status`
+ * query param so the page can surface a toast.
+ */
+
+const PRODUCT_SLUG = 'ai-employee'
+const USERS_PAGE_URL = '/portal/products/ai-employee/settings/users'
+
+function redirectWithStatus(status: string): Response {
+  const target = `${USERS_PAGE_URL}?status=${encodeURIComponent(status)}`
+  return new Response(null, {
+    status: 303,
+    headers: { Location: target },
+  })
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const portalData = await getPortalClient(env.DB, locals)
+  if (!portalData) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  if (!portalData.client) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { user, client } = portalData
+  const orgId = user.org_id
+
+  // Caller must hold the principal role on this entity / product.
+  const callerRoles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
+  if (!callerRoles.includes('principal')) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // Subscription must exist before any role changes (status filter inside
+  // getProductSubscription is provisioning|active|paused — all acceptable
+  // for the principal to manage members).
+  const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
+  if (!subscription) {
+    return new Response(JSON.stringify({ error: 'No active subscription' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const formData = await request.formData()
+  const action = formData.get('action')
+  const targetUserId = formData.get('userId')
+  const role = formData.get('role')
+
+  if (action !== 'grant' && action !== 'revoke') {
+    return redirectWithStatus('invalid_action')
+  }
+  if (typeof targetUserId !== 'string' || targetUserId === '') {
+    return redirectWithStatus('invalid_user')
+  }
+  if (!isAIEmployeeRole(role)) {
+    return redirectWithStatus('invalid_role')
+  }
+
+  // Target user must actually exist in our local users table. We don't
+  // validate Clerk-side org membership here — that's enforced upstream
+  // (the user-list page only renders members who already have at least
+  // one product_roles row, and granting a role to a Clerk-org outsider
+  // would silently no-op when they next sign in since the local user
+  // row wouldn't be JIT-created until they authenticate).
+  const targetUser = await env.DB.prepare('SELECT id FROM users WHERE id = ? AND org_id = ?')
+    .bind(targetUserId, orgId)
+    .first<{ id: string }>()
+  if (!targetUser) {
+    return redirectWithStatus('user_not_found')
+  }
+
+  if (action === 'revoke') {
+    // Self-protection: cannot revoke the last principal grant on this
+    // entity (would lock the customer out). Count other active
+    // principals before allowing.
+    if (role === 'principal' && targetUserId === user.id) {
+      const otherPrincipals = await env.DB.prepare(
+        `SELECT COUNT(*) AS n FROM product_roles
+          WHERE entity_id = ? AND product_slug = ? AND role = 'principal'
+            AND user_id != ?
+            AND revoked_at IS NULL`
+      )
+        .bind(client.id, PRODUCT_SLUG, user.id)
+        .first<{ n: number }>()
+      if (!otherPrincipals || otherPrincipals.n === 0) {
+        return redirectWithStatus('cannot_revoke_last_principal')
+      }
+    }
+
+    const changed = await revokeProductRole(env.DB, {
+      userId: targetUserId,
+      entityId: client.id,
+      productSlug: PRODUCT_SLUG,
+      role,
+    })
+    return redirectWithStatus(changed ? 'revoked' : 'no_change')
+  }
+
+  // action === 'grant'
+  const changed = await grantProductRole(env.DB, {
+    orgId,
+    userId: targetUserId,
+    entityId: client.id,
+    productSlug: PRODUCT_SLUG,
+    role,
+    grantedBy: user.id,
+  })
+  return redirectWithStatus(changed ? 'granted' : 'no_change')
+}

--- a/src/pages/portal/products/ai-employee/settings/users.astro
+++ b/src/pages/portal/products/ai-employee/settings/users.astro
@@ -11,14 +11,15 @@ import { SignOutButton } from '@clerk/astro/components'
 import { env } from 'cloudflare:workers'
 
 /**
- * AI Employee — user management (read-only list).
+ * AI Employee — user management.
  *
  * URL: portal.smd.services/portal/products/ai-employee/settings/users
  *
- * First slice of #883. Lists every local user who has at least one
- * non-revoked role in product_roles for this customer's AI Employee
- * subscription. Renders name, email, granted roles, granted_at, and
- * last_login_at.
+ * Lists every local user who has at least one non-revoked role in
+ * product_roles for this customer's AI Employee subscription, and lets
+ * the principal grant/revoke roles on each member. Renders name, email,
+ * last login, and per-row Grant/Revoke buttons for each of the three
+ * AI Employee roles (principal | operator | compliance).
  *
  * Access gate:
  *   - Clerk session (middleware)
@@ -29,11 +30,21 @@ import { env } from 'cloudflare:workers'
  * Anyone else hitting this URL is redirected to the AI Employee
  * landing page; the page's role-gate empty state explains why.
  *
- * Mutation actions (invite new member, change role, revoke role) land
- * in follow-on PRs against #883. This slice intentionally ships no
- * action UI — dead buttons would be worse than no buttons. A short
- * note at the bottom tells principals to contact us for member
- * changes until self-service controls land.
+ * Mutations are HTML-form POSTs to
+ * /api/portal/products/ai-employee/role-action. No JS / fetch logic
+ * here — the action endpoint redirects back with a `?status=` query
+ * param that drives the banner at the top of the page.
+ *
+ * Self-protection: server-side, the action endpoint blocks revoking
+ * your own LAST principal grant (would lock the customer out).
+ *
+ * Not yet shipped (next slice):
+ *   - Invite-new-member flow (Clerk Organization invitation API)
+ *   - Audit-log entries on each role change
+ *   - Listing Clerk Organization members who don't yet have a local
+ *     users row (so principals can grant roles to invitees who haven't
+ *     signed in yet — currently new members appear here only after
+ *     their first portal sign-in JIT-creates the local users row).
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -123,6 +134,8 @@ for (const m of members) {
   m.roles.sort((a, b) => (ROLE_ORDER[a] ?? 99) - (ROLE_ORDER[b] ?? 99))
 }
 
+const ALL_ROLES = ['principal', 'operator', 'compliance'] as const
+
 function formatLastLogin(iso: string | null): string {
   if (!iso) return 'Never'
   const d = new Date(iso)
@@ -130,11 +143,25 @@ function formatLastLogin(iso: string | null): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
-function formatGrantedAt(iso: string): string {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ''
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+// Status banner — set by the role-action endpoint on redirect.
+const status = Astro.url.searchParams.get('status')
+type BannerStatus = { text: string; tone: 'success' | 'error' | 'info' }
+const STATUS_BANNERS: Record<string, BannerStatus> = {
+  granted: { text: 'Role granted.', tone: 'success' },
+  revoked: { text: 'Role revoked.', tone: 'success' },
+  no_change: { text: 'No change applied.', tone: 'info' },
+  invalid_action: { text: 'Invalid action.', tone: 'error' },
+  invalid_user: { text: 'Invalid user.', tone: 'error' },
+  invalid_role: { text: 'Invalid role.', tone: 'error' },
+  user_not_found: { text: 'User not found.', tone: 'error' },
+  cannot_revoke_last_principal: {
+    text:
+      'You are the only principal on this account. Grant another user the principal role before ' +
+      'revoking your own.',
+    tone: 'error',
+  },
 }
+const banner = status ? (STATUS_BANNERS[status] ?? null) : null
 ---
 
 <!doctype html>
@@ -178,6 +205,24 @@ function formatGrantedAt(iso: string): string {
         meta={`${members.length} ${members.length === 1 ? 'member' : 'members'}`}
       />
 
+      {
+        banner && (
+          <div
+            role="status"
+            class:list={[
+              'mt-6 px-4 py-3 border-[3px] text-sm',
+              banner.tone === 'success'
+                ? 'border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-complete)]/10 text-[color:var(--ss-color-complete)]'
+                : banner.tone === 'error'
+                  ? 'border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-error)]/10 text-[color:var(--ss-color-error)]'
+                  : 'border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-primary)]',
+            ]}
+          >
+            {banner.text}
+          </div>
+        )
+      }
+
       <section class="mt-8">
         <p
           class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
@@ -192,59 +237,77 @@ function formatGrantedAt(iso: string): string {
                 No members yet
               </p>
               <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
-                Once you invite team members and grant them roles, they'll appear here.
+                Once your team members sign in and you grant them roles, they'll appear here.
               </p>
             </div>
           ) : (
             <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
-              {/* Header row */}
-              <div class="hidden md:grid grid-cols-[2fr_2fr_1fr_1fr_140px] gap-4 px-5 py-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                <span>Name</span>
-                <span>Email</span>
-                <span>Roles</span>
-                <span>Last login</span>
-                <span class="text-right">Granted</span>
-              </div>
-              {members.map((m, idx) => (
-                <div
-                  class:list={[
-                    'px-5 py-4 md:py-3',
-                    idx > 0 ? 'border-t-[2px] border-[color:var(--ss-color-text-primary)]' : '',
-                    'md:grid md:grid-cols-[2fr_2fr_1fr_1fr_140px] md:gap-4 md:items-center',
-                  ]}
-                >
-                  <div class="md:hidden flex flex-col gap-1 mb-2">
-                    <span class="font-['Archivo'] text-base font-bold text-[color:var(--ss-color-text-primary)]">
-                      {m.name || m.email}
-                    </span>
-                    <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
-                      {m.email}
-                    </span>
+              {members.map((m, idx) => {
+                const activeRoles = new Set(m.roles)
+                return (
+                  <div
+                    class:list={[
+                      'px-5 py-4',
+                      idx > 0 ? 'border-t-[2px] border-[color:var(--ss-color-text-primary)]' : '',
+                    ]}
+                  >
+                    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-6">
+                      <div class="flex flex-col gap-0.5 min-w-0">
+                        <span class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] truncate">
+                          {m.name || m.email}
+                        </span>
+                        <span class="text-sm text-[color:var(--ss-color-text-secondary)] truncate">
+                          {m.email}
+                        </span>
+                        <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                          Last login: {formatLastLogin(m.last_login_at)}
+                        </span>
+                      </div>
+
+                      <div class="flex flex-wrap gap-2 md:justify-end">
+                        {ALL_ROLES.map((role) => {
+                          const isActive = activeRoles.has(role)
+                          return (
+                            <form
+                              method="POST"
+                              action="/api/portal/products/ai-employee/role-action"
+                              class="inline-flex"
+                            >
+                              <input
+                                type="hidden"
+                                name="action"
+                                value={isActive ? 'revoke' : 'grant'}
+                              />
+                              <input type="hidden" name="userId" value={m.id} />
+                              <input type="hidden" name="role" value={role} />
+                              <button
+                                type="submit"
+                                class:list={[
+                                  "inline-flex items-center px-3 py-1.5 text-xs font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] transition-colors",
+                                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2',
+                                  isActive
+                                    ? 'border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-error)] hover:border-[color:var(--ss-color-error)]'
+                                    : 'border-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-background)]',
+                                ]}
+                              >
+                                {isActive ? `Revoke ${role}` : `Grant ${role}`}
+                              </button>
+                            </form>
+                          )
+                        })}
+                      </div>
+                    </div>
                   </div>
-                  <span class="hidden md:inline font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
-                    {m.name || m.email}
-                  </span>
-                  <span class="hidden md:inline text-sm text-[color:var(--ss-color-text-secondary)] truncate">
-                    {m.email}
-                  </span>
-                  <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)]">
-                    {m.roles.join(', ')}
-                  </span>
-                  <span class="text-sm text-[color:var(--ss-color-text-secondary)]">
-                    {formatLastLogin(m.last_login_at)}
-                  </span>
-                  <span class="text-xs text-[color:var(--ss-color-text-muted)] md:text-right">
-                    Granted {formatGrantedAt(m.earliest_granted_at)}
-                  </span>
-                </div>
-              ))}
+                )
+              })}
             </div>
           )
         }
 
         <p class="mt-6 text-sm text-[color:var(--ss-color-text-secondary)]">
-          To invite new members, change a role, or remove someone, contact us. Self-service controls
-          land in the next release.
+          New team members appear here after their first sign-in to the portal. To invite someone
+          new to your firm's workspace, contact us. Self-service invitations land in the next
+          release.
         </p>
       </section>
     </main>


### PR DESCRIPTION
## Summary

Wires the principal-only role mutations onto the user-list page from slice 1. Each member row now renders three buttons — Grant principal, Grant operator, Grant compliance (or **Revoke \<role\>** when already granted) — that POST to a new action endpoint and redirect back with a status banner.

## New code

### `src/lib/portal/product-roles-mutations.ts`
- `grantProductRole` — idempotent insert into `product_roles`
- `revokeProductRole` — soft-delete via `revoked_at`
- `isAIEmployeeRole` — runtime guard for the role enum

### `src/pages/api/portal/products/ai-employee/role-action.ts`
- POST endpoint handling both grant and revoke
- HTML-form driven, no JSON / fetch logic
- Caller must hold the `principal` role on the active entity/product
- Validates action, target user existence, role enum
- Returns 303 redirects with `?status=...` to surface a banner on the users page

### `settings/users.astro` updates
- Status banner at top driven by `?status=...`
- Per-role Grant/Revoke buttons replace the old read-only roles column
- Doc comment updated to reflect mutation wiring

## Self-protection (server-side)

Principal cannot revoke their own LAST principal grant — would lock the customer out of self-service management. Action returns `status=cannot_revoke_last_principal`. Other revoke scenarios (yourself revoking when another principal exists; revoking someone else's principal role) proceed normally.

## Mutation semantics

- **Grant** is idempotent: existing active grant → no-op (`status=no_change`)
- **Revoke** is idempotent: no active grant → no-op (`status=no_change`)
- Restoring a previously revoked grant inserts a NEW `product_roles` row so audit history of grant→revoke→regrant cycles is preserved (the prior row's `revoked_at` stays set)

## Not in this PR (next #883 slices)

- Invite-new-member flow (Clerk Organization invitation API)
- Audit-log emission on each mutation
- Listing Clerk Org members who don't yet have a local `users` row (so principals can grant roles to invitees pre-sign-in — today they appear in the list only after their first portal sign-in JIT-creates the row)

## Verified locally

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1932 / 1932 pass

## Test plan

- [x] Local typecheck + prettier + tests
- [ ] CI passes
- [ ] After merge: seed two principals; verify revoke buttons work, banner renders, cross-user role changes succeed, self-revoke of last-principal blocks with the expected error

🤖 Generated with [Claude Code](https://claude.com/claude-code)