### PR TITLE
feat(auth): theme Clerk SignIn/SignUp to Plainspoken aesthetic

### DIFF
--- a/src/lib/auth/clerk-appearance.ts
+++ b/src/lib/auth/clerk-appearance.ts
@@ -1,0 +1,121 @@
+/**
+ * Clerk `appearance` configuration that themes the <SignIn> and <SignUp>
+ * widgets to match the SMD Services Plainspoken Sign Shop identity.
+ *
+ * Values are sourced from @venturecrane/tokens/ss.css (the canonical
+ * design tokens for the venture). Clerk's `variables` slot accepts
+ * literal hex strings, not CSS var refs, so we duplicate the hex
+ * values here. If a token shifts, update this file in lockstep.
+ *
+ * Style notes (Plainspoken aesthetic):
+ *   - Sharp corners everywhere (borderRadius: 0)
+ *   - Heavy 3px ink borders on cards, inputs, and primary buttons
+ *   - Cream background, ink text, burnt-orange primary
+ *   - Archivo / Archivo Narrow typography (matches header monogram)
+ *   - All-caps Archivo Narrow on buttons and small labels
+ *
+ * The "Secured by Clerk" footer is locked to the Hobby tier and
+ * remains visible until we upgrade. Everything else is themed below.
+ */
+
+// Hex values mirror @venturecrane/tokens/ss.css.
+const COLOR = {
+  background: '#f5f0e3',
+  textPrimary: '#1a1512',
+  textSecondary: '#4a423c',
+  primary: '#c5501e',
+  primaryHover: '#a84318',
+  complete: '#4a6b3e',
+  error: '#a02a2a',
+} as const
+
+export const clerkAppearance = {
+  variables: {
+    colorPrimary: COLOR.textPrimary,
+    colorBackground: COLOR.background,
+    colorText: COLOR.textPrimary,
+    colorTextSecondary: COLOR.textSecondary,
+    colorTextOnPrimaryBackground: '#ffffff',
+    colorInputBackground: COLOR.background,
+    colorInputText: COLOR.textPrimary,
+    colorDanger: COLOR.error,
+    colorSuccess: COLOR.complete,
+    colorNeutral: COLOR.textPrimary,
+    borderRadius: '0',
+    fontFamily: 'Archivo, system-ui, sans-serif',
+    fontFamilyButtons: 'Archivo, system-ui, sans-serif',
+    fontSize: '0.9375rem',
+    fontWeight: {
+      normal: '400',
+      medium: '500',
+      bold: '700',
+    },
+    spacingUnit: '0.25rem',
+  },
+  elements: {
+    // Card chrome: 3px ink border, sharp corners, cream background, no shadow.
+    card:
+      'rounded-none border-[3px] border-[color:var(--ss-color-text-primary)] ' +
+      'bg-[color:var(--ss-color-background)] shadow-none',
+    rootBox: 'w-full',
+    // Header
+    headerTitle:
+      "font-['Archivo'] font-black uppercase tracking-tight " +
+      'text-[color:var(--ss-color-text-primary)]',
+    headerSubtitle:
+      "font-['Archivo_Narrow'] uppercase tracking-[0.12em] " +
+      'text-[color:var(--ss-color-text-secondary)]',
+    // Primary button: ink filled, sharp, uppercase Archivo Narrow, burnt-orange on hover.
+    formButtonPrimary:
+      'rounded-none border-[3px] border-[color:var(--ss-color-text-primary)] ' +
+      'bg-[color:var(--ss-color-text-primary)] text-white ' +
+      "font-['Archivo_Narrow'] font-bold uppercase tracking-[0.12em] " +
+      'hover:bg-[color:var(--ss-color-primary)] hover:border-[color:var(--ss-color-primary)] ' +
+      'focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] ' +
+      'focus-visible:ring-offset-2 transition-colors',
+    // Secondary / form button reset
+    formButtonReset:
+      'rounded-none text-[color:var(--ss-color-text-secondary)] ' +
+      'hover:text-[color:var(--ss-color-text-primary)]',
+    // Input fields: heavy ink border, sharp, cream background.
+    formFieldInput:
+      'rounded-none border-[3px] border-[color:var(--ss-color-text-primary)] ' +
+      'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] ' +
+      'focus:ring-2 focus:ring-[color:var(--ss-color-action)] focus:ring-offset-0',
+    formFieldLabel:
+      "font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold text-sm " +
+      'text-[color:var(--ss-color-text-primary)]',
+    formFieldHintText: 'text-xs text-[color:var(--ss-color-text-secondary)]',
+    formFieldErrorText: 'text-xs text-[color:var(--ss-color-error)]',
+    // Social buttons (Google, etc. — if enabled later)
+    socialButtonsBlockButton:
+      'rounded-none border-[3px] border-[color:var(--ss-color-text-primary)] ' +
+      'bg-[color:var(--ss-color-background)] text-[color:var(--ss-color-text-primary)] ' +
+      "font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold " +
+      'hover:bg-[color:var(--ss-color-border-subtle)]',
+    socialButtonsBlockButtonText: "font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold",
+    // Footer + action links
+    footer: 'rounded-none bg-[color:var(--ss-color-background)]',
+    footerAction: "font-['Archivo_Narrow'] uppercase tracking-[0.12em] text-sm",
+    footerActionLink:
+      'text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-primary-hover)] underline-offset-2',
+    footerActionText: 'text-[color:var(--ss-color-text-secondary)]',
+    // Identity preview (e.g., signed in as ___)
+    identityPreviewText: 'text-[color:var(--ss-color-text-secondary)]',
+    identityPreviewEditButton: 'text-[color:var(--ss-color-primary)]',
+    // OTP / verification code inputs
+    otpCodeFieldInput:
+      'rounded-none border-[3px] border-[color:var(--ss-color-text-primary)] ' +
+      'bg-[color:var(--ss-color-background)]',
+    // Form section divider
+    dividerLine: 'bg-[color:var(--ss-color-text-primary)]',
+    dividerText:
+      "font-['Archivo_Narrow'] uppercase tracking-[0.14em] text-xs " +
+      'text-[color:var(--ss-color-text-secondary)]',
+    // Alert + notice surfaces
+    alert: 'rounded-none border-[3px]',
+    alertText: "font-['Archivo_Narrow'] text-sm",
+    // Spinner + busy state
+    spinner: 'text-[color:var(--ss-color-primary)]',
+  },
+} as const

