### PR TITLE
feat(portal): AI Employee invite-by-email (#883 slice 3)

### DIFF
--- a/src/lib/db/entities.ts
+++ b/src/lib/db/entities.ts
@@ -45,6 +45,15 @@ export interface Entity {
   source_pipeline: string | null
   created_at: string
   updated_at: string
+  /**
+   * Clerk Organization ID bound to this customer. Populated when the
+   * entity is provisioned for portal access (PR #904 bridge column).
+   * Null for prospect / pre-purchase entities. Optional in the type
+   * so legacy fixtures constructing Entity literals without this
+   * field continue to compile; D1 reads always materialize it (null
+   * when the row was inserted before the column was added).
+   */
+  clerk_org_id?: string | null
 }
 
 // prettier-ignore

--- a/src/pages/api/portal/products/ai-employee/invitations.ts
+++ b/src/pages/api/portal/products/ai-employee/invitations.ts
@@ -1,0 +1,122 @@
+import type { APIRoute, APIContext } from 'astro'
+import { clerkClient } from '@clerk/astro/server'
+import { getPortalClient } from '../../../../../lib/portal/session'
+import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
+import type { PortalUserRow } from '../../../../../lib/auth/clerk-bridge'
+import type { Entity } from '../../../../../lib/db/entities'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/portal/products/ai-employee/invitations
+ *
+ * Creates a Clerk Organization invitation. After the invitee accepts
+ * and signs in for the first time, the JIT bridge (clerk-bridge.ts)
+ * creates their local users row, and the principal returns to the
+ * Users page to grant them a product role. Two-step UX intentionally
+ * — pre-assigning roles via invitation metadata + webhook is deferred
+ * to a future slice.
+ *
+ * Form fields:
+ *   email: TEXT  — invitee email address
+ *
+ * Authorization (same as role-action):
+ *   - Clerk session required (middleware)
+ *   - Active AI Employee subscription on this entity
+ *   - Caller holds the 'principal' role on (entity, 'ai-employee')
+ *
+ * Also requires that the entity has been bound to a Clerk Organization
+ * (entities.clerk_org_id IS NOT NULL). If not bound yet, redirects
+ * back with status=no_clerk_org so the principal sees a clear message.
+ *
+ * Clerk's Organization role for the invitation is hardcoded to
+ * 'org:member'. Org-admin Clerk role is reserved for SMD-side
+ * accounts. Product roles (principal | operator | compliance) are a
+ * separate axis managed via role-action.ts after the invitee accepts.
+ */
+
+const PRODUCT_SLUG = 'ai-employee'
+const USERS_PAGE_URL = '/portal/products/ai-employee/settings/users'
+
+function redirectWithStatus(status: string): Response {
+  const target = `${USERS_PAGE_URL}?status=${encodeURIComponent(status)}`
+  return new Response(null, {
+    status: 303,
+    headers: { Location: target },
+  })
+}
+
+function jsonError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+interface AuthorizedContext {
+  user: PortalUserRow
+  client: Entity
+}
+
+async function authorize(locals: App.Locals): Promise<Response | AuthorizedContext> {
+  const portalData = await getPortalClient(env.DB, locals)
+  if (!portalData) return jsonError(401, 'Unauthorized')
+  if (!portalData.client) return jsonError(403, 'Forbidden')
+
+  const { user, client } = portalData
+  const roles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
+  if (!roles.includes('principal')) return jsonError(403, 'Forbidden')
+
+  const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
+  if (!subscription) return jsonError(404, 'No active subscription')
+
+  return { user, client }
+}
+
+// RFC 5322-lite email check. Sufficient guard against accidental
+// nonsense (the canonical validator is Clerk itself, which will
+// reject malformed addresses with a clearer error).
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function parseEmail(formData: FormData): string | null {
+  const raw = formData.get('email')
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!EMAIL_RE.test(trimmed)) return null
+  return trimmed
+}
+
+export const POST: APIRoute = async (context: APIContext) => {
+  const ctxOrResponse = await authorize(context.locals)
+  if (ctxOrResponse instanceof Response) return ctxOrResponse
+  const ctx = ctxOrResponse
+
+  if (!ctx.client.clerk_org_id) return redirectWithStatus('no_clerk_org')
+  if (!ctx.user.clerk_user_id) return redirectWithStatus('no_clerk_user')
+
+  const formData = await context.request.formData()
+  const email = parseEmail(formData)
+  if (!email) return redirectWithStatus('invalid_email')
+
+  const redirectUrl = `${new URL(context.request.url).origin}/portal/products/ai-employee`
+  try {
+    await clerkClient(context).organizations.createOrganizationInvitation({
+      organizationId: ctx.client.clerk_org_id,
+      emailAddress: email,
+      role: 'org:member',
+      inviterUserId: ctx.user.clerk_user_id,
+      redirectUrl,
+    })
+  } catch (err) {
+    // Clerk's typed errors: duplicate, already-member, etc. We don't
+    // surface raw Clerk error codes to the principal. Instead map a
+    // small set to friendly status values and fall back to a generic
+    // 'invite_failed' otherwise.
+    const message = err instanceof Error ? err.message : String(err)
+    if (/already a member/i.test(message)) return redirectWithStatus('already_member')
+    if (/already invited|duplicate/i.test(message)) return redirectWithStatus('already_invited')
+    console.error('Clerk invitation failed', { email, message })
+    return redirectWithStatus('invite_failed')
+  }
+
+  return redirectWithStatus('invited')
+}

