### PR TITLE
feat(portal): customer.yaml storage substrate (ADR 0012)

### DIFF
--- a/docs/adr/0012-customer-yaml-storage.md
+++ b/docs/adr/0012-customer-yaml-storage.md
@@ -1,0 +1,261 @@
+---
+title: customer.yaml Storage — Git as Source of Truth, D1/R2 as Materialized Replicas
+date: 2026-05-21
+status: accepted
+captain: Scott Durgan
+supersedes: none
+related-prd: docs/pm/ai-employee/platform-prd.md §7.3, §9, §20
+related-spec: docs/specs/ai-employee/customer-yaml-schema.md
+related-issue: https://github.com/venturecrane/ss-console/issues/790, https://github.com/venturecrane/ss-console/issues/924
+---
+
+# ADR 0012 — customer.yaml Storage
+
+**Status:** Accepted. The storage architecture below is the durable answer to "where does `customer.yaml` live?" — a question deferred when [ADR 0011](./0011-multi-persona-per-customer.md) §4 declared the file authoritative without pinning its location. This ADR pins it.
+
+**Source:** Captain prompt 2026-05-21 — _"what is best for the long term durability of the product that does not cut corners or make assumptions?"_ — in the context of building the [#924](https://github.com/venturecrane/ss-console/issues/924) `getActivePersona()` portal resolver, which needs to read from `customer.yaml`.
+
+Pairs with [ADR 0007](./0007-per-customer-machine-isolation.md) (per-customer Machine isolation), [ADR 0008](./0008-customer-owned-memory-artifact.md) (customer-owned memory artifact), [ADR 0009](./0009-cross-machine-query-prohibition.md) (cross-Machine query prohibition), and [ADR 0011](./0011-multi-persona-per-customer.md) (multi-persona per customer).
+
+---
+
+## Context
+
+[ADR 0011](./0011-multi-persona-per-customer.md) §4 commits `customer.yaml` as the authoritative source for product configuration — personas, connectors, voice samples reference, scope envelope, escalation rules, business hours. The earlier proposal to read configuration from `subscriptions.settings_json` was explicitly rejected as a sync-trap.
+
+But the ADR did not pin storage. Two real consumers need to read this file:
+
+1. **The portal Worker** — on every authenticated portal request that needs persona context (the `getActivePersona()` helper [#924](https://github.com/venturecrane/ss-console/issues/924) being the immediate consumer; future surfaces follow). The portal runs on Cloudflare Workers, has hot-path latency budgets, and per [ADR 0009](./0009-cross-machine-query-prohibition.md) cannot bind to per-customer Hermes D1 databases.
+2. **Each customer's Hermes Machine** — on boot and on reload, to resolve its persona configuration, skill assignments, signature blocks, channel bindings. Hermes runs on Fly Machines inside the per-customer isolation boundary established by [ADR 0007](./0007-per-customer-machine-isolation.md), with each Machine reading only its own state.
+
+Six storage candidates were considered:
+
+| Option                                                                        | Why it fails the long-term-durability test                                                                                                                                                                                                                                                                                                      |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1 only** (a `customer_configs` table that's written via admin UI)          | No version control, no PR review, no diff history. Every change is a database mutation with no audit trail of intent. Schema evolution requires migration coordination across SMD and customer state.                                                                                                                                           |
+| **R2 only** (per-customer prefix, portal reads R2 directly)                   | Portal hot-path latency: every authenticated portal request requiring persona context pays a ~50–100ms R2 round-trip. A cache layer would mitigate this — and that cache layer becomes another moving part to keep coherent.                                                                                                                    |
+| **Per-customer Hermes D1 only**                                               | Portal cannot read it per [ADR 0009](./0009-cross-machine-query-prohibition.md). Forces an outbound portal-to-Machine call for every config lookup. Couples portal availability to every Machine being warm. Cold-start Machines (which [ADR 0007](./0007-per-customer-machine-isolation.md) explicitly allows) would fail portal page renders. |
+| **Hermes-exposed API** (Machine serves its own config to portal)              | Same coupling as above. Also requires Machines to expose an authenticated endpoint to SMD's portal, which thickens the security surface for no gain.                                                                                                                                                                                            |
+| **Git only** (portal reads from GitHub via API on every request)              | Portal Worker hitting GitHub on every request: latency, rate limits, GitHub credentials in runtime. Couples product runtime to a developer-facing tool. Equivalent failure mode to a third-party SaaS dependency.                                                                                                                               |
+| **Hybrid — git as source of truth, materialized replicas at the read points** | The pattern Kubernetes manifests, Terraform state, Helm charts, and every serious GitOps system converged on. Reviewability, versioning, and audit trail come from git; read-path latency comes from local replicas.                                                                                                                            |
+
+The hybrid pattern is the only one that does not cut a corner on either reviewability, latency, or isolation. It is the decision.
+
+---
+
+## Decision
+
+### 1. Git is the source of truth
+
+Each customer's configuration lives at one canonical path: `customer-configs/<customer-slug>.yaml`. The file is human-edited, PR-reviewed, and validated against the [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) contract before merge.
+
+**Repository location:** TBD — captured as a follow-on decision in the implementation issue. Two options:
+
+- (a) A subdirectory under `ss-console/` (e.g. `ss-console/customer-configs/`). Lower operational overhead — one repo, one PR flow. Mixes operational config with application source.
+- (b) A separate `smd-customer-configs` repo. Cleaner separation, but adds a second repo with its own access controls, CI, and review cadence.
+
+Captain decides at the implementation issue. The storage architecture below is identical in either case; only the path prefix changes.
+
+### 2. Replicas are projections, not competing sources
+
+On every merge to the canonical branch, CI:
+
+1. Validates the YAML against the schema spec (closes [#790](https://github.com/venturecrane/ss-console/issues/790) at the validator level).
+2. Checks for secret leakage. Refuses to merge if any field matches a secret heuristic (gitleaks rules + a project-specific allowlist of public fields).
+3. Parses the YAML into a normalized JSON projection.
+4. Writes the projection to portal D1 (`customer_configs` table, keyed by `entity_id`).
+5. Uploads the canonical YAML to per-customer R2 (`r2://customers/<slug>/customer.yaml`).
+6. Stamps both replicas with the git SHA and a `synced_at` timestamp.
+
+**The replicas are never edited directly.** No admin UI mutates them. No script writes to them outside CI. If a divergence is detected (see _Drift detection_ below), the resolution is always "re-sync from git" — never "patch the replica."
+
+### 3. Portal reads from portal D1
+
+The new `customer_configs` table in portal D1 (migration 0039):
+
+```sql
+CREATE TABLE customer_configs (
+  entity_id           TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  org_id              TEXT NOT NULL REFERENCES organizations(id),
+  customer_slug       TEXT NOT NULL UNIQUE,
+  schema_version      TEXT NOT NULL,
+  personas_json       TEXT NOT NULL,        -- JSON array, length ≥1 (ADR 0011 §1)
+  voice_library_json  TEXT,                  -- nullable until voice library exists
+  escalation_json     TEXT,
+  business_hours_json TEXT,
+  connectors_json     TEXT,                  -- non-secret connector references only
+  scope_json          TEXT,
+  git_sha             TEXT NOT NULL,        -- commit SHA the projection was built from
+  synced_at           TEXT NOT NULL,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_customer_configs_org ON customer_configs(org_id);
+CREATE INDEX idx_customer_configs_slug ON customer_configs(customer_slug);
+```
+
+**The shape is a projection of customer.yaml, not a mirror.** It stores only fields the portal needs to render. Secrets (API tokens, OAuth refresh tokens, anything sensitive) never enter this table — they live in Infisical with references denormalized into `connectors_json` if needed.
+
+**Read path:** `src/lib/portal/customer-config.ts` exports `getCustomerConfig(db, entity_id)` and `getActivePersona(db, entity_id)`. `getActivePersona` returns `personas[0]` if present, else `null`. Phase 2 of [ADR 0011](./0011-multi-persona-per-customer.md) (when N > 1) extends the selector but the function signature is stable.
+
+### 4. Hermes reads from per-customer R2
+
+The canonical YAML is uploaded to the customer's R2 prefix on every CI sync. Hermes Machines read from their own prefix only — same isolation discipline as memory vault objects ([ADR 0008](./0008-customer-owned-memory-artifact.md)).
+
+Hermes-side schema parsing remains in Hermes's existing pydantic validator. The portal projection is independent — both consumers parse the YAML against the same schema spec but maintain independent typed representations.
+
+**Why not portal pushes config to Hermes via API?** Because pull-from-R2 is simpler, cheaper, and aligned with the Machine's existing R2 access pattern for the memory vault. Push-from-portal would require an inbound authenticated endpoint on every Machine, thickening the security surface.
+
+### 5. Onboarding flow
+
+1. Captain (or admin) creates a PR against the canonical repo: `customer-configs/<new-slug>.yaml`.
+2. CI runs the schema + secret validators. Failures block the PR.
+3. Captain reviews diff (since it's a PR, normal review applies).
+4. On merge, CI's sync job:
+   - Inserts the projection into portal D1 `customer_configs`.
+   - Uploads the YAML to `r2://customers/<slug>/customer.yaml`.
+   - Provisions the Hermes Machine if it doesn't exist (existing tooling — `provision-customer.sh`).
+5. Captain inserts the `subscriptions` row to activate portal access (per [ADR 0011](./0011-multi-persona-per-customer.md) §4; Stripe automation deferred to [#917](https://github.com/venturecrane/ss-console/issues/917)).
+
+**Hand-edits are a defect.** If anyone hand-edits the D1 row or the R2 object outside CI, drift detection (§6) will page on the next run.
+
+### 6. Drift detection
+
+A scheduled Cloudflare cron job runs daily:
+
+1. Reads the canonical YAML for every customer from the git repo.
+2. Compares its content hash against the `git_sha` + reconstructed projection in D1.
+3. Compares against the R2 object hash.
+4. On mismatch: emits a Sentry event tagged `customer_config_drift`, names the customer, names the divergent replica, and includes the diff.
+
+The resolution path is always re-sync from git. The drift event names the canonical state; the operator does not have to investigate which side is "right."
+
+### 7. Offboarding
+
+Customer offboarding is a PR that deletes `customer-configs/<slug>.yaml`. CI on merge:
+
+1. Removes the row from portal D1 `customer_configs`.
+2. Removes (or archives — Captain decision per customer) the R2 object.
+3. Deactivates the `subscriptions` row.
+4. Decommissions the Hermes Machine per the existing decommission runbook.
+
+Cleaner than D1-only or R2-only paths, where offboarding can leave orphan rows or objects that nobody finds.
+
+### 8. Schema evolution
+
+When the schema changes (new fields, new validations), the order of operations:
+
+1. Update [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) and the pydantic validator + portal projection mapping.
+2. Bump `schema_version` in the spec.
+3. Migrate existing customer YAML files via PR — each customer file gets the new field, defaults applied, validated.
+4. CI on merge re-syncs all replicas with the new schema_version.
+
+Old `schema_version` in D1 → CI sync warns and re-projects. No customer is silently running on a stale schema.
+
+### 9. Escape hatches
+
+Two scenarios where CI sync alone is not enough:
+
+- **CI is broken on the day a customer needs to onboard.** An admin CLI (`smd-config sync --customer=<slug> --from-sha=<sha>`) re-runs the sync locally. Logs the deviation; Sentry event named `manual_config_sync`. Acceptable in emergencies, not as routine practice.
+- **A drift event needs immediate triage outside the cron window.** Same CLI. Same logging.
+
+The escape hatches do not write to git. They only re-project from a known-good git SHA. This preserves git's role as source of truth even when CI is down.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Single source of truth, two read replicas.** Disputes resolve at git. No question about which side is authoritative.
+- **Reviewable.** Every config change is a PR with diff. Captain can review before customer state changes.
+- **Versioned.** Full history. `git log -- customer-configs/<slug>.yaml` shows every change with intent.
+- **Auditable.** The `git_sha` column on the D1 row ties every portal read to a specific commit. Audit log entries can cite the commit a decision was made against.
+- **Fast portal reads.** D1 lookup on the hot path. Same latency profile as `subscriptions` and `product_roles` reads (which the portal already does).
+- **ADR-compliant Hermes reads.** Per-customer R2 prefix keeps the isolation boundary [ADR 0008](./0008-customer-owned-memory-artifact.md) and [ADR 0009](./0009-cross-machine-query-prohibition.md) established.
+- **Onboarding and offboarding are PRs.** Same review, same audit, same revert path as code changes.
+- **Secret-exclusion enforced at write time.** Bad-secret commits fail CI before they merge. Cannot enter the replicas.
+- **Schema evolution is bounded.** All customers on the same schema version, enforced at sync.
+
+### Negative / accepted
+
+- **More moving parts than D1-only or R2-only.** A CI workflow, a sync job, a drift cron, an admin CLI. Each is a small piece; together they're more surface than a single store. Accepted because the alternative is corner-cutting.
+- **CI flakiness can block onboarding.** Mitigated by the escape-hatch CLI. Not eliminated. Accepted because the alternative — letting anyone hand-edit a replica — is worse.
+- **Two schema parsers.** Portal projects from YAML to JSON; Hermes parses YAML to its pydantic model. They must stay aligned against the same schema spec. Drift between them is a class of bug. Mitigated by both consumers building against the [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) contract and a cross-consumer test suite (Phase 2). Accepted at v1 because divergence at one customer × one persona × one schema version is detectable in QA.
+- **Storage cost of the canonical YAML.** R2 is cheap, but every Hermes Machine pulls its YAML at boot. Insignificant at any plausible customer count. Noted for completeness.
+
+### Out of scope
+
+- **Whether the configs repo lives in `ss-console/` or a separate `smd-customer-configs` repo.** Captured as a follow-on decision at the implementation issue.
+- **Stripe Subscriptions ↔ subscriptions row automation.** [#917](https://github.com/venturecrane/ss-console/issues/917). Compatible with this ADR.
+- **Cross-customer config policies** (e.g. enterprise-wide voice library updates that propagate to every customer). Out of scope; if it ever becomes relevant, the canonical repo's directory structure supports it.
+- **Customer-self-serve config edits via the portal.** Out of scope at v1. If ever desired, the path is: portal write → PR-via-API → CI sync. Not a database mutation.
+
+---
+
+## Verification
+
+### Schema readiness checks
+
+1. The portal projection mapping (`src/lib/portal/customer-config.ts:projectFromYaml`) round-trips: a valid YAML parses to a projection that can be inserted into D1, and the projection's fields satisfy every read site in the portal.
+2. The Hermes pydantic validator and the portal projection parse the same YAML without divergence — verified by a cross-consumer fixture test (Phase 2).
+3. The drift cron detects a deliberately-injected divergence (test fixture).
+4. CI rejects a YAML that contains a known-shape secret (test fixture).
+
+### Onboarding rehearsal
+
+End-to-end rehearsal for a new customer:
+
+1. PR with `customer-configs/<new-slug>.yaml` opens.
+2. CI validates → passes.
+3. PR merges.
+4. CI sync job runs.
+5. Portal D1 has the new row.
+6. R2 has the new object.
+7. `getActivePersona(db, <entity_id>)` returns the persona configured in the YAML.
+8. Hermes Machine, when provisioned, reads the YAML from R2 successfully.
+
+If any step fails, the customer is not onboarded — the partial state must be cleaned up before the next attempt. The PR can be reverted to roll back.
+
+### Adversarial review
+
+Hand the ADR to a fresh agent and ask: _"How do I add a new persona to an existing v1 customer?"_
+
+Acceptable answer:
+
+1. Open a PR editing `customer-configs/<slug>.yaml` to add a second entry to `personas[]`.
+2. Wait for CI to validate.
+3. Merge the PR.
+4. CI re-syncs both replicas; the portal D1 row now has two personas in `personas_json`.
+5. Phase 2 runtime (per [ADR 0011](./0011-multi-persona-per-customer.md)) handles the second persona's Machine, AgentMail inbox, and routing.
+
+No database mutation. No admin UI. No script run by hand. The PR is the change.
+
+---
+
+## Implementation
+
+The Phase 1 sequence — recorded here, executed by the follow-on PRs:
+
+1. **This ADR lands** (recording the architectural commitment).
+2. **Portal D1 substrate PR** — adds the `customer_configs` migration, the `getCustomerConfig` / `getActivePersona` helpers, and unit tests. Does NOT depend on the git repo or CI sync existing yet; the helpers read whatever is in `customer_configs`. Captain can hand-seed rows for the alpha customer via an admin endpoint or direct SQL. The git/CI side lands separately.
+3. **PRD + runbook vocabulary update PR** ([#921](https://github.com/venturecrane/ss-console/issues/921)) — independent of (2); the docs update can land in parallel.
+4. **Canonical configs repo + CI sync PR** (separate, follow-on) — establishes the git repo (location decision deferred), the CI workflow, the secret validator, and the R2 upload.
+5. **Drift detection cron + admin CLI** (separate, follow-on) — adds the daily comparison, the Sentry integration, and the escape-hatch CLI.
+6. **Schema validator integration** ([#790](https://github.com/venturecrane/ss-console/issues/790)) — the YAML schema spec gets a runtime validator that CI invokes.
+
+Phases 2–3 are the minimum coherent slice for this session. Phases 4–6 are durable architecture work for follow-on sessions and do not block [#924](https://github.com/venturecrane/ss-console/issues/924).
+
+---
+
+## References
+
+- [ADR 0007](./0007-per-customer-machine-isolation.md) — per-customer Machine isolation
+- [ADR 0008](./0008-customer-owned-memory-artifact.md) — customer-owned memory artifact
+- [ADR 0009](./0009-cross-machine-query-prohibition.md) — cross-Machine query prohibition
+- [ADR 0011](./0011-multi-persona-per-customer.md) — multi-persona per customer (§4 declares customer.yaml authoritative; this ADR pins its storage)
+- [Platform PRD](../pm/ai-employee/platform-prd.md) §7.3 (customer.yaml example), §9 (persona model), §20 (Phase 1 deliverables)
+- [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) — formal schema contract
+- [Issue #790](https://github.com/venturecrane/ss-console/issues/790) — customer.yaml formal schema with secret-exclusion enforcement
+- [Issue #917](https://github.com/venturecrane/ss-console/issues/917) — Stripe Subscriptions wiring
+- [Issue #924](https://github.com/venturecrane/ss-console/issues/924) — `getActivePersona()` portal resolver helper (immediate consumer of this ADR)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,3 +22,4 @@ Architecture Decision Records (ADRs) capturing strategic and technical decisions
 - [0009-cross-machine-query-prohibition.md](./0009-cross-machine-query-prohibition.md) - Cross-Machine query prohibition: boot-time storage-binding check + shared-catalog merge gate; no runtime data path between customers
 - [0010-per-customer-oauth-token-storage.md](./0010-per-customer-oauth-token-storage.md) - Per-customer OAuth token storage location (Infisical vs. Fly volume)
 - [0011-multi-persona-per-customer.md](./0011-multi-persona-per-customer.md) - Multi-persona per customer: schema-locked at v1 (`personas: []` array length=1), runtime deferred to Phase 2
+- [0012-customer-yaml-storage.md](./0012-customer-yaml-storage.md) - customer.yaml storage: git as source of truth, portal D1 + per-customer R2 as materialized replicas

--- a/migrations/0039_customer_configs.sql
+++ b/migrations/0039_customer_configs.sql
@@ -1,0 +1,62 @@
+-- Portal projection of customer.yaml — read replica for hot-path portal lookups
+-- ============================================================================
+--
+-- Adds the `customer_configs` table that holds the portal's projection of each
+-- customer's canonical `customer.yaml`. Per ADR 0012, customer.yaml lives in a
+-- git repository (source of truth); CI on merge projects it into this table
+-- (portal read replica) and uploads the original to per-customer R2 (Hermes
+-- read replica). Portal pages read from this table on the hot path; they never
+-- write to it. Hand-edits are a defect detected by the daily drift cron.
+--
+-- The projection holds only fields the portal needs to render. Secrets never
+-- enter this table — they live in Infisical, with non-secret references
+-- denormalized into `connectors_json` where the portal needs them.
+--
+-- Personas vocabulary follows ADR 0011 (`personas:` array, length ≥1 at v1).
+-- `personas_json` is the parsed array; helper functions in
+-- src/lib/portal/customer-config.ts decode it into typed PersonaConfig values.
+--
+-- Forward-only, additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS customer_configs (
+  entity_id           TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  org_id              TEXT NOT NULL REFERENCES organizations(id),
+
+  -- Stable slug for the customer (e.g. "smith-pi-firm"). Used to address the
+  -- Hermes Machine, the R2 prefix, and the canonical customer-configs path
+  -- in git. UNIQUE across customers.
+  customer_slug       TEXT NOT NULL UNIQUE,
+
+  -- Schema version the projection was built from. Each schema evolution
+  -- bumps this; drift detection flags rows whose schema_version lags the
+  -- canonical schema.
+  schema_version      TEXT NOT NULL,
+
+  -- Parsed projections of customer.yaml fields the portal reads. All TEXT
+  -- columns hold JSON; helpers parse on read and never on write. NULL is
+  -- meaningful for fields a customer may legitimately not have configured
+  -- yet (no voice library, no escalation rules).
+  personas_json       TEXT NOT NULL,
+  voice_library_json  TEXT,
+  escalation_json     TEXT,
+  business_hours_json TEXT,
+  connectors_json     TEXT,
+  scope_json          TEXT,
+
+  -- Commit SHA the projection was built from. Audit log entries cite this
+  -- so any decision can be tied back to the exact config in effect.
+  git_sha             TEXT NOT NULL,
+
+  -- When CI last synced this row from git. Drift detection uses this with
+  -- `git_sha` to spot stale projections.
+  synced_at           TEXT NOT NULL,
+
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_configs_org
+  ON customer_configs(org_id);
+CREATE INDEX IF NOT EXISTS idx_customer_configs_slug
+  ON customer_configs(customer_slug);

--- a/migrations/rollbacks/0039_customer_configs_down.sql
+++ b/migrations/rollbacks/0039_customer_configs_down.sql
@@ -1,0 +1,12 @@
+-- Manual rollback for migration 0039. NOT auto-applied.
+-- See migrations/rollbacks/README.md.
+--
+-- DESTRUCTIVE: dropping `customer_configs` removes the portal's projection
+-- of every customer's canonical customer.yaml. The source of truth (git)
+-- is unaffected — re-running the CI sync repopulates the table.
+--
+-- Drop indexes before the table for re-apply safety.
+
+DROP INDEX IF EXISTS idx_customer_configs_slug;
+DROP INDEX IF EXISTS idx_customer_configs_org;
+DROP TABLE IF EXISTS customer_configs;

--- a/src/lib/portal/ai-employee-access.ts
+++ b/src/lib/portal/ai-employee-access.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared access gate for the AI Employee product surfaces under
+ * `/portal/products/ai-employee/*`.
+ *
+ * Every product surface needs the same four checks, in order:
+ *
+ *   1. Clerk session present                  → otherwise sign-in
+ *   2. Local entity bound to Clerk org        → otherwise sign-in with no_subscription marker
+ *   3. AI Employee subscription on the entity → otherwise landing page (which renders the
+ *                                                no_subscription / provisioning / paused state)
+ *   4. Caller holds at least one allowed role → otherwise landing page (no_role state)
+ *
+ * Each surface differs only in which roles it accepts. Drafts, matters, and calendar are
+ * for active users (operator or principal); audit is open to all three roles since
+ * compliance is the dedicated viewer; settings is principal-only.
+ *
+ * Status check: this helper treats provisioning, active, and paused subscriptions as
+ * "exists" — same posture as `getProductSubscription`. Surfaces render their empty
+ * state regardless of lifecycle status. The landing page is the only surface that
+ * branches on status (see src/pages/portal/products/ai-employee/index.astro).
+ */
+
+import type { Entity } from '../db/entities'
+import type { PortalUserRow } from '../auth/clerk-bridge'
+import { getPortalClient } from './session'
+import { getProductSubscription, listProductRoles, type SubscriptionRow } from './product-access'
+
+export const AI_EMPLOYEE_PRODUCT_SLUG = 'ai-employee'
+
+export const AI_EMPLOYEE_LANDING_PATH = '/portal/products/ai-employee'
+export const PORTAL_SIGN_IN_PATH = '/auth/portal-sign-in'
+export const PORTAL_SIGN_IN_NO_SUBSCRIPTION_PATH = `${PORTAL_SIGN_IN_PATH}?status=no_subscription`
+
+export type AiEmployeeAccess =
+  | { kind: 'redirect'; to: string }
+  | {
+      kind: 'allowed'
+      user: PortalUserRow
+      client: Entity
+      subscription: SubscriptionRow
+      roles: string[]
+    }
+
+export interface ResolveAiEmployeeAccessOptions {
+  /**
+   * Roles that grant access to the surface. Any one match is enough. Pass the
+   * canonical product_roles vocabulary values (`principal`, `operator`,
+   * `compliance`) — typos will silently 401 every visitor.
+   */
+  allowedRoles: readonly string[]
+}
+
+/**
+ * Resolve access for an AI Employee product surface. Returns either a redirect
+ * target (caller does `Astro.redirect(access.to)`) or the resolved
+ * user/client/subscription/roles tuple ready to render.
+ *
+ * The helper does not call `Astro.redirect` itself because Astro's redirect is
+ * a context-bound method on the page; returning the path keeps the helper
+ * unit-testable with a plain DB + locals.
+ */
+export async function resolveAiEmployeeAccess(
+  db: D1Database,
+  locals: App.Locals,
+  options: ResolveAiEmployeeAccessOptions
+): Promise<AiEmployeeAccess> {
+  const portalData = await getPortalClient(db, locals)
+  if (!portalData) {
+    return { kind: 'redirect', to: PORTAL_SIGN_IN_PATH }
+  }
+  if (!portalData.client) {
+    return { kind: 'redirect', to: PORTAL_SIGN_IN_NO_SUBSCRIPTION_PATH }
+  }
+
+  const { user, client } = portalData
+
+  const subscription = await getProductSubscription(db, client.id, AI_EMPLOYEE_PRODUCT_SLUG)
+  if (!subscription) {
+    return { kind: 'redirect', to: AI_EMPLOYEE_LANDING_PATH }
+  }
+
+  const roles = await listProductRoles(db, user.id, client.id, AI_EMPLOYEE_PRODUCT_SLUG)
+  const hasAllowedRole = options.allowedRoles.some((r) => roles.includes(r))
+  if (!hasAllowedRole) {
+    return { kind: 'redirect', to: AI_EMPLOYEE_LANDING_PATH }
+  }
+
+  return { kind: 'allowed', user, client, subscription, roles }
+}

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -1,0 +1,160 @@
+/**
+ * Customer config — portal read path for the projection of `customer.yaml`.
+ *
+ * Per ADR 0012, `customer.yaml` lives in a canonical git repository and is
+ * projected on every merge into two read replicas:
+ *
+ *   1. portal D1 `customer_configs` table  (this module reads from here)
+ *   2. per-customer R2 prefix              (Hermes reads from there)
+ *
+ * Neither replica is hand-edited. Drift detection (a daily cron, lands in a
+ * follow-on PR) reconciles them against git. This module is read-only on
+ * principle: any write path that bypasses git breaks the source-of-truth
+ * commitment in ADR 0012 §2.
+ *
+ * Per ADR 0011, `personas` is an array (length ≥1 at v1, with the v1
+ * customer's sole persona at index 0). `getActivePersona` returns the first
+ * persona whose `status === 'active'`. Phase 2 extends the selector when a
+ * second persona ships — the function signature stays additive (Phase 2 adds
+ * an optional selector parameter; v1 callers continue to work).
+ */
+
+export type PersonaStatus = 'active' | 'archived'
+
+export interface PersonaSendAs {
+  agentmail_identity: string
+}
+
+export interface PersonaSkill {
+  name: string
+  trust_ceiling: string
+}
+
+export interface PersonaChannelBinding {
+  integration: string
+  channels: string[]
+}
+
+export interface PersonaConfig {
+  slug: string
+  status: PersonaStatus
+  name: string
+  title: string | null
+  signature_html: string | null
+  tone: string[]
+  send_as: PersonaSendAs | null
+  skills: PersonaSkill[]
+  channel_bindings: PersonaChannelBinding[]
+}
+
+export interface CustomerConfigRow {
+  entity_id: string
+  org_id: string
+  customer_slug: string
+  schema_version: string
+  personas: PersonaConfig[]
+  voice_library: unknown
+  escalation: unknown
+  business_hours: unknown
+  connectors: unknown
+  scope: unknown
+  git_sha: string
+  synced_at: string
+}
+
+interface CustomerConfigDbRow {
+  entity_id: string
+  org_id: string
+  customer_slug: string
+  schema_version: string
+  personas_json: string
+  voice_library_json: string | null
+  escalation_json: string | null
+  business_hours_json: string | null
+  connectors_json: string | null
+  scope_json: string | null
+  git_sha: string
+  synced_at: string
+}
+
+/**
+ * Parse a JSON column that may be null. Returns `null` when the column is
+ * null. Throws on malformed JSON — drift detection / CI sync are responsible
+ * for ensuring the projection is well-formed; a malformed JSON column is a
+ * corruption signal, not a routine condition to recover from.
+ */
+function parseJsonNullable<T>(value: string | null): T | null {
+  if (value === null) return null
+  return JSON.parse(value) as T
+}
+
+/**
+ * Parse a required JSON column. Throws on null OR malformed JSON — both are
+ * corruption signals at the projection layer.
+ */
+function parseJsonRequired<T>(value: string, column: string, entityId: string): T {
+  try {
+    return JSON.parse(value) as T
+  } catch (err) {
+    throw new Error(
+      `customer_configs.${column} is malformed JSON for entity_id=${entityId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err }
+    )
+  }
+}
+
+function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
+  return {
+    entity_id: row.entity_id,
+    org_id: row.org_id,
+    customer_slug: row.customer_slug,
+    schema_version: row.schema_version,
+    personas: parseJsonRequired<PersonaConfig[]>(row.personas_json, 'personas_json', row.entity_id),
+    voice_library: parseJsonNullable(row.voice_library_json),
+    escalation: parseJsonNullable(row.escalation_json),
+    business_hours: parseJsonNullable(row.business_hours_json),
+    connectors: parseJsonNullable(row.connectors_json),
+    scope: parseJsonNullable(row.scope_json),
+    git_sha: row.git_sha,
+    synced_at: row.synced_at,
+  }
+}
+
+/**
+ * Read the projected customer config for an entity. Returns null when no row
+ * exists — a meaningful state during alpha when CI sync has not been wired
+ * up yet (rows are hand-seeded only).
+ */
+export async function getCustomerConfig(
+  db: D1Database,
+  entityId: string
+): Promise<CustomerConfigRow | null> {
+  const row = await db
+    .prepare('SELECT * FROM customer_configs WHERE entity_id = ?')
+    .bind(entityId)
+    .first<CustomerConfigDbRow>()
+  if (!row) return null
+  return projectRow(row)
+}
+
+/**
+ * Return the active persona for this customer, or null when no config row
+ * exists or no persona's `status === 'active'`. At v1 the personas array is
+ * length 1 (ADR 0011 §1), so this returns personas[0] when active.
+ *
+ * Phase 2 (multi-persona runtime) will extend the resolver with a selector
+ * — likely a `persona_slug` argument backed by URL or session state. The
+ * signature stays additive: v1 callers passing only (db, entityId) keep
+ * working when the Phase 2 selector lands.
+ */
+export async function getActivePersona(
+  db: D1Database,
+  entityId: string
+): Promise<PersonaConfig | null> {
+  const config = await getCustomerConfig(db, entityId)
+  if (!config) return null
+  const active = config.personas.find((p) => p.status === 'active')
+  return active ?? null
+}

--- a/src/pages/portal/products/ai-employee/audit/index.astro
+++ b/src/pages/portal/products/ai-employee/audit/index.astro
@@ -1,0 +1,112 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Audit log viewer.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/audit
+ *
+ * Per #873 and #895, every action the AI Employee takes — drafts
+ * created, sends approved, identity attributions, trust-ceiling
+ * decisions, memory access — emits an audit event. This surface is the
+ * read-only viewer over those events. Persistence and writer modules
+ * land separately (#891, #842, #864).
+ *
+ * Audit events live on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821) and the
+ * compliance evidence pipeline (#892, #894).
+ *
+ * Until the read path lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated events, no synthetic
+ * trace, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds principal OR operator OR compliance role
+ *
+ * Compliance is the dedicated viewer for this surface (#895), but
+ * audit transparency is for the whole team — operators see what they
+ * acted on, principals see firm-wide activity.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'operator', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Audit | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Audit"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No audit events yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Every action your AI Employee takes is recorded here: drafts created, sends approved,
+            identity changes, memory access.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/calendar/index.astro
+++ b/src/pages/portal/products/ai-employee/calendar/index.astro
@@ -1,0 +1,105 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Calendar.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/calendar
+ *
+ * Per #872, the calendar surfaces deadlines, hearings, depositions, and
+ * scheduled follow-ups the AI Employee is tracking. Connector wiring for
+ * Google Calendar / Outlook / case-management deadlines lands as part of
+ * the per-customer Hermes Machine runtime (#821, #923 connector
+ * addressing) — none of that data is reachable from the portal Worker
+ * directly per ADR 0009.
+ *
+ * Until the read path lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated events, no fake
+ * deadlines, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Calendar | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Calendar"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No upcoming events
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Hearings, depositions, and deadlines your AI Employee is tracking will appear here.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/drafts/index.astro
+++ b/src/pages/portal/products/ai-employee/drafts/index.astro
@@ -1,0 +1,107 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Drafts list.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/drafts
+ *
+ * Per PRD §12, the draft queue is the primary user-facing surface: every
+ * message the AI Employee proposes lands here for human review before it
+ * goes out (reviewer-as-sender, ADR 0005). Listing fields per #869:
+ * sender, recipient, skill, trust-ceiling decision, age, priority.
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated drafts, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing; the
+ * audit surface is their primary read view, not drafts.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Drafts | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Drafts"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No drafts yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Drafts your AI Employee prepares land here for review before any message goes out.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -32,10 +32,11 @@ import { env } from 'cloudflare:workers'
  * docs/style/empty-state-pattern.md. No fabrication.
  *
  * This page is the routing entry point. Internal product surfaces
- * (Today, Drafts, Matters, Audit, Settings) live under
- * /portal/products/ai-employee/* and are introduced by subsequent PRs
- * (#869 drafts, #871 matters, #872 calendar, #873 audit, #874
- * settings, etc.).
+ * (Drafts, Matters, Calendar, Audit, Settings) live under
+ * /portal/products/ai-employee/* and are reached via the section card
+ * grid rendered in the active-state branch below. Each child surface
+ * uses the shared resolveAiEmployeeAccess helper to enforce its own
+ * role gate; the landing only orchestrates which cards to render.
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -79,6 +80,47 @@ if (!subscription) {
     surfaceState = 'active'
     access = { subscription, roles }
   }
+}
+
+// Section cards in the active-state main column. Filtered by the
+// caller's roles so operators / principals see the act-on-the-product
+// surfaces (drafts, matters, calendar) and every role sees Audit.
+// Each destination uses resolveAiEmployeeAccess to enforce the gate
+// server-side; this list is the visual filter only.
+interface SectionCard {
+  href: string
+  label: string
+  description: string
+}
+const sectionCards: SectionCard[] = []
+if (access) {
+  const userRoles = access.roles
+  const ACTIVE_DOER_ROLES = ['operator', 'principal']
+  const canAct = userRoles.some((r) => ACTIVE_DOER_ROLES.includes(r))
+  if (canAct) {
+    sectionCards.push({
+      href: '/portal/products/ai-employee/drafts',
+      label: 'Drafts',
+      description: 'Review drafts your AI Employee has prepared before any message goes out.',
+    })
+    sectionCards.push({
+      href: '/portal/products/ai-employee/matters',
+      label: 'Matters',
+      description:
+        'Active matters your AI Employee is tracking across communications and documents.',
+    })
+    sectionCards.push({
+      href: '/portal/products/ai-employee/calendar',
+      label: 'Calendar',
+      description: 'Hearings, depositions, and deadlines your AI Employee is watching.',
+    })
+  }
+  sectionCards.push({
+    href: '/portal/products/ai-employee/audit',
+    label: 'Audit',
+    description:
+      'A full record of every action your AI Employee takes: drafts created, sends approved, identity changes.',
+  })
 }
 ---
 
@@ -182,25 +224,38 @@ if (!subscription) {
         surfaceState === 'active' && (
           <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
             <div class="flex flex-col gap-8 min-w-0">
-              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  <span>Today</span>
-                  <span class="text-[color:var(--ss-color-primary)]">§ 01</span>
-                </div>
-                <div class="px-5 md:px-7 py-6">
-                  <p class="text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
-                    Your AI Employee dashboard is ready. Activity, drafts, and matters appear here
-                    once the agent has been working with your firm.
-                  </p>
+              <section>
+                <p class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+                  Sections
+                </p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]">
+                  {sectionCards.map((s, i) => {
+                    const anchor = String(i + 1).padStart(2, '0')
+                    return (
+                      <a
+                        href={s.href}
+                        class="block bg-[color:var(--ss-color-background)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                      >
+                        <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
+                          § {anchor}
+                        </p>
+                        <h2 class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                          {s.label}
+                        </h2>
+                        <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+                          {s.description}
+                        </p>
+                      </a>
+                    )
+                  })}
                 </div>
               </section>
             </div>
 
             <aside class="flex flex-col gap-8 min-w-0">
               <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  <span>Your roles</span>
-                  <span class="text-[color:var(--ss-color-primary)]">§ 02</span>
+                <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  Your roles
                 </div>
                 <div class="px-5 md:px-7 py-6">
                   <ul
@@ -216,9 +271,8 @@ if (!subscription) {
 
               {access?.roles.includes('principal') && (
                 <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                  <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                    <span>Manage</span>
-                    <span class="text-[color:var(--ss-color-primary)]">§ 03</span>
+                  <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                    Manage
                   </div>
                   <ul
                     class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]"

--- a/src/pages/portal/products/ai-employee/matters/index.astro
+++ b/src/pages/portal/products/ai-employee/matters/index.astro
@@ -1,0 +1,107 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Matters list.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/matters
+ *
+ * Per #871, matters are the per-engagement aggregates the AI Employee
+ * tracks across communications, deadlines, and documents. The list view
+ * shows matter title, opposing party, last activity, and status. Detail
+ * pages land in a follow-on slice once the schema exists.
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated matters, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Matters | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Matters"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No matters yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Active matters appear here as your AI Employee tracks them across communications and
+            documents.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/ai-employee-access.test.ts
+++ b/tests/ai-employee-access.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Tests for the AI Employee access gate (src/lib/portal/ai-employee-access.ts).
+ *
+ * Each AI Employee surface page calls `resolveAiEmployeeAccess` with the set
+ * of roles it accepts. The helper returns either `{ kind: 'redirect', to }` —
+ * the page does `Astro.redirect(access.to)` — or `{ kind: 'allowed', ... }`
+ * with the resolved user/client/subscription/roles. This contract is what
+ * keeps wrong-role users out of drafts, matters, calendar, audit, and the
+ * settings sub-pages.
+ *
+ * We mock `getPortalClient` so the test can exercise each redirect branch
+ * without standing up a Clerk session, then drive subscriptions and
+ * product_roles via a real test D1. Migrations are applied per spec so the
+ * schema constraints (UNIQUE(entity_id, product_slug), the CHECK on status,
+ * the UNIQUE on (user, entity, product_slug, role)) are real.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+
+// Mock getPortalClient before importing the helper. The portal-session
+// module pulls in @clerk/astro middleware types that aren't available in
+// the vitest environment, so we replace the whole module surface.
+vi.mock('../src/lib/portal/session', () => ({
+  getPortalClient: vi.fn(),
+}))
+
+import { getPortalClient } from '../src/lib/portal/session'
+import { resolveAiEmployeeAccess } from '../src/lib/portal/ai-employee-access'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ENTITY_ID = 'entity-test'
+const USER_ID = 'user-test'
+const OTHER_USER_ID = 'user-other'
+const PRODUCT_SLUG = 'ai-employee'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Test Firm', 'test-firm')
+    .run()
+}
+
+async function seedUser(db: D1Database, userId: string, email: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role, entity_id, clerk_user_id)
+       VALUES (?, ?, ?, ?, 'client', ?, ?)`
+    )
+    .bind(userId, ORG_ID, email, email, ENTITY_ID, `clerk_${userId}`)
+    .run()
+}
+
+async function seedSubscription(
+  db: D1Database,
+  status: 'provisioning' | 'active' | 'paused' | 'cancelled'
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO subscriptions (id, org_id, entity_id, product_slug, status)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .bind('sub-test', ORG_ID, ENTITY_ID, PRODUCT_SLUG, status)
+    .run()
+}
+
+async function grantRole(db: D1Database, userId: string, role: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO product_roles (id, org_id, user_id, entity_id, product_slug, role)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(`pr-${userId}-${role}`, ORG_ID, userId, ENTITY_ID, PRODUCT_SLUG, role)
+    .run()
+}
+
+function mockUser(id: string, email: string) {
+  return {
+    id,
+    org_id: ORG_ID,
+    email,
+    name: email,
+    role: 'client',
+    entity_id: ENTITY_ID,
+    clerk_user_id: `clerk_${id}`,
+  }
+}
+
+function mockClient() {
+  return {
+    id: ENTITY_ID,
+    org_id: ORG_ID,
+    name: 'Test Firm',
+    slug: 'test-firm',
+    phone: null,
+    website: null,
+    stage: 'engaged' as const,
+    stage_changed_at: '2026-05-21T00:00:00Z',
+    pain_score: null,
+    vertical: null,
+    area: null,
+    employee_count: null,
+    tier: null,
+    summary: null,
+    next_action: null,
+    next_action_at: null,
+    source_pipeline: null,
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    clerk_org_id: 'clerk_org_test',
+  }
+}
+
+const fakeLocals = {} as App.Locals
+
+describe('resolveAiEmployeeAccess', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+    vi.mocked(getPortalClient).mockReset()
+  })
+
+  it('redirects to sign-in when no portal session exists', async () => {
+    vi.mocked(getPortalClient).mockResolvedValue(null)
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/auth/portal-sign-in')
+    }
+  })
+
+  it('redirects to no-subscription sign-in when entity not provisioned', async () => {
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: null,
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/auth/portal-sign-in?status=no_subscription')
+    }
+  })
+
+  it('redirects to landing when entity has no AI Employee subscription', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('redirects to landing when subscription is cancelled', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'cancelled')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('redirects to landing when user has no role on this product', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'noaccess@firm.com')
+    await seedSubscription(db, 'active')
+    // No grantRole — caller has zero product_roles rows
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'noaccess@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it("redirects to landing when caller's role isn't in allowedRoles (compliance hitting drafts)", async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'compliance@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'compliance@firm.com'),
+      client: mockClient(),
+    })
+
+    // Drafts allows operator | principal only — compliance must be redirected
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('allows access when caller has principal role and surface accepts principal', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.user.id).toBe(USER_ID)
+      expect(result.client.id).toBe(ENTITY_ID)
+      expect(result.subscription.status).toBe('active')
+      expect(result.roles).toContain('principal')
+    }
+  })
+
+  it('allows access when caller has operator role and surface accepts operator', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'operator@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'operator')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'operator@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toContain('operator')
+    }
+  })
+
+  it('allows access during provisioning status (matches surface gate posture)', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'provisioning')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    // Provisioning subscriptions DO return — the helper matches getProductSubscription
+    // which treats provisioning/active/paused as "exists". Surfaces render their
+    // own empty state. Only the landing branches on lifecycle status.
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.subscription.status).toBe('provisioning')
+    }
+  })
+
+  it('allows access during paused status', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'paused')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.subscription.status).toBe('paused')
+    }
+  })
+
+  it('audit-surface configuration allows all three role vocabularies', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'compliance@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'compliance@firm.com'),
+      client: mockClient(),
+    })
+
+    // Audit accepts principal | operator | compliance
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal', 'operator', 'compliance'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toEqual(['compliance'])
+    }
+  })
+
+  it('returns all of the caller’s granted roles, not just the matched one', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'wearsmanyhats@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'wearsmanyhats@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toEqual(expect.arrayContaining(['principal', 'compliance']))
+      expect(result.roles).toHaveLength(2)
+    }
+  })
+
+  it('only counts non-revoked roles', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'wasprincipal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    // Revoke the only role
+    await db
+      .prepare(
+        `UPDATE product_roles SET revoked_at = datetime('now')
+         WHERE user_id = ? AND entity_id = ? AND product_slug = ?`
+      )
+      .bind(USER_ID, ENTITY_ID, PRODUCT_SLUG)
+      .run()
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'wasprincipal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('isolates roles per (user, entity, product) — another user’s role doesn’t grant access', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'noaccess@firm.com')
+    await seedUser(db, OTHER_USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, OTHER_USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'noaccess@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+})

--- a/tests/customer-config.test.ts
+++ b/tests/customer-config.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the customer_configs projection helpers
+ * (src/lib/portal/customer-config.ts).
+ *
+ * Per ADR 0012, customer_configs is a read replica of `customer.yaml` (which
+ * lives in a canonical git repo). The helpers under test parse projected JSON
+ * columns into typed shapes and resolve the active persona per ADR 0011 §1.
+ *
+ * Each test seeds a customer_configs row directly via the test D1 — emulating
+ * what CI will do post-merge, since the CI sync path lands in a follow-on
+ * PR. The schema constraints (FK to entities, UNIQUE customer_slug, NOT NULL
+ * on personas_json) are exercised through real seeds.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  getCustomerConfig,
+  getActivePersona,
+  type PersonaConfig,
+} from '../src/lib/portal/customer-config'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ENTITY_ID = 'entity-config-test'
+const CUSTOMER_SLUG = 'smith-pi-firm'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Smith PI Firm', 'smith-pi-firm')
+    .run()
+}
+
+interface SeedOptions {
+  entity_id?: string
+  customer_slug?: string
+  schema_version?: string
+  personas?: PersonaConfig[]
+  voice_library?: unknown
+  escalation?: unknown
+  business_hours?: unknown
+  connectors?: unknown
+  scope?: unknown
+  git_sha?: string
+  synced_at?: string
+}
+
+async function seedConfig(db: D1Database, opts: SeedOptions = {}): Promise<void> {
+  const personas = opts.personas ?? [makePersona({ slug: 'marcus' })]
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+        (entity_id, org_id, customer_slug, schema_version,
+         personas_json, voice_library_json, escalation_json, business_hours_json,
+         connectors_json, scope_json, git_sha, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      opts.entity_id ?? ENTITY_ID,
+      ORG_ID,
+      opts.customer_slug ?? CUSTOMER_SLUG,
+      opts.schema_version ?? '1.0.0',
+      JSON.stringify(personas),
+      opts.voice_library === undefined ? null : JSON.stringify(opts.voice_library),
+      opts.escalation === undefined ? null : JSON.stringify(opts.escalation),
+      opts.business_hours === undefined ? null : JSON.stringify(opts.business_hours),
+      opts.connectors === undefined ? null : JSON.stringify(opts.connectors),
+      opts.scope === undefined ? null : JSON.stringify(opts.scope),
+      opts.git_sha ?? 'a1b2c3d4e5f6',
+      opts.synced_at ?? '2026-05-21T12:00:00Z'
+    )
+    .run()
+}
+
+function makePersona(overrides: Partial<PersonaConfig> = {}): PersonaConfig {
+  return {
+    slug: 'marcus',
+    status: 'active',
+    name: 'Marcus',
+    title: 'AI Associate',
+    signature_html: '<p>Marcus<br/>AI Associate</p>',
+    tone: ['warm-but-professional'],
+    send_as: { agentmail_identity: 'marcus@smith-pi-firm.agents.smd.services' },
+    skills: [{ name: 'inbox-triage-and-draft', trust_ceiling: 'draft_for_review' }],
+    channel_bindings: [{ integration: 'ms-graph', channels: ['primary-inbox'] }],
+    ...overrides,
+  }
+}
+
+describe('getCustomerConfig', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns null when no config row exists for the entity', async () => {
+    await seedEntity(db)
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('parses personas_json and other JSON columns into typed shape', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [makePersona()],
+      escalation: { red_flag_recipients: ['partner@firm.com'] },
+      business_hours: { start: '08:00', end: '18:00', tz: 'America/Phoenix' },
+    })
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result).not.toBeNull()
+    expect(result?.personas).toHaveLength(1)
+    expect(result?.personas[0].name).toBe('Marcus')
+    expect(result?.personas[0].skills[0].name).toBe('inbox-triage-and-draft')
+    expect(result?.escalation).toEqual({ red_flag_recipients: ['partner@firm.com'] })
+    expect(result?.business_hours).toEqual({ start: '08:00', end: '18:00', tz: 'America/Phoenix' })
+  })
+
+  it('returns the row’s schema_version and git_sha verbatim for drift detection', async () => {
+    await seedEntity(db)
+    await seedConfig(db, { schema_version: '2.3.1', git_sha: 'deadbeef1234' })
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result?.schema_version).toBe('2.3.1')
+    expect(result?.git_sha).toBe('deadbeef1234')
+  })
+
+  it('returns null for nullable columns that were not populated', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [makePersona()],
+      // voice_library, escalation, business_hours, connectors, scope all omitted
+    })
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result?.voice_library).toBeNull()
+    expect(result?.escalation).toBeNull()
+    expect(result?.business_hours).toBeNull()
+    expect(result?.connectors).toBeNull()
+    expect(result?.scope).toBeNull()
+  })
+})
+
+describe('getActivePersona', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns null when no config row exists', async () => {
+    await seedEntity(db)
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when personas array is empty (degenerate but well-formed)', async () => {
+    await seedEntity(db)
+    await seedConfig(db, { personas: [] })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when every persona is archived', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [
+        makePersona({ slug: 'marcus', status: 'archived' }),
+        makePersona({ slug: 'casey', status: 'archived', name: 'Casey' }),
+      ],
+    })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('returns the single active persona at v1 (length-1 array)', async () => {
+    await seedEntity(db)
+    await seedConfig(db, { personas: [makePersona({ slug: 'marcus' })] })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result?.slug).toBe('marcus')
+    expect(result?.name).toBe('Marcus')
+  })
+
+  it('skips archived personas even when they appear before an active one', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [
+        makePersona({ slug: 'marcus-old', status: 'archived', name: 'Marcus Old' }),
+        makePersona({ slug: 'casey', status: 'active', name: 'Casey' }),
+      ],
+    })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result?.slug).toBe('casey')
+    expect(result?.name).toBe('Casey')
+  })
+})
+
+describe('customer_configs schema integrity', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('FK from entity_id to entities.id rejects an orphan insert', async () => {
+    // Insert with a non-existent entity_id should fail
+    await expect(seedConfig(db, { entity_id: 'no-such-entity' })).rejects.toThrow()
+  })
+
+  it('UNIQUE(customer_slug) rejects duplicate-slug insert across different entities', async () => {
+    await seedEntity(db)
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind('entity-other', ORG_ID, 'Other Firm', 'other-firm')
+      .run()
+
+    await seedConfig(db, { entity_id: ENTITY_ID, customer_slug: 'same-slug' })
+    await expect(
+      seedConfig(db, { entity_id: 'entity-other', customer_slug: 'same-slug' })
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Records ADR 0012 — git as source of truth for `customer.yaml`, portal D1 `customer_configs` table as the portal's read replica, per-customer R2 prefix as Hermes's read replica. Ships the portal-side substrate (migration, helpers, tests) plus the ADR. The git repo, CI sync workflow, R2 upload, drift detection cron, and admin escape-hatch CLI are deferred to follow-on PRs.

## Linked issue

Refs #790, #924, ADR 0011 §4

This PR pins the storage location that ADR 0011 §4 deferred when it declared `customer.yaml` authoritative without specifying where it lives. #924 (`getActivePersona()` portal resolver) is the immediate consumer — exported here, not yet wired to any page on principle that UI integration is a deliberate UX decision separate from infrastructure.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Portal can read customer.yaml projection (pre-req for #924) | met | `src/lib/portal/customer-config.ts` |
| `getActivePersona()` exported helper | met | `getActivePersona(db, entityId)` returns first persona with `status === 'active'`, null otherwise |
| #790 customer.yaml formal schema | deferred | This PR establishes the storage; the runtime schema validator + secret-exclusion enforcement remain |
| #924 portal landing integration | deferred | Helper exported; landing-page wiring is a separate UX decision |

## Deferred ACs

- **AC:** #790 — formal customer.yaml schema with secret-exclusion enforcement
  - **Why deferred:** ADR 0012 covers _where_ the YAML lives and _how_ it's validated at write time conceptually. The runtime schema spec + gitleaks-style secret check land with the CI sync workflow PR.
  - **Tracked in:** #790 (still open)
- **AC:** #924 — portal page consumes `getActivePersona()`
  - **Why deferred:** No current UI surface references a persona name or attribute. Integrating without a deliberate UX call would be Pattern A territory. Follow-on PR introduces the consumer.
  - **Tracked in:** #924 (still open)
- **AC:** ADR 0012 §Implementation steps 4-6 (canonical configs repo, CI sync, drift detection, admin CLI)
  - **Why deferred:** Each is its own coherent piece. They land sequentially in follow-on PRs.
  - **Tracked in:** to be filed against ADR 0012 once this lands

## Test plan

- [x] `npm run verify` passes (typecheck, typecheck:workers, format:check, lint, build, test, test:workers — 0 errors)
- [x] 11 new unit tests in `tests/customer-config.test.ts`:
  - `getCustomerConfig` returns null for missing rows
  - parses `personas_json` + nullable JSON columns into typed shape
  - returns `schema_version` + `git_sha` verbatim (drift-detection foundation)
  - nullable columns parse to null when omitted
  - `getActivePersona` returns null for: missing row, empty personas array, all-archived personas
  - returns active persona at v1 (length-1 array)
  - skips archived personas when an active one is later in the array
  - FK from `entity_id` to `entities.id` rejects orphan insert
  - UNIQUE `customer_slug` rejects duplicate-slug insert

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses — no new endpoints, helpers read-only
- [x] Input validation on new endpoints — no new endpoints
- [x] Parameterized queries for any SQL — `.bind()` throughout
- [x] Auth required on new endpoints — no new endpoints
- [x] No internal IDs that enable enumeration

## Feature Impact

None — this PR adds a new table, two helpers, and the ADR. No existing flows are modified. The helpers are not yet called from any page; integration follows in a separate PR.