--- a/src/pages/auth/portal-sign-in.astro
+++ b/src/pages/auth/portal-sign-in.astro
@@ -3,6 +3,7 @@ import Base from '../../layouts/Base.astro'
 import AuthHeader from '../../components/AuthHeader.astro'
 import Footer from '../../components/Footer.astro'
 import { SignIn } from '@clerk/astro/components'
+import { clerkAppearance } from '../../lib/auth/clerk-appearance'
 
 /**
  * Client portal sign-in. Renders Clerk's SignIn component, which handles
@@ -71,6 +72,7 @@ const message = status ? statusMessages[status] : null
           signUpUrl="/auth/portal-sign-up"
           fallbackRedirectUrl="/portal"
           forceRedirectUrl="/portal"
+          appearance={clerkAppearance}
         />
       </div>
     </main>

--- a/src/pages/auth/portal-sign-up.astro
+++ b/src/pages/auth/portal-sign-up.astro
@@ -3,6 +3,7 @@ import Base from '../../layouts/Base.astro'
 import AuthHeader from '../../components/AuthHeader.astro'
 import Footer from '../../components/Footer.astro'
 import { SignUp } from '@clerk/astro/components'
+import { clerkAppearance } from '../../lib/auth/clerk-appearance'
 
 /**
  * Client portal sign-up. Renders Clerk's SignUp component, which handles
@@ -41,6 +42,7 @@ import { SignUp } from '@clerk/astro/components'
           signInUrl="/auth/portal-sign-in"
           fallbackRedirectUrl="/portal"
           forceRedirectUrl="/portal"
+          appearance={clerkAppearance}
         />
       </div>
     </main>


### PR DESCRIPTION
## Summary

Wires Clerk's `appearance` prop on `<SignIn>` and `<SignUp>` so the widget itself matches the SMD Services chrome we shipped around it in PR #914. Sharp corners, 3px ink borders on cards/inputs/primary buttons, cream background, ink-on-white primary button with burnt-orange hover, Archivo / Archivo Narrow typography, uppercase labels.

## New shared config

`src/lib/auth/clerk-appearance.ts`:

- **`variables`** — hex values mirroring `@venturecrane/tokens/ss.css` (Clerk's `variables` slot doesn't resolve CSS var refs, so we duplicate the hex strings here)
- **`elements`** — Tailwind class strings on every key Clerk surface: `card`, `headerTitle`, `formButtonPrimary`, `formFieldInput`, `formFieldLabel`, `socialButtonsBlockButton`, `footer`, `otpCodeFieldInput`, `dividerLine`, `alert`, `spinner`

Wired into both `portal-sign-in.astro` and `portal-sign-up.astro` via `appearance={clerkAppearance}`.

## What stays Clerk-default

The "Secured by Clerk" footer is locked to the Hobby tier and remains until we upgrade to Pro. Everything else is themed.

## Verified locally

- `npm run typecheck` — 0 errors, 0 warnings
- `prettier --check` — clean
- `npx vitest run` — 1938 / 1938 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)