### PR TITLE
feat(portal): AI Employee product surfaces (drafts, matters, calendar, audit)

### DIFF
--- a/src/lib/portal/ai-employee-access.ts
+++ b/src/lib/portal/ai-employee-access.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared access gate for the AI Employee product surfaces under
+ * `/portal/products/ai-employee/*`.
+ *
+ * Every product surface needs the same four checks, in order:
+ *
+ *   1. Clerk session present                  → otherwise sign-in
+ *   2. Local entity bound to Clerk org        → otherwise sign-in with no_subscription marker
+ *   3. AI Employee subscription on the entity → otherwise landing page (which renders the
+ *                                                no_subscription / provisioning / paused state)
+ *   4. Caller holds at least one allowed role → otherwise landing page (no_role state)
+ *
+ * Each surface differs only in which roles it accepts. Drafts, matters, and calendar are
+ * for active users (operator or principal); audit is open to all three roles since
+ * compliance is the dedicated viewer; settings is principal-only.
+ *
+ * Status check: this helper treats provisioning, active, and paused subscriptions as
+ * "exists" — same posture as `getProductSubscription`. Surfaces render their empty
+ * state regardless of lifecycle status. The landing page is the only surface that
+ * branches on status (see src/pages/portal/products/ai-employee/index.astro).
+ */
+
+import type { Entity } from '../db/entities'
+import type { PortalUserRow } from '../auth/clerk-bridge'
+import { getPortalClient } from './session'
+import { getProductSubscription, listProductRoles, type SubscriptionRow } from './product-access'
+
+export const AI_EMPLOYEE_PRODUCT_SLUG = 'ai-employee'
+
+export const AI_EMPLOYEE_LANDING_PATH = '/portal/products/ai-employee'
+export const PORTAL_SIGN_IN_PATH = '/auth/portal-sign-in'
+export const PORTAL_SIGN_IN_NO_SUBSCRIPTION_PATH = `${PORTAL_SIGN_IN_PATH}?status=no_subscription`
+
+export type AiEmployeeAccess =
+  | { kind: 'redirect'; to: string }
+  | {
+      kind: 'allowed'
+      user: PortalUserRow
+      client: Entity
+      subscription: SubscriptionRow
+      roles: string[]
+    }
+
+export interface ResolveAiEmployeeAccessOptions {
+  /**
+   * Roles that grant access to the surface. Any one match is enough. Pass the
+   * canonical product_roles vocabulary values (`principal`, `operator`,
+   * `compliance`) — typos will silently 401 every visitor.
+   */
+  allowedRoles: readonly string[]
+}
+
+/**
+ * Resolve access for an AI Employee product surface. Returns either a redirect
+ * target (caller does `Astro.redirect(access.to)`) or the resolved
+ * user/client/subscription/roles tuple ready to render.
+ *
+ * The helper does not call `Astro.redirect` itself because Astro's redirect is
+ * a context-bound method on the page; returning the path keeps the helper
+ * unit-testable with a plain DB + locals.
+ */
+export async function resolveAiEmployeeAccess(
+  db: D1Database,
+  locals: App.Locals,
+  options: ResolveAiEmployeeAccessOptions
+): Promise<AiEmployeeAccess> {
+  const portalData = await getPortalClient(db, locals)
+  if (!portalData) {
+    return { kind: 'redirect', to: PORTAL_SIGN_IN_PATH }
+  }
+  if (!portalData.client) {
+    return { kind: 'redirect', to: PORTAL_SIGN_IN_NO_SUBSCRIPTION_PATH }
+  }
+
+  const { user, client } = portalData
+
+  const subscription = await getProductSubscription(db, client.id, AI_EMPLOYEE_PRODUCT_SLUG)
+  if (!subscription) {
+    return { kind: 'redirect', to: AI_EMPLOYEE_LANDING_PATH }
+  }
+
+  const roles = await listProductRoles(db, user.id, client.id, AI_EMPLOYEE_PRODUCT_SLUG)
+  const hasAllowedRole = options.allowedRoles.some((r) => roles.includes(r))
+  if (!hasAllowedRole) {
+    return { kind: 'redirect', to: AI_EMPLOYEE_LANDING_PATH }
+  }
+
+  return { kind: 'allowed', user, client, subscription, roles }
+}

