### PR TITLE
feat(ai-employee): OAuth callback endpoint (#879)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -147,6 +147,26 @@ declare namespace Cloudflare {
      * standard wrangler secret bulk pattern documented in CLAUDE.md.
      */
     CLERK_SECRET_KEY?: string
+    /**
+     * Microsoft Graph OAuth 2.0 client ID and secret. Used by the
+     * ai-employee OAuth callback (issue #879) to exchange authorization
+     * codes for tokens during connector consent flows. Issued by an
+     * Azure AD app registration whose redirect URI list includes
+     * `${ADMIN_BASE_URL}/api/oauth/callback`.
+     */
+    MICROSOFT_GRAPH_CLIENT_ID?: string
+    MICROSOFT_GRAPH_CLIENT_SECRET?: string
+    /**
+     * HMAC-SHA256 signing key for stateless OAuth state parameters used
+     * by /api/oauth/callback (issue #879, ai-employee connector consent).
+     * 32 random bytes, base64-encoded. Generate with
+     * `openssl rand -base64 32`. Rotation: bump the secret in Workers
+     * env; in-flight states issued under the old key fail validation at
+     * the callback and the reviewer simply re-initiates consent. No
+     * grace window required because state TTL is 10 minutes. See
+     * src/lib/oauth/state.ts.
+     */
+    OAUTH_STATE_SIGNING_KEY?: string
   }
 }
 

--- a/src/lib/oauth/audit.ts
+++ b/src/lib/oauth/audit.ts
@@ -1,0 +1,55 @@
+/**
+ * OAuth audit event emission.
+ *
+ * Every invocation of /api/oauth/callback emits an audit event:
+ *
+ *   - `oauth-callback.token-issued`  — state validated, token exchanged
+ *     and accepted by the store.
+ *   - `oauth-callback.token-rejected` — state invalid, provider unknown,
+ *     reviewer mismatch, exchange failed, or store rejected the token.
+ *
+ * v1 ships a console-only writer. The audit log persistence layer is
+ * tracked in issue #891 (D1 audit_log table per
+ * docs/specs/ai-employee/d1-schema.md). When #891 lands, swap
+ * `emitAuditEvent` to write rows there. The shape of the event payload
+ * is stable so the swap is a one-line change inside this file.
+ *
+ * Token material is NEVER included in audit events. Only the metadata
+ * fields below.
+ */
+
+export type OAuthAuditAction = 'token-issued' | 'token-rejected'
+
+export interface OAuthAuditEvent {
+  skill: 'oauth-callback'
+  action: OAuthAuditAction
+  customer_id: string | null
+  provider: string | null
+  reviewer_id: string | null
+  reason?: string
+  ts: string
+}
+
+export interface EmitOAuthAuditInput {
+  action: OAuthAuditAction
+  customer_id: string | null
+  provider: string | null
+  reviewer_id: string | null
+  reason?: string
+}
+
+export function emitAuditEvent(input: EmitOAuthAuditInput): Promise<void> {
+  const event: OAuthAuditEvent = {
+    skill: 'oauth-callback',
+    action: input.action,
+    customer_id: input.customer_id,
+    provider: input.provider,
+    reviewer_id: input.reviewer_id,
+    ts: new Date().toISOString(),
+  }
+  if (input.reason) event.reason = input.reason
+
+  // TODO(#891): persist to D1 audit_log table once that issue lands.
+  console.log('[oauth/audit]', JSON.stringify(event))
+  return Promise.resolve()
+}

