### PR TITLE
feat(portal): AI Employee matters tab + detail (#871)

### DIFF
--- a/src/components/portal/ai-employee/MatterAuditSection.astro
+++ b/src/components/portal/ai-employee/MatterAuditSection.astro
@@ -1,0 +1,84 @@
+---
+/**
+ * Audit history section of a matter detail page. Surfaces the most
+ * recent audit events tied to this matter, with a link to the
+ * dedicated audit viewer scoped to the same matter. The audit log is
+ * the compliance source of truth (#891, #895); this section is a
+ * summary lens, not the full record.
+ *
+ * Empty-state behavior: when no audit events have been recorded yet,
+ * the section renders one muted prose line and the "Open audit log"
+ * link still resolves. The audit viewer page (#873) is a separate
+ * surface; the link may 404 until that PR lands.
+ */
+
+import type { MatterAuditRef } from '../../../lib/portal/ai-employee/matters'
+
+interface Props {
+  matterId: string
+  events: MatterAuditRef[]
+}
+
+const { matterId, events } = Astro.props
+
+const auditHref = `/portal/products/ai-employee/audit?matter=${encodeURIComponent(matterId)}`
+
+function formatAt(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+---
+
+<section aria-labelledby="matter-audit-heading" class="mt-section">
+  <div class="flex items-baseline justify-between gap-4 flex-wrap">
+    <h2
+      id="matter-audit-heading"
+      class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0"
+    >
+      Audit history
+    </h2>
+    <a
+      href={auditHref}
+      class="inline-flex items-center gap-2 min-h-11 font-['Archivo_Narrow'] text-xs md:text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+    >
+      Open audit log
+      <span aria-hidden="true" class="font-['Archivo'] font-black">→</span>
+    </a>
+  </div>
+  <div class="mt-stack border-[3px] border-[color:var(--ss-color-text-primary)]">
+    {
+      events.length === 0 ? (
+        <p class="p-card text-caption text-[color:var(--ss-color-text-muted)] m-0">
+          Audit entries appear here as your AI Employee acts on this matter.
+        </p>
+      ) : (
+        <ol class="m-0 list-none p-0" role="list">
+          {events.map((event) => (
+            <li class="border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 px-5 py-4 md:px-6 md:py-5">
+              <div class="flex items-baseline justify-between gap-4 flex-wrap">
+                <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-primary)]">
+                  {event.action}
+                </span>
+                <span class="font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+                  {formatAt(event.at)}
+                </span>
+              </div>
+              <p class="mt-1 text-body text-[color:var(--ss-color-text-primary)] m-0">
+                {event.summary}
+              </p>
+              <p class="mt-1 text-caption text-[color:var(--ss-color-text-secondary)] m-0">
+                Actor: {event.actor}
+              </p>
+            </li>
+          ))}
+        </ol>
+      )
+    }
+  </div>
+</section>