--- a/src/pages/portal/products/ai-employee/settings/users.astro
+++ b/src/pages/portal/products/ai-employee/settings/users.astro
@@ -143,7 +143,7 @@ function formatLastLogin(iso: string | null): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
-// Status banner — set by the role-action endpoint on redirect.
+// Status banner — set by the role-action and invitations endpoints on redirect.
 const status = Astro.url.searchParams.get('status')
 type BannerStatus = { text: string; tone: 'success' | 'error' | 'info' }
 const STATUS_BANNERS: Record<string, BannerStatus> = {
@@ -158,6 +158,35 @@ const STATUS_BANNERS: Record<string, BannerStatus> = {
     text:
       'You are the only principal on this account. Grant another user the principal role before ' +
       'revoking your own.',
+    tone: 'error',
+  },
+  invited: {
+    text:
+      'Invitation sent. The invitee will appear here after they accept and sign in for the ' +
+      'first time. Grant them a role then.',
+    tone: 'success',
+  },
+  invalid_email: { text: 'Enter a valid email address.', tone: 'error' },
+  already_member: {
+    text: 'That email is already a member of your workspace.',
+    tone: 'info',
+  },
+  already_invited: {
+    text: 'That email already has an open invitation.',
+    tone: 'info',
+  },
+  no_clerk_org: {
+    text:
+      "Your account isn't bound to a Clerk Organization yet. Contact us to finish setting up " +
+      'invitations.',
+    tone: 'error',
+  },
+  no_clerk_user: {
+    text: 'Your sign-in session is incomplete. Sign out and back in, then try again.',
+    tone: 'error',
+  },
+  invite_failed: {
+    text: 'We could not send the invitation. Try again or contact us if the problem persists.',
     tone: 'error',
   },
 }
@@ -305,9 +334,41 @@ const banner = status ? (STATUS_BANNERS[status] ?? null) : null
         }
 
         <p class="mt-6 text-sm text-[color:var(--ss-color-text-secondary)]">
-          New team members appear here after their first sign-in to the portal. To invite someone
-          new to your firm's workspace, contact us. Self-service invitations land in the next
-          release.
+          New team members appear here after they accept their invitation and sign in for the first
+          time. Grant them a role with the buttons above once they appear.
+        </p>
+      </section>
+
+      <section class="mt-12">
+        <p
+          class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Invite a new member
+        </p>
+
+        <form
+          method="POST"
+          action="/api/portal/products/ai-employee/invitations"
+          class="flex flex-col sm:flex-row gap-3 max-w-2xl"
+        >
+          <input
+            type="email"
+            name="email"
+            required
+            placeholder="colleague@firm.com"
+            autocomplete="off"
+            class="flex-1 px-4 py-2 border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] placeholder-[color:var(--ss-color-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+          />
+          <button
+            type="submit"
+            class="inline-flex items-center justify-center px-5 py-2 font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold text-sm border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-primary)] hover:border-[color:var(--ss-color-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+          >
+            Send invitation
+          </button>
+        </form>
+        <p class="mt-3 text-xs text-[color:var(--ss-color-text-muted)]">
+          The invitee gets a Clerk-hosted sign-up email. Once they sign in, grant them roles from
+          the list above.
         </p>
       </section>
     </main>


### PR DESCRIPTION
## Summary

Adds the principal-facing invite form on the AI Employee Users page plus a Clerk-backed action endpoint that issues a Clerk Organization invitation. After the invitee accepts and signs in for the first time, the JIT bridge (PR #906) creates their local users row, and the principal grants them a product role using the buttons added in slice 2 (PR #910).

## What ships

### `POST /api/portal/products/ai-employee/invitations`
- Authorization shape mirrors `role-action`: Clerk session → active subscription → principal role on `(entity, 'ai-employee')`
- Requires `entities.clerk_org_id IS NOT NULL` (entity must be bound to a Clerk org) and the inviter must have `users.clerk_user_id` populated
- Calls `clerkClient(context).organizations.createOrganizationInvitation` with `role='org:member'` (Clerk-org role, separate axis from product role) and `redirectUrl` pointing at the AI Employee landing
- Maps Clerk error messages to friendly status codes (`already_member`, `already_invited`); generic `invite_failed` otherwise

### `settings/users.astro`
- New invite section below the member list: email input + submit button
- Status banner gains 7 new states covering the invitation flow outcomes (`invited`, `invalid_email`, `already_member`, `already_invited`, `no_clerk_org`, `no_clerk_user`, `invite_failed`)
- Doc comment updated to reflect mutation + invitation wiring

## Schema

`entities.clerk_org_id` added to the `Entity` TS type (optional `string | null`). The DB column has existed since PR #904; only the type declaration lagged. Optional rather than required so legacy test fixtures constructing Entity literals continue to compile.

## Intentional cut

Roles are **not** pre-assigned at invitation time. That requires Clerk webhooks (`organizationMembership.created`) which is its own integration. Two-step UX is acceptable for v1:

1. Principal invites by email → Clerk sends invitation
2. Invitee accepts → signs in → JIT user row created → no_role empty state on landing
3. Principal returns to Users page → invitee now appears in list → Grant role

## Verified locally

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1932 / 1932 pass

## Test plan

- [x] Local typecheck + prettier + tests
- [ ] CI passes
- [ ] After merge: bind an entity to a Clerk Organization, sign in as principal, invite a fresh email, complete sign-up flow, verify new member appears in list, grant role end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)