### PR TITLE
feat(auth): wrap sign-in / sign-up in site brand chrome

### DIFF
--- a/src/components/AuthHeader.astro
+++ b/src/components/AuthHeader.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * Brand header for unauthenticated routes (sign-in / sign-up / verify).
+ *
+ * Same monogram and chrome as Nav.astro (the marketing site header) so
+ * the auth surfaces feel like part of the same site. No nav links and
+ * no CTA — those would distract from the sign-in flow. Optional
+ * cross-link (Sign in ↔ Create account) renders on the right when a
+ * crossLinkHref/Label pair is provided.
+ */
+
+interface Props {
+  crossLinkHref?: string
+  crossLinkLabel?: string
+}
+
+const { crossLinkHref, crossLinkLabel } = Astro.props
+---
+
+<header
+  role="banner"
+  class="sticky top-0 z-40 border-b-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+>
+  <div
+    class="mx-auto flex h-14 md:h-16 w-full max-w-5xl items-center justify-between gap-3 px-4 md:px-6"
+  >
+    <a
+      href="/"
+      aria-label="SMD Services"
+      class="inline-flex items-baseline gap-2 text-base md:text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+    >
+      <span
+        class="inline-block bg-[color:var(--ss-color-primary)] px-1.5 py-0.5 font-['Archivo'] font-black uppercase leading-none tracking-tight text-white"
+        >SMD</span
+      >
+      <span
+        class="font-['Archivo_Narrow'] font-semibold uppercase tracking-[0.08em] leading-none text-[color:var(--ss-color-text-primary)]"
+        >Services</span
+      >
+    </a>
+
+    {
+      crossLinkHref && crossLinkLabel && (
+        <a
+          href={crossLinkHref}
+          class="inline-flex items-center min-h-11 px-1 font-['Archivo_Narrow'] text-sm font-semibold uppercase tracking-[0.12em] text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+        >
+          {crossLinkLabel}
+        </a>
+      )
+    }
+  </div>
+</header>

--- a/src/pages/auth/portal-sign-in.astro
+++ b/src/pages/auth/portal-sign-in.astro
@@ -1,12 +1,18 @@
 ---