--- a/src/lib/oauth/providers.ts
+++ b/src/lib/oauth/providers.ts
@@ -1,0 +1,166 @@
+/**
+ * OAuth provider registry for AI Employee connector consent flows.
+ *
+ * Each provider entry knows how to exchange an authorization code for an
+ * access + refresh token pair on its issuer. The callback at
+ * /api/oauth/callback dispatches by provider slug after validating the
+ * signed state parameter.
+ *
+ * Provider slugs match the `connectors:` value shape in customer.yaml
+ * (see docs/specs/ai-employee/customer-yaml-schema.md and the per-connector
+ * oauth_scopes.json files in ai-employee/connectors/). v1 covers the
+ * Phase 1 connectors that ship with first customer-zero: Microsoft Graph
+ * and Google Workspace. Subsequent providers (Clio, LawPay, QuickBooks,
+ * Slack, etc.) layer in by extending PROVIDERS without touching the
+ * callback endpoint.
+ *
+ * Token responses are normalized to the shape described in ADR 0010 §
+ * "Storage shape" so the store interface in src/lib/oauth/store.ts has a
+ * single contract regardless of which provider issued the token.
+ *
+ * Client secrets are read from Cloudflare Workers env at exchange time.
+ * Secrets are never logged. Error payloads from the issuer are passed to
+ * the caller as opaque strings (no token material), so the callback can
+ * surface a short error code to the dashboard without exposing details
+ * upstream.
+ */
+
+import { env } from 'cloudflare:workers'
+
+export interface ProviderTokenResponse {
+  /** Short-lived access token. */
+  access_token: string
+  /** Long-lived refresh token, if the provider issued one. */
+  refresh_token: string | null
+  /** Space-separated scopes the issuer actually granted. */
+  scopes: string
+  /** ISO 8601 timestamp at which `access_token` expires. */
+  expires_at: string
+  /** ISO 8601 timestamp at which this token was obtained. */
+  obtained_at: string
+}
+
+export interface OAuthProvider {
+  /** Slug used in customer.yaml `connectors:` and the state parameter. */
+  slug: string
+  /** Human label for logs and dashboard surfaces. */
+  label: string
+  /** Issuer token endpoint. */
+  token_url: string
+  /**
+   * Exchange an authorization code for tokens. Implementations call
+   * `token_url` with `grant_type=authorization_code`, normalize the
+   * response to `ProviderTokenResponse`, and throw on non-2xx.
+   */
+  exchange_code(args: { code: string; redirect_uri: string }): Promise<ProviderTokenResponse>
+}
+
+const MS_GRAPH_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+
+interface RawTokenJson {
+  access_token?: unknown
+  refresh_token?: unknown
+  scope?: unknown
+  expires_in?: unknown
+}
+
+async function postFormForToken(
+  tokenUrl: string,
+  body: URLSearchParams,
+  providerLabel: string
+): Promise<ProviderTokenResponse> {
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    // Issuer error bodies are not logged with token material — they only
+    // contain error codes and descriptions per the OAuth 2 RFC.
+    throw new Error(`${providerLabel} token exchange failed (${response.status}): ${text}`)
+  }
+
+  const raw: RawTokenJson = await response.json()
+
+  if (typeof raw.access_token !== 'string' || raw.access_token.length === 0) {
+    throw new Error(`${providerLabel} token exchange returned no access_token`)
+  }
+
+  const expiresInSec = typeof raw.expires_in === 'number' ? raw.expires_in : 3600
+  const now = Date.now()
+  return {
+    access_token: raw.access_token,
+    refresh_token: typeof raw.refresh_token === 'string' ? raw.refresh_token : null,
+    scopes: typeof raw.scope === 'string' ? raw.scope : '',
+    expires_at: new Date(now + expiresInSec * 1000).toISOString(),
+    obtained_at: new Date(now).toISOString(),
+  }
+}
+
+const microsoftGraph: OAuthProvider = {
+  slug: 'microsoft-graph',
+  label: 'Microsoft Graph',
+  token_url: MS_GRAPH_TOKEN_URL,
+  async exchange_code({ code, redirect_uri }) {
+    const clientId = env.MICROSOFT_GRAPH_CLIENT_ID
+    const clientSecret = env.MICROSOFT_GRAPH_CLIENT_SECRET
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        'Microsoft Graph client credentials are not configured (MICROSOFT_GRAPH_CLIENT_ID / MICROSOFT_GRAPH_CLIENT_SECRET).'
+      )
+    }
+    return postFormForToken(
+      MS_GRAPH_TOKEN_URL,
+      new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri,
+        grant_type: 'authorization_code',
+      }),
+      microsoftGraph.label
+    )
+  },
+}
+
+const googleWorkspace: OAuthProvider = {
+  slug: 'google-workspace',
+  label: 'Google Workspace',
+  token_url: GOOGLE_TOKEN_URL,
+  async exchange_code({ code, redirect_uri }) {
+    const clientId = env.GOOGLE_CLIENT_ID
+    const clientSecret = env.GOOGLE_CLIENT_SECRET
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        'Google Workspace client credentials are not configured (GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET).'
+      )
+    }
+    return postFormForToken(
+      GOOGLE_TOKEN_URL,
+      new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri,
+        grant_type: 'authorization_code',
+      }),
+      googleWorkspace.label
+    )
+  },
+}
+
+const PROVIDERS: Record<string, OAuthProvider> = {
+  [microsoftGraph.slug]: microsoftGraph,
+  [googleWorkspace.slug]: googleWorkspace,
+}
+
+export function getOAuthProvider(slug: string): OAuthProvider | null {
+  return PROVIDERS[slug] ?? null
+}
+
+export function listOAuthProviderSlugs(): string[] {
+  return Object.keys(PROVIDERS)
+}

