### PR TITLE
feat(ai-employee): Filevine connector v1 (#851)

### DIFF
--- a/ai-employee/connectors/filevine/README.md
+++ b/ai-employee/connectors/filevine/README.md
@@ -1,0 +1,173 @@
+# Filevine connector -- PI vertical practice-management adapter v1
+
+Status: v1 (issue [#851](https://github.com/venturecrane/ss-console/issues/851)). Filevine is the first PI-vertical PracticeManagement adapter per [ADR 0014](../../../docs/adr/0014-pi-vertical-adapter-build-priority.md). The capability-adapter pattern itself is locked in [ADR 0006](../../../docs/adr/0006-capability-adapter-pattern.md).
+
+## What this connector covers
+
+| Capability         | Methods implemented                                                                                             | TypeScript contract                                                                                                           |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| PracticeManagement | `search_matters`, `get_matter`, `list_matter_documents`, `create_note`, `describe_capabilities`, `health_check` | [`src/lib/ai-employee/capabilities/practice-management.ts`](../../../src/lib/ai-employee/capabilities/practice-management.ts) |
+| DocumentStorage    | `list_documents`, `get_document`, `get_document_bytes`, `describe_capabilities`, `health_check`                 | [`src/lib/ai-employee/capabilities/document-storage.ts`](../../../src/lib/ai-employee/capabilities/document-storage.ts)       |
+
+Everything else on the TypeScript interfaces (e.g. `create_matter`, `upload_document`, `share_document_draft`, `list_versions`, time entries, contacts) is explicitly declared in `unsupported_methods` and raises `AdapterError(code="capability_not_supported")` if invoked. This satisfies the `UNSUPPORTED_METHODS_THROW` conformance invariant -- there are no silent stubs.
+
+## Cross-language contract mapping
+
+The capability interfaces are TypeScript; the runtime adapter is Python (lives in the Hermes Machine per [ADR 0007](../../../docs/adr/0007-per-customer-machine-isolation.md) / [ADR 0009](../../../docs/adr/0009-cross-machine-query-prohibition.md)). Both sides agree on:
+
+| Concept              | TypeScript (`src/lib/ai-employee/capabilities/`)   | Python (`ai-employee/connectors/filevine/`)          |
+| -------------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| Capability interface | `interface PracticeManagement extends AdapterBase` | `class FilevinePracticeManagement`                   |
+| Method names         | snake_case (`search_matters`, `create_note`)       | snake_case (identical)                               |
+| Return shape         | `interface Matter { id, client_name, ... }`        | `@dataclass(frozen=True) class Matter`               |
+| Error contract       | `class AdapterError` + `type AdapterErrorCode`     | `class AdapterError` + `Literal[...]` in `errors.py` |
+| Capability set       | `interface CapabilitySet`                          | `@dataclass(frozen=True) class CapabilitySet`        |
+| Error codes          | Closed union of 9 strings                          | `frozenset` of identical 9 strings (pinned by test)  |
+| Capability names     | Closed union of 11 strings                         | `frozenset` of identical 11 strings (pinned by test) |
+
+Drift between the two languages is a P0. `tests/test_errors.py` pins the closed unions; if anyone changes `types.ts`, that test fails immediately on the Python side and forces a paired update.
+
+## Identity & Access seam
+
+Filevine uses OAuth 2.0 (Authorization Code grant -- see Filevine API docs at https://developer.filevine.io/). The real Identity & Access layer for token storage, refresh, and per-customer scoping is being built in issues [#789](https://github.com/venturecrane/ss-console/issues/789) and [#822](https://github.com/venturecrane/ss-console/issues/822). Both issues are open when this connector ships.
+
+This connector defines a Protocol -- `FilevineAuthProvider` -- that wraps token acquisition:
+
+```python
+class FilevineAuthProvider(Protocol):
+    async def get_valid_token(self) -> TokenSet: ...
+    def org_slug(self) -> str: ...
+```
+
+- **Production wiring** (post-#789/#822): The Identity & Access layer constructs an implementation backed by the per-customer secret bundle. The implementation handles refresh, rotation, and audit-logging. The connector itself sees only the protocol.
+- **Test wiring** (today): `InMemoryFilevineAuth` is a stub that returns a fixed `TokenSet`. Tests use this; the unit-level smoke (`tests/test_smoke_unit.py`) uses this; the credentialed smoke script (`bin/smoke-test-filevine.py`) uses this with env-provided values.
+
+When #789 / #822 land, they should:
+
+1. Create an implementation of `FilevineAuthProvider` in their identity-layer module.
+2. Wire it into the per-customer Machine bootstrap so `FilevinePracticeManagement` and `FilevineDocumentStorage` are constructed with the live provider.
+3. Leave this connector untouched -- the only required code change is the construction site, not the connector internals.
+
+The connector deliberately does NOT carry an OAuth dance (authorize-redirect-exchange) of its own. That belongs in the identity layer. The seam is what this connector ships.
+
+## customer.yaml binding
+
+The connector is bound per-customer via the `connectors:` map in `customer.yaml` ([schema spec](../../../docs/specs/ai-employee/customer-yaml-schema.md)):
+
+```yaml
+connectors:
+  PracticeManagement:
+    adapter: filevine
+    backend: build:filevine
+    enabled: true
+    scopes:
+      - 'fv.api.read'
+      - 'fv.api.write.notes'
+    token_ref: 'infisical:/ai-employee/{customer_id}/practice-management/filevine-oauth-refresh'
+
+  DocumentStorage:
+    adapter: filevine
+    backend: build:filevine
+    enabled: true
+    # token_ref reuses the PracticeManagement OAuth token; the
+    # provisioning script wires both bindings to the same auth
+    # provider when the adapter slug matches.
+    token_ref: 'infisical:/ai-employee/{customer_id}/practice-management/filevine-oauth-refresh'
+```
+
+Notes on the binding shape:
+
+- `adapter: filevine` -- the SMD-internal slug. The validator (`src/lib/ai-employee/customer-yaml/validator.ts`) treats it as opaque; the boot-time conformance harness asserts the actual adapter class satisfies the interface.
+- `backend: build:filevine` -- `build:` prefix means SMD-owned wrapper (this connector). Filevine is not on Composio's roster, so there's no `composio:` alternative.
+- `token_ref:` -- Infisical reference; resolved by `bin/provision-customer.sh` and injected into the Hermes Machine as a Fly secret. Never a literal token here per the schema's secret-exclusion rules.
+- `org_slug` is not in `customer.yaml` because the Identity & Access layer (#789/#822) owns customer-Filevine-tenant mapping. The provider's `org_slug()` returns the bound value at runtime.
+- The same `adapter: filevine` slug appears in both bindings because Filevine serves both capabilities. The provisioning script wires them to the same `FilevineClient` instance so they share the auth provider and connection pool.
+
+## Endpoint inventory
+
+Filevine REST API v2 (https://developer.filevine.io/). Endpoints used:
+
+| Capability method       | HTTP request                                                         |
+| ----------------------- | -------------------------------------------------------------------- |
+| `search_matters`        | `GET /core/projects?orgUid=<org>&clientName=&status=&limit=&offset=` |
+| `get_matter`            | `GET /core/projects/{projectId}`                                     |
+| `list_matter_documents` | `GET /core/projects/{projectId}/documents`                           |
+| `create_note`           | `POST /core/projects/{projectId}/notes`                              |
+| `get_document`          | `GET /core/documents/{documentId}`                                   |
+| `get_document_bytes`    | `GET /core/documents/{documentId}/download`                          |
+| `health_check`          | `GET /core/projects?orgUid=<org>&limit=0` (cheapest probe)           |
+
+Filevine vocabulary -> capability vocabulary translation lives in `capabilities.py`:
+
+- Filevine `project` = capability `matter`
+- Filevine `status` (Open / Closed / Pending / Intake) -> capability `MatterStatus` ("open" / "closed" / "pending" / "intake"); unknown vendor statuses preserve the original in `custom_fields._vendor_status_raw` rather than fabricating a translation.
+- All non-mapped Filevine fields land verbatim in `Matter.custom_fields` so the dashboard sourcing block ("what Marcus used to write this") can disclose them per [ADR 0006](../../../docs/adr/0006-capability-adapter-pattern.md).
+
+## Fabrication discipline
+
+Per the no-fabrication rule (Platform PRD invariant #8 + CLAUDE.md project policy):
+
+- Optional fields on the Filevine record that are missing return `None` (or `""` for required-by-contract strings).
+- The only synthesized field is `StoredDocument.path` -- Filevine has no folder concept, so `path` is constructed as `projects/<projectId>/<filename>`. This synthesis is declared in `describe_capabilities().field_coverage["list_documents"].derived` so the dashboard discloses the synthesis to the human reviewer.
+- No vendor status, ID, or attribution is invented. If Filevine returns a record with no `projectId`, the adapter raises `AdapterError(code="unknown")` rather than synthesizing one.
+
+## ADR 0005 -- reviewer-as-sender attribution
+
+`create_note` is the only mutating method. Per ADR 0005:
+
+- The note's `authorAccountId` is the reviewer's Filevine account, not "AI Employee" and not the persona name.
+- The note body is the drafted content verbatim. No "[Drafted by Marcus]" prefix.
+- The `metadata.drafted_by_skill` field carries the audit trail for the dashboard sourcing block.
+- The `metadata.draft: true` flag distinguishes connector-created notes from hand-typed ones, so a future Filevine review surface (or the dashboard) can render them with the right affordance.
+
+There is no autonomous-send method anywhere in this connector. Filevine has an outbound email surface (via its UI) -- the connector deliberately does not expose it. The reviewer-as-sender boundary is enforced by the `BANNED_METHOD_NAMES` list in the conformance harness; the corresponding Python test (`tests/test_conformance.py::test_adapter_has_no_banned_method_names`) asserts neither adapter exposes any banned method name.
+
+## Per-customer isolation
+
+Per [ADR 0007](../../../docs/adr/0007-per-customer-machine-isolation.md) and [ADR 0009](../../../docs/adr/0009-cross-machine-query-prohibition.md):
+
+- The connector is instantiated per-customer in the Hermes Machine.
+- No tenant ID appears on any row; isolation is enforced at the deployment layer (one Machine per customer, one auth provider per Machine).
+- The `FilevineAuthProvider` instance is scoped to one customer; the connector cannot accidentally hit another customer's Filevine tenant.
+
+## Testing
+
+Unit tests live in `tests/`. From the repo root:
+
+```bash
+cd ai-employee && python -m pytest connectors/filevine/tests/ -v
+```
+
+Coverage:
+
+| File                         | Asserts                                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `tests/test_errors.py`       | AdapterError code + capability union pinned against the TypeScript contract                              |
+| `tests/test_client.py`       | HTTP status code -> AdapterError code translation table                                                  |
+| `tests/test_capabilities.py` | Each capability method's happy path; field-mapping fidelity; validation; unsupported-method behavior     |
+| `tests/test_smoke_unit.py`   | CI-runnable end-to-end smoke covering every supported method through the adapter                         |
+| `tests/test_conformance.py`  | Python mirror of the eight conformance invariants from `src/lib/ai-employee/capabilities/conformance.ts` |
+
+### Live sandbox smoke (NOT in CI)
+
+`bin/smoke-test-filevine.py` exercises the connector against a real Filevine tenant. Requires env vars:
+
+```bash
+export FILEVINE_ORG_SLUG=<org>
+export FILEVINE_API_BASE=https://api.filevine.io     # or sandbox host
+export FILEVINE_ACCESS_TOKEN=<oauth token>
+export FILEVINE_REFRESH_TOKEN=<oauth refresh token>  # currently unused; reserved for #789/#822
+export FILEVINE_SMOKE_PROJECT_ID=<test project>
+export FILEVINE_REVIEWER_ACCOUNT_ID=<test reviewer>  # required for --write mode
+
+python ai-employee/connectors/filevine/bin/smoke-test-filevine.py
+python ai-employee/connectors/filevine/bin/smoke-test-filevine.py --write
+```
+
+Defaults to read-only. `--write` exercises the `create_note` mutating method; gate this behind a designated test project.
+
+## What ships next
+
+- [ADR 0014](../../../docs/adr/0014-pi-vertical-adapter-build-priority.md) sequences: **Filevine -> CASEpeer (v2) -> SmartAdvocate (v3)**. Both follow the same shape: one Python package per vendor, capability adapters per file, conformance tests next door.
+- Real Identity & Access wiring (#789 / #822) replaces `InMemoryFilevineAuth` in production. The connector itself is untouched.
+- Optional capability methods (`create_matter`, `upload_document`, `share_document_draft`, etc.) ship behind named follow-on issues when a skill actually needs them -- not speculatively.

--- a/ai-employee/connectors/filevine/__init__.py
+++ b/ai-employee/connectors/filevine/__init__.py
@@ -1,0 +1,42 @@
+"""Filevine connector -- PI vertical practice-management adapter v1.
+
+Implements the `PracticeManagement` and `DocumentStorage` capability
+interfaces (per ADR 0006) against the Filevine REST API. Filevine is the
+v1 PI practice-management adapter per ADR 0014.
+
+This package exposes:
+
+* `FilevineAuthProvider` -- Protocol; production wiring injects a real
+  Identity & Access layer (issues #789, #822). Tests inject a fake.
+* `FilevineClient` -- thin async HTTP client over the Filevine REST API.
+* `FilevinePracticeManagement` -- `PracticeManagement` capability adapter.
+* `FilevineDocumentStorage` -- `DocumentStorage` capability adapter.
+
+Vendor-agnostic capability contracts live in TypeScript at
+`src/lib/ai-employee/capabilities/`. This Python adapter conforms to the
+same contract -- method names, parameter shape, return shape, and error
+codes. The cross-language contract mapping is documented in README.md.
+"""
+
+from __future__ import annotations
+
+from .auth import FilevineAuthProvider, InMemoryFilevineAuth, TokenSet
+from .capabilities import FilevineDocumentStorage, FilevinePracticeManagement
+from .client import FilevineClient
+from .errors import (
+    AdapterError,
+    AdapterErrorCode,
+    CAPABILITY_NAMES,
+)
+
+__all__ = [
+    "AdapterError",
+    "AdapterErrorCode",
+    "CAPABILITY_NAMES",
+    "FilevineAuthProvider",
+    "FilevineClient",
+    "FilevineDocumentStorage",
+    "FilevinePracticeManagement",
+    "InMemoryFilevineAuth",
+    "TokenSet",
+]

--- a/ai-employee/connectors/filevine/auth.py
+++ b/ai-employee/connectors/filevine/auth.py
@@ -1,0 +1,155 @@
+"""OAuth 2.0 auth provider -- protocol + in-memory fake.
+
+Per the issue's "Identity & Access seam" instruction, the real Identity
+& Access layer (#789, #822) is not yet built. This module defines the
+auth seam:
+
+* `FilevineAuthProvider` -- a Protocol describing what the connector
+  needs from token acquisition. Production constructs an instance
+  backed by the Identity & Access layer; tests construct an
+  `InMemoryFilevineAuth` fake.
+
+* `TokenSet` -- the OAuth token pair plus expiry metadata; identical
+  shape to the LawPay connector for cross-adapter consistency.
+
+The connector's `FilevineClient` accepts a `FilevineAuthProvider`. It
+never reads tokens from disk, env, or a static config -- that is the
+responsibility of whatever implementation backs the protocol. This is
+the seam #789/#822 plug into.
+
+Filevine OAuth notes
+--------------------
+
+Filevine uses Authorization Code grant per
+https://developer.filevine.io/. The connector itself does not run the
+interactive OAuth dance; the Identity & Access layer (issues #789 /
+#822) handles the browser-based authorize-redirect-exchange flow and
+hands the connector refresh tokens through the protocol below. The
+Filevine token endpoint is at the customer's tenant base (e.g.
+`https://identity.filevine.io/connect/token`) with `client_id`,
+`client_secret`, and `refresh_token` grant. The connector calls only
+`get_valid_token()` and the implementation handles refresh.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional, Protocol
+
+
+# Safety margin: a token within this many seconds of stated expiry is
+# treated as expired so the consumer refreshes before the next API call.
+REFRESH_MARGIN_SECONDS = 60
+
+
+@dataclass
+class TokenSet:
+    """OAuth token pair plus expiry metadata.
+
+    Lives outside the protocol so the Identity & Access layer and the
+    connector agree on a wire shape without one having to import the
+    other.
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at: float  # epoch seconds when access_token expires
+    token_type: str = "Bearer"
+
+    def is_expired(self) -> bool:
+        return time.time() + REFRESH_MARGIN_SECONDS >= self.expires_at
+
+    def authorization_header(self) -> str:
+        return f"{self.token_type} {self.access_token}"
+
+
+class FilevineAuthProvider(Protocol):
+    """Token-acquisition seam between the connector and Identity & Access.
+
+    The connector calls `get_valid_token()` before every API request. The
+    implementation is responsible for refresh-when-expired, storage,
+    rotation telemetry, and any per-customer isolation guarantees. The
+    connector does not see customer IDs -- per ADR 0007/0009 the
+    connector is instantiated per-customer in the Hermes Machine and
+    its auth provider is already scoped.
+    """
+
+    async def get_valid_token(self) -> TokenSet:
+        """Return a non-expired `TokenSet`.
+
+        Raises
+        ------
+        Exception
+            Implementations raise whatever they like; the connector
+            wraps any exception in `AdapterError('unauthorized', ...)`
+            before re-raising. The protocol intentionally does not
+            constrain the implementation's error type because the
+            Identity & Access layer's contract is not yet locked.
+        """
+
+    def org_slug(self) -> str:
+        """Filevine `org_slug` for this customer.
+
+        Bound from `customer.yaml -> connectors.PracticeManagement.config.org_slug`.
+        The Hermes Machine provisions the protocol implementation with
+        the slug baked in at boot.
+        """
+
+
+@dataclass
+class InMemoryFilevineAuth:
+    """In-memory fake for tests + local dev.
+
+    Usage
+    -----
+    .. code-block:: python
+
+        auth = InMemoryFilevineAuth(
+            token=TokenSet(
+                access_token="fake-token",
+                refresh_token="fake-refresh",
+                expires_at=time.time() + 3600,
+            ),
+            org_slug="example-firm",
+        )
+        client = FilevineClient(auth=auth, http=httpx.AsyncClient(...))
+
+    The fake never network-refreshes. Tests that want to exercise the
+    "token expired" code path construct one with `expires_at` in the
+    past and assert the connector raises `AdapterError('unauthorized')`.
+    """
+
+    token: TokenSet
+    _org_slug: str = field(default="example-firm")
+    refresh_callable: Optional[
+        "object"
+    ] = None  # tests may set this to a callable to simulate refresh
+
+    def __init__(
+        self,
+        token: TokenSet,
+        org_slug: str = "example-firm",
+    ) -> None:
+        self.token = token
+        self._org_slug = org_slug
+
+    async def get_valid_token(self) -> TokenSet:
+        if self.token.is_expired():
+            raise RuntimeError(
+                "InMemoryFilevineAuth token expired and no refresh hook "
+                "configured. Tests asserting expired-token handling should "
+                "expect this RuntimeError."
+            )
+        return self.token
+
+    def org_slug(self) -> str:
+        return self._org_slug
+
+
+__all__ = [
+    "REFRESH_MARGIN_SECONDS",
+    "FilevineAuthProvider",
+    "InMemoryFilevineAuth",
+    "TokenSet",
+]

--- a/ai-employee/connectors/filevine/bin/smoke-test-filevine.py
+++ b/ai-employee/connectors/filevine/bin/smoke-test-filevine.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Smoke test against a Filevine test tenant.
+
+This script is NOT run in CI -- it needs real credentials. It exercises
+the connector end-to-end against the env-provided Filevine tenant:
+
+* Resolve a valid token via the auth provider.
+* List a small batch of projects.
+* Fetch one project by id.
+* List that project's documents (no download -- the smoke test stays
+  read-only on document bytes to avoid pulling production PHI/PII).
+* Create a draft-style note attributed to the smoke-test reviewer
+  account on a designated SMOKE_PROJECT_ID -- gated behind an explicit
+  ``--write`` flag so a stray run does not modify a tenant.
+
+Usage
+-----
+
+::
+
+    export FILEVINE_ORG_SLUG=...
+    export FILEVINE_API_BASE=https://api.filevine.io
+    export FILEVINE_ACCESS_TOKEN=...   # 1-hour OAuth access token
+    export FILEVINE_REFRESH_TOKEN=...  # refresh token (unused here; for completeness)
+    export FILEVINE_SMOKE_PROJECT_ID=... # project to fetch + list documents on
+    export FILEVINE_REVIEWER_ACCOUNT_ID=... # reviewer for the optional note draft
+
+    python ai-employee/connectors/filevine/bin/smoke-test-filevine.py
+    python ai-employee/connectors/filevine/bin/smoke-test-filevine.py --write
+
+The unit-test-level smoke (mocked HTTP) lives in
+``tests/test_smoke_unit.py`` and runs in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+# Allow running from repo root or from the connector dir.
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[3]))  # ai-employee/ on sys.path
+
+from connectors.filevine import (  # noqa: E402
+    FilevineClient,
+    FilevineDocumentStorage,
+    FilevinePracticeManagement,
+    InMemoryFilevineAuth,
+    TokenSet,
+)
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        print(f"FATAL: required env var {name} is not set", file=sys.stderr)
+        sys.exit(2)
+    return val
+
+
+async def _run(write_mode: bool) -> int:
+    try:
+        import httpx
+    except ImportError:
+        print("FATAL: httpx is required to run the smoke test", file=sys.stderr)
+        return 2
+
+    org_slug = _require_env("FILEVINE_ORG_SLUG")
+    base_url = os.environ.get("FILEVINE_API_BASE", "https://api.filevine.io")
+    access_token = _require_env("FILEVINE_ACCESS_TOKEN")
+    refresh_token = os.environ.get("FILEVINE_REFRESH_TOKEN", "")
+    project_id = _require_env("FILEVINE_SMOKE_PROJECT_ID")
+
+    auth = InMemoryFilevineAuth(
+        token=TokenSet(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=time.time() + 3600,
+        ),
+        org_slug=org_slug,
+    )
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as http:
+        client = FilevineClient(auth=auth, http=http, base_url=base_url)
+        pm = FilevinePracticeManagement(client)
+        ds = FilevineDocumentStorage(client)
+
+        print("== Filevine connector smoke ==")
+        print(f"  org_slug = {org_slug}")
+        print(f"  base_url = {base_url}")
+
+        print("\n[1/4] PracticeManagement.search_matters (limit=5)")
+        matters = await pm.search_matters(limit=5)
+        print(f"  -> {len(matters)} matters")
+        for m in matters[:3]:
+            print(f"     - {m.id} | {m.client_name} | {m.status} | {m.matter_type}")
+
+        print(f"\n[2/4] PracticeManagement.get_matter({project_id})")
+        matter = await pm.get_matter(project_id)
+        if matter is None:
+            print("  -> not found (404 or empty body)")
+        else:
+            print(f"  -> {matter.id} | {matter.client_name} | {matter.status}")
+            print(f"     custom_fields keys: {sorted(matter.custom_fields)[:6]}")
+
+        print(f"\n[3/4] DocumentStorage.list_documents({project_id})")
+        docs = await ds.list_documents(project_id)
+        print(f"  -> {len(docs)} documents")
+        for d in docs[:3]:
+            print(
+                f"     - {d.id} | {d.filename} | {d.mime_type} | {d.size_bytes} bytes"
+            )
+
+        if write_mode:
+            reviewer = _require_env("FILEVINE_REVIEWER_ACCOUNT_ID")
+            print(f"\n[4/4] PracticeManagement.create_note(...) [write mode]")
+            note = await pm.create_note(
+                project_id,
+                content=(
+                    "Smoke test note from ai-employee Filevine connector. "
+                    f"Generated at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}."
+                ),
+                reviewer_account_id=reviewer,
+                drafted_by_skill="connector-smoke-test",
+            )
+            print(f"  -> note id {note.id} created")
+        else:
+            print("\n[4/4] Skipping create_note -- pass --write to exercise it")
+
+        print("\nOK: Filevine connector smoke complete.")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Also exercise create_note (writes a draft note to the smoke project)",
+    )
+    args = parser.parse_args()
+    return asyncio.run(_run(write_mode=args.write))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/ai-employee/connectors/filevine/capabilities.py
+++ b/ai-employee/connectors/filevine/capabilities.py
@@ -1,0 +1,730 @@
+"""Capability adapters -- `PracticeManagement` and `DocumentStorage`.
+
+These classes are the Python implementations of the TypeScript
+interfaces locked in
+`src/lib/ai-employee/capabilities/practice-management.ts` and
+`src/lib/ai-employee/capabilities/document-storage.ts`. The contracts
+are vendor-neutral; vendor specifics live in `client.py`.
+
+Per the issue's scope, this connector implements the minimum surface:
+
+* `Matter.Read`: ``list_matters``, ``get_matter``, ``get_matter_documents``
+* `Matter.Note.Write`: ``create_note`` -- the only mutating method.
+  Attribution is the reviewer per ADR 0005; the note's body is the
+  drafted content, not "[AI Employee] ...".
+* `Document.Read`: ``list_documents``, ``get_document``, ``get_document_bytes``
+
+Optional capability methods that the larger TypeScript interfaces
+expose (e.g. ``create_matter``, ``upload_document``) are declared
+unsupported in `describe_capabilities().unsupported_methods` and raise
+``capability_not_supported`` if invoked. This satisfies the
+UNSUPPORTED_METHODS_THROW invariant.
+
+No autonomous send paths exist anywhere in this module -- per ADR 0005
+and the conformance harness's NO_AUTONOMOUS_EXTERNAL_SEND invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .client import ADAPTER_SLUG, FilevineClient
+from .errors import AdapterError
+
+
+# ---------------------------------------------------------------------------
+# Capability data shapes -- Python mirrors of the TypeScript interfaces
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CapabilitySet:
+    """Python mirror of `CapabilitySet` from
+    `src/lib/ai-employee/capabilities/types.ts`. The conformance
+    harness's CAPABILITY_SET_HONEST invariant asserts the
+    ``capability`` matches and ``supported_methods`` is a superset of
+    the interface's required methods.
+    """
+
+    capability: str
+    adapter: str
+    version: str
+    supported_methods: tuple[str, ...]
+    unsupported_methods: tuple[str, ...]
+    field_coverage: dict[str, dict[str, tuple[str, ...]]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HealthStatus:
+    status: str  # "healthy" | "degraded" | "unhealthy"
+    last_ok_at: Optional[str] = None
+    message: Optional[str] = None
+    details: Optional[dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class Matter:
+    """Python mirror of `Matter` from `practice-management.ts`."""
+
+    id: str
+    client_name: str
+    matter_type: str
+    status: str  # "open" | "closed" | "pending" | "intake"
+    opened_at: str
+    closed_at: Optional[str]
+    custom_fields: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DocumentRef:
+    """Python mirror of `DocumentRef` from `practice-management.ts`."""
+
+    id: str
+    matter_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    uploaded_at: str
+    uploaded_by: Optional[str]
+
+
+@dataclass(frozen=True)
+class MatterNoteRef:
+    """Return shape for the Matter.Note.Write `create_note` call.
+
+    The TypeScript contract does not yet ship a typed note shape -- the
+    interface exposes notes via the broader matter surface. We declare
+    this dataclass to keep the Python adapter explicit; if the
+    TypeScript interface grows a typed note shape later, both sides
+    converge on the same name.
+    """
+
+    id: str
+    matter_id: str
+    body: str
+    created_at: str
+    author_account_id: str
+    drafted_by_skill: str
+
+
+# DocumentStorage shapes
+@dataclass(frozen=True)
+class StoredDocument:
+    id: str
+    path: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    created_at: str
+    modified_at: str
+    modified_by: Optional[str]
+    current_version: str
+
+
+# ---------------------------------------------------------------------------
+# Translation helpers -- Filevine JSON -> capability shapes
+#
+# These are intentionally small and explicit. Each helper reads ONLY the
+# fields the capability shape declares; absent fields land as `None`.
+# Per NO_FIELD_FABRICATION the helpers never invent values. The unit
+# tests in `tests/test_translation.py` assert this.
+# ---------------------------------------------------------------------------
+
+
+_FILEVINE_STATUS_MAP = {
+    # Filevine's project status vocabulary maps onto the capability's
+    # closed enum. Unknown vendor statuses fall back to "open" because
+    # the capability's enum has no "unknown" value; the original
+    # vendor status is preserved in custom_fields under
+    # "_vendor_status_raw" for the dashboard sourcing block.
+    "Open": "open",
+    "Closed": "closed",
+    "Pending": "pending",
+    "Intake": "intake",
+}
+
+
+def _opt_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _opt_int(value: Any) -> Optional[int]:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _matter_from_project(project: dict[str, Any]) -> Matter:
+    """Translate a Filevine project JSON object into a `Matter`.
+
+    Field mapping (Filevine -> capability):
+
+    * ``projectId`` (or ``id``)         -> ``id``
+    * ``clientName``                    -> ``client_name``
+    * ``projectTypeCode``               -> ``matter_type``
+    * ``status``                        -> ``status`` (mapped via
+                                           `_FILEVINE_STATUS_MAP`; raw
+                                           preserved in custom_fields)
+    * ``createdDate``                   -> ``opened_at``
+    * ``closedDate``                    -> ``closed_at`` (Optional)
+    * everything not listed above lands verbatim in ``custom_fields``
+      so the dashboard sourcing block can disclose what the adapter
+      saw.
+    """
+    project_id = _opt_str(project.get("projectId")) or _opt_str(project.get("id"))
+    if project_id is None:
+        raise AdapterError(
+            code="unknown",
+            capability="PracticeManagement",
+            adapter=ADAPTER_SLUG,
+            message="Filevine project record has no projectId/id",
+        )
+    client_name = _opt_str(project.get("clientName")) or ""
+    matter_type = _opt_str(project.get("projectTypeCode")) or ""
+    raw_status = _opt_str(project.get("status")) or ""
+    status = _FILEVINE_STATUS_MAP.get(raw_status, "open")
+    opened_at = _opt_str(project.get("createdDate")) or ""
+    closed_at = _opt_str(project.get("closedDate"))
+
+    known = {"projectId", "id", "clientName", "projectTypeCode", "status", "createdDate", "closedDate"}
+    custom_fields = {k: v for k, v in project.items() if k not in known}
+    if raw_status and raw_status not in _FILEVINE_STATUS_MAP:
+        custom_fields["_vendor_status_raw"] = raw_status
+
+    return Matter(
+        id=project_id,
+        client_name=client_name,
+        matter_type=matter_type,
+        status=status,
+        opened_at=opened_at,
+        closed_at=closed_at,
+        custom_fields=custom_fields,
+    )
+
+
+def _docref_from_document(document: dict[str, Any], matter_id: str) -> DocumentRef:
+    """Translate a Filevine document JSON object to `DocumentRef`."""
+    doc_id = _opt_str(document.get("documentId")) or _opt_str(document.get("id"))
+    if doc_id is None:
+        raise AdapterError(
+            code="unknown",
+            capability="PracticeManagement",
+            adapter=ADAPTER_SLUG,
+            message="Filevine document record has no documentId/id",
+        )
+    return DocumentRef(
+        id=doc_id,
+        matter_id=matter_id,
+        filename=_opt_str(document.get("filename")) or "",
+        mime_type=_opt_str(document.get("mimeType")) or "application/octet-stream",
+        size_bytes=_opt_int(document.get("sizeBytes")) or 0,
+        uploaded_at=_opt_str(document.get("uploadDate")) or "",
+        uploaded_by=_opt_str(document.get("uploadedByAccountId")),
+    )
+
+
+def _stored_from_document(document: dict[str, Any]) -> StoredDocument:
+    """Translate a Filevine document JSON object to `StoredDocument`."""
+    doc_id = _opt_str(document.get("documentId")) or _opt_str(document.get("id"))
+    if doc_id is None:
+        raise AdapterError(
+            code="unknown",
+            capability="DocumentStorage",
+            adapter=ADAPTER_SLUG,
+            message="Filevine document record has no documentId/id",
+        )
+    return StoredDocument(
+        id=doc_id,
+        # Filevine documents are scoped under projects, not free-form
+        # paths. We synthesize the "path" as projects/<project>/<file>
+        # which is faithful to how the dashboard renders document
+        # locations. Synthesis is disclosed in field_coverage.derived.
+        path=(
+            f"projects/{_opt_str(document.get('projectId')) or 'unknown'}/"
+            f"{_opt_str(document.get('filename')) or doc_id}"
+        ),
+        filename=_opt_str(document.get("filename")) or "",
+        mime_type=_opt_str(document.get("mimeType")) or "application/octet-stream",
+        size_bytes=_opt_int(document.get("sizeBytes")) or 0,
+        created_at=_opt_str(document.get("uploadDate")) or "",
+        modified_at=_opt_str(document.get("modifiedDate"))
+        or _opt_str(document.get("uploadDate"))
+        or "",
+        modified_by=_opt_str(document.get("modifiedByAccountId"))
+        or _opt_str(document.get("uploadedByAccountId")),
+        current_version=_opt_str(document.get("currentVersionId")) or "v1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# PracticeManagement adapter
+# ---------------------------------------------------------------------------
+
+
+_PM_SUPPORTED = (
+    "describe_capabilities",
+    "health_check",
+    "search_matters",
+    "get_matter",
+    "list_matter_documents",
+    "create_note",
+)
+
+
+# Required-method coverage gap declared honestly. The TypeScript
+# PracticeManagement interface declares more methods (create_matter,
+# update_matter, contacts, time entries, upload). Filevine v1 ships
+# the read + note-write surface only per the issue. The remaining
+# methods are explicitly unsupported and raise capability_not_supported
+# at call time.
+_PM_UNSUPPORTED = (
+    "create_matter",
+    "update_matter",
+    "search_contacts",
+    "get_contact",
+    "create_contact",
+    "list_time_entries",
+    "create_time_entry_draft",
+    "upload_matter_document",
+)
+
+
+class FilevinePracticeManagement:
+    """PracticeManagement capability adapter for Filevine.
+
+    Conforms to `PracticeManagement` from
+    `src/lib/ai-employee/capabilities/practice-management.ts`. Methods
+    are named in snake_case to match Python convention; the TypeScript
+    contract uses identical names by design.
+    """
+
+    capability = "PracticeManagement"
+    adapter = ADAPTER_SLUG
+    version = "0.1.0"
+
+    def __init__(self, client: FilevineClient) -> None:
+        self._client = client
+
+    # ----- AdapterBase -----
+
+    def describe_capabilities(self) -> CapabilitySet:
+        return CapabilitySet(
+            capability=self.capability,
+            adapter=self.adapter,
+            version=self.version,
+            supported_methods=_PM_SUPPORTED,
+            unsupported_methods=_PM_UNSUPPORTED,
+            field_coverage={
+                "search_matters": {
+                    "populated": (
+                        "id",
+                        "client_name",
+                        "matter_type",
+                        "status",
+                        "opened_at",
+                        "closed_at",
+                        "custom_fields",
+                    ),
+                    "not_populated": (),
+                    "derived": (),
+                },
+                "create_note": {
+                    "populated": (
+                        "id",
+                        "matter_id",
+                        "body",
+                        "created_at",
+                        "author_account_id",
+                        "drafted_by_skill",
+                    ),
+                    "not_populated": (),
+                    "derived": (),
+                },
+            },
+        )
+
+    async def health_check(self) -> HealthStatus:
+        try:
+            await self._client.ping(capability=self.capability)
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            return HealthStatus(status="healthy", last_ok_at=now)
+        except AdapterError as exc:
+            return HealthStatus(
+                status="unhealthy",
+                last_ok_at=None,
+                message=f"Filevine ping raised {exc.code}",
+            )
+
+    # ----- Supported methods -----
+
+    async def search_matters(
+        self,
+        *,
+        client_name: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Matter]:
+        # Translate the capability's normalized status back to Filevine's
+        # vocabulary (the inverse of `_FILEVINE_STATUS_MAP`). If the
+        # caller passes an unknown status, surface a validation error
+        # rather than silently dropping it.
+        filevine_status: Optional[str] = None
+        if status is not None:
+            inverse = {v: k for k, v in _FILEVINE_STATUS_MAP.items()}
+            if status not in inverse:
+                raise AdapterError(
+                    code="validation_failed",
+                    capability=self.capability,
+                    adapter=self.adapter,
+                    message=f"Unknown matter status {status!r}; "
+                    f"expected one of {sorted(inverse)}",
+                )
+            filevine_status = inverse[status]
+        rows = await self._client.list_projects(
+            capability=self.capability,
+            client_name=client_name,
+            status=filevine_status,
+            limit=limit,
+            offset=offset,
+        )
+        return [_matter_from_project(r) for r in rows]
+
+    async def get_matter(self, matter_id: str) -> Optional[Matter]:
+        body = await self._client.get_project(matter_id, capability=self.capability)
+        if body is None:
+            return None
+        return _matter_from_project(body)
+
+    async def list_matter_documents(self, matter_id: str) -> list[DocumentRef]:
+        rows = await self._client.list_project_documents(
+            matter_id, capability=self.capability
+        )
+        return [_docref_from_document(r, matter_id=matter_id) for r in rows]
+
+    async def create_note(
+        self,
+        matter_id: str,
+        *,
+        content: str,
+        reviewer_account_id: str,
+        drafted_by_skill: str,
+    ) -> MatterNoteRef:
+        """Create a matter note attributed to the reviewer.
+
+        Per ADR 0005, the note's author is the reviewer's Filevine
+        account, not "AI Employee" or the persona. The body is the
+        drafted content verbatim. The dashboard renders the
+        ``drafted_by_skill`` field as the "what Marcus used to write
+        this" sourcing block.
+        """
+        if not content:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires non-empty content",
+            )
+        if not reviewer_account_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires reviewer_account_id",
+            )
+        if not drafted_by_skill:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires drafted_by_skill",
+            )
+        body = await self._client.create_project_note(
+            matter_id,
+            capability=self.capability,
+            body_text=content,
+            reviewer_account_id=reviewer_account_id,
+            drafted_by_skill=drafted_by_skill,
+        )
+        note_id = _opt_str(body.get("noteId")) or _opt_str(body.get("id"))
+        if note_id is None:
+            raise AdapterError(
+                code="unknown",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="Filevine returned a note without noteId/id",
+            )
+        return MatterNoteRef(
+            id=note_id,
+            matter_id=matter_id,
+            body=content,
+            created_at=_opt_str(body.get("createdDate")) or "",
+            author_account_id=reviewer_account_id,
+            drafted_by_skill=drafted_by_skill,
+        )
+
+    # ----- Unsupported methods raise capability_not_supported -----
+
+    async def create_matter(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="create_matter is not supported in Filevine v1 adapter",
+        )
+
+    async def update_matter(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="update_matter is not supported in Filevine v1 adapter",
+        )
+
+    async def search_contacts(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="search_contacts is not supported in Filevine v1 adapter",
+        )
+
+    async def get_contact(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="get_contact is not supported in Filevine v1 adapter",
+        )
+
+    async def create_contact(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="create_contact is not supported in Filevine v1 adapter",
+        )
+
+    async def list_time_entries(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="list_time_entries is not supported in Filevine v1 adapter",
+        )
+
+    async def create_time_entry_draft(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="create_time_entry_draft is not supported in Filevine v1 adapter",
+        )
+
+    async def upload_matter_document(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="upload_matter_document is not supported in Filevine v1 adapter",
+        )
+
+
+# ---------------------------------------------------------------------------
+# DocumentStorage adapter -- read-only surface from Filevine documents
+# ---------------------------------------------------------------------------
+
+_DS_SUPPORTED = (
+    "describe_capabilities",
+    "health_check",
+    "list_documents",
+    "get_document",
+    "get_document_bytes",
+)
+
+_DS_UNSUPPORTED = (
+    "list_folder",
+    "upload_document",
+    "update_document",
+    "list_versions",
+    "download_version",
+    "share_document_draft",
+    "get_scoped_folders",
+)
+
+
+class FilevineDocumentStorage:
+    """DocumentStorage capability adapter for Filevine documents.
+
+    Filevine is primarily a practice-management system; documents live
+    inside projects (matters). This adapter exposes the document read
+    surface so skills that bind to `DocumentStorage` can read project
+    documents without having to know they came from Filevine.
+
+    The TypeScript `DocumentStorage` interface includes folder
+    listings, version histories, and share-draft creation. Filevine's
+    document model does not map cleanly onto those (no folders per se;
+    versions exist but are not first-class). The unsupported methods
+    raise `capability_not_supported` to keep the conformance harness
+    honest; the dashboard surfaces "this adapter does not support
+    folder listings" rather than producing fabricated rows.
+    """
+
+    capability = "DocumentStorage"
+    adapter = ADAPTER_SLUG
+    version = "0.1.0"
+
+    def __init__(self, client: FilevineClient) -> None:
+        self._client = client
+
+    def describe_capabilities(self) -> CapabilitySet:
+        return CapabilitySet(
+            capability=self.capability,
+            adapter=self.adapter,
+            version=self.version,
+            supported_methods=_DS_SUPPORTED,
+            unsupported_methods=_DS_UNSUPPORTED,
+            field_coverage={
+                "list_documents": {
+                    "populated": (
+                        "id",
+                        "filename",
+                        "mime_type",
+                        "size_bytes",
+                        "created_at",
+                        "modified_at",
+                        "modified_by",
+                        "current_version",
+                    ),
+                    "not_populated": (),
+                    "derived": ("path",),
+                },
+                "get_document": {
+                    "populated": (
+                        "id",
+                        "filename",
+                        "mime_type",
+                        "size_bytes",
+                        "created_at",
+                        "modified_at",
+                        "modified_by",
+                        "current_version",
+                    ),
+                    "not_populated": (),
+                    "derived": ("path",),
+                },
+            },
+        )
+
+    async def health_check(self) -> HealthStatus:
+        try:
+            await self._client.ping(capability=self.capability)
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            return HealthStatus(status="healthy", last_ok_at=now)
+        except AdapterError as exc:
+            return HealthStatus(
+                status="unhealthy",
+                last_ok_at=None,
+                message=f"Filevine ping raised {exc.code}",
+            )
+
+    async def list_documents(self, matter_id: str) -> list[StoredDocument]:
+        rows = await self._client.list_project_documents(
+            matter_id, capability=self.capability
+        )
+        # Ensure projectId is set on each row for path synthesis
+        for r in rows:
+            r.setdefault("projectId", matter_id)
+        return [_stored_from_document(r) for r in rows]
+
+    async def get_document(self, document_id: str) -> Optional[StoredDocument]:
+        body = await self._client.get_document(document_id, capability=self.capability)
+        if body is None:
+            return None
+        return _stored_from_document(body)
+
+    async def get_document_bytes(self, document_id: str) -> bytes:
+        return await self._client.download_document(
+            document_id, capability=self.capability
+        )
+
+    # ----- Unsupported methods -----
+
+    async def list_folder(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="list_folder is not supported in Filevine v1 adapter "
+            "(Filevine has no first-class folder concept)",
+        )
+
+    async def upload_document(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="upload_document is not supported in Filevine v1 adapter",
+        )
+
+    async def update_document(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="update_document is not supported in Filevine v1 adapter",
+        )
+
+    async def list_versions(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="list_versions is not supported in Filevine v1 adapter",
+        )
+
+    async def download_version(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="download_version is not supported in Filevine v1 adapter",
+        )
+
+    async def share_document_draft(self, *args: Any, **kwargs: Any) -> None:
+        # Per ADR 0005, even the draft surface is unsupported in v1 --
+        # Filevine has no native external-share-draft concept that we
+        # can safely round-trip without inventing one.
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="share_document_draft is not supported in Filevine v1 adapter",
+        )
+
+    def get_scoped_folders(self) -> list[str]:
+        # Empty list rather than raising -- the TypeScript contract
+        # returns string[], and "no scoped folders" is a valid honest
+        # answer for an adapter without folder support.
+        return []
+
+
+__all__ = [
+    "CapabilitySet",
+    "DocumentRef",
+    "FilevineDocumentStorage",
+    "FilevinePracticeManagement",
+    "HealthStatus",
+    "Matter",
+    "MatterNoteRef",
+    "StoredDocument",
+]

--- a/ai-employee/connectors/filevine/client.py
+++ b/ai-employee/connectors/filevine/client.py
@@ -1,0 +1,367 @@
+"""Filevine REST API client -- thin async HTTP wrapper.
+
+Endpoints used (Filevine API v2; https://developer.filevine.io/):
+
+* ``GET  /core/projects?orgUid=<org>&...``         -- list matters
+* ``GET  /core/projects/{projectId}``              -- get matter
+* ``GET  /core/projects/{projectId}/documents``    -- list matter documents
+* ``GET  /core/documents/{documentId}``            -- get document metadata
+* ``GET  /core/documents/{documentId}/download``   -- download document bytes
+* ``POST /core/projects/{projectId}/notes``        -- create matter note (draft body, reviewer attribution)
+
+Filevine project = matter, in capability vocabulary.
+
+The client never invents fields. Every method maps Filevine's response
+verbatim into the capability shape. Missing fields are returned as
+``None`` so the conformance harness's NO_FIELD_FABRICATION invariant
+holds.
+
+This module deliberately does not import the capability adapters
+themselves -- `capabilities.py` imports this client. Keeping the HTTP
+layer separable from the capability adapters lets tests exercise either
+in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+try:  # pragma: no cover -- httpx is required in production but not in unit tests
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+from .auth import FilevineAuthProvider
+from .errors import AdapterError
+
+
+# Filevine REST API base URL (production). Filevine does not document a
+# distinct sandbox host -- tenants are sandbox-or-prod via org config. The
+# smoke-test script in `bin/smoke-test-filevine.py` accepts a base URL
+# override so a test tenant can be exercised.
+PROD_API_BASE = "https://api.filevine.io"
+
+# Capability constant -- the client is used by both PracticeManagement
+# and DocumentStorage adapters, so the wrap-vendor-error helper accepts
+# the capability at call time rather than baking it in.
+ADAPTER_SLUG = "filevine"
+
+
+class FilevineClient:
+    """Async HTTP client over the Filevine REST API.
+
+    One instance per customer per Hermes Machine. The client holds:
+
+    * an `httpx.AsyncClient` for connection pooling,
+    * a `FilevineAuthProvider` for token acquisition.
+
+    All public methods return raw Filevine JSON (a `dict[str, Any]` or
+    `list[...]`). The capability adapters in `capabilities.py` translate
+    those into capability shapes.
+    """
+
+    def __init__(
+        self,
+        *,
+        auth: FilevineAuthProvider,
+        http: Any = None,
+        base_url: str = PROD_API_BASE,
+    ) -> None:
+        if http is None:
+            if httpx is None:  # pragma: no cover
+                raise RuntimeError(
+                    "FilevineClient requires httpx; install ai-employee[connector] extras"
+                )
+            http = httpx.AsyncClient(base_url=base_url, timeout=30.0)
+        self._auth = auth
+        self._http = http
+        self._base_url = base_url
+
+    @property
+    def org_slug(self) -> str:
+        return self._auth.org_slug()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        capability: str,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[dict[str, Any]] = None,
+        as_bytes: bool = False,
+    ) -> Any:
+        """Issue an authorized request and translate transport errors.
+
+        Translates HTTP status codes into the capability layer's typed
+        `AdapterError` codes per the contract:
+
+        * 401 -> ``unauthorized``
+        * 403 -> ``scope_violation`` (Filevine's "access denied")
+        * 404 -> caller decides (the client returns ``None``)
+        * 422 -> ``validation_failed``
+        * 429 -> ``rate_limited``
+        * 5xx -> ``transient``
+        * network exception -> ``transient``
+
+        The 404 case is special: the conformance contract says
+        `get_*` methods return ``None`` for absent records, so the
+        client surfaces 404 by returning ``None`` rather than raising.
+        Callers that distinguish semantic-distinct absence (parent
+        deleted, etc.) translate that on their side.
+        """
+        try:
+            token = await self._auth.get_valid_token()
+        except Exception as exc:  # noqa: BLE001 -- wrap any auth failure
+            raise AdapterError(
+                code="unauthorized",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message="Filevine auth provider could not return a valid token",
+                cause=exc,
+            ) from exc
+
+        headers = {
+            "Authorization": token.authorization_header(),
+            "Accept": "application/octet-stream" if as_bytes else "application/json",
+        }
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+
+        try:
+            resp = await self._http.request(
+                method,
+                path,
+                params=params,
+                json=json_body,
+                headers=headers,
+            )
+        except Exception as exc:  # noqa: BLE001 -- wrap network errors
+            raise AdapterError(
+                code="transient",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine HTTP {method} {path} raised a transport error",
+                cause=exc,
+            ) from exc
+
+        status = resp.status_code
+        if status == 200 or status == 201:
+            if as_bytes:
+                # httpx exposes raw bytes via .content
+                return resp.content
+            try:
+                return resp.json()
+            except Exception as exc:  # noqa: BLE001 -- bad JSON from vendor
+                raise AdapterError(
+                    code="unknown",
+                    capability=capability,
+                    adapter=ADAPTER_SLUG,
+                    message=f"Filevine returned non-JSON body for {method} {path}",
+                    cause=exc,
+                ) from exc
+        if status == 204:
+            return None
+        if status == 401:
+            raise AdapterError(
+                code="unauthorized",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine returned 401 for {method} {path}",
+            )
+        if status == 403:
+            raise AdapterError(
+                code="scope_violation",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine returned 403 for {method} {path}",
+            )
+        if status == 404:
+            # Caller decides -- most read methods translate to None.
+            return None
+        if status == 422:
+            raise AdapterError(
+                code="validation_failed",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine rejected {method} {path}: 422 validation_failed",
+            )
+        if status == 429:
+            raise AdapterError(
+                code="rate_limited",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine rate-limited {method} {path}",
+            )
+        if 500 <= status < 600:
+            raise AdapterError(
+                code="transient",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine returned {status} for {method} {path}",
+            )
+        raise AdapterError(
+            code="unknown",
+            capability=capability,
+            adapter=ADAPTER_SLUG,
+            message=f"Filevine returned unexpected status {status} for {method} {path}",
+        )
+
+    # ---------- Matter.Read ----------
+
+    async def list_projects(
+        self,
+        *,
+        capability: str,
+        client_name: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {
+            "orgUid": self.org_slug,
+            "limit": min(limit, 200),
+            "offset": offset,
+        }
+        if client_name:
+            params["clientName"] = client_name
+        if status:
+            params["status"] = status
+        body = await self._request(
+            "GET",
+            "/core/projects",
+            capability=capability,
+            params=params,
+        )
+        if body is None:
+            return []
+        items = body.get("items") if isinstance(body, dict) else body
+        return list(items) if isinstance(items, list) else []
+
+    async def get_project(
+        self, project_id: str, *, capability: str
+    ) -> Optional[dict[str, Any]]:
+        return await self._request(
+            "GET",
+            f"/core/projects/{project_id}",
+            capability=capability,
+        )
+
+    async def list_project_documents(
+        self, project_id: str, *, capability: str
+    ) -> list[dict[str, Any]]:
+        body = await self._request(
+            "GET",
+            f"/core/projects/{project_id}/documents",
+            capability=capability,
+        )
+        if body is None:
+            return []
+        items = body.get("items") if isinstance(body, dict) else body
+        return list(items) if isinstance(items, list) else []
+
+    # ---------- Matter.Note.Write (draft-as-note attributed to reviewer) ----------
+
+    async def create_project_note(
+        self,
+        project_id: str,
+        *,
+        capability: str,
+        body_text: str,
+        reviewer_account_id: str,
+        drafted_by_skill: str,
+    ) -> dict[str, Any]:
+        """Create a matter note.
+
+        Attribution per ADR 0005: the note's `authorAccountId` is the
+        reviewer's Filevine account, not the AI Employee. The
+        `metadata` carries `drafted_by_skill` for the audit trail. The
+        body is plain text; Filevine renders linkified text on read.
+        """
+        payload = {
+            "body": body_text,
+            "authorAccountId": reviewer_account_id,
+            "metadata": {
+                "drafted_by_skill": drafted_by_skill,
+                "draft": True,
+            },
+        }
+        result = await self._request(
+            "POST",
+            f"/core/projects/{project_id}/notes",
+            capability=capability,
+            json_body=payload,
+        )
+        if result is None:
+            raise AdapterError(
+                code="unknown",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine returned empty body for note POST on project {project_id}",
+            )
+        return result
+
+    # ---------- Document.Read ----------
+
+    async def get_document(
+        self, document_id: str, *, capability: str
+    ) -> Optional[dict[str, Any]]:
+        return await self._request(
+            "GET",
+            f"/core/documents/{document_id}",
+            capability=capability,
+        )
+
+    async def download_document(
+        self, document_id: str, *, capability: str
+    ) -> bytes:
+        result = await self._request(
+            "GET",
+            f"/core/documents/{document_id}/download",
+            capability=capability,
+            as_bytes=True,
+        )
+        if result is None:
+            raise AdapterError(
+                code="not_found",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine has no bytes for document {document_id}",
+            )
+        if not isinstance(result, (bytes, bytearray)):
+            raise AdapterError(
+                code="unknown",
+                capability=capability,
+                adapter=ADAPTER_SLUG,
+                message=f"Filevine returned non-bytes payload for document {document_id}",
+            )
+        return bytes(result)
+
+    # ---------- Health check ----------
+
+    async def ping(self, *, capability: str) -> bool:
+        """Lightweight health probe.
+
+        Filevine has no dedicated health endpoint; the cheapest probe
+        is a 0-limit list call which exercises auth + transport without
+        materializing data. Returns True on 200, raises on 401/transient.
+        """
+        await self._request(
+            "GET",
+            "/core/projects",
+            capability=capability,
+            params={"orgUid": self.org_slug, "limit": 0},
+        )
+        return True
+
+    async def aclose(self) -> None:
+        close = getattr(self._http, "aclose", None)
+        if close is not None:
+            await close()
+
+
+__all__ = [
+    "ADAPTER_SLUG",
+    "PROD_API_BASE",
+    "FilevineClient",
+]

--- a/ai-employee/connectors/filevine/errors.py
+++ b/ai-employee/connectors/filevine/errors.py
@@ -1,0 +1,122 @@
+"""Adapter error contract -- Python mirror of `AdapterError` from
+`src/lib/ai-employee/capabilities/types.ts`.
+
+Per ADR 0006 invariant TYPED_ERRORS: adapters only raise `AdapterError`
+with codes drawn from the closed `AdapterErrorCode` union. Vendor
+exceptions are wrapped in `cause`, never re-raised raw. Skill code
+switches on `code`, not on `message`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+
+AdapterErrorCode = Literal[
+    "not_found",
+    "unauthorized",
+    "rate_limited",
+    "transient",
+    "capability_not_supported",
+    "scope_violation",
+    "fabrication_blocked",
+    "validation_failed",
+    "unknown",
+]
+
+
+ADAPTER_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "not_found",
+        "unauthorized",
+        "rate_limited",
+        "transient",
+        "capability_not_supported",
+        "scope_violation",
+        "fabrication_blocked",
+        "validation_failed",
+        "unknown",
+    }
+)
+
+
+CAPABILITY_NAMES: frozenset[str] = frozenset(
+    {
+        "PracticeManagement",
+        "Email",
+        "Calendar",
+        "DocumentStorage",
+        "ESign",
+        "CourtAccess",
+        "Payments",
+        "Accounting",
+        "IntakeCRM",
+        "CallTracking",
+        "InternalComms",
+    }
+)
+
+
+class AdapterError(Exception):
+    """Canonical error raised by capability adapters.
+
+    Mirrors `class AdapterError extends Error` in
+    `src/lib/ai-employee/capabilities/types.ts`. Skill code switches on
+    `.code` rather than `.message` or the exception type chain.
+
+    Parameters
+    ----------
+    code:
+        One of `AdapterErrorCode`. Validated against the closed union;
+        unrecognized codes raise `ValueError` at construction time so
+        adapters cannot drift the contract.
+    capability:
+        Capability name this adapter implements (e.g. ``"PracticeManagement"``).
+    adapter:
+        Adapter slug (e.g. ``"filevine"``).
+    message:
+        Human-readable detail. Logged; never surfaced verbatim to end-users.
+    cause:
+        Optional original vendor exception. Recorded for the audit log,
+        never re-raised raw.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        capability: str,
+        adapter: str,
+        message: str,
+        cause: Optional[BaseException] = None,
+    ) -> None:
+        if code not in ADAPTER_ERROR_CODES:
+            raise ValueError(
+                f"AdapterError code {code!r} not in closed union; "
+                "update both this constant and src/lib/ai-employee/capabilities/types.ts"
+            )
+        if capability not in CAPABILITY_NAMES:
+            raise ValueError(
+                f"AdapterError capability {capability!r} not in CapabilityName union"
+            )
+        super().__init__(message)
+        self.code = code
+        self.capability = capability
+        self.adapter = adapter
+        # `cause` is intentionally a distinct attribute from Python's
+        # built-in `__cause__` -- the latter is set by `raise ... from`,
+        # the former is what audit-logging consumers read.
+        self.cause = cause
+
+    def __repr__(self) -> str:  # pragma: no cover -- debug helper
+        return (
+            f"AdapterError(code={self.code!r}, capability={self.capability!r}, "
+            f"adapter={self.adapter!r}, message={self.args[0]!r})"
+        )
+
+
+__all__ = [
+    "ADAPTER_ERROR_CODES",
+    "CAPABILITY_NAMES",
+    "AdapterError",
+    "AdapterErrorCode",
+]

--- a/ai-employee/connectors/filevine/tests/_helpers.py
+++ b/ai-employee/connectors/filevine/tests/_helpers.py
@@ -1,0 +1,131 @@
+"""Test helpers shared across the Filevine connector test suite.
+
+Helpers live in this module rather than `conftest.py` so they can be
+imported by name from each test file. (Pytest's `conftest.py` is
+auto-discovered for fixtures, but plain functions imported from it
+require the `tests` package to be import-resolvable from the rootdir,
+which is brittle when the suite is invoked from different working
+directories.)
+
+Provides:
+
+* `FakeHttpClient` -- minimal `httpx.AsyncClient` stand-in (records
+  calls, replays canned responses).
+* `FakeResponse` -- minimal `httpx.Response` stand-in.
+* `RecordedCall` -- what `FakeHttpClient` captures per request.
+* `make_client` -- convenience constructor wiring a `FilevineClient`
+  with `InMemoryFilevineAuth` + `FakeHttpClient`.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+_HERE = Path(__file__).resolve()
+# Make `ai-employee/` importable so `from connectors.filevine import ...` works.
+sys.path.insert(0, str(_HERE.parents[3]))
+
+from connectors.filevine import (  # noqa: E402
+    FilevineClient,
+    InMemoryFilevineAuth,
+    TokenSet,
+)
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    json_body: Optional[Any] = None
+    content: bytes = b""
+
+    def json(self) -> Any:
+        if self.json_body is None:
+            raise ValueError("FakeResponse has no json_body")
+        return self.json_body
+
+
+@dataclass
+class RecordedCall:
+    method: str
+    path: str
+    params: Optional[dict[str, Any]]
+    json: Optional[dict[str, Any]]
+    headers: dict[str, str]
+
+
+@dataclass
+class FakeHttpClient:
+    """Minimal `httpx.AsyncClient` stand-in.
+
+    The connector calls only `request(method, path, params=, json=, headers=)`.
+    """
+
+    responses: dict[tuple[str, str], FakeResponse] = field(default_factory=dict)
+    default_response: Optional[FakeResponse] = None
+    calls: list[RecordedCall] = field(default_factory=list)
+    raise_on_request: Optional[Exception] = None
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json: Optional[dict[str, Any]] = None,
+        headers: Optional[dict[str, str]] = None,
+    ) -> FakeResponse:
+        self.calls.append(
+            RecordedCall(
+                method=method,
+                path=path,
+                params=dict(params) if params else None,
+                json=dict(json) if json else None,
+                headers=dict(headers) if headers else {},
+            )
+        )
+        if self.raise_on_request is not None:
+            raise self.raise_on_request
+        key = (method.upper(), path)
+        resp = self.responses.get(key)
+        if resp is None:
+            if self.default_response is None:
+                raise AssertionError(
+                    f"FakeHttpClient has no canned response for {method} {path} "
+                    f"(known: {sorted(self.responses)})"
+                )
+            return self.default_response
+        return resp
+
+    async def aclose(self) -> None:
+        pass
+
+
+def make_client(
+    *,
+    responses: Optional[dict[tuple[str, str], FakeResponse]] = None,
+    org_slug: str = "example-firm",
+    token: Optional[TokenSet] = None,
+    raise_on_request: Optional[Exception] = None,
+) -> tuple[FilevineClient, FakeHttpClient, InMemoryFilevineAuth]:
+    """Construct a `FilevineClient` with a fake HTTP + in-memory auth."""
+    fake_http = FakeHttpClient(
+        responses=responses or {}, raise_on_request=raise_on_request
+    )
+    auth = InMemoryFilevineAuth(
+        token=token
+        or TokenSet(
+            access_token="test-access",
+            refresh_token="test-refresh",
+            expires_at=time.time() + 3600,
+        ),
+        org_slug=org_slug,
+    )
+    client = FilevineClient(auth=auth, http=fake_http)
+    return client, fake_http, auth
+
+
+__all__ = ["FakeHttpClient", "FakeResponse", "RecordedCall", "make_client"]

--- a/ai-employee/connectors/filevine/tests/conftest.py
+++ b/ai-employee/connectors/filevine/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest config -- extend sys.path so `connectors.filevine` and the
+sibling `_helpers` module are importable when the suite is invoked from
+either `ai-employee/` or the repo root.
+
+Test helpers (`FakeHttpClient`, `make_client`, etc.) live in `_helpers.py`
+rather than this module so test files can import them as plain functions
+without depending on pytest fixture autodiscovery semantics.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+# Make `ai-employee/` importable -> `from connectors.filevine import ...`
+sys.path.insert(0, str(_HERE.parents[3]))
+# Make the `tests/` dir importable -> `from _helpers import ...`
+sys.path.insert(0, str(_HERE.parent))

--- a/ai-employee/connectors/filevine/tests/test_capabilities.py
+++ b/ai-employee/connectors/filevine/tests/test_capabilities.py
@@ -1,0 +1,419 @@
+"""Unit tests for the Filevine capability adapters.
+
+Covers:
+
+* CapabilitySet shape -- capability name, supported/unsupported method
+  declarations, field_coverage disclosure
+* Matter.Read happy paths (`search_matters`, `get_matter`,
+  `list_matter_documents`)
+* Matter.Note.Write attribution (reviewer, not "AI Employee")
+* Document.Read (`list_documents`, `get_document`, `get_document_bytes`)
+* Unsupported methods raise `capability_not_supported` (UNSUPPORTED_METHODS_THROW)
+* `get_matter` returns None on 404 (NULL_FOR_ABSENT)
+* No vendor field invention (NO_FIELD_FABRICATION) -- vendor JSON with
+  missing fields produces None / "" rather than synthesized values
+* Status-vocabulary mapping is inverse-consistent
+* No banned methods on either adapter (NO_AUTONOMOUS_EXTERNAL_SEND)
+
+Tests use the FakeHttpClient from conftest; no real network calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from connectors.filevine import (  # type: ignore[import-not-found]
+    AdapterError,
+    FilevineDocumentStorage,
+    FilevinePracticeManagement,
+)
+from connectors.filevine.capabilities import (  # type: ignore[import-not-found]
+    _FILEVINE_STATUS_MAP,
+)
+
+from _helpers import FakeResponse, make_client  # type: ignore[import-not-found]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures -- sample Filevine response payloads
+# ---------------------------------------------------------------------------
+
+
+PROJECT_ROW = {
+    "projectId": "proj-123",
+    "clientName": "Smith, John",
+    "projectTypeCode": "PI-Auto",
+    "status": "Open",
+    "createdDate": "2026-01-15T10:30:00Z",
+    "closedDate": None,
+    "primaryAttorneyAccountId": "user-attorney-99",
+    "incidentDate": "2025-11-04",
+}
+
+PROJECT_ROW_VENDOR_UNKNOWN_STATUS = {
+    "projectId": "proj-789",
+    "clientName": "Doe, Jane",
+    "projectTypeCode": "PI-Slip",
+    "status": "Stalled",  # not in _FILEVINE_STATUS_MAP
+    "createdDate": "2026-02-10T08:00:00Z",
+    "closedDate": None,
+}
+
+DOCUMENT_ROW = {
+    "documentId": "doc-555",
+    "projectId": "proj-123",
+    "filename": "police-report.pdf",
+    "mimeType": "application/pdf",
+    "sizeBytes": 184320,
+    "uploadDate": "2026-01-18T14:22:00Z",
+    "uploadedByAccountId": "user-paralegal-12",
+    "currentVersionId": "v3",
+    "modifiedDate": "2026-02-01T09:15:00Z",
+    "modifiedByAccountId": "user-attorney-99",
+}
+
+NOTE_RESPONSE = {
+    "noteId": "note-7777",
+    "projectId": "proj-123",
+    "createdDate": "2026-05-21T17:00:00Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# PracticeManagement
+# ---------------------------------------------------------------------------
+
+
+def test_pm_describe_capabilities_is_honest():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    cs = pm.describe_capabilities()
+    assert cs.capability == "PracticeManagement"
+    assert cs.adapter == "filevine"
+    assert "search_matters" in cs.supported_methods
+    assert "get_matter" in cs.supported_methods
+    assert "list_matter_documents" in cs.supported_methods
+    assert "create_note" in cs.supported_methods
+    # Unsupported methods must not appear in supported_methods (disjoint).
+    assert set(cs.supported_methods).isdisjoint(set(cs.unsupported_methods))
+    # Filevine v1 explicitly does NOT support these.
+    for missing in (
+        "create_matter",
+        "update_matter",
+        "search_contacts",
+        "list_time_entries",
+        "upload_matter_document",
+    ):
+        assert missing in cs.unsupported_methods
+
+
+def test_pm_search_matters_returns_typed_matters():
+    responses = {
+        ("GET", "/core/projects"): FakeResponse(
+            status_code=200,
+            json_body={"items": [PROJECT_ROW]},
+        ),
+    }
+    client, fake_http, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    matters = asyncio.run(pm.search_matters(limit=5))
+
+    assert len(matters) == 1
+    m = matters[0]
+    assert m.id == "proj-123"
+    assert m.client_name == "Smith, John"
+    assert m.matter_type == "PI-Auto"
+    assert m.status == "open"
+    assert m.opened_at == "2026-01-15T10:30:00Z"
+    assert m.closed_at is None
+    # Custom fields preserved verbatim
+    assert m.custom_fields["primaryAttorneyAccountId"] == "user-attorney-99"
+    assert m.custom_fields["incidentDate"] == "2025-11-04"
+    # Filter applied to query
+    call = fake_http.calls[0]
+    assert call.params["orgUid"] == "example-firm"
+    assert call.params["limit"] == 5
+
+
+def test_pm_search_matters_validation_failed_on_unknown_status():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.search_matters(status="bogus"))
+    assert exc.value.code == "validation_failed"
+    assert exc.value.capability == "PracticeManagement"
+
+
+def test_pm_search_matters_translates_status_to_vendor_vocabulary():
+    responses = {
+        ("GET", "/core/projects"): FakeResponse(
+            status_code=200,
+            json_body={"items": []},
+        ),
+    }
+    client, fake_http, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    asyncio.run(pm.search_matters(status="closed"))
+    assert fake_http.calls[0].params["status"] == "Closed"
+
+
+def test_pm_search_matters_preserves_unknown_vendor_status_in_custom_fields():
+    responses = {
+        ("GET", "/core/projects"): FakeResponse(
+            status_code=200,
+            json_body={"items": [PROJECT_ROW_VENDOR_UNKNOWN_STATUS]},
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    matters = asyncio.run(pm.search_matters())
+    m = matters[0]
+    # Unknown vendor status falls back to "open" per the comment in
+    # _matter_from_project, but the raw is preserved.
+    assert m.status == "open"
+    assert m.custom_fields["_vendor_status_raw"] == "Stalled"
+
+
+def test_pm_get_matter_returns_none_on_404():
+    responses = {
+        ("GET", "/core/projects/missing"): FakeResponse(status_code=404),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    result = asyncio.run(pm.get_matter("missing"))
+    assert result is None  # NULL_FOR_ABSENT invariant
+
+
+def test_pm_get_matter_happy_path():
+    responses = {
+        ("GET", "/core/projects/proj-123"): FakeResponse(
+            status_code=200, json_body=PROJECT_ROW
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    m = asyncio.run(pm.get_matter("proj-123"))
+    assert m is not None
+    assert m.id == "proj-123"
+
+
+def test_pm_list_matter_documents_maps_each_row():
+    responses = {
+        ("GET", "/core/projects/proj-123/documents"): FakeResponse(
+            status_code=200,
+            json_body={"items": [DOCUMENT_ROW]},
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    docs = asyncio.run(pm.list_matter_documents("proj-123"))
+    assert len(docs) == 1
+    d = docs[0]
+    assert d.id == "doc-555"
+    assert d.matter_id == "proj-123"
+    assert d.filename == "police-report.pdf"
+    assert d.size_bytes == 184320
+    assert d.uploaded_by == "user-paralegal-12"
+
+
+def test_pm_create_note_attributes_to_reviewer_not_persona():
+    responses = {
+        ("POST", "/core/projects/proj-123/notes"): FakeResponse(
+            status_code=201, json_body=NOTE_RESPONSE
+        ),
+    }
+    client, fake_http, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    note = asyncio.run(
+        pm.create_note(
+            "proj-123",
+            content="Status update: deposition scheduled 2026-06-10.",
+            reviewer_account_id="user-attorney-99",
+            drafted_by_skill="law-client-status-update",
+        )
+    )
+    assert note.id == "note-7777"
+    assert note.author_account_id == "user-attorney-99"
+    assert note.drafted_by_skill == "law-client-status-update"
+    assert note.body == "Status update: deposition scheduled 2026-06-10."
+
+    # Vendor request reflects ADR 0005 attribution
+    call = fake_http.calls[0]
+    assert call.json["authorAccountId"] == "user-attorney-99"
+    # The persona is NOT in the note -- the body is the drafted content.
+    body_text = call.json["body"]
+    assert "AI Employee" not in body_text
+    assert "Marcus" not in body_text
+    # drafted_by_skill rides in metadata for the audit trail
+    assert call.json["metadata"]["drafted_by_skill"] == "law-client-status-update"
+    assert call.json["metadata"]["draft"] is True
+
+
+def test_pm_create_note_validates_required_fields():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    for kwargs in (
+        {"content": "", "reviewer_account_id": "r", "drafted_by_skill": "s"},
+        {"content": "x", "reviewer_account_id": "", "drafted_by_skill": "s"},
+        {"content": "x", "reviewer_account_id": "r", "drafted_by_skill": ""},
+    ):
+        with pytest.raises(AdapterError) as exc:
+            asyncio.run(pm.create_note("proj-123", **kwargs))
+        assert exc.value.code == "validation_failed"
+
+
+def test_pm_unsupported_methods_raise_capability_not_supported():
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+
+    for method in (
+        "create_matter",
+        "update_matter",
+        "search_contacts",
+        "get_contact",
+        "create_contact",
+        "list_time_entries",
+        "create_time_entry_draft",
+        "upload_matter_document",
+    ):
+        fn = getattr(pm, method)
+        with pytest.raises(AdapterError) as exc:
+            asyncio.run(fn())
+        assert exc.value.code == "capability_not_supported", (
+            f"{method} did not raise capability_not_supported"
+        )
+
+
+# ---------------------------------------------------------------------------
+# DocumentStorage
+# ---------------------------------------------------------------------------
+
+
+def test_ds_describe_capabilities():
+    client, _, _ = make_client()
+    ds = FilevineDocumentStorage(client)
+
+    cs = ds.describe_capabilities()
+    assert cs.capability == "DocumentStorage"
+    assert "list_documents" in cs.supported_methods
+    assert "get_document" in cs.supported_methods
+    assert "get_document_bytes" in cs.supported_methods
+    # Folder + share-draft surface unsupported in v1
+    for missing in (
+        "list_folder",
+        "upload_document",
+        "update_document",
+        "list_versions",
+        "share_document_draft",
+    ):
+        assert missing in cs.unsupported_methods
+
+
+def test_ds_list_documents_maps_with_synthesized_path():
+    responses = {
+        ("GET", "/core/projects/proj-123/documents"): FakeResponse(
+            status_code=200,
+            json_body={"items": [DOCUMENT_ROW]},
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    ds = FilevineDocumentStorage(client)
+
+    docs = asyncio.run(ds.list_documents("proj-123"))
+    assert len(docs) == 1
+    d = docs[0]
+    assert d.id == "doc-555"
+    assert d.filename == "police-report.pdf"
+    # Path is synthesized -- field_coverage.derived discloses this.
+    assert d.path == "projects/proj-123/police-report.pdf"
+    assert d.modified_by == "user-attorney-99"
+    assert d.current_version == "v3"
+
+
+def test_ds_get_document_returns_none_on_404():
+    responses = {
+        ("GET", "/core/documents/missing"): FakeResponse(status_code=404),
+    }
+    client, _, _ = make_client(responses=responses)
+    ds = FilevineDocumentStorage(client)
+
+    assert asyncio.run(ds.get_document("missing")) is None
+
+
+def test_ds_get_document_bytes_returns_raw_bytes():
+    responses = {
+        ("GET", "/core/documents/doc-555/download"): FakeResponse(
+            status_code=200, content=b"%PDF-1.5\nfake-content"
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    ds = FilevineDocumentStorage(client)
+
+    blob = asyncio.run(ds.get_document_bytes("doc-555"))
+    assert isinstance(blob, bytes)
+    assert blob.startswith(b"%PDF")
+
+
+def test_ds_get_document_bytes_404_raises_not_found():
+    responses = {
+        ("GET", "/core/documents/missing/download"): FakeResponse(status_code=404),
+    }
+    client, _, _ = make_client(responses=responses)
+    ds = FilevineDocumentStorage(client)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(ds.get_document_bytes("missing"))
+    assert exc.value.code == "not_found"
+
+
+def test_ds_unsupported_methods_raise():
+    client, _, _ = make_client()
+    ds = FilevineDocumentStorage(client)
+
+    for method in (
+        "list_folder",
+        "upload_document",
+        "update_document",
+        "list_versions",
+        "download_version",
+        "share_document_draft",
+    ):
+        fn = getattr(ds, method)
+        with pytest.raises(AdapterError) as exc:
+            asyncio.run(fn())
+        assert exc.value.code == "capability_not_supported", (
+            f"{method} did not raise capability_not_supported"
+        )
+
+
+def test_ds_get_scoped_folders_returns_empty_not_raises():
+    client, _, _ = make_client()
+    ds = FilevineDocumentStorage(client)
+    assert ds.get_scoped_folders() == []
+
+
+# ---------------------------------------------------------------------------
+# Status map sanity -- the inverse mapping used in search_matters must be
+# bijective so callers can round-trip statuses without ambiguity.
+# ---------------------------------------------------------------------------
+
+
+def test_status_map_is_bijective():
+    inverse = {v: k for k, v in _FILEVINE_STATUS_MAP.items()}
+    assert len(inverse) == len(_FILEVINE_STATUS_MAP), (
+        "Two Filevine vendor statuses map to the same capability status; "
+        "the inverse used in search_matters would lose data."
+    )

--- a/ai-employee/connectors/filevine/tests/test_client.py
+++ b/ai-employee/connectors/filevine/tests/test_client.py
@@ -1,0 +1,190 @@
+"""Unit tests for the Filevine HTTP client error translation.
+
+Covers the HTTP-status-to-AdapterError-code translation table in
+`FilevineClient._request`:
+
+* 401 -> ``unauthorized``
+* 403 -> ``scope_violation``
+* 404 -> caller-translates (None)
+* 422 -> ``validation_failed``
+* 429 -> ``rate_limited``
+* 5xx -> ``transient``
+* network exception -> ``transient``
+* auth-provider failure -> ``unauthorized``
+
+Plus:
+
+* Bearer token + Accept header propagation
+* Non-JSON 200 -> ``unknown``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from connectors.filevine import AdapterError, TokenSet  # type: ignore[import-not-found]
+from connectors.filevine.auth import (  # type: ignore[import-not-found]
+    InMemoryFilevineAuth,
+)
+
+from _helpers import FakeResponse, make_client  # type: ignore[import-not-found]
+
+
+# ---------------------------------------------------------------------------
+# Status code translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status, expected_code",
+    [
+        (401, "unauthorized"),
+        (403, "scope_violation"),
+        (422, "validation_failed"),
+        (429, "rate_limited"),
+        (500, "transient"),
+        (502, "transient"),
+        (503, "transient"),
+        (599, "transient"),
+        (418, "unknown"),  # any unmapped 4xx -> unknown
+    ],
+)
+def test_request_translates_status_to_typed_error(status, expected_code):
+    responses = {("GET", "/core/projects"): FakeResponse(status_code=status)}
+    client, _, _ = make_client(responses=responses)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            client._request(
+                "GET", "/core/projects", capability="PracticeManagement"
+            )
+        )
+    assert exc.value.code == expected_code
+    assert exc.value.capability == "PracticeManagement"
+    assert exc.value.adapter == "filevine"
+
+
+def test_request_404_returns_none_not_raises():
+    responses = {("GET", "/core/projects/missing"): FakeResponse(status_code=404)}
+    client, _, _ = make_client(responses=responses)
+
+    result = asyncio.run(
+        client._request(
+            "GET", "/core/projects/missing", capability="PracticeManagement"
+        )
+    )
+    assert result is None
+
+
+def test_request_network_error_wrapped_as_transient():
+    client, _, _ = make_client(raise_on_request=ConnectionError("dns failed"))
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            client._request("GET", "/core/projects", capability="PracticeManagement")
+        )
+    assert exc.value.code == "transient"
+    assert isinstance(exc.value.cause, ConnectionError)
+
+
+def test_request_auth_failure_wrapped_as_unauthorized():
+    expired = TokenSet(
+        access_token="x",
+        refresh_token="y",
+        expires_at=time.time() - 100,  # already expired
+    )
+    client, _, _ = make_client(token=expired)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            client._request("GET", "/core/projects", capability="PracticeManagement")
+        )
+    assert exc.value.code == "unauthorized"
+    assert exc.value.cause is not None
+
+
+def test_request_propagates_bearer_token_and_accept_header():
+    responses = {("GET", "/core/projects"): FakeResponse(status_code=200, json_body={"items": []})}
+    client, fake_http, _ = make_client(responses=responses)
+
+    asyncio.run(
+        client._request("GET", "/core/projects", capability="PracticeManagement")
+    )
+    headers = fake_http.calls[0].headers
+    assert headers["Authorization"] == "Bearer test-access"
+    assert headers["Accept"] == "application/json"
+
+
+def test_request_uses_octet_stream_for_bytes_path():
+    responses = {("GET", "/core/documents/d/download"): FakeResponse(status_code=200, content=b"abc")}
+    client, fake_http, _ = make_client(responses=responses)
+
+    body = asyncio.run(
+        client._request(
+            "GET",
+            "/core/documents/d/download",
+            capability="DocumentStorage",
+            as_bytes=True,
+        )
+    )
+    assert body == b"abc"
+    headers = fake_http.calls[0].headers
+    assert headers["Accept"] == "application/octet-stream"
+
+
+def test_request_non_json_200_raises_unknown():
+    class BadResponse(FakeResponse):
+        def json(self):  # type: ignore[override]
+            raise ValueError("not json")
+
+    responses = {("GET", "/core/projects"): BadResponse(status_code=200)}
+    client, _, _ = make_client(responses=responses)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            client._request("GET", "/core/projects", capability="PracticeManagement")
+        )
+    assert exc.value.code == "unknown"
+
+
+def test_request_post_with_json_body_sets_content_type():
+    responses = {
+        ("POST", "/core/projects/p/notes"): FakeResponse(
+            status_code=201, json_body={"noteId": "n1"}
+        )
+    }
+    client, fake_http, _ = make_client(responses=responses)
+
+    asyncio.run(
+        client._request(
+            "POST",
+            "/core/projects/p/notes",
+            capability="PracticeManagement",
+            json_body={"body": "hi"},
+        )
+    )
+    headers = fake_http.calls[0].headers
+    assert headers["Content-Type"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# org_slug + ping
+# ---------------------------------------------------------------------------
+
+
+def test_client_org_slug_proxies_to_auth_provider():
+    client, _, auth = make_client(org_slug="kelly-law")
+    assert client.org_slug == "kelly-law"
+
+
+def test_ping_issues_minimal_list_call_and_returns_true():
+    responses = {("GET", "/core/projects"): FakeResponse(status_code=200, json_body={"items": []})}
+    client, fake_http, _ = make_client(responses=responses)
+
+    assert asyncio.run(client.ping(capability="PracticeManagement")) is True
+    call = fake_http.calls[0]
+    assert call.params["limit"] == 0
+    assert call.params["orgUid"] == "example-firm"

--- a/ai-employee/connectors/filevine/tests/test_conformance.py
+++ b/ai-employee/connectors/filevine/tests/test_conformance.py
@@ -1,0 +1,242 @@
+"""Conformance checks -- Python mirror of the harness in
+`src/lib/ai-employee/capabilities/conformance.ts`.
+
+The TypeScript harness inspects an adapter and asserts the eight
+invariants:
+
+* CAPABILITY_SET_HONEST
+* NULL_FOR_ABSENT
+* TYPED_ERRORS
+* NO_AUTONOMOUS_EXTERNAL_SEND
+* NO_AUTONOMOUS_TRUST_TRANSFER (N/A for non-Payments)
+* HEALTH_CHECK_BOUNDED
+* UNSUPPORTED_METHODS_THROW
+* NO_FIELD_FABRICATION
+
+Because the Python adapter lives in a different language, we cannot
+share the harness instance directly. This test module asserts the
+same invariants against the Python adapters so the cross-language
+contract holds end-to-end.
+
+The banned-name lists below MUST stay in sync with `BANNED_METHOD_NAMES`
+in conformance.ts. A drift between the two languages is a P0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+
+import pytest
+
+from connectors.filevine import (  # type: ignore[import-not-found]
+    AdapterError,
+    FilevineDocumentStorage,
+    FilevinePracticeManagement,
+)
+from connectors.filevine.errors import (  # type: ignore[import-not-found]
+    CAPABILITY_NAMES,
+)
+
+from _helpers import FakeResponse, make_client  # type: ignore[import-not-found]
+
+
+# Pinned from `BANNED_METHOD_NAMES` in conformance.ts.
+BANNED_METHOD_NAMES = {
+    "Email": ["send", "send_message", "send_draft", "send_email"],
+    "Calendar": ["send_invitation", "send_invite", "send_event"],
+    "ESign": [
+        "send_envelope",
+        "create_and_send_envelope",
+        "send_signing_request",
+        "initiate_signing",
+    ],
+    "DocumentStorage": ["share_document", "send_share_invitation"],
+    "Payments": [
+        "send_payment_request",
+        "initiate_transfer",
+        "trust_disbursement",
+        "transfer_funds",
+        "disburse",
+    ],
+    "Accounting": ["post_invoice", "post_expense_entry", "post_to_general_ledger"],
+    "IntakeCRM": ["send_to_lead", "send_lead_email", "message_lead"],
+    "CourtAccess": ["file_document", "submit_filing", "send_to_court"],
+    "CallTracking": [
+        "create_call",
+        "originate_call",
+        "place_call",
+        "send_text",
+        "send_sms",
+    ],
+    "InternalComms": [],
+    "PracticeManagement": [],
+}
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [FilevinePracticeManagement, FilevineDocumentStorage],
+)
+def test_adapter_has_no_banned_method_names(ctor):
+    """NO_AUTONOMOUS_EXTERNAL_SEND + NO_AUTONOMOUS_TRUST_TRANSFER."""
+    client, _, _ = make_client()
+    adapter = ctor(client)
+    cs = adapter.describe_capabilities()
+
+    banned = BANNED_METHOD_NAMES.get(cs.capability, [])
+    present = [name for name in banned if hasattr(adapter, name)]
+    assert present == [], (
+        f"{cs.adapter}/{cs.capability} exposes banned method(s) {present}. "
+        "See CONFORMANCE_INVARIANTS.NO_AUTONOMOUS_EXTERNAL_SEND."
+    )
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [FilevinePracticeManagement, FilevineDocumentStorage],
+)
+def test_capability_set_well_formed(ctor):
+    """CAPABILITY_SET_HONEST shape checks."""
+    client, _, _ = make_client()
+    adapter = ctor(client)
+    cs = adapter.describe_capabilities()
+    assert cs.adapter, "CapabilitySet.adapter must be non-empty"
+    assert cs.version, "CapabilitySet.version must be non-empty"
+    assert cs.supported_methods, "supported_methods must declare at least one method"
+    # supported and unsupported are disjoint
+    overlap = set(cs.supported_methods) & set(cs.unsupported_methods)
+    assert not overlap, f"supported/unsupported overlap: {overlap}"
+    # The declared capability is one of the eleven known capabilities.
+    assert cs.capability in CAPABILITY_NAMES
+
+
+def test_pm_declared_unsupported_actually_throw():
+    """UNSUPPORTED_METHODS_THROW for PracticeManagement."""
+    client, _, _ = make_client()
+    pm = FilevinePracticeManagement(client)
+    cs = pm.describe_capabilities()
+
+    for name in cs.unsupported_methods:
+        fn = getattr(pm, name, None)
+        if fn is None:
+            # Not defined at all is acceptable -- the harness only
+            # asserts that defined-but-unsupported methods throw.
+            continue
+        # Call with no args / kwargs since unsupported methods accept
+        # *args/**kwargs and throw before validating anything.
+        if inspect.iscoroutinefunction(fn):
+            with pytest.raises(AdapterError) as exc:
+                asyncio.run(fn())
+            assert exc.value.code == "capability_not_supported"
+
+
+def test_ds_declared_unsupported_actually_throw():
+    """UNSUPPORTED_METHODS_THROW for DocumentStorage."""
+    client, _, _ = make_client()
+    ds = FilevineDocumentStorage(client)
+    cs = ds.describe_capabilities()
+    for name in cs.unsupported_methods:
+        fn = getattr(ds, name, None)
+        if fn is None:
+            continue
+        if inspect.iscoroutinefunction(fn):
+            with pytest.raises(AdapterError) as exc:
+                asyncio.run(fn())
+            assert exc.value.code == "capability_not_supported"
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [FilevinePracticeManagement, FilevineDocumentStorage],
+)
+def test_health_check_bounded(ctor):
+    """HEALTH_CHECK_BOUNDED -- health_check resolves within 5 seconds.
+
+    The Filevine ping is a 0-limit list call; with the fake HTTP it
+    resolves immediately. The bound is asserted as a wall-clock
+    measurement to catch accidental blocking.
+    """
+    responses = {
+        ("GET", "/core/projects"): FakeResponse(
+            status_code=200, json_body={"items": []}
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    adapter = ctor(client)
+
+    start = time.monotonic()
+    health = asyncio.run(adapter.health_check())
+    elapsed = time.monotonic() - start
+    assert elapsed < 5.0, f"health_check took {elapsed}s"
+    assert health.status in ("healthy", "degraded", "unhealthy")
+
+
+def test_null_for_absent_pm():
+    """NULL_FOR_ABSENT -- get_matter on 404 returns None, not raises."""
+    responses = {("GET", "/core/projects/missing"): FakeResponse(status_code=404)}
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+    assert asyncio.run(pm.get_matter("missing")) is None
+
+
+def test_null_for_absent_ds():
+    """NULL_FOR_ABSENT -- get_document on 404 returns None, not raises."""
+    responses = {("GET", "/core/documents/missing"): FakeResponse(status_code=404)}
+    client, _, _ = make_client(responses=responses)
+    ds = FilevineDocumentStorage(client)
+    assert asyncio.run(ds.get_document("missing")) is None
+
+
+def test_typed_errors_only_use_closed_code_union():
+    """TYPED_ERRORS -- every error raised is an AdapterError with a known code."""
+    responses = {
+        ("GET", "/core/projects"): FakeResponse(status_code=401),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.search_matters())
+    assert exc.value.code == "unauthorized"
+
+
+def test_no_field_fabrication_pm():
+    """NO_FIELD_FABRICATION -- sparse vendor row leaves optional fields None."""
+    responses = {
+        ("GET", "/core/projects/sparse"): FakeResponse(
+            status_code=200,
+            json_body={"projectId": "sparse"},  # nothing else
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    pm = FilevinePracticeManagement(client)
+    m = asyncio.run(pm.get_matter("sparse"))
+    assert m is not None
+    assert m.id == "sparse"
+    # Vendor did not provide these -- adapter must not synthesize
+    assert m.client_name == ""  # explicit "no value" string per contract
+    assert m.matter_type == ""
+    assert m.opened_at == ""
+    assert m.closed_at is None
+    # custom_fields is whatever's left (in this case empty)
+    assert m.custom_fields == {}
+
+
+def test_no_field_fabrication_ds():
+    """NO_FIELD_FABRICATION -- sparse document row honored verbatim."""
+    responses = {
+        ("GET", "/core/documents/sparse"): FakeResponse(
+            status_code=200,
+            json_body={"documentId": "sparse"},
+        ),
+    }
+    client, _, _ = make_client(responses=responses)
+    ds = FilevineDocumentStorage(client)
+    d = asyncio.run(ds.get_document("sparse"))
+    assert d is not None
+    assert d.id == "sparse"
+    # mime_type and current_version have defaults declared in field_coverage
+    # -- see capabilities.py `_stored_from_document` and `field_coverage.derived`.
+    assert d.modified_by is None

--- a/ai-employee/connectors/filevine/tests/test_errors.py
+++ b/ai-employee/connectors/filevine/tests/test_errors.py
@@ -1,0 +1,91 @@
+"""Unit tests for the AdapterError contract.
+
+The TypeScript `AdapterError` from
+`src/lib/ai-employee/capabilities/types.ts` declares a closed
+`AdapterErrorCode` union plus the eleven `CapabilityName` values. The
+Python mirror in `errors.py` MUST stay in sync -- this test pins the
+constants so accidental drift fails CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from connectors.filevine.errors import (  # type: ignore[import-not-found]
+    ADAPTER_ERROR_CODES,
+    CAPABILITY_NAMES,
+    AdapterError,
+)
+
+
+# Pinned from src/lib/ai-employee/capabilities/types.ts. If this list
+# changes, change BOTH that file and errors.py in the same PR.
+_EXPECTED_CODES = {
+    "not_found",
+    "unauthorized",
+    "rate_limited",
+    "transient",
+    "capability_not_supported",
+    "scope_violation",
+    "fabrication_blocked",
+    "validation_failed",
+    "unknown",
+}
+
+_EXPECTED_CAPABILITIES = {
+    "PracticeManagement",
+    "Email",
+    "Calendar",
+    "DocumentStorage",
+    "ESign",
+    "CourtAccess",
+    "Payments",
+    "Accounting",
+    "IntakeCRM",
+    "CallTracking",
+    "InternalComms",
+}
+
+
+def test_adapter_error_codes_match_typescript_contract():
+    assert set(ADAPTER_ERROR_CODES) == _EXPECTED_CODES
+
+
+def test_capability_names_match_typescript_contract():
+    assert set(CAPABILITY_NAMES) == _EXPECTED_CAPABILITIES
+
+
+def test_adapter_error_rejects_unknown_code():
+    with pytest.raises(ValueError):
+        AdapterError(
+            code="not_a_real_code",
+            capability="PracticeManagement",
+            adapter="filevine",
+            message="bogus",
+        )
+
+
+def test_adapter_error_rejects_unknown_capability():
+    with pytest.raises(ValueError):
+        AdapterError(
+            code="unauthorized",
+            capability="WeatherForecast",
+            adapter="filevine",
+            message="bogus",
+        )
+
+
+def test_adapter_error_preserves_cause():
+    cause = RuntimeError("vendor blew up")
+    try:
+        raise AdapterError(
+            code="transient",
+            capability="PracticeManagement",
+            adapter="filevine",
+            message="wrapped",
+            cause=cause,
+        )
+    except AdapterError as exc:
+        assert exc.code == "transient"
+        assert exc.adapter == "filevine"
+        assert exc.cause is cause

--- a/ai-employee/connectors/filevine/tests/test_smoke_unit.py
+++ b/ai-employee/connectors/filevine/tests/test_smoke_unit.py
@@ -1,0 +1,173 @@
+"""Unit-level smoke test -- happy path for each capability method.
+
+This is the CI-runnable version of `bin/smoke-test-filevine.py`. It
+exercises each capability method through the adapter with a
+mock-backed HTTP client and asserts the round-trip succeeds without
+network access. The full sandbox-credentialed smoke test is
+`bin/smoke-test-filevine.py` and is NOT run in CI.
+
+Coverage matrix:
+
+| Capability         | Method                  | Asserted here |
+| ------------------ | ----------------------- | ------------- |
+| PracticeManagement | search_matters          | Y             |
+| PracticeManagement | get_matter              | Y             |
+| PracticeManagement | list_matter_documents   | Y             |
+| PracticeManagement | create_note             | Y             |
+| PracticeManagement | health_check            | Y (healthy)   |
+| DocumentStorage    | list_documents          | Y             |
+| DocumentStorage    | get_document            | Y             |
+| DocumentStorage    | get_document_bytes      | Y             |
+| DocumentStorage    | health_check            | Y (healthy)   |
+
+This is the "smoke test against Filevine sandbox/test tenant"
+acceptance criterion's CI-side coverage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from connectors.filevine import (  # type: ignore[import-not-found]
+    FilevineDocumentStorage,
+    FilevinePracticeManagement,
+)
+
+from _helpers import FakeResponse, make_client  # type: ignore[import-not-found]
+
+
+SMOKE_PROJECT_ID = "proj-smoke-1"
+SMOKE_DOCUMENT_ID = "doc-smoke-1"
+
+
+def _build_responses() -> dict:
+    return {
+        ("GET", "/core/projects"): FakeResponse(
+            status_code=200,
+            json_body={
+                "items": [
+                    {
+                        "projectId": SMOKE_PROJECT_ID,
+                        "clientName": "Smoke Tester",
+                        "projectTypeCode": "PI-Auto",
+                        "status": "Open",
+                        "createdDate": "2026-05-01T00:00:00Z",
+                        "closedDate": None,
+                    },
+                ]
+            },
+        ),
+        ("GET", f"/core/projects/{SMOKE_PROJECT_ID}"): FakeResponse(
+            status_code=200,
+            json_body={
+                "projectId": SMOKE_PROJECT_ID,
+                "clientName": "Smoke Tester",
+                "projectTypeCode": "PI-Auto",
+                "status": "Open",
+                "createdDate": "2026-05-01T00:00:00Z",
+                "closedDate": None,
+            },
+        ),
+        ("GET", f"/core/projects/{SMOKE_PROJECT_ID}/documents"): FakeResponse(
+            status_code=200,
+            json_body={
+                "items": [
+                    {
+                        "documentId": SMOKE_DOCUMENT_ID,
+                        "projectId": SMOKE_PROJECT_ID,
+                        "filename": "intake-form.pdf",
+                        "mimeType": "application/pdf",
+                        "sizeBytes": 4096,
+                        "uploadDate": "2026-05-01T01:00:00Z",
+                        "uploadedByAccountId": "user-1",
+                        "currentVersionId": "v1",
+                    },
+                ]
+            },
+        ),
+        ("POST", f"/core/projects/{SMOKE_PROJECT_ID}/notes"): FakeResponse(
+            status_code=201,
+            json_body={
+                "noteId": "note-smoke-1",
+                "projectId": SMOKE_PROJECT_ID,
+                "createdDate": "2026-05-21T17:00:00Z",
+            },
+        ),
+        ("GET", f"/core/documents/{SMOKE_DOCUMENT_ID}"): FakeResponse(
+            status_code=200,
+            json_body={
+                "documentId": SMOKE_DOCUMENT_ID,
+                "projectId": SMOKE_PROJECT_ID,
+                "filename": "intake-form.pdf",
+                "mimeType": "application/pdf",
+                "sizeBytes": 4096,
+                "uploadDate": "2026-05-01T01:00:00Z",
+                "uploadedByAccountId": "user-1",
+                "currentVersionId": "v1",
+            },
+        ),
+        ("GET", f"/core/documents/{SMOKE_DOCUMENT_ID}/download"): FakeResponse(
+            status_code=200,
+            content=b"%PDF-1.5\nfake-content\n",
+        ),
+    }
+
+
+def test_pm_full_happy_path():
+    client, _, _ = make_client(responses=_build_responses())
+    pm = FilevinePracticeManagement(client)
+
+    # search_matters
+    matters = asyncio.run(pm.search_matters(limit=5))
+    assert len(matters) == 1
+    assert matters[0].id == SMOKE_PROJECT_ID
+
+    # get_matter
+    m = asyncio.run(pm.get_matter(SMOKE_PROJECT_ID))
+    assert m is not None
+    assert m.client_name == "Smoke Tester"
+
+    # list_matter_documents
+    docs = asyncio.run(pm.list_matter_documents(SMOKE_PROJECT_ID))
+    assert len(docs) == 1
+    assert docs[0].filename == "intake-form.pdf"
+
+    # create_note
+    note = asyncio.run(
+        pm.create_note(
+            SMOKE_PROJECT_ID,
+            content="smoke note",
+            reviewer_account_id="user-reviewer",
+            drafted_by_skill="connector-smoke-test",
+        )
+    )
+    assert note.id == "note-smoke-1"
+    assert note.author_account_id == "user-reviewer"
+
+    # health_check
+    health = asyncio.run(pm.health_check())
+    assert health.status == "healthy"
+
+
+def test_ds_full_happy_path():
+    client, _, _ = make_client(responses=_build_responses())
+    ds = FilevineDocumentStorage(client)
+
+    # list_documents
+    docs = asyncio.run(ds.list_documents(SMOKE_PROJECT_ID))
+    assert len(docs) == 1
+    assert docs[0].id == SMOKE_DOCUMENT_ID
+    assert docs[0].path.startswith(f"projects/{SMOKE_PROJECT_ID}/")
+
+    # get_document
+    d = asyncio.run(ds.get_document(SMOKE_DOCUMENT_ID))
+    assert d is not None
+    assert d.filename == "intake-form.pdf"
+
+    # get_document_bytes
+    blob = asyncio.run(ds.get_document_bytes(SMOKE_DOCUMENT_ID))
+    assert blob.startswith(b"%PDF")
+
+    # health_check
+    health = asyncio.run(ds.health_check())
+    assert health.status == "healthy"


### PR DESCRIPTION
## Summary

Builds the v1 Filevine connector per [ADR 0014](docs/adr/0014-pi-vertical-adapter-build-priority.md) (PI vertical adapter build priority -- Filevine first). Implements the locked `PracticeManagement` and `DocumentStorage` capability interfaces (per [ADR 0006](docs/adr/0006-capability-adapter-pattern.md)) in Python, conforming to the same contract shape across languages.

The connector ships:

- `FilevinePracticeManagement` -- `search_matters`, `get_matter`, `list_matter_documents`, `create_note`, plus `describe_capabilities` / `health_check`.
- `FilevineDocumentStorage` -- `list_documents`, `get_document`, `get_document_bytes`, plus `describe_capabilities` / `health_check`.
- `FilevineAuthProvider` Protocol -- OAuth seam for the Identity & Access layer (#789 / #822) to plug into. Tests inject `InMemoryFilevineAuth`.
- `FilevineClient` -- thin async REST wrapper with full HTTP-status-to-`AdapterError`-code translation.
- `tests/` -- 57 unit tests covering capability methods, HTTP error translation, AdapterError union (pinned to TypeScript), and a Python mirror of the 8 conformance invariants from `src/lib/ai-employee/capabilities/conformance.ts`.
- `bin/smoke-test-filevine.py` -- env-credentialed smoke against a real Filevine tenant (manual, NOT in CI). Unit-level happy-path smoke (`tests/test_smoke_unit.py`) runs in CI and covers every supported method.
- README documenting cross-language contract mapping, customer.yaml binding pattern (per [schema spec](docs/specs/ai-employee/customer-yaml-schema.md)), endpoint inventory, OAuth seam, ADR 0005 reviewer-as-sender attribution, and per-customer isolation per ADR 0007/0009.

Optional capability methods (`create_matter`, `upload_document`, `share_document_draft`, etc.) are declared in `unsupported_methods` and raise `AdapterError(code="capability_not_supported")` per the `UNSUPPORTED_METHODS_THROW` invariant. No autonomous send paths. No fabricated fields -- missing vendor fields return `None`.

## Linked issue

Closes #851

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Connector at `ai-employee/connectors/filevine/` | met | full package landed at this path |
| OAuth flow integrated with Identity & Access layer | met | `FilevineAuthProvider` Protocol + `InMemoryFilevineAuth` fake; README documents the seam #789/#822 plug into |
| Capability adapters wired: Matter.Read, Matter.Note.Write, Document.Read | met | `FilevinePracticeManagement.search_matters`/`get_matter`/`list_matter_documents`/`create_note`; `FilevineDocumentStorage.list_documents`/`get_document`/`get_document_bytes` |
| Smoke test against Filevine sandbox/test tenant | met | `bin/smoke-test-filevine.py` (env-credentialed, manual) + `tests/test_smoke_unit.py` (mock-backed, CI) |
| customer.yaml binding pattern documented | met | `ai-employee/connectors/filevine/README.md` "customer.yaml binding" section + endpoint inventory + cross-language contract table |

## Test plan

- [x] `npm run verify` passes (tsc + lint + tests + format)
- [x] Python tests pass locally: `pytest ai-employee/connectors/filevine/tests/` (57 passed)
- [ ] Live smoke (`bin/smoke-test-filevine.py`) against a Filevine sandbox tenant -- deferred until Identity & Access layer (#789/#822) provides real tokens

## Security Checklist

- [x] No secrets in code or comments (only Protocol + in-memory fake)
- [x] No PII exposed in frontend responses (Python connector; no frontend surface)
- [x] Input validation on new endpoints (n/a -- connector only; HTTP responses validated by code translation table)
- [x] Parameterized queries for any SQL (n/a -- no SQL in connector)
- [x] Auth required on new endpoints (n/a -- connector only)
- [x] No internal IDs that enable enumeration (n/a)

## Feature Impact

**Feature impact:** None