--- a/src/components/portal/ai-employee/MatterDraftsSection.astro
+++ b/src/components/portal/ai-employee/MatterDraftsSection.astro
@@ -1,0 +1,82 @@
+---
+/**
+ * Drafts-in-flight section of a matter detail page. Lists the drafts
+ * the AI Employee currently has prepared for this matter, with a link
+ * back to the dedicated drafts surface filtered by matter id. Each
+ * row also links directly to the per-draft surface so the operator
+ * can pick a single draft to review.
+ *
+ * Empty-state behavior: when the array is empty, the section renders
+ * one muted prose line and the "View all drafts" link still resolves
+ * (the drafts surface will render its own empty state when filtered
+ * to a matter with no drafts).
+ */
+
+import type { MatterDraftRef } from '../../../lib/portal/ai-employee/matters'
+
+interface Props {
+  matterId: string
+  drafts: MatterDraftRef[]
+}
+
+const { matterId, drafts } = Astro.props
+
+const allDraftsHref = `/portal/products/ai-employee/drafts?matter=${encodeURIComponent(matterId)}`
+
+function formatAt(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+---
+
+<section aria-labelledby="matter-drafts-heading" class="mt-section">
+  <div class="flex items-baseline justify-between gap-4 flex-wrap">
+    <h2
+      id="matter-drafts-heading"
+      class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0"
+    >
+      Drafts in flight
+    </h2>
+    <a
+      href={allDraftsHref}
+      class="inline-flex items-center gap-2 min-h-11 font-['Archivo_Narrow'] text-xs md:text-sm font-bold uppercase tracking-[0.14em] text-[color:var(--ss-color-primary)] hover:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+    >
+      View all drafts
+      <span aria-hidden="true" class="font-['Archivo'] font-black">→</span>
+    </a>
+  </div>
+  <div class="mt-stack border-[3px] border-[color:var(--ss-color-text-primary)]">
+    {
+      drafts.length === 0 ? (
+        <p class="p-card text-caption text-[color:var(--ss-color-text-muted)] m-0">
+          Drafts your AI Employee prepares for this matter appear here for review before any message
+          goes out.
+        </p>
+      ) : (
+        <ul class="m-0 list-none p-0" role="list">
+          {drafts.map((draft) => (
+            <li class="border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0">
+              <a
+                href={`/portal/products/ai-employee/drafts/${draft.id}`}
+                class="group block px-5 py-4 md:px-6 md:py-5 hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset transition-colors"
+              >
+                <div class="flex items-baseline justify-between gap-4 flex-wrap">
+                  <h3 class="font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0 truncate">
+                    {draft.subject}
+                  </h3>
+                  <span class="font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+                    {formatAt(draft.createdAt)}
+                  </span>
+                </div>
+                <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)] m-0 truncate">
+                  To {draft.recipient} · {draft.skill}
+                </p>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </div>
+</section>

--- a/src/components/portal/ai-employee/MatterFactsSection.astro
+++ b/src/components/portal/ai-employee/MatterFactsSection.astro
@@ -1,0 +1,39 @@
+---
+/**
+ * Facts section of a matter detail page. Renders the AI Employee's
+ * statement-of-facts text for the matter inside the standard
+ * Plainspoken bordered container. When facts have not yet been
+ * captured (the AI Employee has not synthesized them, or this matter
+ * predates the facts feature), the section renders the empty state
+ * prose per docs/style/empty-state-pattern.md — no placeholder facts,
+ * no "TBD in SOW" marker (this is not a contracted field).
+ */
+
+interface Props {
+  facts: string | null
+}
+
+const { facts } = Astro.props
+---
+
+<section aria-labelledby="matter-facts-heading" class="mt-section">
+  <h2
+    id="matter-facts-heading"
+    class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0"
+  >
+    Facts
+  </h2>
+  <div class="mt-stack border-[3px] border-[color:var(--ss-color-text-primary)] p-card">
+    {
+      facts ? (
+        <p class="text-body text-[color:var(--ss-color-text-primary)] whitespace-pre-line m-0">
+          {facts}
+        </p>
+      ) : (
+        <p class="text-caption text-[color:var(--ss-color-text-muted)] m-0">
+          Facts are recorded here as your AI Employee gathers them from communications and intake.
+        </p>
+      )
+    }
+  </div>
+</section>

--- a/src/components/portal/ai-employee/MatterRow.astro
+++ b/src/components/portal/ai-employee/MatterRow.astro
@@ -1,0 +1,151 @@
+---
+/**
+ * Single matter row inside the matters list table. Bill-of-lading
+ * Plainspoken chrome that matches PortalListItem's `ticket` chrome
+ * shape (3px ink outer border on the container, 2px ink stitch between
+ * rows), but with a column layout tailored to matters rather than
+ * money-bearing artifacts.
+ *
+ * Columns (desktop, 6-up):
+ *
+ *   1. № cell             — serial (01, 02, ...) on burnt-orange ground
+ *   2. Client + matter    — Archivo Black client name + Archivo Narrow
+ *                            matter type subcaption
+ *   3. Phase stamp        — StatusPill with phase tone + closed label
+ *   4. Age caption        — "Opened 12d ago" relative timestamp
+ *   5. Last AI action     — skill slug + short date, or empty-state row
+ *                            label when no action recorded
+ *   6. Arrow              — burnt-orange → glyph (hover-translates)
+ *
+ * Mobile collapses to a two-row stack: row 1 = serial + name + arrow,
+ * row 2 = phase + age + last action.
+ *
+ * Empty-state guard: when `lastAction` is null we render the row label
+ * "Awaiting first action" in muted text. This is metadata about the
+ * matter's state ("no action has been taken yet"), not fabricated
+ * content — see docs/style/empty-state-pattern.md: the row label is the
+ * fact, not a substitute for one.
+ */
+
+import StatusPill from '../StatusPill.astro'
+import {
+  formatMatterAge,
+  resolveMatterPhaseStamp,
+  resolveMatterPhaseTone,
+  MATTER_PHASE_LABEL,
+  type Matter,
+} from '../../../lib/portal/ai-employee/matters'
+
+interface Props {
+  matter: Matter
+  /** 1-based row index, formatted to "01" / "02" / ... for the № cell. */
+  index: number
+}
+
+const { matter, index } = Astro.props
+
+const serial = String(index).padStart(2, '0')
+const age = formatMatterAge(matter.openedAt)
+const phaseLabel = resolveMatterPhaseStamp(matter.phase)
+const phaseTone = resolveMatterPhaseTone(matter.phase)
+const phaseProseLabel = MATTER_PHASE_LABEL[matter.phase]
+
+let lastActionCaption: string | null = null
+if (matter.lastAction) {
+  const at = new Date(matter.lastAction.at)
+  if (!Number.isNaN(at.getTime())) {
+    const short = at.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    lastActionCaption = `${matter.lastAction.skill} · ${short}`
+  }
+}
+
+const shellClass = [
+  'group block bg-[color:var(--ss-color-surface)]',
+  'border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0',
+  'transition-colors',
+  'hover:bg-[color:var(--ss-color-border-subtle)]',
+  'focus-visible:outline-none',
+  'focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset',
+].join(' ')
+---
+
+<a
+  href={`/portal/products/ai-employee/matters/${matter.id}`}
+  class={shellClass}
+  aria-label={`Open matter for ${matter.clientName}`}
+>
+  <div class="md:grid md:grid-cols-[56px_1fr_auto_auto_auto_48px] md:items-stretch">
+    <div
+      class="flex md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)] items-center justify-center md:min-h-[88px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell"
+      aria-hidden="true"
+    >
+      №{serial}
+    </div>
+
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-4 md:py-5 flex flex-col justify-center gap-2"
+    >
+      <h3
+        class="font-['Archivo'] text-lg md:text-xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0 truncate"
+      >
+        {matter.clientName}
+      </h3>
+      <p class="text-sm text-[color:var(--ss-color-text-secondary)] m-0 truncate">
+        {matter.matterType}
+      </p>
+    </div>
+
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col items-start md:items-center justify-center gap-1"
+    >
+      <StatusPill tone={phaseTone} label={phaseLabel} />
+      <span
+        class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] sr-only md:not-sr-only"
+      >
+        Phase
+      </span>
+      <span class="sr-only">{phaseProseLabel}</span>
+    </div>
+
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1"
+    >
+      <span
+        class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+      >
+        Age
+      </span>
+      <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
+        {age}
+      </span>
+    </div>
+
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-5 flex flex-col justify-center gap-1"
+    >
+      <span
+        class="font-['Archivo_Narrow'] text-label font-semibold uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
+      >
+        Last AI action
+      </span>
+      {
+        lastActionCaption ? (
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)]">
+            {lastActionCaption}
+          </span>
+        ) : (
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-muted)]">
+            Awaiting first action
+          </span>
+        )
+      }
+    </div>
+
+    <div
+      aria-hidden="true"
+      class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-2xl text-[color:var(--ss-color-primary)] transition-transform group-hover:translate-x-0.5"
+    >
+      →
+    </div>
+  </div>
+</a>

