### PR TITLE
feat(ai-employee): 11 capability interface contracts + conformance harness (#791)

### DIFF
--- a/docs/adr/0012-customer-yaml-storage.md
+++ b/docs/adr/0012-customer-yaml-storage.md
@@ -1,0 +1,261 @@
+---
+title: customer.yaml Storage — Git as Source of Truth, D1/R2 as Materialized Replicas
+date: 2026-05-21
+status: accepted
+captain: Scott Durgan
+supersedes: none
+related-prd: docs/pm/ai-employee/platform-prd.md §7.3, §9, §20
+related-spec: docs/specs/ai-employee/customer-yaml-schema.md
+related-issue: https://github.com/venturecrane/ss-console/issues/790, https://github.com/venturecrane/ss-console/issues/924
+---
+
+# ADR 0012 — customer.yaml Storage
+
+**Status:** Accepted. The storage architecture below is the durable answer to "where does `customer.yaml` live?" — a question deferred when [ADR 0011](./0011-multi-persona-per-customer.md) §4 declared the file authoritative without pinning its location. This ADR pins it.
+
+**Source:** Captain prompt 2026-05-21 — _"what is best for the long term durability of the product that does not cut corners or make assumptions?"_ — in the context of building the [#924](https://github.com/venturecrane/ss-console/issues/924) `getActivePersona()` portal resolver, which needs to read from `customer.yaml`.
+
+Pairs with [ADR 0007](./0007-per-customer-machine-isolation.md) (per-customer Machine isolation), [ADR 0008](./0008-customer-owned-memory-artifact.md) (customer-owned memory artifact), [ADR 0009](./0009-cross-machine-query-prohibition.md) (cross-Machine query prohibition), and [ADR 0011](./0011-multi-persona-per-customer.md) (multi-persona per customer).
+
+---
+
+## Context
+
+[ADR 0011](./0011-multi-persona-per-customer.md) §4 commits `customer.yaml` as the authoritative source for product configuration — personas, connectors, voice samples reference, scope envelope, escalation rules, business hours. The earlier proposal to read configuration from `subscriptions.settings_json` was explicitly rejected as a sync-trap.
+
+But the ADR did not pin storage. Two real consumers need to read this file:
+
+1. **The portal Worker** — on every authenticated portal request that needs persona context (the `getActivePersona()` helper [#924](https://github.com/venturecrane/ss-console/issues/924) being the immediate consumer; future surfaces follow). The portal runs on Cloudflare Workers, has hot-path latency budgets, and per [ADR 0009](./0009-cross-machine-query-prohibition.md) cannot bind to per-customer Hermes D1 databases.
+2. **Each customer's Hermes Machine** — on boot and on reload, to resolve its persona configuration, skill assignments, signature blocks, channel bindings. Hermes runs on Fly Machines inside the per-customer isolation boundary established by [ADR 0007](./0007-per-customer-machine-isolation.md), with each Machine reading only its own state.
+
+Six storage candidates were considered:
+
+| Option                                                                        | Why it fails the long-term-durability test                                                                                                                                                                                                                                                                                                      |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1 only** (a `customer_configs` table that's written via admin UI)          | No version control, no PR review, no diff history. Every change is a database mutation with no audit trail of intent. Schema evolution requires migration coordination across SMD and customer state.                                                                                                                                           |
+| **R2 only** (per-customer prefix, portal reads R2 directly)                   | Portal hot-path latency: every authenticated portal request requiring persona context pays a ~50–100ms R2 round-trip. A cache layer would mitigate this — and that cache layer becomes another moving part to keep coherent.                                                                                                                    |
+| **Per-customer Hermes D1 only**                                               | Portal cannot read it per [ADR 0009](./0009-cross-machine-query-prohibition.md). Forces an outbound portal-to-Machine call for every config lookup. Couples portal availability to every Machine being warm. Cold-start Machines (which [ADR 0007](./0007-per-customer-machine-isolation.md) explicitly allows) would fail portal page renders. |
+| **Hermes-exposed API** (Machine serves its own config to portal)              | Same coupling as above. Also requires Machines to expose an authenticated endpoint to SMD's portal, which thickens the security surface for no gain.                                                                                                                                                                                            |
+| **Git only** (portal reads from GitHub via API on every request)              | Portal Worker hitting GitHub on every request: latency, rate limits, GitHub credentials in runtime. Couples product runtime to a developer-facing tool. Equivalent failure mode to a third-party SaaS dependency.                                                                                                                               |
+| **Hybrid — git as source of truth, materialized replicas at the read points** | The pattern Kubernetes manifests, Terraform state, Helm charts, and every serious GitOps system converged on. Reviewability, versioning, and audit trail come from git; read-path latency comes from local replicas.                                                                                                                            |
+
+The hybrid pattern is the only one that does not cut a corner on either reviewability, latency, or isolation. It is the decision.
+
+---
+
+## Decision
+
+### 1. Git is the source of truth
+
+Each customer's configuration lives at one canonical path: `customer-configs/<customer-slug>.yaml`. The file is human-edited, PR-reviewed, and validated against the [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) contract before merge.
+
+**Repository location:** TBD — captured as a follow-on decision in the implementation issue. Two options:
+
+- (a) A subdirectory under `ss-console/` (e.g. `ss-console/customer-configs/`). Lower operational overhead — one repo, one PR flow. Mixes operational config with application source.
+- (b) A separate `smd-customer-configs` repo. Cleaner separation, but adds a second repo with its own access controls, CI, and review cadence.
+
+Captain decides at the implementation issue. The storage architecture below is identical in either case; only the path prefix changes.
+
+### 2. Replicas are projections, not competing sources
+
+On every merge to the canonical branch, CI:
+
+1. Validates the YAML against the schema spec (closes [#790](https://github.com/venturecrane/ss-console/issues/790) at the validator level).
+2. Checks for secret leakage. Refuses to merge if any field matches a secret heuristic (gitleaks rules + a project-specific allowlist of public fields).
+3. Parses the YAML into a normalized JSON projection.
+4. Writes the projection to portal D1 (`customer_configs` table, keyed by `entity_id`).
+5. Uploads the canonical YAML to per-customer R2 (`r2://customers/<slug>/customer.yaml`).
+6. Stamps both replicas with the git SHA and a `synced_at` timestamp.
+
+**The replicas are never edited directly.** No admin UI mutates them. No script writes to them outside CI. If a divergence is detected (see _Drift detection_ below), the resolution is always "re-sync from git" — never "patch the replica."
+
+### 3. Portal reads from portal D1
+
+The new `customer_configs` table in portal D1 (migration 0039):
+
+```sql
+CREATE TABLE customer_configs (
+  entity_id           TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  org_id              TEXT NOT NULL REFERENCES organizations(id),
+  customer_slug       TEXT NOT NULL UNIQUE,
+  schema_version      TEXT NOT NULL,
+  personas_json       TEXT NOT NULL,        -- JSON array, length ≥1 (ADR 0011 §1)
+  voice_library_json  TEXT,                  -- nullable until voice library exists
+  escalation_json     TEXT,
+  business_hours_json TEXT,
+  connectors_json     TEXT,                  -- non-secret connector references only
+  scope_json          TEXT,
+  git_sha             TEXT NOT NULL,        -- commit SHA the projection was built from
+  synced_at           TEXT NOT NULL,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_customer_configs_org ON customer_configs(org_id);
+CREATE INDEX idx_customer_configs_slug ON customer_configs(customer_slug);
+```
+
+**The shape is a projection of customer.yaml, not a mirror.** It stores only fields the portal needs to render. Secrets (API tokens, OAuth refresh tokens, anything sensitive) never enter this table — they live in Infisical with references denormalized into `connectors_json` if needed.
+
+**Read path:** `src/lib/portal/customer-config.ts` exports `getCustomerConfig(db, entity_id)` and `getActivePersona(db, entity_id)`. `getActivePersona` returns `personas[0]` if present, else `null`. Phase 2 of [ADR 0011](./0011-multi-persona-per-customer.md) (when N > 1) extends the selector but the function signature is stable.
+
+### 4. Hermes reads from per-customer R2
+
+The canonical YAML is uploaded to the customer's R2 prefix on every CI sync. Hermes Machines read from their own prefix only — same isolation discipline as memory vault objects ([ADR 0008](./0008-customer-owned-memory-artifact.md)).
+
+Hermes-side schema parsing remains in Hermes's existing pydantic validator. The portal projection is independent — both consumers parse the YAML against the same schema spec but maintain independent typed representations.
+
+**Why not portal pushes config to Hermes via API?** Because pull-from-R2 is simpler, cheaper, and aligned with the Machine's existing R2 access pattern for the memory vault. Push-from-portal would require an inbound authenticated endpoint on every Machine, thickening the security surface.
+
+### 5. Onboarding flow
+
+1. Captain (or admin) creates a PR against the canonical repo: `customer-configs/<new-slug>.yaml`.
+2. CI runs the schema + secret validators. Failures block the PR.
+3. Captain reviews diff (since it's a PR, normal review applies).
+4. On merge, CI's sync job:
+   - Inserts the projection into portal D1 `customer_configs`.
+   - Uploads the YAML to `r2://customers/<slug>/customer.yaml`.
+   - Provisions the Hermes Machine if it doesn't exist (existing tooling — `provision-customer.sh`).
+5. Captain inserts the `subscriptions` row to activate portal access (per [ADR 0011](./0011-multi-persona-per-customer.md) §4; Stripe automation deferred to [#917](https://github.com/venturecrane/ss-console/issues/917)).
+
+**Hand-edits are a defect.** If anyone hand-edits the D1 row or the R2 object outside CI, drift detection (§6) will page on the next run.
+
+### 6. Drift detection
+
+A scheduled Cloudflare cron job runs daily:
+
+1. Reads the canonical YAML for every customer from the git repo.
+2. Compares its content hash against the `git_sha` + reconstructed projection in D1.
+3. Compares against the R2 object hash.
+4. On mismatch: emits a Sentry event tagged `customer_config_drift`, names the customer, names the divergent replica, and includes the diff.
+
+The resolution path is always re-sync from git. The drift event names the canonical state; the operator does not have to investigate which side is "right."
+
+### 7. Offboarding
+
+Customer offboarding is a PR that deletes `customer-configs/<slug>.yaml`. CI on merge:
+
+1. Removes the row from portal D1 `customer_configs`.
+2. Removes (or archives — Captain decision per customer) the R2 object.
+3. Deactivates the `subscriptions` row.
+4. Decommissions the Hermes Machine per the existing decommission runbook.
+
+Cleaner than D1-only or R2-only paths, where offboarding can leave orphan rows or objects that nobody finds.
+
+### 8. Schema evolution
+
+When the schema changes (new fields, new validations), the order of operations:
+
+1. Update [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) and the pydantic validator + portal projection mapping.
+2. Bump `schema_version` in the spec.
+3. Migrate existing customer YAML files via PR — each customer file gets the new field, defaults applied, validated.
+4. CI on merge re-syncs all replicas with the new schema_version.
+
+Old `schema_version` in D1 → CI sync warns and re-projects. No customer is silently running on a stale schema.
+
+### 9. Escape hatches
+
+Two scenarios where CI sync alone is not enough:
+
+- **CI is broken on the day a customer needs to onboard.** An admin CLI (`smd-config sync --customer=<slug> --from-sha=<sha>`) re-runs the sync locally. Logs the deviation; Sentry event named `manual_config_sync`. Acceptable in emergencies, not as routine practice.
+- **A drift event needs immediate triage outside the cron window.** Same CLI. Same logging.
+
+The escape hatches do not write to git. They only re-project from a known-good git SHA. This preserves git's role as source of truth even when CI is down.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Single source of truth, two read replicas.** Disputes resolve at git. No question about which side is authoritative.
+- **Reviewable.** Every config change is a PR with diff. Captain can review before customer state changes.
+- **Versioned.** Full history. `git log -- customer-configs/<slug>.yaml` shows every change with intent.
+- **Auditable.** The `git_sha` column on the D1 row ties every portal read to a specific commit. Audit log entries can cite the commit a decision was made against.
+- **Fast portal reads.** D1 lookup on the hot path. Same latency profile as `subscriptions` and `product_roles` reads (which the portal already does).
+- **ADR-compliant Hermes reads.** Per-customer R2 prefix keeps the isolation boundary [ADR 0008](./0008-customer-owned-memory-artifact.md) and [ADR 0009](./0009-cross-machine-query-prohibition.md) established.
+- **Onboarding and offboarding are PRs.** Same review, same audit, same revert path as code changes.
+- **Secret-exclusion enforced at write time.** Bad-secret commits fail CI before they merge. Cannot enter the replicas.
+- **Schema evolution is bounded.** All customers on the same schema version, enforced at sync.
+
+### Negative / accepted
+
+- **More moving parts than D1-only or R2-only.** A CI workflow, a sync job, a drift cron, an admin CLI. Each is a small piece; together they're more surface than a single store. Accepted because the alternative is corner-cutting.
+- **CI flakiness can block onboarding.** Mitigated by the escape-hatch CLI. Not eliminated. Accepted because the alternative — letting anyone hand-edit a replica — is worse.
+- **Two schema parsers.** Portal projects from YAML to JSON; Hermes parses YAML to its pydantic model. They must stay aligned against the same schema spec. Drift between them is a class of bug. Mitigated by both consumers building against the [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) contract and a cross-consumer test suite (Phase 2). Accepted at v1 because divergence at one customer × one persona × one schema version is detectable in QA.
+- **Storage cost of the canonical YAML.** R2 is cheap, but every Hermes Machine pulls its YAML at boot. Insignificant at any plausible customer count. Noted for completeness.
+
+### Out of scope
+
+- **Whether the configs repo lives in `ss-console/` or a separate `smd-customer-configs` repo.** Captured as a follow-on decision at the implementation issue.
+- **Stripe Subscriptions ↔ subscriptions row automation.** [#917](https://github.com/venturecrane/ss-console/issues/917). Compatible with this ADR.
+- **Cross-customer config policies** (e.g. enterprise-wide voice library updates that propagate to every customer). Out of scope; if it ever becomes relevant, the canonical repo's directory structure supports it.
+- **Customer-self-serve config edits via the portal.** Out of scope at v1. If ever desired, the path is: portal write → PR-via-API → CI sync. Not a database mutation.
+
+---
+
+## Verification
+
+### Schema readiness checks
+
+1. The portal projection mapping (`src/lib/portal/customer-config.ts:projectFromYaml`) round-trips: a valid YAML parses to a projection that can be inserted into D1, and the projection's fields satisfy every read site in the portal.
+2. The Hermes pydantic validator and the portal projection parse the same YAML without divergence — verified by a cross-consumer fixture test (Phase 2).
+3. The drift cron detects a deliberately-injected divergence (test fixture).
+4. CI rejects a YAML that contains a known-shape secret (test fixture).
+
+### Onboarding rehearsal
+
+End-to-end rehearsal for a new customer:
+
+1. PR with `customer-configs/<new-slug>.yaml` opens.
+2. CI validates → passes.
+3. PR merges.
+4. CI sync job runs.
+5. Portal D1 has the new row.
+6. R2 has the new object.
+7. `getActivePersona(db, <entity_id>)` returns the persona configured in the YAML.
+8. Hermes Machine, when provisioned, reads the YAML from R2 successfully.
+
+If any step fails, the customer is not onboarded — the partial state must be cleaned up before the next attempt. The PR can be reverted to roll back.
+
+### Adversarial review
+
+Hand the ADR to a fresh agent and ask: _"How do I add a new persona to an existing v1 customer?"_
+
+Acceptable answer:
+
+1. Open a PR editing `customer-configs/<slug>.yaml` to add a second entry to `personas[]`.
+2. Wait for CI to validate.
+3. Merge the PR.
+4. CI re-syncs both replicas; the portal D1 row now has two personas in `personas_json`.
+5. Phase 2 runtime (per [ADR 0011](./0011-multi-persona-per-customer.md)) handles the second persona's Machine, AgentMail inbox, and routing.
+
+No database mutation. No admin UI. No script run by hand. The PR is the change.
+
+---
+
+## Implementation
+
+The Phase 1 sequence — recorded here, executed by the follow-on PRs:
+
+1. **This ADR lands** (recording the architectural commitment).
+2. **Portal D1 substrate PR** — adds the `customer_configs` migration, the `getCustomerConfig` / `getActivePersona` helpers, and unit tests. Does NOT depend on the git repo or CI sync existing yet; the helpers read whatever is in `customer_configs`. Captain can hand-seed rows for the alpha customer via an admin endpoint or direct SQL. The git/CI side lands separately.
+3. **PRD + runbook vocabulary update PR** ([#921](https://github.com/venturecrane/ss-console/issues/921)) — independent of (2); the docs update can land in parallel.
+4. **Canonical configs repo + CI sync PR** (separate, follow-on) — establishes the git repo (location decision deferred), the CI workflow, the secret validator, and the R2 upload.
+5. **Drift detection cron + admin CLI** (separate, follow-on) — adds the daily comparison, the Sentry integration, and the escape-hatch CLI.
+6. **Schema validator integration** ([#790](https://github.com/venturecrane/ss-console/issues/790)) — the YAML schema spec gets a runtime validator that CI invokes.
+
+Phases 2–3 are the minimum coherent slice for this session. Phases 4–6 are durable architecture work for follow-on sessions and do not block [#924](https://github.com/venturecrane/ss-console/issues/924).
+
+---
+
+## References
+
+- [ADR 0007](./0007-per-customer-machine-isolation.md) — per-customer Machine isolation
+- [ADR 0008](./0008-customer-owned-memory-artifact.md) — customer-owned memory artifact
+- [ADR 0009](./0009-cross-machine-query-prohibition.md) — cross-Machine query prohibition
+- [ADR 0011](./0011-multi-persona-per-customer.md) — multi-persona per customer (§4 declares customer.yaml authoritative; this ADR pins its storage)
+- [Platform PRD](../pm/ai-employee/platform-prd.md) §7.3 (customer.yaml example), §9 (persona model), §20 (Phase 1 deliverables)
+- [`customer-yaml-schema.md`](../specs/ai-employee/customer-yaml-schema.md) — formal schema contract
+- [Issue #790](https://github.com/venturecrane/ss-console/issues/790) — customer.yaml formal schema with secret-exclusion enforcement
+- [Issue #917](https://github.com/venturecrane/ss-console/issues/917) — Stripe Subscriptions wiring
+- [Issue #924](https://github.com/venturecrane/ss-console/issues/924) — `getActivePersona()` portal resolver helper (immediate consumer of this ADR)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,3 +22,4 @@ Architecture Decision Records (ADRs) capturing strategic and technical decisions
 - [0009-cross-machine-query-prohibition.md](./0009-cross-machine-query-prohibition.md) - Cross-Machine query prohibition: boot-time storage-binding check + shared-catalog merge gate; no runtime data path between customers
 - [0010-per-customer-oauth-token-storage.md](./0010-per-customer-oauth-token-storage.md) - Per-customer OAuth token storage location (Infisical vs. Fly volume)
 - [0011-multi-persona-per-customer.md](./0011-multi-persona-per-customer.md) - Multi-persona per customer: schema-locked at v1 (`personas: []` array length=1), runtime deferred to Phase 2
+- [0012-customer-yaml-storage.md](./0012-customer-yaml-storage.md) - customer.yaml storage: git as source of truth, portal D1 + per-customer R2 as materialized replicas

--- a/docs/pm/ai-employee/platform-prd.md
+++ b/docs/pm/ai-employee/platform-prd.md
@@ -290,6 +290,44 @@ Capability interfaces (sketch — full set defined in `ai-employee/capabilities/
 
 Concrete adapters live at `ai-employee/connectors/{capability}/{system}/` and implement the relevant interface.
 
+### 7.2.1 Capability interface specifications
+
+The formal TypeScript signatures for all eleven capability interfaces live at `src/lib/ai-employee/capabilities/` in the ss-console repo. Each interface is a single file (e.g. `email.ts`, `practice-management.ts`); shared types (`DateRange`, `CapabilitySet`, `HealthStatus`, `AdapterError`) live in `types.ts`; the adapter conformance harness lives in `conformance.ts`. The TypeScript source is the contract — this PRD section summarizes the commitments.
+
+**Adapter base contract.** Every adapter implements `describe_capabilities(): CapabilitySet` and `health_check(): Promise<HealthStatus>`. The `CapabilitySet` declares the capability name, the adapter slug, the version, the set of methods supported, the set of optional methods explicitly NOT supported, and (recommended) per-method field-coverage disclosure that feeds the §12 dashboard "what Marcus used to write this" sourcing block.
+
+**Email pattern decision — Pattern A locked at v1.** The Tech Lead's synthesis-round-1 contribution surfaced two architecturally distinct draft-and-send patterns:
+
+- **Pattern A.** Agent creates a draft in the reviewer's drafts folder. The reviewer reviews, edits, and sends from their own email client. The platform has no programmatic send path.
+- **Pattern B.** Agent surfaces a pending action in the dashboard Queue. Reviewer clicks Approve in the dashboard. The platform's backend sends programmatically using a stored OAuth token.
+
+**Pattern A is the architectural answer per [ADR 0005 (Reviewer-as-Sender)](../../adr/0005-reviewer-as-sender.md).** Pattern B was considered and explicitly rejected — it surrenders the architectural property ADR 0005 protects (no agent-to-external send path under any identity other than the reviewer's own client). The `Email` interface has no `send` method; the conformance harness blocks adapters that add one.
+
+**The eleven interfaces (one-line summary; full signatures in source):**
+
+| Interface            | Role                                                       | Key methods                                                                                                                  | Outbound posture                                                                                     |
+| -------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `PracticeManagement` | Matters, contacts, time entries, PM documents              | `search_matters`, `create_matter`, `update_matter`, `list_time_entries`, `create_time_entry_draft`, `upload_matter_document` | Write to PM system only; no external send                                                            |
+| `Email`              | Inbox, threads, drafts, labels, sent-folder watch          | `list_threads`, `get_thread`, `create_draft`, `update_draft`, `apply_label`, `list_sent_since`                               | **Pattern A only**: no send method                                                                   |
+| `Calendar`           | Read events, propose events, suggest times                 | `list_events`, `suggest_time`, `create_event_draft`, `update_event_draft`                                                    | Drafts only; reviewer adds external attendees and sends invite from their own client                 |
+| `DocumentStorage`    | Folders, versioned documents, share drafts                 | `list_folder`, `download_document`, `upload_document`, `update_document`, `share_document_draft`                             | Internal writes allowed; external shares are drafts only                                             |
+| `ESign`              | Envelope status, reminder drafts, completed-doc retrieval  | `list_envelopes`, `get_envelope`, `create_reminder_draft`, `download_completed`                                              | No `send_envelope`: reviewer creates and sends envelopes from the source platform                    |
+| `CourtAccess`        | Case search, dockets, filing retrieval                     | `search_cases`, `get_docket`, `get_docket_entries`, `get_filing_document`                                                    | **Read-only**: no filing or write methods                                                            |
+| `Payments`           | Transactions, trust-balance lookup, payment-request drafts | `list_transactions`, `get_trust_balance`, `create_payment_request_draft`                                                     | **Read + draft only**: no autonomous trust transfers or sends (invariant #3)                         |
+| `Accounting`         | Invoices, A/R, expense entries                             | `list_invoices`, `list_accounts_receivable`, `create_invoice_draft`, `create_expense_entry_draft`                            | **Read + draft only**: no posting to the GL                                                          |
+| `IntakeCRM`          | Leads, lead status, intake-form responses                  | `list_leads`, `update_lead`, `append_lead_note`, `list_intake_form_responses`                                                | Internal CRM mutations allowed; outreach goes through Email                                          |
+| `CallTracking`       | Call records, recordings, attribution                      | `list_calls`, `get_recording`, `get_attribution`                                                                             | **Read-only**: no origination or messaging methods                                                   |
+| `InternalComms`      | Slack/Teams channels, DMs, mentions                        | `list_channels`, `post_to_channel`, `send_dm`, `react_to_message`, `list_recent_mentions`                                    | **Persona-as-sender for internal-only destinations**: adapters refuse channels with external members |
+
+**Adapter conformance.** `src/lib/ai-employee/capabilities/conformance.ts` defines eight invariants every adapter must satisfy. The two most architecturally load-bearing:
+
+- `NO_AUTONOMOUS_EXTERNAL_SEND` — No adapter exposes a method that sends external messages under any identity other than the reviewer's drafts folder. The harness enforces this by reflecting on the adapter's method names against `BANNED_METHOD_NAMES` (per-capability lists of forbidden names: `Email.send`, `ESign.send_envelope`, `Calendar.send_invitation`, etc.).
+- `NO_AUTONOMOUS_TRUST_TRANSFER` — No `Payments` adapter exposes `initiate_transfer`, `trust_disbursement`, or equivalents, regardless of vendor capability. Per Platform PRD invariant #3 and ADR 0005.
+
+The full eight invariants — including `NULL_FOR_ABSENT` (read methods return null, don't throw), `TYPED_ERRORS` (only `AdapterError` with codes from the closed `AdapterErrorCode` union), `HEALTH_CHECK_BOUNDED` (5-second budget), `UNSUPPORTED_METHODS_THROW` (no silent stubs), and `NO_FIELD_FABRICATION` (only fields read from source; inferred fields declared in `CapabilitySet.field_coverage.derived`) — are documented inline in `conformance.ts`.
+
+Conformance suites are authored as `*.conformance.test.ts` files next to each adapter. Adapter PRs that do not include a passing conformance suite are blocked at review.
+
 ### 7.3 `customer.yaml` as the wiring layer
 
 Each customer has one `customer.yaml` declaring: persona, voice, vertical, region, connectors per capability, skills enabled, trust ceilings, scope, escalation rules.

--- a/migrations/0039_customer_configs.sql
+++ b/migrations/0039_customer_configs.sql
@@ -1,0 +1,62 @@
+-- Portal projection of customer.yaml — read replica for hot-path portal lookups
+-- ============================================================================
+--
+-- Adds the `customer_configs` table that holds the portal's projection of each
+-- customer's canonical `customer.yaml`. Per ADR 0012, customer.yaml lives in a
+-- git repository (source of truth); CI on merge projects it into this table
+-- (portal read replica) and uploads the original to per-customer R2 (Hermes
+-- read replica). Portal pages read from this table on the hot path; they never
+-- write to it. Hand-edits are a defect detected by the daily drift cron.
+--
+-- The projection holds only fields the portal needs to render. Secrets never
+-- enter this table — they live in Infisical, with non-secret references
+-- denormalized into `connectors_json` where the portal needs them.
+--
+-- Personas vocabulary follows ADR 0011 (`personas:` array, length ≥1 at v1).
+-- `personas_json` is the parsed array; helper functions in
+-- src/lib/portal/customer-config.ts decode it into typed PersonaConfig values.
+--
+-- Forward-only, additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS customer_configs (
+  entity_id           TEXT PRIMARY KEY REFERENCES entities(id) ON DELETE CASCADE,
+  org_id              TEXT NOT NULL REFERENCES organizations(id),
+
+  -- Stable slug for the customer (e.g. "smith-pi-firm"). Used to address the
+  -- Hermes Machine, the R2 prefix, and the canonical customer-configs path
+  -- in git. UNIQUE across customers.
+  customer_slug       TEXT NOT NULL UNIQUE,
+
+  -- Schema version the projection was built from. Each schema evolution
+  -- bumps this; drift detection flags rows whose schema_version lags the
+  -- canonical schema.
+  schema_version      TEXT NOT NULL,
+
+  -- Parsed projections of customer.yaml fields the portal reads. All TEXT
+  -- columns hold JSON; helpers parse on read and never on write. NULL is
+  -- meaningful for fields a customer may legitimately not have configured
+  -- yet (no voice library, no escalation rules).
+  personas_json       TEXT NOT NULL,
+  voice_library_json  TEXT,
+  escalation_json     TEXT,
+  business_hours_json TEXT,
+  connectors_json     TEXT,
+  scope_json          TEXT,
+
+  -- Commit SHA the projection was built from. Audit log entries cite this
+  -- so any decision can be tied back to the exact config in effect.
+  git_sha             TEXT NOT NULL,
+
+  -- When CI last synced this row from git. Drift detection uses this with
+  -- `git_sha` to spot stale projections.
+  synced_at           TEXT NOT NULL,
+
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_configs_org
+  ON customer_configs(org_id);
+CREATE INDEX IF NOT EXISTS idx_customer_configs_slug
+  ON customer_configs(customer_slug);

--- a/migrations/rollbacks/0039_customer_configs_down.sql
+++ b/migrations/rollbacks/0039_customer_configs_down.sql
@@ -1,0 +1,12 @@
+-- Manual rollback for migration 0039. NOT auto-applied.
+-- See migrations/rollbacks/README.md.
+--
+-- DESTRUCTIVE: dropping `customer_configs` removes the portal's projection
+-- of every customer's canonical customer.yaml. The source of truth (git)
+-- is unaffected — re-running the CI sync repopulates the table.
+--
+-- Drop indexes before the table for re-apply safety.
+
+DROP INDEX IF EXISTS idx_customer_configs_slug;
+DROP INDEX IF EXISTS idx_customer_configs_org;
+DROP TABLE IF EXISTS customer_configs;

--- a/src/lib/ai-employee/capabilities/accounting.ts
+++ b/src/lib/ai-employee/capabilities/accounting.ts
@@ -1,0 +1,143 @@
+/**
+ * Accounting capability — invoice drafts, AR query, expense-entry
+ * drafts.
+ *
+ * READ access to ledger state. WRITE access is limited to DRAFT
+ * invoices and DRAFT expense entries (per ADR 0005 reviewer-as-sender
+ * and invariant #3 no commitment execution). The agent does not post
+ * to the general ledger; the reviewer reviews and posts.
+ *
+ * Implemented by adapters for QuickBooks Online, Xero, Wave,
+ * vendor-specific firm-accounting systems (Cosmolex, Soluno).
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Invoices
+// ---------------------------------------------------------------------------
+
+export type InvoiceStatus = 'draft' | 'sent' | 'partially_paid' | 'paid' | 'overdue' | 'void'
+
+export interface InvoiceLineItem {
+  description: string
+  /** Quantity (hours for time-based billing; units for fixed-price). */
+  quantity: number
+  /** Unit price in minor units. */
+  unit_price_cents: number
+  /** Optional time-entry ref the line was generated from. */
+  time_entry_ref?: string | null
+}
+
+export interface Invoice {
+  id: string
+  invoice_number: string
+  status: InvoiceStatus
+  /** Customer/matter the invoice bills. */
+  matter_ref: string | null
+  client_name: string
+  issue_date: string
+  due_date: string | null
+  total_cents: number
+  amount_paid_cents: number
+  currency: string
+  line_items: InvoiceLineItem[]
+}
+
+export interface InvoiceQuery {
+  status?: InvoiceStatus
+  matter_ref?: string
+  client_name?: string
+  date_range?: DateRange
+  limit?: number
+  cursor?: string
+}
+
+export interface CreateInvoiceDraftInput {
+  client_name: string
+  matter_ref?: string | null
+  issue_date: string
+  due_date?: string
+  currency: string
+  line_items: InvoiceLineItem[]
+  /** Optional notes/terms shown on the invoice. */
+  notes?: string
+  drafted_by_skill: string
+}
+
+export interface InvoiceDraftRef {
+  id: string
+  invoice_number: string
+  status: 'draft'
+  created_at: string
+  reviewer_ui_hint: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Accounts receivable
+// ---------------------------------------------------------------------------
+
+export interface AccountsReceivableEntry {
+  matter_ref: string | null
+  client_name: string
+  /** Sum of outstanding invoice balances. */
+  outstanding_cents: number
+  currency: string
+  /** Oldest outstanding invoice's issue date. */
+  oldest_invoice_at: string | null
+  /** Number of days the oldest invoice is overdue. Null when nothing
+   * is overdue. */
+  days_overdue: number | null
+}
+
+export interface AccountsReceivableQuery {
+  /** Only return clients with at least this much outstanding. */
+  min_outstanding_cents?: number
+  /** Only return clients overdue by at least this many days. */
+  min_days_overdue?: number
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Expense entries — drafts only
+// ---------------------------------------------------------------------------
+
+export interface ExpenseEntryDraftInput {
+  matter_ref: string | null
+  date: string
+  amount_cents: number
+  currency: string
+  category: string
+  description: string
+  /** Whether the expense is billable to the matter's client. */
+  billable: boolean
+  drafted_by_skill: string
+}
+
+export interface ExpenseEntryDraftRef {
+  id: string
+  status: 'draft'
+  created_at: string
+  reviewer_ui_hint: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface Accounting extends AdapterBase {
+  // Read
+  list_invoices(query: InvoiceQuery): Promise<Invoice[]>
+  get_invoice(invoice_id: string): Promise<Invoice | null>
+
+  list_accounts_receivable(query: AccountsReceivableQuery): Promise<AccountsReceivableEntry[]>
+
+  // Drafts — reviewer posts to the GL
+  create_invoice_draft(input: CreateInvoiceDraftInput): Promise<InvoiceDraftRef>
+  create_expense_entry_draft(input: ExpenseEntryDraftInput): Promise<ExpenseEntryDraftRef>
+
+  // NO post_invoice, NO post_expense_entry, NO post_to_general_ledger.
+  // The reviewer posts from the source platform's native UI. The
+  // conformance harness asserts no autonomous-post methods are added.
+}

--- a/src/lib/ai-employee/capabilities/calendar.ts
+++ b/src/lib/ai-employee/capabilities/calendar.ts
@@ -1,0 +1,183 @@
+/**
+ * Calendar capability — read events, draft proposed events, suggest
+ * times.
+ *
+ * Calendar events with attendees implicitly send invitations when saved.
+ * Per ADR 0005 (reviewer-as-sender), the agent does not send invites to
+ * external attendees. v1 split:
+ *
+ *   - Read methods (list_events, get_event) are unrestricted within the
+ *     customer.yaml calendar scope.
+ *   - create_event_draft creates a private event on the reviewer's
+ *     calendar with no attendees (or only internal-team attendees, when
+ *     the adapter can distinguish). The reviewer reviews, adds external
+ *     attendees from their own client, and sends the invite themselves.
+ *   - suggest_time is a pure read operation.
+ *
+ * Implemented by adapters for Microsoft Graph (Outlook Calendar) and
+ * Google Workspace (Google Calendar). Apple Calendar / CalDAV are
+ * possible future adapters.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+import type { EmailAddress } from './email'
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export type EventStatus = 'tentative' | 'confirmed' | 'cancelled'
+
+export interface Attendee {
+  email: EmailAddress
+  /** Whether this attendee is part of the customer's organization. Null
+   * when the adapter cannot determine (e.g. the email domain isn't
+   * recognized). */
+  is_internal: boolean | null
+  response_status: 'needs_action' | 'accepted' | 'declined' | 'tentative'
+  /** Whether attendance is required vs optional (vendor-specific). */
+  required: boolean
+}
+
+export interface CalendarEvent {
+  id: string
+  /** Calendar ID the event lives on. Adapters that surface only one
+   * calendar may return the reviewer's primary calendar slug here. */
+  calendar_id: string
+  organizer: EmailAddress
+  title: string
+  description: string | null
+  location: string | null
+  start: string
+  end: string
+  all_day: boolean
+  status: EventStatus
+  attendees: Attendee[]
+  /** Whether this event has external attendees. Null when the adapter
+   * cannot determine (e.g. organizer-only events). */
+  has_external_attendees: boolean | null
+  /** When the event was created in the source calendar. */
+  created_at: string
+  last_modified_at: string
+}
+
+export interface EventQuery {
+  /** Which calendar to read. Adapters MAY accept the reviewer's primary
+   * calendar slug; the customer.yaml may also list additional readable
+   * calendars (matter calendars, shared resource calendars). */
+  calendar_id?: string
+  date_range: DateRange
+  /** Free-text title/description search. Adapters translate to the
+   * vendor's query syntax. */
+  search?: string
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Time suggestion
+// ---------------------------------------------------------------------------
+
+export interface SuggestTimeInput {
+  /** Email addresses to find a common free slot for. The reviewer's
+   * email must be in the list; adapters MUST refuse otherwise. */
+  attendees: string[]
+  duration_minutes: number
+  /** When to start looking. */
+  earliest_start: string
+  /** When to stop looking. */
+  latest_end: string
+  /** Preferred hours-of-day in the reviewer's timezone. Adapters that
+   * can't honor this return slots regardless. */
+  preferred_hours?: { start_hour: number; end_hour: number }
+  /** How many candidate slots to return. */
+  limit?: number
+}
+
+export interface SuggestedSlot {
+  start: string
+  end: string
+  /** Adapter's confidence that every requested attendee is actually free
+   * during this slot. Null when the adapter can only see the reviewer's
+   * own calendar. */
+  attendee_availability_known: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Draft events
+// ---------------------------------------------------------------------------
+
+/**
+ * Input for a draft event. Per ADR 0005, drafts may include internal
+ * attendees but adapters MUST omit external attendees — the reviewer
+ * adds those from their own client before sending the invite. The
+ * `internal_attendees` field is advisory; adapters that cannot
+ * distinguish internal-vs-external must reject inputs with any
+ * attendees and require the reviewer to add them.
+ */
+export interface CreateEventDraftInput {
+  /** The reviewer's calendar to create the draft on. */
+  reviewer_account_id: string
+  calendar_id?: string
+  title: string
+  description?: string
+  location?: string
+  start: string
+  end: string
+  all_day?: boolean
+  /** Internal-only attendees the adapter can verify are inside the
+   * customer's organization. Adapters that cannot verify this MUST
+   * leave the attendee list empty and document the limitation in
+   * CapabilitySet.field_coverage. */
+  internal_attendees?: string[]
+  /** Skill that authored the draft. Audit-required. */
+  drafted_by_skill: string
+  /** Matter the event relates to. */
+  matter_ref?: string | null
+}
+
+export interface EventDraftRef {
+  id: string
+  calendar_id: string
+  /** When the draft is materialized, where the reviewer can find it.
+   * Vendor-specific (e.g. "Tentative" on Outlook, the calendar UI on
+   * Google). */
+  status_in_reviewer_ui: 'tentative' | 'unconfirmed' | 'draft'
+  created_at: string
+}
+
+export interface EventDraftUpdate {
+  title?: string
+  description?: string
+  location?: string
+  start?: string
+  end?: string
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface Calendar extends AdapterBase {
+  // Read
+  list_events(query: EventQuery): Promise<CalendarEvent[]>
+  get_event(event_id: string): Promise<CalendarEvent | null>
+
+  // Time suggestion
+  suggest_time(input: SuggestTimeInput): Promise<SuggestedSlot[]>
+
+  // Drafts — reviewer-as-sender per ADR 0005
+  create_event_draft(input: CreateEventDraftInput): Promise<EventDraftRef>
+  update_event_draft(event_id: string, updates: EventDraftUpdate): Promise<EventDraftRef>
+
+  // NO send_invitation method. The reviewer adds external attendees
+  // and sends invites from their own calendar client. The conformance
+  // harness asserts adapters do not implement an autonomous send path.
+
+  /**
+   * Calendars the customer.yaml scope envelope makes readable.
+   * Skills never bypass this list — querying outside the scoped
+   * calendars throws `scope_violation`.
+   */
+  get_scoped_calendars(): string[]
+}

--- a/src/lib/ai-employee/capabilities/call-tracking.ts
+++ b/src/lib/ai-employee/capabilities/call-tracking.ts
@@ -1,0 +1,118 @@
+/**
+ * CallTracking capability — call records, call recordings, attribution
+ * data. READ-ONLY.
+ *
+ * No write methods. The agent reads call history and recordings to
+ * inform drafts (intake-call-follow-up skill, attribution analytics)
+ * but never originates calls or modifies call records. Phone-call
+ * outreach, if ever implemented, lives in a separate Voice/Phone
+ * capability — not here.
+ *
+ * Implemented by adapters for CallRail, CallTrackingMetrics, Aircall.
+ * Adapters for vendor systems that bundle call tracking with CRM
+ * (e.g. RingCentral with HubSpot integration) implement the
+ * call-data portion here and the CRM portion in IntakeCRM.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Call records
+// ---------------------------------------------------------------------------
+
+export type CallDirection = 'inbound' | 'outbound'
+
+export type CallOutcome = 'answered' | 'missed' | 'voicemail' | 'busy' | 'no_answer' | 'forwarded'
+
+export interface CallRecord {
+  id: string
+  direction: CallDirection
+  /** Caller's phone number (E.164 when the adapter normalizes). */
+  from_number: string
+  /** Recipient's phone number. */
+  to_number: string
+  /** Customer's tracking number that received/originated the call.
+   * Distinct from to_number when forwarding is involved. */
+  tracked_number: string | null
+  /** ISO 8601 timestamps. */
+  started_at: string
+  ended_at: string | null
+  duration_seconds: number | null
+  outcome: CallOutcome
+  /** Whether a recording exists for this call. Adapters that cannot
+   * determine return null. */
+  has_recording: boolean | null
+  /** Reference to attribution data (campaign, source). Null when the
+   * call wasn't attributed. */
+  attribution_ref: string | null
+  /** Lead reference when the adapter can correlate. */
+  lead_ref: string | null
+}
+
+export interface CallQuery {
+  direction?: CallDirection
+  outcome?: CallOutcome
+  from_number?: string
+  to_number?: string
+  date_range?: DateRange
+  has_recording?: boolean
+  /** Filter to calls correlated with a specific lead. */
+  lead_ref?: string
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Recordings
+// ---------------------------------------------------------------------------
+
+export interface CallRecording {
+  call_id: string
+  /** Time-limited URL to retrieve the recording media. Adapters set
+   * the expiry; skill code re-requests when stale. */
+  media_url: string
+  /** ISO 8601 expiry. */
+  url_expires_at: string
+  mime_type: string
+  /** Duration in seconds. */
+  duration_seconds: number
+  /** When the adapter has a transcription, this is the text body.
+   * Null when no transcription exists or the adapter cannot retrieve
+   * it. */
+  transcript: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Attribution
+// ---------------------------------------------------------------------------
+
+export interface CallAttribution {
+  /** Adapter-internal attribution ID. */
+  id: string
+  call_id: string
+  /** Source identifier as the adapter reports it (e.g.
+   * "google-ads:campaign=intake-q2", "referral:jdoe@partner.com"). */
+  source: string
+  /** Campaign name when the adapter exposes one. */
+  campaign: string | null
+  /** Medium classification (e.g. "cpc", "organic", "direct", "referral"). */
+  medium: string | null
+  /** Landing page URL that preceded the call, when known. */
+  landing_url: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface CallTracking extends AdapterBase {
+  list_calls(query: CallQuery): Promise<CallRecord[]>
+  get_call(call_id: string): Promise<CallRecord | null>
+
+  get_recording(call_id: string): Promise<CallRecording | null>
+
+  get_attribution(call_id: string): Promise<CallAttribution | null>
+
+  // NO write methods. The conformance harness asserts the interface
+  // remains read-only.
+}

--- a/src/lib/ai-employee/capabilities/conformance.ts
+++ b/src/lib/ai-employee/capabilities/conformance.ts
@@ -1,0 +1,277 @@
+/**
+ * Adapter conformance test contract.
+ *
+ * Every vendor adapter implementing one of the capability interfaces
+ * MUST satisfy the invariants encoded here. The harness is the
+ * boot-time line of defense behind the type system: TypeScript catches
+ * structural drift; conformance catches behavioral drift (e.g. an
+ * adapter that silently stubs an "optional" method, or a Payments
+ * adapter that quietly exposes a trust-disbursement method that
+ * Platform PRD invariant #3 prohibits).
+ *
+ * Per ADR 0006, the invariants are architectural commitments, not
+ * style preferences. A failing invariant is a release blocker.
+ *
+ * Conformance suites are authored as plain test files (`*.conformance.test.ts`)
+ * next to each adapter. They import `CONFORMANCE_INVARIANTS` and
+ * `runConformanceSuite` and pass their adapter instance through.
+ */
+
+import type {
+  AdapterBase,
+  AdapterErrorCode,
+  CapabilityName,
+  CapabilitySet,
+  HealthStatus,
+} from './types'
+
+/**
+ * The invariants every adapter must satisfy. Each is a machine-checkable
+ * behavioral assertion. Tests must cover every invariant; the suite
+ * fails closed when any are unverified.
+ *
+ * The invariant list is intentionally short. Adding a new invariant
+ * requires an ADR — adapters trust this list to be stable across
+ * vendors.
+ */
+export const CONFORMANCE_INVARIANTS = {
+  /**
+   * `describe_capabilities()` returns a CapabilitySet whose
+   * `capability` matches the interface the adapter implements, and
+   * whose `supported_methods` is a superset of the interface's
+   * required-method set.
+   */
+  CAPABILITY_SET_HONEST:
+    'describe_capabilities() must declare the correct capability name and list every required method as supported.',
+
+  /**
+   * Adapters never throw `not_found` for normal absence — they return
+   * null. `not_found` is reserved for semantic-distinct absence
+   * (e.g. the parent matter was deleted).
+   */
+  NULL_FOR_ABSENT:
+    "Read methods (get_*) return null for absent records. AdapterError code 'not_found' is reserved for semantic-distinct absence.",
+
+  /**
+   * Adapters only throw AdapterError with codes from `AdapterErrorCode`.
+   * Vendor exceptions are wrapped, never re-thrown raw.
+   */
+  TYPED_ERRORS:
+    'All errors thrown are AdapterError instances with codes in the closed AdapterErrorCode union.',
+
+  /**
+   * Per ADR 0005, no adapter exposes a method that sends an external
+   * message under any identity other than the reviewer's drafts
+   * folder. Email cannot have `send`; ESign cannot have
+   * `send_envelope`; Calendar cannot have `send_invitation`;
+   * DocumentStorage cannot have `share_document` (only
+   * `share_document_draft`); Payments cannot have
+   * `send_payment_request` (only `create_payment_request_draft`);
+   * etc. The harness asserts these method names are not present.
+   */
+  NO_AUTONOMOUS_EXTERNAL_SEND:
+    "No adapter exposes a method that sends external messages under any identity other than the reviewer's drafts folder.",
+
+  /**
+   * Per Platform PRD invariant #3, no Payments adapter exposes a
+   * trust-disbursement or autonomous-transfer method, regardless of
+   * vendor capability. The harness asserts these names are not
+   * present on Payments adapters.
+   */
+  NO_AUTONOMOUS_TRUST_TRANSFER:
+    'Payments adapters MUST NOT expose initiate_transfer / send_payment_request / trust_disbursement methods.',
+
+  /**
+   * `health_check()` resolves within 5 seconds. Adapters that need
+   * longer must cache and return the cached result, not block on a
+   * synchronous probe.
+   */
+  HEALTH_CHECK_BOUNDED:
+    'health_check() resolves within 5 seconds. Implementations cache where vendor latency exceeds the budget.',
+
+  /**
+   * Adapters that declare a method as `unsupported_methods` in their
+   * CapabilitySet MUST throw `capability_not_supported` when that
+   * method is invoked. Silent stubs are forbidden.
+   */
+  UNSUPPORTED_METHODS_THROW:
+    "Methods listed in CapabilitySet.unsupported_methods throw AdapterError('capability_not_supported') when invoked.",
+
+  /**
+   * Per Platform PRD invariant #8 (fabrication discipline), adapters
+   * MUST NOT infer fields. Returned objects expose only what the
+   * underlying source system actually provides; absent fields are
+   * null. Synthetic / inferred fields, when present, MUST be
+   * declared in CapabilitySet.field_coverage.derived.
+   */
+  NO_FIELD_FABRICATION:
+    'Returned objects expose only fields read from the source. Inferred fields are declared in field_coverage.derived.',
+} as const
+
+export type ConformanceInvariantKey = keyof typeof CONFORMANCE_INVARIANTS
+
+/**
+ * Methods banned per capability. The harness reflects on the adapter's
+ * prototype and asserts none of these names are defined as functions.
+ * Adding a banned name requires an ADR.
+ */
+export const BANNED_METHOD_NAMES: Record<CapabilityName, string[]> = {
+  Email: ['send', 'send_message', 'send_draft', 'send_email'],
+  Calendar: ['send_invitation', 'send_invite', 'send_event'],
+  ESign: ['send_envelope', 'create_and_send_envelope', 'send_signing_request', 'initiate_signing'],
+  DocumentStorage: ['share_document', 'send_share_invitation'],
+  Payments: [
+    'send_payment_request',
+    'initiate_transfer',
+    'trust_disbursement',
+    'transfer_funds',
+    'disburse',
+  ],
+  Accounting: ['post_invoice', 'post_expense_entry', 'post_to_general_ledger'],
+  IntakeCRM: ['send_to_lead', 'send_lead_email', 'message_lead'],
+  CourtAccess: ['file_document', 'submit_filing', 'send_to_court'],
+  CallTracking: ['create_call', 'originate_call', 'place_call', 'send_text', 'send_sms'],
+  InternalComms: [],
+  PracticeManagement: [],
+}
+
+/**
+ * Conformance result for one adapter. Suites return one of these and
+ * a CI step fails the build when `passed === false`.
+ */
+export interface ConformanceResult {
+  capability: CapabilityName
+  adapter: string
+  /** Per-invariant outcome. `null` means the invariant was not
+   * applicable (e.g. NO_AUTONOMOUS_TRUST_TRANSFER on a non-Payments
+   * adapter). */
+  invariants: Record<ConformanceInvariantKey, boolean | null>
+  /** Banned method names actually present on the adapter (should be
+   * empty on a passing adapter). */
+  banned_methods_present: string[]
+  passed: boolean
+  /** Human-readable explanation of any failures. */
+  notes: string[]
+}
+
+/**
+ * Inspect an adapter and return a ConformanceResult. The harness does
+ * not invoke vendor APIs — it inspects the adapter's surface via
+ * `describe_capabilities()` and reflection. Suites complement this
+ * with per-invariant behavioral tests (calling methods, asserting
+ * results).
+ *
+ * Returns a result object rather than throwing; callers decide whether
+ * a failed invariant aborts CI or surfaces as a warning during
+ * development.
+ */
+export function inspectAdapter(adapter: AdapterBase): ConformanceResult {
+  const set: CapabilitySet = adapter.describe_capabilities()
+  const notes: string[] = []
+  const invariants: Record<ConformanceInvariantKey, boolean | null> = {
+    CAPABILITY_SET_HONEST: true,
+    NULL_FOR_ABSENT: null,
+    TYPED_ERRORS: null,
+    NO_AUTONOMOUS_EXTERNAL_SEND: true,
+    NO_AUTONOMOUS_TRUST_TRANSFER: null,
+    HEALTH_CHECK_BOUNDED: null,
+    UNSUPPORTED_METHODS_THROW: null,
+    NO_FIELD_FABRICATION: null,
+  }
+
+  // CAPABILITY_SET_HONEST — the adapter declares a known capability.
+  if (!(set.capability in BANNED_METHOD_NAMES)) {
+    invariants.CAPABILITY_SET_HONEST = false
+    notes.push(
+      `describe_capabilities() returned unknown capability "${set.capability}". Capability names are a closed union.`
+    )
+  }
+
+  // NO_AUTONOMOUS_EXTERNAL_SEND and NO_AUTONOMOUS_TRUST_TRANSFER —
+  // both reduce to "none of these method names are defined on the
+  // adapter."
+  const banned = BANNED_METHOD_NAMES[set.capability] ?? []
+  const present: string[] = []
+  for (const name of banned) {
+    if (typeof (adapter as unknown as Record<string, unknown>)[name] === 'function') {
+      present.push(name)
+    }
+  }
+  if (present.length > 0) {
+    invariants.NO_AUTONOMOUS_EXTERNAL_SEND = false
+    if (set.capability === 'Payments') invariants.NO_AUTONOMOUS_TRUST_TRANSFER = false
+    notes.push(
+      `Adapter exposes banned method(s): ${present.join(', ')}. See CONFORMANCE_INVARIANTS.NO_AUTONOMOUS_EXTERNAL_SEND.`
+    )
+  } else if (set.capability === 'Payments') {
+    invariants.NO_AUTONOMOUS_TRUST_TRANSFER = true
+  }
+
+  const passed = !Object.values(invariants).some((v) => v === false)
+
+  return {
+    capability: set.capability,
+    adapter: set.adapter,
+    invariants,
+    banned_methods_present: present,
+    passed,
+    notes,
+  }
+}
+
+/**
+ * Helper for suite authors: assert a CapabilitySet has a coherent
+ * shape. Used in unit tests; the runtime harness uses inspectAdapter().
+ */
+export function assertCapabilitySetWellFormed(set: CapabilitySet): void {
+  if (!set.adapter || set.adapter.length === 0) {
+    throw new Error('CapabilitySet.adapter must be a non-empty string')
+  }
+  if (!set.version || set.version.length === 0) {
+    throw new Error('CapabilitySet.version must be a non-empty string')
+  }
+  if (!Array.isArray(set.supported_methods) || set.supported_methods.length === 0) {
+    throw new Error('CapabilitySet.supported_methods must declare at least one method')
+  }
+  // unsupported_methods and supported_methods must be disjoint
+  const sup = new Set(set.supported_methods)
+  for (const m of set.unsupported_methods ?? []) {
+    if (sup.has(m)) {
+      throw new Error(
+        `CapabilitySet method "${m}" appears in both supported_methods and unsupported_methods`
+      )
+    }
+  }
+}
+
+/**
+ * Helper for suite authors: assert a HealthStatus has the expected shape.
+ */
+export function assertHealthStatusWellFormed(h: HealthStatus): void {
+  const valid: HealthStatus['status'][] = ['healthy', 'degraded', 'unhealthy']
+  if (!valid.includes(h.status)) {
+    throw new Error(`HealthStatus.status must be one of ${valid.join(', ')}; got "${h.status}"`)
+  }
+  if (h.status === 'unhealthy' && h.last_ok_at === undefined) {
+    throw new Error('HealthStatus.last_ok_at must be set (null is allowed for never-reached)')
+  }
+}
+
+/**
+ * Helper for suite authors: build an AdapterError with the right
+ * shape. Adapters can use this directly; suite authors can use it as
+ * a fixture in tests.
+ */
+export function makeAdapterErrorCodes(): readonly AdapterErrorCode[] {
+  return [
+    'not_found',
+    'unauthorized',
+    'rate_limited',
+    'transient',
+    'capability_not_supported',
+    'scope_violation',
+    'fabrication_blocked',
+    'validation_failed',
+    'unknown',
+  ] as const
+}

--- a/src/lib/ai-employee/capabilities/court-access.ts
+++ b/src/lib/ai-employee/capabilities/court-access.ts
@@ -1,0 +1,100 @@
+/**
+ * CourtAccess capability — case law lookup, docket query, citation
+ * extraction. READ-ONLY.
+ *
+ * This is a raw data retrieval layer. The citation-refusal filter
+ * (invariant #6, Platform PRD §9 / Law-firm PRD §9) runs on ALL
+ * outputs BEFORE surfacing to any skill or draft surface — including
+ * any content retrieved via this interface. CourtAccess does not
+ * filter; the runtime layer does.
+ *
+ * Phase-1 signatures adopted from the Tech Lead contribution.
+ * Implemented by adapters for CourtListener, Westlaw (when licensed),
+ * LexisNexis (when licensed), state-specific court PACER systems.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Case search
+// ---------------------------------------------------------------------------
+
+export interface CaseQuery {
+  /** Free-text search across case title, parties, and judges. */
+  search?: string
+  jurisdiction?: string
+  court?: string
+  /** Filing date window. */
+  filed_within?: DateRange
+  limit?: number
+  cursor?: string
+}
+
+export interface CaseResult {
+  /** Adapter-specific case identifier. */
+  id: string
+  /** Full case title (e.g. "Smith v. Jones"). */
+  title: string
+  /** Court that heard the case. */
+  court: string
+  jurisdiction: string
+  /** ISO 8601 filing date. Null when the source doesn't expose it. */
+  filed_at: string | null
+  /** Citation string as the source formats it. May be a Bluebook-style
+   * cite; the citation-refusal filter inspects this downstream. */
+  citation: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Dockets
+// ---------------------------------------------------------------------------
+
+export interface Docket {
+  case_id: string
+  title: string
+  court: string
+  /** Latest activity timestamp. */
+  last_activity_at: string | null
+  /** Whether the docket is publicly accessible (PACER fee, free, etc.).
+   * Affects whether the runtime caches retrieved content. */
+  access_class: 'public' | 'paid' | 'restricted'
+}
+
+export interface DocketEntry {
+  id: string
+  case_id: string
+  /** Entry number as the court orders them. */
+  entry_number: number
+  filed_at: string
+  /** Type of filing (motion, order, brief, etc.) as the source labels it. */
+  filing_type: string
+  description: string
+  /** When the adapter can retrieve the underlying document, this is the
+   * adapter's opaque reference. Skill code passes this back to
+   * `get_filing_document` to fetch the content. */
+  document_ref: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface CourtAccess extends AdapterBase {
+  search_cases(query: CaseQuery): Promise<CaseResult[]>
+  get_case(case_id: string): Promise<CaseResult | null>
+
+  get_docket(case_id: string): Promise<Docket | null>
+  get_docket_entries(case_id: string, range: DateRange): Promise<DocketEntry[]>
+
+  /**
+   * Retrieve the underlying filing document by docket entry. Returns
+   * the raw bytes (typically PDF). The citation-refusal filter runs
+   * AFTER retrieval, in skill code; this method itself does not
+   * inspect content.
+   */
+  get_filing_document(document_ref: string): Promise<Uint8Array | null>
+
+  // NO write methods. The agent does not file documents or post to
+  // the court. The interface is read-only by design; the conformance
+  // harness asserts no write methods are added.
+}

--- a/src/lib/ai-employee/capabilities/document-storage.ts
+++ b/src/lib/ai-employee/capabilities/document-storage.ts
@@ -1,0 +1,152 @@
+/**
+ * DocumentStorage capability — store, retrieve, and version documents
+ * and folders in the customer's document repository.
+ *
+ * Distinct from PracticeManagement.list_matter_documents, which lives
+ * inside the PM system. This capability is the standalone document
+ * store (SharePoint, Google Drive, Dropbox, Box).
+ *
+ * Writes here are not "outbound" in the reviewer-as-sender sense (the
+ * agent writes to the customer's own storage, not to an external
+ * recipient). Sharing a document with an external party IS outbound;
+ * the interface provides `share_document_draft` which, per ADR 0005,
+ * surfaces the share-invitation as a draft in the reviewer's flow
+ * rather than sending an invite directly.
+ */
+
+import type { AdapterBase } from './types'
+
+// ---------------------------------------------------------------------------
+// Documents and folders
+// ---------------------------------------------------------------------------
+
+export interface StoredDocument {
+  id: string
+  /** Full path within the storage namespace (forward-slash separated). */
+  path: string
+  filename: string
+  mime_type: string
+  size_bytes: number
+  /** ISO 8601 timestamps from the source system. */
+  created_at: string
+  modified_at: string
+  modified_by: string | null
+  /** Stable version identifier (commit-sha-like or vendor revision ID). */
+  current_version: string
+}
+
+export interface Folder {
+  id: string
+  path: string
+  name: string
+  /** Whether this folder is shared outside the customer's organization.
+   * Null when the adapter cannot determine. */
+  is_shared_externally: boolean | null
+  created_at: string
+}
+
+export interface DocumentVersion {
+  version_id: string
+  document_id: string
+  created_at: string
+  created_by: string | null
+  size_bytes: number
+  /** Optional vendor-provided change description. */
+  comment: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+export interface ListFolderQuery {
+  folder_path: string
+  /** When true, include sub-folder contents. Adapters that cannot
+   * recurse return only the immediate folder and document the
+   * limitation. */
+  recursive?: boolean
+  limit?: number
+  cursor?: string
+}
+
+export interface FolderListing {
+  folder: Folder
+  documents: StoredDocument[]
+  subfolders: Folder[]
+  next_cursor: string | null
+}
+
+export interface UploadDocumentInput {
+  folder_path: string
+  filename: string
+  mime_type: string
+  content: Uint8Array
+  /** Whether to overwrite if a file with this name exists. Default false. */
+  overwrite?: boolean
+  /** Audit correlation. */
+  matter_ref?: string | null
+  drafted_by_skill: string
+}
+
+export interface UpdateDocumentInput {
+  document_id: string
+  content: Uint8Array
+  /** Optional version comment. */
+  comment?: string
+}
+
+// ---------------------------------------------------------------------------
+// External sharing — drafts only per ADR 0005
+// ---------------------------------------------------------------------------
+
+export interface ShareDocumentDraftInput {
+  /** The reviewer who will send the share invite. */
+  reviewer_account_id: string
+  document_id: string
+  /** Recipients to share with. */
+  recipients: string[]
+  /** Permission grant. Adapters that cannot honor this return
+   * `capability_not_supported`. */
+  permission: 'view' | 'comment' | 'edit'
+  /** Optional message included with the share invitation. */
+  message?: string
+  drafted_by_skill: string
+}
+
+export interface ShareDraftRef {
+  id: string
+  document_id: string
+  status: 'pending_review' | 'ready_for_send'
+  created_at: string
+  /** Vendor-specific UI hint for where the reviewer finds the pending
+   * share. Helps the dashboard render "go to your SharePoint share
+   * panel". */
+  reviewer_ui_hint: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface DocumentStorage extends AdapterBase {
+  list_folder(query: ListFolderQuery): Promise<FolderListing>
+  get_document(document_id: string): Promise<StoredDocument | null>
+  download_document(document_id: string): Promise<Uint8Array>
+
+  upload_document(input: UploadDocumentInput): Promise<StoredDocument>
+  update_document(input: UpdateDocumentInput): Promise<StoredDocument>
+
+  list_versions(document_id: string): Promise<DocumentVersion[]>
+  download_version(document_id: string, version_id: string): Promise<Uint8Array>
+
+  /**
+   * Create a draft share invitation. Per ADR 0005 the agent never
+   * sends external share invites; the reviewer reviews the draft and
+   * sends from their native UI. Adapters that cannot offer a "draft"
+   * concept declare this method unsupported in their CapabilitySet.
+   */
+  share_document_draft(input: ShareDocumentDraftInput): Promise<ShareDraftRef>
+
+  /** Folders the customer.yaml scope envelope makes readable. */
+  get_scoped_folders(): string[]
+}

--- a/src/lib/ai-employee/capabilities/e-sign.ts
+++ b/src/lib/ai-employee/capabilities/e-sign.ts
@@ -1,0 +1,109 @@
+/**
+ * ESign capability — envelope status monitoring, reminder drafts,
+ * completed-document retrieval.
+ *
+ * Per ADR 0005 (reviewer-as-sender), the agent NEVER initiates a
+ * signing flow. The reviewer creates the envelope and sends it; the
+ * agent tracks, drafts reminder language for stalled signers, and
+ * retrieves completed documents.
+ *
+ * Phase-1 signatures adopted from the Tech Lead contribution. Implemented
+ * by adapters for DocuSign, PandaDoc, Adobe Sign, HelloSign.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+import type { DraftRef } from './email'
+
+// ---------------------------------------------------------------------------
+// Envelopes
+// ---------------------------------------------------------------------------
+
+export type EnvelopeStatus =
+  | 'sent'
+  | 'delivered'
+  | 'partial_signed'
+  | 'completed'
+  | 'declined'
+  | 'voided'
+  | 'expired'
+
+export interface Signer {
+  email: string
+  name: string
+  /** Role in the envelope (e.g. "client", "co-counsel"). */
+  role: string | null
+  /** Whether this signer has signed. */
+  signed: boolean
+  /** ISO 8601 timestamp of signing. Null when not yet signed. */
+  signed_at: string | null
+  /** When the platform last reminded this signer. Null when never
+   * reminded. */
+  last_reminded_at: string | null
+}
+
+export interface Envelope {
+  id: string
+  /** Subject as set in the source platform. */
+  subject: string
+  status: EnvelopeStatus
+  /** Who created/sent the envelope. */
+  sender_email: string
+  signers: Signer[]
+  created_at: string
+  sent_at: string | null
+  completed_at: string | null
+  /** Adapter-specific matter or correlation reference, when known. */
+  matter_ref: string | null
+}
+
+export interface EnvelopeQuery {
+  status?: EnvelopeStatus
+  sender_email?: string
+  signer_email?: string
+  date_range?: DateRange
+  /** Free-text subject search. */
+  subject?: string
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Reminder drafts
+// ---------------------------------------------------------------------------
+
+export interface ReminderInput {
+  /** Which signer to chase. */
+  signer_email: string
+  /** The reviewer who will send the reminder. */
+  reviewer_account_id: string
+  /** Optional message override. Adapters fall back to a default body
+   * when omitted. */
+  body_html?: string
+  body_text?: string
+  drafted_by_skill: string
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface ESign extends AdapterBase {
+  list_envelopes(query: EnvelopeQuery): Promise<Envelope[]>
+  get_envelope(envelope_id: string): Promise<Envelope | null>
+
+  /**
+   * Drafts a reminder for a stalled signer. Per ADR 0005 (and the
+   * Tech Lead's Phase-1 signature note), the agent never initiates
+   * signing flows or sends reminders directly. The returned DraftRef
+   * is in the reviewer's email drafts; the reviewer reviews and
+   * sends.
+   */
+  create_reminder_draft(envelope_id: string, input: ReminderInput): Promise<DraftRef>
+
+  download_completed(envelope_id: string): Promise<Uint8Array>
+
+  // NO send_envelope method. The reviewer creates and sends envelopes
+  // from the source platform's native UI. The agent only tracks and
+  // chases. Implementing autonomous send here would violate ADR 0005
+  // and is blocked by the conformance harness.
+}

--- a/src/lib/ai-employee/capabilities/email.ts
+++ b/src/lib/ai-employee/capabilities/email.ts
@@ -1,0 +1,191 @@
+/**
+ * Email capability — watch inboxes, read threads, create drafts, apply
+ * labels, watch the sent folder.
+ *
+ * Pattern A is locked at v1 by ADR 0005 (reviewer-as-sender). The
+ * interface has NO send method. Drafts go to the reviewer's drafts
+ * folder; the reviewer reviews and presses Send from their own email
+ * client. The agent has no autonomous send path.
+ *
+ * The corresponding Pattern B (dashboard-orchestrated programmatic send
+ * via stored OAuth token) was considered and explicitly rejected — it
+ * surrenders the architectural property ADR 0005 protects.
+ *
+ * Implemented by adapters for Microsoft Graph (Outlook), Google
+ * Workspace (Gmail), IMAP/SMTP (rare), and any future vendor where the
+ * `create_draft` semantics align with the reviewer's native client.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Threads and messages
+// ---------------------------------------------------------------------------
+
+export interface EmailAddress {
+  email: string
+  /** Display name when the vendor provides one. */
+  name: string | null
+}
+
+export interface EmailMessage {
+  id: string
+  thread_id: string
+  from: EmailAddress
+  to: EmailAddress[]
+  cc: EmailAddress[]
+  bcc: EmailAddress[]
+  subject: string
+  /** Raw body in the format the vendor provided. Adapters MAY normalize
+   * to text-only and set body_html to null; skills receive whichever the
+   * adapter populates. */
+  body_text: string | null
+  body_html: string | null
+  /** ISO 8601 timestamp. */
+  sent_at: string
+  /** Labels / folders the vendor reports for this message. */
+  labels: string[]
+}
+
+export interface EmailThread {
+  id: string
+  subject: string
+  participants: EmailAddress[]
+  messages: EmailMessage[]
+  /** ISO 8601 timestamp of the most recent message in the thread. */
+  last_message_at: string
+  labels: string[]
+  /** When the adapter cannot return the full message list (e.g. Gmail's
+   * limit), this is the unread/oldest cursor for follow-up reads. */
+  next_cursor: string | null
+}
+
+export interface ThreadQuery {
+  /** Folder name in the reviewer's mail UI (e.g. "Inbox", "Clients"). */
+  folder?: string
+  /** Free-form text search; adapters translate to the vendor's search
+   * syntax. */
+  search?: string
+  /** Sender email filter. */
+  from?: string
+  /** Recipient email filter. */
+  to?: string
+  date_range?: DateRange
+  /** Only threads matching at least one of these labels. */
+  any_labels?: string[]
+  limit?: number
+  /** Cursor from a prior list_threads response. */
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Drafts — reviewer-as-sender contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Draft input. CRITICAL: per ADR 0005, the `reviewer_account_id` MUST
+ * resolve to the human reviewer's email account, not the agent's
+ * AgentMail identity. Adapters that cannot enforce this routing must
+ * throw `validation_failed` at construction; they must not silently
+ * route to the agent's account.
+ */
+export interface DraftInput {
+  /** The human reviewer's account ID as known to the adapter. */
+  reviewer_account_id: string
+  to: string[]
+  cc?: string[]
+  bcc?: string[]
+  subject: string
+  body_html: string
+  body_text: string
+  /** When null, this is a new thread. When set, the draft is a reply
+   * within the named thread. */
+  thread_id?: string | null
+  /** Audit correlation: the matter the draft pertains to, when known.
+   * Surfaces in the dashboard "what Marcus used" sourcing block. */
+  matter_ref?: string | null
+  /** Skill that authored the draft. Audit-required. */
+  drafted_by_skill: string
+}
+
+export interface DraftRef {
+  id: string
+  /** The thread the draft sits in (existing thread for replies, new
+   * thread ID for new conversations). */
+  thread_id: string
+  /** Where in the reviewer's UI the draft is visible (vendor-specific
+   * folder path). */
+  folder: string
+  /** ISO 8601 timestamp. */
+  created_at: string
+  /** ISO 8601 timestamp; null until the reviewer edits it. */
+  last_edited_at: string | null
+}
+
+export interface DraftUpdate {
+  to?: string[]
+  cc?: string[]
+  bcc?: string[]
+  subject?: string
+  body_html?: string
+  body_text?: string
+}
+
+// ---------------------------------------------------------------------------
+// Sent-folder watching (optional capability)
+// ---------------------------------------------------------------------------
+
+export interface SentItem {
+  message_id: string
+  thread_id: string
+  to: EmailAddress[]
+  cc: EmailAddress[]
+  subject: string
+  body_text: string | null
+  body_html: string | null
+  sent_at: string
+  /** Whether this sent item appears to have originated from an
+   * agent-drafted message (heuristic; null when the adapter cannot
+   * determine). */
+  likely_agent_drafted: boolean | null
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface Email extends AdapterBase {
+  // Inbox watching (poll or webhook depending on adapter)
+  list_threads(query: ThreadQuery): Promise<EmailThread[]>
+  get_thread(thread_id: string): Promise<EmailThread | null>
+
+  /**
+   * Create a draft in the REVIEWER'S drafts folder. Per ADR 0005, this
+   * is the only outbound surface in the Email interface. Adapters MUST
+   * route via the reviewer's account; routing to the agent's AgentMail
+   * identity is a critical bug and must throw `validation_failed`.
+   */
+  create_draft(input: DraftInput): Promise<DraftRef>
+  update_draft(draft_id: string, updates: DraftUpdate): Promise<DraftRef>
+
+  // NO send method. Per ADR 0005 the reviewer sends from their own
+  // client; the agent has no autonomous send path. Adding a `send()`
+  // method here would be an architectural regression and is blocked
+  // by the conformance harness.
+
+  // Label / folder operations
+  apply_label(thread_id: string, label: string): Promise<void>
+  move_to_folder(thread_id: string, folder: string): Promise<void>
+
+  // Sent-folder watching (opt-in; only active when customer.yaml enables it)
+  list_sent_since(cursor: string): Promise<SentItem[]>
+  get_sent_item(message_id: string): Promise<SentItem | null>
+
+  /**
+   * Returns the folders the customer.yaml scope envelope allows reading.
+   * Adapters consult their scope binding at boot. Skills never bypass
+   * this list — calling `list_threads` with a folder outside this set
+   * throws `scope_violation`.
+   */
+  get_scoped_folders(): string[]
+}

--- a/src/lib/ai-employee/capabilities/index.ts
+++ b/src/lib/ai-employee/capabilities/index.ts
@@ -1,0 +1,156 @@
+/**
+ * Public surface for the AI Employee capability layer.
+ *
+ * Skills import capability interfaces from this module:
+ *
+ *   import type { Email, PracticeManagement } from '@/lib/ai-employee/capabilities'
+ *
+ * Adapters import from the same module and from their capability's
+ * specific type exports for the shapes they need to construct.
+ */
+
+export type {
+  AdapterBase,
+  AdapterErrorCode,
+  CapabilityName,
+  CapabilitySet,
+  DateRange,
+  FieldCoverage,
+  HealthStatus,
+  OpaqueRef,
+} from './types'
+export { AdapterError } from './types'
+
+export type {
+  PracticeManagement,
+  Matter,
+  MatterStatus,
+  MatterQuery,
+  CreateMatterInput,
+  MatterUpdate,
+  Contact,
+  ContactQuery,
+  CreateContactInput,
+  TimeEntry,
+  TimeEntryInput,
+  DocumentRef,
+  DocumentUpload,
+} from './practice-management'
+
+export type {
+  Email,
+  EmailAddress,
+  EmailMessage,
+  EmailThread,
+  ThreadQuery,
+  DraftInput,
+  DraftRef,
+  DraftUpdate,
+  SentItem,
+} from './email'
+
+export type {
+  Calendar,
+  CalendarEvent,
+  EventStatus,
+  Attendee,
+  EventQuery,
+  SuggestTimeInput,
+  SuggestedSlot,
+  CreateEventDraftInput,
+  EventDraftRef,
+  EventDraftUpdate,
+} from './calendar'
+
+export type {
+  DocumentStorage,
+  StoredDocument,
+  Folder,
+  DocumentVersion,
+  ListFolderQuery,
+  FolderListing,
+  UploadDocumentInput,
+  UpdateDocumentInput,
+  ShareDocumentDraftInput,
+  ShareDraftRef,
+} from './document-storage'
+
+export type {
+  ESign,
+  Envelope,
+  EnvelopeStatus,
+  Signer,
+  EnvelopeQuery,
+  ReminderInput,
+} from './e-sign'
+
+export type { CourtAccess, CaseQuery, CaseResult, Docket, DocketEntry } from './court-access'
+
+export type {
+  Payments,
+  Transaction,
+  TransactionType,
+  TransactionStatus,
+  TransactionQuery,
+  PaymentRequestDraftInput,
+  PaymentRequestDraftRef,
+  TrustAccountBalance,
+} from './payments'
+
+export type {
+  Accounting,
+  Invoice,
+  InvoiceStatus,
+  InvoiceLineItem,
+  InvoiceQuery,
+  CreateInvoiceDraftInput,
+  InvoiceDraftRef,
+  AccountsReceivableEntry,
+  AccountsReceivableQuery,
+  ExpenseEntryDraftInput,
+  ExpenseEntryDraftRef,
+} from './accounting'
+
+export type {
+  IntakeCRM,
+  Lead,
+  LeadStatus,
+  LeadQuery,
+  UpdateLeadInput,
+  IntakeFormResponse,
+  IntakeFormResponseQuery,
+  LeadNote,
+} from './intake-crm'
+
+export type {
+  CallTracking,
+  CallRecord,
+  CallDirection,
+  CallOutcome,
+  CallQuery,
+  CallRecording,
+  CallAttribution,
+} from './call-tracking'
+
+export type {
+  InternalComms,
+  ChannelSummary,
+  ChannelMessage,
+  ListChannelMessagesQuery,
+  PostToChannelInput,
+  SendDmInput,
+  PostRef,
+  ReactionInput,
+  Mention,
+} from './internal-comms'
+
+export {
+  CONFORMANCE_INVARIANTS,
+  BANNED_METHOD_NAMES,
+  inspectAdapter,
+  assertCapabilitySetWellFormed,
+  assertHealthStatusWellFormed,
+  makeAdapterErrorCodes,
+} from './conformance'
+
+export type { ConformanceInvariantKey, ConformanceResult } from './conformance'

--- a/src/lib/ai-employee/capabilities/intake-crm.ts
+++ b/src/lib/ai-employee/capabilities/intake-crm.ts
@@ -1,0 +1,134 @@
+/**
+ * IntakeCRM capability — lead intake, lead status, intake-form
+ * responses.
+ *
+ * Mutations on lead records (status changes, notes, assignments) are
+ * NOT outbound communications and are allowed per ADR 0005 (which
+ * governs customer-bound external messages). The lead CRM is internal
+ * to the customer's organization; status mutations land in the CRM,
+ * not in an external inbox.
+ *
+ * Outreach to the lead (email, call) is handled by the Email and (when
+ * implemented) Voice/Phone capabilities — IntakeCRM does not duplicate
+ * those send paths.
+ *
+ * Implemented by adapters for Lead Docket, Captorra, Lawmatics (when
+ * client uses it for intake), HubSpot, Salesforce.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Leads
+// ---------------------------------------------------------------------------
+
+export type LeadStatus =
+  | 'new'
+  | 'contacted'
+  | 'qualifying'
+  | 'qualified'
+  | 'disqualified'
+  | 'converted'
+  | 'lost'
+  | 'archived'
+
+export interface Lead {
+  id: string
+  /** Display name (full name or business name). */
+  name: string
+  email: string | null
+  phone: string | null
+  status: LeadStatus
+  /** Source attribution — e.g. "google-ads", "referral:jdoe@partner.com". */
+  source: string | null
+  /** When the lead was first captured. */
+  intake_at: string
+  /** When the status was last changed. */
+  status_changed_at: string
+  /** Matter the lead converted into. Null until conversion. */
+  converted_matter_ref: string | null
+  /** Adapter-specific extra fields. */
+  custom_fields: Record<string, unknown>
+}
+
+export interface LeadQuery {
+  status?: LeadStatus
+  source?: string
+  /** Lead capture window. */
+  intake_window?: DateRange
+  /** Free-text search across name, email, phone. */
+  search?: string
+  limit?: number
+  cursor?: string
+}
+
+export interface UpdateLeadInput {
+  status?: LeadStatus
+  /** Internal note appended to the lead's record. */
+  note?: string
+  /** Assignment to a human in the customer's org. Email is the
+   * canonical identifier. */
+  assigned_to?: string
+  drafted_by_skill: string
+}
+
+// ---------------------------------------------------------------------------
+// Intake forms
+// ---------------------------------------------------------------------------
+
+export interface IntakeFormResponse {
+  id: string
+  lead_id: string | null
+  form_name: string
+  /** ISO 8601. */
+  submitted_at: string
+  /** Form fields keyed by field name as defined in the source form. */
+  fields: Record<string, unknown>
+  /** Optional source URL where the form lives (for audit). */
+  source_url: string | null
+}
+
+export interface IntakeFormResponseQuery {
+  form_name?: string
+  date_range?: DateRange
+  /** Filter to responses for a specific lead. */
+  lead_id?: string
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Notes
+// ---------------------------------------------------------------------------
+
+export interface LeadNote {
+  id: string
+  lead_id: string
+  author: string
+  /** ISO 8601. */
+  created_at: string
+  body: string
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface IntakeCRM extends AdapterBase {
+  // Lead read
+  list_leads(query: LeadQuery): Promise<Lead[]>
+  get_lead(lead_id: string): Promise<Lead | null>
+
+  // Lead mutate (internal — not external comms)
+  update_lead(lead_id: string, updates: UpdateLeadInput): Promise<Lead>
+  append_lead_note(lead_id: string, body: string, drafted_by_skill: string): Promise<LeadNote>
+
+  // Intake forms
+  list_intake_form_responses(query: IntakeFormResponseQuery): Promise<IntakeFormResponse[]>
+  get_intake_form_response(response_id: string): Promise<IntakeFormResponse | null>
+
+  // NO send_to_lead method. Outreach to the lead happens through Email
+  // (drafted in the reviewer's drafts folder per ADR 0005). The
+  // conformance harness asserts IntakeCRM does not duplicate the
+  // Email send path.
+}

--- a/src/lib/ai-employee/capabilities/internal-comms.ts
+++ b/src/lib/ai-employee/capabilities/internal-comms.ts
@@ -1,0 +1,175 @@
+/**
+ * InternalComms capability — Slack / Teams channel posts, DMs,
+ * mentions.
+ *
+ * Per ADR 0005, INTERNAL destinations are persona-visible: posts come
+ * from the named persona as the customer's internal teammate.
+ * External destinations remain reviewer-as-sender (Email). This
+ * interface is for internal-only surfaces; adapters MUST refuse to
+ * post to any channel that has external members or guests.
+ *
+ * Implemented by adapters for Slack and Microsoft Teams. Other
+ * internal-comms platforms (Discord, Mattermost, etc.) are
+ * theoretically addable but not on the v1 roadmap.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Channels and messages
+// ---------------------------------------------------------------------------
+
+export interface ChannelSummary {
+  id: string
+  name: string
+  /** Whether the channel is private. */
+  is_private: boolean
+  /** Whether the channel has any external members or guests.
+   * Adapters MUST refuse posts to external channels. */
+  has_external_members: boolean
+  /** Number of members. Adapters may return null when expensive to
+   * compute. */
+  member_count: number | null
+}
+
+export interface ChannelMessage {
+  id: string
+  channel_id: string
+  thread_id: string | null
+  /** Author of the message. May be the persona, a human teammate, or
+   * a system bot. */
+  author: {
+    /** Email when available; the persona's AgentMail address when
+     * the persona is the author. */
+    email: string | null
+    display_name: string
+    /** Whether this is the AI persona itself. */
+    is_persona: boolean
+  }
+  /** Plain-text body. Adapters MAY also surface a structured-blocks
+   * representation in `blocks`. */
+  body_text: string
+  /** Vendor-specific structured representation (Slack blocks, Teams
+   * adaptive cards). Adapters that don't support structured posts
+   * return null. */
+  blocks: unknown
+  /** ISO 8601 timestamp. */
+  posted_at: string
+  /** ISO 8601 timestamp of the last edit. Null when never edited. */
+  edited_at: string | null
+}
+
+export interface ListChannelMessagesQuery {
+  channel_id: string
+  /** Thread filter. When set, returns only messages in this thread. */
+  thread_id?: string
+  date_range?: DateRange
+  /** Free-text search within the channel. */
+  search?: string
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Post operations — persona-as-sender for internal destinations
+// ---------------------------------------------------------------------------
+
+export interface PostToChannelInput {
+  channel_id: string
+  body_text: string
+  /** Optional structured blocks. Adapters that don't support them
+   * fall back to body_text only. */
+  blocks?: unknown
+  /** When set, posts as a reply in this thread. */
+  thread_id?: string
+  /** Skill that authored the post. Audit-required. */
+  drafted_by_skill: string
+  /** Matter correlation. */
+  matter_ref?: string | null
+}
+
+export interface SendDmInput {
+  /** Recipient's email or vendor-specific user identifier. Must
+   * resolve to an internal teammate; adapters MUST refuse external
+   * users. */
+  recipient: string
+  body_text: string
+  blocks?: unknown
+  drafted_by_skill: string
+}
+
+export interface PostRef {
+  id: string
+  channel_id: string | null
+  thread_id: string | null
+  /** Where the post appears in the vendor UI (for the dashboard's
+   * "where Marcus posted" surface). */
+  vendor_permalink: string | null
+  posted_at: string
+}
+
+// ---------------------------------------------------------------------------
+// Reactions and mentions
+// ---------------------------------------------------------------------------
+
+export interface ReactionInput {
+  message_id: string
+  /** Vendor-specific reaction key (e.g. ":thumbsup:", "approved"). */
+  reaction: string
+  drafted_by_skill: string
+}
+
+export interface Mention {
+  message_id: string
+  channel_id: string
+  thread_id: string | null
+  /** Who was mentioned. The persona's AgentMail or vendor user ID
+   * appears here when the persona was mentioned. */
+  mentioned: {
+    email: string | null
+    display_name: string
+    is_persona: boolean
+  }
+  /** ISO 8601 timestamp of the message containing the mention. */
+  posted_at: string
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface InternalComms extends AdapterBase {
+  // Channel discovery
+  list_channels(): Promise<ChannelSummary[]>
+
+  // Read
+  list_channel_messages(query: ListChannelMessagesQuery): Promise<ChannelMessage[]>
+  get_message(message_id: string): Promise<ChannelMessage | null>
+
+  /**
+   * List recent mentions of the persona across all channels the
+   * adapter can see. The intake-style "Marcus, can you...?" surface
+   * polls this; the customer.yaml scope envelope governs which
+   * channels are visible.
+   */
+  list_recent_mentions(since: string): Promise<Mention[]>
+
+  /**
+   * Post as the persona. Per ADR 0005, internal destinations are
+   * persona-visible: the message appears authored by the named
+   * persona, not the reviewer. Adapters MUST refuse to post to any
+   * channel where `has_external_members` is true.
+   */
+  post_to_channel(input: PostToChannelInput): Promise<PostRef>
+
+  /** Send a DM to an internal teammate as the persona. Adapters MUST
+   * refuse external recipients. */
+  send_dm(input: SendDmInput): Promise<PostRef>
+
+  /** React to a message. Used by skills like inbox-triage to ack a
+   * partner's question without composing a full reply. */
+  react_to_message(input: ReactionInput): Promise<void>
+
+  /** Channels the customer.yaml scope envelope makes readable. */
+  get_scoped_channels(): string[]
+}

--- a/src/lib/ai-employee/capabilities/payments.ts
+++ b/src/lib/ai-employee/capabilities/payments.ts
@@ -1,0 +1,126 @@
+/**
+ * Payments capability — payment-request drafts, transaction lookup,
+ * payment-status monitoring.
+ *
+ * READ-ONLY for transaction data and trust-account state. Writes are
+ * limited to DRAFT payment requests (per ADR 0005 reviewer-as-sender).
+ * The agent does not initiate trust transfers or move money under any
+ * configuration. Invariant #3 (no commitment execution) governs.
+ *
+ * Implemented by adapters for LawPay, Stripe (where applicable),
+ * QuickBooks Payments, and other vendor-specific payment processors.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Transactions
+// ---------------------------------------------------------------------------
+
+export type TransactionType =
+  | 'payment'
+  | 'refund'
+  | 'chargeback'
+  | 'trust_deposit'
+  | 'trust_disbursement'
+  | 'transfer'
+
+export type TransactionStatus = 'pending' | 'completed' | 'failed' | 'reversed' | 'disputed'
+
+export interface Transaction {
+  id: string
+  type: TransactionType
+  status: TransactionStatus
+  /** Amount in minor units (cents). Negative for refunds and reversals. */
+  amount_cents: number
+  currency: string
+  /** Description as the source platform records it. */
+  description: string | null
+  /** When the transaction posted. */
+  posted_at: string
+  /** Matter the transaction relates to, when known. */
+  matter_ref: string | null
+  /** Payer information when known. May be a contact, an opposing party,
+   * or a court. */
+  payer_name: string | null
+}
+
+export interface TransactionQuery {
+  matter_ref?: string
+  type?: TransactionType
+  status?: TransactionStatus
+  date_range?: DateRange
+  /** Minimum amount in minor units. */
+  min_amount_cents?: number
+  limit?: number
+  cursor?: string
+}
+
+// ---------------------------------------------------------------------------
+// Payment requests — drafts only
+// ---------------------------------------------------------------------------
+
+export interface PaymentRequestDraftInput {
+  /** The reviewer who will send the request. */
+  reviewer_account_id: string
+  /** Who to bill. Email is the canonical channel; adapters may also
+   * accept a contact reference. */
+  recipient_email: string
+  recipient_name?: string
+  amount_cents: number
+  currency: string
+  description: string
+  /** Matter correlation. */
+  matter_ref?: string | null
+  /** Optional due date (ISO 8601). */
+  due_at?: string
+  drafted_by_skill: string
+}
+
+export interface PaymentRequestDraftRef {
+  id: string
+  status: 'pending_review' | 'ready_for_send'
+  created_at: string
+  /** Where in the source platform the reviewer finds the draft. */
+  reviewer_ui_hint: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Trust-account balance (read-only)
+// ---------------------------------------------------------------------------
+
+export interface TrustAccountBalance {
+  matter_ref: string
+  /** Current trust balance in minor units. */
+  balance_cents: number
+  currency: string
+  /** When the balance was last updated by the underlying system. */
+  as_of: string
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface Payments extends AdapterBase {
+  // Read
+  list_transactions(query: TransactionQuery): Promise<Transaction[]>
+  get_transaction(transaction_id: string): Promise<Transaction | null>
+
+  /** Trust-account balance by matter. Returns null when the matter has
+   * no trust balance (vs. zero balance, which returns a row with
+   * balance_cents=0). */
+  get_trust_balance(matter_ref: string): Promise<TrustAccountBalance | null>
+
+  /**
+   * Create a draft payment request. Per ADR 0005 the reviewer sends the
+   * request from the source platform's native UI; the agent never
+   * initiates a payment request directly. Per invariant #3, no
+   * autonomous trust transfers — adapters MUST NOT expose any method
+   * that moves money in or out of a trust account.
+   */
+  create_payment_request_draft(input: PaymentRequestDraftInput): Promise<PaymentRequestDraftRef>
+
+  // NO send_payment_request, NO initiate_transfer, NO trust_disbursement.
+  // The conformance harness asserts these methods are absent.
+}

--- a/src/lib/ai-employee/capabilities/practice-management.ts
+++ b/src/lib/ai-employee/capabilities/practice-management.ts
@@ -1,0 +1,168 @@
+/**
+ * PracticeManagement capability — search/create/update entities (matters,
+ * contacts), time and billing entries, documents.
+ *
+ * Implemented by adapters for Filevine, SmartAdvocate, Clio, CASEpeer,
+ * Neos, MyCase, etc. (Law-firm PRD §7.2 Tier-1 ladder).
+ *
+ * Phase-1 signatures adopted from the Tech Lead contribution (round-1
+ * synthesis Theme 4). Vertical-specific fields (PI-only attributes,
+ * employment-only attributes) live in `Matter.custom_fields`; adapters
+ * populate what their source system exposes; skills must not assume any
+ * custom field is present without checking.
+ */
+
+import type { AdapterBase, DateRange } from './types'
+
+// ---------------------------------------------------------------------------
+// Matter
+// ---------------------------------------------------------------------------
+
+export type MatterStatus = 'open' | 'closed' | 'pending' | 'intake'
+
+export interface Matter {
+  id: string
+  client_name: string
+  matter_type: string
+  status: MatterStatus
+  opened_at: string
+  closed_at: string | null
+  /**
+   * Vertical-specific and adapter-specific fields. Adapters populate what
+   * their underlying PM system exposes. Skill code must check for presence
+   * before reading; the conformance harness asserts adapters declare
+   * which custom_fields they populate in their CapabilitySet.
+   */
+  custom_fields: Record<string, unknown>
+}
+
+export interface MatterQuery {
+  client_name?: string
+  matter_type?: string
+  status?: MatterStatus
+  date_range?: DateRange
+  limit?: number
+  offset?: number
+}
+
+export interface CreateMatterInput {
+  client_name: string
+  matter_type: string
+  status?: MatterStatus
+  custom_fields?: Record<string, unknown>
+}
+
+export interface MatterUpdate {
+  client_name?: string
+  matter_type?: string
+  status?: MatterStatus
+  custom_fields?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Contact
+// ---------------------------------------------------------------------------
+
+export interface Contact {
+  id: string
+  name: string
+  email: string | null
+  phone: string | null
+  /** Free-form role (e.g. "client", "opposing-counsel", "expert-witness"). */
+  role: string | null
+  custom_fields: Record<string, unknown>
+}
+
+export interface ContactQuery {
+  name?: string
+  email?: string
+  role?: string
+  limit?: number
+  offset?: number
+}
+
+export interface CreateContactInput {
+  name: string
+  email?: string
+  phone?: string
+  role?: string
+  custom_fields?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Time and billing
+// ---------------------------------------------------------------------------
+
+export interface TimeEntry {
+  id: string
+  matter_id: string
+  date: string
+  duration_minutes: number
+  description: string
+  billable: boolean
+  /** Hourly rate in minor units (cents). null when not yet billed. */
+  rate_cents: number | null
+  /**
+   * Status as known to the PM system. Adapters normalize to this
+   * vocabulary; vendor-specific statuses live in custom_fields.
+   */
+  status: 'draft' | 'pending_review' | 'billed' | 'written_off'
+  custom_fields: Record<string, unknown>
+}
+
+export interface TimeEntryInput {
+  matter_id: string
+  date: string
+  duration_minutes: number
+  description: string
+  billable: boolean
+  rate_cents?: number
+}
+
+// ---------------------------------------------------------------------------
+// Documents (PM-system-scoped)
+// ---------------------------------------------------------------------------
+
+export interface DocumentRef {
+  id: string
+  matter_id: string
+  filename: string
+  mime_type: string
+  size_bytes: number
+  uploaded_at: string
+  uploaded_by: string | null
+}
+
+export interface DocumentUpload {
+  filename: string
+  mime_type: string
+  content: Uint8Array
+  /** Optional folder path within the matter, vendor-permitting. */
+  folder?: string
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface PracticeManagement extends AdapterBase {
+  // Matter operations
+  search_matters(query: MatterQuery): Promise<Matter[]>
+  get_matter(id: string): Promise<Matter | null>
+  create_matter(input: CreateMatterInput): Promise<Matter>
+  update_matter(id: string, updates: MatterUpdate): Promise<Matter>
+
+  // Contact operations
+  search_contacts(query: ContactQuery): Promise<Contact[]>
+  get_contact(id: string): Promise<Contact | null>
+  create_contact(input: CreateContactInput): Promise<Contact>
+
+  // Time and billing (read-only at v1 except for draft creation; no
+  // autonomous billing posts per ADR 0006 + invariant #3 spirit)
+  list_time_entries(matter_id: string, range: DateRange): Promise<TimeEntry[]>
+  create_time_entry_draft(input: TimeEntryInput): Promise<TimeEntry>
+
+  // Document operations within the PM system
+  list_matter_documents(matter_id: string): Promise<DocumentRef[]>
+  upload_matter_document(matter_id: string, doc: DocumentUpload): Promise<DocumentRef>
+}

--- a/src/lib/ai-employee/capabilities/types.ts
+++ b/src/lib/ai-employee/capabilities/types.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared types for the AI Employee capability layer.
+ *
+ * Per ADR 0006, skills bind to capability interfaces; vendor adapters
+ * implement them; customer.yaml wires which adapter serves which capability.
+ * This module is the only place skill code, adapter code, and the
+ * conformance harness all agree on shared shapes (DateRange, error
+ * contracts, capability disclosure).
+ *
+ * Anything specific to one capability lives in that capability's own file
+ * (matter shapes in practice-management.ts, draft shapes in email.ts, etc.).
+ * Keep this module narrow.
+ */
+
+/**
+ * Canonical capability names. The eleven Platform PRD §7.2 capabilities,
+ * recorded here as a closed string union so adapters cannot register against
+ * an unrecognized name. Add new capabilities here only when an ADR records
+ * the addition.
+ */
+export type CapabilityName =
+  | 'PracticeManagement'
+  | 'Email'
+  | 'Calendar'
+  | 'DocumentStorage'
+  | 'ESign'
+  | 'CourtAccess'
+  | 'Payments'
+  | 'Accounting'
+  | 'IntakeCRM'
+  | 'CallTracking'
+  | 'InternalComms'
+
+/**
+ * Inclusive-start / exclusive-end ISO 8601 date range. Used by every
+ * capability that lists time-bound records. `until` may be `null` to mean
+ * "no upper bound" (e.g. "list every time entry since the matter opened").
+ */
+export interface DateRange {
+  /** ISO 8601 timestamp. Inclusive. */
+  since: string
+  /** ISO 8601 timestamp. Exclusive. `null` means open-ended. */
+  until: string | null
+}
+
+/**
+ * Result of `describe_capabilities()`. Every adapter returns one of these
+ * so the dashboard can render "what Marcus used to write this" and the
+ * boot-time conformance harness can verify the adapter satisfies the
+ * interface's required-method set.
+ */
+export interface CapabilitySet {
+  /** Name of the capability this adapter implements. */
+  capability: CapabilityName
+  /** Adapter slug — e.g. "filevine", "microsoft-graph", "docusign". */
+  adapter: string
+  /** Adapter version string. Semver recommended but not enforced. */
+  version: string
+  /**
+   * Method names this adapter implements. Must be a superset of the
+   * interface's required-method set; may include any subset of the
+   * interface's optional methods.
+   */
+  supported_methods: string[]
+  /**
+   * Optional methods this adapter declares it does NOT implement. Skills
+   * that depend on an unsupported optional method should degrade
+   * gracefully or surface an explicit "this adapter doesn't support X"
+   * message; the conformance harness asserts adapters do not silently
+   * stub these.
+   */
+  unsupported_methods: string[]
+  /**
+   * Per-method field-coverage disclosure for the dashboard "what Marcus
+   * used" sourcing block (PRD §12, Synthesis Theme 21). Optional in the
+   * interface but strongly recommended — without it the dashboard renders
+   * "source unknown" rather than the field-level attribution per ADR 0006.
+   */
+  field_coverage?: Record<string, FieldCoverage>
+}
+
+/**
+ * Per-method field disclosure. Says which fields of the return shape
+ * are populated from source data, which are not populated by this
+ * adapter (so the skill should not rely on them), and which were derived
+ * by adapter inference rather than read directly from the source system.
+ */
+export interface FieldCoverage {
+  populated: string[]
+  not_populated: string[]
+  derived: string[]
+}
+
+/**
+ * Adapter health status returned by `health_check()`. Adapters use this
+ * to signal whether the underlying integration is currently usable. The
+ * control plane polls this and surfaces the per-customer dashboard
+ * aliveness signal (PRD §12, issue #875).
+ */
+export interface HealthStatus {
+  status: 'healthy' | 'degraded' | 'unhealthy'
+  /** ISO 8601 timestamp of when the adapter last successfully reached
+   * the underlying system. Null on unhealthy and never-reached. */
+  last_ok_at: string | null
+  /** Human-readable detail. Adapters should keep this short and
+   * non-sensitive — it surfaces in the dashboard. */
+  message?: string
+  /** Adapter-specific machine-readable fields for debugging. Not
+   * surfaced in the dashboard; logged for the control plane. */
+  details?: Record<string, unknown>
+}
+
+/**
+ * Closed set of error codes adapters throw. The conformance harness asserts
+ * adapters only throw these codes — opaque errors are a bug because skills
+ * cannot reason about them. Skill code switches on `code`, not on
+ * `message`.
+ *
+ *  - `not_found`: adapters should prefer returning `null` over throwing
+ *    this. Reserved for cases where the absence is semantically distinct
+ *    from a normal "no row" (e.g. the parent matter was deleted).
+ *  - `unauthorized`: the adapter's OAuth token is missing, expired, or
+ *    lacks the required scope.
+ *  - `rate_limited`: the underlying vendor rate-limited the call. Skills
+ *    should back off; the runtime layer handles retry policy.
+ *  - `transient`: a vendor-side server error or network blip. Retry safe.
+ *  - `capability_not_supported`: the adapter does not implement this
+ *    optional method. The capability_set should already declare this in
+ *    `unsupported_methods`; this throw is the runtime defense.
+ *  - `scope_violation`: the call would access data the customer.yaml
+ *    scope envelope blocks (e.g. an email folder marked as blind).
+ *  - `fabrication_blocked`: the adapter refused to return content that
+ *    would violate invariant #8 (e.g. an inferred field with no source
+ *    evidence). Per CLAUDE.md no-fabrication rule.
+ *  - `validation_failed`: the call's input did not satisfy the adapter's
+ *    or vendor's validation rules.
+ *  - `unknown`: the adapter cannot map the underlying error to one of
+ *    the above. Skill code treats this as non-retryable.
+ */
+export type AdapterErrorCode =
+  | 'not_found'
+  | 'unauthorized'
+  | 'rate_limited'
+  | 'transient'
+  | 'capability_not_supported'
+  | 'scope_violation'
+  | 'fabrication_blocked'
+  | 'validation_failed'
+  | 'unknown'
+
+/**
+ * Canonical error type thrown by adapters. Skill code switches on
+ * `code`; adapters set `cause` to the underlying vendor exception so the
+ * audit log can record what actually went wrong without re-throwing
+ * vendor-shaped objects.
+ */
+export class AdapterError extends Error {
+  readonly code: AdapterErrorCode
+  readonly adapter: string
+  readonly capability: CapabilityName
+  /** Original vendor error if any. Audit-logged, never surfaced to the user. */
+  readonly cause?: unknown
+
+  constructor(
+    code: AdapterErrorCode,
+    capability: CapabilityName,
+    adapter: string,
+    message: string,
+    cause?: unknown
+  ) {
+    super(message, cause === undefined ? undefined : { cause })
+    this.name = 'AdapterError'
+    this.code = code
+    this.capability = capability
+    this.adapter = adapter
+    this.cause = cause
+  }
+}
+
+/**
+ * Every capability interface extends this base. Adapters implement the
+ * two methods on top of the capability-specific surface.
+ */
+export interface AdapterBase {
+  /**
+   * Returns the adapter's CapabilitySet — used by the conformance
+   * harness, the dashboard sourcing block, and operator tooling.
+   * Synchronous because it never crosses the network: it reflects
+   * the adapter's static declaration.
+   */
+  describe_capabilities(): CapabilitySet
+
+  /**
+   * Returns the adapter's current health. Adapters may implement this
+   * with a lightweight ping or a cached recent result; skills should
+   * treat health checks as advisory, not authoritative.
+   */
+  health_check(): Promise<HealthStatus>
+}
+
+/**
+ * A signed, opaque reference to an external resource. Adapters return
+ * these instead of raw vendor IDs so skill code does not depend on the
+ * vendor's ID shape. The reference round-trips through the adapter for
+ * subsequent calls.
+ */
+export interface OpaqueRef {
+  /** Adapter-internal stable identifier. Treat as opaque. */
+  id: string
+  /** Adapter slug that issued this reference. Used to route subsequent calls. */
+  adapter: string
+  /** ISO 8601 timestamp when the reference was issued. */
+  issued_at: string
+}

--- a/src/lib/portal/ai-employee-access.ts
+++ b/src/lib/portal/ai-employee-access.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared access gate for the AI Employee product surfaces under
+ * `/portal/products/ai-employee/*`.
+ *
+ * Every product surface needs the same four checks, in order:
+ *
+ *   1. Clerk session present                  → otherwise sign-in
+ *   2. Local entity bound to Clerk org        → otherwise sign-in with no_subscription marker
+ *   3. AI Employee subscription on the entity → otherwise landing page (which renders the
+ *                                                no_subscription / provisioning / paused state)
+ *   4. Caller holds at least one allowed role → otherwise landing page (no_role state)
+ *
+ * Each surface differs only in which roles it accepts. Drafts, matters, and calendar are
+ * for active users (operator or principal); audit is open to all three roles since
+ * compliance is the dedicated viewer; settings is principal-only.
+ *
+ * Status check: this helper treats provisioning, active, and paused subscriptions as
+ * "exists" — same posture as `getProductSubscription`. Surfaces render their empty
+ * state regardless of lifecycle status. The landing page is the only surface that
+ * branches on status (see src/pages/portal/products/ai-employee/index.astro).
+ */
+
+import type { Entity } from '../db/entities'
+import type { PortalUserRow } from '../auth/clerk-bridge'
+import { getPortalClient } from './session'
+import { getProductSubscription, listProductRoles, type SubscriptionRow } from './product-access'
+
+export const AI_EMPLOYEE_PRODUCT_SLUG = 'ai-employee'
+
+export const AI_EMPLOYEE_LANDING_PATH = '/portal/products/ai-employee'
+export const PORTAL_SIGN_IN_PATH = '/auth/portal-sign-in'
+export const PORTAL_SIGN_IN_NO_SUBSCRIPTION_PATH = `${PORTAL_SIGN_IN_PATH}?status=no_subscription`
+
+export type AiEmployeeAccess =
+  | { kind: 'redirect'; to: string }
+  | {
+      kind: 'allowed'
+      user: PortalUserRow
+      client: Entity
+      subscription: SubscriptionRow
+      roles: string[]
+    }
+
+export interface ResolveAiEmployeeAccessOptions {
+  /**
+   * Roles that grant access to the surface. Any one match is enough. Pass the
+   * canonical product_roles vocabulary values (`principal`, `operator`,
+   * `compliance`) — typos will silently 401 every visitor.
+   */
+  allowedRoles: readonly string[]
+}
+
+/**
+ * Resolve access for an AI Employee product surface. Returns either a redirect
+ * target (caller does `Astro.redirect(access.to)`) or the resolved
+ * user/client/subscription/roles tuple ready to render.
+ *
+ * The helper does not call `Astro.redirect` itself because Astro's redirect is
+ * a context-bound method on the page; returning the path keeps the helper
+ * unit-testable with a plain DB + locals.
+ */
+export async function resolveAiEmployeeAccess(
+  db: D1Database,
+  locals: App.Locals,
+  options: ResolveAiEmployeeAccessOptions
+): Promise<AiEmployeeAccess> {
+  const portalData = await getPortalClient(db, locals)
+  if (!portalData) {
+    return { kind: 'redirect', to: PORTAL_SIGN_IN_PATH }
+  }
+  if (!portalData.client) {
+    return { kind: 'redirect', to: PORTAL_SIGN_IN_NO_SUBSCRIPTION_PATH }
+  }
+
+  const { user, client } = portalData
+
+  const subscription = await getProductSubscription(db, client.id, AI_EMPLOYEE_PRODUCT_SLUG)
+  if (!subscription) {
+    return { kind: 'redirect', to: AI_EMPLOYEE_LANDING_PATH }
+  }
+
+  const roles = await listProductRoles(db, user.id, client.id, AI_EMPLOYEE_PRODUCT_SLUG)
+  const hasAllowedRole = options.allowedRoles.some((r) => roles.includes(r))
+  if (!hasAllowedRole) {
+    return { kind: 'redirect', to: AI_EMPLOYEE_LANDING_PATH }
+  }
+
+  return { kind: 'allowed', user, client, subscription, roles }
+}

--- a/src/lib/portal/customer-config.ts
+++ b/src/lib/portal/customer-config.ts
@@ -1,0 +1,160 @@
+/**
+ * Customer config — portal read path for the projection of `customer.yaml`.
+ *
+ * Per ADR 0012, `customer.yaml` lives in a canonical git repository and is
+ * projected on every merge into two read replicas:
+ *
+ *   1. portal D1 `customer_configs` table  (this module reads from here)
+ *   2. per-customer R2 prefix              (Hermes reads from there)
+ *
+ * Neither replica is hand-edited. Drift detection (a daily cron, lands in a
+ * follow-on PR) reconciles them against git. This module is read-only on
+ * principle: any write path that bypasses git breaks the source-of-truth
+ * commitment in ADR 0012 §2.
+ *
+ * Per ADR 0011, `personas` is an array (length ≥1 at v1, with the v1
+ * customer's sole persona at index 0). `getActivePersona` returns the first
+ * persona whose `status === 'active'`. Phase 2 extends the selector when a
+ * second persona ships — the function signature stays additive (Phase 2 adds
+ * an optional selector parameter; v1 callers continue to work).
+ */
+
+export type PersonaStatus = 'active' | 'archived'
+
+export interface PersonaSendAs {
+  agentmail_identity: string
+}
+
+export interface PersonaSkill {
+  name: string
+  trust_ceiling: string
+}
+
+export interface PersonaChannelBinding {
+  integration: string
+  channels: string[]
+}
+
+export interface PersonaConfig {
+  slug: string
+  status: PersonaStatus
+  name: string
+  title: string | null
+  signature_html: string | null
+  tone: string[]
+  send_as: PersonaSendAs | null
+  skills: PersonaSkill[]
+  channel_bindings: PersonaChannelBinding[]
+}
+
+export interface CustomerConfigRow {
+  entity_id: string
+  org_id: string
+  customer_slug: string
+  schema_version: string
+  personas: PersonaConfig[]
+  voice_library: unknown
+  escalation: unknown
+  business_hours: unknown
+  connectors: unknown
+  scope: unknown
+  git_sha: string
+  synced_at: string
+}
+
+interface CustomerConfigDbRow {
+  entity_id: string
+  org_id: string
+  customer_slug: string
+  schema_version: string
+  personas_json: string
+  voice_library_json: string | null
+  escalation_json: string | null
+  business_hours_json: string | null
+  connectors_json: string | null
+  scope_json: string | null
+  git_sha: string
+  synced_at: string
+}
+
+/**
+ * Parse a JSON column that may be null. Returns `null` when the column is
+ * null. Throws on malformed JSON — drift detection / CI sync are responsible
+ * for ensuring the projection is well-formed; a malformed JSON column is a
+ * corruption signal, not a routine condition to recover from.
+ */
+function parseJsonNullable<T>(value: string | null): T | null {
+  if (value === null) return null
+  return JSON.parse(value) as T
+}
+
+/**
+ * Parse a required JSON column. Throws on null OR malformed JSON — both are
+ * corruption signals at the projection layer.
+ */
+function parseJsonRequired<T>(value: string, column: string, entityId: string): T {
+  try {
+    return JSON.parse(value) as T
+  } catch (err) {
+    throw new Error(
+      `customer_configs.${column} is malformed JSON for entity_id=${entityId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err }
+    )
+  }
+}
+
+function projectRow(row: CustomerConfigDbRow): CustomerConfigRow {
+  return {
+    entity_id: row.entity_id,
+    org_id: row.org_id,
+    customer_slug: row.customer_slug,
+    schema_version: row.schema_version,
+    personas: parseJsonRequired<PersonaConfig[]>(row.personas_json, 'personas_json', row.entity_id),
+    voice_library: parseJsonNullable(row.voice_library_json),
+    escalation: parseJsonNullable(row.escalation_json),
+    business_hours: parseJsonNullable(row.business_hours_json),
+    connectors: parseJsonNullable(row.connectors_json),
+    scope: parseJsonNullable(row.scope_json),
+    git_sha: row.git_sha,
+    synced_at: row.synced_at,
+  }
+}
+
+/**
+ * Read the projected customer config for an entity. Returns null when no row
+ * exists — a meaningful state during alpha when CI sync has not been wired
+ * up yet (rows are hand-seeded only).
+ */
+export async function getCustomerConfig(
+  db: D1Database,
+  entityId: string
+): Promise<CustomerConfigRow | null> {
+  const row = await db
+    .prepare('SELECT * FROM customer_configs WHERE entity_id = ?')
+    .bind(entityId)
+    .first<CustomerConfigDbRow>()
+  if (!row) return null
+  return projectRow(row)
+}
+
+/**
+ * Return the active persona for this customer, or null when no config row
+ * exists or no persona's `status === 'active'`. At v1 the personas array is
+ * length 1 (ADR 0011 §1), so this returns personas[0] when active.
+ *
+ * Phase 2 (multi-persona runtime) will extend the resolver with a selector
+ * — likely a `persona_slug` argument backed by URL or session state. The
+ * signature stays additive: v1 callers passing only (db, entityId) keep
+ * working when the Phase 2 selector lands.
+ */
+export async function getActivePersona(
+  db: D1Database,
+  entityId: string
+): Promise<PersonaConfig | null> {
+  const config = await getCustomerConfig(db, entityId)
+  if (!config) return null
+  const active = config.personas.find((p) => p.status === 'active')
+  return active ?? null
+}

--- a/src/pages/portal/products/ai-employee/audit/index.astro
+++ b/src/pages/portal/products/ai-employee/audit/index.astro
@@ -1,0 +1,112 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Audit log viewer.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/audit
+ *
+ * Per #873 and #895, every action the AI Employee takes — drafts
+ * created, sends approved, identity attributions, trust-ceiling
+ * decisions, memory access — emits an audit event. This surface is the
+ * read-only viewer over those events. Persistence and writer modules
+ * land separately (#891, #842, #864).
+ *
+ * Audit events live on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821) and the
+ * compliance evidence pipeline (#892, #894).
+ *
+ * Until the read path lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated events, no synthetic
+ * trace, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds principal OR operator OR compliance role
+ *
+ * Compliance is the dedicated viewer for this surface (#895), but
+ * audit transparency is for the whole team — operators see what they
+ * acted on, principals see firm-wide activity.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'operator', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Audit | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Audit"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No audit events yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Every action your AI Employee takes is recorded here: drafts created, sends approved,
+            identity changes, memory access.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/calendar/index.astro
+++ b/src/pages/portal/products/ai-employee/calendar/index.astro
@@ -1,0 +1,105 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Calendar.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/calendar
+ *
+ * Per #872, the calendar surfaces deadlines, hearings, depositions, and
+ * scheduled follow-ups the AI Employee is tracking. Connector wiring for
+ * Google Calendar / Outlook / case-management deadlines lands as part of
+ * the per-customer Hermes Machine runtime (#821, #923 connector
+ * addressing) — none of that data is reachable from the portal Worker
+ * directly per ADR 0009.
+ *
+ * Until the read path lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated events, no fake
+ * deadlines, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Calendar | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Calendar"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No upcoming events
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Hearings, depositions, and deadlines your AI Employee is tracking will appear here.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/drafts/index.astro
+++ b/src/pages/portal/products/ai-employee/drafts/index.astro
@@ -1,0 +1,107 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Drafts list.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/drafts
+ *
+ * Per PRD §12, the draft queue is the primary user-facing surface: every
+ * message the AI Employee proposes lands here for human review before it
+ * goes out (reviewer-as-sender, ADR 0005). Listing fields per #869:
+ * sender, recipient, skill, trust-ceiling decision, age, priority.
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated drafts, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing; the
+ * audit surface is their primary read view, not drafts.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Drafts | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Drafts"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No drafts yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Drafts your AI Employee prepares land here for review before any message goes out.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -32,10 +32,11 @@ import { env } from 'cloudflare:workers'
  * docs/style/empty-state-pattern.md. No fabrication.
  *
  * This page is the routing entry point. Internal product surfaces
- * (Today, Drafts, Matters, Audit, Settings) live under
- * /portal/products/ai-employee/* and are introduced by subsequent PRs
- * (#869 drafts, #871 matters, #872 calendar, #873 audit, #874
- * settings, etc.).
+ * (Drafts, Matters, Calendar, Audit, Settings) live under
+ * /portal/products/ai-employee/* and are reached via the section card
+ * grid rendered in the active-state branch below. Each child surface
+ * uses the shared resolveAiEmployeeAccess helper to enforce its own
+ * role gate; the landing only orchestrates which cards to render.
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -79,6 +80,47 @@ if (!subscription) {
     surfaceState = 'active'
     access = { subscription, roles }
   }
+}
+
+// Section cards in the active-state main column. Filtered by the
+// caller's roles so operators / principals see the act-on-the-product
+// surfaces (drafts, matters, calendar) and every role sees Audit.
+// Each destination uses resolveAiEmployeeAccess to enforce the gate
+// server-side; this list is the visual filter only.
+interface SectionCard {
+  href: string
+  label: string
+  description: string
+}
+const sectionCards: SectionCard[] = []
+if (access) {
+  const userRoles = access.roles
+  const ACTIVE_DOER_ROLES = ['operator', 'principal']
+  const canAct = userRoles.some((r) => ACTIVE_DOER_ROLES.includes(r))
+  if (canAct) {
+    sectionCards.push({
+      href: '/portal/products/ai-employee/drafts',
+      label: 'Drafts',
+      description: 'Review drafts your AI Employee has prepared before any message goes out.',
+    })
+    sectionCards.push({
+      href: '/portal/products/ai-employee/matters',
+      label: 'Matters',
+      description:
+        'Active matters your AI Employee is tracking across communications and documents.',
+    })
+    sectionCards.push({
+      href: '/portal/products/ai-employee/calendar',
+      label: 'Calendar',
+      description: 'Hearings, depositions, and deadlines your AI Employee is watching.',
+    })
+  }
+  sectionCards.push({
+    href: '/portal/products/ai-employee/audit',
+    label: 'Audit',
+    description:
+      'A full record of every action your AI Employee takes: drafts created, sends approved, identity changes.',
+  })
 }
 ---
 
@@ -182,25 +224,38 @@ if (!subscription) {
         surfaceState === 'active' && (
           <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
             <div class="flex flex-col gap-8 min-w-0">
-              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  <span>Today</span>
-                  <span class="text-[color:var(--ss-color-primary)]">§ 01</span>
-                </div>
-                <div class="px-5 md:px-7 py-6">
-                  <p class="text-[color:var(--ss-color-text-secondary)] leading-[1.55]">
-                    Your AI Employee dashboard is ready. Activity, drafts, and matters appear here
-                    once the agent has been working with your firm.
-                  </p>
+              <section>
+                <p class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+                  Sections
+                </p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]">
+                  {sectionCards.map((s, i) => {
+                    const anchor = String(i + 1).padStart(2, '0')
+                    return (
+                      <a
+                        href={s.href}
+                        class="block bg-[color:var(--ss-color-background)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                      >
+                        <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
+                          § {anchor}
+                        </p>
+                        <h2 class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                          {s.label}
+                        </h2>
+                        <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+                          {s.description}
+                        </p>
+                      </a>
+                    )
+                  })}
                 </div>
               </section>
             </div>
 
             <aside class="flex flex-col gap-8 min-w-0">
               <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  <span>Your roles</span>
-                  <span class="text-[color:var(--ss-color-primary)]">§ 02</span>
+                <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                  Your roles
                 </div>
                 <div class="px-5 md:px-7 py-6">
                   <ul
@@ -216,9 +271,8 @@ if (!subscription) {
 
               {access?.roles.includes('principal') && (
                 <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                  <div class="flex items-center justify-between gap-3 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                    <span>Manage</span>
-                    <span class="text-[color:var(--ss-color-primary)]">§ 03</span>
+                  <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                    Manage
                   </div>
                   <ul
                     class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]"

--- a/src/pages/portal/products/ai-employee/matters/index.astro
+++ b/src/pages/portal/products/ai-employee/matters/index.astro
@@ -1,0 +1,107 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Matters list.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/matters
+ *
+ * Per #871, matters are the per-engagement aggregates the AI Employee
+ * tracks across communications, deadlines, and documents. The list view
+ * shows matter title, opposing party, last activity, and status. Detail
+ * pages land in a follow-on slice once the schema exists.
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, this surface renders the empty state per
+ * docs/style/empty-state-pattern.md — no fabricated matters, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds operator OR principal role
+ *
+ * Compliance-only users are redirected to the AI Employee landing.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['operator', 'principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Matters | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Matters"
+        meta={null}
+      />
+
+      <section class="mt-10">
+        <div
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+        >
+          <p
+            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+          >
+            No matters yet
+          </p>
+          <p
+            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+          >
+            Active matters appear here as your AI Employee tracks them across communications and
+            documents.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/ai-employee-access.test.ts
+++ b/tests/ai-employee-access.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Tests for the AI Employee access gate (src/lib/portal/ai-employee-access.ts).
+ *
+ * Each AI Employee surface page calls `resolveAiEmployeeAccess` with the set
+ * of roles it accepts. The helper returns either `{ kind: 'redirect', to }` —
+ * the page does `Astro.redirect(access.to)` — or `{ kind: 'allowed', ... }`
+ * with the resolved user/client/subscription/roles. This contract is what
+ * keeps wrong-role users out of drafts, matters, calendar, audit, and the
+ * settings sub-pages.
+ *
+ * We mock `getPortalClient` so the test can exercise each redirect branch
+ * without standing up a Clerk session, then drive subscriptions and
+ * product_roles via a real test D1. Migrations are applied per spec so the
+ * schema constraints (UNIQUE(entity_id, product_slug), the CHECK on status,
+ * the UNIQUE on (user, entity, product_slug, role)) are real.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+
+// Mock getPortalClient before importing the helper. The portal-session
+// module pulls in @clerk/astro middleware types that aren't available in
+// the vitest environment, so we replace the whole module surface.
+vi.mock('../src/lib/portal/session', () => ({
+  getPortalClient: vi.fn(),
+}))
+
+import { getPortalClient } from '../src/lib/portal/session'
+import { resolveAiEmployeeAccess } from '../src/lib/portal/ai-employee-access'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ENTITY_ID = 'entity-test'
+const USER_ID = 'user-test'
+const OTHER_USER_ID = 'user-other'
+const PRODUCT_SLUG = 'ai-employee'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Test Firm', 'test-firm')
+    .run()
+}
+
+async function seedUser(db: D1Database, userId: string, email: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, org_id, email, name, role, entity_id, clerk_user_id)
+       VALUES (?, ?, ?, ?, 'client', ?, ?)`
+    )
+    .bind(userId, ORG_ID, email, email, ENTITY_ID, `clerk_${userId}`)
+    .run()
+}
+
+async function seedSubscription(
+  db: D1Database,
+  status: 'provisioning' | 'active' | 'paused' | 'cancelled'
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO subscriptions (id, org_id, entity_id, product_slug, status)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .bind('sub-test', ORG_ID, ENTITY_ID, PRODUCT_SLUG, status)
+    .run()
+}
+
+async function grantRole(db: D1Database, userId: string, role: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO product_roles (id, org_id, user_id, entity_id, product_slug, role)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(`pr-${userId}-${role}`, ORG_ID, userId, ENTITY_ID, PRODUCT_SLUG, role)
+    .run()
+}
+
+function mockUser(id: string, email: string) {
+  return {
+    id,
+    org_id: ORG_ID,
+    email,
+    name: email,
+    role: 'client',
+    entity_id: ENTITY_ID,
+    clerk_user_id: `clerk_${id}`,
+  }
+}
+
+function mockClient() {
+  return {
+    id: ENTITY_ID,
+    org_id: ORG_ID,
+    name: 'Test Firm',
+    slug: 'test-firm',
+    phone: null,
+    website: null,
+    stage: 'engaged' as const,
+    stage_changed_at: '2026-05-21T00:00:00Z',
+    pain_score: null,
+    vertical: null,
+    area: null,
+    employee_count: null,
+    tier: null,
+    summary: null,
+    next_action: null,
+    next_action_at: null,
+    source_pipeline: null,
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    clerk_org_id: 'clerk_org_test',
+  }
+}
+
+const fakeLocals = {} as App.Locals
+
+describe('resolveAiEmployeeAccess', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+    vi.mocked(getPortalClient).mockReset()
+  })
+
+  it('redirects to sign-in when no portal session exists', async () => {
+    vi.mocked(getPortalClient).mockResolvedValue(null)
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/auth/portal-sign-in')
+    }
+  })
+
+  it('redirects to no-subscription sign-in when entity not provisioned', async () => {
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: null,
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/auth/portal-sign-in?status=no_subscription')
+    }
+  })
+
+  it('redirects to landing when entity has no AI Employee subscription', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('redirects to landing when subscription is cancelled', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'cancelled')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('redirects to landing when user has no role on this product', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'noaccess@firm.com')
+    await seedSubscription(db, 'active')
+    // No grantRole — caller has zero product_roles rows
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'noaccess@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it("redirects to landing when caller's role isn't in allowedRoles (compliance hitting drafts)", async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'compliance@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'compliance@firm.com'),
+      client: mockClient(),
+    })
+
+    // Drafts allows operator | principal only — compliance must be redirected
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('allows access when caller has principal role and surface accepts principal', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.user.id).toBe(USER_ID)
+      expect(result.client.id).toBe(ENTITY_ID)
+      expect(result.subscription.status).toBe('active')
+      expect(result.roles).toContain('principal')
+    }
+  })
+
+  it('allows access when caller has operator role and surface accepts operator', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'operator@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'operator')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'operator@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toContain('operator')
+    }
+  })
+
+  it('allows access during provisioning status (matches surface gate posture)', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'provisioning')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    // Provisioning subscriptions DO return — the helper matches getProductSubscription
+    // which treats provisioning/active/paused as "exists". Surfaces render their
+    // own empty state. Only the landing branches on lifecycle status.
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.subscription.status).toBe('provisioning')
+    }
+  })
+
+  it('allows access during paused status', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'paused')
+    await grantRole(db, USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'principal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['operator', 'principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.subscription.status).toBe('paused')
+    }
+  })
+
+  it('audit-surface configuration allows all three role vocabularies', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'compliance@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'compliance@firm.com'),
+      client: mockClient(),
+    })
+
+    // Audit accepts principal | operator | compliance
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal', 'operator', 'compliance'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toEqual(['compliance'])
+    }
+  })
+
+  it('returns all of the caller’s granted roles, not just the matched one', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'wearsmanyhats@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    await grantRole(db, USER_ID, 'compliance')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'wearsmanyhats@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('allowed')
+    if (result.kind === 'allowed') {
+      expect(result.roles).toEqual(expect.arrayContaining(['principal', 'compliance']))
+      expect(result.roles).toHaveLength(2)
+    }
+  })
+
+  it('only counts non-revoked roles', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'wasprincipal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, USER_ID, 'principal')
+    // Revoke the only role
+    await db
+      .prepare(
+        `UPDATE product_roles SET revoked_at = datetime('now')
+         WHERE user_id = ? AND entity_id = ? AND product_slug = ?`
+      )
+      .bind(USER_ID, ENTITY_ID, PRODUCT_SLUG)
+      .run()
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'wasprincipal@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+
+  it('isolates roles per (user, entity, product) — another user’s role doesn’t grant access', async () => {
+    await seedEntity(db)
+    await seedUser(db, USER_ID, 'noaccess@firm.com')
+    await seedUser(db, OTHER_USER_ID, 'principal@firm.com')
+    await seedSubscription(db, 'active')
+    await grantRole(db, OTHER_USER_ID, 'principal')
+    vi.mocked(getPortalClient).mockResolvedValue({
+      user: mockUser(USER_ID, 'noaccess@firm.com'),
+      client: mockClient(),
+    })
+
+    const result = await resolveAiEmployeeAccess(db, fakeLocals, {
+      allowedRoles: ['principal'],
+    })
+
+    expect(result.kind).toBe('redirect')
+    if (result.kind === 'redirect') {
+      expect(result.to).toBe('/portal/products/ai-employee')
+    }
+  })
+})