--- a/src/lib/oauth/state.ts
+++ b/src/lib/oauth/state.ts
@@ -1,0 +1,181 @@
+/**
+ * OAuth state parameter — signed, stateless, single-use-by-expiry.
+ *
+ * The state parameter on an OAuth authorize URL must round-trip back to the
+ * callback unchanged. We use it for two things:
+ *
+ *   1. CSRF binding — the value is HMAC-signed with a server-side secret,
+ *      so the callback can refuse a state it did not issue.
+ *   2. Context carry — we pack `(customer_id, provider, reviewer_id, nonce,
+ *      expiry)` into the state itself so the callback knows which customer
+ *      and provider this consent was issued for, and which reviewer
+ *      initiated the flow.
+ *
+ * Why not a D1 row keyed by an opaque state? D1 single-use states (the
+ * existing `src/lib/db/oauth-states.ts` pattern) serialize on every flow
+ * across all customers. For multi-tenant AI Employee provisioning we expect
+ * to scale this beyond what a single shared table comfortably owns, and we
+ * already need a server-side secret for downstream token handling. A signed
+ * stateless token is the natural shape.
+ *
+ * Replay protection: the callback caller is responsible for binding the
+ * decoded `reviewer_id` to the currently authenticated reviewer (Clerk or
+ * magic-link session). A leaked state with a valid signature but for the
+ * wrong reviewer must be rejected. Expiry is 10 minutes from issue.
+ *
+ * Encoding format (matches src/lib/booking/conversation-token.ts):
+ *
+ *   `<base64url(json-payload)>.<base64url(hmac-sha256)>`
+ *
+ * Signing key: `OAUTH_STATE_SIGNING_KEY` env var, base64-encoded raw bytes.
+ * Generate with `openssl rand -base64 32`. Rotation: bump the key in
+ * Cloudflare Workers secrets; any in-flight authorize redirects issued
+ * under the old key will fail validation at callback time and the
+ * reviewer can simply re-initiate consent. No grace window — short TTL
+ * makes rotation safe.
+ */
+
+import { env } from 'cloudflare:workers'
+
+const ALGORITHM: HmacImportParams = { name: 'HMAC', hash: 'SHA-256' }
+const ENCODER = new TextEncoder()
+const SCHEMA_VERSION = 1
+
+export const DEFAULT_STATE_TTL_SECONDS = 10 * 60
+
+export interface OAuthStatePayload {
+  v: number
+  customer_id: string
+  provider: string
+  reviewer_id: string
+  nonce: string
+  exp: number
+}
+
+export interface IssueOAuthStateInput {
+  customer_id: string
+  provider: string
+  reviewer_id: string
+  ttl_seconds?: number
+}
+
+export type VerifyOAuthStateResult =
+  | { ok: true; payload: OAuthStatePayload }
+  | { ok: false; error: 'malformed' | 'bad_signature' | 'expired' | 'unknown_version' }
+
+export async function issueOAuthState(input: IssueOAuthStateInput): Promise<string> {
+  const key = await importSigningKey()
+  const ttl = input.ttl_seconds ?? DEFAULT_STATE_TTL_SECONDS
+  const exp = Math.floor(Date.now() / 1000) + ttl
+
+  const payload: OAuthStatePayload = {
+    v: SCHEMA_VERSION,
+    customer_id: input.customer_id,
+    provider: input.provider,
+    reviewer_id: input.reviewer_id,
+    nonce: crypto.randomUUID(),
+    exp,
+  }
+
+  const payloadB64 = base64UrlEncode(ENCODER.encode(JSON.stringify(payload)))
+  const sigBuf = await crypto.subtle.sign(ALGORITHM, key, ENCODER.encode(payloadB64))
+  const sigB64 = base64UrlEncode(new Uint8Array(sigBuf))
+  return `${payloadB64}.${sigB64}`
+}
+
+function splitState(state: string): { payloadB64: string; sigB64: string } | null {
+  if (typeof state !== 'string' || state.length === 0) return null
+  const dot = state.indexOf('.')
+  if (dot <= 0 || dot === state.length - 1) return null
+  return { payloadB64: state.slice(0, dot), sigB64: state.slice(dot + 1) }
+}
+
+function decodePayload(payloadB64: string): OAuthStatePayload | null {
+  try {
+    const json = new TextDecoder().decode(base64UrlDecode(payloadB64))
+    return JSON.parse(json) as OAuthStatePayload
+  } catch {
+    return null
+  }
+}
+
+function payloadShapeOk(payload: OAuthStatePayload): boolean {
+  return (
+    typeof payload.customer_id === 'string' &&
+    typeof payload.provider === 'string' &&
+    typeof payload.reviewer_id === 'string' &&
+    typeof payload.nonce === 'string' &&
+    payload.customer_id.length > 0 &&
+    payload.provider.length > 0 &&
+    payload.reviewer_id.length > 0 &&
+    payload.nonce.length > 0
+  )
+}
+
+export async function verifyOAuthState(state: string): Promise<VerifyOAuthStateResult> {
+  const parts = splitState(state)
+  if (!parts) return { ok: false, error: 'malformed' }
+
+  let sigBytes: Uint8Array
+  try {
+    sigBytes = base64UrlDecode(parts.sigB64)
+  } catch {
+    return { ok: false, error: 'malformed' }
+  }
+
+  const key = await importSigningKey()
+  const valid = await crypto.subtle.verify(
+    ALGORITHM,
+    key,
+    sigBytes as unknown as ArrayBuffer,
+    ENCODER.encode(parts.payloadB64)
+  )
+  if (!valid) return { ok: false, error: 'bad_signature' }
+
+  const payload = decodePayload(parts.payloadB64)
+  if (!payload) return { ok: false, error: 'malformed' }
+  if (payload.v !== SCHEMA_VERSION) return { ok: false, error: 'unknown_version' }
+
+  const now = Math.floor(Date.now() / 1000)
+  if (typeof payload.exp !== 'number' || payload.exp < now) {
+    return { ok: false, error: 'expired' }
+  }
+
+  if (!payloadShapeOk(payload)) return { ok: false, error: 'malformed' }
+
+  return { ok: true, payload }
+}
+
+async function importSigningKey(): Promise<CryptoKey> {
+  const raw = env.OAUTH_STATE_SIGNING_KEY
+  if (!raw || typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error(
+      'OAUTH_STATE_SIGNING_KEY is not configured. Set it in wrangler env (32 random bytes, base64-encoded) before issuing OAuth states.'
+    )
+  }
+  let bin: string
+  try {
+    bin = atob(raw)
+  } catch {
+    throw new Error('OAUTH_STATE_SIGNING_KEY is not valid base64.')
+  }
+  const keyBytes = Uint8Array.from(bin, (c) => c.charCodeAt(0))
+  return crypto.subtle.importKey('raw', keyBytes, ALGORITHM, false, ['sign', 'verify'])
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  const b64 = btoa(bin)
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/')
+  const padLen = (4 - (padded.length % 4)) % 4
+  const b64 = padded + '='.repeat(padLen)
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -1,0 +1,81 @@
+/**
+ * OAuth token storage interface.
+ *
+ * Per [ADR 0010](../../../docs/adr/0010-per-customer-oauth-token-storage.md),
+ * customer-side OAuth tokens (Gmail, MS Graph, etc.) live on the
+ * customer's per-Machine Fly volume at `/opt/data/oauth/<provider>.json`,
+ * NOT in Infisical and NOT in a shared store on this Worker. The Worker
+ * receives the OAuth callback (because the redirect URI must be a
+ * publicly addressable, TLS-fronted endpoint) but it does not own the
+ * token. Its job is to relay the token to the customer's Fly Machine.
+ *
+ * Storage interface contract:
+ *
+ *   The Worker POSTs the token payload to an authenticated control-plane
+ *   endpoint on the customer's Hermes Machine (private network or signed
+ *   request, TBD with per-Machine wiring in #850 / #878 follow-ons), and
+ *   the Machine writes `/opt/data/oauth/<provider>.json` atomically per
+ *   ADR 0010 § "Storage shape". The Worker never holds the token in
+ *   memory longer than the duration of the relay.
+ *
+ * Why per-Machine HTTP relay rather than direct volume write: Cloudflare
+ * Workers do not have filesystem access to Fly volumes (different
+ * platforms, different trust boundaries). The Machine is the only thing
+ * with the volume mounted. ADR 0010's "Workers can't do that" point is
+ * resolved by treating the Worker as a thin OAuth front door that hands
+ * the token off; the Machine owns persistence.
+ *
+ * v1 status: the per-Machine relay endpoint and the customer registry it
+ * needs (Machine hostname + auth token per customer_id) are not yet
+ * wired. This file ships the interface plus a no-op implementation that
+ * records the storage intent in the audit log and returns success. The
+ * no-op lets the callback path be exercised end-to-end (state issuance,
+ * provider exchange, dashboard redirect) without requiring a real
+ * Hermes Machine to be running. Follow-on issue: TODO #879-follow-on
+ * (file when Hermes Machine control plane lands per #850).
+ */
+
+import type { ProviderTokenResponse } from './providers.js'
+
+export interface StoreTokenInput {
+  customer_id: string
+  provider: string
+  reviewer_id: string
+  token: ProviderTokenResponse
+}
+
+export type StoreTokenResult =
+  | { ok: true }
+  | { ok: false; reason: 'unavailable' | 'rejected' | 'unknown_customer' | 'network' }
+
+export interface OAuthTokenStore {
+  store(input: StoreTokenInput): Promise<StoreTokenResult>
+}
+
+/**
+ * No-op token store for v1. Records the storage attempt to console (with
+ * NO token material) and returns success so the callback redirect can
+ * complete. Replaced by `createMachineRelayStore` once the Hermes
+ * Machine control plane endpoints are available.
+ *
+ * This is deliberately a separate symbol from the interface so the
+ * eventual swap to a real implementation is a one-line callback edit.
+ */
+export function createNoOpTokenStore(): OAuthTokenStore {
+  return {
+    store(input) {
+      console.warn(
+        `[oauth/store] no-op store: token for customer=${input.customer_id} provider=${input.provider} reviewer=${input.reviewer_id} accepted but not persisted. Wire the Hermes Machine relay (ADR 0010, follow-on to #879) before going to production.`
+      )
+      return Promise.resolve({ ok: true })
+    },
+  }
+}
+
+/**
+ * Default store selection for the callback endpoint. Returns the no-op
+ * store until the Machine relay lands; callers should not need to know.
+ */
+export function getDefaultTokenStore(): OAuthTokenStore {
+  return createNoOpTokenStore()
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -79,7 +79,8 @@ function handleSubdomainRewrite(
     !pathname.startsWith('/admin') &&
     !pathname.startsWith('/api/admin') &&
     !pathname.startsWith('/auth') &&
-    !pathname.startsWith('/api/auth')
+    !pathname.startsWith('/api/auth') &&
+    !pathname.startsWith('/api/oauth')
   ) {
     const adminPath = pathname === '/' ? '/admin' : `/admin${pathname}`
     return context.rewrite(new Request(new URL(adminPath, context.url), context.request))

--- a/src/pages/api/oauth/callback.ts
+++ b/src/pages/api/oauth/callback.ts
@@ -1,0 +1,231 @@
+import type { APIRoute } from 'astro'
+import { verifyOAuthState, type OAuthStatePayload } from '../../../lib/oauth/state.js'
+import { getOAuthProvider, type ProviderTokenResponse } from '../../../lib/oauth/providers.js'
+import { getDefaultTokenStore } from '../../../lib/oauth/store.js'
+import { emitAuditEvent } from '../../../lib/oauth/audit.js'
+import { requireAdminBaseUrl } from '../../../lib/config/app-url.js'
+import { env } from 'cloudflare:workers'
+
+/**
+ * GET /api/oauth/callback
+ *
+ * Unified OAuth callback for AI Employee connector consent flows
+ * (issue #879, spec docs/specs/ai-employee/oauth-lifecycle.md,
+ * storage decision docs/adr/0010-per-customer-oauth-token-storage.md).
+ *
+ * Lives on the admin subdomain. Provider apps are registered with their
+ * redirect URI list pointing at `${ADMIN_BASE_URL}/api/oauth/callback`
+ * (a single URL for all providers — provider is carried in the state).
+ *
+ * Flow:
+ *
+ *   1. Verify state parameter signature + expiry (HMAC-SHA256, 10 min TTL).
+ *   2. Verify the state's `reviewer_id` matches the currently
+ *      authenticated admin session. This is the CSRF defense — a
+ *      leaked state is useless without the reviewer's cookie.
+ *   3. Dispatch to the provider registry for token exchange.
+ *   4. Hand the token to the per-customer store (delegates to the
+ *      customer's Fly Machine per ADR 0010; v1 is a no-op pending
+ *      Hermes Machine control plane wiring).
+ *   5. Audit-log the outcome (writer is a no-op until #891 lands).
+ *   6. Redirect the reviewer to the admin connectors page with a
+ *      `status=connected` or `status=failed&reason=<short>` query
+ *      string. The dashboard page consumes these params; this endpoint
+ *      does not depend on the page existing yet.
+ *
+ * Failure modes redirect with short reason codes:
+ *   provider_error, missing_params, bad_state, expired_state,
+ *   reviewer_mismatch, unknown_provider, exchange_failed, store_failed.
+ *
+ * No token material is logged, returned in response bodies, or placed
+ * in URLs. Issuer error payloads stay on the server side.
+ */
+
+type RedirectFn = (path: string, status?: 300 | 301 | 302 | 303 | 304 | 307 | 308) => Response
+
+interface CallbackCtx {
+  redirect: RedirectFn
+  adminBase: string
+}
+
+function buildResultUrl(
+  adminBase: string,
+  customerSlug: string,
+  params: Record<string, string>
+): string {
+  const url = new URL(`${adminBase}/admin/customers/${encodeURIComponent(customerSlug)}/connectors`)
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return url.toString()
+}
+
+async function reject(
+  ctx: CallbackCtx,
+  reason: string,
+  meta: {
+    customer_id: string | null
+    provider: string | null
+    reviewer_id: string | null
+    auditReason?: string
+  }
+): Promise<Response> {
+  await emitAuditEvent({
+    action: 'token-rejected',
+    customer_id: meta.customer_id,
+    provider: meta.provider,
+    reviewer_id: meta.reviewer_id,
+    reason: meta.auditReason ?? reason,
+  })
+  const params: Record<string, string> = { status: 'failed', reason }
+  if (meta.provider) params.provider = meta.provider
+  return ctx.redirect(buildResultUrl(ctx.adminBase, meta.customer_id ?? 'unknown', params), 302)
+}
+
+async function handleProviderError(
+  ctx: CallbackCtx,
+  url: URL,
+  providerError: string,
+  providerErrorDescription: string | null
+): Promise<Response> {
+  // Provider rejected the consent (user denied, scope mismatch, etc).
+  // Try to read state for audit context, but don't fail the failure
+  // path on a missing or invalid state.
+  const rawState = url.searchParams.get('state')
+  let customer: string | null = null
+  let provider: string | null = null
+  if (rawState) {
+    const result = await verifyOAuthState(rawState)
+    if (result.ok) {
+      customer = result.payload.customer_id
+      provider = result.payload.provider
+    }
+  }
+  const detail = providerErrorDescription ? `:${providerErrorDescription}` : ''
+  return reject(ctx, 'provider_error', {
+    customer_id: customer,
+    provider,
+    reviewer_id: null,
+    auditReason: `provider_error:${providerError}${detail}`,
+  })
+}
+
+interface ValidatedState {
+  payload: OAuthStatePayload
+}
+
+async function validateStateOrReject(
+  ctx: CallbackCtx,
+  stateParam: string
+): Promise<Response | ValidatedState> {
+  const stateResult = await verifyOAuthState(stateParam)
+  if (stateResult.ok) return { payload: stateResult.payload }
+  const reason = stateResult.error === 'expired' ? 'expired_state' : 'bad_state'
+  return reject(ctx, reason, {
+    customer_id: null,
+    provider: null,
+    reviewer_id: null,
+    auditReason: `${reason}:${stateResult.error}`,
+  })
+}
+
+async function exchangeOrReject(
+  ctx: CallbackCtx,
+  payload: OAuthStatePayload,
+  code: string
+): Promise<Response | ProviderTokenResponse> {
+  const provider = getOAuthProvider(payload.provider)
+  if (!provider) {
+    return reject(ctx, 'unknown_provider', {
+      customer_id: payload.customer_id,
+      provider: payload.provider,
+      reviewer_id: payload.reviewer_id,
+    })
+  }
+  try {
+    return await provider.exchange_code({
+      code,
+      redirect_uri: `${ctx.adminBase}/api/oauth/callback`,
+    })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'unknown'
+    console.error(`[oauth/callback] exchange_failed provider=${payload.provider}: ${detail}`)
+    return reject(ctx, 'exchange_failed', {
+      customer_id: payload.customer_id,
+      provider: payload.provider,
+      reviewer_id: payload.reviewer_id,
+    })
+  }
+}
+
+function reviewerMatches(
+  session: { userId: string; role: string } | null | undefined,
+  reviewer_id: string
+): boolean {
+  return Boolean(session && session.role === 'admin' && session.userId === reviewer_id)
+}
+
+export const GET: APIRoute = async ({ request, redirect, locals }) => {
+  const url = new URL(request.url)
+  const ctx: CallbackCtx = { redirect, adminBase: requireAdminBaseUrl(env) }
+
+  const providerError = url.searchParams.get('error')
+  if (providerError) {
+    return handleProviderError(ctx, url, providerError, url.searchParams.get('error_description'))
+  }
+
+  const code = url.searchParams.get('code')
+  const stateParam = url.searchParams.get('state')
+  if (!code || !stateParam) {
+    return reject(ctx, 'missing_params', {
+      customer_id: null,
+      provider: null,
+      reviewer_id: null,
+    })
+  }
+
+  const stateOrFail = await validateStateOrReject(ctx, stateParam)
+  if (stateOrFail instanceof Response) return stateOrFail
+
+  const { customer_id, provider: providerSlug, reviewer_id } = stateOrFail.payload
+
+  if (!reviewerMatches(locals.session, reviewer_id)) {
+    return reject(ctx, 'reviewer_mismatch', {
+      customer_id,
+      provider: providerSlug,
+      reviewer_id,
+    })
+  }
+
+  const tokenOrFail = await exchangeOrReject(ctx, stateOrFail.payload, code)
+  if (tokenOrFail instanceof Response) return tokenOrFail
+
+  const storeResult = await getDefaultTokenStore().store({
+    customer_id,
+    provider: providerSlug,
+    reviewer_id,
+    token: tokenOrFail,
+  })
+
+  if (!storeResult.ok) {
+    return reject(ctx, 'store_failed', {
+      customer_id,
+      provider: providerSlug,
+      reviewer_id,
+      auditReason: `store_failed:${storeResult.reason}`,
+    })
+  }
+
+  await emitAuditEvent({
+    action: 'token-issued',
+    customer_id,
+    provider: providerSlug,
+    reviewer_id,
+  })
+
+  return redirect(
+    buildResultUrl(ctx.adminBase, customer_id, {
+      status: 'connected',
+      provider: providerSlug,
+    }),
+    302
+  )
+}

--- a/tests/oauth-callback.test.ts
+++ b/tests/oauth-callback.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+
+import {
+  issueOAuthState,
+  verifyOAuthState,
+  DEFAULT_STATE_TTL_SECONDS,
+} from '../src/lib/oauth/state'
+import { getOAuthProvider, listOAuthProviderSlugs } from '../src/lib/oauth/providers'
+import { GET as oauthCallback } from '../src/pages/api/oauth/callback'
+
+const SIGNING_KEY_B64 = 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE='
+const ALT_SIGNING_KEY_B64 = 'YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI='
+
+const ADMIN_BASE = 'https://admin.smd.services'
+
+function clearEnv(): void {
+  for (const key of Object.keys(testEnv)) {
+    delete (testEnv as unknown as Record<string, unknown>)[key]
+  }
+}
+
+function applyDefaultEnv(): void {
+  Object.assign(testEnv, {
+    ADMIN_BASE_URL: ADMIN_BASE,
+    OAUTH_STATE_SIGNING_KEY: SIGNING_KEY_B64,
+    GOOGLE_CLIENT_ID: 'google-client-id',
+    GOOGLE_CLIENT_SECRET: 'google-client-secret',
+    MICROSOFT_GRAPH_CLIENT_ID: 'msgraph-client-id',
+    MICROSOFT_GRAPH_CLIENT_SECRET: 'msgraph-client-secret',
+  })
+}
+
+function redirect(url: string, status?: number): Response {
+  return new Response(null, {
+    status: status ?? 302,
+    headers: { Location: url },
+  })
+}
+
+async function invoke(opts: {
+  url: string
+  session?: { userId: string; role: string } | null
+}): Promise<Response> {
+  return await oauthCallback({
+    request: new Request(opts.url),
+    redirect,
+    locals: {
+      session: opts.session ?? null,
+    },
+  } as unknown as Parameters<typeof oauthCallback>[0])
+}
+
+function parseRedirect(response: Response): URL {
+  const location = response.headers.get('Location')
+  if (!location) throw new Error('redirect response missing Location header')
+  return new URL(location)
+}
+
+describe('oauth/state', () => {
+  beforeEach(() => {
+    applyDefaultEnv()
+  })
+  afterEach(() => {
+    clearEnv()
+  })
+
+  it('round-trips a valid state', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const result = await verifyOAuthState(state)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.payload.customer_id).toBe('acme')
+      expect(result.payload.provider).toBe('google-workspace')
+      expect(result.payload.reviewer_id).toBe('user-1')
+      expect(result.payload.nonce).toMatch(/^[0-9a-f-]{36}$/)
+      expect(result.payload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000))
+    }
+  })
+
+  it('rejects a tampered payload (bad signature)', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const [payloadB64, sigB64] = state.split('.')
+    const tampered = `${payloadB64}A.${sigB64}`
+    const result = await verifyOAuthState(tampered)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      // Tampering the payload changes the input to HMAC verify; signature
+      // no longer matches.
+      expect(result.error).toBe('bad_signature')
+    }
+  })
+
+  it('rejects a state signed with a different key', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    // Rotate the signing key. The previously-issued state should now
+    // fail signature verification.
+    Object.assign(testEnv, { OAUTH_STATE_SIGNING_KEY: ALT_SIGNING_KEY_B64 })
+    const result = await verifyOAuthState(state)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('bad_signature')
+  })
+
+  it('rejects an expired state', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+      ttl_seconds: 1,
+    })
+    // Advance wall clock past expiry.
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 2_000)
+    try {
+      const result = await verifyOAuthState(state)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error).toBe('expired')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects a malformed state', async () => {
+    const result = await verifyOAuthState('not-a-state')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('malformed')
+  })
+
+  it('defaults to a 10-minute TTL', () => {
+    expect(DEFAULT_STATE_TTL_SECONDS).toBe(600)
+  })
+
+  it('refuses to issue a state when the signing key is missing', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).OAUTH_STATE_SIGNING_KEY
+    await expect(
+      issueOAuthState({
+        customer_id: 'acme',
+        provider: 'google-workspace',
+        reviewer_id: 'user-1',
+      })
+    ).rejects.toThrow(/OAUTH_STATE_SIGNING_KEY/)
+  })
+})
+
+describe('oauth/providers registry', () => {
+  it('exposes microsoft-graph and google-workspace by their canonical slugs', () => {
+    const slugs = listOAuthProviderSlugs()
+    expect(slugs).toContain('microsoft-graph')
+    expect(slugs).toContain('google-workspace')
+  })
+
+  it('returns null for an unknown slug', () => {
+    expect(getOAuthProvider('not-a-provider')).toBeNull()
+  })
+
+  it('points microsoft-graph at the v2 login endpoint', () => {
+    const provider = getOAuthProvider('microsoft-graph')
+    expect(provider).not.toBeNull()
+    expect(provider?.token_url).toBe('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+  })
+
+  it('points google-workspace at the oauth2.googleapis.com token endpoint', () => {
+    const provider = getOAuthProvider('google-workspace')
+    expect(provider).not.toBeNull()
+    expect(provider?.token_url).toBe('https://oauth2.googleapis.com/token')
+  })
+})
+
+describe('oauth/callback endpoint', () => {
+  const ORIGINAL_FETCH = globalThis.fetch
+
+  beforeEach(() => {
+    applyDefaultEnv()
+  })
+
+  afterEach(() => {
+    clearEnv()
+    globalThis.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  it('redirects with provider_error reason when the provider returns an error', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?error=access_denied&error_description=user+declined&state=${encodeURIComponent(state)}`
+
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    expect(response.status).toBe(302)
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('status')).toBe('failed')
+    expect(location.searchParams.get('reason')).toBe('provider_error')
+    expect(location.searchParams.get('provider')).toBe('google-workspace')
+    expect(location.pathname).toBe('/admin/customers/acme/connectors')
+  })
+
+  it('redirects with missing_params when code or state is absent', async () => {
+    const response = await invoke({
+      url: `${ADMIN_BASE}/api/oauth/callback`,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    expect(response.status).toBe(302)
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('status')).toBe('failed')
+    expect(location.searchParams.get('reason')).toBe('missing_params')
+  })
+
+  it('redirects with bad_state when the state signature does not verify', async () => {
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=bogus`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    expect(response.status).toBe(302)
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('status')).toBe('failed')
+    expect(location.searchParams.get('reason')).toBe('bad_state')
+  })
+
+  it('redirects with expired_state when the state has expired', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+      ttl_seconds: 1,
+    })
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 2_000)
+    try {
+      const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+      const response = await invoke({
+        url,
+        session: { userId: 'user-1', role: 'admin' },
+      })
+      expect(response.status).toBe(302)
+      const location = parseRedirect(response)
+      expect(location.searchParams.get('reason')).toBe('expired_state')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('redirects with reviewer_mismatch when the session reviewer does not match the state', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-2', role: 'admin' },
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('reviewer_mismatch')
+  })
+
+  it('redirects with reviewer_mismatch when no session is present', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: null,
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('reviewer_mismatch')
+  })
+
+  it('redirects with reviewer_mismatch when the session role is not admin', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'client' },
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('reviewer_mismatch')
+  })
+
+  it('redirects with unknown_provider when the state targets an unregistered provider', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'not-a-real-provider',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('unknown_provider')
+  })
+
+  it('redirects with exchange_failed when the provider rejects the code', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 })
+    )
+
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('exchange_failed')
+  })
+
+  it('redirects to the success page when state, reviewer, and exchange all pass', async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'access-xxx',
+            refresh_token: 'refresh-yyy',
+            scope: 'https://www.googleapis.com/auth/gmail.readonly',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    )
+
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'google-workspace',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    expect(response.status).toBe(302)
+    const location = parseRedirect(response)
+    expect(location.pathname).toBe('/admin/customers/acme/connectors')
+    expect(location.searchParams.get('status')).toBe('connected')
+    expect(location.searchParams.get('provider')).toBe('google-workspace')
+  })
+
+  it('dispatches to microsoft-graph when the state provider is microsoft-graph', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'access-ms',
+            refresh_token: 'refresh-ms',
+            scope: 'Mail.Read',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    )
+    globalThis.fetch = fetchMock
+
+    const state = await issueOAuthState({
+      customer_id: 'acme',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user-1',
+    })
+    const url = `${ADMIN_BASE}/api/oauth/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      session: { userId: 'user-1', role: 'admin' },
+    })
+    expect(response.status).toBe(302)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const firstCallArgs = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(firstCallArgs[0]).toBe('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+  })
+})
+
+describe('oauth/callback source assertions', () => {
+  it('endpoint file does not log token values', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const source = readFileSync(resolve('src/pages/api/oauth/callback.ts'), 'utf-8')
+    // No access_token / refresh_token references inside console.log/error
+    // calls — token material must never reach logs.
+    const logLines = source.split('\n').filter((l) => l.includes('console.'))
+    for (const line of logLines) {
+      expect(line).not.toMatch(/access_token|refresh_token/)
+    }
+  })
+
+  it('audit writer leaves a TODO for #891', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const source = readFileSync(resolve('src/lib/oauth/audit.ts'), 'utf-8')
+    expect(source).toMatch(/TODO.*#891/)
+  })
+
+  it('store interface documents ADR 0010 and ships a no-op v1', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const source = readFileSync(resolve('src/lib/oauth/store.ts'), 'utf-8')
+    expect(source).toContain('ADR 0010')
+    expect(source).toContain('createNoOpTokenStore')
+  })
+})


### PR DESCRIPTION
## Summary

- Unified OAuth callback at `/api/oauth/callback` (admin subdomain) for AI Employee connector consent flows. Single endpoint dispatches to any provider; provider is carried in a signed state parameter.
- HMAC-SHA256 stateless state with 10-minute TTL, signed by `OAUTH_STATE_SIGNING_KEY`. State payload binds `(customer_id, provider, reviewer_id, nonce, expiry)`. CSRF defense: callback rejects unless the state's `reviewer_id` matches the currently authenticated admin session.
- Provider registry ships `microsoft-graph` (Azure AD v2) and `google-workspace`. Token responses normalized to a shared shape so the store contract is provider-agnostic.
- Token storage interface per [ADR 0010](docs/adr/0010-per-customer-oauth-token-storage.md) — tokens live on the customer's Fly volume, not in the Worker. v1 ships a no-op store that records the storage intent; the Hermes Machine relay is wired in a follow-on.
- Audit emission for `token-issued` / `token-rejected` with a console writer; the D1 `audit_log` persistence is deferred to #891.
- Middleware exempts `/api/oauth/*` from the admin subdomain rewrite (matching the existing `/api/auth/*` precedent) so the endpoint resolves at `admin.smd.services/api/oauth/callback`.

No token material is logged, returned in response bodies, or placed in URLs. Issuer error payloads stay on the server side; callbacks surface short reason codes (`provider_error`, `missing_params`, `bad_state`, `expired_state`, `reviewer_mismatch`, `unknown_provider`, `exchange_failed`, `store_failed`) to the dashboard.

Closes #879. Refs ADR 0010, `docs/specs/ai-employee/oauth-lifecycle.md`.

## Deferred ACs

Two `TODO(#NNN)` deferrals, both load-bearing for v1 but unblocked by infrastructure that lands separately:

- **`src/lib/oauth/audit.ts` — TODO(#891).** The audit-log persistence layer (D1 `audit_log` table per `docs/specs/ai-employee/d1-schema.md`) is the explicit deliverable of #891. This PR ships the audit-event emission shape (`oauth-callback.token-issued` / `token-rejected`) and a console-only writer; when #891 lands, the swap is a one-line change inside `audit.ts`. Shipping the callback ahead of #891 is correct sequencing — the callback is on the critical path for connector consent in customer-zero, the audit table can backfill from console logs in the interim, and a stable event shape is what #891 needs to consume.
- **`src/lib/oauth/store.ts` — TODO #879-follow-on.** Per [ADR 0010](docs/adr/0010-per-customer-oauth-token-storage.md), tokens live on the customer's Fly volume. The Worker can't write a Fly volume directly; it must POST the token to an authenticated control-plane endpoint on the customer's Hermes Machine. That Machine endpoint and the per-customer Machine registry it needs (hostname + auth token per `customer_id`) are not yet wired — they layer in with #850 and the Hermes Machine control plane work. v1 ships the storage interface plus a no-op implementation that audits the intent so the callback path can be exercised end-to-end without a real Machine. Follow-on issue will be filed in the same area as #850 once the control-plane surface is named; the TODO points at it explicitly so the swap is a one-line callback edit.

Neither deferral compromises the security boundary: the signed-state CSRF defense, reviewer-binding, and "no token material in logs / URLs" guarantees all ship in this PR.

## Test plan

- [x] `npm run typecheck` — 0 errors on changed files
- [x] `npx prettier --check` on changed files — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run tests/oauth-callback.test.ts` — 25/25 passing
  - state.ts: round-trip, bad-signature on tampered payload, signature failure under key rotation, expiry, malformed, missing-key error, TTL default
  - providers: registry exposure, unknown slug → null, MS Graph + Google endpoint URLs
  - callback: every failure path (provider error, missing params, bad/expired state, three reviewer-mismatch variants, unknown provider, exchange failure)
  - callback: success path on google-workspace, dispatch correctness for microsoft-graph
  - source-level: no token material in console logs, audit writer carries `#891` TODO, store cites ADR 0010
- [ ] Provision OAuth client credentials in production: `OAUTH_STATE_SIGNING_KEY` (`openssl rand -base64 32`), `MICROSOFT_GRAPH_CLIENT_ID` / `MICROSOFT_GRAPH_CLIENT_SECRET` (Azure AD app registration with `${ADMIN_BASE_URL}/api/oauth/callback` in the redirect URI list). `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are already provisioned for booking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)