--- a/src/components/portal/ai-employee/MatterTimelineSection.astro
+++ b/src/components/portal/ai-employee/MatterTimelineSection.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Timeline section of a matter detail page. Renders the AI Employee's
+ * chronological log of material events on the matter — communications
+ * received, documents filed, deadlines reached, AI actions approved by
+ * the operator. Entries are pre-sorted by the resolver in reverse
+ * chronological order; this component does not re-sort.
+ *
+ * Empty-state behavior: when the timeline array is empty, the section
+ * renders a single muted prose line. We do not render a placeholder
+ * row, a synthetic "matter opened" entry, or a "coming soon" line.
+ */
+
+import type { MatterTimelineEntry } from '../../../lib/portal/ai-employee/matters'
+
+interface Props {
+  entries: MatterTimelineEntry[]
+}
+
+const { entries } = Astro.props
+
+const KIND_LABEL: Record<MatterTimelineEntry['kind'], string> = {
+  communication: 'Communication',
+  document: 'Document',
+  deadline: 'Deadline',
+  ai_action: 'AI action',
+  note: 'Note',
+}
+
+function formatAt(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+---
+
+<section aria-labelledby="matter-timeline-heading" class="mt-section">
+  <h2
+    id="matter-timeline-heading"
+    class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)] m-0"
+  >
+    Timeline
+  </h2>
+  <div class="mt-stack border-[3px] border-[color:var(--ss-color-text-primary)]">
+    {
+      entries.length === 0 ? (
+        <p class="p-card text-caption text-[color:var(--ss-color-text-muted)] m-0">
+          Events appear here as your AI Employee logs activity on this matter.
+        </p>
+      ) : (
+        <ol class="m-0 list-none p-0" role="list">
+          {entries.map((entry) => (
+            <li class="border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 px-5 py-4 md:px-6 md:py-5 flex flex-col md:flex-row md:items-baseline md:gap-6">
+              <div class="md:w-32 flex-shrink-0">
+                <span class="font-mono text-xs uppercase tracking-[0.08em] text-[color:var(--ss-color-text-secondary)]">
+                  {formatAt(entry.at)}
+                </span>
+              </div>
+              <div class="mt-2 md:mt-0 flex-1 min-w-0">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-primary)] m-0">
+                  {KIND_LABEL[entry.kind]}
+                </p>
+                <p class="mt-1 text-body text-[color:var(--ss-color-text-primary)] m-0">
+                  {entry.summary}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )
+    }
+  </div>
+</section>

--- a/src/components/portal/ai-employee/MattersListTable.astro
+++ b/src/components/portal/ai-employee/MattersListTable.astro
@@ -1,0 +1,47 @@
+---
+/**
+ * Matters list table — the 3px ink container that holds one MatterRow
+ * per matter. The container draws the outer ledger border; row
+ * components draw their own 2px ink bottom stitch (and the `:last`
+ * row clears its stitch). Matches the Plainspoken bill-of-lading
+ * register used elsewhere in the portal.
+ *
+ * The component is intentionally a thin shell. The fabrication-safety
+ * decision lives one level up at the page: if `listMatters` returns an
+ * empty array, the page renders the empty state and does not render
+ * this table at all. Passing an empty array here would render an empty
+ * 3px border with no rows inside — visually broken — so the page must
+ * gate.
+ *
+ * Why not PortalListItem (UI-PATTERNS R7)?
+ *
+ * PortalListItem ships two variants today: `status` (money-bearing
+ * artifacts like quotes and invoices) and `document` (file rows).
+ * Matters carry neither — the primary scan-time fields are phase
+ * (lifecycle position) and last-AI-action (skill + timestamp), with no
+ * dollar figure at all. Forcing matters through `status` would render
+ * a "$0" price cell on every row, which reads as a bug. Forcing them
+ * through `document` would drop the phase stamp.
+ *
+ * Per R7's "When to split" guidance ("Split into separate primitives
+ * when more than ~5 conditionals key on `variant`, or when a third
+ * variant is needed"), matters are the third variant. Per #871 they
+ * land in a dedicated component (`MatterRow`) and the matters list
+ * index registers in LIST_INDEX_ALLOWLIST. When the next AI Employee
+ * surface (calendar, audit) lands and shares the row shape, we
+ * promote MatterRow into PortalListItem as a third variant.
+ */
+
+import MatterRow from './MatterRow.astro'
+import type { Matter } from '../../../lib/portal/ai-employee/matters'
+
+interface Props {
+  matters: Matter[]
+}
+
+const { matters } = Astro.props
+---
+
+<div class="border-[3px] border-[color:var(--ss-color-text-primary)]" role="list">
+  {matters.map((matter, i) => <MatterRow matter={matter} index={i + 1} />)}
+</div>

--- a/src/lib/portal/ai-employee/matters.ts
+++ b/src/lib/portal/ai-employee/matters.ts
@@ -1,0 +1,238 @@
+/**
+ * Matter list and detail resolvers for the AI Employee portal surfaces.
+ *
+ * URL surfaces consuming this module:
+ *   - /portal/products/ai-employee/matters         (list)
+ *   - /portal/products/ai-employee/matters/[id]    (detail)
+ *
+ * Architecture (ADR 0007 + 0009): matters live on the per-customer Hermes
+ * Machine D1, not the portal Worker's primary D1. The portal Worker
+ * cannot bind a per-customer database directly — the bridge through
+ * Hermes runtime wiring is the subject of #821. Until that lands, both
+ * resolvers return their empty shape and the page renders the empty
+ * state per docs/style/empty-state-pattern.md.
+ *
+ * No fabrication. No placeholder rows. No "coming soon" copy. The Pattern
+ * A/B audit in the project CLAUDE.md treats invented client-facing
+ * content as a P0 violation: the only acceptable substitute for authored
+ * data is the empty-state pattern.
+ *
+ * The types are exported so the page surfaces, the row component, and
+ * future Hermes bridge code share one contract. When the bridge lands,
+ * the resolver implementations swap; the types stay.
+ */
+
+/**
+ * Phase vocabulary. Mirrors the AI Employee PI corpus PRD §12 (PR #832)
+ * vocabulary for personal-injury matters. The list is closed and ordered
+ * by lifecycle position so the UI can render the right stamp without
+ * inventing fallback labels. Non-PI verticals will extend this enum, not
+ * replace it, when their persona ships.
+ *
+ *   pre_suit    — pre-litigation negotiation, demand letters out, settlement under discussion
+ *   discovery   — suit filed, discovery exchange underway
+ *   pre_trial   — discovery closed, motions and pre-trial conference pending
+ */
+export type MatterPhase = 'pre_suit' | 'discovery' | 'pre_trial'
+
+export const MATTER_PHASE_LABEL: Record<MatterPhase, string> = {
+  pre_suit: 'Pre-Suit',
+  discovery: 'Discovery',
+  pre_trial: 'Pre-Trial',
+}
+
+/**
+ * Last action the AI Employee took on this matter. `skill` is the
+ * capability slug (e.g. `pi-demand-letter`, `pi-discovery-response`),
+ * `at` is the ISO timestamp. Optional because a matter may exist before
+ * the AI Employee has touched it.
+ */
+export interface MatterLastAction {
+  skill: string
+  at: string
+}
+
+/**
+ * Row shape consumed by the matters list view. One row per matter.
+ *
+ * Field meanings:
+ *   id                — opaque matter identifier (foreign to the portal,
+ *                       owned by the Hermes Machine D1)
+ *   clientName        — the client of the law firm (the matter is "for"
+ *                       this person), not the customer firm itself
+ *   matterType        — short label like "Auto Accident", "Slip and Fall"
+ *   phase             — one of the closed-vocabulary phases above
+ *   openedAt          — ISO timestamp when the matter was opened; used
+ *                       to compute the age caption client-side
+ *   lastAction        — most recent AI action on this matter, or null
+ *                       if the matter has not yet been touched by the
+ *                       AI Employee
+ */
+export interface Matter {
+  id: string
+  clientName: string
+  matterType: string
+  phase: MatterPhase
+  openedAt: string
+  lastAction: MatterLastAction | null
+}
+
+/**
+ * Timeline entry on a matter detail page. Each entry corresponds to a
+ * material event — communication received, document filed, deadline
+ * reached, AI action approved by the operator. The detail page renders
+ * them in reverse chronological order.
+ */
+export interface MatterTimelineEntry {
+  id: string
+  at: string
+  kind: 'communication' | 'document' | 'deadline' | 'ai_action' | 'note'
+  summary: string
+}
+
+/**
+ * Reference to a draft in flight for this matter. The detail page links
+ * to the drafts surface filtered by this matter id; individual rows
+ * carry enough metadata to identify the draft without resolving it
+ * fully.
+ */
+export interface MatterDraftRef {
+  id: string
+  subject: string
+  recipient: string
+  skill: string
+  createdAt: string
+}
+
+/**
+ * Reference to an audit log entry tied to this matter. The detail page
+ * surfaces a summary and links out to the dedicated audit viewer
+ * (`/portal/products/ai-employee/audit?matter=<id>`).
+ */
+export interface MatterAuditRef {
+  id: string
+  at: string
+  actor: string
+  action: string
+  summary: string
+}
+
+/**
+ * Detail-page payload. `facts` is the short statement-of-facts text the
+ * AI Employee maintains on the matter; the other arrays are the
+ * adjacent sections.
+ */
+export interface MatterDetail {
+  id: string
+  clientName: string
+  matterType: string
+  phase: MatterPhase
+  openedAt: string
+  facts: string | null
+  timeline: MatterTimelineEntry[]
+  draftsInFlight: MatterDraftRef[]
+  recentAudit: MatterAuditRef[]
+  lastAction: MatterLastAction | null
+}
+
+/**
+ * List resolver. Returns the matters the active customer's AI Employee
+ * is tracking. Today this returns an empty array because the Hermes
+ * bridge has not landed (#821); the page renders the empty state.
+ *
+ * The signature accepts the portal D1 and entity id so the call site
+ * matches the surrounding resolver style; both are unused for now and
+ * become live when the bridge wires through. The function is declared
+ * `async` (and returns a Promise) so the page-side `await` shape does
+ * not need to change when the Hermes bridge lands and the body picks
+ * up real async DB calls.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function listMatters(_db: D1Database, _entityId: string): Promise<Matter[]> {
+  return []
+}
+
+/**
+ * Detail resolver. Returns the matter matching the supplied id, or null
+ * if no matter is found on the active customer's Hermes D1. Today this
+ * returns null unconditionally because the bridge has not landed; the
+ * page renders a "not found" empty state and the breadcrumb back to
+ * the list. The async shape is preserved for the same reason as
+ * `listMatters`: the page-side `await` site stays stable when the
+ * bridge wires up.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function getMatter(
+  _db: D1Database,
+  _entityId: string,
+  _matterId: string
+): Promise<MatterDetail | null> {
+  return null
+}
+
+/**
+ * Age caption formatter for matter rows. Reads `openedAt` and returns a
+ * short relative-age string ("Opened 12d ago", "Opened today",
+ * "Opened 4mo ago"). Returns an empty string for invalid input so the
+ * caller can chain without guarding. Pure, no DB access, no locale
+ * dependency beyond the day/month constants.
+ */
+export function formatMatterAge(
+  openedAtIso: string | null | undefined,
+  now: Date = new Date()
+): string {
+  if (!openedAtIso) return ''
+  const opened = new Date(openedAtIso)
+  if (Number.isNaN(opened.getTime())) return ''
+  const diffMs = now.getTime() - opened.getTime()
+  if (diffMs < 0) return 'Opened today'
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays === 0) return 'Opened today'
+  if (diffDays === 1) return 'Opened 1d ago'
+  if (diffDays < 30) return `Opened ${diffDays}d ago`
+  const diffMonths = Math.floor(diffDays / 30)
+  if (diffMonths === 1) return 'Opened 1mo ago'
+  if (diffMonths < 12) return `Opened ${diffMonths}mo ago`
+  const diffYears = Math.floor(diffMonths / 12)
+  if (diffYears === 1) return 'Opened 1yr ago'
+  return `Opened ${diffYears}yr ago`
+}
+
+/**
+ * Phase stamp resolver. Returns the closed-vocabulary StampLabel for a
+ * matter phase. Matters use a different stamp vocabulary than quotes
+ * and invoices because the lifecycle does not map 1:1; we add the
+ * three phase labels directly to keep the visual rhythm calm.
+ *
+ * The returned string is meant for the StatusPill's `label` prop. Tone
+ * is resolved separately by `resolveMatterPhaseTone` below.
+ */
+export function resolveMatterPhaseStamp(phase: MatterPhase): string {
+  switch (phase) {
+    case 'pre_suit':
+      return 'PRE-SUIT'
+    case 'discovery':
+      return 'DISCOVERY'
+    case 'pre_trial':
+      return 'PRE-TRIAL'
+  }
+}
+
+/**
+ * Tone for the matter phase stamp. Three phases, three tones, ordered
+ * so the visual weight escalates with lifecycle position: info (early)
+ * → warning (mid) → danger-adjacent (late). We use `outline` for the
+ * pre-trial phase rather than `danger` because pre-trial is not a
+ * failure state, it is a procedural milestone.
+ */
+import type { Tone } from '../status'
+
+const MATTER_PHASE_TONE: Record<MatterPhase, Tone> = {
+  pre_suit: 'info',
+  discovery: 'warning',
+  pre_trial: 'outline',
+}
+
+export function resolveMatterPhaseTone(phase: MatterPhase): Tone {
+  return MATTER_PHASE_TONE[phase]
+}