--- a/tests/capability-conformance.test.ts
+++ b/tests/capability-conformance.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the AI Employee capability conformance harness
+ * (src/lib/ai-employee/capabilities/conformance.ts).
+ *
+ * The harness defends ADR 0005 (reviewer-as-sender) and the Platform
+ * PRD invariants at the adapter layer: an adapter that exposes
+ * `Email.send` or `Payments.initiate_transfer` is a release blocker,
+ * not a code-review nit. These tests verify the harness catches what
+ * it claims to catch.
+ *
+ * Vendor adapters do not exist yet — the tests use minimal in-test
+ * fakes to drive each invariant. Adapter authors copy the fake shape
+ * when wiring real vendors.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  AdapterError,
+  CONFORMANCE_INVARIANTS,
+  BANNED_METHOD_NAMES,
+  inspectAdapter,
+  assertCapabilitySetWellFormed,
+  assertHealthStatusWellFormed,
+  makeAdapterErrorCodes,
+  type AdapterBase,
+  type CapabilityName,
+  type CapabilitySet,
+  type HealthStatus,
+} from '../src/lib/ai-employee/capabilities'
+
+function makeAdapter(
+  capability: CapabilityName,
+  extra: Record<string, unknown> = {},
+  setOverrides: Partial<CapabilitySet> = {}
+): AdapterBase {
+  const set: CapabilitySet = {
+    capability,
+    adapter: 'test-adapter',
+    version: '1.0.0',
+    supported_methods: ['describe_capabilities', 'health_check'],
+    unsupported_methods: [],
+    ...setOverrides,
+  }
+  const adapter: AdapterBase = {
+    describe_capabilities: () => set,
+    health_check: () =>
+      Promise.resolve({
+        status: 'healthy' as const,
+        last_ok_at: new Date().toISOString(),
+      }),
+  }
+  return Object.assign(adapter, extra)
+}
+
+describe('capability conformance: invariant constants', () => {
+  it('CONFORMANCE_INVARIANTS includes every invariant the harness claims to check', () => {
+    const expected = [
+      'CAPABILITY_SET_HONEST',
+      'NULL_FOR_ABSENT',
+      'TYPED_ERRORS',
+      'NO_AUTONOMOUS_EXTERNAL_SEND',
+      'NO_AUTONOMOUS_TRUST_TRANSFER',
+      'HEALTH_CHECK_BOUNDED',
+      'UNSUPPORTED_METHODS_THROW',
+      'NO_FIELD_FABRICATION',
+    ]
+    expect(Object.keys(CONFORMANCE_INVARIANTS).sort()).toEqual(expected.sort())
+  })
+
+  it('BANNED_METHOD_NAMES enumerates every capability so the harness never silently skips one', () => {
+    const expected: CapabilityName[] = [
+      'PracticeManagement',
+      'Email',
+      'Calendar',
+      'DocumentStorage',
+      'ESign',
+      'CourtAccess',
+      'Payments',
+      'Accounting',
+      'IntakeCRM',
+      'CallTracking',
+      'InternalComms',
+    ]
+    expect(Object.keys(BANNED_METHOD_NAMES).sort()).toEqual(expected.sort())
+  })
+
+  it('makeAdapterErrorCodes returns the closed set of AdapterErrorCode values', () => {
+    const codes = makeAdapterErrorCodes()
+    expect(codes).toContain('not_found')
+    expect(codes).toContain('unauthorized')
+    expect(codes).toContain('scope_violation')
+    expect(codes).toContain('fabrication_blocked')
+    expect(codes).toContain('capability_not_supported')
+  })
+})
+
+describe('capability conformance: NO_AUTONOMOUS_EXTERNAL_SEND', () => {
+  it('passes a vanilla Email adapter without forbidden methods', () => {
+    const adapter = makeAdapter('Email')
+    const result = inspectAdapter(adapter)
+    expect(result.passed).toBe(true)
+    expect(result.banned_methods_present).toEqual([])
+    expect(result.invariants.NO_AUTONOMOUS_EXTERNAL_SEND).toBe(true)
+  })
+
+  it('fails an Email adapter that exposes a send() method (ADR 0005 violation)', () => {
+    const adapter = makeAdapter('Email', { send: () => Promise.resolve() })
+    const result = inspectAdapter(adapter)
+    expect(result.passed).toBe(false)
+    expect(result.banned_methods_present).toContain('send')
+    expect(result.invariants.NO_AUTONOMOUS_EXTERNAL_SEND).toBe(false)
+    expect(result.notes.some((n) => n.includes('send'))).toBe(true)
+  })
+
+  it('fails an ESign adapter that exposes send_envelope (ADR 0005 violation)', () => {
+    const adapter = makeAdapter('ESign', { send_envelope: () => Promise.resolve() })
+    const result = inspectAdapter(adapter)
+    expect(result.passed).toBe(false)
+    expect(result.banned_methods_present).toContain('send_envelope')
+  })
+
+  it('fails a Calendar adapter that exposes send_invitation', () => {
+    const adapter = makeAdapter('Calendar', { send_invitation: () => Promise.resolve() })
+    const result = inspectAdapter(adapter)
+    expect(result.passed).toBe(false)
+    expect(result.banned_methods_present).toContain('send_invitation')
+  })
+
+  it('fails a DocumentStorage adapter that exposes share_document (use share_document_draft)', () => {
+    const adapter = makeAdapter('DocumentStorage', { share_document: () => Promise.resolve() })
+    const result = inspectAdapter(adapter)
+    expect(result.passed).toBe(false)
+    expect(result.banned_methods_present).toContain('share_document')
+  })
+
+  it('lists every forbidden method when an adapter exposes several', () => {
+    const adapter = makeAdapter('Email', {
+      send: () => Promise.resolve(),
+      send_email: () => Promise.resolve(),
+      send_message: () => Promise.resolve(),
+    })
+    const result = inspectAdapter(adapter)
+    expect(result.banned_methods_present).toEqual(
+      expect.arrayContaining(['send', 'send_email', 'send_message'])
+    )
+    expect(result.banned_methods_present).toHaveLength(3)
+  })
+})
+
+describe('capability conformance: NO_AUTONOMOUS_TRUST_TRANSFER', () => {
+  it('marks the invariant as N/A for non-Payments adapters', () => {
+    const adapter = makeAdapter('PracticeManagement')
+    const result = inspectAdapter(adapter)
+    expect(result.invariants.NO_AUTONOMOUS_TRUST_TRANSFER).toBe(null)
+  })
+
+  it('passes a Payments adapter with no transfer methods', () => {
+    const adapter = makeAdapter('Payments')
+    const result = inspectAdapter(adapter)
+    expect(result.invariants.NO_AUTONOMOUS_TRUST_TRANSFER).toBe(true)
+    expect(result.passed).toBe(true)
+  })
+
+  it('fails a Payments adapter that exposes trust_disbursement (invariant #3 violation)', () => {
+    const adapter = makeAdapter('Payments', { trust_disbursement: () => Promise.resolve() })
+    const result = inspectAdapter(adapter)
+    expect(result.invariants.NO_AUTONOMOUS_TRUST_TRANSFER).toBe(false)
+    expect(result.banned_methods_present).toContain('trust_disbursement')
+  })
+
+  it('fails a Payments adapter that exposes initiate_transfer', () => {
+    const adapter = makeAdapter('Payments', { initiate_transfer: () => Promise.resolve() })
+    const result = inspectAdapter(adapter)
+    expect(result.invariants.NO_AUTONOMOUS_TRUST_TRANSFER).toBe(false)
+    expect(result.banned_methods_present).toContain('initiate_transfer')
+  })
+})
+
+describe('capability conformance: CAPABILITY_SET_HONEST', () => {
+  it('flags an adapter whose capability is not in the closed union', () => {
+    const adapter = makeAdapter(
+      'Email',
+      {},
+      {
+        capability: 'NotARealCapability' as CapabilityName,
+      }
+    )
+    const result = inspectAdapter(adapter)
+    expect(result.invariants.CAPABILITY_SET_HONEST).toBe(false)
+    expect(result.passed).toBe(false)
+  })
+})
+
+describe('AdapterError', () => {
+  it('preserves the code, adapter, and capability', () => {
+    const err = new AdapterError('rate_limited', 'Email', 'microsoft-graph', 'slow down')
+    expect(err.code).toBe('rate_limited')
+    expect(err.adapter).toBe('microsoft-graph')
+    expect(err.capability).toBe('Email')
+    expect(err.message).toBe('slow down')
+  })
+
+  it('attaches cause when given', () => {
+    const cause = new Error('original')
+    const err = new AdapterError('transient', 'Payments', 'lawpay', 'wrapped', cause)
+    expect(err.cause).toBe(cause)
+  })
+
+  it('omits cause when not provided', () => {
+    const err = new AdapterError('not_found', 'Email', 'gmail', 'missing')
+    expect(err.cause).toBeUndefined()
+  })
+})
+
+describe('capability conformance: helpers', () => {
+  it('assertCapabilitySetWellFormed rejects empty adapter slug', () => {
+    expect(() =>
+      assertCapabilitySetWellFormed({
+        capability: 'Email',
+        adapter: '',
+        version: '1.0.0',
+        supported_methods: ['x'],
+        unsupported_methods: [],
+      })
+    ).toThrow(/adapter/)
+  })
+
+  it('assertCapabilitySetWellFormed rejects empty supported_methods', () => {
+    expect(() =>
+      assertCapabilitySetWellFormed({
+        capability: 'Email',
+        adapter: 'a',
+        version: '1.0.0',
+        supported_methods: [],
+        unsupported_methods: [],
+      })
+    ).toThrow(/supported_methods/)
+  })
+
+  it('assertCapabilitySetWellFormed rejects supported / unsupported overlap', () => {
+    expect(() =>
+      assertCapabilitySetWellFormed({
+        capability: 'Email',
+        adapter: 'a',
+        version: '1.0.0',
+        supported_methods: ['x', 'y'],
+        unsupported_methods: ['y', 'z'],
+      })
+    ).toThrow(/y/)
+  })
+
+  it('assertCapabilitySetWellFormed accepts a well-formed set', () => {
+    expect(() =>
+      assertCapabilitySetWellFormed({
+        capability: 'Email',
+        adapter: 'a',
+        version: '1.0.0',
+        supported_methods: ['x'],
+        unsupported_methods: ['y'],
+      })
+    ).not.toThrow()
+  })
+
+  it('assertHealthStatusWellFormed rejects an unknown status', () => {
+    expect(() =>
+      assertHealthStatusWellFormed({
+        status: 'fine' as HealthStatus['status'],
+        last_ok_at: null,
+      })
+    ).toThrow(/status/)
+  })
+
+  it('assertHealthStatusWellFormed accepts a healthy status', () => {
+    expect(() =>
+      assertHealthStatusWellFormed({
+        status: 'healthy',
+        last_ok_at: '2026-05-21T12:00:00Z',
+      })
+    ).not.toThrow()
+  })
+
+  it('assertHealthStatusWellFormed accepts unhealthy with null last_ok_at (never reached)', () => {
+    expect(() =>
+      assertHealthStatusWellFormed({
+        status: 'unhealthy',
+        last_ok_at: null,
+      })
+    ).not.toThrow()
+  })
+})

