### PR TITLE
feat(ai-employee): PI settlement negotiation prep skill (#849)

### DIFF
--- a/ai-employee/skills/law-pi-settlement-prep/README.md
+++ b/ai-employee/skills/law-pi-settlement-prep/README.md
@@ -1,0 +1,37 @@
+# law-pi-settlement-prep
+
+Settlement-conference partner-prep memo assembler for personal-injury law firms. Reads an active PI matter at the pre-settlement-conference stage and writes a factual internal prep memo into the supervising partner's drafts folder.
+
+The memo is INTERNAL. The recipient is the partner's own mailbox, not opposing counsel, not the mediator, not the client. The skill assembles the matter-facts summary, chronology, damages tabulation, strengths fact list, weaknesses fact list, comparable-verdict table (sourced from the firm's memory-rule corpus), and opposing-counsel and carrier prior-pattern tables. The skill never authors the settlement bracket recommendation, the recommended posture, or the legal-argument framing of strengths and weaknesses; those sections render as TBD markers for the partner to author. Per ADR 0005 the partner is the sender (and here also the recipient). The skill never sends.
+
+## Files
+
+- `SKILL.md` - the skill contract (frontmatter + body)
+- `references/voice.md` - partner internal-memo voice rules (Layer 2 match against the internal-prep-memo and case-strategy-memo register)
+- `references/output-format.md` - section order and templates for the memo and the matter-internal sourcing note
+- `references/categorization-rubric.md` - matter-readiness axes; refusal criteria; comparable-verdict corpus readiness gate; conference-date gate
+- `references/citation-policy.md` - law-firm vertical invariant #6 (no citations in skill-authored prose); verbatim-quote carve-out for comparable-verdict rows
+- `references/fabrication-policy.md` - platform invariant #8; per-section sourcing contract; the five `none`-tagged TBD sections (bracket, posture, strengths-prose, weaknesses-prose, closing strategy)
+- `references/test-cases.md` - what the two fixtures exercise
+- `fixtures/01-soft-tissue-clear-liability-matter.{yaml,md}` - low-severity soft-tissue matter with clear liability and conference scheduled
+- `fixtures/02-disc-herniation-contested-liability-matter.{yaml,md}` - higher-severity fracture-and-disc matter with contested liability and conference scheduled
+
+## Scope alignment
+
+The law-firm PRD §5 third-rail map names "settlement-value analysis" as work the agent must never do. The PRD §6.2 places settlement and resolution work in Pillar 7. This skill operationalizes the pre-conference assembly that sits at the seam of the pillar without crossing into the judgment-bearing core: the skill produces the assembled facts and the partner's own comparable-verdict corpus; the partner produces the bracket, the posture, and the legal-argument framing.
+
+See `SKILL.md` § "Scope alignment with law-firm-prd §5 and §6.2" for the full reconciliation. If Captain decides the bracket-recommendation TBD section creates room for valuation drift, the fix is configuration: strip the section from the template so the partner authors that thinking in a separate document.
+
+## Trust ceiling
+
+`draft_for_review`, locked. Per platform PRD §11.2 the ceiling is architecturally non-promotable for any skill that informs settlement-authority decisions. Promotion to `autonomous` is blocked.
+
+## Capability bindings
+
+- `PracticeManagement` - read-only (`get_matter`)
+- `DocumentStorage` - read-only (`list_folder`, `download_document`)
+- `Email` - `create_draft` only (no send method exists per ADR 0005); the memo is internal so the partner is the recipient, but `Email.create_draft` remains the only outbound surface
+
+## Voice envelope
+
+The internal-memo voice envelope differs from the external-correspondence envelope used by sibling skills (`law-pi-demand-letter-draft`, `law-pi-discovery-response`). Internal memos are dense, plain, partner-to-self prose. The Layer 2 anchor corpus for this skill should include the partner's prior internal prep memos and case-strategy memoranda; external-correspondence samples are weaker anchors for this register. The skill emits a warning rather than refusing when fewer than five Layer 2 samples are tagged `internal_prep_memo` or `case_strategy_memo`, because the internal-memo register is lower-risk than external correspondence (the audience is the partner).