-import '../../styles/global.css'
-import SkipToMain from '../../components/SkipToMain.astro'
+import Base from '../../layouts/Base.astro'
+import AuthHeader from '../../components/AuthHeader.astro'
+import Footer from '../../components/Footer.astro'
 import { SignIn } from '@clerk/astro/components'
 
 /**
  * Client portal sign-in. Renders Clerk's SignIn component, which handles
  * email + password (primary), email verification code (passwordless
  * fallback), and Organization-invitation acceptance natively.
+ *
+ * Wrapped in the standard marketing/site chrome (Base layout +
+ * AuthHeader + Footer) so the auth surface feels like part of the same
+ * SMD Services site as the marketing pages, the admin console, and
+ * the authenticated portal.
  *
  * Replaces the legacy magic-link entry at /auth/portal-login (now a
  * 301 redirect to this route).
@@ -30,50 +36,30 @@ const statusMessages: Record<string, { text: string; type: 'success' | 'error' }
 const message = status ? statusMessages[status] : null
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
-    <title>Sign In | SMD Services Portal</title>
-  </head>
-  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
-    <SkipToMain />
-    <header
-      role="banner"
-      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--ss-color-border)]"
-    >
-      <div class="max-w-md mx-auto h-full flex items-center justify-center px-4">
-        <span class="text-lg font-bold tracking-tight text-[color:var(--ss-color-text-primary)]"
-          >SMD Services</span
-        >
-      </div>
-    </header>
+<Base title="Sign In | SMD Services Portal" disableAnalytics={true}>
+  <div class="flex min-h-screen flex-col bg-[color:var(--ss-color-background)]">
+    <AuthHeader crossLinkHref="/auth/portal-sign-up" crossLinkLabel="Create account" />
+
     <main
       id="main"
       role="main"
-      class="flex items-start md:items-center justify-center px-4 py-10"
-      style="min-height: calc(100vh - 3.5rem)"
+      class="flex-1 flex items-start md:items-center justify-center px-4 py-10 md:py-16"
     >
       <div class="w-full max-w-sm">
-        <div class="text-center mb-6">
-          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Client portal sign-in</p>
-        </div>
+        <p
+          class="mb-6 text-center font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Client portal sign-in
+        </p>
 
         {
           message && (
             <div
               class:list={[
-                'mb-4 px-3 py-2 border rounded text-sm',
+                'mb-4 px-3 py-2 border-[3px] text-sm',
                 message.type === 'success'
-                  ? 'bg-[color:var(--ss-color-complete)]/5 border-[color:var(--ss-color-complete)]/30 text-[color:var(--ss-color-complete)]'
-                  : 'bg-[color:var(--ss-color-error)]/5 border-[color:var(--ss-color-error)]/30 text-[color:var(--ss-color-error)]',
+                  ? 'border-[color:var(--ss-color-complete)] bg-[color:var(--ss-color-complete)]/10 text-[color:var(--ss-color-complete)]'
+                  : 'border-[color:var(--ss-color-error)] bg-[color:var(--ss-color-error)]/10 text-[color:var(--ss-color-error)]',
               ]}
             >
               {message.text}
@@ -88,5 +74,7 @@ const message = status ? statusMessages[status] : null
         />
       </div>
     </main>
-  </body>
-</html>
+
+    <Footer />
+  </div>
+</Base>

--- a/src/pages/auth/portal-sign-up.astro
+++ b/src/pages/auth/portal-sign-up.astro
@@ -1,6 +1,7 @@
 ---
-import '../../styles/global.css'
-import SkipToMain from '../../components/SkipToMain.astro'
+import Base from '../../layouts/Base.astro'
+import AuthHeader from '../../components/AuthHeader.astro'
+import Footer from '../../components/Footer.astro'
 import { SignUp } from '@clerk/astro/components'
 
 /**
@@ -10,46 +11,31 @@ import { SignUp } from '@clerk/astro/components'
  * the SignUp form is pre-populated with the invitee's email and the
  * accepted Organization membership is created on completion).
  *
+ * Wrapped in the standard marketing/site chrome (Base layout +
+ * AuthHeader + Footer) so the auth surface feels like part of the same
+ * SMD Services site as the marketing pages, the admin console, and
+ * the authenticated portal.
+ *
  * Most portal users will arrive here from an Organization invitation
  * email rather than discovering the URL directly.
  */
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="robots" content="noindex, nofollow" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
-    <title>Create Account | SMD Services Portal</title>
-  </head>
-  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
-    <SkipToMain />
-    <header
-      role="banner"
-      class="sticky top-0 z-50 h-14 md:h-16 bg-white border-b border-[color:var(--ss-color-border)]"
-    >
-      <div class="max-w-md mx-auto h-full flex items-center justify-center px-4">
-        <span class="text-lg font-bold tracking-tight text-[color:var(--ss-color-text-primary)]"
-          >SMD Services</span
-        >
-      </div>
-    </header>
+<Base title="Create Account | SMD Services Portal" disableAnalytics={true}>
+  <div class="flex min-h-screen flex-col bg-[color:var(--ss-color-background)]">
+    <AuthHeader crossLinkHref="/auth/portal-sign-in" crossLinkLabel="Sign in" />
+
     <main
       id="main"
       role="main"
-      class="flex items-start md:items-center justify-center px-4 py-10"
-      style="min-height: calc(100vh - 3.5rem)"
+      class="flex-1 flex items-start md:items-center justify-center px-4 py-10 md:py-16"
     >
       <div class="w-full max-w-sm">
-        <div class="text-center mb-6">
-          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">Create your account</p>
-        </div>
+        <p
+          class="mb-6 text-center font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Create your account
+        </p>
 
         <SignUp
           signInUrl="/auth/portal-sign-in"
@@ -58,5 +44,7 @@ import { SignUp } from '@clerk/astro/components'
         />
       </div>
     </main>
-  </body>
-</html>
+
+    <Footer />
+  </div>
+</Base>


### PR DESCRIPTION
## Summary

The Clerk `<SignIn>` / `<SignUp>` cards previously rendered in a minimal custom layout with a bare "SMD Services" text header — visually disconnected from the marketing site, portal, and admin console. This PR wraps them in the same chrome the rest of the site uses, so the auth surface feels like part of the same SMD Services site.

## What changes

- **`Base.astro` layout** — same head metadata, fonts, skip-to-main treatment as marketing pages
- **`AuthHeader` (new component)** — matches `Nav.astro`'s brand monogram (orange "SMD" block + "Services" wordmark, 3px ink bottom border, sticky). No marketing nav links / CTA — those would distract from the sign-in flow. Optional cross-link (Sign in ↔ Create account) on the right.
- **`Footer.astro`** — the same inverse-surface footer the marketing site uses (brand monogram + VentureCrane / Terms / Privacy / colophon)

## What's unchanged

The Clerk widget itself. Visual customization of the Clerk-rendered card (button colors, card chrome, typography) is a separate `appearance` prop pass that can land when we want. The "Secured by Clerk" footer is locked to Pro tier — we'll remove that when we upgrade.

## Verified

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1938 / 1938 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)