### PR TITLE
feat(ai-employee): voice sample ingestion pipeline (#856)

### DIFF
--- a/ai-employee/adapter/tests/test_voice_pipeline.py
+++ b/ai-employee/adapter/tests/test_voice_pipeline.py
@@ -1,0 +1,797 @@
+"""Tests for the voice sample ingestion pipeline (issue #856).
+
+Covers:
+
+* Structural-diff extraction is deterministic, body-free, and labels
+  greetings/signoffs/cohorts correctly.
+* Partner-authored filter excludes adapter-tagged drafts, audit-log
+  digest matches, and shape-heuristic hits.
+* Runner: scheduled + on-demand modes share the same write path.
+* Runner: each ingested message writes to R2 at the right key, inserts a
+  provenance row, and upserts the state row's cohort histogram.
+* Filtered messages get a provenance row with ``partner_authored=0``,
+  no R2 object, and the reason persisted for dashboard drill-down.
+* Deduplication: re-running over the same cursor does not re-write.
+* Retention enforcer deletes R2 objects older than the configured
+  window and soft-deletes provenance rows.
+* Decommission hook removes every R2 object for one source.
+* Privacy: the raw body never lands in the structural-diff JSON or in
+  any D1 column.
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_voice_pipeline.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from adapter.voice import (  # noqa: E402
+    ACCEPT_REASON,
+    COHORT_UNASSIGNED,
+    CandidateMessage,
+    GreetingStyle,
+    IngestionItemRecord,
+    IngestionMode,
+    IngestionStateUpdate,
+    NoEmailSource,
+    PartnerAuthoredFilter,
+    REASON_ADAPTER_AGENT_DRAFTED,
+    REASON_AUDIT_LOG_DIGEST_MATCH,
+    REASON_EMPTY_BODY,
+    REASON_SHAPE_HEURISTIC,
+    REASON_TOO_SHORT,
+    SentMessage,
+    SignoffStyle,
+    StaticCohortResolver,
+    VoiceIngestionRunner,
+    VoiceSourceStateStore,
+    compute_body_digest,
+    decommission_source,
+    enforce_retention,
+    extract_structural_diff,
+    structural_diff_digest,
+)
+from adapter.voice.state import (  # noqa: E402
+    INGEST_STATUS_OK,
+    INGEST_STATUS_ERROR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema: in-test copy of migration 0004 so the tests do not shell out.
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """
+CREATE TABLE voice_source_state (
+  source_kind             TEXT NOT NULL,
+  source_id               TEXT NOT NULL,
+  last_ingestion_at       TEXT NOT NULL,
+  last_success_at         TEXT,
+  last_error              TEXT,
+  ingest_status           TEXT NOT NULL,
+  items_last_run          INTEGER NOT NULL DEFAULT 0,
+  samples_by_cohort_json  TEXT,
+  schema_version          INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (source_kind, source_id)
+);
+
+CREATE TABLE voice_ingestion_items (
+  id                       TEXT PRIMARY KEY,
+  source_kind              TEXT NOT NULL,
+  source_id                TEXT NOT NULL,
+  source_message_digest    TEXT NOT NULL,
+  recipient_cohort_id      TEXT NOT NULL,
+  partner_authored         INTEGER NOT NULL,
+  filter_reason            TEXT,
+  ingested_at              TEXT NOT NULL,
+  sent_at                  TEXT NOT NULL,
+  r2_key                   TEXT,
+  structural_diff_digest   TEXT,
+  word_count               INTEGER,
+  schema_version           INTEGER NOT NULL DEFAULT 1,
+  deleted_at               TEXT
+);
+
+CREATE INDEX idx_voice_items_source
+  ON voice_ingestion_items(source_kind, source_id, deleted_at);
+
+CREATE UNIQUE INDEX idx_voice_items_dedupe
+  ON voice_ingestion_items(source_kind, source_id, source_message_digest)
+  WHERE deleted_at IS NULL;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Test fakes
+# ---------------------------------------------------------------------------
+
+
+class SqliteWriteExecutor:
+    """Write executor matching adapter.audit_log.SqliteExecutor's shape."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    async def execute(self, sql: str, params: list) -> None:
+        cur = self._conn.cursor()
+        cur.execute(sql, params)
+        self._conn.commit()
+
+
+class SqliteQueryExecutor:
+    """Query executor returning ``list[dict]``."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    async def query(self, sql: str, params: list) -> list[dict]:
+        cur = self._conn.cursor()
+        cur.execute(sql, params)
+        cols = [d[0] for d in cur.description] if cur.description else []
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+class FakeR2Client:
+    """In-memory R2 client. Records every put + delete for assertions."""
+
+    def __init__(self, customer_slug: str) -> None:
+        self.customer_slug = customer_slug
+        self.objects: dict[str, bytes] = {}
+        self.deletes: list[str] = []
+        self.fail_next_put: bool = False
+
+    async def put(self, key: str, body: bytes, content_type: str) -> None:  # noqa: ARG002
+        if self.fail_next_put:
+            self.fail_next_put = False
+            raise RuntimeError("simulated R2 outage")
+        self.objects[key] = body
+
+    async def delete(self, key: str) -> None:
+        self.deletes.append(key)
+        self.objects.pop(key, None)
+
+
+class FakeCursorStore:
+    def __init__(self, initial: str | None = None) -> None:
+        self.value = initial
+        self.history: list[str | None] = []
+
+    async def get(self) -> str | None:
+        return self.value
+
+    async def set(self, cursor: str | None) -> None:
+        self.value = cursor
+        self.history.append(cursor)
+
+
+class FakeAuditLookup:
+    def __init__(self, matching: set[str] | None = None) -> None:
+        self.matching = matching or set()
+
+    async def has_draft_with_digest(self, digest: str) -> bool:
+        return digest in self.matching
+
+
+class FakeEmailSource:
+    def __init__(self, messages: list[SentMessage], next_cursor: str | None) -> None:
+        self.source_id = "test-adapter"
+        self._messages = messages
+        self._next_cursor = next_cursor
+        self.calls = 0
+
+    async def list_sent_since(self, cursor: str | None):  # noqa: ARG002
+        self.calls += 1
+        return self._messages, self._next_cursor
+
+
+class ErroringEmailSource:
+    source_id = "test-adapter"
+
+    async def list_sent_since(self, cursor):  # noqa: ARG002
+        raise RuntimeError("connector exploded")
+
+
+class DictCohortResolver:
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self.mapping = mapping
+
+    async def resolve(self, recipient_email: str) -> str | None:
+        return self.mapping.get(recipient_email.lower())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.executescript(_SCHEMA_SQL)
+    return c
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _store(conn: sqlite3.Connection) -> VoiceSourceStateStore:
+    return VoiceSourceStateStore(SqliteWriteExecutor(conn), SqliteQueryExecutor(conn))
+
+
+def _make_runner(
+    *,
+    messages: list[SentMessage] | None = None,
+    cohort_mapping: dict[str, str] | None = None,
+    audit_matches: set[str] | None = None,
+    cursor: str | None = None,
+    next_cursor: str | None = "cursor-2",
+    customer_slug: str = "demo-firm",
+):
+    conn = _conn()
+    source = FakeEmailSource(messages or [], next_cursor)
+    resolver = (
+        DictCohortResolver(cohort_mapping)
+        if cohort_mapping is not None
+        else StaticCohortResolver()
+    )
+    r2 = FakeR2Client(customer_slug)
+    cursor_store = FakeCursorStore(cursor)
+    audit_lookup = FakeAuditLookup(audit_matches)
+    runner = VoiceIngestionRunner(
+        source=source,
+        cohort_resolver=resolver,
+        r2_client=r2,
+        state_store=_store(conn),
+        cursor_store=cursor_store,
+        audit_lookup=audit_lookup,
+    )
+    return runner, conn, r2, cursor_store, source
+
+
+def _mk_msg(
+    *,
+    id_: str = "msg-1",
+    body: str = "Hi Sarah,\n\nLet's plan to meet next week to discuss the matter.\n\nBest,\nMarcus",
+    subject: str = "Meeting next week",
+    recipients=("sarah@example.com",),
+    likely_agent_drafted: bool | None = False,
+    sent_at: str = "2026-05-21T12:00:00.000Z",
+) -> SentMessage:
+    return SentMessage(
+        message_id=id_,
+        sent_at=sent_at,
+        body_text=body,
+        subject=subject,
+        recipients=list(recipients),
+        likely_agent_drafted=likely_agent_drafted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural diff
+# ---------------------------------------------------------------------------
+
+
+def test_structural_diff_is_deterministic():
+    body = "Hi Sarah,\n\nThanks for the update. We will respond Monday.\n\nBest,\nMarcus"
+    a = extract_structural_diff(body_text=body, subject="Re: matter", recipient_cohort="client")
+    b = extract_structural_diff(body_text=body, subject="Re: matter", recipient_cohort="client")
+    assert a.as_dict() == b.as_dict()
+    assert structural_diff_digest(a) == structural_diff_digest(b)
+
+
+def test_structural_diff_drops_raw_body():
+    body = "Hi Sarah,\n\nThe deposition for Smith vs. Jones is set for Tuesday.\n\nBest,\nMarcus"
+    diff = extract_structural_diff(body_text=body, subject="depo", recipient_cohort="client")
+    blob = diff.to_json_bytes()
+    decoded = blob.decode("utf-8")
+    # No content tokens survive.
+    assert "Sarah" not in decoded
+    assert "Smith" not in decoded
+    assert "Jones" not in decoded
+    assert "deposition" not in decoded
+    assert "Marcus" not in decoded
+
+
+def test_structural_diff_word_and_sentence_counts():
+    body = "We will call you tomorrow. The discovery deadline moved. Plan for Monday."
+    diff = extract_structural_diff(body_text=body, subject="", recipient_cohort="client")
+    assert diff.sentence_count == 3
+    # 5 + 4 + 3 words across the three sentences.
+    assert diff.word_count == 12
+    assert diff.avg_sentence_length == pytest.approx(12 / 3, rel=1e-2)
+
+
+def test_structural_diff_classifies_greetings():
+    cases = {
+        "Dear Mr. Smith,\n\nLet's discuss the matter.\n\nBest,\nMarcus": GreetingStyle.FORMAL_NAMED,
+        "Hi Sarah,\n\nLet's discuss the matter.\n\nBest,\nMarcus": GreetingStyle.FIRST_NAME,
+        "Hi Mr. Smith,\n\nLet's discuss the matter.\n\nBest,\nMarcus": GreetingStyle.SEMI_FORMAL,
+        "Team,\n\nLet's discuss the matter.\n\nBest,\nMarcus": GreetingStyle.GROUP,
+        "Hello,\n\nLet's discuss the matter.\n\nBest,\nMarcus": GreetingStyle.BARE_HI,
+    }
+    for body, expected in cases.items():
+        diff = extract_structural_diff(body_text=body, subject="", recipient_cohort="client")
+        assert diff.greeting_style == expected.value
+
+
+def test_structural_diff_classifies_signoffs():
+    body = "Hi Sarah,\n\nLet's plan to meet.\n\nThanks,\nMarcus"
+    diff = extract_structural_diff(body_text=body, subject="", recipient_cohort="client")
+    assert diff.signoff_style == SignoffStyle.THANKS.value
+
+
+def test_structural_diff_strips_quoted_reply_chain():
+    body = (
+        "Hi Sarah,\n\nLet's plan to meet next week.\n\nBest,\nMarcus\n\n"
+        "On 2026-05-20, Sarah wrote:\n> Original message\n> with content"
+    )
+    diff = extract_structural_diff(body_text=body, subject="", recipient_cohort="client")
+    blob = diff.to_json_bytes().decode("utf-8")
+    assert "Original message" not in blob
+
+
+def test_structural_diff_punctuation_rhythm():
+    body = "We need to confirm. Are you available tomorrow? Thanks."
+    diff = extract_structural_diff(body_text=body, subject="", recipient_cohort="client")
+    # 9 words; 2 periods + 1 question + 1 trailing period = 3 periods + 1 q
+    rhythm = diff.punctuation_rhythm
+    assert rhythm["period_per_100"] > 0
+    assert rhythm["question_per_100"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Partner-authored filter
+# ---------------------------------------------------------------------------
+
+
+def test_filter_excludes_empty_body():
+    fil = PartnerAuthoredFilter(FakeAuditLookup())
+    result = _run(
+        fil.evaluate(
+            CandidateMessage(
+                body_text="",
+                word_count=0,
+                likely_agent_drafted=None,
+                body_digest=compute_body_digest(""),
+            )
+        )
+    )
+    assert not result.accept
+    assert result.reason == REASON_EMPTY_BODY
+
+
+def test_filter_excludes_too_short():
+    body = "Got it, thanks."
+    fil = PartnerAuthoredFilter(FakeAuditLookup())
+    result = _run(
+        fil.evaluate(
+            CandidateMessage(
+                body_text=body,
+                word_count=3,
+                likely_agent_drafted=False,
+                body_digest=compute_body_digest(body),
+            )
+        )
+    )
+    assert not result.accept
+    assert result.reason == REASON_TOO_SHORT
+
+
+def test_filter_excludes_adapter_tagged_agent_drafts():
+    body = "Hello team, here is a sufficiently long body to pass the length gate."
+    fil = PartnerAuthoredFilter(FakeAuditLookup())
+    result = _run(
+        fil.evaluate(
+            CandidateMessage(
+                body_text=body,
+                word_count=20,
+                likely_agent_drafted=True,
+                body_digest=compute_body_digest(body),
+            )
+        )
+    )
+    assert not result.accept
+    assert result.reason == REASON_ADAPTER_AGENT_DRAFTED
+
+
+def test_filter_excludes_audit_log_digest_match():
+    body = "Hello, here is a sufficiently long body that the AI Employee originally drafted."
+    digest = compute_body_digest(body)
+    fil = PartnerAuthoredFilter(FakeAuditLookup({digest}))
+    result = _run(
+        fil.evaluate(
+            CandidateMessage(
+                body_text=body,
+                word_count=20,
+                likely_agent_drafted=None,
+                body_digest=digest,
+            )
+        )
+    )
+    assert not result.accept
+    assert result.reason == REASON_AUDIT_LOG_DIGEST_MATCH
+
+
+def test_filter_excludes_shape_heuristic_marker():
+    body = (
+        "Hi Sarah, here is the response we discussed.\n"
+        "[Drafted by your AI Employee for review]\n"
+        "Please review before sending."
+    )
+    fil = PartnerAuthoredFilter(FakeAuditLookup())
+    result = _run(
+        fil.evaluate(
+            CandidateMessage(
+                body_text=body,
+                word_count=20,
+                likely_agent_drafted=False,
+                body_digest=compute_body_digest(body),
+            )
+        )
+    )
+    assert not result.accept
+    assert result.reason == REASON_SHAPE_HEURISTIC
+
+
+def test_filter_accepts_clean_partner_authored_message():
+    body = (
+        "Hi Sarah,\n\nLet's plan to meet next Tuesday at two PM to walk through the "
+        "deposition outline together.\n\nBest,\nMarcus"
+    )
+    fil = PartnerAuthoredFilter(FakeAuditLookup())
+    result = _run(
+        fil.evaluate(
+            CandidateMessage(
+                body_text=body,
+                word_count=30,
+                likely_agent_drafted=False,
+                body_digest=compute_body_digest(body),
+            )
+        )
+    )
+    assert result.accept
+    assert result.reason == ACCEPT_REASON
+
+
+# ---------------------------------------------------------------------------
+# Runner — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_runner_ingests_and_writes_to_r2():
+    messages = [_mk_msg(id_="msg-1"), _mk_msg(id_="msg-2", body=_mk_msg().body_text + " Plus a second paragraph here for variety.")]
+    runner, conn, r2, cursor_store, _ = _make_runner(
+        messages=messages,
+        cohort_mapping={"sarah@example.com": "client"},
+    )
+
+    result = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+
+    assert result.items_seen == 2
+    assert result.items_ingested == 2
+    assert result.items_filtered == 0
+    assert result.items_errored == 0
+    assert result.status == INGEST_STATUS_OK
+    assert result.cohort_histogram == {"client": 2}
+    assert result.next_cursor == "cursor-2"
+    # Two R2 objects, both under the customer slug and cohort path.
+    assert len(r2.objects) == 2
+    for key in r2.objects:
+        assert key.startswith("demo-firm/voice/cohort/client/")
+        assert key.endswith(".json")
+    # Cursor was advanced.
+    assert cursor_store.value == "cursor-2"
+
+    # State row reflects the cohort histogram.
+    row = conn.execute(
+        "SELECT items_last_run, samples_by_cohort_json, ingest_status FROM voice_source_state"
+    ).fetchone()
+    assert row[0] == 2
+    assert json.loads(row[1]) == {"client": 2}
+    assert row[2] == INGEST_STATUS_OK
+
+    # Two provenance rows, all partner_authored=1.
+    rows = conn.execute(
+        "SELECT partner_authored, recipient_cohort_id, r2_key, structural_diff_digest "
+        "FROM voice_ingestion_items ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 2
+    for partner_authored, cohort, r2_key, diff_digest in rows:
+        assert partner_authored == 1
+        assert cohort == "client"
+        assert r2_key.startswith("demo-firm/voice/cohort/client/")
+        assert len(diff_digest) == 64  # SHA-256 hex
+
+
+def test_runner_tags_unassigned_when_cohort_resolver_returns_none():
+    messages = [_mk_msg(id_="msg-1", recipients=("nobody@example.com",))]
+    runner, conn, r2, _, _ = _make_runner(messages=messages, cohort_mapping={})
+    result = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert result.items_ingested == 1
+    assert result.cohort_histogram == {COHORT_UNASSIGNED: 1}
+    # R2 key uses 'unassigned' segment.
+    assert all(f"/cohort/{COHORT_UNASSIGNED}/" in key for key in r2.objects)
+
+
+def test_runner_filtered_messages_record_provenance_but_no_r2():
+    body = "Quick note."
+    messages = [_mk_msg(id_="msg-1", body=body, likely_agent_drafted=False)]
+    runner, conn, r2, _, _ = _make_runner(messages=messages)
+    result = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert result.items_filtered == 1
+    assert result.items_ingested == 0
+    assert len(r2.objects) == 0
+    row = conn.execute(
+        "SELECT partner_authored, filter_reason, r2_key FROM voice_ingestion_items"
+    ).fetchone()
+    assert row == (0, REASON_TOO_SHORT, None)
+
+
+def test_runner_dedupes_on_re_run():
+    msg = _mk_msg(id_="msg-stable")
+    runner, conn, r2, _, source = _make_runner(messages=[msg])
+    first = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert first.items_ingested == 1
+    assert len(r2.objects) == 1
+
+    # Re-run: the source yields the same message again.
+    second = _run(runner.run_ingestion(mode=IngestionMode.ON_DEMAND))
+    assert second.items_ingested == 0
+    assert second.items_skipped_duplicate == 1
+    # No new R2 objects.
+    assert len(r2.objects) == 1
+    rows = conn.execute(
+        "SELECT COUNT(*) FROM voice_ingestion_items WHERE deleted_at IS NULL"
+    ).fetchone()
+    assert rows[0] == 1
+
+
+def test_runner_records_error_when_source_blows_up():
+    runner, conn, _, _, _ = _make_runner()
+    runner.source = ErroringEmailSource()  # type: ignore[assignment]
+    result = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert result.items_seen == 0
+    assert result.status == INGEST_STATUS_ERROR
+    assert "connector exploded" in (result.error or "")
+    # State row still upserted so the dashboard surfaces the failure.
+    row = conn.execute(
+        "SELECT ingest_status, last_error FROM voice_source_state"
+    ).fetchone()
+    assert row[0] == INGEST_STATUS_ERROR
+    assert "connector exploded" in (row[1] or "")
+
+
+def test_runner_continues_on_per_item_r2_failure():
+    messages = [_mk_msg(id_="ok-1"), _mk_msg(id_="boom-2"), _mk_msg(id_="ok-3")]
+    runner, conn, r2, _, _ = _make_runner(
+        messages=messages, cohort_mapping={"sarah@example.com": "client"}
+    )
+
+    # Inject a one-shot failure on the second put.
+    original_put = r2.put
+    call_count = {"n": 0}
+
+    async def flaky_put(key, body, content_type):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("transient R2 outage")
+        return await original_put(key, body, content_type)
+
+    r2.put = flaky_put  # type: ignore[assignment]
+
+    result = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert result.items_ingested == 2
+    assert result.items_errored == 1
+    # Final status remains OK because at least one item ingested.
+    assert result.status == INGEST_STATUS_OK
+
+
+def test_runner_with_no_email_source_returns_zero_items_state_row():
+    runner, conn, _, _, _ = _make_runner()
+    runner.source = NoEmailSource()  # type: ignore[assignment]
+    result = _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert result.items_seen == 0
+    assert result.items_ingested == 0
+    assert result.status == INGEST_STATUS_OK
+    row = conn.execute("SELECT source_id, items_last_run FROM voice_source_state").fetchone()
+    assert row == ("none", 0)
+
+
+# ---------------------------------------------------------------------------
+# Retention enforcer
+# ---------------------------------------------------------------------------
+
+
+def test_retention_enforcer_deletes_expired_items():
+    conn = _conn()
+    store = _store(conn)
+    r2 = FakeR2Client("demo-firm")
+
+    # Insert one fresh + one expired item.
+    fresh_id = _run(
+        store.insert_item(
+            IngestionItemRecord(
+                source_kind="email",
+                source_id="ms-graph",
+                source_message_digest="a" * 64,
+                recipient_cohort_id="client",
+                partner_authored=True,
+                sent_at="2026-05-20T00:00:00.000Z",
+                filter_reason=ACCEPT_REASON,
+                r2_key="demo-firm/voice/cohort/client/fresh.json",
+                structural_diff_digest="b" * 64,
+                word_count=42,
+            )
+        )
+    )
+    expired_id = _run(
+        store.insert_item(
+            IngestionItemRecord(
+                source_kind="email",
+                source_id="ms-graph",
+                source_message_digest="c" * 64,
+                recipient_cohort_id="client",
+                partner_authored=True,
+                sent_at="2024-01-01T00:00:00.000Z",
+                filter_reason=ACCEPT_REASON,
+                r2_key="demo-firm/voice/cohort/client/expired.json",
+                structural_diff_digest="d" * 64,
+                word_count=99,
+            )
+        )
+    )
+    # Backdate the expired row's ingested_at directly (the insert helper
+    # always stamps "now").
+    conn.execute(
+        "UPDATE voice_ingestion_items SET ingested_at = ? WHERE id = ?",
+        ("2024-01-01T00:00:00.000Z", expired_id),
+    )
+    conn.commit()
+    r2.objects[
+        "demo-firm/voice/cohort/client/fresh.json"
+    ] = b"{}"
+    r2.objects[
+        "demo-firm/voice/cohort/client/expired.json"
+    ] = b"{}"
+
+    summary = _run(
+        enforce_retention(
+            state_store=store,
+            r2_client=r2,
+            voice_retention_days=365,
+            now=datetime(2026, 5, 21, tzinfo=timezone.utc),
+        )
+    )
+    assert summary["considered"] == 1
+    assert summary["deleted"] == 1
+    assert summary["errors"] == 0
+    # Fresh row untouched.
+    assert "demo-firm/voice/cohort/client/fresh.json" in r2.objects
+    # Expired row's R2 object removed.
+    assert "demo-firm/voice/cohort/client/expired.json" not in r2.objects
+    # Expired provenance row soft-deleted.
+    deleted_at = conn.execute(
+        "SELECT deleted_at FROM voice_ingestion_items WHERE id = ?", (expired_id,)
+    ).fetchone()[0]
+    assert deleted_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Decommission hook
+# ---------------------------------------------------------------------------
+
+
+def test_decommission_source_removes_every_r2_object_and_state_row():
+    messages = [_mk_msg(id_=f"msg-{i}") for i in range(3)]
+    runner, conn, r2, _, _ = _make_runner(
+        messages=messages, cohort_mapping={"sarah@example.com": "client"}
+    )
+    _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+    assert len(r2.objects) == 3
+
+    summary = _run(
+        decommission_source(
+            state_store=runner.state_store,
+            r2_client=r2,
+            source_kind="email",
+            source_id="test-adapter",
+        )
+    )
+    assert summary["removed"] == 3
+    assert summary["errors"] == 0
+    assert len(r2.objects) == 0
+    # State row deleted.
+    rows = conn.execute(
+        "SELECT COUNT(*) FROM voice_source_state WHERE source_id = 'test-adapter'"
+    ).fetchone()
+    assert rows[0] == 0
+    # Every provenance row soft-deleted.
+    active = conn.execute(
+        "SELECT COUNT(*) FROM voice_ingestion_items WHERE deleted_at IS NULL"
+    ).fetchone()[0]
+    assert active == 0
+
+
+# ---------------------------------------------------------------------------
+# Privacy: substantive content never lands anywhere
+# ---------------------------------------------------------------------------
+
+
+def test_no_raw_body_in_r2_or_d1():
+    secret_body = (
+        "Hi Sarah,\n\nThe SETTLEMENT-MAGIC-PHRASE for Smith vs. Jones is "
+        "absolutely confidential and must not leak.\n\nBest,\nMarcus"
+    )
+    msg = _mk_msg(id_="msg-1", body=secret_body)
+    runner, conn, r2, _, _ = _make_runner(
+        messages=[msg], cohort_mapping={"sarah@example.com": "client"}
+    )
+    _run(runner.run_ingestion(mode=IngestionMode.SCHEDULED))
+
+    # R2 object never contains the secret.
+    for key, blob in r2.objects.items():
+        assert b"SETTLEMENT-MAGIC-PHRASE" not in blob, f"leak in {key}"
+        assert b"Sarah" not in blob, f"name leak in {key}"
+        assert b"Smith" not in blob, f"matter leak in {key}"
+        assert b"Marcus" not in blob, f"signer leak in {key}"
+
+    # D1 rows never contain the secret either.
+    for table in ("voice_source_state", "voice_ingestion_items"):
+        for row in conn.execute(f"SELECT * FROM {table}").fetchall():
+            for value in row:
+                if isinstance(value, str):
+                    assert "SETTLEMENT-MAGIC-PHRASE" not in value
+                    assert "Sarah" not in value
+                    assert "Smith" not in value
+
+
+# ---------------------------------------------------------------------------
+# State / dashboard surface
+# ---------------------------------------------------------------------------
+
+
+def test_state_store_round_trip_decodes_cohort_histogram():
+    conn = _conn()
+    store = _store(conn)
+    _run(
+        store.upsert_state(
+            IngestionStateUpdate(
+                source_kind="email",
+                source_id="ms-graph",
+                ingested_at="2026-05-21T12:00:00.000Z",
+                status=INGEST_STATUS_OK,
+                items_last_run=4,
+                samples_by_cohort={"client": 3, "opposing_counsel": 1},
+            )
+        )
+    )
+    rows = _run(store.read_states())
+    assert len(rows) == 1
+    assert rows[0].samples_by_cohort == {"client": 3, "opposing_counsel": 1}
+    assert rows[0].ingest_status == INGEST_STATUS_OK
+    assert rows[0].last_success_at == "2026-05-21T12:00:00.000Z"
+
+
+def test_ingestion_state_update_rejects_invalid_status():
+    with pytest.raises(ValueError, match="ingest_status"):
+        IngestionStateUpdate(
+            source_kind="email",
+            source_id="ms-graph",
+            ingested_at="2026-05-21T12:00:00.000Z",
+            status="bogus",
+            items_last_run=0,
+            samples_by_cohort={},
+        )

--- a/ai-employee/adapter/voice/__init__.py
+++ b/ai-employee/adapter/voice/__init__.py
@@ -1,0 +1,131 @@
+"""Voice sample ingestion pipeline (issue #856).
+
+Consumes the Email capability's sent folder, filters AI-drafted
+messages out, extracts structural-diff representations (never raw
+bodies), and writes them to the per-customer R2 vault at
+``{customer-slug}/voice/cohort/{cohort-id}/{sample-id}.json``.
+
+Sibling to the memory ingestion pipeline (PR #944) — same shape,
+distinct concern. Voice anchors Layer 2 of the voice gate; memory
+holds matter and document context.
+
+Public surface:
+
+* :class:`VoiceIngestionRunner` — the orchestrator. Construct with
+  the Email source, cohort resolver, R2 client, state store, cursor
+  store, and audit-log lookup; call
+  :meth:`VoiceIngestionRunner.run_ingestion` with a mode.
+* :func:`enforce_retention` — deletes samples older than the
+  ``voice_retention_days`` window from customer.yaml.
+* :func:`decommission_source` — removes every voice artifact the
+  pipeline persisted for one source. Called by
+  ``bin/decommission-customer.sh``.
+* :class:`PartnerAuthoredFilter` — three-pass AI-vs-partner detector.
+* :func:`extract_structural_diff` — the privacy primitive.
+
+See ADR 0005, 0006, 0008, 0009 and
+``docs/specs/ai-employee/voice-ingestion.md``.
+"""
+
+from __future__ import annotations
+
+from .diff import (
+    SCHEMA_VERSION as STRUCTURAL_DIFF_SCHEMA_VERSION,
+    GreetingStyle,
+    SignoffStyle,
+    StructuralDiff,
+    extract_structural_diff,
+    structural_diff_digest,
+)
+from .filter import (
+    ACCEPT_REASON,
+    AuditDigestLookup,
+    CandidateMessage,
+    FilterResult,
+    MIN_WORD_COUNT_FOR_SAMPLE,
+    PartnerAuthoredFilter,
+    REASON_ADAPTER_AGENT_DRAFTED,
+    REASON_AUDIT_LOG_DIGEST_MATCH,
+    REASON_EMPTY_BODY,
+    REASON_SHAPE_HEURISTIC,
+    REASON_TOO_SHORT,
+    compute_body_digest,
+)
+from .pipeline import (
+    CohortResolver,
+    CursorStore,
+    EmailSource,
+    IngestionMode,
+    IngestionResult,
+    NoEmailSource,
+    R2Client,
+    SentMessage,
+    StaticCohortResolver,
+    StorageError,
+    VoiceIngestionRunner,
+    decommission_source,
+    enforce_retention,
+)
+from .state import (
+    COHORT_UNASSIGNED,
+    INGEST_STATUS_ERROR,
+    INGEST_STATUS_NEVER_RUN,
+    INGEST_STATUS_OK,
+    INGEST_STATUS_STALE,
+    IngestionItemRecord,
+    IngestionStateUpdate,
+    QueryExecutor,
+    VALID_STATUSES,
+    VoiceIngestionItem,
+    VoiceSourceState,
+    VoiceSourceStateStore,
+    WriteExecutor,
+)
+
+__all__ = [
+    "ACCEPT_REASON",
+    "AuditDigestLookup",
+    "COHORT_UNASSIGNED",
+    "CandidateMessage",
+    "CohortResolver",
+    "CursorStore",
+    "EmailSource",
+    "FilterResult",
+    "GreetingStyle",
+    "INGEST_STATUS_ERROR",
+    "INGEST_STATUS_NEVER_RUN",
+    "INGEST_STATUS_OK",
+    "INGEST_STATUS_STALE",
+    "IngestionItemRecord",
+    "IngestionMode",
+    "IngestionResult",
+    "IngestionStateUpdate",
+    "MIN_WORD_COUNT_FOR_SAMPLE",
+    "NoEmailSource",
+    "PartnerAuthoredFilter",
+    "QueryExecutor",
+    "R2Client",
+    "REASON_ADAPTER_AGENT_DRAFTED",
+    "REASON_AUDIT_LOG_DIGEST_MATCH",
+    "REASON_EMPTY_BODY",
+    "REASON_SHAPE_HEURISTIC",
+    "REASON_TOO_SHORT",
+    "STRUCTURAL_DIFF_SCHEMA_VERSION",
+    "SentMessage",
+    "SignoffStyle",
+    "StaticCohortResolver",
+    "StorageError",
+    "StorageError",
+    "StructuralDiff",
+    "VALID_STATUSES",
+    "VoiceIngestionItem",
+    "VoiceIngestionRunner",
+    "VoiceSourceState",
+    "VoiceSourceStateStore",
+    "WriteExecutor",
+    "compute_body_digest",
+    "decommission_source",
+    "enforce_retention",
+    "extract_structural_diff",
+    "structural_diff_digest",
+]

--- a/ai-employee/adapter/voice/diff.py
+++ b/ai-employee/adapter/voice/diff.py
@@ -1,0 +1,396 @@
+"""Structural-diff extractor for voice samples (issue #856).
+
+The privacy floor for Voice Layer 2: a raw sent email is NEVER persisted.
+The pipeline computes a structural representation of the message — what
+the partner's writing looks like, not what they wrote — and that is what
+lands in R2.
+
+Per the issue scope, the extractor produces:
+
+* word_count, sentence_count, paragraph_count
+* sentence_length_distribution (5-bucket histogram)
+* greeting_style, signoff_style (categorical labels from a closed set)
+* opener_template, closer_template (the literal greeting/closer line
+  reduced to its category, never the recipient or signer name)
+* punctuation_rhythm (counts of period, comma, semicolon, dash, question,
+  exclamation per 100 words)
+* recipient_cohort (assigned by the pipeline; this module does not invent
+  cohorts — that is the caller's responsibility)
+
+What is NOT in the output:
+
+* No body text, not even a snippet
+* No quoted text
+* No recipient names or email addresses
+* No specific content tokens or n-grams
+* No subject line content (only its word count)
+* No URLs, no attachments, no inline images
+
+The output is JSON-serializable and bounded in size. The JSON object is
+what the caller writes to R2 at
+``{customer-slug}/voice/cohort/{cohort-id}/{sample-id}.json``.
+
+Design rules
+------------
+
+* Deterministic. Same input produces the same diff. The structural-diff
+  digest written to D1 lets the retention enforcer verify removal.
+* Cheap. The extractor is a pure-Python module with no model calls and
+  no network I/O. It runs in the ingestion loop, not asynchronously.
+* Conservative. When in doubt, the extractor labels something as
+  ``unknown`` rather than guessing. The voice library quality bar is
+  satisfied by the volume of samples, not by per-sample inference.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Closed-set category labels
+#
+# These vocabularies are fixed so the structural-diff schema does not drift
+# silently across runs. Adding a new label here means updating the schema
+# version on voice_ingestion_items and any dashboard renderer that maps
+# labels onto display strings.
+# ---------------------------------------------------------------------------
+
+
+class GreetingStyle(str, enum.Enum):
+    """Closed set of greeting categorizations.
+
+    The classifier inspects only the first non-empty line and matches
+    against bounded regex patterns. The recipient name itself is never
+    captured.
+    """
+
+    FORMAL_NAMED = "formal_named"            # "Dear Mr. Smith,"
+    SEMI_FORMAL = "semi_formal"              # "Hi Mr. Smith,"
+    FIRST_NAME = "first_name"                # "Hi Sarah," / "Hello Sarah,"
+    GROUP = "group"                          # "Team," / "All," / "Counsel,"
+    BARE_HI = "bare_hi"                      # "Hi," / "Hello,"
+    NONE = "none"                            # No greeting line
+    UNKNOWN = "unknown"
+
+
+class SignoffStyle(str, enum.Enum):
+    """Closed set of signoff categorizations."""
+
+    BEST = "best"                            # "Best," / "Best regards,"
+    THANKS = "thanks"                        # "Thanks," / "Thank you,"
+    REGARDS = "regards"                      # "Regards," / "Kind regards,"
+    SINCERELY = "sincerely"                  # "Sincerely,"
+    INITIAL = "initial"                      # "-S" / "S." (single initial)
+    NAMED = "named"                          # First name only on its own line
+    NONE = "none"
+    UNKNOWN = "unknown"
+
+
+# Five buckets for the sentence-length histogram. Boundaries chosen to
+# match the natural English distribution (short / typical / long / very
+# long / paragraph-as-sentence).
+SENTENCE_LENGTH_BUCKETS = (5, 10, 20, 35)  # exclusive upper bounds
+
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9])")
+_WORD_SPLIT = re.compile(r"\b\w+\b")
+_PARAGRAPH_SPLIT = re.compile(r"\n\s*\n+")
+_QUOTED_LINE = re.compile(r"^\s*>", re.MULTILINE)
+_SIGNATURE_DELIMITER = re.compile(r"^--\s*$", re.MULTILINE)
+_REPLY_HEADER = re.compile(
+    r"^(?:On .{1,80} wrote:|From: .{1,200}$|Sent: .{1,80}$|To: .{1,200}$)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+# Greeting regexes. Each pattern matches the literal opening, and the
+# named captures are discarded — only the category survives into the
+# structural diff.
+_FORMAL_NAMED_RE = re.compile(
+    r"^(?:Dear|To)\s+(?:Mr\.|Ms\.|Mrs\.|Dr\.|Hon\.|Justice|Judge|Counsel)\s+\S+",
+    re.IGNORECASE,
+)
+_SEMI_FORMAL_RE = re.compile(
+    r"^(?:Hi|Hello|Good (?:morning|afternoon|evening))\s+(?:Mr\.|Ms\.|Mrs\.|Dr\.)\s+\S+",
+    re.IGNORECASE,
+)
+_FIRST_NAME_RE = re.compile(
+    r"^(?:Hi|Hello|Hey|Good (?:morning|afternoon|evening))\s+[A-Z][a-z]+\b",
+)
+_GROUP_RE = re.compile(
+    r"^(?:Hi|Hello|Hey)?\s*(?:Team|All|Counsel|Everyone|Folks)[,:]?\s*$",
+    re.IGNORECASE,
+)
+_BARE_HI_RE = re.compile(
+    r"^(?:Hi|Hello|Hey|Greetings)[,!.]?\s*$",
+    re.IGNORECASE,
+)
+
+
+_BEST_RE = re.compile(r"^Best(?:\s+regards)?[,.]?\s*$", re.IGNORECASE)
+_THANKS_RE = re.compile(r"^(?:Thanks(?:\s+so\s+much)?|Thank\s+you)[,.!]?\s*$", re.IGNORECASE)
+_REGARDS_RE = re.compile(r"^(?:Kind\s+)?Regards[,.]?\s*$", re.IGNORECASE)
+_SINCERELY_RE = re.compile(r"^Sincerely(?:\s+yours)?[,.]?\s*$", re.IGNORECASE)
+_INITIAL_RE = re.compile(r"^-?[A-Z]\.?\s*$")
+_NAMED_LINE_RE = re.compile(r"^[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?\s*$")
+
+
+@dataclass(frozen=True)
+class StructuralDiff:
+    """JSON-serializable structural representation of one sent message.
+
+    The fields here are everything the voice library learns from this
+    sample. The original body is gone by the time this object exists.
+    """
+
+    schema_version: int
+    word_count: int
+    sentence_count: int
+    paragraph_count: int
+    subject_word_count: int
+    avg_sentence_length: float
+    sentence_length_distribution: dict
+    greeting_style: str
+    signoff_style: str
+    opener_template: str
+    closer_template: str
+    punctuation_rhythm: dict
+    recipient_cohort: str
+
+    def to_json_bytes(self) -> bytes:
+        """Return the canonical JSON encoding used for R2 storage + digest."""
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    def as_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "word_count": self.word_count,
+            "sentence_count": self.sentence_count,
+            "paragraph_count": self.paragraph_count,
+            "subject_word_count": self.subject_word_count,
+            "avg_sentence_length": self.avg_sentence_length,
+            "sentence_length_distribution": self.sentence_length_distribution,
+            "greeting_style": self.greeting_style,
+            "signoff_style": self.signoff_style,
+            "opener_template": self.opener_template,
+            "closer_template": self.closer_template,
+            "punctuation_rhythm": self.punctuation_rhythm,
+            "recipient_cohort": self.recipient_cohort,
+        }
+
+
+SCHEMA_VERSION = 1
+
+
+def extract_structural_diff(
+    *,
+    body_text: Optional[str],
+    subject: Optional[str],
+    recipient_cohort: str,
+) -> StructuralDiff:
+    """Compute the structural-diff for one sent message.
+
+    Args:
+        body_text: The plain-text body of the message. The caller is
+            responsible for selecting body_text over body_html — this
+            extractor does not handle HTML.
+        subject: Subject line. Only its word count enters the diff.
+        recipient_cohort: Pre-resolved cohort tag for this message. The
+            extractor does not infer cohorts.
+
+    Returns:
+        A :class:`StructuralDiff`. The original body is not retained
+        anywhere in the returned object — it is gone after this call
+        returns to the caller's local scope.
+    """
+    body = _strip_reply_quoting(body_text or "")
+    paragraphs = [p.strip() for p in _PARAGRAPH_SPLIT.split(body) if p.strip()]
+    sentences = _split_sentences(body)
+    words = _WORD_SPLIT.findall(body)
+
+    word_count = len(words)
+    sentence_count = len(sentences)
+    paragraph_count = len(paragraphs)
+    avg_sentence_length = (
+        round(word_count / sentence_count, 2) if sentence_count else 0.0
+    )
+
+    return StructuralDiff(
+        schema_version=SCHEMA_VERSION,
+        word_count=word_count,
+        sentence_count=sentence_count,
+        paragraph_count=paragraph_count,
+        subject_word_count=len(_WORD_SPLIT.findall(subject or "")),
+        avg_sentence_length=avg_sentence_length,
+        sentence_length_distribution=_distribute_sentence_lengths(sentences),
+        greeting_style=_classify_greeting(body).value,
+        signoff_style=_classify_signoff(body).value,
+        opener_template=_classify_greeting(body).value,
+        closer_template=_classify_signoff(body).value,
+        punctuation_rhythm=_punctuation_rhythm(body, word_count),
+        recipient_cohort=recipient_cohort,
+    )
+
+
+def structural_diff_digest(diff: StructuralDiff) -> str:
+    """SHA-256 hex digest of the canonical-JSON form. Used by the
+    retention enforcer to verify R2 removal."""
+    return hashlib.sha256(diff.to_json_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_reply_quoting(body: str) -> str:
+    """Remove quoted reply chains and signature blocks.
+
+    Voice analysis applies only to what the partner wrote in this
+    message, not to inherited threads. The stripping is conservative —
+    we want fewer false positives over more samples. Lines starting with
+    ``>`` are dropped. Anything after a ``-- `` signature delimiter or
+    a reply header is dropped.
+    """
+    sig_match = _SIGNATURE_DELIMITER.search(body)
+    if sig_match:
+        body = body[: sig_match.start()]
+    reply_match = _REPLY_HEADER.search(body)
+    if reply_match:
+        body = body[: reply_match.start()]
+    body = _QUOTED_LINE.sub("", body)
+    return body.strip()
+
+
+def _split_sentences(body: str) -> list[str]:
+    if not body:
+        return []
+    return [s.strip() for s in _SENTENCE_SPLIT.split(body) if s.strip()]
+
+
+def _distribute_sentence_lengths(sentences: list[str]) -> dict:
+    buckets = {
+        "lt_5": 0,
+        "lt_10": 0,
+        "lt_20": 0,
+        "lt_35": 0,
+        "gte_35": 0,
+    }
+    for sentence in sentences:
+        n = len(_WORD_SPLIT.findall(sentence))
+        if n < 5:
+            buckets["lt_5"] += 1
+        elif n < 10:
+            buckets["lt_10"] += 1
+        elif n < 20:
+            buckets["lt_20"] += 1
+        elif n < 35:
+            buckets["lt_35"] += 1
+        else:
+            buckets["gte_35"] += 1
+    return buckets
+
+
+def _classify_greeting(body: str) -> GreetingStyle:
+    if not body:
+        return GreetingStyle.NONE
+    first_line = body.splitlines()[0].strip()
+    if not first_line:
+        return GreetingStyle.NONE
+
+    if _FORMAL_NAMED_RE.match(first_line):
+        return GreetingStyle.FORMAL_NAMED
+    if _SEMI_FORMAL_RE.match(first_line):
+        return GreetingStyle.SEMI_FORMAL
+    if _GROUP_RE.match(first_line):
+        return GreetingStyle.GROUP
+    if _FIRST_NAME_RE.match(first_line):
+        return GreetingStyle.FIRST_NAME
+    if _BARE_HI_RE.match(first_line):
+        return GreetingStyle.BARE_HI
+
+    # First line looks like prose (no salutation pattern). Treat as no
+    # greeting rather than guessing — the structural-diff prefers
+    # ``none`` to a wrong category.
+    return GreetingStyle.NONE
+
+
+def _classify_signoff(body: str) -> SignoffStyle:
+    if not body:
+        return SignoffStyle.NONE
+    # The signoff is the last meaningful line. Look at the last three
+    # non-empty lines so we can find phrases like "Thanks, / Marcus" or
+    # "Best regards, / Marcus Thompson" where the printed name lives on
+    # the line after the closer.
+    lines = [line.strip() for line in body.splitlines() if line.strip()]
+    if not lines:
+        return SignoffStyle.NONE
+    candidates = lines[-3:]
+    # Prefer phrase closers over bare-name lines — writers commonly put
+    # the name on the very last line and the phrase one above it.
+    for line in candidates:
+        if _BEST_RE.match(line):
+            return SignoffStyle.BEST
+        if _THANKS_RE.match(line):
+            return SignoffStyle.THANKS
+        if _REGARDS_RE.match(line):
+            return SignoffStyle.REGARDS
+        if _SINCERELY_RE.match(line):
+            return SignoffStyle.SINCERELY
+    # Fallback: only bare initial or name remained.
+    last = candidates[-1]
+    if _INITIAL_RE.match(last):
+        return SignoffStyle.INITIAL
+    if _NAMED_LINE_RE.match(last):
+        return SignoffStyle.NAMED
+    return SignoffStyle.NONE
+
+
+def _punctuation_rhythm(body: str, word_count: int) -> dict:
+    """Counts of each punctuation mark, normalized per 100 words.
+
+    A rhythm-style signature, not a content signature: it captures how
+    densely the writer punctuates, not what they wrote.
+    """
+    if word_count == 0:
+        return {
+            "period_per_100": 0.0,
+            "comma_per_100": 0.0,
+            "semicolon_per_100": 0.0,
+            "dash_per_100": 0.0,
+            "question_per_100": 0.0,
+            "exclamation_per_100": 0.0,
+        }
+    counts = {
+        ".": body.count("."),
+        ",": body.count(","),
+        ";": body.count(";"),
+        "-": body.count(" - ") + body.count("—"),
+        "?": body.count("?"),
+        "!": body.count("!"),
+    }
+    factor = 100.0 / word_count
+    return {
+        "period_per_100": round(counts["."] * factor, 2),
+        "comma_per_100": round(counts[","] * factor, 2),
+        "semicolon_per_100": round(counts[";"] * factor, 2),
+        "dash_per_100": round(counts["-"] * factor, 2),
+        "question_per_100": round(counts["?"] * factor, 2),
+        "exclamation_per_100": round(counts["!"] * factor, 2),
+    }
+
+
+__all__ = [
+    "GreetingStyle",
+    "SignoffStyle",
+    "SCHEMA_VERSION",
+    "StructuralDiff",
+    "extract_structural_diff",
+    "structural_diff_digest",
+]

--- a/ai-employee/adapter/voice/filter.py
+++ b/ai-employee/adapter/voice/filter.py
@@ -1,0 +1,207 @@
+"""Partner-authored filter for voice samples (issue #856).
+
+The voice library is the partner's voice, not the agent's. Samples that
+the AI Employee drafted (and the partner sent unedited or lightly
+edited) would feed the agent back its own output through Layer 2.
+
+The filter has three signals, applied in this order:
+
+1. ``SentItem.likely_agent_drafted`` — when the adapter populates this
+   field (MS Graph and Gmail can tag drafts created by the agent's
+   AgentMail identity), the filter trusts it. ``True`` means exclude.
+
+2. Audit log cross-check — when the adapter does not populate the field
+   (mobile clients, IMAP/SMTP), the filter consults the audit log for a
+   ``DRAFT_CREATED`` row whose ``input_payload`` digest matches the
+   sent message body. The lookup is by digest, not body — bodies are
+   never persisted to the audit log either.
+
+3. Body-shape heuristic — a final pass that excludes messages whose
+   shape (length, structure, signature markers) matches the agent's
+   draft templates. This is a soft signal and the only one that can
+   produce false positives; rejecting a true partner-authored message
+   has lower cost than admitting a stowaway AI-drafted message, so the
+   filter biases toward exclusion when shape signals fire.
+
+The filter does NOT inspect the recipient address or the matter to
+decide partner-authoredness. Those are the cohort tag's job, and any
+content-based filtering would be a privacy regression.
+
+Output is a :class:`FilterResult` carrying the boolean decision and a
+short reason string (max 200 chars) used by the dashboard's
+"why was this excluded" drill-down.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+log = logging.getLogger("aie.voice.filter")
+
+
+# Reason codes (closed set) — keep the string short so the D1 column
+# stays compact and the dashboard can map them onto friendly labels.
+REASON_ADAPTER_AGENT_DRAFTED = "adapter_agent_drafted"
+REASON_AUDIT_LOG_DIGEST_MATCH = "audit_log_digest_match"
+REASON_SHAPE_HEURISTIC = "shape_heuristic"
+REASON_EMPTY_BODY = "empty_body"
+REASON_TOO_SHORT = "too_short"
+
+ACCEPT_REASON = "partner_authored"
+
+# Body shorter than this is skipped even before the AI filter — there is
+# not enough signal for the structural-diff to learn from.
+MIN_WORD_COUNT_FOR_SAMPLE = 15
+
+
+@dataclass(frozen=True)
+class FilterResult:
+    """Decision for one candidate sent message.
+
+    Args:
+        accept: True when the message should land in the voice library.
+            False when it is excluded (AI-drafted, too short, empty).
+        reason: One of the REASON_* constants. Used by the dashboard
+            drill-down and by tests.
+    """
+
+    accept: bool
+    reason: str
+
+
+class AuditDigestLookup(Protocol):
+    """Read-only protocol the filter uses to consult the audit log.
+
+    Production wires this to a small D1 SELECT (``WHERE action_type =
+    'DRAFT_CREATED' AND input_digest = ?``); tests pass an in-memory
+    fake.
+    """
+
+    async def has_draft_with_digest(self, digest: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class CandidateMessage:
+    """Vendor-neutral input to the filter.
+
+    Built by the pipeline from the ``SentItem`` returned by the Email
+    capability adapter. The pipeline computes ``body_digest`` once and
+    passes it to both the filter (for audit-log lookup) and the
+    deduplication path (so we do not re-extract the same sample).
+    """
+
+    body_text: str
+    word_count: int
+    likely_agent_drafted: Optional[bool]   # None when the adapter cannot tell
+    body_digest: str                       # SHA-256 hex of body_text
+
+
+def compute_body_digest(body_text: Optional[str]) -> str:
+    """SHA-256 hex of the body as UTF-8 bytes. Empty string hashes to
+    the empty-input SHA-256 — that case is short-circuited by the
+    filter's empty-body check before any audit lookup happens."""
+    if not body_text:
+        return hashlib.sha256(b"").hexdigest()
+    return hashlib.sha256(body_text.encode("utf-8")).hexdigest()
+
+
+class PartnerAuthoredFilter:
+    """Three-pass filter for partner-authored voice samples.
+
+    Construction takes the audit-log lookup; that lookup is the only
+    side-effecting collaborator. The filter has no other state.
+    """
+
+    def __init__(self, audit_lookup: AuditDigestLookup) -> None:
+        self._audit_lookup = audit_lookup
+
+    async def evaluate(self, candidate: CandidateMessage) -> FilterResult:
+        """Run the three-pass evaluation. Returns a :class:`FilterResult`."""
+        if not candidate.body_text or not candidate.body_text.strip():
+            return FilterResult(accept=False, reason=REASON_EMPTY_BODY)
+
+        if candidate.word_count < MIN_WORD_COUNT_FOR_SAMPLE:
+            return FilterResult(accept=False, reason=REASON_TOO_SHORT)
+
+        # Pass 1: adapter-reported provenance.
+        if candidate.likely_agent_drafted is True:
+            return FilterResult(accept=False, reason=REASON_ADAPTER_AGENT_DRAFTED)
+
+        # Pass 2: audit-log digest match. Only consulted when the
+        # adapter could not determine provenance (None) or said False
+        # but we want a second check.
+        try:
+            digest_match = await self._audit_lookup.has_draft_with_digest(
+                candidate.body_digest
+            )
+        except Exception as e:  # noqa: BLE001 — defensive against D1 hiccups
+            log.warning(
+                "audit_log digest lookup failed for body digest %s: %s",
+                candidate.body_digest[:12],
+                e,
+            )
+            digest_match = False
+
+        if digest_match:
+            return FilterResult(accept=False, reason=REASON_AUDIT_LOG_DIGEST_MATCH)
+
+        # Pass 3: shape heuristic. Cheap signals that an AI-drafted
+        # message slipped past the first two passes. A single hit is
+        # enough to exclude — the cost of a false-positive exclusion
+        # is one missed sample; the cost of a false-positive inclusion
+        # is the voice library learning the agent's voice from the
+        # agent's own output.
+        if _shape_looks_agent_drafted(candidate.body_text):
+            return FilterResult(accept=False, reason=REASON_SHAPE_HEURISTIC)
+
+        return FilterResult(accept=True, reason=ACCEPT_REASON)
+
+
+# ---------------------------------------------------------------------------
+# Shape heuristic
+# ---------------------------------------------------------------------------
+
+
+_AGENT_DRAFT_MARKERS = (
+    # Signature blocks that AgentMail / persona templates emit verbatim.
+    # The persona signature is platform property (ADR 0008); when it
+    # appears in the body, the message went out of the agent's drafts
+    # folder, not the partner's.
+    "[Drafted by your AI Employee for review]",
+    "[Drafted for review]",
+    "-- This draft was prepared by",
+    # The platform's safety footer that the draft pipeline appends
+    # automatically. Partner-edited sends keep it; clean sends drop it.
+    # Either way its presence is a strong signal.
+    "(this draft has not been sent — review before pressing send)",
+)
+
+
+def _shape_looks_agent_drafted(body_text: str) -> bool:
+    """Return True when the body shape matches the agent's draft templates."""
+    if not body_text:
+        return False
+    lowered = body_text.lower()
+    for marker in _AGENT_DRAFT_MARKERS:
+        if marker.lower() in lowered:
+            return True
+    return False
+
+
+__all__ = [
+    "ACCEPT_REASON",
+    "AuditDigestLookup",
+    "CandidateMessage",
+    "FilterResult",
+    "MIN_WORD_COUNT_FOR_SAMPLE",
+    "PartnerAuthoredFilter",
+    "REASON_ADAPTER_AGENT_DRAFTED",
+    "REASON_AUDIT_LOG_DIGEST_MATCH",
+    "REASON_EMPTY_BODY",
+    "REASON_SHAPE_HEURISTIC",
+    "REASON_TOO_SHORT",
+    "compute_body_digest",
+]

--- a/ai-employee/adapter/voice/pipeline.py
+++ b/ai-employee/adapter/voice/pipeline.py
@@ -1,0 +1,632 @@
+"""Voice sample ingestion pipeline (issue #856).
+
+The pipeline runs in two modes — scheduled (daily cron) and on-demand
+(synchronous call) — through a single entrypoint,
+:meth:`VoiceIngestionRunner.run_ingestion`. Both modes share the same
+write path:
+
+  1. Read the Email capability's sent folder from the last cursor.
+  2. For each :class:`SentItem`, build a :class:`CandidateMessage`.
+  3. Run the partner-authored filter. Excluded messages get a
+     provenance row with ``partner_authored=0`` and no R2 object.
+  4. Extract the structural-diff via
+     :func:`extract_structural_diff`. The raw body is dropped after
+     this call.
+  5. Resolve the recipient cohort via
+     :class:`CohortResolver`. Unassigned recipients tag the sample
+     ``unassigned``.
+  6. Write the structural-diff JSON to R2 at
+     ``{slug}/voice/cohort/{cohort}/{ulid}.json``.
+  7. Insert one provenance row in ``voice_ingestion_items``.
+
+After the loop, upsert ``voice_source_state`` with the per-cohort
+histogram. Failures during the loop are caught per-item; the run does
+NOT abort on a single bad message — the run summary records the count
+of items processed vs filtered vs errored, and ``ingest_status`` lands
+on ``"error"`` only when zero successful items were ingested AND at
+least one error fired.
+
+Design rules
+------------
+
+* ADR 0006 (capability-adapter pattern): the pipeline depends on the
+  ``EmailSource`` adapter, which wraps the :class:`Email` capability.
+  No MS Graph or Gmail specifics live in this module.
+* ADR 0008 (customer-owned memory): every persisted artifact is
+  recorded in ``voice_ingestion_items`` so :func:`decommission_source`
+  can remove it.
+* ADR 0009 (cross-machine query prohibition): no tenant ID on rows;
+  isolation is the D1/R2 binding.
+* ADR 0005 (reviewer-as-sender): the pipeline only READS from the sent
+  folder. It never sends.
+
+Per-issue acceptance:
+
+* Scheduled + on-demand: both modes flow through
+  :meth:`VoiceIngestionRunner.run_ingestion` with the
+  :class:`IngestionMode` flag.
+* R2 vault per customer, namespaced: R2 keys follow the
+  ``{customer-slug}/voice/cohort/{cohort-id}/{sample-id}.json`` pattern
+  documented in ``docs/specs/ai-employee/r2-vectorize-naming.md``.
+* Structural-diff format, no PII retained: enforced by
+  :func:`extract_structural_diff` and the body-discard contract.
+* Captain can review what was ingested: the run upserts
+  ``samples_by_cohort_json`` so the dashboard renders the histogram
+  without a join.
+* Removable per customer.yaml retention policy: see
+  :func:`enforce_retention`.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, Optional, Protocol, Sequence
+
+from .diff import (
+    SCHEMA_VERSION as DIFF_SCHEMA_VERSION,
+    StructuralDiff,
+    extract_structural_diff,
+    structural_diff_digest,
+)
+from .filter import (
+    ACCEPT_REASON,
+    AuditDigestLookup,
+    CandidateMessage,
+    FilterResult,
+    PartnerAuthoredFilter,
+    compute_body_digest,
+)
+from .state import (
+    COHORT_UNASSIGNED,
+    INGEST_STATUS_ERROR,
+    INGEST_STATUS_OK,
+    IngestionItemRecord,
+    IngestionStateUpdate,
+    VoiceSourceStateStore,
+    _iso_utc,
+)
+
+log = logging.getLogger("aie.voice.pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Domain types — vendor-neutral
+# ---------------------------------------------------------------------------
+
+
+class IngestionMode(str, enum.Enum):
+    """Sibling to ``memory.IngestionMode``. Recorded in metadata so the
+    dashboard renders which kind of run produced the last state row."""
+
+    SCHEDULED = "scheduled"
+    ON_DEMAND = "on_demand"
+
+
+@dataclass(frozen=True)
+class SentMessage:
+    """Vendor-neutral sent-folder message.
+
+    Mirrors the relevant subset of :class:`SentItem` from
+    ``src/lib/ai-employee/capabilities/email.ts`` — the pipeline does
+    not depend on the TypeScript type, only on this shape.
+    """
+
+    message_id: str
+    sent_at: str
+    body_text: Optional[str]
+    subject: Optional[str]
+    recipients: Sequence[str]              # email addresses; used by the cohort resolver
+    likely_agent_drafted: Optional[bool]
+
+
+@dataclass(frozen=True)
+class IngestionResult:
+    """One-run summary returned by :meth:`run_ingestion`."""
+
+    source_kind: str
+    source_id: str
+    mode: IngestionMode
+    items_seen: int
+    items_ingested: int                    # partner_authored=1, R2 object written
+    items_filtered: int                    # partner_authored=0, provenance row only
+    items_skipped_duplicate: int           # already_ingested short-circuit
+    items_errored: int
+    cohort_histogram: dict                 # cohort_id -> count of ingested
+    status: str
+    started_at: str
+    finished_at: str
+    duration_ms: int
+    next_cursor: Optional[str]
+    error: Optional[str] = None
+
+
+class StorageError(RuntimeError):
+    """Raised when R2 write or delete fails. The caller logs and continues
+    to the next item — one bad R2 write does not abort the entire run."""
+
+
+# ---------------------------------------------------------------------------
+# Capability-adapter wrappers (vendor-neutral)
+# ---------------------------------------------------------------------------
+
+
+class EmailSource(Protocol):
+    """The pipeline's view of the Email capability.
+
+    Implementations wrap the TypeScript ``Email`` capability surface
+    (``list_sent_since`` + ``get_sent_item``). The pipeline does not
+    care which adapter produces the rows — MS Graph, Gmail, IMAP — only
+    that the contract is honored.
+    """
+
+    source_id: str
+
+    async def list_sent_since(
+        self, cursor: Optional[str]
+    ) -> tuple[Sequence[SentMessage], Optional[str]]: ...
+
+
+class NoEmailSource:
+    """Fallback when no Email connector is bound to this customer.
+
+    A scheduled run still completes — it upserts a zero-items state row
+    so the dashboard can render "no email source bound" without erroring.
+    Mirrors the ``NoPracticeManagementSource`` fallback from memory.
+    """
+
+    source_id = "none"
+
+    async def list_sent_since(
+        self, cursor: Optional[str]
+    ) -> tuple[Sequence[SentMessage], Optional[str]]:
+        return [], cursor
+
+
+class CohortResolver(Protocol):
+    """Reads the customer's memory rules to resolve a recipient → cohort.
+
+    Production implementation reads ``memory_rules`` rows where
+    ``rule_type='voice'`` and ``category='recipient_cohort'`` and
+    matches by email domain or full address. Tests pass in-memory fakes.
+    """
+
+    async def resolve(self, recipient_email: str) -> Optional[str]: ...
+
+
+class StaticCohortResolver:
+    """Trivial resolver used by ``NoEmailSource`` flows and tests.
+
+    Returns ``None`` for every recipient — i.e. tags every sample
+    ``unassigned`` per state.COHORT_UNASSIGNED.
+    """
+
+    async def resolve(self, recipient_email: str) -> Optional[str]:  # noqa: ARG002
+        return None
+
+
+class R2Client(Protocol):
+    """Per-customer R2 binding. The pipeline writes structural-diff
+    objects and (on retention / decommission) deletes them."""
+
+    customer_slug: str
+
+    async def put(self, key: str, body: bytes, content_type: str) -> None: ...
+    async def delete(self, key: str) -> None: ...
+
+
+class CursorStore(Protocol):
+    """Persisted cursor for the sent-folder watcher.
+
+    In production this is a small D1 row on ``sent_folder_state``
+    (already in migration 0001). The pipeline does not own the schema;
+    it asks for the cursor and stores the new one.
+    """
+
+    async def get(self) -> Optional[str]: ...
+    async def set(self, cursor: Optional[str]) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VoiceIngestionRunner:
+    """Orchestrates one ingestion run.
+
+    Construction binds the runner to one customer's full storage stack.
+    A single instance per Machine is sufficient; the runner has no
+    process-wide state.
+    """
+
+    source: EmailSource
+    cohort_resolver: CohortResolver
+    r2_client: R2Client
+    state_store: VoiceSourceStateStore
+    cursor_store: CursorStore
+    audit_lookup: AuditDigestLookup
+    source_kind: str = "email"
+    _clock: Optional[Callable[[], datetime]] = None
+
+    def _now(self) -> datetime:
+        return self._clock() if self._clock else datetime.now(timezone.utc)
+
+    async def run_ingestion(self, *, mode: IngestionMode) -> IngestionResult:
+        """Run one ingestion pass.
+
+        Returns a :class:`IngestionResult` regardless of outcome. The
+        caller logs the result; the row written to ``voice_source_state``
+        is the durable record.
+        """
+        started_at_dt = self._now()
+        started_at = _iso_utc(started_at_dt)
+        t0 = time.perf_counter()
+
+        filter_pass = PartnerAuthoredFilter(self.audit_lookup)
+        cursor = await self.cursor_store.get()
+        items_seen = 0
+        items_ingested = 0
+        items_filtered = 0
+        items_skipped_duplicate = 0
+        items_errored = 0
+        cohort_histogram: dict = {}
+        next_cursor = cursor
+        run_error: Optional[str] = None
+
+        try:
+            messages, next_cursor = await self.source.list_sent_since(cursor)
+        except Exception as e:  # noqa: BLE001
+            run_error = f"list_sent_since failed: {type(e).__name__}: {e}"[:500]
+            log.error(run_error)
+            messages = []
+            next_cursor = cursor
+
+        for message in messages:
+            items_seen += 1
+            try:
+                outcome = await self._ingest_one(message, filter_pass)
+            except Exception as e:  # noqa: BLE001 — one bad row never aborts the run
+                items_errored += 1
+                log.exception(
+                    "voice ingestion errored on message digest=%s: %s",
+                    compute_body_digest(message.body_text)[:12],
+                    e,
+                )
+                continue
+
+            if outcome == "ingested":
+                items_ingested += 1
+                cohort = self._latest_cohort
+                cohort_histogram[cohort] = cohort_histogram.get(cohort, 0) + 1
+            elif outcome == "duplicate":
+                items_skipped_duplicate += 1
+            else:  # filtered
+                items_filtered += 1
+
+        if run_error is None:
+            try:
+                await self.cursor_store.set(next_cursor)
+            except Exception as e:  # noqa: BLE001
+                # Cursor write failure is recoverable on the next run, but it
+                # would mean the same window gets re-scanned; flag it on the
+                # state row so the dashboard surfaces the problem.
+                run_error = f"cursor_store.set failed: {type(e).__name__}: {e}"[:500]
+                log.error(run_error)
+
+        finished_at_dt = self._now()
+        duration_ms = int((time.perf_counter() - t0) * 1000)
+
+        status = self._compute_status(
+            items_ingested=items_ingested,
+            items_errored=items_errored,
+            run_error=run_error,
+        )
+
+        update = IngestionStateUpdate(
+            source_kind=self.source_kind,
+            source_id=self.source.source_id,
+            ingested_at=_iso_utc(finished_at_dt),
+            status=status,
+            items_last_run=items_ingested,
+            samples_by_cohort=cohort_histogram,
+            error=run_error,
+        )
+        await self.state_store.upsert_state(update)
+
+        return IngestionResult(
+            source_kind=self.source_kind,
+            source_id=self.source.source_id,
+            mode=mode,
+            items_seen=items_seen,
+            items_ingested=items_ingested,
+            items_filtered=items_filtered,
+            items_skipped_duplicate=items_skipped_duplicate,
+            items_errored=items_errored,
+            cohort_histogram=cohort_histogram,
+            status=status,
+            started_at=started_at,
+            finished_at=_iso_utc(finished_at_dt),
+            duration_ms=duration_ms,
+            next_cursor=next_cursor,
+            error=run_error,
+        )
+
+    # ----- single-message ingest path -----
+
+    _latest_cohort: str = COHORT_UNASSIGNED   # set inside _ingest_one for histogramming
+
+    async def _ingest_one(
+        self,
+        message: SentMessage,
+        filter_pass: PartnerAuthoredFilter,
+    ) -> str:
+        """Process one message. Returns 'ingested' | 'filtered' | 'duplicate'."""
+        import hashlib
+
+        source_message_digest = hashlib.sha256(
+            message.message_id.encode("utf-8")
+        ).hexdigest()
+
+        # Deduplication: if we already ingested this message, skip without
+        # re-writing anything. Lets scheduled re-runs be idempotent.
+        if await self.state_store.already_ingested(
+            self.source_kind, self.source.source_id, source_message_digest
+        ):
+            return "duplicate"
+
+        body_text = message.body_text or ""
+        body_digest = compute_body_digest(body_text)
+        word_count = len(_word_split(body_text))
+
+        candidate = CandidateMessage(
+            body_text=body_text,
+            word_count=word_count,
+            likely_agent_drafted=message.likely_agent_drafted,
+            body_digest=body_digest,
+        )
+        decision: FilterResult = await filter_pass.evaluate(candidate)
+
+        if not decision.accept:
+            # Record the exclusion so the dashboard can drill into "why
+            # was this not learned from" without retaining the body.
+            await self.state_store.insert_item(
+                IngestionItemRecord(
+                    source_kind=self.source_kind,
+                    source_id=self.source.source_id,
+                    source_message_digest=source_message_digest,
+                    recipient_cohort_id=COHORT_UNASSIGNED,
+                    partner_authored=False,
+                    sent_at=message.sent_at,
+                    filter_reason=decision.reason,
+                    r2_key=None,
+                    structural_diff_digest=None,
+                    word_count=word_count,
+                    schema_version=DIFF_SCHEMA_VERSION,
+                )
+            )
+            return "filtered"
+
+        # Resolve cohort from the customer's memory rules. The pipeline
+        # consults the resolver for each recipient and picks the first
+        # cohort-bearing match; when no recipient has a cohort, the
+        # sample is tagged 'unassigned'.
+        cohort_id = await self._resolve_cohort(message.recipients)
+        self._latest_cohort = cohort_id
+
+        diff = extract_structural_diff(
+            body_text=body_text,
+            subject=message.subject,
+            recipient_cohort=cohort_id,
+        )
+        # The body lifetime ends here. Everything below operates on the
+        # structural-diff only.
+        body_text = ""  # noqa: F841 — explicit local-scope drop
+
+        digest = structural_diff_digest(diff)
+
+        # ULID generated inside the store so retention/decommission can
+        # find the row by ID; the same ULID is the R2 sample-id segment.
+        sample_id = await self.state_store.insert_item(
+            IngestionItemRecord(
+                source_kind=self.source_kind,
+                source_id=self.source.source_id,
+                source_message_digest=source_message_digest,
+                recipient_cohort_id=cohort_id,
+                partner_authored=True,
+                sent_at=message.sent_at,
+                filter_reason=ACCEPT_REASON,
+                r2_key=None,                # filled in after the R2 put
+                structural_diff_digest=digest,
+                word_count=diff.word_count,
+                schema_version=DIFF_SCHEMA_VERSION,
+            )
+        )
+
+        r2_key = (
+            f"{self.r2_client.customer_slug}/voice/cohort/{cohort_id}/{sample_id}.json"
+        )
+        try:
+            await self.r2_client.put(
+                r2_key, diff.to_json_bytes(), "application/json"
+            )
+        except Exception as e:  # noqa: BLE001
+            # The provenance row exists but the R2 object failed. Mark
+            # the row soft-deleted so the next run can re-ingest, and
+            # raise StorageError so the per-item counter increments.
+            await self.state_store.mark_item_deleted(sample_id)
+            raise StorageError(
+                f"R2 put failed for {r2_key}: {type(e).__name__}: {e}"
+            ) from e
+
+        # We inserted with r2_key=NULL because the ULID is generated
+        # inside the store. Patch the row in-place with the resolved
+        # key; this is the only mutating UPDATE the pipeline performs.
+        await self.state_store._write.execute(  # noqa: SLF001 — co-owned module
+            "UPDATE voice_ingestion_items SET r2_key = ? WHERE id = ?",
+            [r2_key, sample_id],
+        )
+
+        return "ingested"
+
+    async def _resolve_cohort(self, recipients: Sequence[str]) -> str:
+        for recipient in recipients:
+            if not recipient:
+                continue
+            try:
+                cohort = await self.cohort_resolver.resolve(recipient)
+            except Exception as e:  # noqa: BLE001
+                log.warning("cohort resolver failed for recipient: %s", e)
+                cohort = None
+            if cohort:
+                return cohort
+        return COHORT_UNASSIGNED
+
+    @staticmethod
+    def _compute_status(
+        *, items_ingested: int, items_errored: int, run_error: Optional[str]
+    ) -> str:
+        if run_error and items_ingested == 0:
+            return INGEST_STATUS_ERROR
+        if items_errored > 0 and items_ingested == 0:
+            return INGEST_STATUS_ERROR
+        return INGEST_STATUS_OK
+
+
+# ---------------------------------------------------------------------------
+# Retention enforcer
+# ---------------------------------------------------------------------------
+
+
+async def enforce_retention(
+    *,
+    state_store: VoiceSourceStateStore,
+    r2_client: R2Client,
+    voice_retention_days: int,
+    now: Optional[datetime] = None,
+) -> dict:
+    """Delete voice samples older than ``voice_retention_days``.
+
+    Reads the retention window from the caller (sourced from
+    customer.yaml). Walks ``voice_ingestion_items`` for active rows
+    older than the cutoff, deletes the R2 object, and soft-deletes the
+    provenance row.
+
+    Returns a summary dict: ``{"considered": N, "deleted": M, "errors": E}``.
+    """
+    now_dt = now or datetime.now(timezone.utc)
+    cutoff = now_dt - timedelta(days=voice_retention_days)
+    cutoff_iso = _iso_utc(cutoff)
+
+    rows = await state_store.list_items_for_retention(cutoff_iso)
+    considered = len(rows)
+    deleted = 0
+    errors = 0
+
+    for row in rows:
+        r2_key = row.get("r2_key")
+        item_id = row.get("id")
+        if not r2_key or not item_id:
+            continue
+        try:
+            await r2_client.delete(r2_key)
+        except Exception as e:  # noqa: BLE001
+            errors += 1
+            log.error("retention enforcer R2 delete failed for %s: %s", r2_key, e)
+            continue
+        try:
+            await state_store.mark_item_deleted(item_id)
+            deleted += 1
+        except Exception as e:  # noqa: BLE001
+            errors += 1
+            log.error("retention enforcer state update failed for %s: %s", item_id, e)
+
+    return {"considered": considered, "deleted": deleted, "errors": errors}
+
+
+# ---------------------------------------------------------------------------
+# Decommission hook
+# ---------------------------------------------------------------------------
+
+
+async def decommission_source(
+    *,
+    state_store: VoiceSourceStateStore,
+    r2_client: R2Client,
+    source_kind: str,
+    source_id: str,
+) -> dict:
+    """Remove every voice artifact the pipeline persisted for one source.
+
+    Called by ``bin/decommission-customer.sh`` and by
+    ``bin/pause-customer.sh`` (the latter snapshots first; this function
+    only removes the live artifacts).
+
+    Steps:
+      1. Enumerate active provenance rows for the source.
+      2. For each row with an R2 key, delete the R2 object.
+      3. Soft-delete every provenance row for the source.
+      4. Remove the state row.
+
+    Returns ``{"removed": N, "errors": E}``.
+    """
+    rows = await state_store.list_items_for_decommission(source_kind, source_id)
+    removed = 0
+    errors = 0
+    for row in rows:
+        r2_key = row.get("r2_key")
+        if r2_key:
+            try:
+                await r2_client.delete(r2_key)
+                removed += 1
+            except Exception as e:  # noqa: BLE001
+                errors += 1
+                log.error("decommission R2 delete failed for %s: %s", r2_key, e)
+    try:
+        await state_store.mark_items_deleted_by_source(source_kind, source_id)
+        await state_store.delete_state(source_kind, source_id)
+    except Exception as e:  # noqa: BLE001
+        errors += 1
+        log.error(
+            "decommission state cleanup failed for (%s, %s): %s",
+            source_kind,
+            source_id,
+            e,
+        )
+    return {"removed": removed, "errors": errors}
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+import re as _re  # local import to keep top-level imports tight
+
+_WORD_RE = _re.compile(r"\b\w+\b")
+
+
+def _word_split(text: str) -> list[str]:
+    return _WORD_RE.findall(text or "")
+
+
+__all__ = [
+    "CohortResolver",
+    "CursorStore",
+    "EmailSource",
+    "IngestionMode",
+    "IngestionResult",
+    "NoEmailSource",
+    "R2Client",
+    "SentMessage",
+    "StaticCohortResolver",
+    "StorageError",
+    "VoiceIngestionRunner",
+    "decommission_source",
+    "enforce_retention",
+]

--- a/ai-employee/adapter/voice/state.py
+++ b/ai-employee/adapter/voice/state.py
@@ -1,0 +1,443 @@
+"""Per-source ingestion state for voice samples — D1 reads and writes.
+
+The dashboard reads ``voice_source_state`` to render the
+``last-ingestion-at`` health indicator and the per-cohort sample count
+("Captain can review what was ingested" — AC #4).
+
+The pipeline upserts on every run regardless of outcome so that even a
+failed run produces a fresh row the dashboard can light up red.
+
+Decommission (ADR 0008) walks ``voice_ingestion_items``, removes every
+R2 object, and clears the state row. The retention enforcer uses the
+same table to select expired rows and remove their R2 objects per the
+``voice_retention_days`` setting on customer.yaml.
+
+Sibling to ``ai-employee/adapter/memory/state.py`` from PR #944 — same
+shape, distinct table set. The two stores do not share rows.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Optional, Protocol, Sequence
+
+log = logging.getLogger("aie.voice.state")
+
+
+# Ingestion status vocabulary. The dashboard maps these onto health
+# colors (green / yellow / red).
+INGEST_STATUS_OK = "ok"
+INGEST_STATUS_STALE = "stale"
+INGEST_STATUS_ERROR = "error"
+INGEST_STATUS_NEVER_RUN = "never_run"
+
+VALID_STATUSES = frozenset(
+    {INGEST_STATUS_OK, INGEST_STATUS_STALE, INGEST_STATUS_ERROR, INGEST_STATUS_NEVER_RUN}
+)
+
+
+# When a recipient has no cohort assigned in memory rules, the sample
+# is tagged with this sentinel. See voice-ingestion.md §"Recipient
+# cohort tagging".
+COHORT_UNASSIGNED = "unassigned"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (local copies to avoid coupling to audit_log internals)
+# ---------------------------------------------------------------------------
+
+
+def _iso_utc(now: Optional[datetime] = None) -> str:
+    dt = now if now is not None else datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _encode_crockford(value: int, length: int) -> str:
+    out = []
+    for _ in range(length):
+        value, rem = divmod(value, 32)
+        out.append(_CROCKFORD[rem])
+    return "".join(reversed(out))
+
+
+def _ulid(now_ms: Optional[int] = None) -> str:
+    ts = now_ms if now_ms is not None else int(time.time() * 1000)
+    rand = secrets.randbits(80)
+    return _encode_crockford(ts, 10) + _encode_crockford(rand, 16)
+
+
+# ---------------------------------------------------------------------------
+# Read model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VoiceSourceState:
+    """Dashboard read model for one (source_kind, source_id) pair.
+
+    The Captain dashboard renders a row per source. ``samples_by_cohort``
+    is the JSON object the pipeline wrote on the last run, decoded into
+    a Python dict; the dashboard renders it as a one-line histogram.
+    """
+
+    source_kind: str
+    source_id: str
+    last_ingestion_at: str
+    last_success_at: Optional[str]
+    last_error: Optional[str]
+    ingest_status: str
+    items_last_run: int
+    samples_by_cohort: dict
+    schema_version: int
+
+
+@dataclass(frozen=True)
+class VoiceIngestionItem:
+    """Provenance row for one ingested voice sample.
+
+    Used by:
+
+    * The retention enforcer (selects rows older than the retention
+      window).
+    * The decommission hook (walks every row for one source and removes
+      the R2 object).
+    * Tests verifying the audit-style insert path.
+
+    ``source_message_digest`` is the SHA-256 of the upstream message ID,
+    not the message ID itself.
+    """
+
+    id: str
+    source_kind: str
+    source_id: str
+    source_message_digest: str
+    recipient_cohort_id: str
+    partner_authored: bool
+    filter_reason: Optional[str]
+    ingested_at: str
+    sent_at: str
+    r2_key: Optional[str]
+    structural_diff_digest: Optional[str]
+    word_count: Optional[int]
+    schema_version: int
+    deleted_at: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Executor protocols
+# ---------------------------------------------------------------------------
+
+
+class WriteExecutor(Protocol):
+    async def execute(self, sql: str, params: list) -> None: ...
+
+
+class QueryExecutor(Protocol):
+    """A query executor returns rows for SELECT statements.
+
+    Production wires this to the Cloudflare D1 HTTP API's ``query``
+    endpoint; tests pass a sqlite-backed executor that returns
+    ``list[dict[str, object]]``.
+    """
+
+    async def query(self, sql: str, params: list) -> list[dict]: ...
+
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+
+_UPSERT_STATE_SQL = (
+    "INSERT INTO voice_source_state "
+    "(source_kind, source_id, last_ingestion_at, last_success_at, last_error, "
+    "ingest_status, items_last_run, samples_by_cohort_json, schema_version) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+    "ON CONFLICT(source_kind, source_id) DO UPDATE SET "
+    "last_ingestion_at      = excluded.last_ingestion_at, "
+    "last_success_at        = COALESCE(excluded.last_success_at, voice_source_state.last_success_at), "
+    "last_error             = excluded.last_error, "
+    "ingest_status          = excluded.ingest_status, "
+    "items_last_run         = excluded.items_last_run, "
+    "samples_by_cohort_json = excluded.samples_by_cohort_json, "
+    "schema_version         = excluded.schema_version"
+)
+
+
+_INSERT_ITEM_SQL = (
+    "INSERT INTO voice_ingestion_items "
+    "(id, source_kind, source_id, source_message_digest, recipient_cohort_id, "
+    "partner_authored, filter_reason, ingested_at, sent_at, r2_key, "
+    "structural_diff_digest, word_count, schema_version) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+_SELECT_STATES_SQL = (
+    "SELECT source_kind, source_id, last_ingestion_at, last_success_at, "
+    "last_error, ingest_status, items_last_run, samples_by_cohort_json, "
+    "schema_version "
+    "FROM voice_source_state "
+    "ORDER BY last_ingestion_at DESC"
+)
+
+
+_SELECT_ITEMS_FOR_DECOMMISSION_SQL = (
+    "SELECT id, r2_key, structural_diff_digest "
+    "FROM voice_ingestion_items "
+    "WHERE source_kind = ? AND source_id = ? AND deleted_at IS NULL"
+)
+
+
+_SELECT_ITEMS_FOR_RETENTION_SQL = (
+    "SELECT id, r2_key, structural_diff_digest "
+    "FROM voice_ingestion_items "
+    "WHERE ingested_at < ? AND deleted_at IS NULL AND r2_key IS NOT NULL"
+)
+
+
+_MARK_ITEMS_DELETED_BY_SOURCE_SQL = (
+    "UPDATE voice_ingestion_items "
+    "SET deleted_at = ? "
+    "WHERE source_kind = ? AND source_id = ? AND deleted_at IS NULL"
+)
+
+
+_MARK_ITEMS_DELETED_BY_ID_SQL = (
+    "UPDATE voice_ingestion_items SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL"
+)
+
+
+_DELETE_STATE_SQL = (
+    "DELETE FROM voice_source_state WHERE source_kind = ? AND source_id = ?"
+)
+
+
+_SELECT_EXISTING_DIGEST_SQL = (
+    "SELECT id FROM voice_ingestion_items "
+    "WHERE source_kind = ? AND source_id = ? AND source_message_digest = ? "
+    "AND deleted_at IS NULL LIMIT 1"
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses for writes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IngestionStateUpdate:
+    """One ingestion-run outcome destined for ``voice_source_state``.
+
+    ``samples_by_cohort`` is the histogram for THIS run only — the
+    upsert replaces the row's snapshot wholesale. The dashboard renders
+    "what was ingested in the last run."
+    """
+
+    source_kind: str
+    source_id: str
+    ingested_at: str
+    status: str
+    items_last_run: int
+    samples_by_cohort: dict
+    error: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.status not in VALID_STATUSES:
+            raise ValueError(
+                f"ingest_status {self.status!r} not in {sorted(VALID_STATUSES)}"
+            )
+
+
+@dataclass
+class IngestionItemRecord:
+    """One provenance row destined for ``voice_ingestion_items``."""
+
+    source_kind: str
+    source_id: str
+    source_message_digest: str
+    recipient_cohort_id: str
+    partner_authored: bool
+    sent_at: str
+    filter_reason: Optional[str] = None
+    r2_key: Optional[str] = None
+    structural_diff_digest: Optional[str] = None
+    word_count: Optional[int] = None
+    schema_version: int = 1
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class VoiceSourceStateStore:
+    """D1-backed store for voice ingestion state and provenance.
+
+    Construction takes a write executor and (optionally) a query
+    executor. Reads are only required for the dashboard (read_states)
+    and the retention / decommission code paths. The pipeline itself
+    only needs writes.
+    """
+
+    def __init__(
+        self,
+        write_executor: WriteExecutor,
+        query_executor: Optional[QueryExecutor] = None,
+    ) -> None:
+        self._write = write_executor
+        self._query = query_executor
+
+    async def upsert_state(self, update: IngestionStateUpdate) -> None:
+        """Upsert the per-source state row. Called once per run."""
+        params = [
+            update.source_kind,
+            update.source_id,
+            update.ingested_at,
+            update.ingested_at if update.status == INGEST_STATUS_OK else None,
+            update.error,
+            update.status,
+            update.items_last_run,
+            json.dumps(update.samples_by_cohort, sort_keys=True, separators=(",", ":")),
+            1,
+        ]
+        await self._write.execute(_UPSERT_STATE_SQL, params)
+
+    async def insert_item(self, item: IngestionItemRecord) -> str:
+        """Insert one provenance row. Returns the generated ULID."""
+        ulid = _ulid()
+        ts = _iso_utc()
+        params = [
+            ulid,
+            item.source_kind,
+            item.source_id,
+            item.source_message_digest,
+            item.recipient_cohort_id,
+            1 if item.partner_authored else 0,
+            item.filter_reason,
+            ts,
+            item.sent_at,
+            item.r2_key,
+            item.structural_diff_digest,
+            item.word_count,
+            item.schema_version,
+        ]
+        await self._write.execute(_INSERT_ITEM_SQL, params)
+        return ulid
+
+    async def already_ingested(
+        self, source_kind: str, source_id: str, source_message_digest: str
+    ) -> bool:
+        """Return True when a non-deleted row already exists for this
+        (source, message digest). Lets the pipeline skip re-ingestion
+        without duplicating R2 objects.
+        """
+        if self._query is None:
+            return False
+        rows = await self._query.query(
+            _SELECT_EXISTING_DIGEST_SQL,
+            [source_kind, source_id, source_message_digest],
+        )
+        return len(rows) > 0
+
+    async def read_states(self) -> list[VoiceSourceState]:
+        """Return all (source_kind, source_id) rows, newest run first."""
+        if self._query is None:
+            raise RuntimeError("read_states requires a query executor")
+        rows = await self._query.query(_SELECT_STATES_SQL, [])
+        out: list[VoiceSourceState] = []
+        for row in rows:
+            samples_json = row.get("samples_by_cohort_json")
+            samples_by_cohort: dict = {}
+            if samples_json:
+                try:
+                    samples_by_cohort = json.loads(samples_json)
+                except json.JSONDecodeError:
+                    log.warning(
+                        "voice_source_state.samples_by_cohort_json failed to parse for "
+                        "(%s, %s); rendering empty",
+                        row.get("source_kind"),
+                        row.get("source_id"),
+                    )
+            out.append(
+                VoiceSourceState(
+                    source_kind=row["source_kind"],
+                    source_id=row["source_id"],
+                    last_ingestion_at=row["last_ingestion_at"],
+                    last_success_at=row.get("last_success_at"),
+                    last_error=row.get("last_error"),
+                    ingest_status=row["ingest_status"],
+                    items_last_run=row["items_last_run"],
+                    samples_by_cohort=samples_by_cohort,
+                    schema_version=row.get("schema_version", 1),
+                )
+            )
+        return out
+
+    async def list_items_for_decommission(
+        self, source_kind: str, source_id: str
+    ) -> list[dict]:
+        """Enumerate provenance rows still active for one source."""
+        if self._query is None:
+            raise RuntimeError("list_items_for_decommission requires a query executor")
+        return await self._query.query(
+            _SELECT_ITEMS_FOR_DECOMMISSION_SQL, [source_kind, source_id]
+        )
+
+    async def list_items_for_retention(self, older_than_iso: str) -> list[dict]:
+        """Enumerate active rows ingested before ``older_than_iso``.
+
+        Caller computes the cutoff from ``voice_retention_days`` on
+        customer.yaml; this method does not know the policy.
+        """
+        if self._query is None:
+            raise RuntimeError("list_items_for_retention requires a query executor")
+        return await self._query.query(
+            _SELECT_ITEMS_FOR_RETENTION_SQL, [older_than_iso]
+        )
+
+    async def mark_items_deleted_by_source(
+        self, source_kind: str, source_id: str
+    ) -> None:
+        """Soft-delete all active items for one source. Called by the
+        decommission hook before the state row is removed."""
+        await self._write.execute(
+            _MARK_ITEMS_DELETED_BY_SOURCE_SQL,
+            [_iso_utc(), source_kind, source_id],
+        )
+
+    async def mark_item_deleted(self, item_id: str) -> None:
+        """Soft-delete a single item by ID. Used by the retention
+        enforcer after the R2 object has been removed."""
+        await self._write.execute(_MARK_ITEMS_DELETED_BY_ID_SQL, [_iso_utc(), item_id])
+
+    async def delete_state(self, source_kind: str, source_id: str) -> None:
+        """Remove the source's state row. Called only by the decommission
+        hook after all items have been soft-deleted and their R2 objects
+        removed."""
+        await self._write.execute(_DELETE_STATE_SQL, [source_kind, source_id])
+
+
+__all__ = [
+    "COHORT_UNASSIGNED",
+    "INGEST_STATUS_ERROR",
+    "INGEST_STATUS_NEVER_RUN",
+    "INGEST_STATUS_OK",
+    "INGEST_STATUS_STALE",
+    "IngestionItemRecord",
+    "IngestionStateUpdate",
+    "QueryExecutor",
+    "VALID_STATUSES",
+    "VoiceIngestionItem",
+    "VoiceSourceState",
+    "VoiceSourceStateStore",
+    "WriteExecutor",
+]

--- a/ai-employee/migrations/0004_voice_ingestion.sql
+++ b/ai-employee/migrations/0004_voice_ingestion.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- Migration 0004: voice sample ingestion state (issue #856)
+-- ============================================================================
+--
+-- Adds the per-source ingestion state table that the voice sample ingestion
+-- pipeline writes to on every run (scheduled or on-demand), and a provenance
+-- table that lets the decommission hook enumerate every artifact the
+-- pipeline persisted. Sibling to the memory ingestion state from migration
+-- 0003 — voice samples are the dedicated pipeline for the customer's sent
+-- folder, anchored to structural-diff format per PRD §10.4.
+--
+-- Two tables:
+--
+--   1. voice_source_state — one row per (source_kind, source_id). For Voice
+--      Layer 2 the source_kind is always 'email' and source_id is the email
+--      connector adapter slug ('microsoft-graph', 'gmail', 'none' for the
+--      no-connector fallback). The row carries last_ingestion_at,
+--      last_success_at, last_error, ingest_status, items_last_run, and
+--      samples_by_cohort_json so the dashboard can render
+--      "Captain can review what was ingested" per AC.
+--
+--   2. voice_ingestion_items — per-ingested-sample provenance row. Lets the
+--      retention enforcer and the decommission hook enumerate every R2
+--      object the pipeline stored. One row per sample; large samples are
+--      not chunked because the structural-diff is small by construction
+--      (counts and signatures, never the body — see voice-ingestion.md).
+--
+-- Privacy posture (PRD §10.4 + AC #3):
+--   The raw email body is NEVER persisted. Only the structural-diff
+--   representation lands in R2, and only the SHA-256 digest of the source
+--   message ID lands in D1 (so re-runs can detect the same source without
+--   storing the upstream identifier). No quoted text, no recipient
+--   addresses, no PII.
+--
+-- ADR 0008 (customer-owned memory artifact): both tables live in the
+--   per-customer D1 database; the R2 keys point at
+--   {customer-slug}/voice/cohort/{cohort-id}/{sample-id}.md per
+--   r2-vectorize-naming.md.
+-- ADR 0009 (cross-machine query prohibition): isolation is the binding,
+--   not the schema. No tenant column.
+-- ADR 0006 (capability adapter pattern): source_kind names the capability
+--   (Email), source_id names the adapter slug. The pipeline talks to the
+--   Email interface, never to MS Graph or Gmail directly.
+-- ============================================================================
+
+-- ---------- 1. Voice source state ----------
+-- One row per (source_kind, source_id). The pipeline upserts on every run
+-- regardless of outcome so the dashboard can light up red when ingestion
+-- has failed. samples_by_cohort_json is a JSON object mapping cohort_id ->
+-- count for the most recent run; the dashboard renders this directly so
+-- Captain can review "what was ingested" without a second query.
+CREATE TABLE voice_source_state (
+  source_kind             TEXT NOT NULL,        -- 'email' (extension point for future capabilities)
+  source_id               TEXT NOT NULL,        -- email adapter slug or 'none'
+  last_ingestion_at       TEXT NOT NULL,        -- ISO 8601 UTC; updated on every run
+  last_success_at         TEXT,                 -- ISO 8601 UTC; updated only on success
+  last_error              TEXT,                 -- nullable; cleared on success
+  ingest_status           TEXT NOT NULL,        -- 'ok' | 'stale' | 'error' | 'never_run'
+  items_last_run          INTEGER NOT NULL DEFAULT 0,
+  samples_by_cohort_json  TEXT,                 -- JSON {"cohort_id": count, ...}; Captain review surface
+  schema_version          INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (source_kind, source_id)
+);
+
+CREATE INDEX idx_voice_source_state_status
+  ON voice_source_state(ingest_status, last_ingestion_at DESC);
+
+-- ---------- 2. Voice ingestion items ----------
+-- Provenance row per ingested voice sample. Decommission walks this table
+-- to enumerate every R2 object the pipeline stored; retention enforcer
+-- selects rows older than the customer.yaml retention window and removes
+-- the corresponding R2 objects.
+--
+-- recipient_cohort_id is the cohort tag assigned by the pipeline at write
+-- time. When the recipient has no cohort assigned in memory rules, the
+-- value is 'unassigned' (NOT NULL, per AC documentation).
+--
+-- source_message_digest is a SHA-256 of the upstream message ID. The
+-- upstream message ID itself is NOT stored — the digest lets a re-run
+-- detect the same source without retaining the vendor identifier.
+--
+-- partner_authored is the result of the filter pass: 1 when the heuristic
+-- judged the message partner-authored (no AI-employee provenance), 0 when
+-- excluded. Excluded rows are persisted for audit but not surfaced to
+-- the voice library; the dashboard can drill into them via the filter
+-- explanation field.
+--
+-- structural_diff_digest is SHA-256 of the structural-diff payload written
+-- to R2 — used by the retention enforcer to verify removal.
+CREATE TABLE voice_ingestion_items (
+  id                       TEXT PRIMARY KEY,    -- ULID, sortable
+  source_kind              TEXT NOT NULL,
+  source_id                TEXT NOT NULL,
+  source_message_digest    TEXT NOT NULL,       -- SHA-256 of upstream message_id (NOT the id itself)
+  recipient_cohort_id      TEXT NOT NULL,       -- cohort tag or 'unassigned'
+  partner_authored         INTEGER NOT NULL,    -- 0/1 — filter result
+  filter_reason            TEXT,                -- short reason when partner_authored=0
+  ingested_at              TEXT NOT NULL,       -- ISO 8601 UTC
+  sent_at                  TEXT NOT NULL,       -- ISO 8601 UTC; the original sent_at
+  r2_key                   TEXT,                -- {slug}/voice/cohort/{cohort}/{ulid}.json; NULL when filtered out
+  structural_diff_digest   TEXT,                -- SHA-256 of the structural-diff payload; NULL when filtered out
+  word_count               INTEGER,             -- sample size hint for the dashboard
+  schema_version           INTEGER NOT NULL DEFAULT 1,
+  deleted_at               TEXT                 -- set by retention enforcer or decommission hook
+);
+
+CREATE INDEX idx_voice_items_source
+  ON voice_ingestion_items(source_kind, source_id, deleted_at);
+
+CREATE INDEX idx_voice_items_cohort
+  ON voice_ingestion_items(recipient_cohort_id, ingested_at DESC)
+  WHERE deleted_at IS NULL AND partner_authored = 1;
+
+CREATE INDEX idx_voice_items_retention
+  ON voice_ingestion_items(ingested_at, deleted_at);
+
+CREATE UNIQUE INDEX idx_voice_items_dedupe
+  ON voice_ingestion_items(source_kind, source_id, source_message_digest)
+  WHERE deleted_at IS NULL;
+
+-- ---------- Schema version ----------
+-- 0001 set 1, 0002 set 2, 0003 set 3; this is migration 4.
+PRAGMA user_version = 4;

--- a/ai-employee/migrations/0005_voice_ingestion.sql
+++ b/ai-employee/migrations/0005_voice_ingestion.sql
@@ -120,4 +120,4 @@ CREATE UNIQUE INDEX idx_voice_items_dedupe
 
 -- ---------- Schema version ----------
 -- 0001 set 1, 0002 set 2, 0003 set 3; this is migration 4.
-PRAGMA user_version = 4;
+PRAGMA user_version = 5;

--- a/docs/specs/ai-employee/voice-ingestion.md
+++ b/docs/specs/ai-employee/voice-ingestion.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft (issue #856). Sibling pipeline to memory ingestion (issue #860).
 **Code:** `ai-employee/adapter/voice/`
-**Migration:** `ai-employee/migrations/0004_voice_ingestion.sql`
+**Migration:** `ai-employee/migrations/0005_voice_ingestion.sql`
 
 ---
 

--- a/docs/specs/ai-employee/voice-ingestion.md
+++ b/docs/specs/ai-employee/voice-ingestion.md
@@ -1,0 +1,210 @@
+# Voice sample ingestion pipeline
+
+**Status:** Draft (issue #856). Sibling pipeline to memory ingestion (issue #860).
+**Code:** `ai-employee/adapter/voice/`
+**Migration:** `ai-employee/migrations/0004_voice_ingestion.sql`
+
+---
+
+## Purpose
+
+Voice Layer 2 ("the agent learns the partner's writing by reading what they
+actually send") requires a stream of real partner-authored sent messages,
+captured in a privacy-preserving form, tagged by recipient cohort, and
+removable on demand. This pipeline is the producer side of that stream.
+
+It is the sibling of the memory ingestion pipeline:
+
+- Memory ingestion = matters, documents, recipients from the
+  PracticeManagement capability
+- Voice ingestion = structural-diffs of partner-sent emails from the
+  Email capability
+
+The two pipelines do not share rows. They share the substrate (per-customer
+D1 + R2 + audit log) and the architectural rules (ADR 0006, 0008, 0009).
+
+## Contract
+
+The pipeline depends on the **Email capability** interface defined in
+`src/lib/ai-employee/capabilities/email.ts`. Specifically the read-side
+methods `list_sent_since(cursor)` and `get_sent_item(message_id)`. The
+pipeline never sends. The pipeline never calls MS Graph or Gmail directly.
+
+A concrete adapter is wired by issue #822 (MS Graph + Gmail OAuth). Until
+that ships, the pipeline runs against `NoEmailSource`, which always
+returns the empty sequence and produces a clean zero-items state row.
+
+## Flow
+
+```
+                  +---------------------------------+
+  scheduled cron  |  VoiceIngestionRunner           |  on-demand call
+        \         |  .run_ingestion(mode=...)       |        /
+         \-->>----+                                 +----<<-/
+                  |  for each SentMessage:          |
+                  |    1. dedupe (digest lookup)    |
+                  |    2. PartnerAuthoredFilter     |
+                  |    3. extract_structural_diff   |
+                  |    4. resolve cohort            |
+                  |    5. insert provenance row     |
+                  |    6. write R2 object           |
+                  |  upsert voice_source_state      |
+                  +----+---------------------+------+
+                       |                     |
+                       v                     v
+                voice_ingestion_items   {slug}/voice/cohort/{cohort}/{id}.json
+                (D1)                    (R2)
+```
+
+## Privacy posture
+
+The raw email body is **never persisted**. The structural-diff extractor
+(`adapter/voice/diff.py`) computes:
+
+- word_count, sentence_count, paragraph_count, subject_word_count
+- sentence_length_distribution (5-bucket histogram)
+- avg_sentence_length
+- greeting_style + signoff_style (closed-set categorical labels)
+- opener_template + closer_template (the category, never the recipient
+  name)
+- punctuation_rhythm (counts per 100 words)
+- recipient_cohort
+
+Output is JSON-serializable, deterministic, and bounded in size. The
+body lifetime ends inside `_ingest_one()`; everything downstream operates
+on the structural-diff only.
+
+No quoted text, no recipient names, no email addresses, no PII, no
+specific content tokens. The `source_message_digest` in D1 is the
+SHA-256 of the upstream message ID — the message ID itself is not
+stored.
+
+## Partner-authored filter
+
+Three signals, in order:
+
+1. **Adapter-reported provenance.** When the Email adapter populates
+   `SentItem.likely_agent_drafted = True`, the message is excluded
+   immediately. This is the strongest signal — the adapter is telling
+   us it can see the agent's identity in the draft history.
+
+2. **Audit-log digest match.** When the adapter cannot tell, the
+   filter computes a SHA-256 of the body and consults the audit log
+   for a `DRAFT_CREATED` row whose `input_digest` matches. The audit
+   log stores digests only (per issue #891), so this cross-check costs
+   nothing extra in privacy terms.
+
+3. **Body-shape heuristic.** A final pass that excludes messages whose
+   shape (signature markers, the "Drafted by your AI Employee for
+   review" footer) matches the agent's draft templates. Single hit is
+   enough to exclude.
+
+The filter biases toward exclusion. A false-positive exclusion costs
+one missed sample; a false-positive inclusion teaches the voice
+library the agent's own voice. We accept the asymmetry.
+
+Excluded messages still receive a provenance row with
+`partner_authored = 0` and a `filter_reason` string. The dashboard
+drill-down surface uses these for "why was this not learned from"
+explanations without ever retaining the body.
+
+## Recipient cohort tagging
+
+Per PRD §17.1, recipient cohort is a derived attribute (e.g.,
+`opposing-counsel`, `client`, `expert-witness`). The cohort assignment
+lives in the customer's memory store as `memory_rules` rows where
+`rule_type = 'voice'` and `category = 'recipient_cohort'`.
+
+The pipeline reads the cohort via a `CohortResolver` injected at
+construction; it does NOT invent cohorts. When no recipient has a
+cohort assignment, the sample is tagged `unassigned` (defined in
+`adapter/voice/state.COHORT_UNASSIGNED`). The dashboard surfaces the
+unassigned bucket so the principal can add memory rules later.
+
+## Storage layout
+
+**R2 key.** Per `docs/specs/ai-employee/r2-vectorize-naming.md`:
+
+```
+{customer-slug}/voice/cohort/{cohort-id}/{sample-id}.json
+```
+
+`sample-id` is the same ULID as the `voice_ingestion_items.id` row,
+so retention and decommission can resolve a row to its R2 object by
+construction.
+
+**D1 tables (migration 0004).**
+
+- `voice_source_state` — one row per `(source_kind, source_id)`.
+  Upserted on every run, regardless of outcome. Holds
+  `samples_by_cohort_json` so the dashboard renders the per-cohort
+  histogram without a join.
+- `voice_ingestion_items` — one provenance row per sample, including
+  excluded samples. `r2_key` and `structural_diff_digest` are NULL on
+  excluded rows; populated on accepted rows.
+
+## Captain review surface (AC #4)
+
+The dashboard reads `voice_source_state` (single SELECT) to render:
+
+- Last ingestion timestamp + status (green / yellow / red)
+- Per-cohort sample count from the last run
+- Last error text when status is `error`
+- Items considered / accepted / filtered breakdown via a follow-up
+  count query on `voice_ingestion_items`
+
+Captain can drill into any cohort and see the provenance rows. The
+provenance row carries the filter reason, sent timestamp, word count,
+and the R2 key (when accepted). The structural-diff JSON itself is
+small and human-readable; Captain can fetch it directly from R2 to
+audit what the agent is learning.
+
+## Retention (AC #5)
+
+Customer.yaml carries the retention window (proposed addition under
+`memory:`):
+
+```yaml
+memory:
+  d1_namespace: demo-firm
+  r2_vault_path: vaults/demo-firm/
+  vectorize_index: hermes-demo-firm-vault
+  voice_retention_days: 365 # OPTIONAL; default 365
+```
+
+`enforce_retention()` is run on a separate daily cron. It walks
+`voice_ingestion_items` for rows older than the cutoff, deletes the R2
+object, and soft-deletes the provenance row. The state row's
+`samples_by_cohort_json` snapshot persists — retention removes samples,
+not the dashboard's historical view of the last run.
+
+## Decommission (ADR 0008)
+
+`decommission_source()` is called by `bin/decommission-customer.sh`.
+It walks every active provenance row, deletes each R2 object,
+soft-deletes every provenance row, and removes the state row. The
+result is reported back to the operator as `{removed: N, errors: E}`
+so the decommission script can refuse to mark the customer offboarded
+when `errors > 0`.
+
+## ADR conformance
+
+- **ADR 0005 (reviewer-as-sender).** Pipeline reads sent folder only.
+  No send paths.
+- **ADR 0006 (capability adapter pattern).** Pipeline depends on
+  `EmailSource` (which wraps the `Email` capability), never on MS
+  Graph or Gmail directly.
+- **ADR 0008 (customer-owned memory).** R2 keys land under the
+  customer slug; every persisted artifact has a provenance row;
+  decommission removes everything.
+- **ADR 0009 (cross-machine query prohibition).** No tenant ID on
+  rows; isolation is the D1 + R2 binding.
+
+## Out of scope
+
+- The MS Graph and Gmail adapter implementations (issue #822).
+- The Captain dashboard endpoint that queries `voice_source_state` and
+  `voice_ingestion_items` (filed as a follow-up).
+- Voice gate scoring against the ingested library (issues #823, #939).
+- Voice library training itself — the structural-diffs are the
+  durable input; downstream training reads them on demand.


### PR DESCRIPTION
## Summary

Implements the Voice Layer 2 producer: pulls sent items from the Email capability, filters AI-drafted content, extracts structural-diff representations (never raw bodies), tags by recipient cohort, and writes per-customer to R2. Sibling to the memory ingestion pipeline (PR #944) — same shape, distinct concern.

## Linked issue

Closes #856

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Ingestion runs scheduled (daily) or on-demand | met | `ai-employee/adapter/voice/pipeline.py` `IngestionMode.SCHEDULED` / `ON_DEMAND` share one entrypoint (`VoiceIngestionRunner.run_ingestion`); both modes covered by `test_runner_ingests_and_writes_to_r2` and `test_runner_dedupes_on_re_run` |
| Storage: R2 vault per customer, namespaced | met | R2 keys follow `{customer-slug}/voice/cohort/{cohort-id}/{sample-id}.json` per `docs/specs/ai-employee/r2-vectorize-naming.md`; built in `_ingest_one()` from `r2_client.customer_slug`; asserted by `test_runner_ingests_and_writes_to_r2` |
| Privacy: structural-diff format, no PII retained | met | `ai-employee/adapter/voice/diff.py` `extract_structural_diff` returns counts + closed-set labels only; body lifetime ends inside `_ingest_one`; `source_message_digest` is SHA-256 of the upstream ID (not the ID); `test_no_raw_body_in_r2_or_d1` asserts secret/name/matter tokens never reach R2 or D1 |
| Captain can review what was ingested | met | `voice_source_state.samples_by_cohort_json` upserted per run; dashboard reads it without a join; `test_state_store_round_trip_decodes_cohort_histogram` covers; review surface documented in `docs/specs/ai-employee/voice-ingestion.md` §"Captain review surface" |
| Removable per customer.yaml retention policy | met | `enforce_retention(voice_retention_days)` deletes expired R2 objects and soft-deletes provenance rows; `test_retention_enforcer_deletes_expired_items` covers; `decommission_source` removes everything for a source (ADR 0008) |

## Design notes

- **Capability interface** — pipeline consumes the Email capability (`src/lib/ai-employee/capabilities/email.ts`) via the vendor-neutral `EmailSource` protocol. No MS Graph / Gmail specifics. `NoEmailSource` is the no-connector fallback.
- **Partner-authored filter** (three signals in order): adapter `likely_agent_drafted`, audit-log digest match against `DRAFT_CREATED` rows from PR #942, body-shape heuristic. Biases toward exclusion. Filtered rows persist with `partner_authored=0` and a `filter_reason` for dashboard drill-down.
- **Recipient cohort tagging** — pipeline reads cohort via injected `CohortResolver`; never invents. No-cohort recipients tagged `unassigned` per `state.COHORT_UNASSIGNED`.
- **Migration 0004** — adds `voice_source_state` + `voice_ingestion_items`. No drops to existing schema.
- **ADR conformance** — 0005 (read-only, no send), 0006 (capability interface), 0008 (per-customer R2, decommission walks provenance), 0009 (no tenant column).

## Test plan

- [x] `cd ai-employee && python -m pytest adapter/tests/test_voice_pipeline.py -v` — 25 tests pass locally (asyncio + sqlite in-memory)
- [x] `cd ai-employee && python -m pytest adapter/tests/ -v` — full adapter suite passes (41 tests; existing audit_log tests untouched)
- [x] `npm run verify` — exit 0 locally (typecheck + lint + build + tests + workers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)