--- a/src/pages/portal/products/ai-employee/audit/index.astro
+++ b/src/pages/portal/products/ai-employee/audit/index.astro
@@ -1,0 +1,112 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Audit log viewer.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/audit
+ *
+ * Per #873 and #895, every action the AI Employee takes — drafts
+ * created, sends approved, identity attributions, trust-ceiling
+ * decisions, memory access — emits an audit event. This surface is the
+ * read-only viewer over those events. Persistence and writer modules
+ * land separately (#891, #842, #864).
+ *
+ * Audit events live on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821) and the
+ * compliance evidence pipeline (#892, #894).
+ *
+ * Until the read path lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated events, no synthetic
+ * trace, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds principal OR operator OR compliance role
+ *
+ * Compliance is the dedicated viewer for this surface (#895), but
+ * audit transparency is for the whole team — operators see what they
+ * acted on, principals see firm-wide activity.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'operator', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Audit | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Audit"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No audit events yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Every action your AI Employee takes is recorded here: drafts created, sends approved,
+            identity changes, memory access.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/calendar/index.astro
+++ b/src/pages/portal/products/ai-employee/calendar/index.astro
@@ -1,0 +1,105 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Calendar.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/calendar
+ *
+ * Per #872, the calendar surfaces deadlines, hearings, depositions, and
+ * scheduled follow-ups the AI Employee is tracking. Connector wiring for
+ * Google Calendar / Outlook / case-management deadlines lands as part of
+ * the per-customer Hermes Machine runtime (#821, #923 connector
+ * addressing) — none of that data is reachable from the portal Worker
+ * directly per ADR 0009.
+ *
+ * Until the read path lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated events, no fake
+ * deadlines, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Calendar | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Calendar"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No upcoming events
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Hearings, depositions, and deadlines your AI Employee is tracking will appear here.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/drafts/index.astro
+++ b/src/pages/portal/products/ai-employee/drafts/index.astro
@@ -1,0 +1,107 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Drafts list.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/drafts
+ *
+ * Per PRD §12, the draft queue is the primary user-facing surface: every
+ * message the AI Employee proposes lands here for human review before it
+ * goes out (reviewer-as-sender, ADR 0005). Listing fields per #869:
+ * sender, recipient, skill, trust-ceiling decision, age, priority.
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated drafts, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing; the
+ * audit surface is their primary read view, not drafts.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Drafts | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Drafts"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No drafts yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Drafts your AI Employee prepares land here for review before any message goes out.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -32,10 +32,11 @@ import { env } from 'cloudflare:workers'
  * docs/style/empty-state-pattern.md. No fabrication.
  *
  * This page is the routing entry point. Internal product surfaces
- * (Today, Drafts, Matters, Audit, Settings) live under
- * /portal/products/ai-employee/* and are introduced by subsequent PRs
- * (#869 drafts, #871 matters, #872 calendar, #873 audit, #874
- * settings, etc.).
+ * (Drafts, Matters, Calendar, Audit, Settings) live under
+ * /portal/products/ai-employee/* and are reached via the section card
+ * grid rendered in the active-state branch below. Each child surface
+ * uses the shared resolveAiEmployeeAccess helper to enforce its own
+ * role gate; the landing only orchestrates which cards to render.
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -79,6 +80,47 @@ if (!subscription) {
     surfaceState = 'active'
     access = { subscription, roles }
   }
+}
+
+// Section cards in the active-state main column. Filtered by the
+// caller's roles so operators / principals see the act-on-the-product
+// surfaces (drafts, matters, calendar) and every role sees Audit.
+// Each destination uses resolveAiEmployeeAccess to enforce the gate
+// server-side; this list is the visual filter only.
+interface SectionCard {
+  href: string
+  label: string
+  description: string
+}
+const sectionCards: SectionCard[] = []
+if (access) {
+  const userRoles = access.roles
+  const ACTIVE_DOER_ROLES = ['operator', 'principal']
+  const canAct = userRoles.some((r) => ACTIVE_DOER_ROLES.includes(r))
+  if (canAct) {
+    sectionCards.push({
+      href: '/portal/products/ai-employee/drafts',
+      label: 'Drafts',
+      description: 'Review drafts your AI Employee has prepared before any message goes out.',
+    })
+    sectionCards.push({
+      href: '/portal/products/ai-employee/matters',
+      label: 'Matters',
+      description:
+        'Active matters your AI Employee is tracking across communications and documents.',
+    })
+    sectionCards.push({
+      href: '/portal/products/ai-employee/calendar',
+      label: 'Calendar',
+      description: 'Hearings, depositions, and deadlines your AI Employee is watching.',
+    })
+  }
+  sectionCards.push({
+    href: '/portal/products/ai-employee/audit',
+    label: 'Audit',
+    description:
+      'A full record of every action your AI Employee takes: drafts created, sends approved, identity changes.',
+  })
 }
 ---
 
@@ -182,25 +224,38 @@ if (!subscription) {
         surfaceState === 'active' && (
           <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
             <div class="flex flex-col gap-8 min-w-0">
-              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  <span>Today</span>
-                  <span class="text-[color:var(--ss-color-primary)]">§ 01</span>
-                </div>
-                <div class="px-5 md:px-7 py-6">
-                  <p class="text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
-                    Your AI Employee dashboard is ready. Activity, drafts, and matters appear here
-                    once the agent has been working with your firm.
-                  </p>
+              <section>
+                <p class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+                  Sections
+                </p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]">
+                  {sectionCards.map((s, i) => {
+                    const anchor = String(i + 1).padStart(2, '0')
+                    return (
+                      <a
+                        href={s.href}
+                        class="block bg-[color:var(--ss-color-background)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                      >
+                        <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
+                          § {anchor}
+                        </p>
+                        <h2 class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                          {s.label}
+                        </h2>
+                        <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+                          {s.description}
+                        </p>
+                      </a>
+                    )
+                  })}
                 </div>
               </section>
             </div>
 
             <aside class="flex flex-col gap-8 min-w-0">
               <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  <span>Your roles</span>
-                  <span class="text-[color:var(--ss-color-primary)]">§ 02</span>
+                <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  Your roles
                 </div>
                 <div class="px-5 md:px-7 py-6">
                   <ul
@@ -216,9 +271,8 @@ if (!subscription) {
 
               {access?.roles.includes('principal') && (
                 <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                  <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                    <span>Manage</span>
-                    <span class="text-[color:var(--ss-color-primary)]">§ 03</span>
+                  <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                    Manage
                   </div>
                   <ul
                     class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]"

--- a/src/pages/portal/products/ai-employee/matters/index.astro
+++ b/src/pages/portal/products/ai-employee/matters/index.astro
@@ -1,0 +1,107 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Matters list.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/matters
+ *
+ * Per #871, matters are the per-engagement aggregates the AI Employee
+ * tracks across communications, deadlines, and documents. The list view
+ * shows matter title, opposing party, last activity, and status. Detail
+ * pages land in a follow-on slice once the schema exists.
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated matters, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Matters | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Matters"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No matters yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Active matters appear here as your AI Employee tracks them across communications and
+            documents.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/ai-employee-access.test.ts
+++ b/tests/ai-employee-access.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Tests for the AI Employee access gate (src/lib/portal/ai-employee-access.ts).
+ *
+ * Each AI Employee surface page calls `resolveAiEmployeeAccess` with the set
+ * of roles it accepts. The helper returns either `{ kind: 'redirect', to }` —
+ * the page does `Astro.redirect(access.to)` — or `{ kind: 'allowed', ... }`
+ * with the resolved user/client/subscription/roles. This contract is what
+ * keeps wrong-role users out of drafts, matters, calendar, audit, and the
+ * settings sub-pages.
+ *
+ * We mock `getPortalClient` so the test can exercise each redirect branch
+ * without standing up a Clerk session, then drive subscriptions and
+ * product_roles via a real test D1. Migrations are applied per spec so the
+ * schema constraints (UNIQUE(entity_id, product_slug), the CHECK on status,
+ * the UNIQUE on (user, entity, product_slug, role)) are real.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+
+// Mock getPortalClient before importing the helper. The portal-session
+// module pulls in @clerk/astro middleware types that aren't available in
+// the vitest environment, so we replace the whole module surface.
+vi.mock('../src/lib/portal/session', () => ({
+  getPortalClient: vi.fn(),
+}))
+
+import { getPortalClient } from '../src/lib/portal/session'
+import { resolveAiEmployeeAccess } from '../src/lib/portal/ai-employee-access'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ENTITY_ID = 'entity-test'
+const USER_ID = 'user-test'
+const OTHER_USER_ID = 'user-other'
+const PRODUCT_SLUG = 'ai-employee'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Test Firm', 'test-firm')
+    .run()
+}
+
+async function seedUser(db: D1Database, userId: string, email: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role, entity_id, clerk_user_id)
+       VALUES (?, ?, ?, ?, 'client', ?, ?)`
+    )
+    .bind(userId, ORG_ID, email, email, ENTITY_ID, `clerk_${userId}`)
+    .run()
+}
+
+async function seedSubscription(
+  db: D1Database,
+  status: 'provisioning' | 'active' | 'paused' | 'cancelled'
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO subscriptions (id, org_id, entity_id, product_slug, status)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .bind('sub-test', ORG_ID, ENTITY_ID, PRODUCT_SLUG, status)
+    .run()
+}
+
+async function grantRole(db: D1Database, userId: string, role: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO product_roles (id, org_id, user_id, entity_id, product_slug, role)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(`pr-${userId}-${role}`, ORG_ID, userId, ENTITY_ID, PRODUCT_SLUG, role)
+    .run()
+}
+
+function mockUser(id: string, email: string) {
+  return {
+    id,
+    org_id: ORG_ID,
+    email,
+    name: email,
+    role: 'client',
+    entity_id: ENTITY_ID,
+    clerk_user_id: `clerk_${id}`,
+  }
+}
+
+function mockClient() {
+  return {
+    id: ENTITY_ID,
+    org_id: ORG_ID,
+    name: 'Test Firm',
+    slug: 'test-firm',
+    phone: null,
+    website: null,
+    stage: 'engaged' as const,
+    stage_changed_at: '2026-05-21T00:00:00Z',
+    pain_score: null,
+    vertical: null,
+    area: null,
+    employee_count: null,
+    tier: null,
+    summary: null,
+    next_action: null,
+    next_action_at: null,
+    source_pipeline: null,
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    clerk_org_id: 'clerk_org_test',
+  }
+}
+
+const fakeLocals = {} as App.Locals
+
+describe('resolveAiEmployeeAccess', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+    vi.mocked(getPortalClient).mockReset()
+  })
+
+  it('redirects to sign-in when no portal session exists', async () => {
+    vi.mocked(getPortalClient).mockResolvedValue(null)
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/auth/portal-sign-in')
+    }
+  })
+
+  it('redirects to no-subscription sign-in when entity not provisioned', async () => {
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: null,
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/auth/portal-sign-in?status=no_subscription')
+    }
+  })
+
+  it('redirects to landing when entity has no AI Employee subscription', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('redirects to landing when subscription is cancelled', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'cancelled')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('redirects to landing when user has no role on this product', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'noaccess@firm.com')
+    await seedSubscription(db, 'active')
+    // No grantRole — caller has zero product_roles rows
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'noaccess@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it("redirects to landing when caller's role isn't in allowedRoles (compliance hitting drafts)", async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'compliance@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'compliance@firm.com'),
+      client: mockClient(),
+    })
+
+    // Drafts allows operator | principal only — compliance must be redirected
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('allows access when caller has principal role and surface accepts principal', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.user.id).toBe(USER_ID)
+      expect(result.client.id).toBe(ENTITY_ID)
+      expect(result.subscription.status).toBe('active')
+      expect(result.roles).toContain('principal')
+    }
+  })
+
+  it('allows access when caller has operator role and surface accepts operator', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'operator@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'operator')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'operator@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toContain('operator')
+    }
+  })
+
+  it('allows access during provisioning status (matches surface gate posture)', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'provisioning')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    // Provisioning subscriptions DO return — the helper matches getProductSubscription
+    // which treats provisioning/active/paused as "exists". Surfaces render their
+    // own empty state. Only the landing branches on lifecycle status.
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.subscription.status).toBe('provisioning')
+    }
+  })
+
+  it('allows access during paused status', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'paused')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.subscription.status).toBe('paused')
+    }
+  })
+
+  it('audit-surface configuration allows all three role vocabularies', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'compliance@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'compliance@firm.com'),
+      client: mockClient(),
+    })
+
+    // Audit accepts principal | operator | compliance
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal', 'operator', 'compliance'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toEqual(['compliance'])
+    }
+  })
+
+  it('returns all of the caller’s granted roles, not just the matched one', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'wearsmanyhats@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'wearsmanyhats@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toEqual(expect.arrayContaining(['principal', 'compliance']))
+      expect(result.roles).toHaveLength(2)
+    }
+  })
+
+  it('only counts non-revoked roles', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'wasprincipal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    // Revoke the only role
+    await db
+      .prepare(
+        `UPDATE product_roles SET revoked_at = datetime('now')
+         WHERE user_id = ? AND entity_id = ? AND product_slug = ?`
+      )
+      .bind(USER_ID, ENTITY_ID, PRODUCT_SLUG)
+      .run()
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'wasprincipal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('isolates roles per (user, entity, product) — another user’s role doesn’t grant access', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'noaccess@firm.com')
+    await seedUser(db, OTHER_USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, OTHER_USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'noaccess@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds the four missing AI Employee product-tab routes — Drafts, Matters, Calendar, and Audit — as role-gated empty-state shells under `/portal/products/ai-employee/*`. Each surface uses a new shared `resolveAiEmployeeAccess` helper to enforce Clerk session, subscription, and product-role checks. The landing page's stub Today panel is replaced with a role-filtered section card grid that points at the four new surfaces.

Data layer for these surfaces lives on per-customer Hermes Machine D1 (ADR 0007 + 0009) and is reached through Hermes runtime wiring (#821). Until that lands, the surfaces render the empty state per `docs/style/empty-state-pattern.md` — no fabricated drafts, matters, events, or audit entries.

## Linked issue

Refs #868, #869, #871, #872, #873

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| #868 — Astro routes under `src/pages/portal/products/ai-employee/` | met | `src/pages/portal/products/ai-employee/{drafts,matters,calendar,audit}/index.astro` |
| #868 — Role gate reading from `product_roles` | met | `src/lib/portal/ai-employee-access.ts` + per-surface gate |
| #868 — Empty state pattern per `docs/style/empty-state-pattern.md` for surfaces with no data | met | All four new surfaces render explicit empty-state blocks |
| #869 — Page at `/ai-employee/drafts` | met | `src/pages/portal/products/ai-employee/drafts/index.astro` |
| #869 — List of pending drafts (sender, recipient, skill, trust-ceiling decision, age, priority) | deferred | Pending Hermes runtime read path (#821) |
| #869 — Filter/sort, click into draft detail, pagination | deferred | Pending data layer |
| #869 — Empty state per docs/style/empty-state-pattern.md | met | `drafts/index.astro` |
| #871 — Matters tab and matter detail | n/a | This PR is the tab shell only; detail pages are a follow-on issue |
| #872 — Calendar tab | met (shell) | `calendar/index.astro` with empty state; event sync deferred |
| #873 — Audit log viewer | met (shell) | `audit/index.astro` accepts all three roles; data layer deferred |

## Deferred ACs

- **AC:** #869 — list/filter/sort/pagination of drafts
  - **Why deferred:** Per ADR 0009 the portal Worker cannot bind directly to a per-customer Hermes D1. Read path lands with Hermes runtime wiring.
  - **Tracked in:** #821
- **AC:** #871 — matter detail page
  - **Why deferred:** Same as #869 — needs the per-customer read path.
  - **Tracked in:** #821
- **AC:** #872 — calendar event sync
  - **Why deferred:** Connector wiring + per-customer Hermes runtime.
  - **Tracked in:** #821, #923
- **AC:** #873 — audit event display
  - **Why deferred:** Audit persistence + reader.
  - **Tracked in:** #891 (persistence), #821 (read path)

## Test plan

- [x] `npm run verify` passes (typecheck, typecheck:workers, format:check, lint, build, test, test:workers — 1976 tests + workers, all green)
- [x] 14 new unit tests in `tests/ai-employee-access.test.ts` exercise every redirect branch and the allowed-access happy paths, including:
  - Unauthenticated → `/auth/portal-sign-in`
  - Authenticated but no entity → `/auth/portal-sign-in?status=no_subscription`
  - No subscription → landing
  - Cancelled subscription → landing
  - Subscription exists but no role → landing
  - Wrong role (compliance hitting operator-only surface) → landing
  - Principal/operator/compliance hitting their allowed surfaces → allowed
  - Provisioning/paused subscriptions allowed (surface renders its own empty state)
  - Multi-role users (principal + compliance) → all roles returned
  - Revoked roles excluded
  - Cross-user isolation (another user's role doesn't grant access)

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints — no new endpoints; pages read-only
- [x] Parameterized queries for any SQL — all `.bind()`
- [x] Auth required on new endpoints — every surface gates via `resolveAiEmployeeAccess`
- [x] No internal IDs that enable enumeration

## Feature Impact

None — this PR adds new routes and replaces a placeholder Today panel on the existing landing with a navigable section grid. No existing flows are removed or disabled.