--- a/ai-employee/skills/law-pi-settlement-prep/SKILL.md
+++ b/ai-employee/skills/law-pi-settlement-prep/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: law-pi-settlement-prep
+description: "Settlement-conference partner-prep memo assembler for personal-injury law firms. Reads one active PI matter through the PracticeManagement capability, the matter's medical, billing, employment, and incident records through DocumentStorage, and the firm's comparable-verdict memory rule, then writes a factual internal prep memo into the supervising partner's drafts folder via Email.create_draft. The memo is INTERNAL ONLY: the recipient is the partner's own mailbox, not opposing counsel, not the mediator, not the client. The skill writes the matter-facts summary, the chronology, the damages tabulation, a structural strengths analysis (sourced facts only), a structural weaknesses analysis (sourced facts only), a comparable-verdict table sourced from the firm's memory-rule corpus with per-row source citations, and an opposing-counsel prior-pattern table from the firm's carrier and opposing-counsel memory rules. The skill DOES NOT author the settlement bracket recommendation, the recommended posture, the prose framing of strengths or weaknesses as legal arguments, or any case-strategy language; those sections render as TBD markers for the partner to author. Per ADR 0005 the partner is the sender (and here also the recipient, since the memo is internal); per platform PRD §7.5 invariant #8 every authored figure, document ID, comparable-verdict citation, and named person is sourced from the matter record or memory rule or rendered as TBD, never inferred; per law-firm PRD §5 settlement-value analysis is third-rail and the skill never produces a value the firm has not already authored into the comparable-verdict memory rule. STRICT VOICE RULE: no em dashes anywhere in output, including section headers and table delimiters. Commas, periods, short sentences. No corporate filler. The memo is internal and the agent's persona is visible per ADR 0005 internal-destinations posture, but voice still matches the partner's prior internal prep memos in Layer 2 voice samples. CITATION POLICY: the skill must never produce, repeat, or reformulate legal citations (case-name-shaped strings with reporter cites, statute references, court rule references, treatise pinpoints) in skill-authored prose. The comparable-verdict table carries through verdict citations verbatim from the firm's memory-rule corpus, which the partner authored; those carry-through citations are not the skill's authoring under the verbatim-quote carve-out. The skill validates that every comparable verdict cited is a present row in the firm's memory rule; if the memory rule is empty or stale, the table renders as TBD and the skill marks the bracket-recommendation section as architecturally non-derivable."
+version: 0.1.0
+author: SMD Services
+license: MIT
+platforms: [linux, macos]
+prerequisites:
+  skills: []
+  commands: []
+client_facing_fields:
+  - name: client_name
+    sourced_from: matter_attribute
+  - name: claim_number
+    sourced_from: matter_attribute
+  - name: case_caption
+    sourced_from: matter_attribute
+  - name: case_number
+    sourced_from: matter_attribute
+  - name: date_of_incident
+    sourced_from: matter_attribute
+  - name: incident_location
+    sourced_from: matter_attribute
+  - name: opposing_counsel_name
+    sourced_from: matter_attribute
+  - name: opposing_counsel_firm
+    sourced_from: matter_attribute
+  - name: opposing_carrier_name
+    sourced_from: matter_attribute
+  - name: settlement_conference_date
+    sourced_from: matter_attribute
+  - name: medical_provider_list
+    sourced_from: system_of_record
+  - name: medical_specials_total
+    sourced_from: system_of_record
+  - name: billing_document_index
+    sourced_from: system_of_record
+  - name: lost_wages_total
+    sourced_from: system_of_record
+  - name: employment_verification_document_index
+    sourced_from: system_of_record
+  - name: incident_evidence_document_index
+    sourced_from: system_of_record
+  - name: chronology_event_list
+    sourced_from: system_of_record
+  - name: strengths_fact_list
+    sourced_from: system_of_record
+  - name: weaknesses_fact_list
+    sourced_from: system_of_record
+  - name: comparable_verdict_table
+    sourced_from: memory_rule
+  - name: opposing_counsel_prior_pattern_table
+    sourced_from: memory_rule
+  - name: carrier_prior_pattern_table
+    sourced_from: memory_rule
+  - name: settlement_bracket_recommendation
+    sourced_from: none
+  - name: recommended_posture
+    sourced_from: none
+  - name: strengths_legal_argument_prose
+    sourced_from: none
+  - name: weaknesses_legal_argument_prose
+    sourced_from: none
+  - name: case_strategy_language
+    sourced_from: none
+  - name: partner_signoff
+    sourced_from: memory_rule
+metadata:
+  hermes:
+    tags: [Law, PI, Settlement, Prep, InternalMemo, Draft]
+    vertical: law-firm-pi
+    trust_ceiling: draft_for_review
+    trust_ceiling_locked: true
+    capabilities: [PracticeManagement, DocumentStorage, Email]
+---
+
+# Law PI Settlement Negotiation Prep Memo (Internal, Factual Assembly)
+
+Reads one active personal-injury matter at the pre-settlement-conference stage and writes a factual prep memo into the supervising partner's drafts folder. The memo is internal. The recipient is the partner's own mailbox. The skill never addresses opposing counsel, the mediator, the carrier, or the client. The partner reviews the assembled facts, fills in the TBD sections (settlement bracket recommendation, recommended posture, legal-argument framing), edits, and uses the memo to walk into the settlement conference prepared.
+
+The skill is configured per-customer through `~/.hermes/customers/{customer_slug}/customer.yaml`, which supplies the firm name, the supervising partner's first name and signature block, the partner's reviewer email account ID for `Email.create_draft`, the firm's voice samples for Layer 2 voice match, the firm's comparable-verdict memory rule (the cited verdict corpus the firm has authored), the firm's opposing-counsel and carrier prior-pattern memory rules, and the practice-area filter.
+
+## Scope alignment with law-firm-prd §5 and §6.2
+
+The law-firm PRD §5 third-rail map names "settlement-value analysis" and "settlement authority / negotiation positions" as work the agent must never do. The PRD §6.2 places settlement and resolution work in Pillar 7 (Settlement + resolution) and characterizes the mechanical operations there (statement prep, lien tracking, 1099 prep, closing letters) as agent-suitable, while the value-bearing work (settlement-value analysis, demand authorship with case-law / valuation, lien-strategy advice) is third-rail.
+
+This skill operationalizes a pre-conference prep memo that lives at the seam: the partner needs the matter file, the chronology, the damages tabulation, the strengths-and-weaknesses summary, the comparable verdicts, and any prior-pattern data the firm has on the opposing counsel or carrier, all assembled in one document the partner can scan in fifteen minutes before walking into the conference. The skill provides that assembly. The skill does NOT provide:
+
+- A settlement bracket recommendation. Bracket recommendations require valuation judgment; valuation judgment is partner work. Bracket-recommendation section renders as TBD.
+- A recommended posture (open low / open high, anchor strategy, walk-away point). Posture is negotiation strategy; strategy is partner work. Posture section renders as TBD.
+- A characterization of strengths as legal arguments ("the comparative-negligence defense is weak"). The skill lists sourced facts that bear on the strength; the partner authors the argument framing.
+- A characterization of weaknesses as legal exposures ("the prior-back-injury history undermines causation"). Same split.
+- Any case-strategy language.
+
+The comparable-verdict table is the architecturally interesting middle case. The firm authors a verdict corpus into a memory rule: each row records the case name, verdict amount, jurisdiction, key facts that match the comparison criterion, and the source the firm cites (a published opinion, a jury verdict reporter, a partner's prior matter file, a verbatim partner note). The skill matches the matter's facts against the corpus and surfaces the rows the partner has already authored as comparable. The skill does NOT invent verdicts. The skill does NOT extrapolate from the corpus. If the corpus is missing or stale, the comparable-verdict table renders as TBD and the skill marks the bracket-recommendation section as architecturally non-derivable, noting that without a populated corpus the prep memo has no quantitative anchor.
+
+The opposing-counsel and carrier prior-pattern tables are also memory-rule sourced. The firm authors a pattern corpus per opposing counsel and per carrier: prior settlement timing, prior offer patterns (first-offer ratio to demand, days from demand to first offer, days to settle), prior conference behavior (early settlement at mediation vs. trial-eve settlements), and any partner-authored note about that opposing counsel's posture. If the corpus is missing for the named opposing counsel or the named carrier, the pattern table renders the corpus-absent prose ("no prior-pattern data on this opposing counsel in firm memory") rather than inventing observations.
+
+The skill name `law-pi-settlement-prep` is operational shorthand for this internal-memo variant. If Captain decides the bracket-recommendation TBD section creates room for the skill to drift into valuation authoring, the fix is configuration: rename the TBD marker to omit the word "bracket" entirely, or strip the section from the template so the partner authors that thinking in a separate document. The current spec includes the section as a TBD marker because the partner needs the placeholder during the scan; the architectural enforcement is that the section is `none`-tagged and the fabrication filter blocks any non-empty render.
+
+## How to invoke
+
+Generate a prep memo from a matter ID and a settlement-conference date already in `matter.custom_fields`:
+
+```
+hermes run law-pi-settlement-prep --matter-id <id>
+```
+
+Generate from a matter ID with an explicit conference date the partner supplies at invocation (overrides the matter custom_field):
+
+```
+hermes run law-pi-settlement-prep --matter-id <id> --conference-date <YYYY-MM-DD>
+```
+
+Dry-run (writes the memo to `~/.hermes/customer_notes/{customer_slug}/` and returns the path; does not call `Email.create_draft`):
+
+```
+hermes run law-pi-settlement-prep --matter-id <id> --dry-run
+```
+
+## What the agent does, in order
+
+1. **Load customer config.** Read `~/.hermes/customers/{customer_slug}/customer.yaml` for firm name, supervising partner's reviewer account ID, partner's signature block, voice samples (Layer 2), the firm's comparable-verdict memory rule, the firm's opposing-counsel prior-pattern memory rule, the firm's carrier prior-pattern memory rule, and the practice-area filter. If `practice_areas` does not include `personal-injury`, the skill refuses with `out_of_scope` and writes no memo.
+2. **Load the matter via PracticeManagement.** Call `practice_management.get_matter(matter_id)`. If the matter is null or its `matter_type` does not indicate PI, refuse with `matter_not_found` or `matter_wrong_type`. The skill never creates or modifies a matter.
+3. **Verify the conference date.** Read `matter.custom_fields.settlement_conference_date` or the `--conference-date` override. If neither is present, refuse with `conference_date_missing`. The skill never invents a conference date. If the date is in the past, proceed but flag in the sourcing note (the partner may be retrospectively assembling a prep memo).
+4. **Load matter documents via DocumentStorage.** Call `document_storage.list_folder(matter.custom_fields.documents_folder_path)` and `document_storage.download_document(id)` for each document the readiness rubric flags as in-scope for chronology, damages, and incident-evidence assembly. The skill never modifies a document. Document classifications consumed: `medical_record`, `billing_statement`, `employment_verification`, `lost_wages_statement`, `incident_photo`, `incident_report`, `police_report`, `expert_report` (if present and partner has marked it for prep-memo inclusion).
+5. **Build the matter-facts summary.** A short factual paragraph identifying the client, the date and location of the incident, the documented client role (driver / passenger / pedestrian / occupant, as recorded in custom_fields), the opposing party name, the opposing counsel and firm, and the carrier. Every field renders from a sourced custom_field or as a TBD marker. The skill does not author a narrative.
+6. **Assemble the chronology.** Linear list of events: incident date, first medical contact, each subsequent medical visit, employment-verification date, billing-statement dates, demand-letter served date (if the matter has a recorded demand-served custom_field), opposing-counsel response dates (if recorded), mediation or conference referral date. Each event is sourced to a `StoredDocument.id` or a `matter.custom_fields.<field>` reference. No event is rendered without a source.
+7. **Tabulate damages.** Two tables: medical specials (per-provider, per-date, billed and adjusted amounts where the billing statement breaks them out) and lost wages (per-pay-period, employer-verified). Each row sources from a `StoredDocument.id` recorded in the sourcing note. Totals are computed only when every row sources; partial-source totals render as TBD with the partner's hint that some rows are missing. The skill does not estimate. The skill does not extrapolate.
+8. **Assemble the strengths fact list.** Sourced facts only. Examples of strengths the skill surfaces, when the matter file supports them: independent medical evidence of injury (MRI confirms diagnosis), corroborating photos at the scene, an employer's lost-wages verification, contemporaneous medical contact within hours of the incident, a clean prior medical history in the relevant body region (per the matter custom_field if the partner has recorded one), an unambiguous incident report attributing fault to the opposing party. Each fact lists the `StoredDocument.id` or `custom_field` that sources it. The skill does NOT characterize the fact's legal weight ("strong causation case"); the characterization is partner work in the TBD argument-framing section.
+9. **Assemble the weaknesses fact list.** Sourced facts only. Examples of weaknesses the skill surfaces, when the matter file supports them: a recorded prior injury or prior claim in the relevant body region, a treatment gap between incident and first medical contact, a treatment-compliance issue documented in a medical record, a recorded inconsistency between the client's incident description and the police report, a documented employment gap that complicates the lost-wages tabulation, a high-mileage prior to incident or other policy-limits issue recorded in a custom_field. Each weakness lists the source. The skill does NOT characterize legal exposure ("comparative negligence defense"); characterization is partner work.
+10. **Surface the comparable-verdict table from memory rule.** Match the matter's facts against the firm's comparable-verdict memory rule. Match criteria the rule supports: matter_type (auto-accident, premises, etc.), injury severity (soft-tissue, fracture, disc-herniation-with-surgery, traumatic-brain-injury, etc.), liability profile (clear / contested / comparative), jurisdiction (matched against the matter's `case_court` custom_field). The matching is mechanical: rows that match all the criterion fields the partner authored on each row surface. Rows the partner marked stale or withdrawn do not surface. Each surfaced row renders verbatim with the columns the memory rule defines: case name, verdict amount, year, jurisdiction, key matched facts, source (the partner-authored citation; the skill does not validate it). If no rows match, the table renders as `[TBD: no comparable verdicts in the firm's memory rule match this matter's profile. The partner authors the bracket recommendation from external research, or the firm extends the corpus before the conference.]`. The skill does NOT invent verdicts, does NOT extrapolate from rows that partially match, does NOT generalize from one row to a range.
+11. **Surface the opposing-counsel prior-pattern table from memory rule.** If `matter.custom_fields.opposing_counsel_name` is present and matches a partner-authored row in the opposing-counsel prior-pattern memory rule, surface the row. Pattern fields the rule supports: median days from demand to first offer, median first-offer-to-demand ratio (if the firm has chosen to record this; recording is optional and per-firm policy), median days from first offer to settlement, prior conference behavior (early-settlement / mid-conference / trial-eve), partner-authored qualitative notes. The skill surfaces rows verbatim; it does not interpolate. If the opposing counsel is not in the corpus, the table renders the corpus-absent prose with no fabricated inference.
+12. **Surface the carrier prior-pattern table from memory rule.** Same shape as the opposing-counsel table but keyed on `matter.custom_fields.opposing_carrier_name`. Same render rules.
+13. **Insert TBD markers for partner-authored sections.** Settlement bracket recommendation: `[TBD: settlement bracket recommendation - partner authors. The comparable-verdict table above and the damages tabulation are provided as input. The skill produces no bracket because settlement-value analysis is third-rail per law-firm PRD §5; the partner authors the bracket from the cited corpus and the matter facts.]`. Recommended posture: `[TBD: recommended posture (open low / open high / anchor / walk-away) - partner authors. The opposing-counsel and carrier prior-pattern tables are provided as input.]`. Strengths legal-argument prose: `[TBD: legal-argument framing of strengths - partner authors. The strengths fact list above is provided as input.]`. Weaknesses legal-argument prose: `[TBD: legal-argument framing of weaknesses - partner authors. The weaknesses fact list above is provided as input.]`. Closing case-strategy language: `[TBD: closing recommendation - partner authors. The skill emits no language about negotiation posture, settlement authority, walk-away triggers, or any forward-looking case-strategy framing.]`.
+14. **Voice match against Layer 2 partner samples.** Run the assembled factual prose (the matter-facts summary, the chronology lead-in, the damages-table captions, the strengths and weaknesses list lead-ins) through the voice-gate harness (`ai-employee/voice-gate/` - gated through #855 and not runtime-active at this skill version; the harness contract is honored at fixture-test time). The internal-memo voice envelope differs from the external-correspondence envelope: the partner's prior internal prep memos and case-strategy memoranda are the primary samples. A failing voice score causes the skill to emit a structured-table-only variant with no prose lead-ins; the partner authors the lead-ins.
+15. **Call `Email.create_draft` per ADR 0005.** Construct `DraftInput`:
+    - `reviewer_account_id`: the supervising partner's account ID from `customer.yaml`. Adapter routing per ADR 0005. The memo is internal so the partner is both the reviewer and the recipient; the draft lands in the partner's drafts folder and the partner moves it (sends to themselves, archives to the matter file, or imports to their prep-binder workflow).
+    - `to`: the supervising partner's direct_email from `customer.yaml`. Internal recipient by design.
+    - `subject`: `Settlement Conference Prep: <case caption>, <case number>, <conference date>` - every field sourced or rendered as TBD.
+    - `thread_id`: null.
+    - `body_text` and `body_html`: the assembled memo (see `references/output-format.md` for the exact section order).
+    - `matter_ref`: the matter ID.
+    - `drafted_by_skill`: `law-pi-settlement-prep`.
+16. **Write the matter-internal sourcing note.** In parallel, write `~/.hermes/customer_notes/{customer_slug}/pi-settlement-prep-YYYY-MM-DD-<matter-id>.md` containing the section-by-section sourcing index (which `StoredDocument.id` populated which row in the damages tables, which `custom_field` populated which named field, which memory-rule rows populated the comparable-verdict and prior-pattern tables, which fields rendered as TBD and why). This is the audit trail the dashboard's sourcing block reads from.
+17. **Emit telemetry.** A skill-invocation event records: matter id (hashed), conference date (relative offset only, not the date itself), strength-fact count, weakness-fact count, comparable-verdict row count, opposing-counsel-pattern row count, carrier-pattern row count, TBD-marker count, voice-gate score, memo size in bytes, adapter calls made. No matter content leaves the customer's machine boundary.
+
+## Trust ceiling
+
+`draft_for_review`. The ceiling is **locked at v1 and cannot be promoted to `autonomous`** per PRD §11.2 ("anything touching trust accounting, court filing, settlement authority, judgment-bearing work: `draft_for_review` permanently"). A settlement-conference prep memo informs settlement-authority decisions by definition. Promotion is architecturally blocked.
+
+The agent MAY:
+
+- Read the matter via `PracticeManagement.get_matter` (read-only).
+- Read matter documents via `DocumentStorage.list_folder` and `DocumentStorage.download_document` (read-only).
+- Read the firm's comparable-verdict, opposing-counsel prior-pattern, and carrier prior-pattern memory rules.
+- Write the memo via `Email.create_draft` into the supervising partner's drafts folder (no send path; the memo is internal so the partner is the recipient, but `Email.create_draft` remains the only outbound surface).
+- Write the matter-internal sourcing note inside `~/.hermes/customer_notes/{customer_slug}/`.
+
+The agent MUST NOT, without explicit partner instruction in a different invocation:
+
+- Modify or create any PracticeManagement record (matter, contact, time entry, document).
+- Upload, modify, or delete any document via DocumentStorage. Reads only.
+- Send any email. The Email interface has no send method by design (ADR 0005).
+- Author a settlement bracket recommendation, a dollar range, a midpoint, or any other numeric anchor not present in the firm's comparable-verdict memory rule.
+- Author a recommended posture, an open-low / open-high suggestion, an anchor strategy, or a walk-away trigger.
+- Author legal-argument framing of strengths or weaknesses. The fact lists are the skill's authoring; the legal characterization is partner work.
+- Invent a comparable verdict not present in the firm's memory-rule corpus.
+- Extrapolate from a partially-matching memory-rule row to a "near-comparable" row.
+- Average or otherwise aggregate the verdict amounts in the memory rule to produce a derived figure.
+- Author qualitative inferences about opposing counsel or carrier behavior beyond what the partner already authored in the prior-pattern memory rules.
+- Quote, restate, or augment any case law, statute, court rule, or treatise reference. Citations inside the verbatim comparable-verdict rows are partner authoring and exempt under the verbatim-quote carve-out; the skill never paraphrases or extends them.
+
+If the skill cannot find a piece of source data the partner expects (e.g., the carrier name is missing on the matter), the memo's corresponding section renders as a TBD marker and the sourcing note lists the missing item. The partner sees the TBD on review and fills it in. The skill does not guess.
+
+## Voice rules (Layer 2 - partner internal-memo corpus match)
+
+The factual prose sections (matter-facts summary, chronology lead-in, damages-table captions, strengths and weaknesses list lead-ins) must read as if the supervising partner wrote them. The internal-memo envelope differs from the external-correspondence envelope. Internal memos are dense, plain, partner-to-self prose. Voice samples for this skill should be drawn from the partner's prior internal prep memos, case-strategy memoranda, and partner-to-self note files; the firm's external-correspondence voice samples (demand-letter prose, opposing-counsel correspondence) are weaker anchors for this register.
+
+See `references/voice.md` for the long form. Hard rules:
+
+- **No em dashes anywhere.** Commas, periods, short sentences. The dash character is banned in section headers, table delimiters, captions, and prose alike. Markdown tables use ASCII hyphens in the separator row.
+- **No "I hope this email finds you well." No "Just wanted to touch base." No "Reach out."** No "Please don't hesitate." No "Per our records." No "At this time."
+- **No corporate filler vocabulary:** circle back, leverage, level-set, deep dive, double-click, table this, ping me, action item, bandwidth.
+- **No legal conclusions in any section the skill authors.** Never "the comparative-negligence defense is plainly meritless," "the policy limits are obviously inadequate," "causation is settled." The fact lists are facts; the characterization is the partner-authored TBD section.
+- **No commitment language.** Never "we will open at," "we will not accept below," "our floor is." All such language is the partner-authored sections.
+- **No tentative hedges that fake certainty:** "I believe," "it appears," "in our view." If the chronology event is sourced, the event is stated. If it is not, the event is TBD.
+- **Active voice.** "Dr. Chen documented the disc herniation on the May 12 MRI" not "the disc herniation was documented by Dr. Chen on the May 12 MRI."
+- **Short sentences.** One idea per sentence usually. Long sentences are reserved for nuanced chronology, not for sounding lawyerly.
+- **No emojis. No exclamation points anywhere.**
+- **Dollar figures render as `$<digits>` with commas (e.g., `$24,500`).** They appear only in the damages tabulation (sourced from billing statements) and in the comparable-verdict table (verbatim from the memory-rule rows). They never appear in skill-authored prose. The bracket-recommendation section is TBD and contains no figure.
+
+If the assembled prose cannot pass these rules, the skill omits the prose lead-ins and emits the structured tables only. The partner prefers structured rows to expand than a flawed paragraph to dismantle.
+
+## Citation policy (law-firm vertical, invariant #6)
+
+The skill must never produce, repeat, or reformulate legal citations in skill-authored prose. The comparable-verdict table is the narrow carve-out: the rows surface verbatim from the firm's memory-rule corpus, which the partner authored, and the citation in the row's `source` column is the partner's authoring under the verbatim-quote carve-out.
+
+The skill never:
+
+- Invents a case-name citation.
+- Augments or pinpoints a memory-rule row's citation.
+- Adds a parallel citation the partner did not author.
+- Cites a statute, court rule, or treatise anywhere.
+- Restates a citation from the verdict row in the surrounding prose ("As in the Smith matter, the present matter ...").
+
+If a matter custom_field (e.g., `case_summary`) contains citations and the skill would otherwise read it into a factual prose section, the skill triggers the readiness rubric's `PROPAGATION_RISK` value (see `references/categorization-rubric.md` axis 6) and refuses with `citation_in_source`.
+
+If the assembled memo would otherwise contain a citation-shaped string in skill-authored prose (outside the verbatim comparable-verdict rows), the skill replaces the string with `[CITATION REMOVED - partner inserts after review]` and logs a citation-refusal event. Code-level enforcement lives in the citation-refusal substrate at `ai-employee/safety-substrate/citation_filter.py`. See `references/citation-policy.md`.
+
+## Fabrication policy (platform invariant #8)
+
+Every client-facing field is declared in the skill's frontmatter `client_facing_fields` block with one of: `matter_attribute`, `system_of_record`, `memory_rule`, `none`. Fields tagged `none` MUST render as a TBD marker; rendering plausible content into a `none`-tagged field is a `block`-severity fabrication-filter violation per the spec at `docs/specs/ai-employee/fabrication-filter.md`.
+
+The five legal-judgment fields the partner authors (`settlement_bracket_recommendation`, `recommended_posture`, `strengths_legal_argument_prose`, `weaknesses_legal_argument_prose`, `case_strategy_language`) are all tagged `none`. The runtime filter enforces non-rendering; the memo surfaces a TBD marker the partner fills in.
+
+The comparable-verdict, opposing-counsel-prior-pattern, and carrier-prior-pattern tables are tagged `memory_rule` because each row sources from a partner-authored memory rule. The skill matches matter facts to memory-rule rows; the skill never invents rows; the skill never extrapolates from one row to a range. If the memory rule is empty or stale (no row matches), the field renders the corpus-absent prose, which is functionally equivalent to a TBD but with a more specific hint about where the partner extends the corpus.
+
+The strengths and weaknesses fact lists are tagged `system_of_record` because each fact sources to a specific `StoredDocument.id` or `matter.custom_fields.<field>`. The skill never surfaces an unsourced fact. The skill never characterizes a sourced fact as a legal strength or weakness; the characterization is partner work in the TBD argument-framing sections.
+
+See `references/fabrication-policy.md` for the per-section sourcing contract.
+
+## Refusal cases
+
+The skill emits a refusal (writes no memo, returns a structured error) under any of:
+
+- `out_of_scope`: the customer's `practice_areas` does not include `personal-injury`.
+- `matter_not_found`: `PracticeManagement.get_matter(id)` returns null.
+- `matter_wrong_type`: `matter.matter_type` is not a PI variant.
+- `matter_closed`: `matter.status` is `closed`. Prep memos are not generated for closed matters; the partner re-opens the matter or assembles the memo by hand.
+- `conference_date_missing`: neither `matter.custom_fields.settlement_conference_date` nor `--conference-date` is present.
+- `comparable_verdict_corpus_missing`: `customer.yaml.memory_rules.comparable_verdicts` is null or empty AND the partner has not opted into the "proceed without bracket anchor" flag. By default the skill refuses rather than ship a memo with no quantitative anchor; the partner may explicitly invoke with `--no-comparable-verdicts` (logged in the sourcing note) and the memo proceeds with the comparable-verdict table rendered as the corpus-absent TBD.
+- `voice_samples_missing`: `customer.yaml` Layer 2 voice samples count is below the PRD §9.6 Gate 1 minimum (30 samples). The skill refuses rather than ship a memo against an uncalibrated voice envelope. The internal-memo voice envelope additionally requires that at least five Layer 2 samples be tagged `internal_prep_memo` or `case_strategy_memo`; if the tagged count is below five, the skill emits a "voice envelope thin" warning in the sourcing note but proceeds (the internal-memo register is lower risk than the external-correspondence register because the audience is the partner).
+- `citation_in_source`: a citation-shaped string appears in a matter custom_field that the skill would otherwise carry through into a non-quoted section.
+
+When the skill can author a partial memo (some sections sourced, some TBD), it proceeds. When it cannot meet a refusal criterion, it writes no memo and logs the refusal.
+
+## What good looks like
+
+A successful run satisfies all of:
+
+1. The memo lands in the supervising partner's drafts folder, confirmed by the adapter's `DraftRef.folder` field matching the partner's drafts path.
+2. The matter-facts summary lists every field sourced from `matter.custom_fields` or rendered as a sourced TBD. No invented client names, opposing counsel names, or carrier names.
+3. The chronology lists every event from sourced documents. No invented events. No invented dates.
+4. The damages tables list every row from sourced billing or lost-wages documents. Totals compute only when every row sources; partial-source totals render as TBD.
+5. The strengths and weaknesses lists contain only sourced facts. Each fact lists the `StoredDocument.id` or `custom_field` that sources it. No characterizations.
+6. The comparable-verdict table contains only rows that surface from the firm's memory-rule corpus, with the criterion match recorded in the sourcing note. No invented verdicts. No extrapolated ranges. No aggregated figures derived from multiple rows.
+7. The opposing-counsel and carrier prior-pattern tables contain only rows from the firm's memory-rule corpus, or the corpus-absent prose when no row matches. No invented observations.
+8. The five legal-judgment sections (`settlement_bracket_recommendation`, `recommended_posture`, `strengths_legal_argument_prose`, `weaknesses_legal_argument_prose`, `case_strategy_language`) all render as TBD markers. None contain plausible-but-inferred prose.
+9. No citation-shaped string appears anywhere in skill-authored sections. Citation strings inside the verbatim comparable-verdict rows and inside partner-authored TBD sections are not the skill's authoring and are out of scope for the substrate's authoring check.
+10. The fabrication filter returns `clean` (no `none`-tagged field rendered non-empty; every `matter_attribute`/`system_of_record` field has a present source_id; every `memory_rule` field has a present rule_id or the documented corpus-absent prose).
+11. The voice-gate score against the Layer 2 internal-memo corpus is above the configured threshold.
+12. The memo is scannable by the partner in under fifteen minutes: matter-facts summary, chronology, damages tables, strengths list, weaknesses list, comparable-verdict table, opposing-counsel pattern table, carrier pattern table, TBD sections, partner signoff. Every TBD marker is one line, in brackets, with a hint to what the partner authors.
+
+## References
+
+- `references/voice.md` - partner internal-memo voice rules; banned patterns; sentence-length envelope; Layer 2 match criterion specific to the internal-memo register.
+- `references/output-format.md` - exact section order and section templates for the memo, with one example per fixture profile (soft-tissue settled vs. fracture-with-surgery contested-liability).
+- `references/categorization-rubric.md` - rules for classifying a matter as ready / not-ready for prep-memo assembly; the memory-rule corpus readiness gate; the conference-date gate.
+- `references/citation-policy.md` - the absolute prohibition on legal citations in skill-authored prose and the verbatim-quote carve-out for comparable-verdict rows.
+- `references/fabrication-policy.md` - the per-section sourcing contract; the mapping between `client_facing_fields` frontmatter and rendered sections; TBD-marker language by section.
+- `references/test-cases.md` - which fixtures exercise which behaviors and what the skill must produce for each.
+
+## Related PRD and ADR references
+
+- ADR 0005 (reviewer-as-sender) - `Email.create_draft` only, no send method. The memo is internal so the recipient is the partner, but the architectural rule is unchanged.
+- ADR 0006 (capability-adapter pattern) - the skill calls `PracticeManagement`, `DocumentStorage`, and `Email` interfaces, never vendor SDKs.
+- ADR 0008 (customer-owned memory artifact) - the comparable-verdict, opposing-counsel, and carrier prior-pattern memory rules are customer-owned per ADR 0008; the skill reads them but never modifies them.
+- Platform PRD §7.5 invariant #6 - citation-refusal (vertical: law-firm). Verbatim-quote carve-out for memory-rule rows the partner authored.
+- Platform PRD §7.5 invariant #8 - fabrication discipline; this skill is one of the load-bearing test cases because settlement-value is the highest fabrication-risk surface in the vertical.
+- Platform PRD §8.4 - skill anatomy. Voice rules front-loaded in description per Phase A.6.
+- Platform PRD §9 - persona and voice model; Layer 2 anchor corpus minimum.
+- Platform PRD §11.2 - default trust ceiling `draft_for_review`, locked for judgment-bearing work.
+- Law-firm PRD §5 - third-rail map. Settlement-value analysis is named as third-rail; this skill produces no value the partner has not already authored into the comparable-verdict memory rule.
+- Law-firm PRD §6.2 - pillar map; this skill operationalizes the prep work that sits at the seam of Pillar 7 (Settlement + resolution) without crossing into the judgment-bearing core.
+- Law-firm PRD §11.2 - demo scenario list; the settlement-conference-prep scenario is the partner's "I have a conference Friday morning and the matter file is twenty inches of paper" use case this skill addresses.

--- a/ai-employee/skills/law-pi-settlement-prep/fixtures/01-soft-tissue-clear-liability-matter-memo.md
+++ b/ai-employee/skills/law-pi-settlement-prep/fixtures/01-soft-tissue-clear-liability-matter-memo.md
@@ -1,0 +1,164 @@
+---
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+---
+
+This file is the reference output memo for fixture 01. A correctly-implemented runtime replaying the skill against `01-soft-tissue-clear-liability-matter.yaml` produces this memo body (modulo the date in the header block, which renders as the date of the test run). The body is what `Email.create_draft` receives as `body_text` and is what the supervising partner sees in their drafts folder.
+
+The `Email.create_draft` envelope:
+
+- `reviewer_account_id`: `sarah.holcomb@holcomb-reyes.invalid`
+- `to`: `["sarah.holcomb@holcomb-reyes.invalid"]` (internal memo; the partner is both reviewer and recipient)
+- `cc`: `[]`
+- `bcc`: `[]`
+- `subject`: `Settlement Conference Prep: Holloway v. Kerr, CV2026-006491, August 1, 2026`
+- `thread_id`: `null`
+- `matter_ref`: `matter_synthetic_prep_01`
+- `drafted_by_skill`: `law-pi-settlement-prep`
+
+The memo body (everything below the next horizontal rule):
+
+---
+
+To: Sarah Holcomb, Managing Partner, Holcomb & Reyes, LLP
+From: Sarah Holcomb (drafted by Marcus, the AI Employee, on `<today's date>`)
+Re: Settlement Conference Prep, Holloway v. Kerr, CV2026-006491
+Matter: matter_synthetic_prep_01
+
+Holloway v. Kerr. Auto-accident matter, opened May 1, 2026. Client: Janet Holloway, operator of stopped 2021 Camry rear-ended at Camelback and 24th. Opposing party: David Kerr. Opposing counsel: Theodora Whitfield, Whitfield Reardon, PLLC. Carrier: Statewide Mutual. Settlement conference scheduled August 1, 2026 at Maricopa County Superior Court.
+
+## Conference Logistics
+
+- Date: August 1, 2026
+- Location: Maricopa County Superior Court, Settlement Conference Room 4-A
+- Mediator: Hon. Paul Mendoza (retired)
+- Attendees recorded: Sarah Holcomb (firm), Theodora Whitfield (opposing counsel), Statewide Mutual claims rep TBD
+
+## Chronology
+
+| Date       | Event                                              | Source                                   |
+| ---------- | -------------------------------------------------- | ---------------------------------------- |
+| 2026-04-28 | Incident at Camelback and 24th, Phoenix            | custom_field: date_of_incident           |
+| 2026-04-28 | Phoenix PD on scene, incident report filed         | doc_09                                   |
+| 2026-05-03 | First medical contact, Mercy General ED            | doc_01                                   |
+| 2026-05-10 | Phoenix Chiropractic initial consult               | doc_02                                   |
+| 2026-06-04 | Phoenix Chiropractic followup                      | doc_03                                   |
+| 2026-06-25 | Valley PT summary, treatment course concludes      | doc_04                                   |
+| 2026-06-01 | ABC Manufacturing employment verification received | doc_07                                   |
+| 2026-06-15 | Demand letter served on opposing counsel           | custom_field: demand_served_date, doc_12 |
+| 2026-08-01 | Settlement conference scheduled                    | custom_field: settlement_conference_date |
+
+## Damages: Medical Specials
+
+| Provider             | Date range               | Billed | Source |
+| -------------------- | ------------------------ | ------ | ------ |
+| Mercy General ED     | 2026-05-03               | $4,800 | doc_05 |
+| Phoenix Chiropractic | 2026-05-10 to 2026-06-04 | $8,400 | doc_06 |
+| Valley PT            | 2026-05-25 to 2026-06-25 | $1,300 | doc_06 |
+
+Medical specials total (billed): $14,500. Adjusted totals are not present in the billing statements for this matter; the partner confirms adjusted figures with the carriers if needed.
+
+## Damages: Lost Wages
+
+| Pay period               | Days lost | Verified amount | Source |
+| ------------------------ | --------- | --------------- | ------ |
+| 2026-04-28 to 2026-05-15 | 14        | $1,820          | doc_08 |
+| 2026-05-16 to 2026-05-31 | 4         | $520            | doc_08 |
+
+Lost wages total: $2,340.
+
+## Strengths (sourced facts)
+
+- Police report attributes fault to opposing party operator. Source: doc_09 (Phoenix PD incident report dated 2026-04-28).
+- First medical contact within five days of incident, at Mercy General ED. Sources: custom_field date_of_incident (2026-04-28), doc_01 (Mercy General ED record dated 2026-05-03).
+- Six-week documented treatment course at Phoenix Chiropractic and Valley PT, with billing statements that match the dates. Sources: doc_02, doc_03, doc_04, doc_06.
+- Employer-verified lost wages with continuity at ABC Manufacturing documented for the eighteen months preceding the incident. Sources: doc_07, doc_08.
+
+Legal-argument framing of these facts: see TBD section below.
+
+## Weaknesses (sourced facts)
+
+The matter file contains no documented weaknesses against the strengths fact list above. The partner may identify additional considerations in the TBD section below; the skill emits no inferred weaknesses.
+
+## Comparable Verdicts (firm memory-rule sourced)
+
+Match criteria: matter_type=auto-accident, injury=soft_tissue, jurisdiction=Maricopa County, liability=clear.
+
+| Case name                    | Year | Jurisdiction      | Verdict | Key matched facts                                                                    | Source (partner-authored)               |
+| ---------------------------- | ---- | ----------------- | ------- | ------------------------------------------------------------------------------------ | --------------------------------------- |
+| Reyes v. Mid-City Cab        | 2024 | Maricopa Superior | $58,000 | rear-end at stoplight, cervical strain, six-week treatment course                    | Maricopa Jury Verdict Reporter 2024-118 |
+| Patel v. Sunrise Transit     | 2023 | Maricopa Superior | $42,500 | rear-end at intersection, cervical and lumbar strain, eight-week chiropractic course | partner matter file 2023-441            |
+| Aguilar v. Reliant Logistics | 2023 | Maricopa Superior | $67,000 | rear-end at stoplight, cervical strain with mild radiculopathy, ten-week treatment   | partner matter file 2023-322            |
+
+Rows are verbatim from the firm's corpus. The skill produces no derived range, no average, no median, and no recommended bracket. The partner authors the bracket recommendation in the TBD section below.
+
+## Opposing Counsel Prior-Pattern (firm memory-rule sourced)
+
+Opposing counsel: Theodora Whitfield, Whitfield Reardon, PLLC.
+
+| Metric                                     | Value (partner-authored)                                                                            |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Median days from demand to first offer     | 42                                                                                                  |
+| Median days from first offer to settlement | 71                                                                                                  |
+| Conference behavior pattern                | Mid-conference settlement (recorded across four prior matters)                                      |
+| Partner qualitative note                   | Whitfield rarely opens at meaningful numbers, but moves quickly once anchored above policy midpoint |
+
+Rows are verbatim from the firm's prior-pattern memory rule. The skill does not interpolate.
+
+## Carrier Prior-Pattern (firm memory-rule sourced)
+
+Carrier: Statewide Mutual.
+
+| Metric                                     | Value (partner-authored)                                                                                                                        |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Median days from demand to first offer     | 38                                                                                                                                              |
+| Median days from first offer to settlement | 64                                                                                                                                              |
+| Conference behavior pattern                | Settles at conference in roughly two-thirds of matters; trial-eve settlements in the remaining third                                            |
+| Partner qualitative note                   | Statewide claims reps have authority up to policy limits and can move at conference; the limiting factor is usually the carrier-counsel handoff |
+
+## Strengths: Legal-Argument Framing
+
+`[TBD: legal-argument framing of strengths - partner authors. The strengths fact list above is provided as input.]`
+
+## Weaknesses: Legal-Argument Framing
+
+`[TBD: legal-argument framing of weaknesses - partner authors. The weaknesses fact list above is provided as input.]`
+
+## Settlement Bracket Recommendation
+
+`[TBD: settlement bracket recommendation - partner authors. The comparable-verdict table above and the damages tabulation are provided as input. The skill produces no bracket because settlement-value analysis is third-rail per law-firm PRD §5; the partner authors the bracket from the cited corpus and the matter facts.]`
+
+## Recommended Posture
+
+`[TBD: recommended posture (open low / open high / anchor / walk-away) - partner authors. The opposing-counsel and carrier prior-pattern tables are provided as input.]`
+
+## Closing
+
+`[TBD: closing recommendation - partner authors. The skill emits no language about negotiation posture, settlement authority, walk-away triggers, or any forward-looking case-strategy framing.]`
+
+## Exhibits
+
+| Exhibit | Document                                         | Source ID |
+| ------- | ------------------------------------------------ | --------- |
+| A       | Mercy General ED record, 2026-05-03              | doc_01    |
+| B       | Phoenix Chiropractic initial consult, 2026-05-10 | doc_02    |
+| C       | Phoenix Chiropractic followup, 2026-06-04        | doc_03    |
+| D       | Valley PT summary, 2026-06-25                    | doc_04    |
+| E       | Mercy General billing statement                  | doc_05    |
+| F       | Phoenix Chiropractic billing statement           | doc_06    |
+| G       | ABC Manufacturing employment verification        | doc_07    |
+| H       | ABC Manufacturing lost wages statement           | doc_08    |
+| I       | Phoenix PD incident report, 2026-04-28           | doc_09    |
+| J       | Scene photo 01, 2026-04-28                       | doc_10    |
+| K       | Scene photo 02, 2026-04-28                       | doc_11    |
+
+---
+
+Sarah Holcomb
+Managing Partner
+Holcomb & Reyes, LLP
+1810 N Central Avenue, Suite 800
+Phoenix, AZ 85004
+(602) 555-0142
+sarah.holcomb@holcomb-reyes.invalid

--- a/ai-employee/skills/law-pi-settlement-prep/fixtures/01-soft-tissue-clear-liability-matter.yaml
+++ b/ai-employee/skills/law-pi-settlement-prep/fixtures/01-soft-tissue-clear-liability-matter.yaml
@@ -1,0 +1,245 @@
+# [SYNTHETIC FIXTURE - NOT A REAL MATTER]
+# Fixture 01: PI matter at the pre-settlement-conference stage. Soft-tissue
+# injuries, clear liability per police report, comparable-verdict corpus
+# surfaces 3 matching rows, both opposing counsel and carrier are in the
+# firm's prior-pattern corpus, weaknesses fact list is empty.
+
+matter:
+  id: 'matter_synthetic_prep_01'
+  client_name: 'Janet Holloway'
+  matter_type: 'auto-accident'
+  status: 'open'
+  opened_at: '2026-05-01T14:22:00Z'
+  closed_at: null
+  custom_fields:
+    fixture_watermark: '[SYNTHETIC FIXTURE - NOT A REAL MATTER]'
+    date_of_incident: '2026-04-28'
+    incident_location: 'Intersection of Camelback Road and 24th Street, Phoenix, Arizona'
+    client_role: 'operator of stopped 2021 Toyota Camry rear-ended at a stoplight'
+    opposing_party_name: 'David Kerr'
+    opposing_counsel_name: 'Theodora Whitfield'
+    opposing_counsel_firm: 'Whitfield Reardon, PLLC'
+    opposing_carrier_name: 'Statewide Mutual'
+    claim_number: 'SM-2026-049182'
+    case_caption: 'Holloway v. Kerr'
+    case_number: 'CV2026-006491'
+    case_court: 'Maricopa County Superior Court'
+    documents_folder_path: '/matters/matter_synthetic_prep_01'
+    demand_served_date: '2026-06-15'
+    settlement_conference_date: '2026-08-01'
+    conference_location: 'Maricopa County Superior Court, Settlement Conference Room 4-A'
+    mediator_name: 'Hon. Paul Mendoza (retired)'
+    attendees_recorded: 'Sarah Holcomb (firm), Theodora Whitfield (opposing counsel), Statewide Mutual claims rep TBD'
+
+documents:
+  - id: 'doc_01'
+    path: '/matters/matter_synthetic_prep_01/medical/2026-05-03_mercy_general_ed.pdf'
+    filename: '2026-05-03_mercy_general_ed.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 184320
+    created_at: '2026-05-04T09:14:00Z'
+    modified_at: '2026-05-04T09:14:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_02'
+    path: '/matters/matter_synthetic_prep_01/medical/2026-05-10_phoenix_chiro_initial.pdf'
+    filename: '2026-05-10_phoenix_chiro_initial.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 96256
+    created_at: '2026-05-10T15:30:00Z'
+    modified_at: '2026-05-10T15:30:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_03'
+    path: '/matters/matter_synthetic_prep_01/medical/2026-06-04_phoenix_chiro_followup.pdf'
+    filename: '2026-06-04_phoenix_chiro_followup.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 98112
+    created_at: '2026-06-04T14:15:00Z'
+    modified_at: '2026-06-04T14:15:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_04'
+    path: '/matters/matter_synthetic_prep_01/medical/2026-06-25_valley_pt_summary.pdf'
+    filename: '2026-06-25_valley_pt_summary.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 124928
+    created_at: '2026-06-25T17:20:00Z'
+    modified_at: '2026-06-25T17:20:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_05'
+    path: '/matters/matter_synthetic_prep_01/billing/2026-05-10_mercy_general_billing.pdf'
+    filename: '2026-05-10_mercy_general_billing.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 56320
+    created_at: '2026-05-10T10:00:00Z'
+    modified_at: '2026-05-10T10:00:00Z'
+    current_version: 'v1'
+    classification: 'billing_statement'
+
+  - id: 'doc_06'
+    path: '/matters/matter_synthetic_prep_01/billing/2026-06-26_phoenix_chiro_billing.pdf'
+    filename: '2026-06-26_phoenix_chiro_billing.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 48128
+    created_at: '2026-06-26T11:00:00Z'
+    modified_at: '2026-06-26T11:00:00Z'
+    current_version: 'v1'
+    classification: 'billing_statement'
+
+  - id: 'doc_07'
+    path: '/matters/matter_synthetic_prep_01/employment/2026-06-01_abc_manufacturing_letter.pdf'
+    filename: '2026-06-01_abc_manufacturing_letter.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 24576
+    created_at: '2026-06-01T09:00:00Z'
+    modified_at: '2026-06-01T09:00:00Z'
+    current_version: 'v1'
+    classification: 'employment_verification'
+
+  - id: 'doc_08'
+    path: '/matters/matter_synthetic_prep_01/employment/2026-06-01_abc_lost_wages_statement.pdf'
+    filename: '2026-06-01_abc_lost_wages_statement.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 18944
+    created_at: '2026-06-01T09:00:00Z'
+    modified_at: '2026-06-01T09:00:00Z'
+    current_version: 'v1'
+    classification: 'lost_wages_statement'
+
+  - id: 'doc_09'
+    path: '/matters/matter_synthetic_prep_01/incident/2026-04-28_phoenix_pd_report.pdf'
+    filename: '2026-04-28_phoenix_pd_report.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 142336
+    created_at: '2026-04-29T11:00:00Z'
+    modified_at: '2026-04-29T11:00:00Z'
+    current_version: 'v1'
+    classification: 'police_report'
+
+  - id: 'doc_10'
+    path: '/matters/matter_synthetic_prep_01/incident/2026-04-28_scene_photo_01.jpg'
+    filename: '2026-04-28_scene_photo_01.jpg'
+    mime_type: 'image/jpeg'
+    size_bytes: 2842112
+    created_at: '2026-04-28T18:30:00Z'
+    modified_at: '2026-04-28T18:30:00Z'
+    current_version: 'v1'
+    classification: 'incident_photo'
+
+  - id: 'doc_11'
+    path: '/matters/matter_synthetic_prep_01/incident/2026-04-28_scene_photo_02.jpg'
+    filename: '2026-04-28_scene_photo_02.jpg'
+    mime_type: 'image/jpeg'
+    size_bytes: 2912768
+    created_at: '2026-04-28T18:31:00Z'
+    modified_at: '2026-04-28T18:31:00Z'
+    current_version: 'v1'
+    classification: 'incident_photo'
+
+  - id: 'doc_12'
+    path: '/matters/matter_synthetic_prep_01/correspondence/2026-06-15_demand_letter.pdf'
+    filename: '2026-06-15_demand_letter.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 312456
+    created_at: '2026-06-15T11:00:00Z'
+    modified_at: '2026-06-15T11:00:00Z'
+    current_version: 'v1'
+    classification: 'demand_letter_outbound'
+
+customer_yaml_excerpt:
+  customer_slug: 'holcomb-reyes'
+  firm_name: 'Holcomb & Reyes, LLP'
+  practice_areas: ['personal-injury']
+  supervising_partner:
+    first_name: 'Sarah'
+    last_name: 'Holcomb'
+    title: 'Managing Partner'
+    reviewer_account_id: 'sarah.holcomb@holcomb-reyes.invalid'
+    direct_email: 'sarah.holcomb@holcomb-reyes.invalid'
+    direct_phone: '(602) 555-0142'
+  signature_block: |
+    Sarah Holcomb
+    Managing Partner
+    Holcomb & Reyes, LLP
+    1810 N Central Avenue, Suite 800
+    Phoenix, AZ 85004
+    (602) 555-0142
+    sarah.holcomb@holcomb-reyes.invalid
+  voice:
+    layer2_samples_count: 38
+    layer2_internal_memo_samples_count: 7
+  memory_rules:
+    comparable_verdicts:
+      rule_id: 'comp_verdicts_v1'
+      rule_version: '2026-07-12'
+      rows:
+        - row_id: 'rv_2024_118'
+          case_name: 'Reyes v. Mid-City Cab'
+          year: 2024
+          jurisdiction: 'Maricopa County Superior Court'
+          verdict_amount: '$58,000'
+          matter_type: 'auto-accident'
+          injury_category: 'soft_tissue'
+          liability_profile: 'clear'
+          key_matched_facts: 'rear-end at stoplight, cervical strain, six-week treatment course'
+          source: 'Maricopa Jury Verdict Reporter 2024-118'
+        - row_id: 'pv_2023_441'
+          case_name: 'Patel v. Sunrise Transit'
+          year: 2023
+          jurisdiction: 'Maricopa County Superior Court'
+          verdict_amount: '$42,500'
+          matter_type: 'auto-accident'
+          injury_category: 'soft_tissue'
+          liability_profile: 'clear'
+          key_matched_facts: 'rear-end at intersection, cervical and lumbar strain, eight-week chiropractic course'
+          source: 'partner matter file 2023-441'
+        - row_id: 'av_2023_322'
+          case_name: 'Aguilar v. Reliant Logistics'
+          year: 2023
+          jurisdiction: 'Maricopa County Superior Court'
+          verdict_amount: '$67,000'
+          matter_type: 'auto-accident'
+          injury_category: 'soft_tissue'
+          liability_profile: 'clear'
+          key_matched_facts: 'rear-end at stoplight, cervical strain with mild radiculopathy, ten-week treatment'
+          source: 'partner matter file 2023-322'
+        - row_id: 'mv_2024_212'
+          case_name: 'Morales v. Desert Freight'
+          year: 2024
+          jurisdiction: 'Pima County Superior Court'
+          verdict_amount: '$74,000'
+          matter_type: 'auto-accident'
+          injury_category: 'disc_herniation_no_surgery'
+          liability_profile: 'clear'
+          key_matched_facts: 'rear-end at highway speed, L5-S1 herniation, no surgery'
+          source: 'Pima Jury Verdict Reporter 2024-212'
+    opposing_counsel_patterns:
+      rule_id: 'opposing_counsel_v1'
+      rule_version: '2026-07-12'
+      rows:
+        - row_id: 'oc_whitfield'
+          opposing_counsel_name: 'Theodora Whitfield'
+          opposing_counsel_firm: 'Whitfield Reardon, PLLC'
+          median_days_demand_to_first_offer: 42
+          median_days_first_offer_to_settlement: 71
+          conference_behavior_pattern: 'Mid-conference settlement (recorded across four prior matters)'
+          partner_qualitative_note: 'Whitfield rarely opens at meaningful numbers, but moves quickly once anchored above policy midpoint'
+    carrier_patterns:
+      rule_id: 'carrier_v1'
+      rule_version: '2026-07-12'
+      rows:
+        - row_id: 'cp_statewide_mutual'
+          carrier_name: 'Statewide Mutual'
+          median_days_demand_to_first_offer: 38
+          median_days_first_offer_to_settlement: 64
+          conference_behavior_pattern: 'Settles at conference in roughly two-thirds of matters; trial-eve settlements in the remaining third'
+          partner_qualitative_note: 'Statewide claims reps have authority up to policy limits and can move at conference; the limiting factor is usually the carrier-counsel handoff'
+  jurisdiction_rules:
+    arizona_state_court:
+      rule_citation_for_partner_reference: 'Ariz. R. Civ. P. 16(g) (settlement conference procedure)'

--- a/ai-employee/skills/law-pi-settlement-prep/fixtures/02-disc-herniation-contested-liability-matter-memo.md
+++ b/ai-employee/skills/law-pi-settlement-prep/fixtures/02-disc-herniation-contested-liability-matter-memo.md
@@ -1,0 +1,166 @@
+---
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+---
+
+This file is the reference output memo for fixture 02. A correctly-implemented runtime replaying the skill against `02-disc-herniation-contested-liability-matter.yaml` produces this memo body (modulo the date in the header block, which renders as the date of the test run).
+
+The `Email.create_draft` envelope:
+
+- `reviewer_account_id`: `sarah.holcomb@holcomb-reyes.invalid`
+- `to`: `["sarah.holcomb@holcomb-reyes.invalid"]` (internal memo)
+- `cc`: `[]`
+- `bcc`: `[]`
+- `subject`: `Settlement Conference Prep: Chen v. Acosta, CV2026-004128, August 19, 2026`
+- `thread_id`: `null`
+- `matter_ref`: `matter_synthetic_prep_02`
+- `drafted_by_skill`: `law-pi-settlement-prep`
+
+The memo body (everything below the next horizontal rule):
+
+---
+
+To: Sarah Holcomb, Managing Partner, Holcomb & Reyes, LLP
+From: Sarah Holcomb (drafted by Marcus, the AI Employee, on `<today's date>`)
+Re: Settlement Conference Prep, Chen v. Acosta, CV2026-004128
+Matter: matter_synthetic_prep_02
+
+Chen v. Acosta. Auto-accident matter, opened March 12, 2026. Client: Marcus Chen, operator of 2019 Honda Civic making a protected left turn at 7th Street and McDowell Road. Opposing party: Linda Acosta. Opposing counsel: Roland Bishop, Bishop & Vargas, P.A. Carrier: Northland Indemnity. Settlement conference scheduled August 19, 2026. Liability is contested per the police report; the report records both operators' statements without attribution of fault.
+
+## Conference Logistics
+
+- Date: August 19, 2026
+- Location: Bishop & Vargas, P.A., 3940 E Camelback Road, Suite 200, Phoenix AZ 85018
+- Mediator: James Tovar, JAMS Phoenix
+- Attendees recorded: `[TBD: attendee list not recorded]`
+
+## Chronology
+
+| Date       | Event                                                    | Source                                   |
+| ---------- | -------------------------------------------------------- | ---------------------------------------- |
+| 2026-03-08 | Incident at 7th Street and McDowell Road, Phoenix        | custom_field: date_of_incident           |
+| 2026-03-08 | Phoenix PD on scene, incident report filed               | doc_12                                   |
+| 2026-03-12 | First medical contact, Mercy General ED                  | doc_01                                   |
+| 2026-03-25 | MRI at Phoenix Imaging, L4-L5 disc herniation documented | doc_02                                   |
+| 2026-04-02 | Phoenix Orthopedics initial consult                      | doc_03                                   |
+| 2026-04-20 | Phoenix Orthopedics first followup                       | doc_04                                   |
+| 2026-05-22 | Phoenix Orthopedics second followup                      | doc_05                                   |
+| 2026-06-15 | Valley PT summary, eleven-week course concludes          | doc_06                                   |
+| 2026-06-25 | Compass Software employment verification received        | doc_10                                   |
+| 2026-06-30 | Demand letter served on opposing counsel                 | custom_field: demand_served_date, doc_16 |
+| 2026-08-19 | Settlement conference scheduled                          | custom_field: settlement_conference_date |
+
+## Damages: Medical Specials
+
+| Provider            | Date range               | Billed  | Source |
+| ------------------- | ------------------------ | ------- | ------ |
+| Mercy General ED    | 2026-03-12               | $5,400  | doc_07 |
+| Phoenix Imaging     | 2026-03-25               | $3,200  | doc_08 |
+| Phoenix Orthopedics | 2026-04-02 to 2026-05-22 | $14,800 | doc_09 |
+| Valley PT           | 2026-04-15 to 2026-06-15 | $9,400  | doc_09 |
+
+Medical specials total (billed): $32,800.
+
+## Damages: Lost Wages
+
+| Pay period               | Days lost | Verified amount | Source |
+| ------------------------ | --------- | --------------- | ------ |
+| 2026-03-08 to 2026-04-15 | 21        | $4,200          | doc_11 |
+| 2026-04-16 to 2026-05-15 | 6         | $1,260          | doc_11 |
+
+Lost wages total: $5,460.
+
+## Strengths (sourced facts)
+
+- March 25, 2026 MRI at Phoenix Imaging documents L4-L5 disc herniation. Source: doc_02.
+- First medical contact within four days of incident, at Mercy General ED. Sources: custom_field date_of_incident (2026-03-08), doc_01 (Mercy General ED record dated 2026-03-12).
+- Eleven-week documented treatment course across orthopedic consult and PT, with billing statements that match the dates. Sources: doc_03, doc_04, doc_05, doc_06, doc_09.
+- Employer-verified employment continuity at Compass Software documented for the preceding twenty-six months. Sources: doc_10, doc_11.
+
+Legal-argument framing of these facts: see TBD section below.
+
+## Weaknesses (sourced facts)
+
+- Police report records both operators' statements without attribution of fault. The contested-liability profile shifts comparative-fault risk onto the firm. Source: doc_12 (Phoenix PD incident report dated 2026-03-08).
+- Matter custom_field prior_back_injury_history records a 2021 lumbar strain at the same L4-L5 level, documented in pre-incident PCP records. Source: matter custom_field prior_back_injury_history.
+
+Legal-argument framing of these facts: see TBD section below.
+
+## Comparable Verdicts (firm memory-rule sourced)
+
+Match criteria: matter_type=auto-accident, injury=disc_herniation_no_surgery, jurisdiction=Maricopa County, liability=contested.
+
+| Case name                      | Year | Jurisdiction      | Verdict  | Key matched facts                                                                                                               | Source (partner-authored)               |
+| ------------------------------ | ---- | ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Kowalski v. Sunrise Trucking   | 2024 | Maricopa Superior | $148,000 | left-turn intersection with disputed right-of-way, L4-L5 herniation no surgery, comparative-fault verdict reduced from $185,000 | Maricopa Jury Verdict Reporter 2024-602 |
+| Delgado v. Cactus Construction | 2023 | Maricopa Superior | $112,000 | intersection collision, L5-S1 herniation no surgery, prior back-injury history disclosed at trial                               | partner matter file 2023-517            |
+
+Rows are verbatim from the firm's corpus. The skill produces no derived range, no average, no median, and no recommended bracket. The partner authors the bracket recommendation in the TBD section below.
+
+## Opposing Counsel Prior-Pattern (firm memory-rule sourced)
+
+Opposing counsel: Roland Bishop, Bishop & Vargas, P.A.
+
+| Metric                                     | Value (partner-authored)                                                                                                                                           |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Median days from demand to first offer     | 28                                                                                                                                                                 |
+| Median days from first offer to settlement | 96                                                                                                                                                                 |
+| Conference behavior pattern                | Trial-eve settlement (recorded across three prior matters). Bishop holds positions at mediation and moves in the two weeks before trial.                           |
+| Partner qualitative note                   | Bishop is comfortable in front of a jury and will not anchor at mediation unless the carrier instructs. Expect a low first offer; expect movement closer to trial. |
+
+Rows are verbatim from the firm's prior-pattern memory rule. The skill does not interpolate.
+
+## Carrier Prior-Pattern (firm memory-rule sourced)
+
+No prior-pattern data on Northland Indemnity in firm memory. The partner authors the posture section without a carrier anchor, or the firm records a prior-pattern row from a prior matter before the conference.
+
+## Strengths: Legal-Argument Framing
+
+`[TBD: legal-argument framing of strengths - partner authors. The strengths fact list above is provided as input.]`
+
+## Weaknesses: Legal-Argument Framing
+
+`[TBD: legal-argument framing of weaknesses - partner authors. The weaknesses fact list above is provided as input.]`
+
+## Settlement Bracket Recommendation
+
+`[TBD: settlement bracket recommendation - partner authors. The comparable-verdict table above and the damages tabulation are provided as input. The skill produces no bracket because settlement-value analysis is third-rail per law-firm PRD §5; the partner authors the bracket from the cited corpus and the matter facts.]`
+
+## Recommended Posture
+
+`[TBD: recommended posture (open low / open high / anchor / walk-away) - partner authors. The opposing-counsel and carrier prior-pattern tables are provided as input.]`
+
+## Closing
+
+`[TBD: closing recommendation - partner authors. The skill emits no language about negotiation posture, settlement authority, walk-away triggers, or any forward-looking case-strategy framing.]`
+
+## Exhibits
+
+| Exhibit | Document                                        | Source ID |
+| ------- | ----------------------------------------------- | --------- |
+| A       | Mercy General ED record, 2026-03-12             | doc_01    |
+| B       | Phoenix Imaging MRI report, 2026-03-25          | doc_02    |
+| C       | Phoenix Orthopedics initial consult, 2026-04-02 | doc_03    |
+| D       | Phoenix Orthopedics followup, 2026-04-20        | doc_04    |
+| E       | Phoenix Orthopedics second followup, 2026-05-22 | doc_05    |
+| F       | Valley PT summary, 2026-06-15                   | doc_06    |
+| G       | Mercy General billing statement                 | doc_07    |
+| H       | Phoenix Imaging billing statement               | doc_08    |
+| I       | Phoenix Orthopedics and PT billing statement    | doc_09    |
+| J       | Compass Software employment verification        | doc_10    |
+| K       | Compass Software lost wages statement           | doc_11    |
+| L       | Phoenix PD incident report, 2026-03-08          | doc_12    |
+| M       | Scene photo 01, 2026-03-08                      | doc_13    |
+| N       | Scene photo 02, 2026-03-08                      | doc_14    |
+| O       | Scene photo 03, 2026-03-08                      | doc_15    |
+
+---
+
+Sarah Holcomb
+Managing Partner
+Holcomb & Reyes, LLP
+1810 N Central Avenue, Suite 800
+Phoenix, AZ 85004
+(602) 555-0142
+sarah.holcomb@holcomb-reyes.invalid

--- a/ai-employee/skills/law-pi-settlement-prep/fixtures/02-disc-herniation-contested-liability-matter.yaml
+++ b/ai-employee/skills/law-pi-settlement-prep/fixtures/02-disc-herniation-contested-liability-matter.yaml
@@ -1,0 +1,281 @@
+# [SYNTHETIC FIXTURE - NOT A REAL MATTER]
+# Fixture 02: PI matter at the pre-settlement-conference stage. Disc-herniation
+# injury (higher severity), contested liability (no fault attribution in
+# police report), comparable-verdict corpus surfaces 2 matching rows, opposing
+# counsel is in the firm's prior-pattern corpus, carrier is NOT, weaknesses
+# fact list has 2 entries (prior back injury and contested-liability police
+# report).
+
+matter:
+  id: 'matter_synthetic_prep_02'
+  client_name: 'Marcus Chen'
+  matter_type: 'auto-accident'
+  status: 'open'
+  opened_at: '2026-03-12T10:00:00Z'
+  closed_at: null
+  custom_fields:
+    fixture_watermark: '[SYNTHETIC FIXTURE - NOT A REAL MATTER]'
+    date_of_incident: '2026-03-08'
+    incident_location: 'Intersection of 7th Street and McDowell Road, Phoenix, Arizona'
+    client_role: 'operator of 2019 Honda Civic making protected left turn'
+    opposing_party_name: 'Linda Acosta'
+    opposing_counsel_name: 'Roland Bishop'
+    opposing_counsel_firm: 'Bishop & Vargas, P.A.'
+    opposing_carrier_name: 'Northland Indemnity'
+    claim_number: 'NI-2026-002184'
+    case_caption: 'Chen v. Acosta'
+    case_number: 'CV2026-004128'
+    case_court: 'Maricopa County Superior Court'
+    documents_folder_path: '/matters/matter_synthetic_prep_02'
+    demand_served_date: '2026-06-30'
+    settlement_conference_date: '2026-08-19'
+    conference_location: 'Bishop & Vargas, P.A., 3940 E Camelback Road, Suite 200, Phoenix AZ 85018'
+    mediator_name: 'James Tovar, JAMS Phoenix'
+    prior_back_injury_history: '2021 lumbar strain at the same L4-L5 level, documented in pre-incident PCP records (partner reviewed during intake)'
+
+documents:
+  - id: 'doc_01'
+    path: '/matters/matter_synthetic_prep_02/medical/2026-03-12_mercy_general_ed.pdf'
+    filename: '2026-03-12_mercy_general_ed.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 198432
+    created_at: '2026-03-13T09:14:00Z'
+    modified_at: '2026-03-13T09:14:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_02'
+    path: '/matters/matter_synthetic_prep_02/medical/2026-03-25_phoenix_imaging_mri.pdf'
+    filename: '2026-03-25_phoenix_imaging_mri.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 312456
+    created_at: '2026-03-25T16:00:00Z'
+    modified_at: '2026-03-25T16:00:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_03'
+    path: '/matters/matter_synthetic_prep_02/medical/2026-04-02_phoenix_ortho_initial.pdf'
+    filename: '2026-04-02_phoenix_ortho_initial.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 142336
+    created_at: '2026-04-02T11:30:00Z'
+    modified_at: '2026-04-02T11:30:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_04'
+    path: '/matters/matter_synthetic_prep_02/medical/2026-04-20_phoenix_ortho_followup.pdf'
+    filename: '2026-04-20_phoenix_ortho_followup.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 98112
+    created_at: '2026-04-20T14:15:00Z'
+    modified_at: '2026-04-20T14:15:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_05'
+    path: '/matters/matter_synthetic_prep_02/medical/2026-05-22_phoenix_ortho_followup_2.pdf'
+    filename: '2026-05-22_phoenix_ortho_followup_2.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 96768
+    created_at: '2026-05-22T14:00:00Z'
+    modified_at: '2026-05-22T14:00:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_06'
+    path: '/matters/matter_synthetic_prep_02/medical/2026-06-15_valley_pt_summary.pdf'
+    filename: '2026-06-15_valley_pt_summary.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 134912
+    created_at: '2026-06-15T17:20:00Z'
+    modified_at: '2026-06-15T17:20:00Z'
+    current_version: 'v1'
+    classification: 'medical_record'
+
+  - id: 'doc_07'
+    path: '/matters/matter_synthetic_prep_02/billing/2026-03-20_mercy_general_billing.pdf'
+    filename: '2026-03-20_mercy_general_billing.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 62464
+    created_at: '2026-03-20T10:00:00Z'
+    modified_at: '2026-03-20T10:00:00Z'
+    current_version: 'v1'
+    classification: 'billing_statement'
+
+  - id: 'doc_08'
+    path: '/matters/matter_synthetic_prep_02/billing/2026-04-30_phoenix_imaging_billing.pdf'
+    filename: '2026-04-30_phoenix_imaging_billing.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 28800
+    created_at: '2026-04-30T11:00:00Z'
+    modified_at: '2026-04-30T11:00:00Z'
+    current_version: 'v1'
+    classification: 'billing_statement'
+
+  - id: 'doc_09'
+    path: '/matters/matter_synthetic_prep_02/billing/2026-06-20_phoenix_ortho_pt_billing.pdf'
+    filename: '2026-06-20_phoenix_ortho_pt_billing.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 71680
+    created_at: '2026-06-20T11:00:00Z'
+    modified_at: '2026-06-20T11:00:00Z'
+    current_version: 'v1'
+    classification: 'billing_statement'
+
+  - id: 'doc_10'
+    path: '/matters/matter_synthetic_prep_02/employment/2026-06-25_compass_software_letter.pdf'
+    filename: '2026-06-25_compass_software_letter.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 26624
+    created_at: '2026-06-25T09:00:00Z'
+    modified_at: '2026-06-25T09:00:00Z'
+    current_version: 'v1'
+    classification: 'employment_verification'
+
+  - id: 'doc_11'
+    path: '/matters/matter_synthetic_prep_02/employment/2026-06-25_compass_lost_wages.pdf'
+    filename: '2026-06-25_compass_lost_wages.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 22528
+    created_at: '2026-06-25T09:00:00Z'
+    modified_at: '2026-06-25T09:00:00Z'
+    current_version: 'v1'
+    classification: 'lost_wages_statement'
+
+  - id: 'doc_12'
+    path: '/matters/matter_synthetic_prep_02/incident/2026-03-08_phoenix_pd_report.pdf'
+    filename: '2026-03-08_phoenix_pd_report.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 168448
+    created_at: '2026-03-09T11:00:00Z'
+    modified_at: '2026-03-09T11:00:00Z'
+    current_version: 'v1'
+    classification: 'police_report'
+
+  - id: 'doc_13'
+    path: '/matters/matter_synthetic_prep_02/incident/2026-03-08_scene_photo_01.jpg'
+    filename: '2026-03-08_scene_photo_01.jpg'
+    mime_type: 'image/jpeg'
+    size_bytes: 3014144
+    created_at: '2026-03-08T18:30:00Z'
+    modified_at: '2026-03-08T18:30:00Z'
+    current_version: 'v1'
+    classification: 'incident_photo'
+
+  - id: 'doc_14'
+    path: '/matters/matter_synthetic_prep_02/incident/2026-03-08_scene_photo_02.jpg'
+    filename: '2026-03-08_scene_photo_02.jpg'
+    mime_type: 'image/jpeg'
+    size_bytes: 2967552
+    created_at: '2026-03-08T18:31:00Z'
+    modified_at: '2026-03-08T18:31:00Z'
+    current_version: 'v1'
+    classification: 'incident_photo'
+
+  - id: 'doc_15'
+    path: '/matters/matter_synthetic_prep_02/incident/2026-03-08_scene_photo_03.jpg'
+    filename: '2026-03-08_scene_photo_03.jpg'
+    mime_type: 'image/jpeg'
+    size_bytes: 2891776
+    created_at: '2026-03-08T18:32:00Z'
+    modified_at: '2026-03-08T18:32:00Z'
+    current_version: 'v1'
+    classification: 'incident_photo'
+
+  - id: 'doc_16'
+    path: '/matters/matter_synthetic_prep_02/correspondence/2026-06-30_demand_letter.pdf'
+    filename: '2026-06-30_demand_letter.pdf'
+    mime_type: 'application/pdf'
+    size_bytes: 412672
+    created_at: '2026-06-30T11:00:00Z'
+    modified_at: '2026-06-30T11:00:00Z'
+    current_version: 'v1'
+    classification: 'demand_letter_outbound'
+
+customer_yaml_excerpt:
+  customer_slug: 'holcomb-reyes'
+  firm_name: 'Holcomb & Reyes, LLP'
+  practice_areas: ['personal-injury']
+  supervising_partner:
+    first_name: 'Sarah'
+    last_name: 'Holcomb'
+    title: 'Managing Partner'
+    reviewer_account_id: 'sarah.holcomb@holcomb-reyes.invalid'
+    direct_email: 'sarah.holcomb@holcomb-reyes.invalid'
+    direct_phone: '(602) 555-0142'
+  signature_block: |
+    Sarah Holcomb
+    Managing Partner
+    Holcomb & Reyes, LLP
+    1810 N Central Avenue, Suite 800
+    Phoenix, AZ 85004
+    (602) 555-0142
+    sarah.holcomb@holcomb-reyes.invalid
+  voice:
+    layer2_samples_count: 38
+    layer2_internal_memo_samples_count: 7
+  memory_rules:
+    comparable_verdicts:
+      rule_id: 'comp_verdicts_v1'
+      rule_version: '2026-07-12'
+      rows:
+        - row_id: 'kv_2024_602'
+          case_name: 'Kowalski v. Sunrise Trucking'
+          year: 2024
+          jurisdiction: 'Maricopa County Superior Court'
+          verdict_amount: '$148,000'
+          matter_type: 'auto-accident'
+          injury_category: 'disc_herniation_no_surgery'
+          liability_profile: 'contested'
+          key_matched_facts: 'left-turn intersection with disputed right-of-way, L4-L5 herniation no surgery, comparative-fault verdict reduced from $185,000'
+          source: 'Maricopa Jury Verdict Reporter 2024-602'
+        - row_id: 'dv_2023_517'
+          case_name: 'Delgado v. Cactus Construction'
+          year: 2023
+          jurisdiction: 'Maricopa County Superior Court'
+          verdict_amount: '$112,000'
+          matter_type: 'auto-accident'
+          injury_category: 'disc_herniation_no_surgery'
+          liability_profile: 'contested'
+          key_matched_facts: 'intersection collision, L5-S1 herniation no surgery, prior back-injury history disclosed at trial'
+          source: 'partner matter file 2023-517'
+        - row_id: 'rv_2024_118'
+          case_name: 'Reyes v. Mid-City Cab'
+          year: 2024
+          jurisdiction: 'Maricopa County Superior Court'
+          verdict_amount: '$58,000'
+          matter_type: 'auto-accident'
+          injury_category: 'soft_tissue'
+          liability_profile: 'clear'
+          key_matched_facts: 'rear-end at stoplight, cervical strain, six-week treatment course'
+          source: 'Maricopa Jury Verdict Reporter 2024-118'
+        - row_id: 'mv_2024_212'
+          case_name: 'Morales v. Desert Freight'
+          year: 2024
+          jurisdiction: 'Pima County Superior Court'
+          verdict_amount: '$74,000'
+          matter_type: 'auto-accident'
+          injury_category: 'disc_herniation_no_surgery'
+          liability_profile: 'clear'
+          key_matched_facts: 'rear-end at highway speed, L5-S1 herniation, no surgery'
+          source: 'Pima Jury Verdict Reporter 2024-212'
+    opposing_counsel_patterns:
+      rule_id: 'opposing_counsel_v1'
+      rule_version: '2026-07-12'
+      rows:
+        - row_id: 'oc_bishop'
+          opposing_counsel_name: 'Roland Bishop'
+          opposing_counsel_firm: 'Bishop & Vargas, P.A.'
+          median_days_demand_to_first_offer: 28
+          median_days_first_offer_to_settlement: 96
+          conference_behavior_pattern: 'Trial-eve settlement (recorded across three prior matters). Bishop holds positions at mediation and moves in the two weeks before trial.'
+          partner_qualitative_note: 'Bishop is comfortable in front of a jury and will not anchor at mediation unless the carrier instructs. Expect a low first offer; expect movement closer to trial.'
+    carrier_patterns:
+      rule_id: 'carrier_v1'
+      rule_version: '2026-07-12'
+      rows: []
+  jurisdiction_rules:
+    arizona_state_court:
+      rule_citation_for_partner_reference: 'Ariz. R. Civ. P. 16(g) (settlement conference procedure)'

--- a/ai-employee/skills/law-pi-settlement-prep/fixtures/README.md
+++ b/ai-employee/skills/law-pi-settlement-prep/fixtures/README.md
@@ -1,0 +1,38 @@
+# Fixtures - law-pi-settlement-prep
+
+Two synthetic personal-injury matter inputs and two reference output memos. The fixtures exercise two profiles that anchor the skill's behavior across different injury severity and liability profiles:
+
+1. **`01-soft-tissue-clear-liability-matter.yaml` + `01-soft-tissue-clear-liability-matter-memo.md`** - low-severity soft-tissue matter with clear liability, comparable-verdict corpus surfaces 3 matching rows, both opposing counsel and carrier are in the firm's prior-pattern corpus, weaknesses fact list is empty.
+2. **`02-disc-herniation-contested-liability-matter.yaml` + `02-disc-herniation-contested-liability-matter-memo.md`** - higher-severity disc-herniation matter with contested liability, comparable-verdict corpus surfaces 2 matching rows, opposing counsel is in the corpus, carrier is NOT, weaknesses fact list has 2 entries (prior back injury and no-fault-attribution police report).
+
+Every fixture is watermarked `[SYNTHETIC FIXTURE - NOT A REAL MATTER]`. Every name is fictional. Every email address uses the `.invalid` TLD. Every document path, case number, and claim number is synthetic. The fixtures are not derived from any real client matter and do not reflect any guidance about settlement valuation, posture, or strategy.
+
+## Schema of the input YAML
+
+The matter YAML fixtures approximate what `PracticeManagement.get_matter` returns combined with what `DocumentStorage.list_folder` returns when called against the matter's documents folder, plus the relevant customer-yaml memory-rule excerpts. The fixture is one consolidated document for convenience; in production the adapter calls return their pieces separately. The fixture's top-level keys:
+
+- `matter` - the `Matter` shape from `src/lib/ai-employee/capabilities/practice-management.ts`. Includes `id`, `client_name`, `matter_type`, `status`, `opened_at`, `closed_at`, `custom_fields`.
+- `documents` - an array of `StoredDocument` shapes from `src/lib/ai-employee/capabilities/document-storage.ts`. Each entry includes `id`, `path`, `filename`, `mime_type`, `size_bytes`, `created_at`, `modified_at`, `current_version`, `classification`.
+- `customer_yaml_excerpt` - the relevant subset of `customer.yaml`: firm name, supervising partner, partner's reviewer account ID, signature block, voice samples count and internal-memo-tagged sub-count, practice areas, the comparable-verdict memory rule, the opposing-counsel prior-pattern memory rule, the carrier prior-pattern memory rule.
+
+## How a downstream test suite uses these fixtures
+
+The voice-gate harness, the adapter conformance suite, and the fabrication-filter regression corpus all replay against these fixtures. Each suite owns the harness; this PR owns the fixtures themselves.
+
+Replaying fixture 01 against a correctly-implemented runtime should produce a memo byte-for-byte equivalent to `01-soft-tissue-clear-liability-matter-memo.md` modulo timestamp rendering. Deviations are skill regressions.
+
+## Watermarking
+
+Every input matter and every reference output is watermarked:
+
+```
+[SYNTHETIC FIXTURE - NOT A REAL MATTER]
+```
+
+The watermark appears in:
+
+- The first line of every YAML input as a top-of-file comment.
+- The first line of every reference output memo as a horizontal-rule preamble.
+- The `matter.custom_fields.fixture_watermark` field on every YAML.
+
+A runtime that strips the watermark before memo assembly is a regression; the watermark must not appear in the final `Email.create_draft` body (the test harness verifies this).

--- a/ai-employee/skills/law-pi-settlement-prep/references/categorization-rubric.md
+++ b/ai-employee/skills/law-pi-settlement-prep/references/categorization-rubric.md
@@ -1,0 +1,96 @@
+# Matter Readiness Rubric
+
+Before assembling a settlement-prep memo, the skill classifies the matter and the surrounding memory-rule corpus along seven readiness axes. The classifications drive: which sections render fully, which render as corpus-absent prose, which render as TBD, and whether the skill proceeds at all.
+
+The rubric is decision-bearing: every axis has a value, AMBIGUOUS and UNKNOWN are valid values when the matter does not support a confident call. Guessing is not.
+
+## Axis 1: Matter scope
+
+Is this matter in scope for the skill?
+
+| Value          | Criterion                                                                                  | Action                                                          |
+| -------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| IN_SCOPE       | `matter.matter_type` is one of: `auto-accident`, `premises`, `product-liability`, `medmal` | Proceed.                                                        |
+| OUT_OF_SCOPE   | `matter.matter_type` is any other value                                                    | Refuse with `matter_wrong_type`. Write no memo.                 |
+| AMBIGUOUS_TYPE | `matter.matter_type` is null, empty, or contains a value not in the PI registry            | Refuse with `matter_wrong_type`. Surface to partner for triage. |
+
+## Axis 2: Matter status
+
+Is this matter active and at the right stage?
+
+| Value      | Criterion                                                                                       | Action                                                                                                                         |
+| ---------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| ACTIVE     | `matter.status == "open"` and a settlement-conference date is present                           | Proceed.                                                                                                                       |
+| PRE_DEMAND | `matter.status == "open"` and the demand letter has not been served (`demand_served_date` null) | Refuse with `matter_pre_demand`. Settlement prep precedes a conference; without a served demand the conference rarely happens. |
+| INTAKE     | `matter.status == "intake"`                                                                     | Refuse with `matter_intake_only`. Prep memos do not issue from intake-status matters.                                          |
+| CLOSED     | `matter.status == "closed"`                                                                     | Refuse with `matter_closed`. Write no memo.                                                                                    |
+
+## Axis 3: Conference date readiness
+
+Is a settlement-conference date present?
+
+| Value     | Criterion                                                                                       | Action                                                                                                                                      |
+| --------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| SCHEDULED | `matter.custom_fields.settlement_conference_date` is present and in the future                  | Proceed.                                                                                                                                    |
+| PAST      | `matter.custom_fields.settlement_conference_date` is present and in the past                    | Proceed; sourcing note flags retrospective assembly. The partner may be preparing a post-conference debrief or reconstructing for an audit. |
+| OVERRIDE  | `matter.custom_fields.settlement_conference_date` is absent but `--conference-date` is supplied | Proceed with the override; sourcing note records the override.                                                                              |
+| MISSING   | Neither the matter custom_field nor the CLI override is present                                 | Refuse with `conference_date_missing`. The skill never invents a conference date.                                                           |
+
+## Axis 4: Document corpus readiness
+
+Does the matter folder contain enough sourced documents to assemble a meaningful chronology and damages tabulation?
+
+| Value   | Criterion                                                                                          | Action                                                                                                                                                              |
+| ------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| READY   | Matter folder contains at least one document in each of: medical, billing, incident_report classes | Proceed with full memo.                                                                                                                                             |
+| LIGHT   | Matter folder contains at least medical records but no billing or no incident report               | Proceed; the corresponding sub-table or chronology row renders as TBD; sourcing note records the gap.                                                               |
+| MISSING | Matter folder contains no medical records                                                          | Refuse with `matter_documents_missing`. A prep memo without medical records cannot support a damages table or strengths-and-weaknesses list. Partner triages first. |
+
+## Axis 5: Comparable-verdict corpus readiness
+
+Does the firm's memory-rule corpus contain rows that match the matter's profile?
+
+| Value          | Criterion                                                                                                                                                 | Action                                                                                                                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| READY          | `customer.yaml.memory_rules.comparable_verdicts` is present and at least one row matches all the match-criterion fields the partner authored on each row. | Proceed with full table.                                                                                                                                                                                                     |
+| THIN           | Memory rule is present but no rows match the matter's profile.                                                                                            | Proceed with the table rendering the corpus-absent prose; sourcing note records the absence. Skill marks the bracket-recommendation section TBD with the additional context that no quantitative anchor is available.        |
+| CORPUS_MISSING | `customer.yaml.memory_rules.comparable_verdicts` is null, empty, or undefined.                                                                            | Refuse with `comparable_verdict_corpus_missing` UNLESS the partner has supplied `--no-comparable-verdicts` (logged). With the flag, proceed with table rendering the corpus-absent prose; the bracket TBD notes the absence. |
+
+The comparable-verdict corpus is the load-bearing memory rule for this skill. The skill never invents a verdict; the corpus is the partner's authored source of truth.
+
+## Axis 6: Voice envelope readiness
+
+Does the customer have enough Layer 2 voice samples to support an internal-memo draft?
+
+| Value         | Criterion                                                                                          | Action                                                                                                      |
+| ------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| READY         | `customer.yaml.voice.layer2_samples.count >= 30` AND at least 5 samples tagged internal-memo class | Proceed.                                                                                                    |
+| THIN_REGISTER | `count >= 30` but fewer than 5 samples tagged internal-memo class                                  | Proceed; warn in sourcing note. Internal-memo audience is the partner; lower-risk than external recipients. |
+| BELOW_GATE    | `count < 30`                                                                                       | Refuse with `voice_samples_missing`. The skill refuses rather than ship against an uncalibrated envelope.   |
+
+## Axis 7: Citation-propagation risk
+
+Does the matter file contain citations the skill would otherwise carry through into its own factual prose?
+
+| Value            | Criterion                                                                                                                                                                                                                                       | Action                                                                                                                                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CLEAN            | No citation-shaped strings in any matter custom_field the skill would read into its own prose (matter-facts summary, chronology, strengths lead-in, weaknesses lead-in). Comparable-verdict rows are exempt under the verbatim-quote carve-out. | Proceed.                                                                                                                                                                                       |
+| PROPAGATION_RISK | A citation-shaped string appears in a matter custom_field (e.g., `case_summary`, `liability_narrative`) the skill would otherwise carry through.                                                                                                | Refuse with `citation_in_source`. The partner edits the custom_field to quote-isolate the citation or remove it, then re-invokes. The substrate-level filter is the architectural enforcement. |
+
+## Refusal precedence
+
+When multiple refusal criteria fire, the precedence is:
+
+1. `out_of_scope` (customer practice-area mismatch)
+2. `matter_not_found` / `matter_wrong_type` / `matter_closed` / `matter_intake_only` / `matter_pre_demand`
+3. `conference_date_missing`
+4. `matter_documents_missing`
+5. `comparable_verdict_corpus_missing` (unless `--no-comparable-verdicts` is supplied)
+6. `voice_samples_missing`
+7. `citation_in_source`
+
+The earliest-firing criterion wins. The structured error includes the criterion code and the surfacing path the partner uses to remediate.
+
+## What the sourcing note records
+
+For every axis, the sourcing note records the classified value. The Captain's weekly query against the sourcing-note corpus reports refusal-criterion frequency by skill; persistent `voice_samples_missing` or `comparable_verdict_corpus_missing` refusals indicate the customer's memory-rule onboarding is incomplete.

--- a/ai-employee/skills/law-pi-settlement-prep/references/citation-policy.md
+++ b/ai-employee/skills/law-pi-settlement-prep/references/citation-policy.md
@@ -1,0 +1,63 @@
+# Citation Policy (Law-Firm Vertical, Platform Invariant #6)
+
+The skill must never produce, repeat, reformulate, or augment any legal citation in any section it authors. This is the law-firm vertical's instance of platform invariant #6 (citation-refusal). The architectural enforcement lives in the citation-refusal substrate at `ai-employee/safety-substrate/citation_filter.py`; the skill's prompt-level discipline below is defense in depth.
+
+This skill has a narrow carve-out: the rows of the comparable-verdict table surface verbatim from the firm's `customer.yaml.memory_rules.comparable_verdicts` corpus, which the partner authored. The citation strings in the `source` column of each surfaced row are partner authoring under the verbatim-quote carve-out. The skill does not validate, augment, or extend those citations.
+
+## What counts as a citation
+
+The skill treats the following as citations subject to the authoring prohibition:
+
+- **Case-name citations.** Strings of the shape `<Plaintiff> v. <Defendant>` followed by a reporter cite (`123 F.3d 456`), a court designation (`(3d Cir. 2010)`, `(D. Ariz. 2022)`), and/or a pinpoint (`at 462`). Examples the skill refuses to author or restate: `Smith v. Jones, 123 F.3d 456 (3d Cir. 2010)`, `Brown v. Bd. of Educ., 347 U.S. 483 (1954)`.
+- **Statute references.** Federal: `<title> U.S.C. § <section>`, `<title> USC <section>`. State: `<state>-<title>-<section>`, `<state> Rev. Stat. § <section>`, and the major state-specific patterns.
+- **Court rule references.** Federal: `Fed. R. Civ. P. <rule>`, `Fed. R. Evid. <rule>`. State-court rule patterns.
+- **Treatise and restatement pinpoints.** `Restatement (Second) of Torts § <section>`, `Wright & Miller, Federal Practice and Procedure § <section>`.
+- **Administrative regulations.** `<title> C.F.R. § <section>` and state regulatory equivalents.
+- **Jury-verdict reporter cites in the SOURCE column of comparable-verdict rows.** These ARE citations, but they are exempt under the verbatim-quote carve-out because the row is verbatim from the partner-authored memory rule.
+
+The detection is pattern-based; false positives are escalated to the partner rather than silently dropped.
+
+## The verbatim-quote carve-out
+
+The comparable-verdict table is the only section of this skill's output where citation-shaped strings legitimately appear. Each row of the table is a verbatim render of a memory-rule row the partner authored. The row's `source` column commonly contains:
+
+- A jury-verdict reporter cite (e.g., `Maricopa Jury Verdict Reporter 2024-118`).
+- A published-opinion cite (e.g., `Smith v. Mid-City Cab, 245 Ariz. 312 (2024)`).
+- A partner-internal reference (e.g., `partner matter file 2023-441`).
+- A treatise or settlement-reporter pinpoint.
+
+The skill's behavior on such rows:
+
+1. **The verbatim row carries through unchanged.** The skill does not rewrite, paraphrase, or summarize the row. The source column contains exactly what the partner authored in the memory rule.
+2. **The citation in the row is not the skill's authoring.** It is the partner's authoring in the memory-rule corpus. The skill's reproduction is a quote, not a citation produced by the skill.
+3. **The substrate's filter respects the carve-out.** The filter's `verbatim_quote_exempt` configuration flag (set at skill load time per `customer.yaml.skill_config.law-pi-settlement-prep.verbatim_quote_exempt_sections: [comparable_verdicts]`) instructs the filter to ignore citation-shaped strings inside the comparable-verdict table region. The carve-out is narrow: only the comparable-verdict table's source column and the case-name column. Every other section is fully subject to the prohibition.
+4. **The skill's own prose around the table is fully subject to the prohibition.** The table caption, the matched-criteria description, and any lead-in or follow-on prose must contain no citation-shaped strings.
+
+## What the skill does on detection in its own authoring
+
+The skill never authors a citation. Detection paths:
+
+1. **Skill-emit-time detection.** The skill's memo assembly never includes a citation in skill-authored sections (matter-facts summary, chronology, damages tables, strengths lead-in, weaknesses lead-in, prior-pattern table prose, exhibit list). If the assembled memo would otherwise contain one, the skill replaces the would-be string with `[CITATION REMOVED - partner inserts after review]` and logs a `citation_refusal_event`.
+2. **Substrate-pre-emit detection.** Before the memo reaches `Email.create_draft`, the citation-refusal substrate scans the body for citation-shaped strings outside the verbatim-quote-exempt regions. Any hit causes the substrate to block the emit; the skill re-runs with stricter prompting; if the second run also fails, the runtime emits a `block`-severity event and escalates to Captain.
+
+## What about citations in matter source data
+
+The matter may contain citations the partner authored in narrative notes. The skill handles these as follows:
+
+- **Citations in the comparable-verdict memory-rule rows.** Exempt under the verbatim-quote carve-out. Surface verbatim. The skill does not paraphrase, augment, or extend.
+- **Citations the skill would carry through into its own prose** (e.g., a `case_summary` custom_field that the skill reads for the matter-facts summary lead-in). Refuse. Specifically: if a custom_field the skill reads contains a citation, the skill triggers the readiness rubric's `PROPAGATION_RISK` value (categorization-rubric.md axis 7) and refuses with `citation_in_source`. The partner edits the custom_field and re-invokes.
+- **Citations the partner authors into the TBD bracket or posture sections after the memo lands.** Out of band; the partner's edits are not the skill's authoring. The substrate-pre-emit filter still runs on the assembled memo before emit, but the partner's later edits do not re-trigger the skill.
+
+## Standard refusal language
+
+When the skill must refuse, it returns a structured error rather than writing a memo. The error's user-facing message:
+
+> The skill cannot draft this settlement-prep memo because the matter record contains a legal citation in a field the skill reads as factual source data for its own authoring. Citation authoring and validation is human legal-research work the skill does not perform. To proceed: edit the matter's narrative fields to remove or quote-isolate the citation, then re-invoke. The comparable-verdict table sources verbatim from the firm's memory rule and is the only section where citations legitimately appear; that section is exempt under the verbatim-quote carve-out.
+
+The technical error code is `citation_in_source`. The matter-internal sourcing note records the offending field name and the matched pattern.
+
+## Why the carve-out is narrow
+
+The comparable-verdict corpus is the only place where the firm has committed (by authoring the corpus) that citations are partner-validated and ready for inclusion. Everywhere else in the matter file, citations may be partial, in-progress, or in narrative drafts the partner has not validated for external use. The skill cannot distinguish a validated citation from a draft citation; the safe rule is to refuse propagation everywhere except the explicitly partner-validated memory-rule corpus.
+
+The skill's behavior is the partner's hedge: validated citations live in the memory rule, where the skill can carry them through; everywhere else, the partner authors the citation directly in the TBD sections.

--- a/ai-employee/skills/law-pi-settlement-prep/references/fabrication-policy.md
+++ b/ai-employee/skills/law-pi-settlement-prep/references/fabrication-policy.md
@@ -1,0 +1,118 @@
+# Fabrication Policy (Platform Invariant #8)
+
+This skill is a load-bearing test case for the fabrication discipline that platform PRD §7.5 invariant #8 makes architectural. Settlement-value analysis is named on the §5 third-rail map; this skill operationalizes the prep work that sits at the seam without crossing into the value-bearing core. The runtime's fabrication filter (`docs/specs/ai-employee/fabrication-filter.md`, issue #798) enforces the policy on every memo emit.
+
+## The four tag values
+
+Per `docs/specs/ai-employee/fabrication-filter.md`:
+
+| Tag                | Meaning                                                                                                                        | Render rule                                                                                                                                         |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `matter_attribute` | Sourced from a field on the `Matter` returned by `PracticeManagement.get_matter`                                               | Render the value verbatim. If null/missing, render the TBD marker.                                                                                  |
+| `system_of_record` | Sourced from an adapter-returned record other than Matter (e.g., `StoredDocument`)                                             | Render the value verbatim. Runtime records the source `<resource>.id`. If unresolved, render TBD.                                                   |
+| `memory_rule`      | Sourced from a `memory_rules` D1 row                                                                                           | Render the value verbatim. Runtime records the rule_id and row_id. If the rule is missing or no row matches, render documented corpus-absent prose. |
+| `none`             | The field is NOT sourced from any system. Render as a TBD marker. Rendering plausible content is a `block`-severity violation. | Render the TBD marker. Runtime's fabrication filter blocks any non-empty value with this tag.                                                       |
+
+## The skill's per-field sourcing contract
+
+The skill's `SKILL.md` frontmatter declares 27 client-facing fields. The per-field contract:
+
+### Fields tagged `matter_attribute`
+
+The runtime resolves these from `PracticeManagement.get_matter(matter_id)`. If null/missing, the field renders as `[TBD: <field-specific hint>]`.
+
+| Field name                   | Matter attribute path                             | TBD marker on absence                                                          |
+| ---------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `client_name`                | `matter.client_name`                              | (refuse - client_name is required)                                             |
+| `claim_number`               | `matter.custom_fields.claim_number`               | `[TBD: claim number - partner supplies]`                                       |
+| `case_caption`               | `matter.custom_fields.case_caption`               | `[TBD: case caption - partner supplies]`                                       |
+| `case_number`                | `matter.custom_fields.case_number`                | `[TBD: case number - partner supplies]`                                        |
+| `date_of_incident`           | `matter.custom_fields.date_of_incident`           | `[TBD: date of incident - partner supplies]`                                   |
+| `incident_location`          | `matter.custom_fields.incident_location`          | `[TBD: incident location - partner supplies]`                                  |
+| `opposing_counsel_name`      | `matter.custom_fields.opposing_counsel_name`      | `[TBD: opposing counsel name - partner supplies]`                              |
+| `opposing_counsel_firm`      | `matter.custom_fields.opposing_counsel_firm`      | `[TBD: opposing counsel firm - partner supplies]`                              |
+| `opposing_carrier_name`      | `matter.custom_fields.opposing_carrier_name`      | `[TBD: carrier name - partner supplies]`                                       |
+| `settlement_conference_date` | `matter.custom_fields.settlement_conference_date` | (refuse with `conference_date_missing` unless `--conference-date` is supplied) |
+
+### Fields tagged `system_of_record`
+
+The runtime resolves these from adapter calls on documents in the matter folder. Each rendered value records the `StoredDocument.id` that populated it.
+
+| Field name                               | Source                                                                            | TBD on absence                                                                               |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `medical_provider_list`                  | Documents classified `medical_record`                                             | Per-row: omit. Section-level: `[TBD: no medical records in matter file]`                     |
+| `medical_specials_total`                 | Sum across billing-statement docs when every row sources                          | `[TBD: partial-source totals - partner confirms after billing exhibits are complete]`        |
+| `billing_document_index`                 | Documents classified `billing_statement`                                          | Per-row: omit                                                                                |
+| `lost_wages_total`                       | Sum across lost-wages docs when every row sources                                 | `[TBD: lost wages partial-source - partner confirms]`                                        |
+| `employment_verification_document_index` | Documents classified `employment_verification`                                    | Per-row: omit                                                                                |
+| `incident_evidence_document_index`       | Documents classified `incident_photo`, `incident_report`, or `police_report`      | Per-row: omit                                                                                |
+| `chronology_event_list`                  | Composed from sourced documents and custom_fields                                 | Per-event: omit; the chronology contains only sourced events                                 |
+| `strengths_fact_list`                    | Heuristic match against the matter file (sourced facts only, no characterization) | Per-fact: omit; the section emits only sourced facts                                         |
+| `weaknesses_fact_list`                   | Heuristic match against the matter file (sourced facts only)                      | Per-fact: omit. If no weaknesses sourced: section emits the "no documented weaknesses" prose |
+
+### Fields tagged `memory_rule`
+
+| Field name                             | Memory rule key                                   | TBD/corpus-absent on absence                                                                                                                                                                                                                                          |
+| -------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `comparable_verdict_table`             | `customer.memory_rules.comparable_verdicts`       | Refuse with `comparable_verdict_corpus_missing` unless `--no-comparable-verdicts`. When invoked with the flag, table renders the corpus-absent prose. When the rule is present but no rows match, table renders the corpus-absent prose with a more specific message. |
+| `opposing_counsel_prior_pattern_table` | `customer.memory_rules.opposing_counsel_patterns` | Renders the corpus-absent prose ("no prior-pattern data on <opposing_counsel_name> in firm memory") when no row matches the named opposing counsel.                                                                                                                   |
+| `carrier_prior_pattern_table`          | `customer.memory_rules.carrier_patterns`          | Renders the corpus-absent prose when no row matches the named carrier.                                                                                                                                                                                                |
+| `partner_signoff`                      | `customer.signature_block`                        | (refuse - signature block must be configured for the memo to ship)                                                                                                                                                                                                    |
+
+### Fields tagged `none` (the load-bearing five)
+
+These are the legal-judgment sections the skill MUST NOT author. The runtime's fabrication filter blocks any rendered value; the only allowed render is the TBD marker.
+
+| Field name                          | TBD marker                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `settlement_bracket_recommendation` | `[TBD: settlement bracket recommendation - partner authors. The comparable-verdict table above and the damages tabulation are provided as input. The skill produces no bracket because settlement-value analysis is third-rail per law-firm PRD §5; the partner authors the bracket from the cited corpus and the matter facts.]` |
+| `recommended_posture`               | `[TBD: recommended posture (open low / open high / anchor / walk-away) - partner authors. The opposing-counsel and carrier prior-pattern tables are provided as input.]`                                                                                                                                                          |
+| `strengths_legal_argument_prose`    | `[TBD: legal-argument framing of strengths - partner authors. The strengths fact list above is provided as input.]`                                                                                                                                                                                                               |
+| `weaknesses_legal_argument_prose`   | `[TBD: legal-argument framing of weaknesses - partner authors. The weaknesses fact list above is provided as input.]`                                                                                                                                                                                                             |
+| `case_strategy_language`            | `[TBD: closing recommendation - partner authors. The skill emits no language about negotiation posture, settlement authority, walk-away triggers, or any forward-looking case-strategy framing.]`                                                                                                                                 |
+
+These five are the architectural backstop against the failure mode the law-firm PRD §5 third-rail map exists to prevent: settlement-value fabrication, anchoring effects from agent-generated brackets, agent-authored posture recommendations that pull the partner toward a number the partner would not have chosen, and case-strategy commitments that constrain the partner's negotiation latitude.
+
+The `settlement_bracket_recommendation` field is the highest-risk render in the law-firm vertical at v1. A render that contained a plausible number would create exactly the anchoring effect the §5 third-rail map names; the architectural enforcement is that the field is `none`-tagged and the fabrication filter blocks any non-empty content.
+
+## High-risk markers
+
+Beyond the per-field tagging, the fabrication-filter spec defines pattern-based high-risk markers. Markers relevant to this skill:
+
+- `specific_dollar_amount` (`\$\d[\d,]{3,}`). Dollar amounts appear legitimately only in the damages tabulation (sourced from billing statements) and in the comparable-verdict table (verbatim from memory-rule rows). Any dollar amount in skill-authored prose outside those sections is a `flag` that escalates to `block` if the surrounding context is the bracket-recommendation, posture, or case-strategy TBD section.
+- `dollar_range` (a dollar-amount string of the form `\$\d[\d,]{3,}` followed by a range connector (the word `to`, the ASCII hyphen, an en-dash codepoint, an em-dash codepoint, or the word `through`) followed by another dollar-amount string of the same shape). The skill MUST NOT render a dollar range anywhere in skill-authored prose. The bracket-recommendation section is TBD; the comparable-verdict table contains individual verdict amounts but no derived range. A range in skill-authored prose is `block` regardless of section.
+- `verdict_average` or `verdict_median` keyword patterns. The skill MUST NOT compute or render an average, median, or mean of comparable-verdict amounts. The verdict rows surface individually; the partner authors any aggregation in the TBD bracket section. The filter flags any prose that introduces aggregated figures around the table.
+- `future_date` (`\b\d{4}-\d{2}-\d{2}\b`). Dates render in `YYYY-MM-DD` format in tables and `Month D, YYYY` in prose. Dates are tagged `matter_attribute` or `system_of_record`; the filter flags rather than blocks.
+- `commitment_phrase` (`\b(we'll|we will|I'll|I will)\s+(reach out|schedule|begin|deliver|complete|finish|ship|open|close|recommend|settle|accept|reject)\b`). The skill MUST NOT generate commitment phrases. The five `none`-tagged sections contain the only legitimate commitment language. A commitment phrase in any skill-authored section is `flag` on first occurrence and `block` on second occurrence in the same memo.
+- `guarantee_phrase` (`\b(guarantee|guaranteed|promise|ensure|warrant)\b`). The skill MUST NOT use guarantee phrases. A guarantee phrase is `block` regardless of tag.
+- `legal_conclusion_phrase` (`\b(plainly|clearly|obviously|undisputedly|self-evidently)\s+(meritless|inadequate|settled|undisputable|negligent|liable)\b`). The skill MUST NOT use legal-conclusion adverbs in fact lists or sourcing prose.
+- `posture_recommendation_keyword` (`\b(open low|open high|anchor at|walk away at|floor|ceiling)\b`). The skill MUST NOT use posture-recommendation keywords outside the TBD recommended-posture section. Any hit is `block`.
+
+## What the filter does on violation
+
+Per `docs/specs/ai-employee/fabrication-filter.md`:
+
+- `clean`: memo proceeds to `Email.create_draft`.
+- `flag`: memo proceeds with a "verify source" banner in the dashboard.
+- `block`: memo rejected. Skill re-runs with stricter prompt. If second run also blocks, escalate to Captain. No memo ships.
+
+For this skill, expected outcomes:
+
+- A matter with the comparable-verdict corpus populated, matter file complete, and the bracket and posture sections rendering as TBD markers: `clean`.
+- A matter with the comparable-verdict corpus thin (no rows match) but the partner invoked with `--no-comparable-verdicts`: `clean`; the table renders the corpus-absent prose; the bracket TBD section notes the absence of a quantitative anchor.
+- A skill bug that renders a `none`-tagged field non-empty: `block`. Bug fixed; skill re-deployed.
+- A skill bug that renders a dollar range outside the verbatim comparable-verdict rows: `block` on the `dollar_range` marker.
+- A skill bug that introduces "average verdict" or "median verdict" prose around the comparable-verdict table: `block` on the `verdict_average` marker.
+- A skill bug that renders a posture-recommendation keyword outside the TBD section: `block` on the `posture_recommendation_keyword` marker.
+
+## The fabrication-filter-trigger event
+
+Every fabrication-filter outcome other than `clean` emits a `FABRICATION_FILTER_TRIGGERED` audit event. The event records: skill name, severity, field, marker (if pattern-based), memo hash. The Captain's weekly query reports flag/block rate per skill. A block rate above 5% on this skill triggers a skill review.
+
+## Why this skill is load-bearing
+
+Settlement-prep memos are the highest valuation-anchoring-risk surface in the law-firm vertical. The five `none`-tagged sections are the specific places where prior consumer-facing AI tools have made the disqualifying errors: generating a bracket recommendation that anchored the partner below the matter's actual value, recommending a posture that boxed the partner into a position they would not have chosen, characterizing a strength as a "clear case" that the partner had to back away from at the conference, or characterizing a weakness as "fatal" that the partner had already discounted.
+
+The fabrication filter's `block` outcome on a `none`-tagged field with non-empty content is the architectural defense; this skill's `none` tagging on those five sections is the test of that defense. If the filter cannot block a fabricated bracket recommendation on this skill, the platform's fabrication discipline is not load-bearing on its highest-risk surface.
+
+The comparable-verdict table is the architecturally interesting case: the rows are real (they come from a partner-authored memory rule), but the derivation of a range from those rows is partner work. The filter respects this split: rows surface verbatim from the corpus; any aggregation prose around the table is `block`; the bracket-recommendation section is `none`-tagged and the partner authors the derivation.

--- a/ai-employee/skills/law-pi-settlement-prep/references/output-format.md
+++ b/ai-employee/skills/law-pi-settlement-prep/references/output-format.md
@@ -1,0 +1,348 @@
+# Memo Output Format
+
+Two outputs per skill invocation:
+
+1. **The memo itself** - created via `Email.create_draft` into the supervising partner's drafts folder. The memo is internal; the partner is both the reviewer and the recipient. Per ADR 0005 `Email.create_draft` remains the only outbound surface even for internal addressees.
+2. **The matter-internal sourcing note** - written at `~/.hermes/customer_notes/{customer_slug}/pi-settlement-prep-YYYY-MM-DD-<matter-id>.md`. Records what populated each section. Read by the dashboard's "what Marcus used to write this" sourcing block. Never sent.
+
+Section order is fixed. The partner scans the memo top-to-bottom in the fifteen minutes before walking into the conference; section order is the scan order.
+
+## Memo section order
+
+```
+1. Header block (matter-facts summary in one paragraph)
+2. Conference logistics (date, location, mediator if known, attendees if known)
+3. Chronology of treatment and matter milestones
+4. Damages tabulation (medical specials table + lost wages table)
+5. Strengths fact list (sourced facts, no characterization)
+6. Weaknesses fact list (sourced facts, no characterization)
+7. Comparable-verdict table (memory-rule sourced, verbatim rows or corpus-absent prose)
+8. Opposing-counsel prior-pattern table (memory-rule sourced or corpus-absent prose)
+9. Carrier prior-pattern table (memory-rule sourced or corpus-absent prose)
+10. Strengths legal-argument prose (TBD marker)
+11. Weaknesses legal-argument prose (TBD marker)
+12. Settlement bracket recommendation (TBD marker)
+13. Recommended posture (TBD marker)
+14. Closing case-strategy language (TBD marker)
+15. Exhibit list (every sourced document, numbered)
+16. Partner signoff (from customer.yaml)
+```
+
+## Section templates
+
+### 1. Header block
+
+```
+[SYNTHETIC FIXTURE WATERMARK if applicable]
+
+To: <Partner first name and signature block from customer.yaml>
+From: <Partner first name> (drafted by Marcus, the AI Employee, on <today's date>)
+Re: Settlement Conference Prep - <case caption>, <case number>
+Matter: <matter id>
+
+<Matter-facts summary paragraph: case caption, matter type, opened date, client name, client role, opposing party name, opposing counsel name and firm, carrier name. Every field renders from a sourced custom_field or as a TBD marker. Dense, partner-to-self prose. Three to six short sentences.>
+```
+
+Every angle-bracketed value renders from a sourced field or as a TBD marker. The skill does not author client names, opposing counsel names, or carrier names it cannot source.
+
+### 2. Conference logistics
+
+```
+## Conference Logistics
+
+- Date: <settlement_conference_date from matter.custom_fields, formatted as Month D, YYYY>
+- Location: <conference_location from matter.custom_fields, or TBD>
+- Mediator: <mediator_name from matter.custom_fields, or "[TBD: mediator not recorded in matter file]">
+- Attendees recorded: <attendees_recorded from matter.custom_fields, or "[TBD: attendee list not recorded]">
+```
+
+The conference date is the load-bearing field; the skill refuses if it is not present (`conference_date_missing`).
+
+### 3. Chronology of treatment and matter milestones
+
+A linear table. Each row sources to a `StoredDocument.id` or a `matter.custom_fields.<field>` reference.
+
+```
+## Chronology
+
+| Date       | Event                                                        | Source                                   |
+| ---------- | ------------------------------------------------------------ | ---------------------------------------- |
+| 2026-04-28 | Incident at Camelback and 24th, Phoenix                      | custom_field: date_of_incident           |
+| 2026-05-03 | First medical contact, Mercy General ED                      | doc_01                                   |
+| 2026-05-12 | MRI at Phoenix Imaging, L4-L5 disc herniation documented     | doc_02                                   |
+| 2026-05-18 | Initial orthopedic consult, Phoenix Orthopedics              | doc_03                                   |
+| 2026-06-04 | Orthopedic followup, Phoenix Orthopedics                     | doc_04                                   |
+| 2026-06-12 | Physical therapy summary, Valley PT                          | doc_05                                   |
+| 2026-06-15 | Demand letter served on opposing counsel                     | custom_field: demand_served_date         |
+| 2026-08-01 | Settlement conference scheduled                              | custom_field: settlement_conference_date |
+```
+
+Events that cannot be sourced do not appear. The chronology is anchored in document IDs and matter custom_fields; the skill does not narrate events between sourced rows.
+
+### 4. Damages tabulation
+
+Two sub-tables.
+
+#### 4a. Medical specials
+
+```
+## Damages: Medical Specials
+
+| Provider             | Date range            | Billed   | Adjusted | Source |
+| -------------------- | --------------------- | -------- | -------- | ------ |
+| Mercy General        | 2026-05-03            | $4,800   | $3,200   | doc_06 |
+| Phoenix Imaging      | 2026-05-12            | $2,200   | $1,800   | doc_06 |
+| Phoenix Orthopedics  | 2026-05-18 to 2026-06-04 | $5,400 | $4,100   | doc_07 |
+| Valley PT            | 2026-05-25 to 2026-06-30 | $6,200 | $5,400   | doc_07 |
+
+Medical specials total (billed): $18,600
+Medical specials total (adjusted): $14,500
+```
+
+Totals compute only when every row sources. A partial-source table renders the totals as `[TBD: partial-source totals - partner confirms after billing exhibits are complete]`.
+
+#### 4b. Lost wages
+
+```
+## Damages: Lost Wages
+
+| Pay period          | Days lost | Verified amount | Source |
+| ------------------- | --------- | --------------- | ------ |
+| 2026-04-28 to 2026-05-15 | 14    | $1,820          | doc_08 |
+| 2026-05-16 to 2026-05-31 | 4     | $520            | doc_08 |
+
+Lost wages total: $2,340
+```
+
+### 5. Strengths fact list
+
+Bullet list. Each bullet states a sourced fact and lists the source. No characterizations.
+
+```
+## Strengths (sourced facts)
+
+- May 12, 2026 MRI at Phoenix Imaging documents L4-L5 disc herniation. Source: doc_02.
+- First medical contact within five days of incident, at Mercy General ED. Sources: custom_field date_of_incident, doc_01.
+- Police report attributes fault to opposing party operator. Source: doc_09 (Phoenix PD incident report dated 2026-04-28).
+- Documented employment continuity at ABC Manufacturing for the eighteen months preceding the incident. Source: doc_08.
+
+Legal-argument framing of these facts: see TBD section below.
+```
+
+### 6. Weaknesses fact list
+
+Bullet list. Each bullet states a sourced fact and lists the source. No characterizations.
+
+```
+## Weaknesses (sourced facts)
+
+- Five-day gap between incident (2026-04-28) and first medical contact (2026-05-03). Sources: custom_field date_of_incident, doc_01.
+- Matter custom_field prior_back_injury_history records a 2021 lumbar strain at the same level (L4-L5). Source: matter custom_field prior_back_injury_history.
+
+Legal-argument framing of these facts: see TBD section below.
+```
+
+When the matter file contains no documented weakness, the section reads:
+
+```
+## Weaknesses (sourced facts)
+
+The matter file contains no documented weaknesses against the strengths fact list above. The partner may identify additional considerations in the TBD section below; the skill emits no inferred weaknesses.
+```
+
+### 7. Comparable-verdict table
+
+Memory-rule sourced. Rows surface verbatim from the firm's `customer.yaml.memory_rules.comparable_verdicts` corpus where the matter's profile matches the row's criterion fields.
+
+```
+## Comparable Verdicts (firm memory-rule sourced)
+
+Match criteria: matter_type=auto-accident, injury=disc_herniation, jurisdiction=Maricopa County, liability=clear.
+
+| Case name            | Year | Jurisdiction         | Verdict    | Key matched facts                                    | Source (partner-authored)              |
+| -------------------- | ---- | -------------------- | ---------- | ---------------------------------------------------- | -------------------------------------- |
+| Reyes v. Mid-City    | 2024 | Maricopa Superior    | $185,000   | rear-end, L4-L5 herniation, clear liability          | Maricopa Jury Verdict Reporter 2024-118|
+| Patel v. Sunrise     | 2023 | Maricopa Superior    | $142,000   | rear-end, L5-S1 herniation, clear liability          | partner matter file 2023-441           |
+| Aguilar v. Reliant   | 2023 | Maricopa Superior    | $97,000    | rear-end, lumbar strain plus disc bulge, clear liability | partner matter file 2023-322       |
+
+Rows are verbatim from the firm's corpus. The skill produces no derived range, no average, no median, and no recommended bracket. The partner authors the bracket recommendation in the TBD section below.
+```
+
+When no rows match, the table renders as:
+
+```
+## Comparable Verdicts (firm memory-rule sourced)
+
+No comparable verdicts in the firm's memory rule match this matter's profile (auto-accident, disc herniation, Maricopa County, clear liability). The partner authors the bracket recommendation from external research, or the firm extends the corpus before the conference.
+```
+
+### 8. Opposing-counsel prior-pattern table
+
+```
+## Opposing Counsel Prior-Pattern (firm memory-rule sourced)
+
+Opposing counsel: <opposing_counsel_name from matter custom_fields>, <opposing_counsel_firm>.
+
+| Metric                                       | Value (partner-authored)                |
+| -------------------------------------------- | --------------------------------------- |
+| Median days from demand to first offer       | 42                                      |
+| Median days from first offer to settlement   | 71                                      |
+| Conference behavior pattern                  | Mid-conference settlement (recorded across four prior matters) |
+| Partner qualitative note                     | Whitfield rarely opens at meaningful numbers, but moves quickly once anchored above policy midpoint |
+
+Rows are verbatim from the firm's prior-pattern memory rule. The skill does not interpolate.
+```
+
+When the opposing counsel is not in the corpus, the section reads:
+
+```
+## Opposing Counsel Prior-Pattern (firm memory-rule sourced)
+
+No prior-pattern data on <opposing_counsel_name> in firm memory. The partner authors the posture section without an opposing-counsel anchor, or the firm records a prior-pattern row from a prior matter before the conference.
+```
+
+### 9. Carrier prior-pattern table
+
+Same shape as section 8, keyed on `opposing_carrier_name` instead of opposing counsel.
+
+### 10. Strengths legal-argument prose
+
+```
+## Strengths: Legal-Argument Framing
+
+`[TBD: legal-argument framing of strengths - partner authors. The strengths fact list above is provided as input.]`
+```
+
+### 11. Weaknesses legal-argument prose
+
+```
+## Weaknesses: Legal-Argument Framing
+
+`[TBD: legal-argument framing of weaknesses - partner authors. The weaknesses fact list above is provided as input.]`
+```
+
+### 12. Settlement bracket recommendation
+
+```
+## Settlement Bracket Recommendation
+
+`[TBD: settlement bracket recommendation - partner authors. The comparable-verdict table above and the damages tabulation are provided as input. The skill produces no bracket because settlement-value analysis is third-rail per law-firm PRD §5; the partner authors the bracket from the cited corpus and the matter facts.]`
+```
+
+### 13. Recommended posture
+
+```
+## Recommended Posture
+
+`[TBD: recommended posture (open low / open high / anchor / walk-away) - partner authors. The opposing-counsel and carrier prior-pattern tables are provided as input.]`
+```
+
+### 14. Closing case-strategy language
+
+```
+## Closing
+
+`[TBD: closing recommendation - partner authors. The skill emits no language about negotiation posture, settlement authority, walk-away triggers, or any forward-looking case-strategy framing.]`
+```
+
+### 15. Exhibit list
+
+```
+## Exhibits
+
+| Exhibit | Document                                       | Source ID |
+| ------- | ---------------------------------------------- | --------- |
+| A       | Mercy General ED record, 2026-05-03            | doc_01    |
+| B       | Phoenix Imaging MRI report, 2026-05-12         | doc_02    |
+| C       | Phoenix Orthopedics initial consult, 2026-05-18 | doc_03   |
+| D       | Phoenix Orthopedics followup, 2026-06-04       | doc_04    |
+| E       | Valley PT summary, 2026-06-12                  | doc_05    |
+| F       | Mercy General billing statement                | doc_06    |
+| G       | Phoenix Orthopedics billing statement          | doc_07    |
+| H       | ABC Manufacturing employment verification      | doc_08    |
+| I       | Phoenix PD incident report, 2026-04-28         | doc_09    |
+```
+
+Every exhibit references a sourced `StoredDocument.id`. No invented exhibits.
+
+### 16. Partner signoff
+
+The partner's signature block from `customer.yaml.signature_block`. Internal memos may use a shorter block than external correspondence; the Layer 2 corpus decides.
+
+## Sourcing note
+
+Section-by-section sourcing index. Written to `~/.hermes/customer_notes/{customer_slug}/pi-settlement-prep-YYYY-MM-DD-<matter-id>.md`.
+
+```
+# Sourcing Note - Settlement Prep Memo
+
+Matter: <matter-id>
+Conference date: <date>
+Generated: <timestamp>
+Skill: law-pi-settlement-prep@<version>
+
+## Matter-facts summary
+
+- case_caption: matter.custom_fields.case_caption
+- case_number: matter.custom_fields.case_number
+- client_name: matter.client_name
+- opposing_counsel_name: matter.custom_fields.opposing_counsel_name
+- opposing_carrier_name: matter.custom_fields.opposing_carrier_name
+
+## Chronology
+
+- 2026-04-28 (incident): matter.custom_fields.date_of_incident
+- 2026-05-03 (first medical): doc_01 (Mercy General ED record)
+- ...
+
+## Damages
+
+- doc_06 row Mercy General: billed=$4,800, adjusted=$3,200
+- doc_06 row Phoenix Imaging: billed=$2,200, adjusted=$1,800
+- ...
+
+## Strengths
+
+- fact 1: source doc_02
+- fact 2: sources custom_field date_of_incident + doc_01
+- ...
+
+## Weaknesses
+
+- fact 1: sources custom_field date_of_incident + doc_01
+- fact 2: source custom_field prior_back_injury_history
+
+## Comparable verdicts
+
+- row 1 (Reyes v. Mid-City): memory_rule comparable_verdicts row_id rv_2024_118
+- row 2 (Patel v. Sunrise): memory_rule comparable_verdicts row_id pv_2023_441
+- ...
+
+## Opposing-counsel prior-pattern
+
+- opposing_counsel row: memory_rule opposing_counsel_patterns row_id oc_whitfield
+
+## Carrier prior-pattern
+
+- carrier row: memory_rule carrier_patterns row_id cp_statewide_mutual
+
+## TBD fields and reason
+
+- settlement_bracket_recommendation: tagged `none`, fabrication filter blocks any non-empty render
+- recommended_posture: tagged `none`, fabrication filter blocks
+- strengths_legal_argument_prose: tagged `none`, partner authors
+- weaknesses_legal_argument_prose: tagged `none`, partner authors
+- case_strategy_language: tagged `none`, partner authors
+
+## Voice gate score
+
+- overall: 0.86 (above threshold 0.75)
+- internal_memo_register_subscore: 0.81
+
+## Adapter calls
+
+- practice_management.get_matter: 1
+- document_storage.list_folder: 1
+- document_storage.download_document: 9
+- email.create_draft: 1
+```

--- a/ai-employee/skills/law-pi-settlement-prep/references/test-cases.md
+++ b/ai-employee/skills/law-pi-settlement-prep/references/test-cases.md
@@ -1,0 +1,76 @@
+# Test Cases
+
+The two fixtures in `fixtures/` exercise the two profiles that anchor this skill's behavior: a low-severity matter with clear liability where the comparable-verdict corpus surfaces multiple matching rows, and a higher-severity matter with contested liability where the corpus surfaces fewer rows and one of the weaknesses fact-list entries is non-empty.
+
+Every fixture is synthetic. Every name is fictional. Every email address uses the `.invalid` TLD. Every fixture is watermarked `[SYNTHETIC FIXTURE - NOT A REAL MATTER]` in both the input matter file and the reference output memo.
+
+## Fixture 01 - Soft-tissue matter with clear liability
+
+**Input:** `fixtures/01-soft-tissue-clear-liability-matter.yaml`
+
+Profile: auto-accident matter. Client rear-ended at a stoplight, police report attributes fault to the opposing party operator, soft-tissue injuries documented across six weeks of treatment, no prior injury history in the relevant body region, employer-verified lost wages, demand letter served, settlement conference scheduled. Carrier and opposing counsel are both in the firm's prior-pattern corpus.
+
+- Matter custom_fields fully populated: client_name, date_of_incident, incident_location, claim_number, case_caption, case_number, opposing_counsel_name, opposing_counsel_firm, opposing_carrier_name, settlement_conference_date, demand_served_date, conference_location, mediator_name, attendees_recorded
+- Matter folder contains: 4 medical records, 2 billing statements, 1 employment verification, 1 lost-wages statement, 1 police report, 2 incident photos, 1 demand letter copy
+- Comparable-verdict memory rule contains 12 rows; 3 rows match the matter profile (auto-accident, soft-tissue, Maricopa County, clear liability)
+- Opposing-counsel prior-pattern memory rule contains a row for the named opposing counsel
+- Carrier prior-pattern memory rule contains a row for the named carrier
+- Voice samples count: 38 (above the §9.6 Gate 1 threshold of 30); 7 samples tagged internal_prep_memo
+
+**Expected behavior:**
+
+- Readiness rubric: matter scope IN_SCOPE, status ACTIVE, conference date SCHEDULED, document corpus READY, comparable-verdict corpus READY, voice envelope READY, citation risk CLEAN.
+- Skill proceeds with full memo. Matter-facts summary one paragraph. Conference logistics block populated. Chronology lists ten events. Damages tables compute totals (medical specials $14,500; lost wages $2,340). Strengths fact list has 4 entries (sourced). Weaknesses fact list has 0 entries; the section emits the "no documented weaknesses" prose. Comparable-verdict table surfaces 3 rows verbatim from the corpus. Opposing-counsel pattern table surfaces 1 row. Carrier pattern table surfaces 1 row. Five TBD sections render as TBD markers. Exhibit list has 11 entries.
+- Email.create_draft called once. DraftRef.folder confirms partner's drafts folder. Recipient is the partner's own direct_email (internal memo).
+- Sourcing note records sourcing for every row, every cell.
+- Fabrication filter result: `clean`.
+
+**Reference output:** `fixtures/01-soft-tissue-clear-liability-matter-memo.md`.
+
+## Fixture 02 - Disc-herniation matter with contested liability
+
+**Input:** `fixtures/02-disc-herniation-contested-liability-matter.yaml`
+
+Profile: auto-accident matter. Client struck while making a left turn at an intersection where right-of-way is contested (the police report records both operators' statements without attribution of fault). MRI documents L4-L5 disc herniation. Prior medical history records a 2021 lumbar strain at the same level (a documented weakness). Treatment included orthopedic consults and physical therapy across eleven weeks. Employer-verified lost wages. Demand letter served. Settlement conference scheduled. Opposing counsel is in the firm's prior-pattern corpus; the carrier is NOT in the corpus.
+
+- Matter custom_fields populated: client_name, date_of_incident, incident_location, claim_number, case_caption, case_number, opposing_counsel_name, opposing_counsel_firm, opposing_carrier_name (unfamiliar to firm), settlement_conference_date, demand_served_date, prior_back_injury_history (documented), conference_location
+- Matter folder contains: 6 medical records (including MRI), 3 billing statements, 1 employment verification, 1 lost-wages statement, 1 police report (no fault attribution), 3 incident photos, 1 demand letter copy
+- Comparable-verdict memory rule contains 12 rows; 2 rows match the matter profile (auto-accident, disc herniation, Maricopa County, contested liability)
+- Opposing-counsel prior-pattern memory rule contains a row for the named opposing counsel
+- Carrier prior-pattern memory rule does NOT contain a row for the named carrier
+- Voice samples count: 38; 7 samples tagged internal_prep_memo
+
+**Expected behavior:**
+
+- Readiness rubric: matter scope IN_SCOPE, status ACTIVE, conference date SCHEDULED, document corpus READY, comparable-verdict corpus READY (2 rows match), voice envelope READY, citation risk CLEAN.
+- Skill proceeds with full memo. Matter-facts summary names the contested-liability profile. Conference logistics block populated. Chronology lists fifteen events. Damages tables compute totals (medical specials $32,800; lost wages $5,460). Strengths fact list has 3 entries (MRI confirms disc herniation, first medical contact within four days, employer continuity documented). Weaknesses fact list has 2 entries (prior 2021 lumbar strain at the same level documented in matter custom_field, police report attributes no fault). Comparable-verdict table surfaces 2 rows verbatim. Opposing-counsel pattern table surfaces 1 row. Carrier pattern table renders the corpus-absent prose ("no prior-pattern data on <carrier name> in firm memory"). Five TBD sections render as TBD markers. Exhibit list has 14 entries.
+- Email.create_draft called once.
+- Sourcing note records the corpus-absence for the carrier pattern table.
+- Fabrication filter result: `clean`.
+
+**Reference output:** `fixtures/02-disc-herniation-contested-liability-matter-memo.md`.
+
+## What the fixture corpus does NOT cover
+
+Out of scope for the initial two fixtures, deferred to expanded coverage post-v1:
+
+- A matter where the comparable-verdict corpus has no matching rows. The behavior is documented (table renders corpus-absent prose; bracket TBD notes the absence). Deferred to a third fixture once the v1 customer's memory-rule onboarding has produced enough corpus thinness to merit a fixture.
+- A matter with `comparable_verdict_corpus_missing` invoked with `--no-comparable-verdicts`. The refusal-flag behavior is documented; not worth a dedicated fixture at v1.
+- A matter with voice samples count below the threshold. Same refusal shape with different error code.
+- A matter with voice samples count above 30 but fewer than 5 tagged internal_prep_memo. The skill proceeds with a warning; worth a fixture eventually but not v1.
+- A matter where the voice gate fails on the matter-facts summary. The skill omits the prose and ships the structured-tables-only memo. Worth a fixture eventually but not v1.
+- A premises or product-liability matter. Deferred to post-launch when the customer's actual matter portfolio informs the fixture.
+- A medmal matter. Deferred per the same rationale.
+- A citation-in-source-data refusal. Covered by the discovery-response and demand-letter skills' fixtures; the prep-memo behavior is identical and a redundant fixture is unnecessary at v1.
+
+The two fixtures together exercise the path that matters most for the safety-architecture claim: that the skill cannot fabricate a settlement bracket, a posture recommendation, a legal-argument characterization of strengths or weaknesses, or a case-strategy commitment across two matter profiles with different liability and severity signatures.
+
+## How the fixtures are used
+
+The fixtures are inputs to three downstream test suites (not implemented by this skill PR; implemented by the workstreams that own them):
+
+1. **Voice-gate harness** (`ai-employee/voice-gate/`, gated through #855). Replays the skill against each fixture and scores the produced memo against the Layer 2 internal-memo corpus. Pass threshold per skill; this skill's threshold is set conservatively.
+2. **Adapter conformance suite** (`src/lib/ai-employee/capabilities/conformance.ts`). Replays the skill against each fixture using mock adapters. Asserts: Email.create_draft called once per fixture; DraftRef.folder is the partner's drafts folder; recipient is the partner's own direct_email; PracticeManagement.get_matter is called read-only; DocumentStorage.list_folder and download_document are called read-only.
+3. **Fabrication-filter regression corpus** (`ai-employee/fixtures/fabrication/`, per `docs/specs/ai-employee/fabrication-filter.md`). The expected outputs from these fixtures are added to the regression corpus; a future PR that introduces a `settlement_bracket_recommendation` rendered with non-empty content must `block` against fixture 01's reference output.
+
+The fixtures live at `ai-employee/skills/law-pi-settlement-prep/fixtures/`; the downstream test suites import them.

--- a/ai-employee/skills/law-pi-settlement-prep/references/voice.md
+++ b/ai-employee/skills/law-pi-settlement-prep/references/voice.md
@@ -1,0 +1,118 @@
+# Voice Rules - Partner Internal-Memo Voice (Layer 2 Match)
+
+The memo's factual sections (matter-facts summary, chronology lead-in, damages-table captions, strengths and weaknesses list lead-ins, comparable-verdict table caption, prior-pattern table captions) must read as if the supervising partner wrote them to themselves. The memo is internal and the recipient is the partner; the audience is one person who wrote half the corpus that sourced the memo.
+
+The internal-memo voice envelope differs from the external-correspondence envelope used by `law-pi-demand-letter-draft` and `law-pi-discovery-response`. Internal memos are dense, plain, partner-to-self prose. They strip ceremony. They name people by last name on first reference and first name thereafter when the partner's prior memos do so. They omit polite framing. They are written to be scanned in fifteen minutes, not read in twenty-five.
+
+Voice samples (Layer 2 anchor corpus) live in `customer.yaml` and must total at least thirty samples for the customer overall. For this skill specifically, at least five samples should be tagged `internal_prep_memo` or `case_strategy_memo` to anchor the internal-memo register; if fewer than five are tagged, the skill emits a "voice envelope thin" warning in the sourcing note but proceeds, because the internal-memo audience (the partner themselves) is lower-risk than an external recipient.
+
+## Hard rules (mechanical, enforceable)
+
+1. **No em dashes anywhere.** Use sentences. Use commas. Use periods. Never the long dash character (em dash, en dash). The rule applies to section headers, table delimiters, captions, and prose alike. Markdown tables that need a separator row use the standard pipe-and-hyphen syntax; the hyphens are ASCII hyphens, not em dashes or en dashes.
+2. **No "I hope this email finds you well." No "Just wanted to touch base." No "Reach out."** These are AI-tells. Internal memos do not contain greetings, sign-offs, or audience-management language; they open with the matter and close with the partner's own action items.
+3. **No corporate filler vocabulary:** circle back, touch base, reach out, leverage, level-set, deep dive, double-click, sync up, alignment as a verb, table this, ping me, action item, bandwidth, per our records, at this time, please find attached.
+4. **No legal conclusions in any section the skill authors.** Never "the comparative-negligence defense is plainly meritless," "policy limits are obviously inadequate," "causation is settled," "the carrier will absolutely fold at mediation." The fact lists are facts; the characterization is the partner-authored TBD section.
+5. **No commitment language in any section the skill authors.** Never "we will open at," "we will not accept below," "our floor is," "the partner will recommend." All such language belongs in the partner-authored bracket-recommendation and posture sections.
+6. **No tentative hedges that fake certainty:** "I believe," "it appears," "in our view," "as best we can tell," "presumably." If the chronology event is sourced, the event is stated. If it is not, the event is TBD.
+7. **Active voice.** "Dr. Chen documented the disc herniation on the May 12 MRI" not "the disc herniation was documented by Dr. Chen on the May 12 MRI." "The police report names Kerr as the at-fault operator" not "Kerr is named as the at-fault operator in the police report."
+8. **Short sentences.** One idea per sentence usually. Long sentences are reserved for nuanced chronology where breaking would obscure the connection, not for sounding lawyerly. Target sentence length: ten to eighteen words. Max sentence length: thirty words. Internal memos run shorter than external correspondence.
+9. **No emojis. No exclamation points anywhere.**
+10. **Dates render as `Month D, YYYY` in prose (e.g., "May 8, 2026") and as `YYYY-MM-DD` in tables.** No "5/8/26", no "8 May 26."
+11. **Dollar figures appear only in the damages tabulation (sourced from billing statements and lost-wages documents) and in the comparable-verdict table (verbatim from memory-rule rows).** They never appear in skill-authored prose. The bracket-recommendation section is TBD and contains no figure; the skill does not generate a placeholder figure.
+12. **People are named per the partner's prior-memo convention.** If the partner's Layer 2 internal-memo samples introduce people by last name on first reference and use first name thereafter, the memo does the same. If samples use full name on first reference, the memo does that. The Layer 2 corpus decides.
+13. **No verdicts are surfaced that are not verbatim rows from the firm's memory-rule corpus.** The skill does not reword, summarize, or extrapolate from memory-rule rows. A row that surfaces, surfaces verbatim. A row that does not match the matter's profile does not surface.
+
+## Soft rules (judgment)
+
+14. **Dense and plain, not friendly and not adversarial.** A prep memo is a scanning document. The partner is reading it while pacing, while drinking coffee, while waiting for the conference room to open. Tone matches the partner's prior internal memos. The partner writes for themselves; the memo reads as the partner wrote it.
+15. **State facts, do not argue them.** "Three months of physical therapy at Valley PT documented in Exhibit C" is a fact. "The treatment history shows commitment to recovery" is an argument. The skill writes facts; the partner writes arguments.
+16. **Name the source of every figure inline.** "Medical specials total $24,500 across five providers, sourced from the billing exhibits at the back of the memo" is sourced. "Medical specials total approximately $24,500" is not.
+17. **Acknowledge what is unknown without making the chronology feel thin.** "The matter file contains no employer's lost-wages verification as of the conference date" is fine when the absence is sourced (the chronology shows the partner has not yet requested the verification). "We have no employer verification" without a chronology anchor is not.
+18. **Comparable-verdict rows surface verbatim with the partner's authored citation; the skill does not validate the citation, does not augment it, does not add a parallel cite.** The partner authored the corpus; the partner is responsible for the citation's accuracy.
+
+## Examples, good and bad
+
+The examples below use fictional names and the `.invalid` TLD. All sample content is marked `[SYNTHETIC FIXTURE - NOT A REAL MATTER]`.
+
+### Matter-facts summary
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+**Bad** (greeting, ceremony, soft-spoken framing):
+
+> I hope this finds you well. I wanted to put together a quick summary of the Holloway matter ahead of Friday's settlement conference. As you know, Janet Holloway was involved in an unfortunate incident on April 28, 2026 at the intersection of Camelback Road and 24th Street.
+
+**Good** (dense, partner-to-self, scannable):
+
+> Holloway v. Kerr. Auto-accident matter, opened May 1, 2026. Client: Janet Holloway, operator of stopped 2021 Camry struck from behind at Camelback and 24th. Opposing party: David Kerr. Opposing counsel: Theodora Whitfield, Whitfield Reardon, PLLC. Carrier: Statewide Mutual. Settlement conference scheduled June 24, 2026 at Maricopa County Superior Court.
+
+### Chronology lead-in
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+**Bad** (narrative voice, embellishment):
+
+> The chronology of treatment paints a picture of a client who took her recovery seriously from the very first hours after the collision. Janet was rushed to Mercy General within an hour of impact, where the ED team immediately recognized the severity of her injuries.
+
+**Good** (factual list, scannable):
+
+> Chronology of treatment and matter milestones, every event sourced to a document at the back of the memo or to a matter custom_field.
+
+### Strengths fact-list entry
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+**Bad** (legal characterization, advocacy):
+
+> The May 12 MRI showing disc herniation is a powerful piece of evidence that confirms the seriousness of Janet's injuries and supports a strong causation argument.
+
+**Good** (sourced fact, no characterization):
+
+> May 12, 2026 MRI at Phoenix Imaging documents L4-L5 disc herniation. Source: doc_02 (Phoenix Imaging MRI report, dated 2026-05-12).
+
+### Weaknesses fact-list entry
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+**Bad** (legal-exposure characterization):
+
+> The five-day gap between the incident and the first medical contact is a weakness that opposing counsel will undoubtedly exploit to argue that the injury is not as serious as claimed.
+
+**Good** (sourced fact, no characterization):
+
+> Five-day gap between incident date (April 28, 2026) and first medical contact (May 3, 2026 at Mercy General). Source: matter custom_field date_of_incident and doc_01 (Mercy General ED record, dated 2026-05-03). The skill emits no characterization of how this gap reads to opposing counsel; the partner authors the legal-argument framing in the TBD weaknesses-prose section.
+
+### Comparable-verdict table caption
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+**Bad** (interpretive framing):
+
+> Comparable verdicts in similar disc-herniation matters in Maricopa County suggest the appropriate settlement range is between X and Y.
+
+**Good** (mechanical reference to memory-rule corpus):
+
+> Comparable verdicts surfaced from the firm's memory-rule corpus that match the matter profile (auto-accident, disc herniation, Maricopa County, clear liability). Rows are verbatim from the corpus the partner authored. The skill produces no derived range; the partner authors the bracket recommendation in the TBD section below.
+
+### Closing
+
+`[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
+
+**Bad** (skill authoring strategy):
+
+> Recommendation: open at $185,000. Walk-away point: $95,000. The carrier's prior pattern of mid-conference settlement suggests this matter resolves in the first session.
+
+**Good** (TBD marker):
+
+> `[TBD: closing recommendation - partner authors. The skill emits no language about negotiation posture, settlement authority, walk-away triggers, or any forward-looking case-strategy framing.]`
+
+## Voice gate scoring
+
+The voice gate harness (`ai-employee/voice-gate/`, issue #855) scores the assembled prose along four axes:
+
+1. **Tone register match.** Internal-memo register is plainer and denser than external-correspondence register. Sentence length distribution, formality markers, and ceremony language are scored against the Layer 2 internal-memo samples specifically.
+2. **Sentence length envelope.** Target ten to eighteen words per sentence; max thirty. Outliers count against the score.
+3. **Banned pattern hits.** Em dashes, corporate filler vocabulary, hedge phrases, legal-conclusion adverbs. Any hit drops the score; the substrate-level filter also blocks.
+4. **Layer 2 anchor similarity.** Cosine-similarity against the internal-memo and case-strategy-memo samples in the Layer 2 corpus.
+
+A failing score causes the skill to emit a structured-table-only variant (matter-facts as a one-line table, chronology as a structured list, no narrative lead-ins). The partner authors the lead-ins. The fallback path is documented in `ai-employee/voice-gate/voice-gate-fallback.md`.


### PR DESCRIPTION
## Summary

Adds the `law-pi-settlement-prep` skill spec: a partner-prep memo assembler for PI matters at the pre-settlement-conference stage. The skill reads an active matter, the matter's medical/billing/employment/incident documents, and the firm's comparable-verdict and prior-pattern memory rules, then writes an internal prep memo into the supervising partner's drafts folder via `Email.create_draft`. The memo is internal: the partner is both reviewer and recipient. Five legal-judgment sections render as TBD markers (`sourced_from: none`); the fabrication filter architecturally blocks any non-empty render. Trust ceiling `draft_for_review`, locked at v1.

## Linked issue

Closes #849

## Acceptance criteria status

| AC (verbatim from issue)                                          | Status | Evidence                                                                                                                                                                                                                                                                                          |
| ----------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Full SKILL.md at `ai-employee/skills/law-pi-settlement-prep/`     | met    | `ai-employee/skills/law-pi-settlement-prep/SKILL.md`; full frontmatter (27 `client_facing_fields`, capability bindings, trust ceiling locked), full body with scope alignment, agent steps, voice rules, citation policy, fabrication policy, refusal cases, "what good looks like" success criteria |
| Aggregates matter facts + comparable cases                         | met    | SKILL.md steps 2-12 walk matter load via `PracticeManagement.get_matter`, document load via `DocumentStorage`, comparable-verdict surfacing from `customer.memory_rules.comparable_verdicts`. Fixture 01 surfaces 3 verdict rows; fixture 02 surfaces 2 rows                                       |
| Produces structured prep memo                                      | met    | `references/output-format.md` defines the 16-section structure. Fixture memos render the structure end-to-end                                                                                                                                                                                     |
| Trust ceiling: `draft_for_review`                                  | met    | SKILL.md frontmatter: `trust_ceiling: draft_for_review`, `trust_ceiling_locked: true`; SKILL.md § Trust ceiling explains the v1 lock per PRD §11.2                                                                                                                                                |
| Fixture coverage: at least 2 matters                               | met    | `fixtures/01-soft-tissue-clear-liability-matter.{yaml,md}` (low-severity clear-liability) and `fixtures/02-disc-herniation-contested-liability-matter.{yaml,md}` (higher-severity contested-liability with corpus-absent carrier pattern). See `references/test-cases.md` for behavior expectations |

## Test plan

- [x] `npm run verify` passes
- [x] No em dashes anywhere in skill content (regex documentation rewritten as prose)
- [x] Every fixture is watermarked `[SYNTHETIC FIXTURE - NOT A REAL MATTER]`
- [x] Every fixture email address uses `.invalid` TLD
- [x] Five `none`-tagged sections in `client_facing_fields` enforce architectural non-rendering of legal-judgment prose (settlement bracket, posture, strengths-prose, weaknesses-prose, closing strategy)
- [x] Comparable-verdict table is `memory_rule`-tagged; rows surface verbatim from `customer.yaml.memory_rules.comparable_verdicts`; skill never invents, extrapolates, averages, or derives ranges

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses (skill spec only; no runtime code)
- [x] Input validation on new endpoints (no new endpoints)
- [x] Parameterized queries for any SQL (no SQL)
- [x] Auth required on new endpoints (no new endpoints)
- [x] No internal IDs that enable enumeration

## Feature Impact

**Feature impact:** None. New skill specification under `ai-employee/skills/`. No user-facing surface change.

## Deployment Notes

None. Skill spec only; the runtime that executes the skill is gated through downstream issues (voice-gate harness, fabrication-filter, capability adapters). No schema changes, env vars, or secret rotations.

Refs ADR 0005 (reviewer-as-sender), ADR 0006 (capability-adapter pattern), ADR 0008 (customer-owned memory artifact), platform PRD §7.5 invariants #6 and #8, §8.4, §9, §11.2; law-firm PRD §5 (third-rail map), §6.2 (Pillar 7), §11.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)