### PR TITLE
feat(portal): AI Employee Settings landing page

### DIFF
--- a/src/pages/portal/products/ai-employee/settings/index.astro
+++ b/src/pages/portal/products/ai-employee/settings/index.astro
@@ -1,0 +1,129 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { getPortalClient } from '../../../../../lib/portal/session'
+import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Settings landing.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/settings
+ *
+ * Hub page linking to product configuration sub-surfaces. Today only
+ * Users is implemented; trust ceiling (#811), voice (#855, #856),
+ * skills (#874), and customer.yaml editor (#877) land as future
+ * sub-pages and are added to the link grid as they ship.
+ *
+ * Access gate (same as the Users sub-page):
+ *   - Clerk session (middleware)
+ *   - Active AI Employee subscription on this customer
+ *   - Current user holds the 'principal' role on (entity, 'ai-employee')
+ *
+ * Operators and compliance users hitting /settings/ are redirected
+ * back to the AI Employee landing. Future sub-pages may relax the
+ * principal-only gate for view-only surfaces; this landing keeps
+ * the gate tight so we don't expose a half-locked menu.
+ */
+
+const PRODUCT_SLUG = 'ai-employee'
+
+const portalData = await getPortalClient(env.DB, Astro.locals)
+if (!portalData) {
+  return Astro.redirect('/auth/portal-sign-in')
+}
+if (!portalData.client) {
+  return Astro.redirect('/auth/portal-sign-in?status=no_subscription')
+}
+
+const { user, client } = portalData
+
+const subscription = await getProductSubscription(env.DB, client.id, PRODUCT_SLUG)
+if (!subscription) {
+  return Astro.redirect('/portal/products/ai-employee')
+}
+
+const callerRoles = await listProductRoles(env.DB, user.id, client.id, PRODUCT_SLUG)
+if (!callerRoles.includes('principal')) {
+  return Astro.redirect('/portal/products/ai-employee')
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Settings | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Settings"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]"
+        >
+          <a
+            href="/portal/products/ai-employee/settings/users"
+            class="block bg-[color:var(--ss-color-background)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+          >
+            <p
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]"
+            >
+              § 01
+            </p>
+            <h2
+              class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+            >
+              Users
+            </h2>
+            <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+              Invite team members, grant or revoke roles, and see who has access.
+            </p>
+          </a>
+        </div>
+
+        <p class="mt-6 text-sm text-[color:var(--ss-color-text-secondary)]">
+          Voice samples, skills, trust ceilings, and other configuration land in this section as
+          they become available.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Hub page at `/portal/products/ai-employee/settings` that links to the Users sub-page. Fills what was a 404 between the AI Employee landing and the Users page, and gives future configuration surfaces a natural home as they ship (trust ceiling #811, voice #855/#856, skills #874, customer.yaml editor #877).

## Access gate

Same as the Users sub-page:
- Clerk session
- Active AI Employee subscription
- Caller holds the `principal` role on `(entity, 'ai-employee')`

Operators and compliance users → redirect back to the AI Employee landing. Future view-only sub-pages may relax this, but the hub stays principal-gated so we don't expose a half-locked menu.

## What renders

- Standard portal chrome (header + tabs)
- Breadcrumb: AI Employee → Settings
- Grid of section cards (today just Users)
- Footnote previewing future sections

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1938 / 1938 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)