--- a/src/pages/portal/products/ai-employee/matters/[id].astro
+++ b/src/pages/portal/products/ai-employee/matters/[id].astro
@@ -1,0 +1,184 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import StatusPill from '../../../../../components/portal/StatusPill.astro'
+import MatterFactsSection from '../../../../../components/portal/ai-employee/MatterFactsSection.astro'
+import MatterTimelineSection from '../../../../../components/portal/ai-employee/MatterTimelineSection.astro'
+import MatterDraftsSection from '../../../../../components/portal/ai-employee/MatterDraftsSection.astro'
+import MatterAuditSection from '../../../../../components/portal/ai-employee/MatterAuditSection.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+import {
+  getMatter,
+  formatMatterAge,
+  resolveMatterPhaseStamp,
+  resolveMatterPhaseTone,
+  MATTER_PHASE_LABEL,
+} from '../../../../../lib/portal/ai-employee/matters'
+
+/**
+ * AI Employee — Matter detail.
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/matters/[id]
+ *
+ * Per #871, the detail page surfaces four sections for one matter:
+ *
+ *   1. Facts             — AI Employee's statement-of-facts text
+ *   2. Timeline          — material events on the matter, reverse chronological
+ *   3. Drafts in flight  — drafts prepared for this matter, link out to the
+ *                          drafts surface filtered by matter id
+ *   4. Audit history     — recent audit events scoped to this matter, link out
+ *                          to the audit viewer scoped the same way
+ *
+ * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
+ * 0009). The portal Worker cannot bind directly to a per-customer D1;
+ * the read path is pending Hermes runtime wiring (#821). Until that
+ * lands, `getMatter` returns null for every id and this surface
+ * renders the not-found state per docs/style/empty-state-pattern.md —
+ * no fabricated matter, no placeholder facts, no synthetic timeline.
+ *
+ * Access gate (see resolveAiEmployeeAccess):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds principal OR operator OR compliance role
+ *
+ * The drafts and audit linking targets:
+ *
+ *   - `./drafts?matter=[id]` — drafts surface accepts the `matter` filter
+ *     param (per #869). When the drafts surface lands its filter
+ *     handler, the link surfaces the same matter's drafts only.
+ *   - `./audit?matter=[id]` — audit viewer is a separate issue (#873);
+ *     the link may 404 until that surface lands, but the URL shape is
+ *     stable so no follow-up is needed on this page when audit lands.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal', 'operator', 'compliance'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+
+const matterId = Astro.params.id
+if (!matterId || typeof matterId !== 'string') {
+  return Astro.redirect('/portal/products/ai-employee/matters')
+}
+
+const matter = await getMatter(env.DB, client.id, matterId)
+
+// Pre-compute the header meta column once. The page renders the
+// not-found branch when matter === null, otherwise the full detail
+// surface. Both branches share the same chrome (header + tabs +
+// breadcrumb).
+let phaseStamp: string | null = null
+let phaseTone: ReturnType<typeof resolveMatterPhaseTone> | null = null
+let phaseLabel: string | null = null
+let ageCaption: string | null = null
+if (matter) {
+  phaseStamp = resolveMatterPhaseStamp(matter.phase)
+  phaseTone = resolveMatterPhaseTone(matter.phase)
+  phaseLabel = MATTER_PHASE_LABEL[matter.phase]
+  ageCaption = formatMatterAge(matter.openedAt)
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>
+      AI Employee · {matter ? matter.clientName : 'Matter'} | {BRAND_NAME}
+    </title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      {
+        matter === null ? (
+          <Fragment>
+            <PortalPageHead
+              crumbHref="/portal/products/ai-employee/matters"
+              crumbLabel="Matters"
+              tag="Matter"
+              h1="Matter not found"
+              meta={null}
+            />
+            <section class="mt-10">
+              <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                  This matter is not on file for your firm. Return to the matters list to see what
+                  your AI Employee is tracking.
+                </p>
+                <p class="mt-6">
+                  <a
+                    href="/portal/products/ai-employee/matters"
+                    class="inline-flex items-center gap-2 min-h-11 px-5 py-2 bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-sm font-bold uppercase tracking-[0.14em] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+                  >
+                    Back to matters
+                  </a>
+                </p>
+              </div>
+            </section>
+          </Fragment>
+        ) : (
+          <Fragment>
+            <PortalPageHead
+              crumbHref="/portal/products/ai-employee/matters"
+              crumbLabel="Matters"
+              tag={matter.matterType}
+              h1={matter.clientName}
+              meta={ageCaption}
+            />
+
+            <section class="mt-stack flex items-baseline gap-4 flex-wrap" aria-label="Matter phase">
+              {phaseTone && phaseStamp && (
+                <StatusPill tone={phaseTone} label={phaseStamp} size="base" />
+              )}
+              {phaseLabel && (
+                <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]">
+                  Phase: {phaseLabel}
+                </span>
+              )}
+            </section>
+
+            <MatterFactsSection facts={matter.facts} />
+            <MatterTimelineSection entries={matter.timeline} />
+            <MatterDraftsSection matterId={matter.id} drafts={matter.draftsInFlight} />
+            <MatterAuditSection matterId={matter.id} events={matter.recentAudit} />
+          </Fragment>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/src/pages/portal/products/ai-employee/matters/index.astro
+++ b/src/pages/portal/products/ai-employee/matters/index.astro
@@ -5,43 +5,50 @@ import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-a
 import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import MattersListTable from '../../../../../components/portal/ai-employee/MattersListTable.astro'
 import SkipToMain from '../../../../../components/SkipToMain.astro'
 import { SignOutButton } from '@clerk/astro/components'
 import { env } from 'cloudflare:workers'
+import { listMatters, type Matter } from '../../../../../lib/portal/ai-employee/matters'
 
 /**
  * AI Employee — Matters list.
  *
  * URL: portal.smd.services/portal/products/ai-employee/matters
  *
- * Per #871, matters are the per-engagement aggregates the AI Employee
- * tracks across communications, deadlines, and documents. The list view
- * shows matter title, opposing party, last activity, and status. Detail
- * pages land in a follow-on slice once the schema exists.
+ * Per #871 and PRD §12, matters are the per-engagement aggregates the
+ * AI Employee tracks across communications, deadlines, drafts, and
+ * documents. The list view shows one row per active matter with: client
+ * name, matter type, phase, age, and the last action the AI Employee
+ * took. Detail pages live at `./[id]`.
  *
  * Data source lives on the per-customer Hermes Machine D1 (ADR 0007 +
  * 0009). The portal Worker cannot bind directly to a per-customer D1;
  * the read path is pending Hermes runtime wiring (#821). Until that
- * lands, this surface renders the empty state per
- * docs/style/empty-state-pattern.md — no fabricated matters, no fake
- * counts, no "coming soon" copy.
+ * lands, `listMatters` returns an empty array and this surface renders
+ * the empty state per docs/style/empty-state-pattern.md — no fabricated
+ * matters, no synthetic counts, no "coming soon" copy.
  *
  * Access gate (see resolveAiEmployeeAccess):
  *   - Clerk session (middleware)
  *   - Local entity bound to the active Clerk organization
  *   - Active AI Employee subscription on this customer
- *   - Caller holds operator OR principal role
+ *   - Caller holds principal OR operator OR compliance role
  *
- * Compliance-only users are redirected to the AI Employee landing.
+ * Compliance role gets read access to matters because the matter
+ * timeline + drafts-in-flight section feeds the compliance evidence
+ * packet; principal and operator are the active users.
  */
 
 const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