--- a/tests/customer-config.test.ts
+++ b/tests/customer-config.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the customer_configs projection helpers
+ * (src/lib/portal/customer-config.ts).
+ *
+ * Per ADR 0012, customer_configs is a read replica of `customer.yaml` (which
+ * lives in a canonical git repo). The helpers under test parse projected JSON
+ * columns into typed shapes and resolve the active persona per ADR 0011 §1.
+ *
+ * Each test seeds a customer_configs row directly via the test D1 — emulating
+ * what CI will do post-merge, since the CI sync path lands in a follow-on
+ * PR. The schema constraints (FK to entities, UNIQUE customer_slug, NOT NULL
+ * on personas_json) are exercised through real seeds.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+import { resolve } from 'path'
+import type { D1Database } from '@cloudflare/workers-types'
+import { ORG_ID } from '../src/lib/constants'
+import {
+  getCustomerConfig,
+  getActivePersona,
+  type PersonaConfig,
+} from '../src/lib/portal/customer-config'
+
+const migrationsDir = resolve(process.cwd(), 'migrations')
+
+const ENTITY_ID = 'entity-config-test'
+const CUSTOMER_SLUG = 'smith-pi-firm'
+
+async function freshDb(): Promise<D1Database> {
+  const db = createTestD1()
+  await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+  return db
+}
+
+async function seedEntity(db: D1Database): Promise<void> {
+  await db
+    .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+    .bind(ENTITY_ID, ORG_ID, 'Smith PI Firm', 'smith-pi-firm')
+    .run()
+}
+
+interface SeedOptions {
+  entity_id?: string
+  customer_slug?: string
+  schema_version?: string
+  personas?: PersonaConfig[]
+  voice_library?: unknown
+  escalation?: unknown
+  business_hours?: unknown
+  connectors?: unknown
+  scope?: unknown
+  git_sha?: string
+  synced_at?: string
+}
+
+async function seedConfig(db: D1Database, opts: SeedOptions = {}): Promise<void> {
+  const personas = opts.personas ?? [makePersona({ slug: 'marcus' })]
+  await db
+    .prepare(
+      `INSERT INTO customer_configs
+        (entity_id, org_id, customer_slug, schema_version,
+         personas_json, voice_library_json, escalation_json, business_hours_json,
+         connectors_json, scope_json, git_sha, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      opts.entity_id ?? ENTITY_ID,
+      ORG_ID,
+      opts.customer_slug ?? CUSTOMER_SLUG,
+      opts.schema_version ?? '1.0.0',
+      JSON.stringify(personas),
+      opts.voice_library === undefined ? null : JSON.stringify(opts.voice_library),
+      opts.escalation === undefined ? null : JSON.stringify(opts.escalation),
+      opts.business_hours === undefined ? null : JSON.stringify(opts.business_hours),
+      opts.connectors === undefined ? null : JSON.stringify(opts.connectors),
+      opts.scope === undefined ? null : JSON.stringify(opts.scope),
+      opts.git_sha ?? 'a1b2c3d4e5f6',
+      opts.synced_at ?? '2026-05-21T12:00:00Z'
+    )
+    .run()
+}
+
+function makePersona(overrides: Partial<PersonaConfig> = {}): PersonaConfig {
+  return {
+    slug: 'marcus',
+    status: 'active',
+    name: 'Marcus',
+    title: 'AI Associate',
+    signature_html: '<p>Marcus<br/>AI Associate</p>',
+    tone: ['warm-but-professional'],
+    send_as: { agentmail_identity: 'marcus@smith-pi-firm.agents.smd.services' },
+    skills: [{ name: 'inbox-triage-and-draft', trust_ceiling: 'draft_for_review' }],
+    channel_bindings: [{ integration: 'ms-graph', channels: ['primary-inbox'] }],
+    ...overrides,
+  }
+}
+
+describe('getCustomerConfig', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns null when no config row exists for the entity', async () => {
+    await seedEntity(db)
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('parses personas_json and other JSON columns into typed shape', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [makePersona()],
+      escalation: { red_flag_recipients: ['partner@firm.com'] },
+      business_hours: { start: '08:00', end: '18:00', tz: 'America/Phoenix' },
+    })
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result).not.toBeNull()
+    expect(result?.personas).toHaveLength(1)
+    expect(result?.personas[0].name).toBe('Marcus')
+    expect(result?.personas[0].skills[0].name).toBe('inbox-triage-and-draft')
+    expect(result?.escalation).toEqual({ red_flag_recipients: ['partner@firm.com'] })
+    expect(result?.business_hours).toEqual({ start: '08:00', end: '18:00', tz: 'America/Phoenix' })
+  })
+
+  it('returns the row’s schema_version and git_sha verbatim for drift detection', async () => {
+    await seedEntity(db)
+    await seedConfig(db, { schema_version: '2.3.1', git_sha: 'deadbeef1234' })
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result?.schema_version).toBe('2.3.1')
+    expect(result?.git_sha).toBe('deadbeef1234')
+  })
+
+  it('returns null for nullable columns that were not populated', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [makePersona()],
+      // voice_library, escalation, business_hours, connectors, scope all omitted
+    })
+    const result = await getCustomerConfig(db, ENTITY_ID)
+    expect(result?.voice_library).toBeNull()
+    expect(result?.escalation).toBeNull()
+    expect(result?.business_hours).toBeNull()
+    expect(result?.connectors).toBeNull()
+    expect(result?.scope).toBeNull()
+  })
+})
+
+describe('getActivePersona', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('returns null when no config row exists', async () => {
+    await seedEntity(db)
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when personas array is empty (degenerate but well-formed)', async () => {
+    await seedEntity(db)
+    await seedConfig(db, { personas: [] })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when every persona is archived', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [
+        makePersona({ slug: 'marcus', status: 'archived' }),
+        makePersona({ slug: 'casey', status: 'archived', name: 'Casey' }),
+      ],
+    })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result).toBeNull()
+  })
+
+  it('returns the single active persona at v1 (length-1 array)', async () => {
+    await seedEntity(db)
+    await seedConfig(db, { personas: [makePersona({ slug: 'marcus' })] })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result?.slug).toBe('marcus')
+    expect(result?.name).toBe('Marcus')
+  })
+
+  it('skips archived personas even when they appear before an active one', async () => {
+    await seedEntity(db)
+    await seedConfig(db, {
+      personas: [
+        makePersona({ slug: 'marcus-old', status: 'archived', name: 'Marcus Old' }),
+        makePersona({ slug: 'casey', status: 'active', name: 'Casey' }),
+      ],
+    })
+    const result = await getActivePersona(db, ENTITY_ID)
+    expect(result?.slug).toBe('casey')
+    expect(result?.name).toBe('Casey')
+  })
+})
+
+describe('customer_configs schema integrity', () => {
+  let db: D1Database
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('FK from entity_id to entities.id rejects an orphan insert', async () => {
+    // Insert with a non-existent entity_id should fail
+    await expect(seedConfig(db, { entity_id: 'no-such-entity' })).rejects.toThrow()
+  })
+
+  it('UNIQUE(customer_slug) rejects duplicate-slug insert across different entities', async () => {
+    await seedEntity(db)
+    await db
+      .prepare('INSERT INTO entities (id, org_id, name, slug) VALUES (?, ?, ?, ?)')
+      .bind('entity-other', ORG_ID, 'Other Firm', 'other-firm')
+      .run()
+
+    await seedConfig(db, { entity_id: ENTITY_ID, customer_slug: 'same-slug' })
+    await expect(
+      seedConfig(db, { entity_id: 'entity-other', customer_slug: 'same-slug' })
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Lands formal TypeScript signatures for every Platform PRD §7.2 capability interface, the adapter conformance harness that enforces ADR 0005 and PRD invariant #3 at the adapter layer, and a new PRD §7.2.1 documenting both. The Tech Lead's Phase-1 synthesis-round-1 signatures for PracticeManagement, Email, ESign, and CourtAccess are adopted verbatim; the remaining seven (Calendar, DocumentStorage, Payments, Accounting, IntakeCRM, CallTracking, InternalComms) are authored at the same level of detail.

This is the single biggest engineering-readiness blocker per synthesis-round-1 Theme 4 — adapter implementation cannot start without these contracts.

## Linked issue

Closes #791
Refs ADR 0005 (reviewer-as-sender), ADR 0006 (capability-adapter pattern)

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| platform-prd.md §7.2.1 (new) contains TypeScript signatures for all 11 interfaces | met | New §7.2.1 references the canonical TS source at `src/lib/ai-employee/capabilities/` with a per-interface summary table |
| Each interface includes: method signature, parameter types, return types, error cases | met | All 11 interfaces in `src/lib/ai-employee/capabilities/*.ts`; errors typed via `AdapterError` + `AdapterErrorCode` closed union in `types.ts` |
| Email Pattern A vs Pattern B decision made and documented | met | Pattern A locked per ADR 0005; PRD §7.2.1 records the decision and the rationale for rejecting Pattern B; `Email` interface has no `send` method; conformance harness blocks adapters that add one |
| Adapter conformance test contract per interface (basic invariants every adapter must satisfy) | met | `conformance.ts` defines 8 invariants + per-capability `BANNED_METHOD_NAMES`; 24 tests verify the harness behavior |
| Reference from law-firm-prd.md skill catalog (each skill declares which capabilities it requires) | deferred | Skill catalog still references the un-specified pre-7.2.1 capability names; declaring per-skill capability requirements is a separate doc pass |
| At least one concrete adapter implementation (e.g., Microsoft Graph for Email) demonstrates the pattern | deferred | Vendor adapter implementations are separate per-vendor PRs (filed against the connectors component). This PR establishes the contract every adapter PR will conform to |

## Deferred ACs

- **AC:** Reference from law-firm-prd.md skill catalog (each skill declares which capabilities it requires)
  - **Why deferred:** Cross-document doc pass — touches every skill row in the catalog. Separate from the contracts themselves; lands when the skill catalog gets its next coherent edit
  - **Tracked in:** to file post-merge against the `skills` component
- **AC:** Concrete adapter (e.g., Microsoft Graph for Email)
  - **Why deferred:** Adapter implementations are per-vendor PRs. The contract this PR establishes is what each adapter PR conforms to
  - **Tracked in:** issues already exist per connector (#851 Filevine, etc.); Microsoft Graph adapter to be filed

## Test plan

- [x] `npm run verify` passes (0 errors, 46 warnings — all pre-existing)
- [x] 24 unit tests in `tests/capability-conformance.test.ts` cover:
  - `CONFORMANCE_INVARIANTS` exposes every invariant the harness claims to check
  - `BANNED_METHOD_NAMES` enumerates every capability (no silent skips)
  - `makeAdapterErrorCodes` returns the closed AdapterErrorCode set
  - `inspectAdapter` passes vanilla adapters
  - `inspectAdapter` fails adapters that expose `Email.send` / `ESign.send_envelope` / `Calendar.send_invitation` / `DocumentStorage.share_document`
  - Multiple banned methods reported in one pass
  - `NO_AUTONOMOUS_TRUST_TRANSFER` marked N/A for non-Payments adapters
  - `NO_AUTONOMOUS_TRUST_TRANSFER` fails Payments adapters with `trust_disbursement` / `initiate_transfer`
  - `CAPABILITY_SET_HONEST` flags unknown capability names
  - `AdapterError` preserves code, adapter, capability, and cause
  - `assertCapabilitySetWellFormed` rejects malformed sets (empty adapter, empty supported_methods, supported/unsupported overlap)
  - `assertHealthStatusWellFormed` rejects unknown status, accepts unhealthy with null last_ok_at

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses — no endpoints, type definitions + a synchronous harness
- [x] Input validation on new endpoints — no new endpoints
- [x] Parameterized queries for any SQL — no SQL
- [x] Auth required on new endpoints — no new endpoints
- [x] No internal IDs that enable enumeration

## Feature Impact

None — adds the capability-layer source files, the conformance harness, the test suite, and a new PRD section. No runtime behavior changes; no existing flows touched.