### PR TITLE
feat(portal): principal-only Manage section on AI Employee landing

### DIFF
--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -213,6 +213,46 @@ if (!subscription) {
                   </ul>
                 </div>
               </section>
+
+              {access?.roles.includes('principal') && (
+                <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                  <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                    <span>Manage</span>
+                    <span class="text-[color:var(--ss-color-primary)]">§ 03</span>
+                  </div>
+                  <ul
+                    class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]"
+                    role="list"
+                  >
+                    <li>
+                      <a
+                        href="/portal/products/ai-employee/settings/users"
+                        class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                      >
+                        <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                          Users
+                        </p>
+                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
+                          Invite team members and manage roles.
+                        </p>
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="/portal/products/ai-employee/settings"
+                        class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                      >
+                        <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                          Settings
+                        </p>
+                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
+                          Configure your AI Employee.
+                        </p>
+                      </a>
+                    </li>
+                  </ul>
+                </section>
+              )}
             </aside>
           </div>
         )


### PR DESCRIPTION
## Summary

Adds a **Manage** card to the right rail of the AI Employee landing page's active state, visible only to users who hold the `principal` role. Two link items today:

- **Users** → `/portal/products/ai-employee/settings/users`
- **Settings** → `/portal/products/ai-employee/settings`

Completes the navigation loop opened by PR #909 (user list), #910 (role mutations), #911 (invitations), and #912 (settings landing). Principals previously had to know the URL or use the AI Employee tab + the nothing-here-yet middle area to reach settings.

## Role-aware

Operators and compliance users see only the **Today** + **Your roles** cards (unchanged). The Manage section is gated on `access.roles.includes('principal')`.

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1938 / 1938 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)