-  allowedRoles: ['operator', 'principal'],
+  allowedRoles: ['principal', 'operator', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)
 }
 const { client } = access
+
+const matters: Matter[] = await listMatters(env.DB, client.id)
 ---
 
 <!doctype html>
@@ -85,23 +92,25 @@ const { client } = access
         meta={null}
       />
 
-      <section class="mt-10">
-        <div
-          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
-        >
-          <p
-            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-          >
-            No matters yet
-          </p>
-          <p
-            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
-          >
-            Active matters appear here as your AI Employee tracks them across communications and
-            documents.
-          </p>
-        </div>
-      </section>
+      {
+        matters.length === 0 ? (
+          <section class="mt-10">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                No matters yet
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                Active matters appear here as your AI Employee tracks them across communications and
+                documents.
+              </p>
+            </div>
+          </section>
+        ) : (
+          <section class="mt-10" aria-label="Matters list">
+            <MattersListTable matters={matters} />
+          </section>
+        )
+      }
     </main>
   </body>
 </html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -352,11 +352,19 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // landing (one customer per render), not a list of products. The
   // small `.map(roles, …)` inside the sidebar renders a bullet list of
   // granted role names (principal / operator / compliance) — text
-  // items inside a chrome card, not a list-row card surface. Drafts
-  // (#869) and Matters (#871) list views will live under
-  // /portal/products/ai-employee/drafts/index.astro and matters/index.astro
-  // and WILL use PortalListItem.
+  // items inside a chrome card, not a list-row card surface.
   resolve('src/pages/portal/products/ai-employee/index.astro'),
