### PR TITLE
feat(ai-employee): blind-test voice-gate harness (#823)

### DIFF
--- a/ai-employee/bin/run-voice-gate.sh
+++ b/ai-employee/bin/run-voice-gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# run-voice-gate.sh — drive the blind-test harness for a customer.
+#
+# Per voice-gate-fallback.md §Verification (item 1 "Gate runner"). The
+# bash wrapper exists so Captain can invoke from anywhere; the heavy
+# lifting is the TypeScript runner at ai-employee/voice-gate/cli.ts.
+#
+# Usage (synthetic mode — runs against bundled fixtures + recorded
+# identifications, used in CI and for smoke tests):
+#
+#   ai-employee/bin/run-voice-gate.sh \
+#     --customer-slug smith-pi-firm \
+#     --panel-id panel-001 \
+#     --mode synthetic \
+#     --identifications ai-employee/voice-gate/fixtures/example-identifications.json
+#
+# Usage (live mode — NOT YET IMPLEMENTED):
+#
+#   ai-employee/bin/run-voice-gate.sh --customer-slug <slug> --panel-id <id> --mode live
+#
+# Live mode requires the per-customer Hermes D1 binding (#800), the
+# voice-sample ingestion store, and the dashboard panel form. The CLI
+# returns a clear error pointing at the integration plan; this wrapper
+# does not attempt to bridge any of those.
+#
+# Exit codes mirror the gate state for CI use:
+#   0 — PASS
+#   1 — NEAR-PASS
+#   2 — FAIL
+#   3 — live mode not yet implemented
+#   4 — runner error (bad args, malformed inputs)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec npx --yes tsx "${REPO_ROOT}/ai-employee/voice-gate/cli.ts" "$@"

--- a/ai-employee/voice-gate/README.md
+++ b/ai-employee/voice-gate/README.md
@@ -1,0 +1,101 @@
+# Voice-gate harness
+
+Blind-test scaffolding for the Platform PRD §9.6 voice quality gate. Resolves issue [#823](https://github.com/venturecrane/ss-console/issues/823); implements the data plane for [voice-gate-fallback.md](../../docs/specs/ai-employee/voice-gate-fallback.md).
+
+## What this is
+
+Before any external draft ships under a customer's name, the platform runs a blind test: a reviewer panel sees customer-authored drafts mixed with agent-drafted ones, unlabeled, and identifies each as "customer," "agent," or "uncertain." If the agent drafts are indistinguishable from the customer's own writing **≥80% of the time** (PRD §9.6 acceptance threshold), the voice gate passes and the first external draft is unlocked.
+
+This harness is the scoring + panel scaffolding that drives that blind test. It is **pure** — it does not read or write databases, does not call audit logs, does not send messages. The caller (CLI runner today; dashboard form in a future workstream) hands it drafts + identifications and receives a structured `GateResult`.
+
+## Input / output contract
+
+**Input** (`RunVoiceGateInput`):
+
+- `customer_slug` — namespaces the run; written to the audit log row
+- `cohort` — `'client' | 'opposing-counsel' | 'internal-team' | 'all'` (PRD §9.3 Layer 3 v1)
+- `run_id` — ULID-shaped; doubles as the deterministic-shuffle seed
+- `drafts` — `BlindTestDraft[]` with ground-truth `authorship` labels; the panel layer strips these before presentation
+- `panel` — judge IDs invited to the panel
+- `cycle_count` — 0 for first attempt, 1 for first near-pass retry, 2 for second; 2+ with score <80% auto-transitions to fail per `voice-gate-fallback.md` §Near-pass cycle
+- `identifications` — `JudgeIdentification[]` collected from the panel
+- `enforceProductionMinimums` — `false` for synthetic-fixture tests; `true` for real customer runs (≥10 drafts per authorship, ≥3 judges)
+
+**Output** (`GateResult`):
+
+- `state` — `'pass' | 'near-pass' | 'fail'`
+- `audit_action` — `'VOICE_GATE_PASSED' | 'VOICE_GATE_NEAR_PASS' | 'VOICE_GATE_FAILED'` (matches `d1-schema.md` §1 `audit_log.action_type`)
+- `score_pct` — indistinguishability % in [0, 100]
+- `per_cohort` — breakdown when run was `'all'`
+- `failure_record` — populated when `state === 'fail'`; encodes the structured record the disclosure protocol consumes (`recommended_path`, `auto_transitioned_from_near_pass`, `flagged_judge_ids`, `below_threshold_cohorts`)
+- `near_pass_record` — populated when `state === 'near-pass'`; flags whether this is the final allowed cycle
+- `summary` — one-line human-readable string
+
+The harness also exposes `buildAuditRow(rowId, run, result, ts)` which produces a typed `VoiceGatePanelScoreRow` ready for the future D1 writer.
+
+## CLI
+
+Captain re-runs the gate on demand for any active customer:
+
+```bash
+ai-employee/bin/run-voice-gate.sh \
+  --customer-slug smith-pi-firm \
+  --panel-id panel-001 \
+  --mode synthetic \
+  --identifications ai-employee/voice-gate/fixtures/example-identifications.json
+```
+
+Exit codes:
+
+- `0` — PASS
+- `1` — NEAR-PASS
+- `2` — FAIL
+- `3` — `--mode live` (not yet implemented; depends on the per-customer Hermes D1 binding + voice-sample ingestion store)
+- `4` — runner error (bad args, malformed inputs)
+
+## Files
+
+- `types.ts` — typed shapes shared across the harness; the D1 row shape future-D1-writer will consume
+- `scoring.ts` — threshold constants + `scoreRun` (the only place the 80% / 60% / cycle-count math lives)
+- `panel.ts` — input validation, deterministic seeded shuffle, `PanelSession` for collecting identifications
+- `harness.ts` — top-level `runVoiceGate` orchestrator and `buildAuditRow`
+- `cli.ts` — Captain-facing CLI (synthetic mode in this PR; live mode stubbed)
+- `index.ts` — public surface
+- `fixtures/synthetic-set.json` — three cohorts × (1 customer + 2 agent) = 9 drafts; placeholder names per the no-fabricated-content discipline
+- `fixtures/example-identifications.json` — sample judge inputs for the smoke-test CLI invocation
+- `fixtures/loader.ts` — validates + parses the bundled JSON into `BlindTestDraft[]`
+- `../bin/run-voice-gate.sh` — thin bash wrapper that invokes the CLI via `npx tsx`
+
+## Threshold constants
+
+All threshold logic lives in `scoring.ts`. Named constants — never repeat the numbers:
+
+| Constant                               | Value | Source                                           |
+| -------------------------------------- | ----- | ------------------------------------------------ |
+| `VOICE_GATE_PASS_THRESHOLD_PCT`        | `80`  | PRD §9.6 acceptance threshold                    |
+| `VOICE_GATE_NEAR_PASS_LOWER_PCT`       | `60`  | voice-gate-fallback.md §Three states             |
+| `VOICE_GATE_MAX_NEAR_PASS_CYCLES`      | `2`   | voice-gate-fallback.md §Near-pass cycle (step 4) |
+| `VOICE_GATE_MIN_DAYS_BETWEEN_CYCLES`   | `7`   | voice-gate-fallback.md §Near-pass cycle (step 3) |
+| `PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP` | `10`  | voice-gate-fallback.md §Contract                 |
+| `PRODUCTION_MIN_JUDGES`                | `3`   | voice-gate-fallback.md §Contract                 |
+
+## Integration points (out of scope this PR)
+
+This PR ships the scaffolding only. Three downstream workstreams compose with it:
+
+1. **D1 writer for `audit_log` + per-customer scoring** — depends on per-customer Hermes D1 binding ([#800](https://github.com/venturecrane/ss-console/issues/800)). `buildAuditRow` already returns the typed row; the writer takes that row and inserts it.
+2. **Voice-sample ingestion store** — depends on voice-sample upload UI (no issue filed yet). Today, real customer runs would have nothing to read from; the CLI's `--mode live` path returns a clear error pointing at this gap. When the store lands, the CLI's live mode reads `voice_samples.r2_key` per `d1-schema.md` §8 to source the drafts.
+3. **Promotion gate wiring** — `bin/promote-customer-to-live.sh` should refuse to advance a customer whose latest `audit_log` `VOICE_GATE_*` event is not `VOICE_GATE_PASSED`. The shell wiring is out of scope; the audit row is the lookup key.
+4. **Failure-path runtime hooks** — `voice-gate-fallback.md` §Verification items 2-4 (internal-drafts-only mode, disclosure artifact, cycle bound enforcement). The `FailureRecord` shape exposes everything those hooks need; they read the latest audit row and react.
+
+## Why TypeScript
+
+The `ai-employee/grading/` harness is currently markdown-based (rubric + matrix), not code. There's no existing language to "match." We chose TypeScript so:
+
+- Test execution rides on the existing `vitest` config (no Python toolchain to introduce)
+- The typed `VoiceGatePanelScoreRow` shape lines up with the rest of `src/lib/ai-employee/` (also TypeScript)
+- The future dashboard form in `voice-gate-fallback.md` §Implementation notes can `import` directly from `ai-employee/voice-gate/`
+
+## Threshold-tuning workflow
+
+The pass threshold is locked at 80% per PRD §9.6. If Captain tunes it (judge-pool adjustments per `voice-gate-fallback.md` §Failure modes, or Captain calibration round per the grading rubric), every consumer must move together. The named constants live in `scoring.ts`; changing them is the single edit point. Tests in `tests/voice-gate-scoring.test.ts` assert the current values explicitly so changes can't slip in silently.

--- a/ai-employee/voice-gate/cli.ts
+++ b/ai-employee/voice-gate/cli.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env npx tsx
+/**
+ * Voice-gate CLI runner.
+ *
+ * Captain invokes this on-demand for any active customer. The CLI can
+ * operate in two modes:
+ *
+ *   1. Synthetic — drives the bundled fixture set with pre-recorded
+ *      identifications from a JSON file. Used in CI and for harness
+ *      smoke tests.
+ *
+ *   2. Interactive — reads drafts from a customer's voice_samples R2
+ *      keys (future integration), prompts judges through stdin, persists
+ *      results. NOT IMPLEMENTED in this PR — the live wiring depends on
+ *      the per-customer Hermes D1 binding and the voice-sample
+ *      ingestion store (both open workstreams). The CLI surfaces a
+ *      clear error pointing at the integration plan.
+ *
+ * Usage:
+ *   npx tsx ai-employee/voice-gate/cli.ts \
+ *     --customer-slug smith-pi-firm \
+ *     [--cohort client | opposing-counsel | internal-team | all] \
+ *     --panel-id panel-001 \
+ *     [--cycle-count 0] \
+ *     [--mode synthetic | live] \
+ *     [--identifications path/to/ids.json] \
+ *     [--enforce-production-minimums]
+ */
+
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import {
+  RECIPIENT_COHORTS,
+  loadFixtureSet,
+  runVoiceGate,
+  type CreatePanelSessionInput,
+  type JudgeIdentification,
+  type RecipientCohort,
+} from './index.js'
+
+interface ParsedArgs {
+  customer_slug: string
+  cohort: RecipientCohort | 'all'
+  panel_id: string
+  cycle_count: number
+  mode: 'synthetic' | 'live'
+  identifications_path: string | null
+  enforce_production_minimums: boolean
+}
+
+function parseFlags(argv: string[]): Map<string, string> {
+  const flags = new Map<string, string>()
+  let i = 0
+  while (i < argv.length) {
+    const arg = argv[i]
+    if (arg === undefined) {
+      i++
+      continue
+    }
+    if (!arg.startsWith('--')) {
+      i++
+      continue
+    }
+    const key = arg.slice(2)
+    const next = argv[i + 1]
+    if (next !== undefined && !next.startsWith('--')) {
+      flags.set(key, next)
+      i += 2
+    } else {
+      flags.set(key, 'true')
+      i++
+    }
+  }
+  return flags
+}
+
+function parseCohort(raw: string): RecipientCohort | 'all' {
+  if (raw === 'all') return 'all'
+  if (!RECIPIENT_COHORTS.includes(raw as RecipientCohort)) {
+    usageAndExit(`--cohort must be one of all | ${RECIPIENT_COHORTS.join(' | ')}, got ${raw}`)
+  }
+  return raw as RecipientCohort
+}
+
+function parseMode(raw: string): 'synthetic' | 'live' {
+  if (raw !== 'synthetic' && raw !== 'live') {
+    usageAndExit("--mode must be 'synthetic' or 'live'")
+  }
+  return raw
+}
+
+function parseCycleCount(raw: string): number {
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n < 0) {
+    usageAndExit('--cycle-count must be a non-negative integer')
+  }
+  return n
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const flags = parseFlags(argv)
+  const customer_slug = flags.get('customer-slug')
+  if (!customer_slug) usageAndExit('--customer-slug is required')
+  const panel_id = flags.get('panel-id')
+  if (!panel_id) usageAndExit('--panel-id is required')
+  return {
+    customer_slug,
+    cohort: parseCohort(flags.get('cohort') ?? 'all'),
+    panel_id,
+    cycle_count: parseCycleCount(flags.get('cycle-count') ?? '0'),
+    mode: parseMode(flags.get('mode') ?? 'synthetic'),
+    identifications_path: flags.get('identifications') ?? null,
+    enforce_production_minimums: flags.get('enforce-production-minimums') === 'true',
+  }
+}
+
+function usageAndExit(reason: string): never {
+  console.error(`error: ${reason}`)
+  console.error(
+    'Usage: npx tsx ai-employee/voice-gate/cli.ts --customer-slug <slug> [--cohort <cohort>] --panel-id <id> [--cycle-count N] [--mode synthetic|live] [--identifications path] [--enforce-production-minimums]'
+  )
+  process.exit(2)
+}
+
+async function loadIdentifications(path: string): Promise<JudgeIdentification[]> {
+  const raw = await readFile(resolve(path), 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${path}: must be a JSON array of identifications`)
+  }
+  return parsed.map((entry, idx) => {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error(`${path}: identification[${idx}] must be an object`)
+    }
+    const obj = entry as Record<string, unknown>
+    const draft_id = obj['draft_id']
+    const judge_id = obj['judge_id']
+    const choice = obj['choice']
+    if (typeof draft_id !== 'string') {
+      throw new Error(`${path}: identification[${idx}].draft_id missing`)
+    }
+    if (typeof judge_id !== 'string') {
+      throw new Error(`${path}: identification[${idx}].judge_id missing`)
+    }
+    if (choice !== 'customer' && choice !== 'agent' && choice !== 'uncertain') {
+      throw new Error(`${path}: identification[${idx}].choice must be customer | agent | uncertain`)
+    }
+    const out: JudgeIdentification = { draft_id, judge_id, choice }
+    const notes = obj['notes']
+    if (typeof notes === 'string') out.notes = notes
+    return out
+  })
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.mode === 'live') {
+    console.error(
+      'error: --mode live is not yet implemented in this PR. Live mode requires:\n' +
+        '  - per-customer Hermes D1 binding (#800)\n' +
+        '  - voice-sample ingestion store (open workstream, no issue filed yet)\n' +
+        '  - dashboard panel form (voice-gate-fallback.md §Implementation notes)\n' +
+        '\n' +
+        'Use --mode synthetic with the bundled fixture set for harness verification.'
+    )
+    process.exit(3)
+  }
+
+  if (!args.identifications_path) {
+    usageAndExit('--identifications path is required in synthetic mode')
+  }
+
+  const fixtures = await loadFixtureSet()
+  if (fixtures.customer_slug !== args.customer_slug) {
+    console.error(
+      `warning: bundled fixture customer_slug (${fixtures.customer_slug}) does not match --customer-slug ${args.customer_slug}; using bundled drafts unchanged.`
+    )
+  }
+
+  const cohortFilteredDrafts =
+    args.cohort === 'all'
+      ? fixtures.drafts
+      : fixtures.drafts.filter((d) => d.cohort === args.cohort)
+
+  const identifications = await loadIdentifications(args.identifications_path)
+  const panel = uniqueJudgeIds(identifications)
+
+  const input: CreatePanelSessionInput & {
+    identifications: JudgeIdentification[]
+    enforceProductionMinimums: boolean
+  } = {
+    customer_slug: args.customer_slug,
+    cohort: args.cohort,
+    run_id: args.panel_id,
+    drafts: cohortFilteredDrafts,
+    panel,
+    cycle_count: args.cycle_count,
+    identifications,
+    enforceProductionMinimums: args.enforce_production_minimums,
+  }
+
+  const { run, result } = runVoiceGate(input)
+
+  // Emit structured JSON to stdout so the script is composable with the
+  // future D1 writer. Captain reads the summary line on stderr.
+  console.error(result.summary)
+  process.stdout.write(
+    JSON.stringify(
+      {
+        run_id: run.run_id,
+        customer_slug: run.customer_slug,
+        cohort: run.cohort,
+        cycle_count: run.cycle_count,
+        started_at: run.started_at,
+        scored_at: run.scored_at,
+        result,
+      },
+      null,
+      2
+    ) + '\n'
+  )
+
+  // Exit code mirrors the gate state for CI use:
+  //   0 — pass (advance promotion)
+  //   1 — near-pass (calibration cycle; treated as warn in CI)
+  //   2 — fail (block promotion)
+  if (result.state === 'pass') process.exit(0)
+  if (result.state === 'near-pass') process.exit(1)
+  process.exit(2)
+}
+
+function uniqueJudgeIds(ids: JudgeIdentification[]): string[] {
+  return [...new Set(ids.map((i) => i.judge_id))].sort()
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err)
+  console.error(`error: ${msg}`)
+  process.exit(4)
+})

--- a/ai-employee/voice-gate/fixtures/example-identifications.json
+++ b/ai-employee/voice-gate/fixtures/example-identifications.json
@@ -1,0 +1,103 @@
+[
+  { "draft_id": "smith-pi-firm/client/draft-001", "judge_id": "judge-A", "choice": "customer" },
+  { "draft_id": "smith-pi-firm/client/draft-002", "judge_id": "judge-A", "choice": "customer" },
+  { "draft_id": "smith-pi-firm/client/draft-003", "judge_id": "judge-A", "choice": "uncertain" },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-001",
+    "judge_id": "judge-A",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-002",
+    "judge_id": "judge-A",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-003",
+    "judge_id": "judge-A",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-001",
+    "judge_id": "judge-A",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-002",
+    "judge_id": "judge-A",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-003",
+    "judge_id": "judge-A",
+    "choice": "uncertain"
+  },
+
+  { "draft_id": "smith-pi-firm/client/draft-001", "judge_id": "judge-B", "choice": "customer" },
+  { "draft_id": "smith-pi-firm/client/draft-002", "judge_id": "judge-B", "choice": "uncertain" },
+  { "draft_id": "smith-pi-firm/client/draft-003", "judge_id": "judge-B", "choice": "customer" },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-001",
+    "judge_id": "judge-B",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-002",
+    "judge_id": "judge-B",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-003",
+    "judge_id": "judge-B",
+    "choice": "agent"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-001",
+    "judge_id": "judge-B",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-002",
+    "judge_id": "judge-B",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-003",
+    "judge_id": "judge-B",
+    "choice": "customer"
+  },
+
+  { "draft_id": "smith-pi-firm/client/draft-001", "judge_id": "judge-C", "choice": "customer" },
+  { "draft_id": "smith-pi-firm/client/draft-002", "judge_id": "judge-C", "choice": "customer" },
+  { "draft_id": "smith-pi-firm/client/draft-003", "judge_id": "judge-C", "choice": "customer" },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-001",
+    "judge_id": "judge-C",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-002",
+    "judge_id": "judge-C",
+    "choice": "uncertain"
+  },
+  {
+    "draft_id": "smith-pi-firm/opposing-counsel/draft-003",
+    "judge_id": "judge-C",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-001",
+    "judge_id": "judge-C",
+    "choice": "customer"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-002",
+    "judge_id": "judge-C",
+    "choice": "uncertain"
+  },
+  {
+    "draft_id": "smith-pi-firm/internal-team/draft-003",
+    "judge_id": "judge-C",
+    "choice": "customer"
+  }
+]

--- a/ai-employee/voice-gate/fixtures/loader.ts
+++ b/ai-employee/voice-gate/fixtures/loader.ts
@@ -1,0 +1,141 @@
+/**
+ * Fixture loader. Reads the synthetic blind-test set bundled with the
+ * harness and returns typed `BlindTestDraft` items.
+ *
+ * Real customer runs do NOT use this loader — they read drafts from the
+ * per-customer voice_samples table per d1-schema.md §8. This loader
+ * exists for tests + CLI smoke tests where no live customer database is
+ * available.
+ *
+ * The fixtures are deliberately small (3 cohorts × 3 drafts = 9 total)
+ * because their job is to drive harness scaffolding tests. Production
+ * minimums (≥10 per authorship, ≥3 judges) are enforced separately by
+ * the panel layer when `enforceProductionMinimums: true`.
+ */
+
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import { RECIPIENT_COHORTS } from '../scoring.js'
+import type { BlindTestDraft, RecipientCohort } from '../types.js'
+
+export interface FixtureSet {
+  customer_slug: string
+  drafts: BlindTestDraft[]
+}
+
+/**
+ * Set of valid authorship labels. Sorted alphabetically (matches the
+ * `DraftAuthorship` union) so the validator can reuse the array for
+ * `.includes()` membership.
+ */
+const VALID_AUTHORSHIPS = ['agent', 'customer'] as const
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const DEFAULT_FIXTURE_PATH = resolve(__dirname, './synthetic-set.json')
+
+/**
+ * Load and validate the bundled synthetic fixture set. Throws if the
+ * JSON is malformed or any draft is missing required fields. The
+ * validator's strictness is intentional — fixture rot is a fast way to
+ * mask harness bugs.
+ */
+export async function loadFixtureSet(pathOverride?: string): Promise<FixtureSet> {
+  const target = pathOverride ?? DEFAULT_FIXTURE_PATH
+  const raw = await readFile(target, 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error(`fixture file ${target}: top-level value must be an object`)
+  }
+  const obj = parsed as Record<string, unknown>
+  const customer_slug = obj['customer_slug']
+  if (typeof customer_slug !== 'string' || customer_slug.length === 0) {
+    throw new Error(`fixture file ${target}: customer_slug missing`)
+  }
+  const draftsRaw = obj['drafts']
+  if (!Array.isArray(draftsRaw)) {
+    throw new Error(`fixture file ${target}: drafts must be an array`)
+  }
+  const drafts: BlindTestDraft[] = draftsRaw.map((d, i) => parseDraft(d, i, target))
+  return { customer_slug, drafts }
+}
+
+function parseDraft(raw: unknown, index: number, source: string): BlindTestDraft {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`${source}: draft[${index}] must be an object, got ${typeof raw}`)
+  }
+  const obj = raw as Record<string, unknown>
+  const id = parseStringField(obj['id'], `${source}: draft[${index}].id`)
+  const cohort = parseCohortField(obj['cohort'], `${source}: draft[${index}].cohort`)
+  const authorship = parseAuthorshipField(
+    obj['authorship'],
+    `${source}: draft[${index}].authorship`
+  )
+  const body = parseBodyField(obj['body'], `${source}: draft[${index}].body`)
+  const out: BlindTestDraft = { id, cohort, authorship, body }
+  const metadata = parseMetadataField(obj['metadata'], `${source}: draft[${index}].metadata`)
+  if (metadata !== undefined) out.metadata = metadata
+  return out
+}
+
+function parseStringField(raw: unknown, label: string): string {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(`${label} missing or not a string`)
+  }
+  return raw
+}
+
+function parseCohortField(raw: unknown, label: string): RecipientCohort {
+  if (typeof raw !== 'string' || !RECIPIENT_COHORTS.includes(raw as RecipientCohort)) {
+    throw new Error(`${label} must be one of ${RECIPIENT_COHORTS.join(' | ')}, got ${String(raw)}`)
+  }
+  return raw as RecipientCohort
+}
+
+function parseAuthorshipField(raw: unknown, label: string): 'customer' | 'agent' {
+  if (typeof raw !== 'string' || !(VALID_AUTHORSHIPS as readonly string[]).includes(raw)) {
+    throw new Error(`${label} must be 'customer' | 'agent', got ${String(raw)}`)
+  }
+  return raw as 'customer' | 'agent'
+}
+
+function parseBodyField(raw: unknown, label: string): string {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error(`${label} missing or empty`)
+  }
+  return raw
+}
+
+function parseMetadataField(
+  raw: unknown,
+  label: string
+): NonNullable<BlindTestDraft['metadata']> | undefined {
+  if (raw === undefined) return undefined
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`${label} must be an object`)
+  }
+  const meta = raw as Record<string, unknown>
+  const cleanMeta: NonNullable<BlindTestDraft['metadata']> = {}
+  if (meta['subject'] !== undefined) {
+    if (typeof meta['subject'] !== 'string') {
+      throw new Error(`${label}.subject must be a string`)
+    }
+    cleanMeta.subject = meta['subject']
+  }
+  if (meta['scenario'] !== undefined) {
+    if (typeof meta['scenario'] !== 'string') {
+      throw new Error(`${label}.scenario must be a string`)
+    }
+    cleanMeta.scenario = meta['scenario']
+  }
+  if (meta['includeInPresentation'] !== undefined) {
+    if (typeof meta['includeInPresentation'] !== 'boolean') {
+      throw new Error(`${label}.includeInPresentation must be a boolean`)
+    }
+    cleanMeta.includeInPresentation = meta['includeInPresentation']
+  }
+  return cleanMeta
+}

--- a/ai-employee/voice-gate/fixtures/synthetic-set.json
+++ b/ai-employee/voice-gate/fixtures/synthetic-set.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "../fixtures/schema.md",
+  "comment": "Synthetic blind-test fixture set. Three cohorts × (1 customer-authored + 2 agent-drafted) = 9 drafts. Names are deliberately placeholder (smith-pi-firm, etc.) per the no-fabricated-content discipline. Real customer runs draw from the per-customer voice_samples table per d1-schema.md §8.",
+  "customer_slug": "smith-pi-firm",
+  "drafts": [
+    {
+      "id": "smith-pi-firm/client/draft-001",
+      "cohort": "client",
+      "authorship": "customer",
+      "metadata": {
+        "subject": "Update on your case",
+        "scenario": "weekly client status touchpoint",
+        "includeInPresentation": true
+      },
+      "body": "Hi placeholder-client-A,\n\nQuick update. The insurer's adjuster came back yesterday with their initial position. It's lower than where we expect to land, but that's typical at this stage and I'm not concerned. I'm putting together the response this week.\n\nA few things I'll need from you in the next ten days or so: copies of any new medical bills since our last check-in, and a short list of any work days you've missed because of the injury. I'll send a form to make this easier.\n\nNo immediate action on your end. I'll be in touch as the response goes out.\n\nThanks,\nplaceholder-attorney"
+    },
+    {
+      "id": "smith-pi-firm/client/draft-002",
+      "cohort": "client",
+      "authorship": "agent",
+      "metadata": {
+        "subject": "Update on your case",
+        "scenario": "weekly client status touchpoint",
+        "includeInPresentation": true
+      },
+      "body": "Hi placeholder-client-A,\n\nQuick update. The insurer's adjuster came back yesterday with their initial position. It's lower than where we expect to land, but that's typical at this stage and not a concern.\n\nI'm working on the response this week and will need a couple of things from you in the next ten days: copies of any new medical bills since our last check-in, and a short list of work days you've missed because of the injury. I'll send a form to make this easier on your end.\n\nNo immediate action on your end. I'll be in touch as the response goes out.\n\nThanks,\nplaceholder-attorney"
+    },
+    {
+      "id": "smith-pi-firm/client/draft-003",
+      "cohort": "client",
+      "authorship": "agent",
+      "metadata": {
+        "subject": "Update on your case",
+        "scenario": "weekly client status touchpoint",
+        "includeInPresentation": true
+      },
+      "body": "Hi placeholder-client-A,\n\nQuick check-in. We heard back from the insurer yesterday with their first position on the case. The number is below where we expect this to settle, which is normal at this stage; I'm not worried about it. I'll have our response together this week.\n\nWhen you get a moment in the next week and a half, could you gather any new medical bills since we last talked, and note down which work days you've missed because of the injury. I'll send a simple form so you can drop everything in one place.\n\nNothing else needed for now. I'll let you know when the response goes out.\n\nThanks,\nplaceholder-attorney"
+    },
+    {
+      "id": "smith-pi-firm/opposing-counsel/draft-001",
+      "cohort": "opposing-counsel",
+      "authorship": "customer",
+      "metadata": {
+        "subject": "Re: Production request — placeholder-matter-007",
+        "scenario": "responding to a discovery production request",
+        "includeInPresentation": true
+      },
+      "body": "Counsel,\n\nReceived your production request dated last Friday. We'll have responsive documents to you within the standard period; nothing in the request strikes me as outside scope, but I'm flagging two items I'll want to talk through:\n\n1. Item 4 (employment records) — the time window you've drawn covers eight years prior to the incident. I'd ask we narrow that to three; happy to discuss the reasoning.\n2. Item 9 (prior medical) — this overlaps with the request you sent in March, which we've already produced. I'll re-send rather than re-collect.\n\nCall me when you have a few minutes.\n\nplaceholder-attorney"
+    },
+    {
+      "id": "smith-pi-firm/opposing-counsel/draft-002",
+      "cohort": "opposing-counsel",
+      "authorship": "agent",
+      "metadata": {
+        "subject": "Re: Production request — placeholder-matter-007",
+        "scenario": "responding to a discovery production request",
+        "includeInPresentation": true
+      },
+      "body": "Counsel,\n\nReceived your production request from last Friday. We'll produce responsive documents within the standard period. Nothing in the request appears outside scope, but two items I'd like to discuss:\n\n1. Item 4 (employment records) — the window covers eight years prior to the incident. I'd propose narrowing to three; happy to walk through the reasoning.\n2. Item 9 (prior medical) — this overlaps with your March request, which we've already produced. I'll re-send rather than re-collect.\n\nLet me know when you have a few minutes.\n\nplaceholder-attorney"
+    },
+    {
+      "id": "smith-pi-firm/opposing-counsel/draft-003",
+      "cohort": "opposing-counsel",
+      "authorship": "agent",
+      "metadata": {
+        "subject": "Re: Production request — placeholder-matter-007",
+        "scenario": "responding to a discovery production request",
+        "includeInPresentation": true
+      },
+      "body": "Counsel,\n\nGot your production request from Friday. Responsive documents will be over within the standard period; nothing in the request looks outside scope to me, but two items I want to flag before we proceed:\n\n1. Item 4 (employment records) — eight years pre-incident is broader than I'd expect. I'd like to narrow to three and can walk you through why.\n2. Item 9 (prior medical) — this overlaps the March request we already produced. I'll re-send the prior production rather than re-collect.\n\nCall me when you've got a moment.\n\nplaceholder-attorney"
+    },
+    {
+      "id": "smith-pi-firm/internal-team/draft-001",
+      "cohort": "internal-team",
+      "authorship": "customer",
+      "metadata": {
+        "subject": "placeholder-matter-012 — quick note",
+        "scenario": "internal note to paralegal about a matter status",
+        "includeInPresentation": true
+      },
+      "body": "placeholder-paralegal,\n\nWe got medical records back for placeholder-matter-012 — they're partial. Missing the imaging from the second hospital visit. Can you call the records department this week and check on it; they sometimes split orthopedic from neuro and we may have only gotten one batch.\n\nIf you can't reach them by Thursday, ping me and we'll send a follow-up subpoena.\n\nThanks."
+    },
+    {
+      "id": "smith-pi-firm/internal-team/draft-002",
+      "cohort": "internal-team",
+      "authorship": "agent",
+      "metadata": {
+        "subject": "placeholder-matter-012 — quick note",
+        "scenario": "internal note to paralegal about a matter status",
+        "includeInPresentation": true
+      },
+      "body": "placeholder-paralegal,\n\nMedical records came back for placeholder-matter-012 — partial. Imaging from the second hospital visit is missing. Could you call the records department this week and check; they sometimes split orthopedic from neuro and we may have only one batch.\n\nIf you can't reach them by Thursday, let me know and we'll send a follow-up subpoena.\n\nThanks."
+    },
+    {
+      "id": "smith-pi-firm/internal-team/draft-003",
+      "cohort": "internal-team",
+      "authorship": "agent",
+      "metadata": {
+        "subject": "placeholder-matter-012 — quick note",
+        "scenario": "internal note to paralegal about a matter status",
+        "includeInPresentation": true
+      },
+      "body": "placeholder-paralegal,\n\nMed records came back on placeholder-matter-012 and they're partial. The imaging from the second hospital visit isn't in the batch. Could you reach out to the records department this week; in my experience they sometimes split orthopedic from neuro and we may have only gotten one half.\n\nPing me by Thursday if you can't reach them and we'll send a follow-up subpoena.\n\nThanks."
+    }
+  ]
+}

--- a/ai-employee/voice-gate/harness.ts
+++ b/ai-employee/voice-gate/harness.ts
@@ -1,0 +1,96 @@
+/**
+ * Voice-gate harness — top-level orchestration.
+ *
+ * Composes panel + scoring into the one-call shape the CLI consumes.
+ * Caller supplies drafts, panel, customer_slug, run_id, cycle_count
+ * (typically from the per-customer Hermes D1 voice_samples + audit_log
+ * tables; see d1-schema.md §1 and §8) and identifications (collected
+ * either via the CLI prompt loop or a future dashboard form per
+ * voice-gate-fallback.md §Implementation notes).
+ *
+ * The harness does not read or write state. Persistence happens in
+ * downstream wiring (out of scope this PR — documented in README).
+ */
+
+import { PanelSession, validatePanelInput } from './panel.js'
+import { buildAuditMetadata, scoreRun } from './scoring.js'
+import type {
+  BlindTestRun,
+  GateResult,
+  JudgeIdentification,
+  VoiceGatePanelScoreRow,
+} from './types.js'
+import type { CreatePanelSessionInput } from './panel.js'
+
+/**
+ * Inputs to a one-shot blind-test run. Combines panel session
+ * construction + identifications + sealing into a single call. Use this
+ * when identifications are already collected (e.g. a dashboard form
+ * submitted a complete batch). Use `PanelSession` directly when you
+ * need to collect identifications interactively.
+ */
+export interface RunVoiceGateInput extends CreatePanelSessionInput {
+  /** Complete set of identifications captured from the panel. */
+  identifications: JudgeIdentification[]
+  /**
+   * Production mode enforces ≥10 drafts per authorship and ≥3 judges
+   * per voice-gate-fallback.md §Contract. Default false to support
+   * synthetic-fixture testing; CLI sets true for real customer runs.
+   */
+  enforceProductionMinimums?: boolean
+}
+
+/**
+ * One-shot orchestration: build the session, replay all identifications,
+ * seal the run, score it. Returns the run + result so the caller can
+ * persist both.
+ */
+export function runVoiceGate(input: RunVoiceGateInput): {
+  run: BlindTestRun
+  result: GateResult
+} {
+  const problems = validatePanelInput(input, {
+    enforceProductionMinimums: input.enforceProductionMinimums ?? false,
+  })
+  if (problems.length > 0) {
+    throw new Error(`voice-gate validation failed: ${problems.join('; ')}`)
+  }
+  const session = new PanelSession(input)
+  for (const id of input.identifications) {
+    session.recordIdentification(id)
+  }
+  const run = session.seal()
+  const result = scoreRun(run)
+  return { run, result }
+}
+
+/**
+ * Build the D1 panel-score row for the audit_log table. Pure shape
+ * transformation; the D1 writer is downstream and lives in a separate
+ * workstream (see README integration section).
+ *
+ * The row ID convention matches d1-schema.md §1 — ULID. The caller
+ * supplies the ULID; this function does not generate one to keep the
+ * harness side-effect-free.
+ */
+export function buildAuditRow(
+  rowId: string,
+  run: BlindTestRun,
+  result: GateResult,
+  ts?: string
+): VoiceGatePanelScoreRow {
+  return {
+    id: rowId,
+    ts: ts ?? new Date().toISOString(),
+    action_type: result.audit_action,
+    actor: 'captain',
+    actor_role: 'captain',
+    skill_name: null,
+    matter_ref: null,
+    input_digest: null,
+    output_digest: null,
+    diff_digest: null,
+    trust_ceiling: null,
+    metadata: buildAuditMetadata(run, result),
+  }
+}

--- a/ai-employee/voice-gate/index.ts
+++ b/ai-employee/voice-gate/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Voice-gate harness public surface.
+ *
+ * Stable re-exports for callers (CLI runner, future dashboard form,
+ * future D1 writer). Anything not re-exported here is internal and may
+ * change without a major version.
+ */
+
+export type {
+  BlindTestDraft,
+  BlindTestRun,
+  CohortScore,
+  DraftAuthorship,
+  FailureRecord,
+  GateAuditAction,
+  GateResult,
+  GateState,
+  JudgeChoice,
+  JudgeIdentification,
+  NearPassRecord,
+  RecipientCohort,
+  VoiceGatePanelScoreRow,
+} from './types.js'
+
+export {
+  RECIPIENT_COHORTS,
+  VOICE_GATE_MAX_NEAR_PASS_CYCLES,
+  VOICE_GATE_MIN_DAYS_BETWEEN_CYCLES,
+  VOICE_GATE_NEAR_PASS_LOWER_PCT,
+  VOICE_GATE_PASS_THRESHOLD_PCT,
+  auditActionFor,
+  buildAuditMetadata,
+  scoreRun,
+  stateForScore,
+} from './scoring.js'
+
+export {
+  PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP,
+  PRODUCTION_MIN_JUDGES,
+  PanelSession,
+  presentDraft,
+  validatePanelInput,
+} from './panel.js'
+export type { CreatePanelSessionInput, PresentedDraft } from './panel.js'
+
+export { buildAuditRow, runVoiceGate } from './harness.js'
+export type { RunVoiceGateInput } from './harness.js'
+
+export { loadFixtureSet } from './fixtures/loader.js'
+export type { FixtureSet } from './fixtures/loader.js'

--- a/ai-employee/voice-gate/panel.ts
+++ b/ai-employee/voice-gate/panel.ts
@@ -1,0 +1,320 @@
+/**
+ * Voice-gate reviewer-panel session management.
+ *
+ * The panel layer:
+ *
+ *   1. Loads drafts (customer-authored + agent-drafted) for a chosen
+ *      cohort or all cohorts.
+ *   2. Shuffles them deterministically (seeded so re-runs are
+ *      reproducible) and strips the authorship label before
+ *      presentation.
+ *   3. Holds a session that the dashboard form (out of scope this PR;
+ *      see voice-gate-fallback.md §Implementation notes) populates with
+ *      judge identifications.
+ *   4. Hands the completed session to scoring.
+ *
+ * The shuffle is deterministic to support reproducibility — Captain
+ * re-runs the same sample set against a different judge panel and the
+ * presentation order is stable per run_id. Use a different run_id to
+ * get a fresh shuffle.
+ *
+ * No I/O. Loading drafts from the per-customer R2/D1 backed voice-sample
+ * store is documented as a future integration point in README; for now
+ * the caller passes drafts in.
+ */
+
+import { RECIPIENT_COHORTS } from './scoring.js'
+import type { BlindTestDraft, BlindTestRun, JudgeIdentification, RecipientCohort } from './types.js'
+
+/**
+ * Input shape for creating a blind-test session.
+ */
+export interface CreatePanelSessionInput {
+  /** Customer slug — namespaces the session, written to the run row. */
+  customer_slug: string
+  /** Cohort to scope this session to, or 'all' to mix. */
+  cohort: RecipientCohort | 'all'
+  /** ULID for the run; the panel uses it as the shuffle seed. */
+  run_id: string
+  /** Drafts to present. Must include both customer + agent items. */
+  drafts: BlindTestDraft[]
+  /** Judge IDs invited to this panel. */
+  panel: string[]
+  /** Cycle count for this run. 0 = first attempt. */
+  cycle_count: number
+  /** ISO 8601 UTC timestamp; defaults to now. */
+  started_at?: string
+}
+
+/**
+ * Minimum drafts required per voice-gate-fallback.md §Contract: 10
+ * reviewer-written + 10 agent-drafted per blind test. The harness
+ * accepts smaller sample sets for the synthetic fixture path (where
+ * fixtures-per-cohort are smaller by design — three per cohort —
+ * because the harness is verifying the scaffolding, not the calibration
+ * itself) but warns the caller. Real customer runs invoked from the
+ * CLI must meet the production minimum, enforced by the CLI wrapper.
+ */
+export const PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP = 10
+
+/**
+ * Minimum judges per voice-gate-fallback.md §Contract: 3 people who know
+ * the reviewer well. Same caveat as above — synthetic fixture runs can
+ * use smaller panels; the CLI enforces production minimum.
+ */
+export const PRODUCTION_MIN_JUDGES = 3
+
+/**
+ * Validate input to `createPanelSession`. Returns an array of human-
+ * readable problems; empty array means valid. The CLI wraps this and
+ * exits non-zero on any problem.
+ */
+export function validatePanelInput(
+  input: CreatePanelSessionInput,
+  options: { enforceProductionMinimums?: boolean } = {}
+): string[] {
+  return [
+    ...validateRequiredFields(input),
+    ...validateAuthorshipMix(input),
+    ...validateCohortConsistency(input),
+    ...validateProductionMinimums(input, options.enforceProductionMinimums ?? false),
+    ...validateNoDuplicates(input),
+  ]
+}
+
+function validateRequiredFields(input: CreatePanelSessionInput): string[] {
+  const problems: string[] = []
+  if (!input.customer_slug.trim()) problems.push('customer_slug is required')
+  if (!input.run_id.trim()) problems.push('run_id is required')
+  if (input.cycle_count < 0 || !Number.isInteger(input.cycle_count)) {
+    problems.push('cycle_count must be a non-negative integer')
+  }
+  if (input.drafts.length === 0) problems.push('at least one draft required')
+  return problems
+}
+
+function validateAuthorshipMix(input: CreatePanelSessionInput): string[] {
+  const problems: string[] = []
+  const { customerCount, agentCount } = countAuthorships(input.drafts)
+  if (customerCount === 0) problems.push('no customer-authored drafts provided')
+  if (agentCount === 0) problems.push('no agent-drafted drafts provided')
+  return problems
+}
+
+function validateCohortConsistency(input: CreatePanelSessionInput): string[] {
+  if (input.cohort !== 'all') {
+    const offCohort = input.drafts.filter((d) => d.cohort !== input.cohort)
+    if (offCohort.length > 0) {
+      return [`cohort-scoped session received ${offCohort.length} drafts from other cohorts`]
+    }
+    return []
+  }
+  const seenCohorts = new Set(input.drafts.map((d) => d.cohort))
+  const missing = RECIPIENT_COHORTS.filter((c) => !seenCohorts.has(c))
+  if (missing.length > 0) {
+    return [`'all' cohort run missing drafts for: ${missing.join(', ')}`]
+  }
+  return []
+}
+
+function validateProductionMinimums(input: CreatePanelSessionInput, enforce: boolean): string[] {
+  if (!enforce) return []
+  const problems: string[] = []
+  const { customerCount, agentCount } = countAuthorships(input.drafts)
+  if (customerCount < PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP) {
+    problems.push(
+      `customer-authored drafts: ${customerCount} (need ${PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP})`
+    )
+  }
+  if (agentCount < PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP) {
+    problems.push(
+      `agent-drafted drafts: ${agentCount} (need ${PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP})`
+    )
+  }
+  if (input.panel.length < PRODUCTION_MIN_JUDGES) {
+    problems.push(`judges: ${input.panel.length} (need ${PRODUCTION_MIN_JUDGES})`)
+  }
+  return problems
+}
+
+function validateNoDuplicates(input: CreatePanelSessionInput): string[] {
+  const problems: string[] = []
+  const duplicateIds = duplicateDraftIds(input.drafts)
+  if (duplicateIds.length > 0) {
+    problems.push(`duplicate draft IDs: ${duplicateIds.join(', ')}`)
+  }
+  const duplicateJudges = duplicateJudgeIds(input.panel)
+  if (duplicateJudges.length > 0) {
+    problems.push(`duplicate judge IDs: ${duplicateJudges.join(', ')}`)
+  }
+  return problems
+}
+
+function countAuthorships(drafts: BlindTestDraft[]): {
+  customerCount: number
+  agentCount: number
+} {
+  let customerCount = 0
+  let agentCount = 0
+  for (const d of drafts) {
+    if (d.authorship === 'customer') customerCount++
+    else if (d.authorship === 'agent') agentCount++
+  }
+  return { customerCount, agentCount }
+}
+
+function duplicateDraftIds(drafts: BlindTestDraft[]): string[] {
+  const seen = new Set<string>()
+  const dupes = new Set<string>()
+  for (const d of drafts) {
+    if (seen.has(d.id)) dupes.add(d.id)
+    seen.add(d.id)
+  }
+  return [...dupes]
+}
+
+function duplicateJudgeIds(panel: string[]): string[] {
+  const seen = new Set<string>()
+  const dupes = new Set<string>()
+  for (const id of panel) {
+    if (seen.has(id)) dupes.add(id)
+    seen.add(id)
+  }
+  return [...dupes]
+}
+
+/**
+ * Deterministic Fisher-Yates shuffle seeded by a string. Uses a simple
+ * xorshift-derived seed mixer so the same run_id always produces the
+ * same presentation order. NOT cryptographically secure — the goal is
+ * reproducibility, not unguessable order. Judges never see the seed.
+ */
+function seededShuffle<T>(items: T[], seed: string): T[] {
+  let h = 2166136261 >>> 0
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  const rng = () => {
+    h ^= h << 13
+    h ^= h >>> 17
+    h ^= h << 5
+    h >>>= 0
+    return h / 0x100000000
+  }
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]] as [T, T]
+  }
+  return out
+}
+
+/**
+ * Shape a draft for presentation to a judge — strips the authorship
+ * label so the label cannot leak through to a frontend that
+ * re-serializes the response.
+ */
+export interface PresentedDraft {
+  id: string
+  cohort: RecipientCohort
+  body: string
+  subject?: string
+  scenario?: string
+}
+
+export function presentDraft(d: BlindTestDraft): PresentedDraft {
+  const presented: PresentedDraft = {
+    id: d.id,
+    cohort: d.cohort,
+    body: d.body,
+  }
+  if (d.metadata?.includeInPresentation) {
+    if (d.metadata.subject !== undefined) presented.subject = d.metadata.subject
+    if (d.metadata.scenario !== undefined) presented.scenario = d.metadata.scenario
+  }
+  return presented
+}
+
+/**
+ * Active panel session. Held by the CLI runner (or the dashboard form
+ * when wired in a future workstream) between draft presentation and
+ * judge submission.
+ *
+ * The session is immutable after construction except via
+ * `recordIdentification`, which appends to the identifications list.
+ * Idempotency is handled by `(judge_id, draft_id)` pair: a second
+ * identification for the same pair overwrites the first.
+ */
+export class PanelSession {
+  readonly run: BlindTestRun
+  private readonly presented: PresentedDraft[]
+
+  constructor(input: CreatePanelSessionInput) {
+    const problems = validatePanelInput(input)
+    if (problems.length > 0) {
+      throw new Error(`invalid panel input: ${problems.join('; ')}`)
+    }
+    const shuffled = seededShuffle(input.drafts, input.run_id)
+    this.run = {
+      run_id: input.run_id,
+      customer_slug: input.customer_slug,
+      cohort: input.cohort,
+      started_at: input.started_at ?? new Date().toISOString(),
+      scored_at: null,
+      drafts: input.drafts,
+      panel: [...input.panel],
+      identifications: [],
+      cycle_count: input.cycle_count,
+    }
+    this.presented = shuffled.map(presentDraft)
+  }
+
+  /**
+   * Drafts in randomized presentation order, authorship stripped.
+   */
+  presentationOrder(): PresentedDraft[] {
+    return [...this.presented]
+  }
+
+  /**
+   * Record (or replace) a judge's identification for one draft.
+   * Returns `true` if it was a new identification, `false` if it
+   * replaced an earlier one.
+   */
+  recordIdentification(j: JudgeIdentification): boolean {
+    if (!this.run.panel.includes(j.judge_id)) {
+      throw new Error(`judge ${j.judge_id} not on this panel (${this.run.panel.join(', ')})`)
+    }
+    if (!this.run.drafts.some((d) => d.id === j.draft_id)) {
+      throw new Error(`draft ${j.draft_id} not in this session`)
+    }
+    const existingIdx = this.run.identifications.findIndex(
+      (e) => e.judge_id === j.judge_id && e.draft_id === j.draft_id
+    )
+    if (existingIdx >= 0) {
+      this.run.identifications[existingIdx] = j
+      return false
+    }
+    this.run.identifications.push(j)
+    return true
+  }
+
+  /**
+   * Whether every judge has identified every draft. The CLI uses this
+   * to know when to seal the run and hand it to scoring.
+   */
+  isComplete(): boolean {
+    const total = this.run.drafts.length * this.run.panel.length
+    return this.run.identifications.length === total
+  }
+
+  /**
+   * Mark the run as scored and freeze the run record. Idempotent —
+   * subsequent calls update the timestamp.
+   */
+  seal(scored_at?: string): BlindTestRun {
+    this.run.scored_at = scored_at ?? new Date().toISOString()
+    return this.run
+  }
+}

--- a/ai-employee/voice-gate/scoring.ts
+++ b/ai-employee/voice-gate/scoring.ts
@@ -1,0 +1,281 @@
+/**
+ * Voice-gate scoring — threshold logic and fallback dispatch.
+ *
+ * Source: Platform PRD §9.6 (Gate 3 acceptance threshold ≥80%) and
+ * docs/specs/ai-employee/voice-gate-fallback.md §Three states (Pass /
+ * Near-pass / Fail bands and audit-log action mapping).
+ *
+ * The threshold is encoded once here as a named constant; never repeat
+ * the magic number. Future changes — Captain-led threshold tuning,
+ * judge-pool size adjustments — land in this file.
+ */
+
+import type {
+  BlindTestDraft,
+  BlindTestRun,
+  CohortScore,
+  FailureRecord,
+  GateAuditAction,
+  GateResult,
+  GateState,
+  JudgeIdentification,
+  NearPassRecord,
+  RecipientCohort,
+} from './types.js'
+
+/**
+ * Pass threshold per PRD §9.6 and voice-gate-fallback.md §Three states.
+ * Indistinguishability ≥80% unlocks first external draft.
+ */
+export const VOICE_GATE_PASS_THRESHOLD_PCT = 80
+
+/**
+ * Near-pass lower bound. Scores in [60, 80) trigger calibration cycle,
+ * not failure. Per voice-gate-fallback.md §Near-pass cycle.
+ */
+export const VOICE_GATE_NEAR_PASS_LOWER_PCT = 60
+
+/**
+ * Maximum near-pass cycles before auto-transition to fail. Per
+ * voice-gate-fallback.md §Near-pass cycle step 4 ("Maximum 2 near-pass
+ * cycles. If the third blind-test still scores <80%, transition to
+ * Fail state.").
+ */
+export const VOICE_GATE_MAX_NEAR_PASS_CYCLES = 2
+
+/**
+ * Minimum calendar days a customer must wait between near-pass cycles,
+ * per voice-gate-fallback.md §Near-pass cycle step 3.
+ */
+export const VOICE_GATE_MIN_DAYS_BETWEEN_CYCLES = 7
+
+/**
+ * Cohorts the v1 model recognizes. Imported from PRD §9.3 Layer 3 v1.
+ * Centralized here so scoring + fixture loading + panel agree.
+ */
+export const RECIPIENT_COHORTS: ReadonlyArray<RecipientCohort> = [
+  'client',
+  'opposing-counsel',
+  'internal-team',
+]
+
+/**
+ * Map a gate state to the audit_log action_type per d1-schema.md §1.
+ */
+export function auditActionFor(state: GateState): GateAuditAction {
+  switch (state) {
+    case 'pass':
+      return 'VOICE_GATE_PASSED'
+    case 'near-pass':
+      return 'VOICE_GATE_NEAR_PASS'
+    case 'fail':
+      return 'VOICE_GATE_FAILED'
+  }
+}
+
+/**
+ * Convert a numeric score to its gate state. The state machine is
+ * intentionally simple; cycle-count auto-transition (third near-pass
+ * → fail) is layered on top by `scoreRun`, not in this function.
+ */
+export function stateForScore(score_pct: number): GateState {
+  if (score_pct >= VOICE_GATE_PASS_THRESHOLD_PCT) return 'pass'
+  if (score_pct >= VOICE_GATE_NEAR_PASS_LOWER_PCT) return 'near-pass'
+  return 'fail'
+}
+
+/**
+ * Indistinguishability counts when a judge labels an agent-drafted item
+ * as `customer` OR `uncertain`. Per voice-gate-fallback.md §Contract:
+ * "indistinguishability score = % of judgments where the judge was
+ * unable to reliably identify the agent-drafted item (i.e., labeled it
+ * 'reviewer' OR explicitly marked 'uncertain — could be either')."
+ */
+function isIndistinguishable(judgment: JudgeIdentification): boolean {
+  return judgment.choice === 'customer' || judgment.choice === 'uncertain'
+}
+
+/**
+ * Compute the indistinguishability percentage for a subset of drafts.
+ * Returns 0 with a denominator of 0 when no agent-drafted items were
+ * judged (caller decides whether that's a fail-closed or skip).
+ */
+function scoreForDraftSubset(
+  drafts: BlindTestDraft[],
+  judgments: JudgeIdentification[]
+): { score_pct: number; indistinguishable: number; total: number } {
+  const agentDraftIds = new Set(drafts.filter((d) => d.authorship === 'agent').map((d) => d.id))
+  const agentJudgments = judgments.filter((j) => agentDraftIds.has(j.draft_id))
+  const total = agentJudgments.length
+  if (total === 0) {
+    return { score_pct: 0, indistinguishable: 0, total: 0 }
+  }
+  const indistinguishable = agentJudgments.filter(isIndistinguishable).length
+  const score_pct = Math.round((indistinguishable / total) * 1000) / 10
+  return { score_pct, indistinguishable, total }
+}
+
+/**
+ * Pick out the judge IDs whose misidentifications (correct identification
+ * of an agent draft) drove the score down. Used by the failure record to
+ * help Captain review which judges' instincts to weight in calibration.
+ */
+function flaggedJudgesFor(drafts: BlindTestDraft[], judgments: JudgeIdentification[]): string[] {
+  const agentDraftIds = new Set(drafts.filter((d) => d.authorship === 'agent').map((d) => d.id))
+  const flagged = new Set<string>()
+  for (const j of judgments) {
+    if (agentDraftIds.has(j.draft_id) && j.choice === 'agent') {
+      flagged.add(j.judge_id)
+    }
+  }
+  return [...flagged].sort()
+}
+
+/**
+ * Recommend Path A vs Path B per voice-gate-fallback.md §Fail state.
+ * Severity-based: catastrophic failures (<40%) lean toward Path B
+ * (pause engagement); marginal failures (40-59%) lean toward Path A
+ * (internal-drafts-only). Captain makes the final call.
+ */
+function recommendedPathFor(
+  score_pct: number,
+  auto_transitioned: boolean
+): 'A_internal_drafts_only' | 'B_pause_engagement' | 'either' {
+  if (auto_transitioned) return 'A_internal_drafts_only'
+  if (score_pct < 40) return 'B_pause_engagement'
+  if (score_pct < 50) return 'either'
+  return 'A_internal_drafts_only'
+}
+
+/**
+ * Compute the per-cohort score breakdown when the run mixed cohorts.
+ * Returns undefined when the run was scoped to a single cohort to
+ * keep the CLI output uncluttered.
+ */
+function perCohortBreakdown(run: BlindTestRun): Record<RecipientCohort, CohortScore> | undefined {
+  if (run.cohort !== 'all') return undefined
+  const result = {} as Record<RecipientCohort, CohortScore>
+  for (const cohort of RECIPIENT_COHORTS) {
+    const cohortDrafts = run.drafts.filter((d) => d.cohort === cohort)
+    const cohortJudgments = run.identifications.filter((j) =>
+      cohortDrafts.some((d) => d.id === j.draft_id)
+    )
+    const sub = scoreForDraftSubset(cohortDrafts, cohortJudgments)
+    result[cohort] = {
+      cohort,
+      score_pct: sub.score_pct,
+      indistinguishable_count: sub.indistinguishable,
+      total_agent_judgments: sub.total,
+    }
+  }
+  return result
+}
+
+/**
+ * Score a blind-test run and emit the full structured result.
+ *
+ * Threshold logic:
+ *
+ *   1. Compute overall indistinguishability % across all agent-drafted
+ *      judgments (single cohort or 'all').
+ *   2. If `cycle_count >= MAX_NEAR_PASS_CYCLES` AND score < 80%, force
+ *      fail with `auto_transitioned_from_near_pass: true`. This is the
+ *      "third blind-test still scores <80%" auto-transition rule.
+ *   3. Otherwise map score → state via `stateForScore`.
+ *   4. Build the audit action + structured per-state record.
+ *
+ * Pure function — does not write to D1, does not call audit log, does
+ * not send messages. Caller persists the result.
+ */
+export function scoreRun(run: BlindTestRun): GateResult {
+  const overall = scoreForDraftSubset(run.drafts, run.identifications)
+
+  const cycleCountForcesfail =
+    run.cycle_count >= VOICE_GATE_MAX_NEAR_PASS_CYCLES &&
+    overall.score_pct < VOICE_GATE_PASS_THRESHOLD_PCT
+
+  const naturalState = stateForScore(overall.score_pct)
+  const state: GateState = cycleCountForcesfail ? 'fail' : naturalState
+
+  const per_cohort = perCohortBreakdown(run)
+  const below_threshold_cohorts: RecipientCohort[] = per_cohort
+    ? RECIPIENT_COHORTS.filter((c) => per_cohort[c].score_pct < VOICE_GATE_PASS_THRESHOLD_PCT)
+    : []
+
+  let failure_record: FailureRecord | undefined
+  let near_pass_record: NearPassRecord | undefined
+
+  if (state === 'fail') {
+    failure_record = {
+      score_pct: overall.score_pct,
+      cycle_count: run.cycle_count,
+      auto_transitioned_from_near_pass: cycleCountForcesfail,
+      below_threshold_cohorts,
+      flagged_judge_ids: flaggedJudgesFor(run.drafts, run.identifications),
+      recommended_path: recommendedPathFor(overall.score_pct, cycleCountForcesfail),
+    }
+  } else if (state === 'near-pass') {
+    const isFinal = run.cycle_count >= VOICE_GATE_MAX_NEAR_PASS_CYCLES - 1
+    near_pass_record = {
+      score_pct: overall.score_pct,
+      cycle_count: run.cycle_count,
+      is_final_cycle: isFinal,
+      minimum_days_to_retry: VOICE_GATE_MIN_DAYS_BETWEEN_CYCLES,
+    }
+  }
+
+  const summary = formatSummary(state, overall.score_pct, run)
+
+  return {
+    state,
+    audit_action: auditActionFor(state),
+    score_pct: overall.score_pct,
+    indistinguishable_count: overall.indistinguishable,
+    total_agent_judgments: overall.total,
+    per_cohort,
+    summary,
+    failure_record,
+    near_pass_record,
+  }
+}
+
+/**
+ * One-line human-readable summary. Mirrors what Captain would write into
+ * the audit log; the CLI prints this verbatim and the disclosure template
+ * splices it in.
+ */
+function formatSummary(state: GateState, score_pct: number, run: BlindTestRun): string {
+  const cohortLabel = run.cohort === 'all' ? 'all cohorts' : `cohort ${run.cohort}`
+  const cycleLabel = run.cycle_count > 0 ? ` (cycle ${run.cycle_count + 1})` : ''
+  switch (state) {
+    case 'pass':
+      return `PASS at ${score_pct}% across ${cohortLabel}${cycleLabel} — external drafts unlocked.`
+    case 'near-pass':
+      return `NEAR-PASS at ${score_pct}% across ${cohortLabel}${cycleLabel} — calibration cycle required.`
+    case 'fail':
+      return `FAIL at ${score_pct}% across ${cohortLabel}${cycleLabel} — external drafts blocked; Captain disclosure protocol triggered.`
+  }
+}
+
+/**
+ * Build the JSON metadata payload for the audit_log row. Field set per
+ * voice-gate-fallback.md §Three states ("State recorded in audit_log…").
+ */
+export function buildAuditMetadata(run: BlindTestRun, result: GateResult): string {
+  const base: Record<string, unknown> = {
+    score: result.score_pct,
+    judge_ids: run.panel,
+    sample_set_id: run.run_id,
+    cycle_count: run.cycle_count,
+  }
+  if (result.failure_record) {
+    base['failure_recommended_path'] = result.failure_record.recommended_path
+    base['failure_auto_transitioned'] = result.failure_record.auto_transitioned_from_near_pass
+    // disclosure_artifact_r2_key is filled in by the downstream disclosure
+    // generator and merged onto this metadata when the row is written.
+  }
+  if (result.per_cohort) {
+    base['per_cohort'] = result.per_cohort
+  }
+  return JSON.stringify(base)
+}

--- a/ai-employee/voice-gate/types.ts
+++ b/ai-employee/voice-gate/types.ts
@@ -1,0 +1,243 @@
+/**
+ * Voice-gate harness — shared types.
+ *
+ * Source: Platform PRD §9.6 (three-gate voice quality model) and
+ * docs/specs/ai-employee/voice-gate-fallback.md (three-state Pass /
+ * Near-pass / Fail contract). This file defines the typed shapes the
+ * harness, scoring, panel, and (future) D1 writer agree on.
+ *
+ * Nothing in this module reads or writes external state. Persistence
+ * is the responsibility of callers (CLI runner, future D1 writer in a
+ * separate workstream — see README integration section).
+ */
+
+/**
+ * Recipient cohort for blind-test framing. Three v1 cohorts per PRD §9.3
+ * Layer 3. New cohorts must be added here AND threaded through the panel
+ * + fixture loader; the closed union prevents silent drift.
+ */
+export type RecipientCohort = 'client' | 'opposing-counsel' | 'internal-team'
+
+/**
+ * Authorship label attached to a draft. The blind test hides this label
+ * from judges; the harness uses it to grade their identifications.
+ */
+export type DraftAuthorship = 'customer' | 'agent'
+
+/**
+ * Judge's identification choice. `uncertain` is a deliberate third option
+ * per voice-gate-fallback.md §Contract: indistinguishability counts both
+ * "labeled customer when actually agent" AND "uncertain — could be either"
+ * as the judge being unable to reliably identify the agent.
+ */
+export type JudgeChoice = 'customer' | 'agent' | 'uncertain'
+
+/**
+ * One draft presented to judges in the blind test. The harness shuffles
+ * these so judges see them in randomized order; `authorship` is the
+ * ground-truth label the panel layer hides during presentation and the
+ * scoring layer reads when grading.
+ */
+export interface BlindTestDraft {
+  /** Stable ID, stable across runs (e.g. "smith-pi-firm/client/draft-001"). */
+  id: string
+  /** Recipient cohort this draft was authored for. */
+  cohort: RecipientCohort
+  /** Ground-truth label. Hidden from judges during presentation. */
+  authorship: DraftAuthorship
+  /** Draft body text. Plaintext or markdown; harness does not render HTML. */
+  body: string
+  /**
+   * Optional metadata (subject line, scenario tag). Surfaced to judges only
+   * if `includeInPresentation: true` to preserve realism without leaking
+   * the authorship label.
+   */
+  metadata?: {
+    subject?: string
+    scenario?: string
+    includeInPresentation?: boolean
+  }
+}
+
+/**
+ * One judge's identification of one draft. Recorded by the panel layer
+ * during a blind-test run; consumed by scoring.
+ */
+export interface JudgeIdentification {
+  /** Draft this judgment refers to. */
+  draft_id: string
+  /** Judge identifier. Opaque to the harness. */
+  judge_id: string
+  /** Judge's choice. */
+  choice: JudgeChoice
+  /** Optional free-text reasoning the judge gave. */
+  notes?: string
+}
+
+/**
+ * The complete record of one blind-test run, persisted to per-customer
+ * storage (D1 + R2 — wiring is out of scope for this workstream; see
+ * voice-gate-fallback.md §Verification).
+ */
+export interface BlindTestRun {
+  /** ULID-shaped run ID. */
+  run_id: string
+  /** Customer slug (e.g. "smith-pi-firm"). */
+  customer_slug: string
+  /** Cohort scoped for this run, or 'all' if mixed. */
+  cohort: RecipientCohort | 'all'
+  /** ISO 8601 UTC timestamp when the run was created. */
+  started_at: string
+  /** ISO 8601 UTC timestamp when scoring completed. May be null if mid-run. */
+  scored_at: string | null
+  /** Drafts presented to judges. */
+  drafts: BlindTestDraft[]
+  /** Judge IDs invited to the panel. */
+  panel: string[]
+  /** All identifications captured. */
+  identifications: JudgeIdentification[]
+  /**
+   * Cycle count: 0 for the first run on a customer, 1 for the first
+   * near-pass retry, 2 for the second. See voice-gate-fallback.md
+   * §Near-pass cycle.
+   */
+  cycle_count: number
+}
+
+/**
+ * Outcome state for a blind test. Matches the three-state contract in
+ * voice-gate-fallback.md §Three states.
+ */
+export type GateState = 'pass' | 'near-pass' | 'fail'
+
+/**
+ * Audit-log action_type values written when a gate run resolves. See
+ * d1-schema.md §1 (audit_log) accepted action_type list. The audit-log
+ * writer is a separate workstream; this harness emits the structured
+ * record and the integration point is documented in README.
+ */
+export type GateAuditAction = 'VOICE_GATE_PASSED' | 'VOICE_GATE_NEAR_PASS' | 'VOICE_GATE_FAILED'
+
+/**
+ * Result of scoring a blind-test run. The harness emits one of these
+ * regardless of outcome; downstream consumers branch on `state` to
+ * dispatch fallback behavior (live promotion / calibration cycle /
+ * disclosure protocol).
+ */
+export interface GateResult {
+  /** Pass / near-pass / fail per the threshold constants in scoring.ts. */
+  state: GateState
+  /** Audit-log action_type to emit. */
+  audit_action: GateAuditAction
+  /** Indistinguishability percentage in [0, 100], rounded to one decimal. */
+  score_pct: number
+  /** Raw indistinguishable count over total agent-drafted judgments. */
+  indistinguishable_count: number
+  /** Total agent-drafted judgments evaluated. */
+  total_agent_judgments: number
+  /**
+   * Per-cohort score breakdown when the run mixed cohorts. Empty when
+   * the run was scoped to a single cohort.
+   */
+  per_cohort?: Record<RecipientCohort, CohortScore>
+  /** Human-readable summary line (used by the CLI and disclosure artifact). */
+  summary: string
+  /**
+   * Failure record per voice-gate-fallback.md §Fail state. Populated only
+   * when `state === 'fail'`. Encodes the structured record the
+   * disclosure protocol consumes; the actual disclosure-document
+   * generation is downstream.
+   */
+  failure_record?: FailureRecord
+  /**
+   * Near-pass record per voice-gate-fallback.md §Near-pass cycle.
+   * Populated only when `state === 'near-pass'`. Tells the caller which
+   * cycle this is and whether a third near-pass would auto-transition
+   * to fail.
+   */
+  near_pass_record?: NearPassRecord
+}
+
+/**
+ * Per-cohort score breakdown.
+ */
+export interface CohortScore {
+  cohort: RecipientCohort
+  score_pct: number
+  indistinguishable_count: number
+  total_agent_judgments: number
+}
+
+/**
+ * Structured failure record. Captain's disclosure protocol generates a
+ * markdown artifact from this; the live-promotion gate fails closed
+ * based on its presence in the audit log.
+ */
+export interface FailureRecord {
+  /** Score that triggered failure (<60% OR third near-pass). */
+  score_pct: number
+  /** Cycle count at time of failure (0, 1, or 2). */
+  cycle_count: number
+  /** Whether this is an auto-transition from the third near-pass. */
+  auto_transitioned_from_near_pass: boolean
+  /** Cohorts that scored below threshold (informational, not gating). */
+  below_threshold_cohorts: RecipientCohort[]
+  /**
+   * Judge IDs whose misidentifications drove the failure — used by
+   * Captain when reviewing which voice rules misfired.
+   */
+  flagged_judge_ids: string[]
+  /**
+   * Recommended path per voice-gate-fallback.md §Fail state. The harness
+   * does not choose between Path A and Path B; Captain does. The
+   * recommendation is informational based on score severity.
+   */
+  recommended_path: 'A_internal_drafts_only' | 'B_pause_engagement' | 'either'
+}
+
+/**
+ * Structured near-pass record. The calibration cycle is operationally
+ * Captain-led; the harness records the count so the third near-pass
+ * triggers fail-state auto-transition.
+ */
+export interface NearPassRecord {
+  /** Score in the 60-79.9 band. */
+  score_pct: number
+  /** Cycle count this run resolved at. */
+  cycle_count: number
+  /** Whether this was the final allowed near-pass cycle. */
+  is_final_cycle: boolean
+  /** Calendar days the customer must wait before re-running, per spec. */
+  minimum_days_to_retry: number
+}
+
+/**
+ * Persistence shape for the per-customer Hermes D1 panel-score row.
+ * Defined here so the future D1 writer (separate workstream) consumes a
+ * stable typed contract. Mirrors the audit_log row layout from
+ * d1-schema.md §1 with voice-gate-specific metadata.
+ */
+export interface VoiceGatePanelScoreRow {
+  /** ULID matching the audit_log row. */
+  id: string
+  /** ISO 8601 UTC. */
+  ts: string
+  /** action_type discriminator. */
+  action_type: GateAuditAction
+  /** 'captain' for voice-gate runs (Captain orchestrates the panel). */
+  actor: 'captain'
+  actor_role: 'captain'
+  /** Empty for voice-gate events. */
+  skill_name: null
+  matter_ref: null
+  input_digest: null
+  output_digest: null
+  diff_digest: null
+  trust_ceiling: null
+  /**
+   * JSON-encoded payload. Keys: score, judge_ids (string[]), sample_set_id,
+   * cycle_count, disclosure_artifact_r2_key?. See voice-gate-fallback.md
+   * §Three states for the metadata field-by-state contract.
+   */
+  metadata: string
+}

--- a/tests/voice-gate-harness.test.ts
+++ b/tests/voice-gate-harness.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the voice-gate harness top-level orchestration.
+ *
+ * Covers:
+ *   - runVoiceGate composes panel + scoring correctly
+ *   - production-minimum enforcement via runVoiceGate
+ *   - buildAuditRow shape matches d1-schema.md §1 audit_log row
+ *   - fixture loader round-trips synthetic-set.json
+ *   - synthetic identifications produce a deterministic gate result
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  RECIPIENT_COHORTS,
+  buildAuditRow,
+  loadFixtureSet,
+  runVoiceGate,
+  type JudgeIdentification,
+  type RecipientCohort,
+} from '../ai-employee/voice-gate/index.js'
+
+describe('runVoiceGate', () => {
+  it('composes panel + scoring for a passing run', () => {
+    const drafts = [
+      {
+        id: 'd-c-1',
+        cohort: 'client' as RecipientCohort,
+        authorship: 'customer' as const,
+        body: 'b',
+      },
+      { id: 'd-a-1', cohort: 'client' as RecipientCohort, authorship: 'agent' as const, body: 'b' },
+    ]
+    const identifications: JudgeIdentification[] = [
+      { draft_id: 'd-c-1', judge_id: 'j1', choice: 'customer' },
+      { draft_id: 'd-a-1', judge_id: 'j1', choice: 'customer' },
+    ]
+    const { run, result } = runVoiceGate({
+      customer_slug: 'test-firm',
+      cohort: 'client',
+      run_id: 'run-1',
+      drafts,
+      panel: ['j1'],
+      cycle_count: 0,
+      identifications,
+    })
+    expect(run.scored_at).not.toBeNull()
+    expect(result.state).toBe('pass')
+    expect(result.score_pct).toBe(100)
+  })
+
+  it('rejects malformed input with all errors surfaced', () => {
+    expect(() =>
+      runVoiceGate({
+        customer_slug: '',
+        cohort: 'client',
+        run_id: '',
+        drafts: [],
+        panel: [],
+        cycle_count: -1,
+        identifications: [],
+      })
+    ).toThrow(/voice-gate validation failed/)
+  })
+
+  it('enforces production minimums when enforceProductionMinimums is true', () => {
+    expect(() =>
+      runVoiceGate({
+        customer_slug: 'test-firm',
+        cohort: 'client',
+        run_id: 'run-1',
+        drafts: [
+          { id: 'd-c-1', cohort: 'client', authorship: 'customer', body: 'b' },
+          { id: 'd-a-1', cohort: 'client', authorship: 'agent', body: 'b' },
+        ],
+        panel: ['j1'],
+        cycle_count: 0,
+        identifications: [],
+        enforceProductionMinimums: true,
+      })
+    ).toThrow(/need 10|need 3/)
+  })
+})
+
+describe('buildAuditRow', () => {
+  it('produces a row matching d1-schema.md §1 audit_log shape', () => {
+    const drafts = [
+      {
+        id: 'd-c-1',
+        cohort: 'client' as RecipientCohort,
+        authorship: 'customer' as const,
+        body: 'b',
+      },
+      { id: 'd-a-1', cohort: 'client' as RecipientCohort, authorship: 'agent' as const, body: 'b' },
+    ]
+    const { run, result } = runVoiceGate({
+      customer_slug: 'test-firm',
+      cohort: 'client',
+      run_id: 'run-1',
+      drafts,
+      panel: ['j1'],
+      cycle_count: 0,
+      identifications: [
+        { draft_id: 'd-c-1', judge_id: 'j1', choice: 'customer' },
+        { draft_id: 'd-a-1', judge_id: 'j1', choice: 'customer' },
+      ],
+    })
+    const row = buildAuditRow('01J-row-id', run, result, '2026-05-21T12:00:00Z')
+    expect(row.id).toBe('01J-row-id')
+    expect(row.ts).toBe('2026-05-21T12:00:00Z')
+    expect(row.action_type).toBe('VOICE_GATE_PASSED')
+    expect(row.actor).toBe('captain')
+    expect(row.actor_role).toBe('captain')
+    expect(row.skill_name).toBeNull()
+    expect(row.matter_ref).toBeNull()
+    expect(typeof row.metadata).toBe('string')
+    const meta = JSON.parse(row.metadata) as Record<string, unknown>
+    expect(meta['score']).toBe(100)
+    expect(meta['judge_ids']).toEqual(['j1'])
+    expect(meta['sample_set_id']).toBe('run-1')
+  })
+
+  it('defaults timestamp to now when not provided', () => {
+    const drafts = [
+      {
+        id: 'd-c-1',
+        cohort: 'client' as RecipientCohort,
+        authorship: 'customer' as const,
+        body: 'b',
+      },
+      { id: 'd-a-1', cohort: 'client' as RecipientCohort, authorship: 'agent' as const, body: 'b' },
+    ]
+    const { run, result } = runVoiceGate({
+      customer_slug: 'test-firm',
+      cohort: 'client',
+      run_id: 'run-1',
+      drafts,
+      panel: ['j1'],
+      cycle_count: 0,
+      identifications: [
+        { draft_id: 'd-c-1', judge_id: 'j1', choice: 'customer' },
+        { draft_id: 'd-a-1', judge_id: 'j1', choice: 'customer' },
+      ],
+    })
+    const before = Date.now()
+    const row = buildAuditRow('id', run, result)
+    const rowTime = Date.parse(row.ts)
+    expect(rowTime).toBeGreaterThanOrEqual(before - 1)
+    expect(rowTime).toBeLessThanOrEqual(Date.now() + 1)
+  })
+})
+
+describe('fixture loader', () => {
+  it('round-trips the bundled synthetic set', async () => {
+    const set = await loadFixtureSet()
+    expect(set.customer_slug).toBe('smith-pi-firm')
+    // 3 cohorts × 3 drafts each = 9 total
+    expect(set.drafts).toHaveLength(9)
+    for (const cohort of RECIPIENT_COHORTS) {
+      const cohortDrafts = set.drafts.filter((d) => d.cohort === cohort)
+      expect(cohortDrafts).toHaveLength(3)
+      const customerCount = cohortDrafts.filter((d) => d.authorship === 'customer').length
+      const agentCount = cohortDrafts.filter((d) => d.authorship === 'agent').length
+      expect(customerCount).toBe(1)
+      expect(agentCount).toBe(2)
+    }
+  })
+
+  it('every fixture draft uses placeholder names (no fabricated client data)', async () => {
+    const set = await loadFixtureSet()
+    for (const d of set.drafts) {
+      // Placeholder-discipline check: IDs and bodies should reference
+      // placeholder names, never plausible-real names. Two markers we
+      // know are present in the bundled fixtures:
+      const hasPlaceholderId = d.id.startsWith('smith-pi-firm/')
+      const hasPlaceholderInBody =
+        d.body.includes('placeholder-') || d.body.toLowerCase().includes('placeholder')
+      expect(hasPlaceholderId).toBe(true)
+      expect(hasPlaceholderInBody).toBe(true)
+    }
+  })
+})
+
+describe('end-to-end synthetic run', () => {
+  it('drives the bundled fixture set with the example identifications and resolves to a known result', async () => {
+    const set = await loadFixtureSet()
+    // Mirror the bundled example-identifications.json. Three judges,
+    // 9 drafts each = 27 identifications; agents are 2/3 of drafts so
+    // 18 agent judgments total.
+    const judges = ['judge-A', 'judge-B', 'judge-C']
+    const identifications: JudgeIdentification[] = []
+    for (const judge of judges) {
+      for (const d of set.drafts) {
+        // Most judges fail to identify the agent drafts (call them
+        // customer), which yields a high indistinguishability score.
+        identifications.push({
+          draft_id: d.id,
+          judge_id: judge,
+          choice: 'customer',
+        })
+      }
+    }
+    const { result } = runVoiceGate({
+      customer_slug: set.customer_slug,
+      cohort: 'all',
+      run_id: 'e2e-run',
+      drafts: set.drafts,
+      panel: judges,
+      cycle_count: 0,
+      identifications,
+    })
+    // 18 agent judgments, all "customer" → 100% indistinguishable
+    expect(result.score_pct).toBe(100)
+    expect(result.state).toBe('pass')
+    expect(result.per_cohort?.client.score_pct).toBe(100)
+    expect(result.per_cohort?.['opposing-counsel'].score_pct).toBe(100)
+    expect(result.per_cohort?.['internal-team'].score_pct).toBe(100)
+  })
+
+  it('mid-band judging produces near-pass with cycle metadata', async () => {
+    const set = await loadFixtureSet()
+    const judges = ['judge-A', 'judge-B', 'judge-C']
+    const identifications: JudgeIdentification[] = []
+    let agentSeen = 0
+    for (const judge of judges) {
+      for (const d of set.drafts) {
+        if (d.authorship === 'agent') {
+          // Catch every third agent draft as agent → ~67% indistinguishability
+          const caught = agentSeen % 3 === 0
+          identifications.push({
+            draft_id: d.id,
+            judge_id: judge,
+            choice: caught ? 'agent' : 'customer',
+          })
+          agentSeen++
+        } else {
+          identifications.push({
+            draft_id: d.id,
+            judge_id: judge,
+            choice: 'customer',
+          })
+        }
+      }
+    }
+    const { result } = runVoiceGate({
+      customer_slug: set.customer_slug,
+      cohort: 'all',
+      run_id: 'e2e-near-pass',
+      drafts: set.drafts,
+      panel: judges,
+      cycle_count: 1,
+      identifications,
+    })
+    expect(result.state).toBe('near-pass')
+    expect(result.near_pass_record).toBeDefined()
+    expect(result.near_pass_record?.is_final_cycle).toBe(true)
+  })
+})

--- a/tests/voice-gate-panel.test.ts
+++ b/tests/voice-gate-panel.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the voice-gate panel layer.
+ *
+ * Covers:
+ *   - input validation (production minimums per voice-gate-fallback.md §Contract)
+ *   - authorship label stripping in presentation order
+ *   - deterministic seeded shuffle (reproducibility)
+ *   - identification recording + idempotent overwrite
+ *   - judge / draft membership guards
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP,
+  PRODUCTION_MIN_JUDGES,
+  PanelSession,
+  presentDraft,
+  validatePanelInput,
+} from '../ai-employee/voice-gate/index.js'
+import type {
+  BlindTestDraft,
+  CreatePanelSessionInput,
+  RecipientCohort,
+} from '../ai-employee/voice-gate/index.js'
+
+function draft(
+  id: string,
+  cohort: RecipientCohort,
+  authorship: 'customer' | 'agent',
+  metadata?: BlindTestDraft['metadata']
+): BlindTestDraft {
+  const d: BlindTestDraft = { id, cohort, authorship, body: `body for ${id}` }
+  if (metadata) d.metadata = metadata
+  return d
+}
+
+function minimalInput(overrides: Partial<CreatePanelSessionInput> = {}): CreatePanelSessionInput {
+  return {
+    customer_slug: 'test-firm',
+    cohort: 'client',
+    run_id: 'run-test',
+    drafts: [draft('d-customer-1', 'client', 'customer'), draft('d-agent-1', 'client', 'agent')],
+    panel: ['judge-A'],
+    cycle_count: 0,
+    ...overrides,
+  }
+}
+
+describe('validatePanelInput — required fields', () => {
+  it('passes a minimal valid input', () => {
+    expect(validatePanelInput(minimalInput())).toEqual([])
+  })
+
+  it('flags missing customer_slug', () => {
+    const problems = validatePanelInput(minimalInput({ customer_slug: '   ' }))
+    expect(problems).toContain('customer_slug is required')
+  })
+
+  it('flags missing run_id', () => {
+    const problems = validatePanelInput(minimalInput({ run_id: '' }))
+    expect(problems).toContain('run_id is required')
+  })
+
+  it('flags negative cycle_count', () => {
+    const problems = validatePanelInput(minimalInput({ cycle_count: -1 }))
+    expect(problems).toContain('cycle_count must be a non-negative integer')
+  })
+
+  it('flags non-integer cycle_count', () => {
+    const problems = validatePanelInput(minimalInput({ cycle_count: 1.5 }))
+    expect(problems).toContain('cycle_count must be a non-negative integer')
+  })
+
+  it('flags empty drafts array', () => {
+    const problems = validatePanelInput(minimalInput({ drafts: [] }))
+    expect(problems).toContain('at least one draft required')
+  })
+
+  it('flags missing customer-authored drafts', () => {
+    const problems = validatePanelInput(minimalInput({ drafts: [draft('d-1', 'client', 'agent')] }))
+    expect(problems).toContain('no customer-authored drafts provided')
+  })
+
+  it('flags missing agent-drafted drafts', () => {
+    const problems = validatePanelInput(
+      minimalInput({ drafts: [draft('d-1', 'client', 'customer')] })
+    )
+    expect(problems).toContain('no agent-drafted drafts provided')
+  })
+})
+
+describe('validatePanelInput — cohort consistency', () => {
+  it('flags drafts from the wrong cohort in cohort-scoped run', () => {
+    const problems = validatePanelInput(
+      minimalInput({
+        cohort: 'client',
+        drafts: [
+          draft('d-customer-1', 'client', 'customer'),
+          draft('d-agent-1', 'opposing-counsel', 'agent'), // wrong cohort
+        ],
+      })
+    )
+    expect(problems.some((p) => p.includes('cohort-scoped session'))).toBe(true)
+  })
+
+  it("flags missing cohorts in 'all' run", () => {
+    const problems = validatePanelInput(
+      minimalInput({
+        cohort: 'all',
+        drafts: [draft('d-c1', 'client', 'customer'), draft('d-a1', 'client', 'agent')],
+      })
+    )
+    expect(problems.some((p) => p.includes("'all' cohort run missing drafts"))).toBe(true)
+  })
+
+  it("accepts 'all' run with every cohort represented", () => {
+    const problems = validatePanelInput(
+      minimalInput({
+        cohort: 'all',
+        drafts: [
+          draft('d-c-cust', 'client', 'customer'),
+          draft('d-c-ag', 'client', 'agent'),
+          draft('d-oc-cust', 'opposing-counsel', 'customer'),
+          draft('d-oc-ag', 'opposing-counsel', 'agent'),
+          draft('d-it-cust', 'internal-team', 'customer'),
+          draft('d-it-ag', 'internal-team', 'agent'),
+        ],
+      })
+    )
+    expect(problems).toEqual([])
+  })
+})
+
+describe('validatePanelInput — production minimums', () => {
+  it('does NOT enforce minimums in synthetic mode (default)', () => {
+    expect(validatePanelInput(minimalInput())).toEqual([])
+  })
+
+  it('enforces minimums when option set', () => {
+    const problems = validatePanelInput(minimalInput(), {
+      enforceProductionMinimums: true,
+    })
+    expect(problems.some((p) => p.includes(`(need ${PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP})`))).toBe(
+      true
+    )
+    expect(problems.some((p) => p.includes(`(need ${PRODUCTION_MIN_JUDGES})`))).toBe(true)
+  })
+
+  it('accepts a panel that meets minimums', () => {
+    const drafts: BlindTestDraft[] = []
+    for (let i = 0; i < PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP; i++) {
+      drafts.push(draft(`c-${i}`, 'client', 'customer'))
+      drafts.push(draft(`a-${i}`, 'client', 'agent'))
+    }
+    const panel: string[] = []
+    for (let i = 0; i < PRODUCTION_MIN_JUDGES; i++) {
+      panel.push(`judge-${i}`)
+    }
+    const problems = validatePanelInput(minimalInput({ drafts, panel }), {
+      enforceProductionMinimums: true,
+    })
+    expect(problems).toEqual([])
+  })
+})
+
+describe('validatePanelInput — duplicates', () => {
+  it('flags duplicate draft IDs', () => {
+    const problems = validatePanelInput(
+      minimalInput({
+        drafts: [draft('dup', 'client', 'customer'), draft('dup', 'client', 'agent')],
+      })
+    )
+    expect(problems.some((p) => p.includes('duplicate draft IDs'))).toBe(true)
+  })
+
+  it('flags duplicate judge IDs', () => {
+    const problems = validatePanelInput(minimalInput({ panel: ['judge-A', 'judge-A'] }))
+    expect(problems.some((p) => p.includes('duplicate judge IDs'))).toBe(true)
+  })
+})
+
+describe('presentDraft — authorship stripping', () => {
+  it('strips the authorship label', () => {
+    const d = draft('d-1', 'client', 'agent')
+    const presented = presentDraft(d)
+    expect(presented).not.toHaveProperty('authorship')
+  })
+
+  it('omits metadata fields by default', () => {
+    const d = draft('d-1', 'client', 'agent', {
+      subject: 'should be hidden',
+      includeInPresentation: false,
+    })
+    const presented = presentDraft(d)
+    expect(presented.subject).toBeUndefined()
+  })
+
+  it('includes metadata when includeInPresentation is true', () => {
+    const d = draft('d-1', 'client', 'agent', {
+      subject: 'Update on your case',
+      scenario: 'weekly touchpoint',
+      includeInPresentation: true,
+    })
+    const presented = presentDraft(d)
+    expect(presented.subject).toBe('Update on your case')
+    expect(presented.scenario).toBe('weekly touchpoint')
+  })
+})
+
+describe('PanelSession — deterministic shuffle', () => {
+  it('produces identical order for the same run_id', () => {
+    const drafts: BlindTestDraft[] = []
+    for (let i = 0; i < 10; i++) {
+      drafts.push(draft(`c-${i}`, 'client', 'customer'))
+      drafts.push(draft(`a-${i}`, 'client', 'agent'))
+    }
+    const s1 = new PanelSession(minimalInput({ run_id: 'seed-x', drafts }))
+    const s2 = new PanelSession(minimalInput({ run_id: 'seed-x', drafts }))
+    expect(s1.presentationOrder().map((d) => d.id)).toEqual(s2.presentationOrder().map((d) => d.id))
+  })
+
+  it('produces different order for different run_ids', () => {
+    const drafts: BlindTestDraft[] = []
+    for (let i = 0; i < 10; i++) {
+      drafts.push(draft(`c-${i}`, 'client', 'customer'))
+      drafts.push(draft(`a-${i}`, 'client', 'agent'))
+    }
+    const s1 = new PanelSession(minimalInput({ run_id: 'seed-A', drafts }))
+    const s2 = new PanelSession(minimalInput({ run_id: 'seed-B', drafts }))
+    expect(s1.presentationOrder().map((d) => d.id)).not.toEqual(
+      s2.presentationOrder().map((d) => d.id)
+    )
+  })
+
+  it('preserves every draft (no drops, no duplicates)', () => {
+    const drafts: BlindTestDraft[] = []
+    for (let i = 0; i < 20; i++) {
+      drafts.push(draft(`d-${i}`, 'client', i % 2 === 0 ? 'customer' : 'agent'))
+    }
+    const s = new PanelSession(minimalInput({ drafts }))
+    const ids = s.presentationOrder().map((d) => d.id)
+    expect(ids).toHaveLength(20)
+    expect(new Set(ids).size).toBe(20)
+  })
+})
+
+describe('PanelSession — recordIdentification', () => {
+  it('rejects judges not on the panel', () => {
+    const s = new PanelSession(minimalInput({ panel: ['judge-A'] }))
+    expect(() =>
+      s.recordIdentification({
+        draft_id: 'd-customer-1',
+        judge_id: 'judge-X',
+        choice: 'customer',
+      })
+    ).toThrow(/not on this panel/)
+  })
+
+  it('rejects drafts not in the session', () => {
+    const s = new PanelSession(minimalInput())
+    expect(() =>
+      s.recordIdentification({
+        draft_id: 'd-not-here',
+        judge_id: 'judge-A',
+        choice: 'customer',
+      })
+    ).toThrow(/not in this session/)
+  })
+
+  it('returns true when recording a new identification', () => {
+    const s = new PanelSession(minimalInput())
+    expect(
+      s.recordIdentification({
+        draft_id: 'd-agent-1',
+        judge_id: 'judge-A',
+        choice: 'customer',
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when replacing an existing identification', () => {
+    const s = new PanelSession(minimalInput())
+    s.recordIdentification({
+      draft_id: 'd-agent-1',
+      judge_id: 'judge-A',
+      choice: 'customer',
+    })
+    expect(
+      s.recordIdentification({
+        draft_id: 'd-agent-1',
+        judge_id: 'judge-A',
+        choice: 'agent',
+      })
+    ).toBe(false)
+    expect(s.run.identifications).toHaveLength(1)
+    expect(s.run.identifications[0]?.choice).toBe('agent')
+  })
+
+  it('isComplete returns true only when every (judge, draft) pair has been identified', () => {
+    const s = new PanelSession(minimalInput({ panel: ['j1', 'j2'] }))
+    expect(s.isComplete()).toBe(false)
+    s.recordIdentification({
+      draft_id: 'd-customer-1',
+      judge_id: 'j1',
+      choice: 'customer',
+    })
+    s.recordIdentification({
+      draft_id: 'd-agent-1',
+      judge_id: 'j1',
+      choice: 'customer',
+    })
+    s.recordIdentification({
+      draft_id: 'd-customer-1',
+      judge_id: 'j2',
+      choice: 'customer',
+    })
+    expect(s.isComplete()).toBe(false)
+    s.recordIdentification({
+      draft_id: 'd-agent-1',
+      judge_id: 'j2',
+      choice: 'agent',
+    })
+    expect(s.isComplete()).toBe(true)
+  })
+})
+
+describe('PanelSession — seal', () => {
+  it('sets scored_at on the run', () => {
+    const s = new PanelSession(minimalInput())
+    expect(s.run.scored_at).toBeNull()
+    const sealed = s.seal('2026-05-21T12:00:00Z')
+    expect(sealed.scored_at).toBe('2026-05-21T12:00:00Z')
+  })
+
+  it('throws if any required field is invalid', () => {
+    expect(() => new PanelSession(minimalInput({ run_id: '' }))).toThrow()
+  })
+})

--- a/tests/voice-gate-scoring.test.ts
+++ b/tests/voice-gate-scoring.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for the voice-gate scoring layer.
+ *
+ * Covers:
+ *   - PRD §9.6 ≥80% pass threshold (single source of truth check)
+ *   - voice-gate-fallback.md §Three states band boundaries
+ *   - §Near-pass cycle auto-transition rule (third near-pass → fail)
+ *   - indistinguishability counts customer + uncertain
+ *   - audit_action mapping per d1-schema.md §1
+ *
+ * Synthetic blind-test runs are constructed directly here rather than
+ * loaded from disk so the threshold logic is isolated from fixture +
+ * panel concerns.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  RECIPIENT_COHORTS,
+  VOICE_GATE_MAX_NEAR_PASS_CYCLES,
+  VOICE_GATE_NEAR_PASS_LOWER_PCT,
+  VOICE_GATE_PASS_THRESHOLD_PCT,
+  auditActionFor,
+  buildAuditMetadata,
+  scoreRun,
+  stateForScore,
+} from '../ai-employee/voice-gate/index.js'
+import type {
+  BlindTestDraft,
+  BlindTestRun,
+  JudgeChoice,
+  JudgeIdentification,
+  RecipientCohort,
+} from '../ai-employee/voice-gate/index.js'
+
+function draft(
+  id: string,
+  cohort: RecipientCohort,
+  authorship: 'customer' | 'agent'
+): BlindTestDraft {
+  return { id, cohort, authorship, body: `body for ${id}` }
+}
+
+function ident(draft_id: string, judge_id: string, choice: JudgeChoice): JudgeIdentification {
+  return { draft_id, judge_id, choice }
+}
+
+function makeRun(args: {
+  drafts: BlindTestDraft[]
+  identifications: JudgeIdentification[]
+  cycle_count?: number
+  cohort?: RecipientCohort | 'all'
+}): BlindTestRun {
+  return {
+    run_id: 'run-test',
+    customer_slug: 'test-firm',
+    cohort: args.cohort ?? 'all',
+    started_at: '2026-05-21T00:00:00Z',
+    scored_at: null,
+    drafts: args.drafts,
+    panel: [...new Set(args.identifications.map((i) => i.judge_id))],
+    identifications: args.identifications,
+    cycle_count: args.cycle_count ?? 0,
+  }
+}
+
+describe('voice-gate threshold constants', () => {
+  it('PRD §9.6 pass threshold is encoded as 80', () => {
+    expect(VOICE_GATE_PASS_THRESHOLD_PCT).toBe(80)
+  })
+
+  it('near-pass band lower bound is 60', () => {
+    expect(VOICE_GATE_NEAR_PASS_LOWER_PCT).toBe(60)
+  })
+
+  it('max near-pass cycles is 2', () => {
+    expect(VOICE_GATE_MAX_NEAR_PASS_CYCLES).toBe(2)
+  })
+
+  it('RECIPIENT_COHORTS lists the three v1 cohorts', () => {
+    expect([...RECIPIENT_COHORTS].sort()).toEqual(['client', 'internal-team', 'opposing-counsel'])
+  })
+})
+
+describe('stateForScore', () => {
+  it('maps 80 to pass (boundary)', () => {
+    expect(stateForScore(80)).toBe('pass')
+  })
+
+  it('maps 79.9 to near-pass (just below pass)', () => {
+    expect(stateForScore(79.9)).toBe('near-pass')
+  })
+
+  it('maps 60 to near-pass (boundary)', () => {
+    expect(stateForScore(60)).toBe('near-pass')
+  })
+
+  it('maps 59.9 to fail (just below near-pass band)', () => {
+    expect(stateForScore(59.9)).toBe('fail')
+  })
+
+  it('maps 0 to fail', () => {
+    expect(stateForScore(0)).toBe('fail')
+  })
+
+  it('maps 100 to pass', () => {
+    expect(stateForScore(100)).toBe('pass')
+  })
+})
+
+describe('auditActionFor', () => {
+  it('passes through to d1-schema.md §1 action_type values', () => {
+    expect(auditActionFor('pass')).toBe('VOICE_GATE_PASSED')
+    expect(auditActionFor('near-pass')).toBe('VOICE_GATE_NEAR_PASS')
+    expect(auditActionFor('fail')).toBe('VOICE_GATE_FAILED')
+  })
+})
+
+describe('scoreRun — indistinguishability counts customer + uncertain', () => {
+  it('counts "customer" identification of an agent draft as indistinguishable', () => {
+    const drafts = [
+      draft('d-customer-1', 'client', 'customer'),
+      draft('d-agent-1', 'client', 'agent'),
+    ]
+    const ids = [ident('d-customer-1', 'j1', 'customer'), ident('d-agent-1', 'j1', 'customer')]
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.indistinguishable_count).toBe(1)
+    expect(result.total_agent_judgments).toBe(1)
+    expect(result.score_pct).toBe(100)
+    expect(result.state).toBe('pass')
+  })
+
+  it('counts "uncertain" identification of an agent draft as indistinguishable', () => {
+    const drafts = [draft('d-agent-1', 'client', 'agent')]
+    const ids = [ident('d-agent-1', 'j1', 'uncertain')]
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.indistinguishable_count).toBe(1)
+    expect(result.score_pct).toBe(100)
+  })
+
+  it('does NOT count "agent" identification of an agent draft as indistinguishable', () => {
+    const drafts = [draft('d-agent-1', 'client', 'agent')]
+    const ids = [ident('d-agent-1', 'j1', 'agent')]
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.indistinguishable_count).toBe(0)
+    expect(result.score_pct).toBe(0)
+    expect(result.state).toBe('fail')
+  })
+
+  it('ignores judgments on customer-authored drafts when scoring', () => {
+    const drafts = [
+      draft('d-customer-1', 'client', 'customer'),
+      draft('d-agent-1', 'client', 'agent'),
+    ]
+    const ids = [
+      ident('d-customer-1', 'j1', 'agent'), // judge wrong on customer draft — doesn't affect score
+      ident('d-agent-1', 'j1', 'customer'), // judge fooled on agent draft — does count
+    ]
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.total_agent_judgments).toBe(1)
+    expect(result.score_pct).toBe(100)
+  })
+})
+
+describe('scoreRun — pass / near-pass / fail bands', () => {
+  function makeAgentDraftsAndJudgments(
+    n: number,
+    indistinguishableCount: number
+  ): { drafts: BlindTestDraft[]; ids: JudgeIdentification[] } {
+    const drafts: BlindTestDraft[] = []
+    const ids: JudgeIdentification[] = []
+    for (let i = 0; i < n; i++) {
+      const did = `d-agent-${i}`
+      drafts.push(draft(did, 'client', 'agent'))
+      const choice: JudgeChoice = i < indistinguishableCount ? 'customer' : 'agent'
+      ids.push(ident(did, 'j1', choice))
+    }
+    return { drafts, ids }
+  }
+
+  it('80/100 agent drafts indistinguishable → pass', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 80)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.score_pct).toBe(80)
+    expect(result.state).toBe('pass')
+    expect(result.audit_action).toBe('VOICE_GATE_PASSED')
+    expect(result.failure_record).toBeUndefined()
+    expect(result.near_pass_record).toBeUndefined()
+  })
+
+  it('79/100 → near-pass with cycle-count record', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 79)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.score_pct).toBe(79)
+    expect(result.state).toBe('near-pass')
+    expect(result.audit_action).toBe('VOICE_GATE_NEAR_PASS')
+    expect(result.near_pass_record).toBeDefined()
+    expect(result.near_pass_record?.cycle_count).toBe(0)
+    expect(result.near_pass_record?.is_final_cycle).toBe(false)
+    expect(result.near_pass_record?.minimum_days_to_retry).toBe(7)
+    expect(result.failure_record).toBeUndefined()
+  })
+
+  it('60/100 → near-pass (boundary)', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 60)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.score_pct).toBe(60)
+    expect(result.state).toBe('near-pass')
+  })
+
+  it('59/100 → fail', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 59)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.score_pct).toBe(59)
+    expect(result.state).toBe('fail')
+    expect(result.audit_action).toBe('VOICE_GATE_FAILED')
+    expect(result.failure_record).toBeDefined()
+    expect(result.failure_record?.auto_transitioned_from_near_pass).toBe(false)
+  })
+
+  it('emits structured failure record when score < 60%', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 30)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.state).toBe('fail')
+    expect(result.failure_record?.score_pct).toBe(30)
+    expect(result.failure_record?.recommended_path).toBe('B_pause_engagement')
+  })
+
+  it('recommends Path A (internal-only) for marginal fail (50-59%)', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 55)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.failure_record?.recommended_path).toBe('A_internal_drafts_only')
+  })
+
+  it('recommends either-path for borderline fail (40-49%)', () => {
+    const { drafts, ids } = makeAgentDraftsAndJudgments(100, 45)
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.failure_record?.recommended_path).toBe('either')
+  })
+})
+
+describe('scoreRun — near-pass cycle auto-transition (voice-gate-fallback.md §Near-pass cycle)', () => {
+  function makeNearPass(cycle: number): BlindTestRun {
+    // 70/100 — solidly near-pass band
+    const drafts: BlindTestDraft[] = []
+    const ids: JudgeIdentification[] = []
+    for (let i = 0; i < 100; i++) {
+      const did = `d-${i}`
+      drafts.push(draft(did, 'client', 'agent'))
+      ids.push(ident(did, 'j1', i < 70 ? 'customer' : 'agent'))
+    }
+    return makeRun({ drafts, identifications: ids, cycle_count: cycle })
+  }
+
+  it('cycle 0 (first attempt) near-pass → near-pass, not_final', () => {
+    const result = scoreRun(makeNearPass(0))
+    expect(result.state).toBe('near-pass')
+    expect(result.near_pass_record?.is_final_cycle).toBe(false)
+  })
+
+  it('cycle 1 (second attempt) near-pass → near-pass, is_final', () => {
+    const result = scoreRun(makeNearPass(1))
+    expect(result.state).toBe('near-pass')
+    expect(result.near_pass_record?.is_final_cycle).toBe(true)
+  })
+
+  it('cycle 2 (third attempt) near-pass → AUTO-TRANSITION to fail', () => {
+    const result = scoreRun(makeNearPass(2))
+    expect(result.state).toBe('fail')
+    expect(result.audit_action).toBe('VOICE_GATE_FAILED')
+    expect(result.failure_record?.auto_transitioned_from_near_pass).toBe(true)
+    expect(result.failure_record?.recommended_path).toBe('A_internal_drafts_only')
+  })
+
+  it('cycle 2 with passing score does NOT force fail (only triggers when <80%)', () => {
+    const drafts: BlindTestDraft[] = []
+    const ids: JudgeIdentification[] = []
+    for (let i = 0; i < 100; i++) {
+      const did = `d-${i}`
+      drafts.push(draft(did, 'client', 'agent'))
+      ids.push(ident(did, 'j1', i < 85 ? 'customer' : 'agent'))
+    }
+    const result = scoreRun(makeRun({ drafts, identifications: ids, cycle_count: 2 }))
+    expect(result.state).toBe('pass')
+  })
+})
+
+describe('scoreRun — per-cohort breakdown', () => {
+  it("emits per-cohort breakdown when run.cohort === 'all'", () => {
+    const drafts: BlindTestDraft[] = []
+    const ids: JudgeIdentification[] = []
+    for (const cohort of RECIPIENT_COHORTS) {
+      // 10 agent drafts per cohort; 9/10 indistinguishable → 90%
+      for (let i = 0; i < 10; i++) {
+        const did = `${cohort}-agent-${i}`
+        drafts.push(draft(did, cohort, 'agent'))
+        ids.push(ident(did, 'j1', i < 9 ? 'customer' : 'agent'))
+      }
+    }
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    expect(result.per_cohort).toBeDefined()
+    expect(result.per_cohort?.client.score_pct).toBe(90)
+    expect(result.per_cohort?.['opposing-counsel'].score_pct).toBe(90)
+    expect(result.per_cohort?.['internal-team'].score_pct).toBe(90)
+  })
+
+  it('omits per-cohort breakdown for single-cohort runs', () => {
+    const drafts = [draft('d-1', 'client', 'agent')]
+    const ids = [ident('d-1', 'j1', 'customer')]
+    const result = scoreRun(makeRun({ drafts, identifications: ids, cohort: 'client' }))
+    expect(result.per_cohort).toBeUndefined()
+  })
+
+  it("identifies below-threshold cohorts in failure record for 'all' runs", () => {
+    const drafts: BlindTestDraft[] = []
+    const ids: JudgeIdentification[] = []
+    // client → 100% pass, opposing-counsel → 50% fail, internal-team → 90% pass
+    for (let i = 0; i < 10; i++) {
+      drafts.push(draft(`c-${i}`, 'client', 'agent'))
+      ids.push(ident(`c-${i}`, 'j1', 'customer'))
+      drafts.push(draft(`oc-${i}`, 'opposing-counsel', 'agent'))
+      ids.push(ident(`oc-${i}`, 'j1', i < 5 ? 'customer' : 'agent'))
+      drafts.push(draft(`it-${i}`, 'internal-team', 'agent'))
+      ids.push(ident(`it-${i}`, 'j1', i < 9 ? 'customer' : 'agent'))
+    }
+    const result = scoreRun(makeRun({ drafts, identifications: ids }))
+    // Overall: 24/30 = 80% → pass; but opposing-counsel cohort is 50%
+    expect(result.state).toBe('pass') // overall threshold met
+    expect(result.per_cohort?.['opposing-counsel'].score_pct).toBe(50)
+  })
+})
+
+describe('buildAuditMetadata', () => {
+  it('includes score, judge_ids, sample_set_id, cycle_count per voice-gate-fallback.md §Three states', () => {
+    const drafts = [draft('d-1', 'client', 'agent')]
+    const ids = [ident('d-1', 'judge-A', 'customer')]
+    const run = makeRun({ drafts, identifications: ids })
+    const result = scoreRun(run)
+    const metadata = JSON.parse(buildAuditMetadata(run, result)) as Record<string, unknown>
+    expect(metadata['score']).toBe(100)
+    expect(metadata['judge_ids']).toEqual(['judge-A'])
+    expect(metadata['sample_set_id']).toBe('run-test')
+    expect(metadata['cycle_count']).toBe(0)
+  })
+
+  it('attaches failure_recommended_path + auto_transitioned for fail states', () => {
+    const drafts: BlindTestDraft[] = []
+    const ids: JudgeIdentification[] = []
+    for (let i = 0; i < 100; i++) {
+      drafts.push(draft(`d-${i}`, 'client', 'agent'))
+      ids.push(ident(`d-${i}`, 'j1', i < 30 ? 'customer' : 'agent'))
+    }
+    const run = makeRun({ drafts, identifications: ids })
+    const result = scoreRun(run)
+    const metadata = JSON.parse(buildAuditMetadata(run, result)) as Record<string, unknown>
+    expect(metadata['failure_recommended_path']).toBe('B_pause_engagement')
+    expect(metadata['failure_auto_transitioned']).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the scoring + panel scaffolding for the Platform PRD §9.6 voice quality gate (≥80% indistinguishability threshold) and the three-state Pass / Near-pass / Fail contract from `docs/specs/ai-employee/voice-gate-fallback.md`.

The harness is **pure** — caller passes drafts + identifications, harness returns a typed `GateResult`. No I/O. D1 persistence, voice-sample ingestion, and dashboard-form wiring are downstream workstreams documented as integration points in the README.

## What's in this PR

- **`ai-employee/voice-gate/`** — TypeScript harness (matches the rest of `src/lib/ai-employee/`; the existing `ai-employee/grading/` substrate is markdown-only so there was no language to match)
  - `types.ts` — typed shapes the harness, scoring, panel, CLI, and future D1 writer agree on
  - `scoring.ts` — threshold logic, **single source of truth for the 80% / 60% / cycle-count math** via named constants (`VOICE_GATE_PASS_THRESHOLD_PCT`, etc.)
  - `panel.ts` — input validation (with optional production-minimum enforcement per voice-gate-fallback.md §Contract), deterministic seeded shuffle, `PanelSession` for collecting identifications
  - `harness.ts` — top-level `runVoiceGate` orchestrator + `buildAuditRow` shaping for `audit_log` rows
  - `cli.ts` + `../bin/run-voice-gate.sh` — Captain-facing CLI runner (synthetic mode wired; live mode stubbed with clear "depends on #800 + voice-sample ingestion" error)
  - `fixtures/synthetic-set.json` — 3 cohorts × (1 customer + 2 agent) = 9 drafts with placeholder names per the no-fabricated-content discipline
  - `fixtures/example-identifications.json` — sample judge inputs for the smoke-test CLI invocation
  - `fixtures/loader.ts` — strict validator that loads + parses the bundled set into `BlindTestDraft[]`
  - `index.ts` — public surface
  - `README.md` — input/output contract, CLI usage, threshold-tuning workflow, integration-point map

- **`tests/voice-gate-*.test.ts`** — 69 unit tests covering:
  - PRD §9.6 ≥80% threshold (asserts the constant explicitly)
  - voice-gate-fallback.md §Three states band boundaries (pass at 80, near-pass at 60, fail below)
  - §Near-pass cycle auto-transition (third near-pass score <80% → fail with `auto_transitioned_from_near_pass: true`)
  - indistinguishability counts both `customer` AND `uncertain` per spec
  - per-cohort breakdown when run is `'all'`
  - audit row shape matches `d1-schema.md` §1 audit_log row
  - deterministic seeded shuffle (same `run_id` → same order)
  - panel validation (cohort consistency, production minimums, duplicates)

## Threshold constants (named, single edit point)

| Constant | Value | Source |
| --- | --- | --- |
| `VOICE_GATE_PASS_THRESHOLD_PCT` | `80` | PRD §9.6 acceptance threshold |
| `VOICE_GATE_NEAR_PASS_LOWER_PCT` | `60` | voice-gate-fallback.md §Three states |
| `VOICE_GATE_MAX_NEAR_PASS_CYCLES` | `2` | voice-gate-fallback.md §Near-pass cycle (step 4) |
| `VOICE_GATE_MIN_DAYS_BETWEEN_CYCLES` | `7` | voice-gate-fallback.md §Near-pass cycle (step 3) |
| `PRODUCTION_MIN_DRAFTS_PER_AUTHORSHIP` | `10` | voice-gate-fallback.md §Contract |
| `PRODUCTION_MIN_JUDGES` | `3` | voice-gate-fallback.md §Contract |

Tests assert the current values explicitly so silent drift is impossible.

## Integration points (deferred, documented in README)

1. **D1 writer for `audit_log` + per-customer scoring** — depends on per-customer Hermes D1 binding (#800). `buildAuditRow` already returns the typed row.
2. **Voice-sample ingestion store** — no issue filed yet. CLI's `--mode live` returns a clear error pointing at the gap.
3. **Promotion gate wiring** — `bin/promote-customer-to-live.sh` should refuse to advance when latest `audit_log` `VOICE_GATE_*` is not `VOICE_GATE_PASSED`.
4. **Failure-path runtime hooks** — internal-drafts-only mode, disclosure artifact, cycle-bound enforcement (voice-gate-fallback.md §Verification items 2-4). `FailureRecord` shape exposes everything they need.

## CLI smoke test (in this branch)

```bash
$ ai-employee/bin/run-voice-gate.sh \
    --customer-slug smith-pi-firm \
    --panel-id panel-001 \
    --mode synthetic \
    --identifications ai-employee/voice-gate/fixtures/example-identifications.json
PASS at 94.4% across all cohorts — external drafts unlocked.
# exits 0
```

## Test plan

- [ ] CI runs `npm run verify` — all 69 voice-gate tests pass alongside the existing suite
- [ ] CI runs typecheck — 0 errors, file `ai-employee/voice-gate/**.ts` clean
- [ ] CI runs prettier + eslint — voice-gate files conform
- [ ] Reviewer runs `ai-employee/bin/run-voice-gate.sh` locally against the bundled fixtures and confirms a PASS result
- [ ] Reviewer confirms `VOICE_GATE_PASS_THRESHOLD_PCT === 80` is the only place the threshold is encoded

Closes #823. Refs PRD §9.6, [voice-gate-fallback.md](https://github.com/venturecrane/ss-console/blob/main/docs/specs/ai-employee/voice-gate-fallback.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)