### PR TITLE
feat(ai-employee): sticky-stop mechanism (#843)

### DIFF
--- a/ai-employee/migrations/0004_sticky_stop_state.sql
+++ b/ai-employee/migrations/0004_sticky_stop_state.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Migration 0004: sticky-stop state (issue #843)
+-- ============================================================================
+--
+-- The sticky-stop circuit breaker pins the agent's dispatch path when the
+-- substrate observes runaway-loop signals: consecutive tool failures,
+-- refusal cascades, time-budget overruns, or cost-threshold breaches. The
+-- state machine itself lives at ai-employee/safety-substrate/sticky_stop.py.
+-- This migration adds the D1 row it persists to.
+--
+-- Source spec:    docs/specs/ai-employee/sticky-stop.md
+-- Source PRD:     docs/pm/ai-employee/platform-prd.md §7.5 (invariant #4),
+--                 §11.5 (Sticky stop)
+-- Applied by:     ai-employee/adapter/run_migrations.py (invoked from
+--                 bin/provision-customer.sh during customer provisioning)
+-- Owns the row:   ai-employee/safety-substrate/sticky_stop.py
+--
+-- Per-customer isolation: the table lives in the per-customer D1
+-- (hermes-{slug}-d1) per ADR 0008. The `customer` column is the
+-- customer_id slug, denormalized into the row for audit symmetry with the
+-- machine's API surface. It does NOT lift cross-customer queries — the
+-- D1 binding is still single-tenant per Hermes Machine (ADR 0009).
+--
+-- One row per (customer, persona). The composite primary key enforces
+-- uniqueness without an extra index.
+-- ============================================================================
+
+CREATE TABLE sticky_stop_state (
+  customer                          TEXT NOT NULL,                              -- customer_id slug; matches D1 binding
+  persona                           TEXT NOT NULL,                              -- customer.yaml.personas[].slug
+  level                             TEXT NOT NULL DEFAULT 'OK',                 -- 'OK' | 'WARN' | 'SOFT_STOP' | 'HARD_STOP'
+  updated_at                        TEXT NOT NULL,                              -- ISO 8601 UTC
+  reason                            TEXT,                                       -- human-readable condition snapshot at last transition
+  condition                         TEXT,                                       -- 'consecutive_tool_failures' | 'refusal_cascade' | 'time_budget_exceeded' | 'cost_threshold' | 'captain_clear'
+
+  -- Rolling counters. Persisted in the row so the machine survives
+  -- restarts without losing failure history per safety invariant #4.
+  consecutive_tool_failures         INTEGER NOT NULL DEFAULT 0,
+  tool_failure_window_started_at    TEXT,                                       -- ISO 8601 UTC; NULL when no streak active
+  refusal_count                     INTEGER NOT NULL DEFAULT 0,
+  refusal_window_started_at         TEXT,                                       -- ISO 8601 UTC
+  cost_cents_today                  INTEGER NOT NULL DEFAULT 0,
+  cost_date                         TEXT,                                       -- YYYY-MM-DD; resets cost_cents_today on day rollover
+
+  PRIMARY KEY (customer, persona)
+);
+
+-- Newest-first scan over all personas for dashboard surfacing. The
+-- dashboard "is anything stuck?" indicator queries WHERE level != 'OK'
+-- ORDER BY updated_at DESC.
+CREATE INDEX idx_sticky_stop_active
+  ON sticky_stop_state(updated_at DESC)
+  WHERE level != 'OK';
+
+-- Bump user_version. 0003 set it to 3; this is migration 4.
+PRAGMA user_version = 4;

--- a/ai-employee/safety-substrate/sticky_stop.py
+++ b/ai-employee/safety-substrate/sticky_stop.py
@@ -1,0 +1,861 @@
+"""Sticky-stop circuit breaker for runaway agent loops (issue #843).
+
+The platform PRD §7.5 invariant #4 says "don't act" instructions are sticky:
+they survive context compaction, restart, and skill reload. That invariant
+covers the OPERATOR-INITIATED pause path — a human pinning a stop. This
+module covers the SYSTEM-INITIATED path: the substrate noticing the agent
+is misbehaving (looping on a failing tool, refusing on every call, burning
+budget, exceeding wall-clock time) and pinning a stop on its behalf before
+a runaway loop can land work nobody asked for.
+
+The two paths share a sticky-stop persistence layer (this module's D1
+table). An operator pause and a system-pinned stop produce the same effect
+on the dispatch path; the difference is the action_type tag recorded in
+the audit log and the recovery surface (operator pauses clear by the same
+human; system stops clear via Captain investigation).
+
+Design rules:
+
+* States are forward-only by default. WARN < SOFT_STOP < HARD_STOP. The
+  state machine never DECREASES state autonomously. Only Captain-initiated
+  clear() resets to OK.
+
+* Conditions are read from customer.yaml `safety.sticky_stop` if present;
+  module-level DEFAULT_CONDITIONS apply otherwise. The defaults are
+  intentionally conservative — easier to loosen via customer.yaml than to
+  recover from a tighter-than-needed loop that ran for hours unnoticed.
+
+* SOFT_STOP semantics: the dispatch path still calls skills, but the
+  trust_ceiling for every skill is pinned to draft_for_review for the
+  duration. No autonomous escalation. The UI shows a banner. The dashboard
+  surface is filed separately — this module only persists the state and
+  exposes a read API.
+
+* HARD_STOP semantics: dispatch refuses every skill invocation. The caller
+  receives a StickyStopError it must propagate, NOT swallow. Same invariant
+  as the audit log writer (issue #891): a state the substrate cannot
+  enforce is a state the agent does not run.
+
+* Captain recovery: `clear(customer, persona, captain_id, reason)` resets
+  state to OK and emits an audit row. The Captain-verification mechanism
+  is upstream (control-plane RBAC); this module trusts the caller to have
+  established identity before invoking.
+
+* Persistence: D1 table `sticky_stop_state`, one row per (customer,
+  persona) tuple. The customer dimension is the D1 binding per ADR 0008;
+  the row's persona slug matches `customer.yaml.personas[].slug`.
+
+* Audit emission: every state transition writes one audit_log row via the
+  AuditLogWriter (issue #891). Action type re-uses the existing closed-set
+  vocabulary because the writer enforces ACCEPTED_ACTION_TYPES at the
+  application layer and this module is in a strict file scope:
+
+    - HARD_STOP entry          -> action_type=AGENT_STOPPED
+    - WARN / SOFT_STOP entries -> action_type=INVARIANT_VIOLATION
+    - clear()                  -> action_type=AGENT_RESUMED
+
+  The transition detail (from_state, to_state, condition_triggered,
+  sampled metric values) lives in the metadata column. This keeps the
+  audit-log schema closed-set per d1-schema.md §1 while still carrying
+  the structural information the compliance-evidence packet needs.
+
+* Thread safety: the module exposes a SqliteStickyStopStore (tests + local
+  dev) and an HttpD1StickyStopStore (production). The Sqlite path uses a
+  single-writer connection; the HTTP path issues serial requests. Neither
+  attempts cross-row locks because state is partitioned per (customer,
+  persona) and within one Hermes Machine the runtime is single-tenant.
+
+Module shape:
+
+    state = StickyStopMachine(store=store, audit_writer=writer)
+
+    # Record a tool failure and let the machine decide whether to transition
+    new_state = await state.record_tool_failure(
+        customer="acme",
+        persona="marcus",
+        skill_name="inbox-triage",
+    )
+
+    # Check current state on the dispatch path
+    current = await state.get_state("acme", "marcus")
+    if current.level == StickyStopLevel.HARD_STOP:
+        raise StickyStopError(current)
+
+    # Captain clears after investigation
+    await state.clear(
+        customer="acme",
+        persona="marcus",
+        captain_id="captain-scott",
+        reason="confirmed false-positive tool flap; vendor recovered",
+    )
+
+The state machine has no async wakeup of its own. It transitions in
+response to caller-driven events. Time-budget enforcement is therefore
+a poll: callers feed `record_runtime_seconds()` per turn or per minute,
+and the machine compares against the configured budget.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional, Protocol
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[1]))  # ai-employee/ on sys.path
+
+from adapter.audit_log import (  # noqa: E402
+    ActorRole,
+    AuditEvent,
+    AuditLogWriter,
+)
+
+log = logging.getLogger("aie.sticky_stop")
+
+
+# ---------------------------------------------------------------------------
+# State enum + dataclasses
+# ---------------------------------------------------------------------------
+
+
+class StickyStopLevel(str, enum.Enum):
+    """Forward-only sticky-stop state. clear() is the only path back to OK."""
+
+    OK = "OK"
+    WARN = "WARN"
+    SOFT_STOP = "SOFT_STOP"
+    HARD_STOP = "HARD_STOP"
+
+
+_LEVEL_ORDER = {
+    StickyStopLevel.OK: 0,
+    StickyStopLevel.WARN: 1,
+    StickyStopLevel.SOFT_STOP: 2,
+    StickyStopLevel.HARD_STOP: 3,
+}
+
+
+class StickyStopCondition(str, enum.Enum):
+    """The four conditions that drive transitions. Stored in metadata so the
+    compliance-evidence packet can bucket transitions by cause."""
+
+    CONSECUTIVE_TOOL_FAILURES = "consecutive_tool_failures"
+    REFUSAL_CASCADE = "refusal_cascade"
+    TIME_BUDGET_EXCEEDED = "time_budget_exceeded"
+    COST_THRESHOLD = "cost_threshold"
+    CAPTAIN_CLEAR = "captain_clear"
+
+
+@dataclass(frozen=True)
+class StickyStopThresholds:
+    """Per-condition transition thresholds. Defaults documented in
+    docs/specs/ai-employee/sticky-stop.md §3. Read from
+    customer.yaml.safety.sticky_stop when present.
+    """
+
+    # Consecutive tool-failure counts within tool_failure_window_seconds.
+    tool_failure_warn: int = 3
+    tool_failure_soft_stop: int = 5
+    tool_failure_hard_stop: int = 8
+    tool_failure_window_seconds: int = 600  # 10 minutes
+
+    # Refusal-cascade counts within refusal_window_seconds.
+    refusal_warn: int = 5
+    refusal_soft_stop: int = 10
+    refusal_hard_stop: int = 20
+    refusal_window_seconds: int = 1800  # 30 minutes
+
+    # Wall-clock seconds for a single run. Single-step transition to
+    # SOFT_STOP; the agent has already exceeded its envelope.
+    time_budget_seconds: int = 3600  # 1 hour
+
+    # Daily $ cap on LLM costs. cost_warn_pct / cost_soft_stop_pct /
+    # cost_hard_stop_pct are percentages of cost_daily_cents.
+    cost_daily_cents: int = 5_000  # $50/day default
+    cost_warn_pct: int = 80
+    cost_soft_stop_pct: int = 100
+    cost_hard_stop_pct: int = 200
+
+
+DEFAULT_THRESHOLDS = StickyStopThresholds()
+
+
+@dataclass(frozen=True)
+class StickyStopState:
+    """Persisted state for a (customer, persona) tuple."""
+
+    customer: str
+    persona: str
+    level: StickyStopLevel
+    updated_at: str  # ISO 8601 UTC
+    reason: Optional[str] = None
+    condition: Optional[StickyStopCondition] = None
+    # Rolling counters used by record_* methods. Carried in the row so the
+    # state machine survives restarts without losing failure history.
+    consecutive_tool_failures: int = 0
+    tool_failure_window_started_at: Optional[str] = None
+    refusal_count: int = 0
+    refusal_window_started_at: Optional[str] = None
+    cost_cents_today: int = 0
+    cost_date: Optional[str] = None  # YYYY-MM-DD; resets cost_cents_today
+
+    def __post_init__(self) -> None:
+        if not self.customer:
+            raise ValueError("customer is required")
+        if not self.persona:
+            raise ValueError("persona is required")
+
+
+class StickyStopError(RuntimeError):
+    """Raised by the dispatch path when the current state is HARD_STOP.
+
+    The caller (Hermes dispatch) MUST NOT catch and proceed. The whole
+    point of HARD_STOP is "no further actions until Captain clears."
+    """
+
+    def __init__(self, state: StickyStopState) -> None:
+        super().__init__(
+            f"sticky-stop HARD_STOP active for {state.customer}/{state.persona}: "
+            f"{state.reason or '(no reason)'}"
+        )
+        self.state = state
+
+
+# ---------------------------------------------------------------------------
+# Store protocol + implementations
+# ---------------------------------------------------------------------------
+
+
+class StickyStopStore(Protocol):
+    """Persistence backend for sticky-stop state. Implementations must be
+    safe to call concurrently from the single Hermes runtime; cross-process
+    coordination is not provided because each customer Machine is single-tenant.
+    """
+
+    async def get(self, customer: str, persona: str) -> Optional[StickyStopState]: ...
+
+    async def put(self, state: StickyStopState) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Sqlite-backed store (tests + local dev)
+# ---------------------------------------------------------------------------
+
+
+_SQLITE_UPSERT = (
+    "INSERT INTO sticky_stop_state ("
+    "customer, persona, level, updated_at, reason, condition, "
+    "consecutive_tool_failures, tool_failure_window_started_at, "
+    "refusal_count, refusal_window_started_at, "
+    "cost_cents_today, cost_date"
+    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+    "ON CONFLICT(customer, persona) DO UPDATE SET "
+    "level=excluded.level, updated_at=excluded.updated_at, "
+    "reason=excluded.reason, condition=excluded.condition, "
+    "consecutive_tool_failures=excluded.consecutive_tool_failures, "
+    "tool_failure_window_started_at=excluded.tool_failure_window_started_at, "
+    "refusal_count=excluded.refusal_count, "
+    "refusal_window_started_at=excluded.refusal_window_started_at, "
+    "cost_cents_today=excluded.cost_cents_today, "
+    "cost_date=excluded.cost_date"
+)
+
+_SQLITE_SELECT = (
+    "SELECT customer, persona, level, updated_at, reason, condition, "
+    "consecutive_tool_failures, tool_failure_window_started_at, "
+    "refusal_count, refusal_window_started_at, "
+    "cost_cents_today, cost_date "
+    "FROM sticky_stop_state WHERE customer=? AND persona=?"
+)
+
+
+class SqliteStickyStopStore:
+    """Sqlite-backed StickyStopStore.
+
+    The caller passes a sqlite3.Connection with the sticky_stop_state schema
+    applied (via migration 0004). Used by tests and local-dev scripts.
+    """
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._conn = connection
+
+    async def get(self, customer: str, persona: str) -> Optional[StickyStopState]:
+        cur = self._conn.cursor()
+        row = cur.execute(_SQLITE_SELECT, (customer, persona)).fetchone()
+        if row is None:
+            return None
+        (
+            cust,
+            pers,
+            level,
+            updated_at,
+            reason,
+            condition,
+            tool_fails,
+            tool_win_start,
+            refusals,
+            refusal_win_start,
+            cost_today,
+            cost_date,
+        ) = row
+        return StickyStopState(
+            customer=cust,
+            persona=pers,
+            level=StickyStopLevel(level),
+            updated_at=updated_at,
+            reason=reason,
+            condition=StickyStopCondition(condition) if condition else None,
+            consecutive_tool_failures=tool_fails or 0,
+            tool_failure_window_started_at=tool_win_start,
+            refusal_count=refusals or 0,
+            refusal_window_started_at=refusal_win_start,
+            cost_cents_today=cost_today or 0,
+            cost_date=cost_date,
+        )
+
+    async def put(self, state: StickyStopState) -> None:
+        self._conn.execute(
+            _SQLITE_UPSERT,
+            (
+                state.customer,
+                state.persona,
+                state.level.value,
+                state.updated_at,
+                state.reason,
+                state.condition.value if state.condition else None,
+                state.consecutive_tool_failures,
+                state.tool_failure_window_started_at,
+                state.refusal_count,
+                state.refusal_window_started_at,
+                state.cost_cents_today,
+                state.cost_date,
+            ),
+        )
+        self._conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Time helpers — injectable for deterministic tests
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def _parse_iso(s: str) -> datetime:
+    # Accept the millisecond-Z format we emit; tolerate plain trailing Z.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+# ---------------------------------------------------------------------------
+# The state machine
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Decision:
+    """Internal value object describing a transition computed but not yet
+    persisted. Lets test code assert against the decision separately from
+    the write."""
+
+    next_state: StickyStopState
+    transitioned: bool
+    condition: Optional[StickyStopCondition]
+
+
+class StickyStopMachine:
+    """The sticky-stop state machine.
+
+    Construction takes a store and an AuditLogWriter. The thresholds default
+    to DEFAULT_THRESHOLDS; callers wire customer.yaml-derived thresholds in
+    explicitly via the `thresholds` keyword.
+
+    All `record_*` methods follow the same shape:
+
+      1. Load the current state (creating an OK row if absent).
+      2. Apply the counter update and decide whether to transition.
+      3. If transitioning, write the new state, emit an audit row, return
+         the new state.
+      4. If not transitioning, write the updated counters, return the same
+         level.
+
+    Transitions are forward-only. If the computed level would be lower than
+    the current level, we keep the current level (counters still update).
+    Captain `clear()` is the only path that decreases level.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: StickyStopStore,
+        audit_writer: AuditLogWriter,
+        thresholds: StickyStopThresholds = DEFAULT_THRESHOLDS,
+        clock: Optional[callable] = None,
+    ) -> None:
+        self._store = store
+        self._audit = audit_writer
+        self._thresholds = thresholds
+        self._clock = clock or _now_utc
+
+    # ---- Public read ------------------------------------------------------
+
+    async def get_state(self, customer: str, persona: str) -> StickyStopState:
+        """Return the current state, materializing an OK row if absent.
+
+        The OK row is materialized in-memory; it is NOT persisted on a read
+        — only the first transition or counter update causes a write.
+        """
+        existing = await self._store.get(customer, persona)
+        if existing is not None:
+            return existing
+        return StickyStopState(
+            customer=customer,
+            persona=persona,
+            level=StickyStopLevel.OK,
+            updated_at=_iso(self._clock()),
+        )
+
+    # ---- Counter updates --------------------------------------------------
+
+    async def record_tool_failure(
+        self,
+        *,
+        customer: str,
+        persona: str,
+        skill_name: Optional[str] = None,
+    ) -> StickyStopState:
+        """Record a tool-call failure. May transition to WARN, SOFT_STOP, or
+        HARD_STOP depending on consecutive-failure thresholds.
+
+        Window: failures within `tool_failure_window_seconds` count toward
+        the same streak. A failure outside the window resets the streak to 1
+        and starts a new window.
+        """
+        state = await self.get_state(customer, persona)
+        now = self._clock()
+        new_count, new_window = self._tick_window(
+            count=state.consecutive_tool_failures,
+            window_started_at=state.tool_failure_window_started_at,
+            now=now,
+            window_seconds=self._thresholds.tool_failure_window_seconds,
+        )
+        target = self._level_for_tool_failures(new_count)
+        next_level = self._forward_only(state.level, target)
+        return await self._commit_transition(
+            current=state,
+            next_state=replace(
+                state,
+                level=next_level,
+                updated_at=_iso(now),
+                consecutive_tool_failures=new_count,
+                tool_failure_window_started_at=new_window,
+                reason=(
+                    f"consecutive_tool_failures={new_count} "
+                    f"(window={self._thresholds.tool_failure_window_seconds}s, "
+                    f"skill={skill_name or 'unknown'})"
+                )
+                if next_level != state.level
+                else state.reason,
+                condition=StickyStopCondition.CONSECUTIVE_TOOL_FAILURES
+                if next_level != state.level
+                else state.condition,
+            ),
+            condition=StickyStopCondition.CONSECUTIVE_TOOL_FAILURES,
+            transitioned=next_level != state.level,
+            skill_name=skill_name,
+            extra_metadata={
+                "consecutive_tool_failures": new_count,
+                "window_seconds": self._thresholds.tool_failure_window_seconds,
+                "thresholds": {
+                    "warn": self._thresholds.tool_failure_warn,
+                    "soft_stop": self._thresholds.tool_failure_soft_stop,
+                    "hard_stop": self._thresholds.tool_failure_hard_stop,
+                },
+            },
+        )
+
+    async def record_tool_success(
+        self,
+        *,
+        customer: str,
+        persona: str,
+    ) -> StickyStopState:
+        """Record a successful tool call. Resets the consecutive-failure
+        streak to 0. Does NOT downgrade level — that is Captain-only via
+        clear()."""
+        state = await self.get_state(customer, persona)
+        if state.consecutive_tool_failures == 0:
+            return state
+        now = self._clock()
+        next_state = replace(
+            state,
+            updated_at=_iso(now),
+            consecutive_tool_failures=0,
+            tool_failure_window_started_at=None,
+        )
+        await self._store.put(next_state)
+        return next_state
+
+    async def record_refusal(
+        self,
+        *,
+        customer: str,
+        persona: str,
+        skill_name: Optional[str] = None,
+    ) -> StickyStopState:
+        """Record a trust-ceiling refusal. Tracks refusal-cascade counts
+        within the configured window.
+        """
+        state = await self.get_state(customer, persona)
+        now = self._clock()
+        new_count, new_window = self._tick_window(
+            count=state.refusal_count,
+            window_started_at=state.refusal_window_started_at,
+            now=now,
+            window_seconds=self._thresholds.refusal_window_seconds,
+        )
+        target = self._level_for_refusals(new_count)
+        next_level = self._forward_only(state.level, target)
+        return await self._commit_transition(
+            current=state,
+            next_state=replace(
+                state,
+                level=next_level,
+                updated_at=_iso(now),
+                refusal_count=new_count,
+                refusal_window_started_at=new_window,
+                reason=(
+                    f"refusal_cascade={new_count} "
+                    f"(window={self._thresholds.refusal_window_seconds}s, "
+                    f"skill={skill_name or 'unknown'})"
+                )
+                if next_level != state.level
+                else state.reason,
+                condition=StickyStopCondition.REFUSAL_CASCADE
+                if next_level != state.level
+                else state.condition,
+            ),
+            condition=StickyStopCondition.REFUSAL_CASCADE,
+            transitioned=next_level != state.level,
+            skill_name=skill_name,
+            extra_metadata={
+                "refusal_count": new_count,
+                "window_seconds": self._thresholds.refusal_window_seconds,
+                "thresholds": {
+                    "warn": self._thresholds.refusal_warn,
+                    "soft_stop": self._thresholds.refusal_soft_stop,
+                    "hard_stop": self._thresholds.refusal_hard_stop,
+                },
+            },
+        )
+
+    async def record_runtime_seconds(
+        self,
+        *,
+        customer: str,
+        persona: str,
+        seconds: float,
+    ) -> StickyStopState:
+        """Record observed wall-clock runtime for a single agent run.
+
+        If the value exceeds the configured budget, the machine transitions
+        directly to SOFT_STOP. Forward-only: if the machine is already in
+        HARD_STOP, the level is unchanged.
+        """
+        state = await self.get_state(customer, persona)
+        if seconds <= self._thresholds.time_budget_seconds:
+            return state
+        now = self._clock()
+        next_level = self._forward_only(state.level, StickyStopLevel.SOFT_STOP)
+        return await self._commit_transition(
+            current=state,
+            next_state=replace(
+                state,
+                level=next_level,
+                updated_at=_iso(now),
+                reason=(
+                    f"time_budget_exceeded={seconds:.1f}s "
+                    f"(budget={self._thresholds.time_budget_seconds}s)"
+                )
+                if next_level != state.level
+                else state.reason,
+                condition=StickyStopCondition.TIME_BUDGET_EXCEEDED
+                if next_level != state.level
+                else state.condition,
+            ),
+            condition=StickyStopCondition.TIME_BUDGET_EXCEEDED,
+            transitioned=next_level != state.level,
+            skill_name=None,
+            extra_metadata={
+                "observed_seconds": seconds,
+                "budget_seconds": self._thresholds.time_budget_seconds,
+            },
+        )
+
+    async def record_cost_cents(
+        self,
+        *,
+        customer: str,
+        persona: str,
+        amount_cents: int,
+    ) -> StickyStopState:
+        """Add incremental LLM cost in cents to today's running total.
+
+        Resets the running total when the UTC date rolls over. Transitions
+        on the cost-threshold ladder against the configured daily cap.
+        """
+        if amount_cents < 0:
+            raise ValueError("amount_cents must be non-negative")
+
+        state = await self.get_state(customer, persona)
+        now = self._clock()
+        today = now.strftime("%Y-%m-%d")
+        prior_today = state.cost_date if state.cost_date == today else None
+        new_total = (state.cost_cents_today if prior_today else 0) + amount_cents
+
+        target = self._level_for_cost(new_total)
+        next_level = self._forward_only(state.level, target)
+        return await self._commit_transition(
+            current=state,
+            next_state=replace(
+                state,
+                level=next_level,
+                updated_at=_iso(now),
+                cost_cents_today=new_total,
+                cost_date=today,
+                reason=(
+                    f"cost_threshold={new_total}c / cap={self._thresholds.cost_daily_cents}c "
+                    f"({(new_total / max(self._thresholds.cost_daily_cents, 1)) * 100:.0f}%)"
+                )
+                if next_level != state.level
+                else state.reason,
+                condition=StickyStopCondition.COST_THRESHOLD
+                if next_level != state.level
+                else state.condition,
+            ),
+            condition=StickyStopCondition.COST_THRESHOLD,
+            transitioned=next_level != state.level,
+            skill_name=None,
+            extra_metadata={
+                "cost_cents_today": new_total,
+                "cost_daily_cents_cap": self._thresholds.cost_daily_cents,
+                "warn_pct": self._thresholds.cost_warn_pct,
+                "soft_stop_pct": self._thresholds.cost_soft_stop_pct,
+                "hard_stop_pct": self._thresholds.cost_hard_stop_pct,
+            },
+        )
+
+    # ---- Dispatch guard ---------------------------------------------------
+
+    async def assert_allowed(
+        self,
+        *,
+        customer: str,
+        persona: str,
+    ) -> StickyStopState:
+        """Call from the dispatch path before invoking any skill.
+
+        Raises StickyStopError if the current level is HARD_STOP. Returns
+        the current state otherwise so the caller can pin trust_ceiling to
+        draft_for_review when SOFT_STOP is active.
+        """
+        state = await self.get_state(customer, persona)
+        if state.level == StickyStopLevel.HARD_STOP:
+            raise StickyStopError(state)
+        return state
+
+    # ---- Captain recovery -------------------------------------------------
+
+    async def clear(
+        self,
+        *,
+        customer: str,
+        persona: str,
+        captain_id: str,
+        reason: str,
+    ) -> StickyStopState:
+        """Captain-initiated reset to OK. The ONLY backward transition.
+
+        Caller responsibility: verify the actor is a Captain BEFORE invoking.
+        This module trusts the caller; identity verification lives in the
+        control-plane RBAC layer.
+
+        Emits one audit row with action_type=AGENT_RESUMED and metadata
+        including the reason and the prior state, so the compliance-evidence
+        packet can show the full transition history.
+        """
+        if not captain_id:
+            raise ValueError("captain_id is required for clear()")
+        if not reason:
+            raise ValueError("reason is required for clear()")
+        prior = await self.get_state(customer, persona)
+        now = self._clock()
+        cleared = StickyStopState(
+            customer=customer,
+            persona=persona,
+            level=StickyStopLevel.OK,
+            updated_at=_iso(now),
+            reason=None,
+            condition=None,
+            consecutive_tool_failures=0,
+            tool_failure_window_started_at=None,
+            refusal_count=0,
+            refusal_window_started_at=None,
+            cost_cents_today=prior.cost_cents_today,
+            cost_date=prior.cost_date,
+        )
+        await self._store.put(cleared)
+        await self._audit.write(
+            AuditEvent(
+                action_type="AGENT_RESUMED",
+                actor=captain_id,
+                actor_role=ActorRole.CAPTAIN,
+                metadata={
+                    "sticky_stop_cleared": True,
+                    "customer": customer,
+                    "persona": persona,
+                    "from_state": prior.level.value,
+                    "to_state": StickyStopLevel.OK.value,
+                    "condition_triggered": StickyStopCondition.CAPTAIN_CLEAR.value,
+                    "prior_reason": prior.reason,
+                    "prior_condition": prior.condition.value if prior.condition else None,
+                    "clear_reason": reason,
+                },
+            )
+        )
+        return cleared
+
+    # ---- Internals --------------------------------------------------------
+
+    def _level_for_tool_failures(self, count: int) -> StickyStopLevel:
+        t = self._thresholds
+        if count >= t.tool_failure_hard_stop:
+            return StickyStopLevel.HARD_STOP
+        if count >= t.tool_failure_soft_stop:
+            return StickyStopLevel.SOFT_STOP
+        if count >= t.tool_failure_warn:
+            return StickyStopLevel.WARN
+        return StickyStopLevel.OK
+
+    def _level_for_refusals(self, count: int) -> StickyStopLevel:
+        t = self._thresholds
+        if count >= t.refusal_hard_stop:
+            return StickyStopLevel.HARD_STOP
+        if count >= t.refusal_soft_stop:
+            return StickyStopLevel.SOFT_STOP
+        if count >= t.refusal_warn:
+            return StickyStopLevel.WARN
+        return StickyStopLevel.OK
+
+    def _level_for_cost(self, cents: int) -> StickyStopLevel:
+        t = self._thresholds
+        if t.cost_daily_cents <= 0:
+            return StickyStopLevel.OK
+        pct = (cents * 100) // t.cost_daily_cents
+        if pct >= t.cost_hard_stop_pct:
+            return StickyStopLevel.HARD_STOP
+        if pct >= t.cost_soft_stop_pct:
+            return StickyStopLevel.SOFT_STOP
+        if pct >= t.cost_warn_pct:
+            return StickyStopLevel.WARN
+        return StickyStopLevel.OK
+
+    def _forward_only(
+        self,
+        current: StickyStopLevel,
+        proposed: StickyStopLevel,
+    ) -> StickyStopLevel:
+        return proposed if _LEVEL_ORDER[proposed] > _LEVEL_ORDER[current] else current
+
+    def _tick_window(
+        self,
+        *,
+        count: int,
+        window_started_at: Optional[str],
+        now: datetime,
+        window_seconds: int,
+    ) -> tuple[int, str]:
+        """Increment a window counter; reset to 1 if outside the window.
+
+        Returns (new_count, new_window_started_at_iso).
+        """
+        if window_started_at is None:
+            return 1, _iso(now)
+        try:
+            started = _parse_iso(window_started_at)
+        except ValueError:
+            return 1, _iso(now)
+        if (now - started) > timedelta(seconds=window_seconds):
+            return 1, _iso(now)
+        return count + 1, window_started_at
+
+    async def _commit_transition(
+        self,
+        *,
+        current: StickyStopState,
+        next_state: StickyStopState,
+        condition: StickyStopCondition,
+        transitioned: bool,
+        skill_name: Optional[str],
+        extra_metadata: dict,
+    ) -> StickyStopState:
+        await self._store.put(next_state)
+        if not transitioned:
+            return next_state
+
+        # Pick the action_type that best fits the audit-log closed-set
+        # vocabulary (ACCEPTED_ACTION_TYPES). HARD_STOP -> AGENT_STOPPED;
+        # WARN / SOFT_STOP -> INVARIANT_VIOLATION (the substrate noticed
+        # something wrong before it became unsafe).
+        if next_state.level == StickyStopLevel.HARD_STOP:
+            action_type = "AGENT_STOPPED"
+        else:
+            action_type = "INVARIANT_VIOLATION"
+
+        metadata: dict = {
+            "sticky_stop_transition": True,
+            "customer": next_state.customer,
+            "persona": next_state.persona,
+            "from_state": current.level.value,
+            "to_state": next_state.level.value,
+            "condition_triggered": condition.value,
+            "reason": next_state.reason,
+        }
+        metadata.update(extra_metadata)
+
+        await self._audit.write(
+            AuditEvent(
+                action_type=action_type,
+                actor="agent",
+                actor_role=ActorRole.AGENT,
+                skill_name=skill_name,
+                metadata=metadata,
+            )
+        )
+        return next_state
+
+
+__all__ = [
+    "DEFAULT_THRESHOLDS",
+    "SqliteStickyStopStore",
+    "StickyStopCondition",
+    "StickyStopError",
+    "StickyStopLevel",
+    "StickyStopMachine",
+    "StickyStopState",
+    "StickyStopStore",
+    "StickyStopThresholds",
+]

--- a/ai-employee/safety-substrate/tests/test_sticky_stop.py
+++ b/ai-employee/safety-substrate/tests/test_sticky_stop.py
@@ -1,0 +1,581 @@
+"""Tests for ai-employee/safety-substrate/sticky_stop.py (issue #843).
+
+Covers the four AC conditions:
+
+  - Consecutive tool failures (warn -> soft_stop -> hard_stop)
+  - Refusal cascade (warn -> soft_stop -> hard_stop)
+  - Time budget exceeded (-> soft_stop)
+  - Cost threshold (warn -> soft_stop -> hard_stop)
+
+Plus the state-machine invariants:
+
+  - Forward-only transitions
+  - Captain `clear()` is the only path backwards
+  - SOFT_STOP semantics surface via the returned state
+  - HARD_STOP raises StickyStopError from the dispatch guard
+  - Every transition writes an audit_log row
+  - Captain clear writes an AGENT_RESUMED audit_log row
+
+Tests use the same sqlite-in-memory pattern as test_audit_log.py: schemas
+are mirrored in-process so the test doesn't shell out to wrangler.
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest safety-substrate/tests/test_sticky_stop.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/
+
+# safety-substrate/ is on sys.path through the sticky_stop import below;
+# we use the same dash-named-directory trick the other invariant tests use.
+sys.path.insert(0, str(_HERE.parents[1]))  # ai-employee/safety-substrate/
+
+from adapter.audit_log import (  # noqa: E402
+    AuditLogWriter,
+    SqliteExecutor,
+)
+from sticky_stop import (  # noqa: E402
+    DEFAULT_THRESHOLDS,
+    SqliteStickyStopStore,
+    StickyStopCondition,
+    StickyStopError,
+    StickyStopLevel,
+    StickyStopMachine,
+    StickyStopState,
+    StickyStopThresholds,
+)
+
+
+# ---------------------------------------------------------------------------
+# In-memory schemas — exact copy of migrations 0001/0002/0004 audit_log +
+# sticky_stop_state.
+# ---------------------------------------------------------------------------
+
+_AUDIT_SCHEMA = """
+CREATE TABLE audit_log (
+  id            TEXT PRIMARY KEY,
+  ts            TEXT NOT NULL,
+  action_type   TEXT NOT NULL,
+  actor         TEXT NOT NULL,
+  actor_role    TEXT,
+  skill_name    TEXT,
+  matter_ref    TEXT,
+  input_digest  TEXT,
+  output_digest TEXT,
+  diff_digest   TEXT,
+  trust_ceiling TEXT,
+  metadata      TEXT
+);
+"""
+
+_STICKY_STOP_SCHEMA = """
+CREATE TABLE sticky_stop_state (
+  customer                          TEXT NOT NULL,
+  persona                           TEXT NOT NULL,
+  level                             TEXT NOT NULL DEFAULT 'OK',
+  updated_at                        TEXT NOT NULL,
+  reason                            TEXT,
+  condition                         TEXT,
+  consecutive_tool_failures         INTEGER NOT NULL DEFAULT 0,
+  tool_failure_window_started_at    TEXT,
+  refusal_count                     INTEGER NOT NULL DEFAULT 0,
+  refusal_window_started_at         TEXT,
+  cost_cents_today                  INTEGER NOT NULL DEFAULT 0,
+  cost_date                         TEXT,
+  PRIMARY KEY (customer, persona)
+);
+"""
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_AUDIT_SCHEMA)
+    conn.executescript(_STICKY_STOP_SCHEMA)
+    return conn
+
+
+def _machine(
+    *,
+    thresholds: StickyStopThresholds = DEFAULT_THRESHOLDS,
+    clock=None,
+) -> tuple[StickyStopMachine, sqlite3.Connection]:
+    conn = _make_conn()
+    store = SqliteStickyStopStore(conn)
+    writer = AuditLogWriter(SqliteExecutor(conn))
+    machine = StickyStopMachine(
+        store=store,
+        audit_writer=writer,
+        thresholds=thresholds,
+        clock=clock,
+    )
+    return machine, conn
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _audit_rows(conn: sqlite3.Connection) -> list[dict]:
+    # Order by sqlite rowid — insertion-order across rows that may share a
+    # ULID timestamp prefix (ULIDs are sortable to millisecond precision; the
+    # randomness suffix breaks within-ms order, so id-sort is not insertion
+    # order when multiple writes land in <1ms as they do here).
+    cur = conn.cursor()
+    rows = cur.execute(
+        "SELECT action_type, actor, skill_name, metadata FROM audit_log ORDER BY rowid"
+    ).fetchall()
+    out = []
+    for action_type, actor, skill_name, metadata in rows:
+        out.append(
+            {
+                "action_type": action_type,
+                "actor": actor,
+                "skill_name": skill_name,
+                "metadata": json.loads(metadata) if metadata else None,
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Initial state + idempotent read
+# ---------------------------------------------------------------------------
+
+
+def test_default_state_is_ok_and_not_persisted():
+    machine, conn = _machine()
+    state = _run(machine.get_state("acme", "marcus"))
+    assert state.level == StickyStopLevel.OK
+    # Read alone does NOT persist a row.
+    count = conn.execute("SELECT COUNT(*) FROM sticky_stop_state").fetchone()[0]
+    assert count == 0
+
+
+def test_record_tool_success_on_clean_state_is_noop():
+    machine, conn = _machine()
+    state = _run(machine.record_tool_success(customer="acme", persona="marcus"))
+    assert state.level == StickyStopLevel.OK
+    # No transition -> no audit row, no row in sticky_stop_state.
+    assert _audit_rows(conn) == []
+    count = conn.execute("SELECT COUNT(*) FROM sticky_stop_state").fetchone()[0]
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Condition 1: consecutive tool failures
+# ---------------------------------------------------------------------------
+
+
+def test_consecutive_tool_failures_warn_soft_stop_hard_stop_ladder():
+    machine, conn = _machine()
+
+    # 1 failure -> still OK (warn threshold is 3)
+    s = _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    assert s.level == StickyStopLevel.OK
+    assert s.consecutive_tool_failures == 1
+
+    # 2 failures -> OK
+    _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    # 3 -> WARN
+    s = _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    assert s.level == StickyStopLevel.WARN
+
+    # 4 -> still WARN (soft_stop is 5)
+    s = _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    assert s.level == StickyStopLevel.WARN
+
+    # 5 -> SOFT_STOP
+    s = _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    assert s.level == StickyStopLevel.SOFT_STOP
+
+    # 6, 7 -> still SOFT_STOP (hard_stop is 8)
+    _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+
+    # 8 -> HARD_STOP
+    s = _run(machine.record_tool_failure(customer="acme", persona="marcus", skill_name="inbox-triage"))
+    assert s.level == StickyStopLevel.HARD_STOP
+
+    # Three transitions in the audit log: WARN, SOFT_STOP, HARD_STOP
+    rows = [r for r in _audit_rows(conn) if r["metadata"] and r["metadata"].get("sticky_stop_transition")]
+    assert len(rows) == 3
+    transitions = [(r["metadata"]["from_state"], r["metadata"]["to_state"]) for r in rows]
+    assert transitions == [
+        ("OK", "WARN"),
+        ("WARN", "SOFT_STOP"),
+        ("SOFT_STOP", "HARD_STOP"),
+    ]
+    # Action_type tagging:
+    # - WARN / SOFT_STOP -> INVARIANT_VIOLATION
+    # - HARD_STOP -> AGENT_STOPPED
+    assert rows[0]["action_type"] == "INVARIANT_VIOLATION"
+    assert rows[1]["action_type"] == "INVARIANT_VIOLATION"
+    assert rows[2]["action_type"] == "AGENT_STOPPED"
+    # Condition propagated
+    assert all(r["metadata"]["condition_triggered"] == "consecutive_tool_failures" for r in rows)
+
+
+def test_tool_success_resets_consecutive_failures_counter():
+    machine, _ = _machine()
+    _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    state = _run(machine.record_tool_success(customer="acme", persona="marcus"))
+    assert state.consecutive_tool_failures == 0
+    # Level does NOT downgrade. (We haven't transitioned; it's still OK.)
+    assert state.level == StickyStopLevel.OK
+
+
+def test_tool_success_does_not_downgrade_level():
+    # Drive into SOFT_STOP, then a success arrives. Level stays SOFT_STOP.
+    machine, _ = _machine()
+    for _ in range(5):
+        _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    state = _run(machine.record_tool_success(customer="acme", persona="marcus"))
+    assert state.level == StickyStopLevel.SOFT_STOP
+    assert state.consecutive_tool_failures == 0
+
+
+def test_tool_failures_outside_window_reset_streak():
+    # Drive the clock so consecutive failures fall outside the rolling window.
+    epoch = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
+    times = [epoch]
+
+    def clock() -> datetime:
+        return times[0]
+
+    machine, _ = _machine(clock=clock)
+    _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+
+    # Jump past the 10-minute window.
+    times[0] = epoch + timedelta(seconds=DEFAULT_THRESHOLDS.tool_failure_window_seconds + 1)
+    state = _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    # Streak resets to 1, so we are below the WARN threshold of 3.
+    assert state.consecutive_tool_failures == 1
+    assert state.level == StickyStopLevel.OK
+
+
+# ---------------------------------------------------------------------------
+# Condition 2: refusal cascade
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_cascade_warn_soft_stop_hard_stop_ladder():
+    machine, conn = _machine()
+
+    # 5 refusals -> WARN
+    for _ in range(5):
+        s = _run(machine.record_refusal(customer="acme", persona="marcus", skill_name="commitment-skill"))
+    assert s.level == StickyStopLevel.WARN
+
+    # +5 more -> SOFT_STOP
+    for _ in range(5):
+        s = _run(machine.record_refusal(customer="acme", persona="marcus", skill_name="commitment-skill"))
+    assert s.level == StickyStopLevel.SOFT_STOP
+
+    # +10 more -> HARD_STOP
+    for _ in range(10):
+        s = _run(machine.record_refusal(customer="acme", persona="marcus", skill_name="commitment-skill"))
+    assert s.level == StickyStopLevel.HARD_STOP
+
+    transitions = [
+        (r["metadata"]["from_state"], r["metadata"]["to_state"])
+        for r in _audit_rows(conn)
+        if r["metadata"] and r["metadata"].get("sticky_stop_transition")
+    ]
+    assert transitions == [
+        ("OK", "WARN"),
+        ("WARN", "SOFT_STOP"),
+        ("SOFT_STOP", "HARD_STOP"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Condition 3: time budget exceeded
+# ---------------------------------------------------------------------------
+
+
+def test_time_budget_exceeded_jumps_to_soft_stop():
+    machine, conn = _machine()
+    state = _run(
+        machine.record_runtime_seconds(
+            customer="acme",
+            persona="marcus",
+            seconds=DEFAULT_THRESHOLDS.time_budget_seconds + 1,
+        )
+    )
+    assert state.level == StickyStopLevel.SOFT_STOP
+    rows = [r for r in _audit_rows(conn) if r["metadata"] and r["metadata"].get("sticky_stop_transition")]
+    assert len(rows) == 1
+    assert rows[0]["metadata"]["condition_triggered"] == "time_budget_exceeded"
+    assert rows[0]["action_type"] == "INVARIANT_VIOLATION"
+
+
+def test_time_budget_within_envelope_is_noop():
+    machine, conn = _machine()
+    state = _run(
+        machine.record_runtime_seconds(
+            customer="acme",
+            persona="marcus",
+            seconds=10.0,
+        )
+    )
+    assert state.level == StickyStopLevel.OK
+    assert _audit_rows(conn) == []
+
+
+# ---------------------------------------------------------------------------
+# Condition 4: cost threshold
+# ---------------------------------------------------------------------------
+
+
+def test_cost_threshold_warn_soft_stop_hard_stop_ladder():
+    # Use a tight cap so the test runs with small numbers.
+    thresholds = StickyStopThresholds(
+        cost_daily_cents=1000,  # $10
+        cost_warn_pct=80,
+        cost_soft_stop_pct=100,
+        cost_hard_stop_pct=200,
+    )
+    machine, conn = _machine(thresholds=thresholds)
+
+    # 80% -> WARN
+    state = _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=800))
+    assert state.level == StickyStopLevel.WARN
+
+    # +200 -> 100% -> SOFT_STOP
+    state = _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=200))
+    assert state.level == StickyStopLevel.SOFT_STOP
+
+    # +1000 -> 200% -> HARD_STOP
+    state = _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=1000))
+    assert state.level == StickyStopLevel.HARD_STOP
+
+    transitions = [
+        (r["metadata"]["from_state"], r["metadata"]["to_state"])
+        for r in _audit_rows(conn)
+        if r["metadata"] and r["metadata"].get("sticky_stop_transition")
+    ]
+    assert transitions == [
+        ("OK", "WARN"),
+        ("WARN", "SOFT_STOP"),
+        ("SOFT_STOP", "HARD_STOP"),
+    ]
+
+
+def test_cost_resets_on_utc_day_rollover():
+    times = [datetime(2026, 5, 21, 23, 30, 0, tzinfo=timezone.utc)]
+
+    def clock() -> datetime:
+        return times[0]
+
+    thresholds = StickyStopThresholds(cost_daily_cents=1000, cost_warn_pct=80)
+    machine, _ = _machine(thresholds=thresholds, clock=clock)
+
+    # 80% on Day 1
+    state = _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=800))
+    assert state.level == StickyStopLevel.WARN
+    assert state.cost_cents_today == 800
+
+    # Roll over to Day 2; counter resets.
+    times[0] = datetime(2026, 5, 22, 0, 30, 0, tzinfo=timezone.utc)
+    state = _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=100))
+    assert state.cost_cents_today == 100
+    # Level stays at WARN (forward-only); not OK.
+    assert state.level == StickyStopLevel.WARN
+
+
+def test_cost_amount_must_be_non_negative():
+    machine, _ = _machine()
+    with pytest.raises(ValueError):
+        _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=-1))
+
+
+# ---------------------------------------------------------------------------
+# Forward-only invariant
+# ---------------------------------------------------------------------------
+
+
+def test_state_is_forward_only_no_autonomous_downgrade():
+    machine, _ = _machine()
+    # Drive to SOFT_STOP via cost.
+    thresholds = StickyStopThresholds(cost_daily_cents=1000, cost_warn_pct=80)
+    machine, _ = _machine(thresholds=thresholds)
+    _run(machine.record_cost_cents(customer="acme", persona="marcus", amount_cents=1000))
+    state = _run(machine.get_state("acme", "marcus"))
+    assert state.level == StickyStopLevel.SOFT_STOP
+
+    # A WARN-eligible event MUST NOT downgrade.
+    state = _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    assert state.level == StickyStopLevel.SOFT_STOP
+
+
+# ---------------------------------------------------------------------------
+# Dispatch guard
+# ---------------------------------------------------------------------------
+
+
+def test_assert_allowed_passes_through_below_hard_stop():
+    machine, _ = _machine()
+    # Drive to SOFT_STOP
+    for _ in range(5):
+        _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    state = _run(machine.assert_allowed(customer="acme", persona="marcus"))
+    assert state.level == StickyStopLevel.SOFT_STOP
+
+
+def test_assert_allowed_raises_at_hard_stop():
+    machine, _ = _machine()
+    for _ in range(8):
+        _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    with pytest.raises(StickyStopError) as exc:
+        _run(machine.assert_allowed(customer="acme", persona="marcus"))
+    assert exc.value.state.level == StickyStopLevel.HARD_STOP
+
+
+# ---------------------------------------------------------------------------
+# Captain recovery
+# ---------------------------------------------------------------------------
+
+
+def test_captain_clear_resets_to_ok_and_writes_audit_row():
+    machine, conn = _machine()
+    for _ in range(8):
+        _run(machine.record_tool_failure(customer="acme", persona="marcus"))
+    pre = _run(machine.get_state("acme", "marcus"))
+    assert pre.level == StickyStopLevel.HARD_STOP
+
+    cleared = _run(
+        machine.clear(
+            customer="acme",
+            persona="marcus",
+            captain_id="captain-scott",
+            reason="vendor tool recovered; runaway-loop false positive confirmed",
+        )
+    )
+    assert cleared.level == StickyStopLevel.OK
+    assert cleared.consecutive_tool_failures == 0
+    assert cleared.refusal_count == 0
+    assert cleared.condition is None
+
+    # Persisted change is visible to a fresh read.
+    fresh = _run(machine.get_state("acme", "marcus"))
+    assert fresh.level == StickyStopLevel.OK
+
+    # Audit row recorded with from_state, to_state, captain reason.
+    clear_rows = [
+        r
+        for r in _audit_rows(conn)
+        if r["metadata"] and r["metadata"].get("sticky_stop_cleared")
+    ]
+    assert len(clear_rows) == 1
+    row = clear_rows[0]
+    assert row["action_type"] == "AGENT_RESUMED"
+    assert row["actor"] == "captain-scott"
+    assert row["metadata"]["from_state"] == "HARD_STOP"
+    assert row["metadata"]["to_state"] == "OK"
+    assert row["metadata"]["condition_triggered"] == "captain_clear"
+    assert "false positive" in row["metadata"]["clear_reason"]
+
+
+def test_clear_requires_captain_id_and_reason():
+    machine, _ = _machine()
+    with pytest.raises(ValueError):
+        _run(machine.clear(customer="acme", persona="marcus", captain_id="", reason="x"))
+    with pytest.raises(ValueError):
+        _run(machine.clear(customer="acme", persona="marcus", captain_id="c1", reason=""))
+
+
+# ---------------------------------------------------------------------------
+# Integration: each condition forces a transition and audit emission
+# (the AC: "Integration test forces each condition and verifies trigger")
+# ---------------------------------------------------------------------------
+
+
+def test_integration_each_condition_triggers_a_transition_with_audit():
+    """One scenario per condition, one (customer, persona) per scenario, so
+    each transition is unambiguous against the audit log.
+    """
+    machine, conn = _machine(
+        thresholds=StickyStopThresholds(cost_daily_cents=1000, cost_warn_pct=80),
+    )
+
+    # Condition 1: consecutive tool failures
+    for _ in range(8):
+        _run(machine.record_tool_failure(customer="c1", persona="p", skill_name="s1"))
+    s1 = _run(machine.get_state("c1", "p"))
+    assert s1.level == StickyStopLevel.HARD_STOP
+    assert s1.condition == StickyStopCondition.CONSECUTIVE_TOOL_FAILURES
+
+    # Condition 2: refusal cascade (uses default refusal_hard_stop=20)
+    for _ in range(20):
+        _run(machine.record_refusal(customer="c2", persona="p", skill_name="s2"))
+    s2 = _run(machine.get_state("c2", "p"))
+    assert s2.level == StickyStopLevel.HARD_STOP
+    assert s2.condition == StickyStopCondition.REFUSAL_CASCADE
+
+    # Condition 3: time budget exceeded (single-step to SOFT_STOP)
+    _run(
+        machine.record_runtime_seconds(
+            customer="c3",
+            persona="p",
+            seconds=DEFAULT_THRESHOLDS.time_budget_seconds + 1,
+        )
+    )
+    s3 = _run(machine.get_state("c3", "p"))
+    assert s3.level == StickyStopLevel.SOFT_STOP
+    assert s3.condition == StickyStopCondition.TIME_BUDGET_EXCEEDED
+
+    # Condition 4: cost threshold (cents only; 200% of 1000 = HARD_STOP)
+    _run(machine.record_cost_cents(customer="c4", persona="p", amount_cents=2000))
+    s4 = _run(machine.get_state("c4", "p"))
+    assert s4.level == StickyStopLevel.HARD_STOP
+    assert s4.condition == StickyStopCondition.COST_THRESHOLD
+
+    # Audit log must carry one row per transition. Count rows tagged
+    # sticky_stop_transition, then assert each condition appears at least
+    # once.
+    transition_rows = [
+        r for r in _audit_rows(conn) if r["metadata"] and r["metadata"].get("sticky_stop_transition")
+    ]
+    conditions_seen = {r["metadata"]["condition_triggered"] for r in transition_rows}
+    assert conditions_seen == {
+        "consecutive_tool_failures",
+        "refusal_cascade",
+        "time_budget_exceeded",
+        "cost_threshold",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Restart resilience: state survives persistence
+# ---------------------------------------------------------------------------
+
+
+def test_state_survives_store_round_trip():
+    conn = _make_conn()
+    writer = AuditLogWriter(SqliteExecutor(conn))
+    store_a = SqliteStickyStopStore(conn)
+    machine_a = StickyStopMachine(store=store_a, audit_writer=writer)
+    for _ in range(5):
+        _run(machine_a.record_tool_failure(customer="acme", persona="marcus"))
+
+    # New machine instance over the SAME D1 connection — simulates a Hermes
+    # restart that re-opens the bound database. State is intact.
+    store_b = SqliteStickyStopStore(conn)
+    machine_b = StickyStopMachine(store=store_b, audit_writer=writer)
+    state = _run(machine_b.get_state("acme", "marcus"))
+    assert state.level == StickyStopLevel.SOFT_STOP
+    assert state.consecutive_tool_failures == 5

--- a/docs/specs/ai-employee/index.md
+++ b/docs/specs/ai-employee/index.md
@@ -26,6 +26,7 @@ Build agents consuming these specs should treat the PRDs as **vision/doctrine** 
 | [day-1-onboarding.md](day-1-onboarding.md)                     | [#803](https://github.com/venturecrane/ss-console/issues/803) | First-hour dashboard walkthrough screens                                        |
 | [cost-telemetry-events.md](cost-telemetry-events.md)           | [#804](https://github.com/venturecrane/ss-console/issues/804) | Per-customer cost emission for all 9+ drivers                                   |
 | [decommission-drain.md](decommission-drain.md)                 | [#805](https://github.com/venturecrane/ss-console/issues/805) | 60s drain window before substrate deletion                                      |
+| [sticky-stop.md](sticky-stop.md)                               | [#843](https://github.com/venturecrane/ss-console/issues/843) | System-initiated circuit breaker for runaway agent loops (WARN/SOFT/HARD)       |
 
 ## Open ambiguities requiring Captain decision
 

--- a/docs/specs/ai-employee/sticky-stop.md
+++ b/docs/specs/ai-employee/sticky-stop.md
@@ -1,0 +1,341 @@
+# Sticky-stop circuit breaker
+
+**Spec for issue #843.** A forward-only state machine that pins the agent's
+dispatch path when the substrate observes runaway-loop signals: consecutive
+tool failures, refusal cascades, time-budget overruns, or daily cost-cap
+breaches.
+
+The mechanism is named in platform PRD §11.5 and §7.5 invariant #4 but
+had no emission or enforcement points before this issue. Without it, a
+runaway agent loop has no circuit breaker.
+
+## Source
+
+- platform-prd.md §7.5 ("Safety substrate invariants") — invariant #4
+  defines sticky-stop as architecturally pinned, surviving context
+  compaction, restart, and skill reload
+- platform-prd.md §11.5 ("Sticky stop") — the operator-pause surface
+- d1-schema.md §1 — `audit_log` action_type vocabulary the transitions
+  emit into
+
+## Why two paths share one mechanism
+
+There are two ways the sticky stop fires:
+
+1. **Operator-initiated.** A human clicks "pause all skills" in the
+   dashboard. Covered by platform-prd.md §11.5. The dispatch path
+   consults the pinned slot before invoking any skill. Recovery is
+   one-click by the same operator.
+2. **System-initiated (this spec).** The substrate notices the agent
+   is misbehaving — looping on a failing tool, refusing on every call,
+   burning the cost cap, exceeding wall-clock time — and pins a stop
+   on its behalf. Recovery requires Captain investigation, not a click.
+
+Both paths produce the same dispatch-path effect (skill invocation
+blocked or pinned to draft-for-review). The differences are:
+
+- **Audit tagging.** Operator pauses write `AGENT_STOPPED` with
+  metadata `actor_role=principal|operator`. System stops write
+  `AGENT_STOPPED` (HARD_STOP) or `INVARIANT_VIOLATION` (WARN /
+  SOFT_STOP) with `actor=agent`, `actor_role=agent`.
+- **Recovery actor.** Operator pauses clear via the dashboard pause
+  control. System stops clear via Captain investigation through the
+  control plane.
+- **Conditions.** Operator pauses have no condition — the human chose
+  to stop. System stops always carry a `condition_triggered` value.
+
+The persistence layer (D1 table `sticky_stop_state`) is shared.
+
+## State machine
+
+Four states, forward-only by default:
+
+```
+  OK ----> WARN ----> SOFT_STOP ----> HARD_STOP
+   ^                                       |
+   |                                       |
+   +--- Captain clear() -------------------+
+```
+
+`clear()` is the only path backwards. There is no autonomous downgrade.
+Tool successes reset the failure counter to zero but do NOT downgrade the
+level; the runtime is permitted to keep observing without escalating the
+sticky-stop tier, and the Captain decides when to clear after
+investigation.
+
+### State semantics
+
+| State       | Effect on dispatch                                                                                                                         | UI                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `OK`        | Normal operation                                                                                                                           | No banner                                           |
+| `WARN`      | Normal operation; substrate is watching                                                                                                    | Yellow banner: "Substrate flagged X; investigating" |
+| `SOFT_STOP` | Every skill's `trust_ceiling` pinned to `draft_for_review`. No autonomous escalation. No auto-actions. Drafts continue, queued for review. | Orange banner: "Auto-actions paused; drafts only"   |
+| `HARD_STOP` | Every skill invocation refused. Dispatch entrypoint raises `StickyStopError`.                                                              | Red banner: "Agent paused. Captain investigating"   |
+
+The dashboard surface for these banners is a separate issue. This spec
+covers the state-machine module and its persistence; UI is downstream.
+
+## Conditions and default thresholds
+
+Configurable per customer via `customer.yaml.safety.sticky_stop` (see
+[Customer.yaml shape](#customeryaml-shape) below). When unset, the
+following defaults apply. They are conservative — easier to loosen than
+to recover from a tighter-than-needed loop that ran for hours.
+
+### 1. Consecutive tool failures
+
+A tool call returns a failure within a rolling time window.
+
+| Threshold                     | Default      | Transition               |
+| ----------------------------- | ------------ | ------------------------ |
+| `tool_failure_warn`           | 3            | `OK -> WARN`             |
+| `tool_failure_soft_stop`      | 5            | `WARN -> SOFT_STOP`      |
+| `tool_failure_hard_stop`      | 8            | `SOFT_STOP -> HARD_STOP` |
+| `tool_failure_window_seconds` | 600 (10 min) | window for streak        |
+
+A successful tool call resets the streak. A failure outside the window
+resets the streak to 1 and starts a new window.
+
+### 2. Refusal cascade
+
+A trust-ceiling refusal (the substrate refused to allow a skill action).
+Counts within a rolling window. A skill spamming `refused` responses is
+itself a runaway signal — either the prompt drifted in an unsafe direction
+or the operator's ceiling is incompatible with the skill's request shape.
+
+| Threshold                | Default       | Transition               |
+| ------------------------ | ------------- | ------------------------ |
+| `refusal_warn`           | 5             | `OK -> WARN`             |
+| `refusal_soft_stop`      | 10            | `WARN -> SOFT_STOP`      |
+| `refusal_hard_stop`      | 20            | `SOFT_STOP -> HARD_STOP` |
+| `refusal_window_seconds` | 1800 (30 min) | window for cascade       |
+
+### 3. Time budget exceeded
+
+Wall-clock seconds for a single agent run. If observed runtime exceeds
+the budget, the machine single-steps to `SOFT_STOP` — the agent has
+already exceeded its envelope; we do not wait for a second data point.
+
+| Threshold             | Default       | Transition       |
+| --------------------- | ------------- | ---------------- |
+| `time_budget_seconds` | 3600 (1 hour) | `* -> SOFT_STOP` |
+
+Callers feed `record_runtime_seconds()` per turn or per minute (poll).
+The machine itself has no async wakeup.
+
+### 4. Cost threshold
+
+Daily $ cap on LLM costs in cents (so cost_telemetry's integer-cents
+convention applies). Resets at UTC date rollover.
+
+| Threshold            | Default        | Transition                           |
+| -------------------- | -------------- | ------------------------------------ |
+| `cost_daily_cents`   | 5000 ($50/day) | per-day cap                          |
+| `cost_warn_pct`      | 80             | `OK -> WARN` (at 80% of cap)         |
+| `cost_soft_stop_pct` | 100            | `WARN -> SOFT_STOP` (at cap)         |
+| `cost_hard_stop_pct` | 200            | `SOFT_STOP -> HARD_STOP` (at 2x cap) |
+
+Cost is fed in via `record_cost_cents()` as LLM-cost events fire. The
+cost-telemetry pipeline (cost-telemetry-events.md) is the natural source.
+
+## Captain recovery
+
+`clear()` is the only path that decreases level. The interface:
+
+```python
+await machine.clear(
+    customer="acme",
+    persona="marcus",
+    captain_id="captain-scott",  # caller-asserted identity
+    reason="vendor tool flap confirmed; runaway-loop false positive",
+)
+```
+
+Caller responsibility: the actor must be a Captain. Identity verification
+lives in the control-plane RBAC layer; this module trusts the caller to
+have established identity before invoking. The control plane MUST NOT
+expose `clear()` to non-Captain roles.
+
+`clear()` resets `level=OK`, zeroes the rolling counters
+(`consecutive_tool_failures=0`, `refusal_count=0`), and preserves
+`cost_cents_today` (the cost cap is a daily resource accounting; clearing
+sticky-stop does not buy back budget).
+
+## Audit emission
+
+Every state transition writes exactly one row to `audit_log` via the
+`AuditLogWriter` (`ai-employee/adapter/audit_log.py`, on main from PR
+#942). Action types reuse the existing closed-set vocabulary
+(`ACCEPTED_ACTION_TYPES`) so this module does not need to extend the
+audit-log contract:
+
+| Transition kind                | `action_type`         | `actor`      | `actor_role` |
+| ------------------------------ | --------------------- | ------------ | ------------ |
+| Entry to `HARD_STOP`           | `AGENT_STOPPED`       | `agent`      | `agent`      |
+| Entry to `WARN` or `SOFT_STOP` | `INVARIANT_VIOLATION` | `agent`      | `agent`      |
+| Captain `clear()`              | `AGENT_RESUMED`       | `captain_id` | `captain`    |
+
+The transition-specific detail lives in the `metadata` column as JSON:
+
+```json
+{
+  "sticky_stop_transition": true,
+  "customer": "acme",
+  "persona": "marcus",
+  "from_state": "WARN",
+  "to_state": "SOFT_STOP",
+  "condition_triggered": "consecutive_tool_failures",
+  "reason": "consecutive_tool_failures=5 (window=600s, skill=inbox-triage)",
+  "consecutive_tool_failures": 5,
+  "window_seconds": 600,
+  "thresholds": { "warn": 3, "soft_stop": 5, "hard_stop": 8 }
+}
+```
+
+For Captain clears the metadata sets `sticky_stop_cleared: true` and
+includes the prior state and the Captain's reason. The compliance-evidence
+packet generator (`compliance-evidence-packet.md`) groups rows by these
+metadata keys to render the sticky-stop section.
+
+## Customer.yaml shape
+
+```yaml
+safety:
+  sticky_stop:
+    tool_failure:
+      warn: 3
+      soft_stop: 5
+      hard_stop: 8
+      window_seconds: 600
+    refusal:
+      warn: 5
+      soft_stop: 10
+      hard_stop: 20
+      window_seconds: 1800
+    time_budget_seconds: 3600
+    cost:
+      daily_cents: 5000
+      warn_pct: 80
+      soft_stop_pct: 100
+      hard_stop_pct: 200
+```
+
+All keys optional; module-level defaults apply when absent.
+
+The `customer-yaml-schema.md` schema does not yet have a `safety` top-level
+section. When the schema picks one up (under a future ADR), the sticky-stop
+block lives under it. Until then the block is read directly by the
+sticky-stop module at construction time via a customer.yaml resolver
+(provisioning-time wiring, not in scope of this module).
+
+## D1 table
+
+Per ADR 0008 + 0009 the state lives in the per-customer D1 database
+(`hermes-{slug}-d1`). One row per `(customer, persona)` tuple. The
+composite primary key enforces uniqueness.
+
+Schema in `ai-employee/migrations/0004_sticky_stop_state.sql`. Columns:
+
+| Column                           | Type                       | Notes                                            |
+| -------------------------------- | -------------------------- | ------------------------------------------------ |
+| `customer`                       | TEXT NOT NULL              | customer_id slug; equals the D1 binding's tenant |
+| `persona`                        | TEXT NOT NULL              | `customer.yaml.personas[].slug`                  |
+| `level`                          | TEXT NOT NULL DEFAULT 'OK' | one of OK / WARN / SOFT_STOP / HARD_STOP         |
+| `updated_at`                     | TEXT NOT NULL              | ISO 8601 UTC                                     |
+| `reason`                         | TEXT                       | snapshot at last transition                      |
+| `condition`                      | TEXT                       | last condition that drove a transition           |
+| `consecutive_tool_failures`      | INTEGER NOT NULL DEFAULT 0 | rolling counter                                  |
+| `tool_failure_window_started_at` | TEXT                       | ISO; NULL when no streak                         |
+| `refusal_count`                  | INTEGER NOT NULL DEFAULT 0 | rolling counter                                  |
+| `refusal_window_started_at`      | TEXT                       | ISO                                              |
+| `cost_cents_today`               | INTEGER NOT NULL DEFAULT 0 | resets on UTC day rollover                       |
+| `cost_date`                      | TEXT                       | YYYY-MM-DD                                       |
+
+Index: `idx_sticky_stop_active` on `updated_at DESC WHERE level != 'OK'`,
+for the dashboard's "is anything stuck?" indicator.
+
+## Verification
+
+`ai-employee/safety-substrate/tests/test_sticky_stop.py` exercises:
+
+- Initial state is `OK` and read alone does not persist
+- Each of the four conditions drives the WARN -> SOFT_STOP -> HARD_STOP
+  ladder
+- Tool success resets the failure counter
+- Tool success does NOT downgrade level (forward-only invariant)
+- Failures outside the rolling window reset the streak to 1
+- Time-budget overrun single-steps to SOFT_STOP
+- Cost threshold ladder respects the three percentages and resets on
+  UTC day rollover
+- Negative cost amounts raise `ValueError`
+- State is forward-only — autonomous downgrade is impossible
+- Dispatch guard `assert_allowed()` passes through at SOFT_STOP and
+  raises `StickyStopError` at HARD_STOP
+- Captain `clear()` resets level to OK, zeros counters, and emits an
+  `AGENT_RESUMED` audit row carrying the prior state and clear reason
+- `clear()` requires non-empty captain_id and reason
+- Integration: each of the four conditions, run end-to-end, produces a
+  visible audit-log row tagged with the right `condition_triggered`
+- Restart resilience: opening a fresh `SqliteStickyStopStore` over the
+  same connection returns the persisted state intact
+
+Run locally:
+
+```
+cd ai-employee && uv run --with pytest python -m pytest safety-substrate/tests/test_sticky_stop.py -v
+```
+
+## Failure modes
+
+- **Audit write fails during a transition.** The `AuditWriteError`
+  propagates out of the `record_*` method. The state row WAS persisted
+  before the audit call. This means the runtime can end up with a state
+  change that has no audit trail. The acceptable mitigation: the caller
+  (Hermes dispatch) treats `AuditWriteError` as fatal — same rule as the
+  audit log writer itself — and the boot-check picks up the stale state
+  on restart. A future refinement may wrap the two writes in a
+  best-effort transactional shape, but D1's HTTP API does not support
+  multi-statement transactions across audit-log and sticky-stop-state
+  tables today.
+- **D1 unavailable.** `get_state()` fails with the underlying executor's
+  exception. The dispatch guard then cannot determine state. The caller
+  must treat this as "stop" (fail-closed): if you cannot read the state,
+  you cannot dispatch.
+- **Threshold misconfiguration.** Customer.yaml ships a `cost_daily_cents`
+  of zero. The cost-threshold check short-circuits to OK (division-by-zero
+  guard). This is a configuration error, not a runtime error; the customer
+  has effectively disabled the cost dimension.
+- **Cost rollover skew.** The day boundary uses UTC. Customers in non-UTC
+  time zones see the daily reset at non-midnight local time. This is the
+  same convention as `cost_telemetry.date` (per cost-telemetry-events.md)
+  and is acceptable; the spec calls out the dimension explicitly.
+
+## Implementation notes
+
+- Module: `ai-employee/safety-substrate/sticky_stop.py`
+- Migration: `ai-employee/migrations/0004_sticky_stop_state.sql`
+- Tests: `ai-employee/safety-substrate/tests/test_sticky_stop.py`
+- The module follows the same pure-Python + injectable-store shape as
+  `audit_log.py`. Production wiring uses a D1 HTTP executor (when the
+  Hermes-side `HttpD1StickyStopStore` lands; not in this PR).
+- The state machine is import-callable from any dispatch path. There is
+  no global state, no module-level singleton — callers construct a
+  `StickyStopMachine` from a store and an audit writer.
+- Clock is injectable for deterministic tests via the `clock` constructor
+  kwarg.
+- The `consecutive_tool_failures` and `refusal_count` counters are
+  persisted in the row (not in process memory) so the machine survives
+  Hermes restarts without losing failure history per safety invariant #4.
+
+## Cross-references
+
+- platform-prd.md §7.5 (safety substrate invariants), §11.5 (sticky stop)
+- d1-schema.md §1 (audit_log action types)
+- customer-yaml-schema.md (future `safety.sticky_stop` block)
+- compliance-evidence-packet.md (compliance packet renders the sticky-stop
+  section from `metadata.sticky_stop_transition` and
+  `metadata.sticky_stop_cleared` audit rows)
+- cost-telemetry-events.md (cost source feeding `record_cost_cents()`)
+- ADR 0008 (customer-owned memory artifact)
+- ADR 0009 (cross-machine query prohibition)
+- PR #942 (audit log persistence) — provides `AuditLogWriter`


### PR DESCRIPTION
## Summary

Implements the system-initiated sticky-stop circuit breaker named in platform PRD invariant #4 and §11.5 but previously without emission or enforcement points. A forward-only state machine (`OK -> WARN -> SOFT_STOP -> HARD_STOP`) pins the agent's dispatch path when the substrate observes runaway-loop signals. Captain `clear()` is the only path backwards; every transition writes one `audit_log` row via the writer landed in #942.

## Linked issue

Closes #843

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Define sticky-stop conditions (consecutive tool failures, refusal cascade, time-budget exceeded, cost threshold) | met | `ai-employee/safety-substrate/sticky_stop.py` (StickyStopThresholds, StickyStopCondition, the four record_* methods) + `docs/specs/ai-employee/sticky-stop.md` §3 |
| Implement state machine: warn -> soft-stop (draft-only) -> hard-stop (refuse-all) | met | `sticky_stop.py` StickyStopLevel + StickyStopMachine, forward-only invariant enforced by `_forward_only`. `assert_allowed()` raises `StickyStopError` at HARD_STOP. SOFT_STOP semantics (pin trust_ceiling to draft_for_review) documented in spec §2 for the dispatch path |
| Captain-side recovery action to clear sticky-stop after investigation | met | `StickyStopMachine.clear(customer, persona, captain_id, reason)` resets to OK, zeroes counters, requires non-empty captain_id + reason |
| Audit log captures every sticky-stop transition | met | `_commit_transition` writes one `audit_log` row per transition via the `AuditLogWriter` from PR #942. Action_types reuse the existing closed-set vocabulary: HARD_STOP -> AGENT_STOPPED, WARN/SOFT_STOP -> INVARIANT_VIOLATION, clear -> AGENT_RESUMED. Transition detail (from_state, to_state, condition_triggered, sampled metrics) lives in metadata |
| Integration test forces each condition and verifies trigger | met | `test_sticky_stop.py::test_integration_each_condition_triggers_a_transition_with_audit` drives all four conditions through their full HARD_STOP / SOFT_STOP ladders and asserts the audit-log transitions carry the right `condition_triggered` tag. Plus 18 additional unit tests covering ladders per condition, forward-only invariant, dispatch guard, Captain recovery, restart resilience |

## Test plan

- [x] `npm run verify` passes
- [x] `cd ai-employee && uv run --with pytest python -m pytest safety-substrate/tests/test_sticky_stop.py adapter/tests/ -v` — 63 tests pass (19 new + 44 existing)

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints (Python module; `clear()` requires non-empty captain_id and reason; `record_cost_cents` rejects negative amounts)
- [x] Parameterized queries for any SQL (use `.bind()`) — all sqlite inserts/selects use placeholders
- [x] Auth required on new endpoints (no new HTTP endpoints; Captain identity is caller-asserted per spec, verified by upstream control-plane RBAC)
- [x] No internal IDs that enable enumeration

## Feature Impact

**Feature impact:** None

## Deployment Notes

New D1 migration `0004_sticky_stop_state.sql` (forward-only, additive `CREATE TABLE`; PRAGMA `user_version` bumped to 4). Applied per-customer by `ai-employee/adapter/run_migrations.py` at provisioning time. The runtime wiring of the StickyStopMachine into Hermes dispatch is a follow-on (Hermes scope tracked in #821) — the module is import-callable but no dispatch path yet consults it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)