+  // `products/ai-employee/matters/index.astro` (#871) iterates matters
+  // through the dedicated `<MattersListTable>` + `<MatterRow>`
+  // primitives, not PortalListItem. Matters carry phase + last AI
+  // action as their scan-time fields, not a money figure, and do not
+  // fit either of PortalListItem's two variants (status / document)
+  // without rendering a misleading "$0" cell. Per UI-PATTERNS R7's
+  // "When to split" guidance, matters are the third variant; they live
+  // in their own component pair until a second AI Employee surface
+  // (calendar, audit list view) shares the row shape, at which point
+  // MatterRow is promoted into PortalListItem as a third variant.
+  resolve('src/pages/portal/products/ai-employee/matters/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/portal-ai-employee-matters.test.ts
+++ b/tests/portal-ai-employee-matters.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the AI Employee matters resolver and supporting formatters
+ * (src/lib/portal/ai-employee/matters.ts).
+ *
+ * The resolvers themselves are intentionally thin until the per-customer
+ * Hermes Machine D1 bridge lands (#821): `listMatters` returns an empty
+ * array, `getMatter` returns null. These tests pin that contract so a
+ * later regression (e.g., someone adds placeholder rows) trips the
+ * suite. The Pattern A/B audit in CLAUDE.md treats invented client-
+ * facing content as a P0 violation; the empty-list contract is the
+ * structural enforcement.
+ *
+ * The formatters (`formatMatterAge`, `resolveMatterPhaseStamp`,
+ * `resolveMatterPhaseTone`) are pure — full coverage here because the
+ * surfaces depend on their return shapes verbatim.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createTestD1 } from '@venturecrane/crane-test-harness'
+import {
+  listMatters,
+  getMatter,
+  formatMatterAge,
+  resolveMatterPhaseStamp,
+  resolveMatterPhaseTone,
+  MATTER_PHASE_LABEL,
+  type MatterPhase,
+} from '../src/lib/portal/ai-employee/matters'
+
+describe('listMatters — empty state contract', () => {
+  it('returns an empty array (Hermes bridge not landed; #821)', async () => {
+    const db = createTestD1()
+    const result = await listMatters(db, 'entity-anything')
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty array regardless of entity id', async () => {
+    const db = createTestD1()
+    const result1 = await listMatters(db, 'entity-a')
+    const result2 = await listMatters(db, 'entity-b')
+    expect(result1).toEqual([])
+    expect(result2).toEqual([])
+  })
+})
+
+describe('getMatter — empty state contract', () => {
+  it('returns null for any matter id (Hermes bridge not landed; #821)', async () => {
+    const db = createTestD1()
+    const result = await getMatter(db, 'entity-anything', 'matter-anything')
+    expect(result).toBeNull()
+  })
+})
+
+describe('formatMatterAge', () => {
+  // Anchor "now" so tests are deterministic regardless of when they run.
+  const NOW = new Date('2026-06-15T12:00:00Z')
+
+  it('returns empty string for nullish input', () => {
+    expect(formatMatterAge(null, NOW)).toBe('')
+    expect(formatMatterAge(undefined, NOW)).toBe('')
+    expect(formatMatterAge('', NOW)).toBe('')
+  })
+
+  it('returns empty string for invalid ISO input', () => {
+    expect(formatMatterAge('not a date', NOW)).toBe('')
+  })
+
+  it('returns "Opened today" for the same calendar day', () => {
+    expect(formatMatterAge('2026-06-15T09:00:00Z', NOW)).toBe('Opened today')
+  })
+
+  it('returns "Opened today" for a future date (clock skew tolerance)', () => {
+    expect(formatMatterAge('2026-06-16T00:00:00Z', NOW)).toBe('Opened today')
+  })
+
+  it('returns "Opened 1d ago" for one day prior', () => {
+    expect(formatMatterAge('2026-06-14T12:00:00Z', NOW)).toBe('Opened 1d ago')
+  })
+
+  it('returns "Opened Nd ago" for less than a month', () => {
+    expect(formatMatterAge('2026-06-01T12:00:00Z', NOW)).toBe('Opened 14d ago')
+  })
+
+  it('returns "Opened 1mo ago" for one month prior', () => {
+    expect(formatMatterAge('2026-05-15T12:00:00Z', NOW)).toBe('Opened 1mo ago')
+  })
+
+  it('returns "Opened Nmo ago" for less than a year', () => {
+    expect(formatMatterAge('2026-01-15T12:00:00Z', NOW)).toBe('Opened 5mo ago')
+  })
+
+  it('returns "Opened 1yr ago" for one year prior', () => {
+    expect(formatMatterAge('2025-06-15T12:00:00Z', NOW)).toBe('Opened 1yr ago')
+  })
+
+  it('returns "Opened Nyr ago" for multiple years prior', () => {
+    expect(formatMatterAge('2023-06-15T12:00:00Z', NOW)).toBe('Opened 3yr ago')
+  })
+})
+
+describe('resolveMatterPhaseStamp', () => {
+  const cases: Array<[MatterPhase, string]> = [
+    ['pre_suit', 'PRE-SUIT'],
+    ['discovery', 'DISCOVERY'],
+    ['pre_trial', 'PRE-TRIAL'],
+  ]
+  for (const [phase, expected] of cases) {
+    it(`maps ${phase} → ${expected}`, () => {
+      expect(resolveMatterPhaseStamp(phase)).toBe(expected)
+    })
+  }
+})
+
+describe('resolveMatterPhaseTone', () => {
+  it('escalates tone with lifecycle position', () => {
+    expect(resolveMatterPhaseTone('pre_suit')).toBe('info')
+    expect(resolveMatterPhaseTone('discovery')).toBe('warning')
+    expect(resolveMatterPhaseTone('pre_trial')).toBe('outline')
+  })
+})
+
+describe('MATTER_PHASE_LABEL', () => {
+  it('provides a human-readable label for every phase', () => {
+    expect(MATTER_PHASE_LABEL.pre_suit).toBe('Pre-Suit')
+    expect(MATTER_PHASE_LABEL.discovery).toBe('Discovery')
+    expect(MATTER_PHASE_LABEL.pre_trial).toBe('Pre-Trial')
+  })
+})


### PR DESCRIPTION
## Summary

Adds the AI Employee matters list and per-matter detail surfaces under `/portal/products/ai-employee/matters{,/[id]}`. List shows client name, matter type, phase stamp, opened-age, and last AI action. Detail surfaces Facts, Timeline, Drafts in flight, and Audit history sections with cross-links to the drafts and audit surfaces. Both surfaces render their empty state per `docs/style/empty-state-pattern.md` until the per-customer Hermes Machine D1 bridge lands (#821) — no fabricated rows, no placeholder facts.

## Linked issue

Closes #871

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Page at `/ai-employee/matters` (list) | met | `src/pages/portal/products/ai-employee/matters/index.astro` (mounted under `/portal/products/ai-employee/matters` per #907 routing decision) |
| Page at `/ai-employee/matters/[id]` (detail) | met | `src/pages/portal/products/ai-employee/matters/[id].astro` |
| List shows: client name, matter type, phase (pre-suit / discovery / pre-trial), age, last AI action | met | `src/components/portal/ai-employee/MatterRow.astro`; phase vocabulary + stamps in `src/lib/portal/ai-employee/matters.ts` |
| Detail shows: facts, timeline, drafts in flight, audit history | met | `MatterFactsSection`, `MatterTimelineSection`, `MatterDraftsSection`, `MatterAuditSection` in `src/components/portal/ai-employee/` |
| Empty state per `docs/style/empty-state-pattern.md` | met | List renders bordered empty-state container when `matters.length === 0`; detail renders not-found state with back-link; per-section empty-states are muted prose lines, no fabricated rows |

## Test plan

- [x] `npm run verify` passes (typecheck, lint, format, build, tests — 119 test files / 2212 tests pass)
- [x] New `tests/portal-ai-employee-matters.test.ts` (18 tests) covers the empty-list / null-detail contract and the age + phase formatters
- [x] `tests/forbidden-strings.test.ts` (74 tests) green — no em dashes in user-facing copy, no fabricated phrases, matters list registered in `LIST_INDEX_ALLOWLIST` with rationale
- [ ] Manual verification of the live surface deferred until the Hermes bridge lands (#821); empty-state rendering visually verified locally via build output

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints (no new endpoints — page-level access gate via `resolveAiEmployeeAccess`)
- [x] Parameterized queries for any SQL (resolvers are stubs; no SQL today)
- [x] Auth required on new endpoints (Clerk session + entity binding + active subscription + role gate)
- [x] No internal IDs that enable enumeration (matter id is opaque, owned by Hermes; portal does not list)

## Feature Impact

**Feature impact:** None

## Deployment Notes

Standard deploy. No schema changes, no env vars, no secret rotations. The `listMatters` / `getMatter` resolvers return empty results until #821 (Hermes runtime bridge) lands — both surfaces render their empty-state pattern in the meantime, which is the contracted behavior.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>