### PR TITLE
feat(ai-employee): trust ceiling decision logging (#864)

### DIFF
--- a/ai-employee/safety-substrate/tests/test_trust_ceiling_log.py
+++ b/ai-employee/safety-substrate/tests/test_trust_ceiling_log.py
@@ -1,0 +1,618 @@
+"""Tests for ai-employee/safety-substrate/trust_ceiling_log.py (issue #864).
+
+Covers the audit row contract for every (Decision, DecisionReason) combo
+plus the validation surface (closed enums, missing required fields,
+canonical-key collision detection).
+
+Tests use the same sqlite-in-memory pattern as test_audit_log.py and
+test_sticky_stop.py: the audit_log schema is mirrored in-process so the
+test does not shell out to wrangler.
+
+Run from the repo root:
+
+    cd ai-employee && python -m pytest safety-substrate/tests/test_trust_ceiling_log.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/
+sys.path.insert(0, str(_HERE.parents[1]))  # ai-employee/safety-substrate/
+
+from adapter.audit_log import (  # noqa: E402
+    AuditLogWriter,
+    AuditWriteError,
+    SqliteExecutor,
+)
+from trust_ceiling_log import (  # noqa: E402
+    ActionClassName,
+    CeilingLevel,
+    Decision,
+    DecisionReason,
+    log_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE audit_log (
+  id            TEXT PRIMARY KEY,
+  ts            TEXT NOT NULL,
+  action_type   TEXT NOT NULL,
+  actor         TEXT NOT NULL,
+  actor_role    TEXT,
+  skill_name    TEXT,
+  matter_ref    TEXT,
+  input_digest  TEXT,
+  output_digest TEXT,
+  diff_digest   TEXT,
+  trust_ceiling TEXT,
+  metadata      TEXT
+);
+"""
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_AUDIT_SCHEMA)
+    return conn
+
+
+def _writer() -> tuple[AuditLogWriter, sqlite3.Connection]:
+    conn = _make_conn()
+    return AuditLogWriter(SqliteExecutor(conn)), conn
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _rows(conn: sqlite3.Connection) -> list[dict]:
+    cur = conn.cursor()
+    raw = cur.execute(
+        "SELECT id, action_type, actor, actor_role, skill_name, matter_ref, "
+        "trust_ceiling, metadata FROM audit_log ORDER BY rowid"
+    ).fetchall()
+    out = []
+    for row in raw:
+        (id_, action_type, actor, actor_role, skill_name, matter_ref,
+         trust_ceiling, metadata) = row
+        out.append(
+            {
+                "id": id_,
+                "action_type": action_type,
+                "actor": actor,
+                "actor_role": actor_role,
+                "skill_name": skill_name,
+                "matter_ref": matter_ref,
+                "trust_ceiling": trust_ceiling,
+                "metadata": json.loads(metadata) if metadata else None,
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Smoke: one happy-path row exercises every canonical field
+# ---------------------------------------------------------------------------
+
+
+def test_log_decision_writes_one_row_with_all_canonical_fields():
+    writer, conn = _writer()
+    audit_id = _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class=ActionClassName.EXTERNAL_SEND,
+            ceiling_level=CeilingLevel.DRAFT_FOR_REVIEW,
+            decision=Decision.DRAFT,
+            reason=DecisionReason.EXTERNAL_SEND_DRAFT_ROUTE,
+            skill_version="2.1.0",
+            trace_id="trace-01HXYZ",
+            matter_ref="matter-abc-123",
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == audit_id
+    assert row["action_type"] == "DRAFT_CREATED"
+    assert row["actor"] == "agent"
+    assert row["actor_role"] == "agent"
+    assert row["skill_name"] == "inbox-triage"
+    assert row["matter_ref"] == "matter-abc-123"
+    assert row["trust_ceiling"] == "draft_for_review"
+    md = row["metadata"]
+    assert md["trust_ceiling_decision"] is True
+    assert md["customer"] == "acme"
+    assert md["skill"] == "inbox-triage"
+    assert md["action_class"] == "external_send"
+    assert md["ceiling_level"] == "draft_for_review"
+    assert md["decision"] == "draft_for_review"
+    assert md["reason"] == "external_send_draft_route"
+    assert md["skill_version"] == "2.1.0"
+    assert md["trace_id"] == "trace-01HXYZ"
+
+
+# ---------------------------------------------------------------------------
+# Decision -> action_type mapping
+# ---------------------------------------------------------------------------
+
+
+def test_allow_decision_maps_to_draft_created_action_type():
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="status-report",
+            action_class=ActionClassName.READ,
+            ceiling_level=CeilingLevel.AUTONOMOUS,
+            decision=Decision.ALLOW,
+            reason=DecisionReason.READ_ALLOWED,
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["action_type"] == "DRAFT_CREATED"
+    assert rows[0]["metadata"]["decision"] == "allow"
+    assert rows[0]["metadata"]["reason"] == "read_allowed"
+
+
+def test_draft_decision_maps_to_draft_created_action_type():
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class=ActionClassName.EXTERNAL_SEND,
+            ceiling_level=CeilingLevel.DRAFT_FOR_REVIEW,
+            decision=Decision.DRAFT,
+            reason=DecisionReason.EXTERNAL_SEND_DRAFT_ROUTE,
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["action_type"] == "DRAFT_CREATED"
+    assert rows[0]["metadata"]["decision"] == "draft_for_review"
+
+
+def test_refuse_decision_maps_to_invariant_violation_action_type():
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="settlement-negotiation",
+            action_class=ActionClassName.COMMITMENT,
+            ceiling_level=CeilingLevel.AUTONOMOUS,
+            decision=Decision.REFUSE,
+            reason=DecisionReason.COMMITMENT_NO_APPROVAL,
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["action_type"] == "INVARIANT_VIOLATION"
+    assert rows[0]["metadata"]["decision"] == "refuse"
+    assert rows[0]["metadata"]["reason"] == "commitment_no_approval"
+
+
+# ---------------------------------------------------------------------------
+# Every (Decision, DecisionReason) combo produces a well-shaped row
+# ---------------------------------------------------------------------------
+
+
+_ALLOW_REASONS = [
+    DecisionReason.READ_ALLOWED,
+    DecisionReason.INTERNAL_WRITE_AUTONOMOUS,
+    DecisionReason.EXTERNAL_SEND_AUTONOMOUS_WITH_APPROVAL,
+    DecisionReason.COMMITMENT_WITH_APPROVAL,
+    DecisionReason.DESTRUCTIVE_WITH_APPROVAL,
+]
+
+_DRAFT_REASONS = [
+    DecisionReason.INTERNAL_WRITE_DRAFT_ROUTE,
+    DecisionReason.EXTERNAL_SEND_DRAFT_ROUTE,
+    DecisionReason.COMMITMENT_REQUIRES_AUTONOMOUS,
+]
+
+_REFUSE_REASONS = [
+    DecisionReason.CEILING_DISABLED,
+    DecisionReason.EXTERNAL_SEND_NO_APPROVAL,
+    DecisionReason.COMMITMENT_NO_APPROVAL,
+    DecisionReason.DESTRUCTIVE_NO_APPROVAL,
+    DecisionReason.DESTRUCTIVE_DRAFT_CEILING,
+    DecisionReason.UNKNOWN_ACTION_CLASS,
+]
+
+
+@pytest.mark.parametrize("reason", _ALLOW_REASONS)
+def test_each_allow_reason_emits_correctly(reason):
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="some-skill",
+            action_class=ActionClassName.READ,
+            ceiling_level=CeilingLevel.AUTONOMOUS,
+            decision=Decision.ALLOW,
+            reason=reason,
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["metadata"]["decision"] == "allow"
+    assert rows[0]["metadata"]["reason"] == reason.value
+
+
+@pytest.mark.parametrize("reason", _DRAFT_REASONS)
+def test_each_draft_reason_emits_correctly(reason):
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="some-skill",
+            action_class=ActionClassName.EXTERNAL_SEND,
+            ceiling_level=CeilingLevel.DRAFT_FOR_REVIEW,
+            decision=Decision.DRAFT,
+            reason=reason,
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["metadata"]["decision"] == "draft_for_review"
+    assert rows[0]["metadata"]["reason"] == reason.value
+    assert rows[0]["action_type"] == "DRAFT_CREATED"
+
+
+@pytest.mark.parametrize("reason", _REFUSE_REASONS)
+def test_each_refuse_reason_emits_correctly(reason):
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="some-skill",
+            action_class=ActionClassName.DESTRUCTIVE,
+            ceiling_level=CeilingLevel.DRAFT_FOR_REVIEW,
+            decision=Decision.REFUSE,
+            reason=reason,
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["metadata"]["decision"] == "refuse"
+    assert rows[0]["metadata"]["reason"] == reason.value
+    assert rows[0]["action_type"] == "INVARIANT_VIOLATION"
+
+
+# ---------------------------------------------------------------------------
+# Closed-enum validation
+# ---------------------------------------------------------------------------
+
+
+def test_free_text_reason_rejected():
+    writer, _ = _writer()
+    with pytest.raises(ValueError, match="DecisionReason"):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="some-skill",
+                action_class=ActionClassName.READ,
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision=Decision.ALLOW,
+                reason="just because",  # type: ignore[arg-type]
+            )
+        )
+
+
+def test_free_text_decision_rejected():
+    writer, _ = _writer()
+    with pytest.raises(ValueError, match="Decision"):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="some-skill",
+                action_class=ActionClassName.READ,
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision="maybe",  # type: ignore[arg-type]
+                reason=DecisionReason.READ_ALLOWED,
+            )
+        )
+
+
+def test_invalid_ceiling_level_string_rejected():
+    writer, _ = _writer()
+    with pytest.raises(ValueError):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="some-skill",
+                action_class=ActionClassName.READ,
+                ceiling_level="elevated",
+                decision=Decision.ALLOW,
+                reason=DecisionReason.READ_ALLOWED,
+            )
+        )
+
+
+def test_invalid_action_class_string_rejected():
+    writer, _ = _writer()
+    with pytest.raises(ValueError):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="some-skill",
+                action_class="touch",
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision=Decision.ALLOW,
+                reason=DecisionReason.READ_ALLOWED,
+            )
+        )
+
+
+def test_missing_customer_rejected():
+    writer, _ = _writer()
+    with pytest.raises(ValueError, match="customer"):
+        _run(
+            log_decision(
+                writer,
+                customer="",
+                skill="some-skill",
+                action_class=ActionClassName.READ,
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision=Decision.ALLOW,
+                reason=DecisionReason.READ_ALLOWED,
+            )
+        )
+
+
+def test_missing_skill_rejected():
+    writer, _ = _writer()
+    with pytest.raises(ValueError, match="skill"):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="",
+                action_class=ActionClassName.READ,
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision=Decision.ALLOW,
+                reason=DecisionReason.READ_ALLOWED,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# String-value pass-through (dispatch path passes strings, not enums)
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_string_ceiling_level_and_action_class():
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class="external_send",
+            ceiling_level="draft_for_review",
+            decision=Decision.DRAFT,
+            reason=DecisionReason.EXTERNAL_SEND_DRAFT_ROUTE,
+        )
+    )
+    rows = _rows(conn)
+    assert rows[0]["metadata"]["action_class"] == "external_send"
+    assert rows[0]["metadata"]["ceiling_level"] == "draft_for_review"
+
+
+def test_refused_ceiling_synonym_accepted():
+    # `refused` (adapter convention) and `disabled` (PRD §11.1 wording)
+    # are equivalent. The wrapper accepts both without translating.
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="some-skill",
+            action_class=ActionClassName.EXTERNAL_SEND,
+            ceiling_level="refused",
+            decision=Decision.REFUSE,
+            reason=DecisionReason.CEILING_DISABLED,
+        )
+    )
+    rows = _rows(conn)
+    assert rows[0]["metadata"]["ceiling_level"] == "refused"
+    assert rows[0]["trust_ceiling"] == "refused"
+
+
+# ---------------------------------------------------------------------------
+# extra_metadata behavior
+# ---------------------------------------------------------------------------
+
+
+def test_extra_metadata_merges_after_canonical_keys():
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class=ActionClassName.EXTERNAL_SEND,
+            ceiling_level=CeilingLevel.DRAFT_FOR_REVIEW,
+            decision=Decision.DRAFT,
+            reason=DecisionReason.EXTERNAL_SEND_DRAFT_ROUTE,
+            extra_metadata={"tool_name": "gmail.send", "recipient_domain": "acme.com"},
+        )
+    )
+    md = _rows(conn)[0]["metadata"]
+    assert md["tool_name"] == "gmail.send"
+    assert md["recipient_domain"] == "acme.com"
+    # Canonical keys still present
+    assert md["trust_ceiling_decision"] is True
+    assert md["decision"] == "draft_for_review"
+
+
+def test_extra_metadata_cannot_override_canonical_keys():
+    writer, _ = _writer()
+    with pytest.raises(ValueError, match="canonical keys"):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="inbox-triage",
+                action_class=ActionClassName.READ,
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision=Decision.ALLOW,
+                reason=DecisionReason.READ_ALLOWED,
+                extra_metadata={"decision": "spoofed"},
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Optional-field handling
+# ---------------------------------------------------------------------------
+
+
+def test_optional_fields_default_to_none_in_metadata():
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class=ActionClassName.READ,
+            ceiling_level=CeilingLevel.AUTONOMOUS,
+            decision=Decision.ALLOW,
+            reason=DecisionReason.READ_ALLOWED,
+        )
+    )
+    md = _rows(conn)[0]["metadata"]
+    assert md["skill_version"] is None
+    assert md["trace_id"] is None
+    assert _rows(conn)[0]["matter_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# Audit-write failure propagation
+# ---------------------------------------------------------------------------
+
+
+class _FailingExecutor:
+    """Executor that raises on every write; used to verify the wrapper
+    propagates AuditWriteError to the caller per the spec invariant."""
+
+    async def execute(self, sql, params):
+        raise RuntimeError("simulated D1 outage")
+
+
+def test_audit_write_failure_propagates_as_auditwriteerror():
+    writer = AuditLogWriter(_FailingExecutor())
+    with pytest.raises(AuditWriteError):
+        _run(
+            log_decision(
+                writer,
+                customer="acme",
+                skill="inbox-triage",
+                action_class=ActionClassName.READ,
+                ceiling_level=CeilingLevel.AUTONOMOUS,
+                decision=Decision.ALLOW,
+                reason=DecisionReason.READ_ALLOWED,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard-aggregation contract
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_has_stable_keys_for_aggregation():
+    """The dashboard implementer (separate issue) keys on a stable JSON
+    shape. If this set ever changes, the spec and dashboard contract
+    must change in lockstep."""
+    writer, conn = _writer()
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class=ActionClassName.EXTERNAL_SEND,
+            ceiling_level=CeilingLevel.DRAFT_FOR_REVIEW,
+            decision=Decision.DRAFT,
+            reason=DecisionReason.EXTERNAL_SEND_DRAFT_ROUTE,
+            skill_version="2.1.0",
+            trace_id="trace-01HXYZ",
+        )
+    )
+    md = _rows(conn)[0]["metadata"]
+    assert set(md.keys()) == {
+        "trust_ceiling_decision",
+        "customer",
+        "skill",
+        "action_class",
+        "ceiling_level",
+        "decision",
+        "reason",
+        "skill_version",
+        "trace_id",
+    }
+
+
+def test_filter_predicate_matches_trust_ceiling_rows_only():
+    """Mixed audit rows: only the trust-ceiling-decision rows should match
+    the dashboard's filter predicate (metadata.trust_ceiling_decision = true)."""
+    writer, conn = _writer()
+    # Emit one trust-ceiling row.
+    _run(
+        log_decision(
+            writer,
+            customer="acme",
+            skill="inbox-triage",
+            action_class=ActionClassName.READ,
+            ceiling_level=CeilingLevel.AUTONOMOUS,
+            decision=Decision.ALLOW,
+            reason=DecisionReason.READ_ALLOWED,
+        )
+    )
+    # And one unrelated audit row (mirrors a non-trust-ceiling event).
+    from adapter.audit_log import AuditEvent
+
+    _run(
+        writer.write(
+            AuditEvent(
+                action_type="DRAFT_APPROVED",
+                actor="captain-scott",
+                skill_name="inbox-triage",
+            )
+        )
+    )
+    rows = _rows(conn)
+    assert len(rows) == 2
+    matched = [
+        r for r in rows
+        if r["metadata"] and r["metadata"].get("trust_ceiling_decision") is True
+    ]
+    assert len(matched) == 1
+    assert matched[0]["metadata"]["reason"] == "read_allowed"

--- a/ai-employee/safety-substrate/trust_ceiling_log.py
+++ b/ai-employee/safety-substrate/trust_ceiling_log.py
@@ -1,0 +1,372 @@
+"""Trust-ceiling decision logging (issue #864).
+
+The platform PRD §11 ("Trust Ceiling Model") and §11.4 ("Audit log") say
+every action at every ceiling is logged. The `enforce()` call point in
+`ai-employee/adapter/trust_ceiling.py` makes the allow / draft_for_review /
+refuse call, but nothing emits those decisions as audit rows today. Without
+emission, the trust ceiling is invisible to operators and customers: the
+Captain dashboard has no aggregate view, the customer dashboard has no
+recent-decisions feed, and the compliance-evidence packet (#802) cannot
+show enforcement history.
+
+This module is the emission layer. It wraps a trust-ceiling decision with
+a synchronous audit_log write. The dispatch path on the Hermes side calls
+`log_decision()` once per `enforce()` invocation, on the same code path,
+before the action proceeds (for `allow`) or after the substrate has decided
+to draft / refuse.
+
+Design rules
+------------
+
+* **Closed enum vocabulary.** `Decision` (allow / draft_for_review / refuse)
+  and `DecisionReason` are closed enums. The dashboard aggregates on these
+  values; free-text reasons would make the aggregate view degrade as new
+  variants appear in production. The enum members below are drawn from the
+  decision tree in `adapter/trust_ceiling.py::enforce()`. Adding a new
+  reason means: extend the enum here, extend the wrapper's reason mapping,
+  extend the spec doc, ship in one PR.
+
+* **No PII in audit metadata.** The reason is a closed-enum value. The
+  audit row also carries `customer`, `skill`, `action_class`, and
+  `ceiling_level`. All opaque identifiers / closed-vocabulary values.
+  Substantive payload (the email body the agent wanted to send, etc.)
+  is never logged here; that lives in R2 via the audit_log writer's
+  payload-digest contract.
+
+* **Synchronous emission.** `log_decision()` returns only after the
+  audit_log INSERT lands. Same invariant as the writer itself
+  (`audit_log.AuditLogWriter.write`): a state the substrate cannot
+  enforce or evidence is a state the agent does not run. If the audit
+  write fails, the wrapper propagates `AuditWriteError`; the caller
+  (dispatch path) MUST treat that as a fatal: the unloggable decision
+  must not produce an action.
+
+* **Reuse closed-set action_type vocabulary.** Per the sticky-stop
+  precedent (PR #948) and the audit_log writer's documented protocol,
+  this module reuses `ACCEPTED_ACTION_TYPES` rather than extending it.
+  Mapping is per-decision:
+
+    - `allow`            -> `DRAFT_CREATED` if action_class is internal_write
+                            with a draft routing, otherwise no audit row
+                            emitted here (the downstream action's own audit
+                            row covers the audit trail).
+    - `draft_for_review` -> `DRAFT_CREATED`
+    - `refuse`           -> `INVARIANT_VIOLATION`
+
+  The trust-ceiling-decision detail lives in metadata so the dashboard,
+  audit viewer (#873), and compliance-evidence packet (#802) can aggregate
+  via stable JSON keys.
+
+  NOTE: This is a deliberate scope-respecting choice. The audit_log
+  writer's ACCEPTED_ACTION_TYPES constant is on main from PR #942 and
+  this PR's strict file scope (issue #864 brief) forbids touching it.
+  The sticky-stop module (PR #948) made the same call. The downside:
+  the action_type column does not by itself identify a trust-ceiling
+  row; readers must filter on `metadata.trust_ceiling_decision == true`.
+  The compliance-evidence packet spec already uses that pattern for
+  sticky-stop rows; it works the same way here.
+
+* **`allow` decisions and the audit-floor question.** The AC says "every
+  `enforce()` invocation emits an event." In practice, an `allow` decision
+  means the underlying action proceeds normally and produces its OWN
+  downstream audit row (DRAFT_CREATED on draft creation, SENT_DETECTED on
+  send, etc.); that row already records the actor, skill, and ceiling at
+  action time via the writer's `trust_ceiling` column. To meet the AC
+  without duplicating rows, this module records `allow` decisions via the
+  same `DRAFT_CREATED` shape with `metadata.decision == "allow"` so the
+  dashboard can include allow decisions in its aggregate. The compliance
+  view filters on the decision field, not the action_type.
+
+  Wiring detail for the integration point: `log_decision()` is called on
+  every `enforce()` invocation including allows; the audit row is emitted
+  synchronously; downstream code is free to emit its own action-specific
+  audit row in addition. The two rows are linked by `metadata.trace_id`.
+
+Module shape
+------------
+
+::
+
+    from ai_employee_safety_substrate.trust_ceiling_log import (
+        Decision,
+        DecisionReason,
+        log_decision,
+    )
+
+    # On the Hermes dispatch path, after `enforce()` returns:
+    audit_id = await log_decision(
+        writer=audit_writer,
+        customer="acme",
+        skill="inbox-triage",
+        action_class="external_send",
+        ceiling_level="draft_for_review",
+        decision=Decision.DRAFT,
+        reason=DecisionReason.DRAFT_ROUTE_SEND,
+        skill_version="2.1.0",
+        trace_id="trace-01HXY...",
+    )
+
+Aggregation query shape (for the dashboard implementer, separate issue)
+------------------------------------------------------------------------
+
+The Captain dashboard's "aggregate decisions over time" surface and the
+customer dashboard's "recent decisions for your account" surface both
+filter on `metadata.trust_ceiling_decision = true` and aggregate by
+`metadata.decision`, `metadata.reason`, and `ts` buckets. The full query
+shape is in `docs/specs/ai-employee/trust-ceiling-logging.md` §Aggregation.
+"""
+
+from __future__ import annotations
+
+import enum
+import sys
+from pathlib import Path
+from typing import Optional
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[1]))  # ai-employee/ on sys.path
+
+from adapter.audit_log import (  # noqa: E402
+    ActorRole,
+    AuditEvent,
+    AuditLogWriter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Decision + reason enums
+#
+# Source of truth: platform-prd.md §11 (trust ceiling model) and the
+# decision tree in adapter/trust_ceiling.py::enforce(). The enum members
+# below cover every branch in that decision tree. When the dispatch
+# integration lands, the mapping from enforce()'s EnforcementDecision
+# (allowed, reason_text, audit_action) to the (Decision, DecisionReason)
+# pair lives at the call site, NOT here. This module is a pure emitter;
+# the caller decides what decision was made and why.
+# ---------------------------------------------------------------------------
+
+
+class Decision(str, enum.Enum):
+    """Closed set of trust-ceiling decisions.
+
+    Mirrors `EnforcementDecision.audit_action` in
+    `adapter/trust_ceiling.py`. Names match the platform PRD §11
+    vocabulary verbatim; the underlying string values match the audit_log
+    column convention.
+    """
+
+    ALLOW = "allow"
+    DRAFT = "draft_for_review"
+    REFUSE = "refuse"
+
+
+class CeilingLevel(str, enum.Enum):
+    """The trust ceiling configured for the skill at decision time.
+
+    Values match platform PRD §11.1's three ceilings and the
+    `Ceiling` enum in `adapter/trust_ceiling.py`. The PRD names the
+    third value `disabled`; the adapter uses `refused` for the same
+    semantics (skill does not run). Both spellings are accepted here so
+    the dispatch path can pass through whichever name its source uses
+    without translation. Aggregations should treat the two as equivalent.
+    """
+
+    AUTONOMOUS = "autonomous"
+    DRAFT_FOR_REVIEW = "draft_for_review"
+    DISABLED = "disabled"
+    REFUSED = "refused"  # synonym for DISABLED per adapter convention
+
+
+class ActionClassName(str, enum.Enum):
+    """Action class as declared on the tool the skill is invoking.
+
+    Mirrors `ActionClass` in `adapter/trust_ceiling.py`. Held as a closed
+    set here so the dashboard's "decisions by action class" facet stays
+    well-defined and so new categories can't enter via free-text drift.
+    """
+
+    READ = "read"
+    INTERNAL_WRITE = "internal_write"
+    EXTERNAL_SEND = "external_send"
+    COMMITMENT = "commitment"
+    DESTRUCTIVE = "destructive"
+
+
+class DecisionReason(str, enum.Enum):
+    """Closed set of reasons the trust ceiling reached a given decision.
+
+    Each member maps to exactly one branch in the
+    `adapter/trust_ceiling.py::enforce()` decision tree. Adding a branch
+    means adding a member here; the spec doc and the wrapper test must be
+    updated in the same PR.
+
+    Naming convention: ``<SCOPE>_<OUTCOME>``. Scopes correspond to the
+    action class or ceiling state that drove the decision; outcomes are
+    one of ALLOW / DRAFT / REFUSE matching the `Decision` value.
+    """
+
+    # ALLOW reasons --------------------------------------------------------
+    READ_ALLOWED = "read_allowed"
+    INTERNAL_WRITE_AUTONOMOUS = "internal_write_autonomous"
+    EXTERNAL_SEND_AUTONOMOUS_WITH_APPROVAL = "external_send_autonomous_with_approval"
+    COMMITMENT_WITH_APPROVAL = "commitment_with_approval"
+    DESTRUCTIVE_WITH_APPROVAL = "destructive_with_approval"
+
+    # DRAFT_FOR_REVIEW reasons --------------------------------------------
+    INTERNAL_WRITE_DRAFT_ROUTE = "internal_write_draft_route"
+    EXTERNAL_SEND_DRAFT_ROUTE = "external_send_draft_route"
+    COMMITMENT_REQUIRES_AUTONOMOUS = "commitment_requires_autonomous"
+
+    # REFUSE reasons ------------------------------------------------------
+    CEILING_DISABLED = "ceiling_disabled"
+    EXTERNAL_SEND_NO_APPROVAL = "external_send_no_approval"
+    COMMITMENT_NO_APPROVAL = "commitment_no_approval"
+    DESTRUCTIVE_NO_APPROVAL = "destructive_no_approval"
+    DESTRUCTIVE_DRAFT_CEILING = "destructive_draft_ceiling"
+    UNKNOWN_ACTION_CLASS = "unknown_action_class"
+
+
+# ---------------------------------------------------------------------------
+# Action-type mapping
+#
+# Per the safety-substrate scope rules (issue brief), this module reuses
+# the audit_log writer's closed-set `ACCEPTED_ACTION_TYPES` rather than
+# extending it. Mapping is per-Decision:
+#
+#   - REFUSE -> INVARIANT_VIOLATION (the substrate enforced an invariant)
+#   - DRAFT  -> DRAFT_CREATED       (the substrate routed to a draft)
+#   - ALLOW  -> DRAFT_CREATED       (audit-floor; metadata.decision = allow)
+#
+# Readers identify trust-ceiling rows by `metadata.trust_ceiling_decision`
+# = true (NOT by action_type alone). This mirrors the sticky-stop convention
+# of carrying transition specifics in metadata while reusing existing
+# action_types.
+# ---------------------------------------------------------------------------
+
+
+_DECISION_TO_ACTION_TYPE: dict[Decision, str] = {
+    Decision.ALLOW: "DRAFT_CREATED",
+    Decision.DRAFT: "DRAFT_CREATED",
+    Decision.REFUSE: "INVARIANT_VIOLATION",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public emission API
+# ---------------------------------------------------------------------------
+
+
+async def log_decision(
+    writer: AuditLogWriter,
+    *,
+    customer: str,
+    skill: str,
+    action_class: ActionClassName | str,
+    ceiling_level: CeilingLevel | str,
+    decision: Decision,
+    reason: DecisionReason,
+    skill_version: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    matter_ref: Optional[str] = None,
+    extra_metadata: Optional[dict] = None,
+) -> str:
+    """Emit one audit_log row for a trust-ceiling decision.
+
+    Returns the inserted ULID (the audit_log row id). Synchronous: returns
+    only after the underlying INSERT has been acknowledged. Caller
+    responsibility on `AuditWriteError`: abort the pending action.
+
+    Required:
+        writer         - constructed `AuditLogWriter` (one per Machine)
+        customer       - customer slug; matches the D1 binding's tenant
+        skill          - skill name (from SKILL.md frontmatter)
+        action_class   - one of `ActionClassName` (or its string value)
+        ceiling_level  - the ceiling configured at decision time
+        decision       - one of `Decision`
+        reason         - one of `DecisionReason`; closed enum, NOT free text
+
+    Optional:
+        skill_version  - SKILL.md content hash or version pin
+        trace_id       - opaque request/turn id for cross-row correlation
+        matter_ref     - opaque per-vertical reference (matter id, lead id)
+        extra_metadata - additional JSON-serializable fields; merged after
+                         the canonical keys. Use sparingly: dashboard
+                         aggregations key on the canonical fields, not the
+                         extra bag. Caller may NOT supply keys that
+                         collide with canonical keys.
+
+    Raises:
+        ValueError      - decision / reason / ceiling_level / action_class
+                          are not enum members
+        AuditWriteError - underlying audit_log INSERT failed; caller must
+                          abort the pending action
+    """
+    if not isinstance(decision, Decision):
+        raise ValueError(f"decision must be a Decision enum, got {type(decision)!r}")
+    if not isinstance(reason, DecisionReason):
+        raise ValueError(
+            f"reason must be a DecisionReason enum, got {type(reason)!r}; "
+            "free-text reasons are not allowed (dashboard aggregates on the enum)"
+        )
+
+    # Normalize ceiling_level + action_class. Accept enum or string-value,
+    # validate string-values against the enum to fail fast on typos.
+    ceiling_value = (
+        ceiling_level.value
+        if isinstance(ceiling_level, CeilingLevel)
+        else CeilingLevel(ceiling_level).value
+    )
+    action_class_value = (
+        action_class.value
+        if isinstance(action_class, ActionClassName)
+        else ActionClassName(action_class).value
+    )
+
+    if not customer:
+        raise ValueError("customer is required")
+    if not skill:
+        raise ValueError("skill is required")
+
+    action_type = _DECISION_TO_ACTION_TYPE[decision]
+
+    metadata: dict = {
+        "trust_ceiling_decision": True,
+        "customer": customer,
+        "skill": skill,
+        "action_class": action_class_value,
+        "ceiling_level": ceiling_value,
+        "decision": decision.value,
+        "reason": reason.value,
+        "skill_version": skill_version,
+        "trace_id": trace_id,
+    }
+
+    if extra_metadata:
+        canonical_keys = set(metadata.keys())
+        collisions = canonical_keys & extra_metadata.keys()
+        if collisions:
+            raise ValueError(
+                f"extra_metadata may not override canonical keys: {sorted(collisions)}"
+            )
+        metadata.update(extra_metadata)
+
+    return await writer.write(
+        AuditEvent(
+            action_type=action_type,
+            actor="agent",
+            actor_role=ActorRole.AGENT,
+            skill_name=skill,
+            matter_ref=matter_ref,
+            trust_ceiling=ceiling_value,
+            metadata=metadata,
+        )
+    )
+
+
+__all__ = [
+    "ActionClassName",
+    "CeilingLevel",
+    "Decision",
+    "DecisionReason",
+    "log_decision",
+]

--- a/docs/specs/ai-employee/trust-ceiling-logging.md
+++ b/docs/specs/ai-employee/trust-ceiling-logging.md
@@ -1,0 +1,357 @@
+# Trust-ceiling decision logging
+
+**Spec for issue #864.** Emission contract for trust-ceiling enforcement
+decisions. Wraps `enforce()` with a synchronous audit_log write so the
+substrate's allow / draft_for_review / refuse decisions are visible to
+operators, customers, and the compliance evidence packet.
+
+Before this issue, the trust ceiling was a code-path decision with no
+visibility. The Captain dashboard had no way to aggregate enforcement
+across customers; the customer dashboard had no recent-decisions feed;
+the compliance-evidence packet (#802) could not show enforcement history.
+This spec describes the audit-row contract that fixes that gap.
+
+## Source
+
+- platform-prd.md §11 (Trust Ceiling Model)
+  - §11.1: the three ceilings (autonomous, draft_for_review, disabled)
+  - §11.4: every action at every ceiling is logged
+- platform-prd.md §7.5: safety substrate invariants (invariant #5: ceiling
+  enforced in code, not in prompt)
+- `ai-employee/adapter/trust_ceiling.py`: the `enforce()` decision tree
+  this module wraps
+- `ai-employee/adapter/audit_log.py` (PR #942): the writer + closed-set
+  `ACCEPTED_ACTION_TYPES` vocabulary this module emits into
+- d1-schema.md §1: `audit_log` table the emission lands in
+- compliance-evidence-packet.md (#802): downstream consumer that
+  aggregates the emitted rows
+
+## Module + integration point
+
+The emission module is `ai-employee/safety-substrate/trust_ceiling_log.py`.
+The public surface is one function:
+
+```python
+async def log_decision(
+    writer: AuditLogWriter,
+    *,
+    customer: str,
+    skill: str,
+    action_class: ActionClassName | str,
+    ceiling_level: CeilingLevel | str,
+    decision: Decision,
+    reason: DecisionReason,
+    skill_version: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    matter_ref: Optional[str] = None,
+    extra_metadata: Optional[dict] = None,
+) -> str
+```
+
+Returns the inserted ULID. Synchronous: returns only after the underlying
+INSERT lands. On `AuditWriteError` the caller (dispatch path) MUST abort
+the pending action, same invariant as the audit log writer itself.
+
+### Where `log_decision()` plugs into the dispatch path
+
+`enforce()` in `ai-employee/adapter/trust_ceiling.py` returns an
+`EnforcementDecision(allowed, reason, audit_action)`. The dispatch path
+(Hermes side, separate PR) calls `enforce()` once per tool invocation and
+then calls `log_decision()` on the same code path with the result. The
+mapping from `EnforcementDecision` to the wrapper's `(Decision,
+DecisionReason)` pair is the integration point. The mapping table:
+
+| Branch in `enforce()`                        | `Decision` | `DecisionReason`                       |
+| -------------------------------------------- | ---------- | -------------------------------------- |
+| `ceiling == REFUSED`                         | REFUSE     | CEILING_DISABLED                       |
+| `action == READ`                             | ALLOW      | READ_ALLOWED                           |
+| `COMMITMENT` + `DRAFT_FOR_REVIEW`            | DRAFT      | COMMITMENT_REQUIRES_AUTONOMOUS         |
+| `COMMITMENT` + no approval                   | REFUSE     | COMMITMENT_NO_APPROVAL                 |
+| `COMMITMENT` + approval                      | ALLOW      | COMMITMENT_WITH_APPROVAL               |
+| `DESTRUCTIVE` + `DRAFT_FOR_REVIEW`           | REFUSE     | DESTRUCTIVE_DRAFT_CEILING              |
+| `DESTRUCTIVE` + no approval                  | REFUSE     | DESTRUCTIVE_NO_APPROVAL                |
+| `DESTRUCTIVE` + approval                     | ALLOW      | DESTRUCTIVE_WITH_APPROVAL              |
+| `EXTERNAL_SEND` + `AUTONOMOUS` + approval    | ALLOW      | EXTERNAL_SEND_AUTONOMOUS_WITH_APPROVAL |
+| `EXTERNAL_SEND` + `AUTONOMOUS` + no approval | REFUSE     | EXTERNAL_SEND_NO_APPROVAL              |
+| `EXTERNAL_SEND` + `DRAFT_FOR_REVIEW`         | DRAFT      | EXTERNAL_SEND_DRAFT_ROUTE              |
+| `INTERNAL_WRITE` + `AUTONOMOUS`              | ALLOW      | INTERNAL_WRITE_AUTONOMOUS              |
+| `INTERNAL_WRITE` + `DRAFT_FOR_REVIEW`        | DRAFT      | INTERNAL_WRITE_DRAFT_ROUTE             |
+| Unknown action class                         | REFUSE     | UNKNOWN_ACTION_CLASS                   |
+
+The mapping table is the dispatch path's contract. Adding a branch in
+`enforce()` means adding a `DecisionReason` member here and updating both
+the module and this table in the same PR.
+
+## Closed enums
+
+The wrapper imposes closed enums to keep the dashboard aggregation queries
+stable. Free-text reasons would degrade the aggregate view as new variants
+appeared in production.
+
+### `Decision`
+
+Mirrors `EnforcementDecision.audit_action` from
+`adapter/trust_ceiling.py`. Three members:
+
+| Member   | Value                | Meaning                                    |
+| -------- | -------------------- | ------------------------------------------ |
+| `ALLOW`  | `"allow"`            | Action proceeds normally                   |
+| `DRAFT`  | `"draft_for_review"` | Action routed to drafts for human approval |
+| `REFUSE` | `"refuse"`           | Action blocked by the trust ceiling        |
+
+### `CeilingLevel`
+
+Mirrors `Ceiling` from `adapter/trust_ceiling.py` with one wrinkle: the
+platform PRD §11.1 names the third value `disabled`; the adapter uses
+`refused`. Both spellings are accepted; aggregations treat them as
+equivalent.
+
+| Member             | Value                |
+| ------------------ | -------------------- |
+| `AUTONOMOUS`       | `"autonomous"`       |
+| `DRAFT_FOR_REVIEW` | `"draft_for_review"` |
+| `DISABLED`         | `"disabled"`         |
+| `REFUSED`          | `"refused"`          |
+
+### `ActionClassName`
+
+Mirrors `ActionClass` from `adapter/trust_ceiling.py`.
+
+| Member           | Value              |
+| ---------------- | ------------------ |
+| `READ`           | `"read"`           |
+| `INTERNAL_WRITE` | `"internal_write"` |
+| `EXTERNAL_SEND`  | `"external_send"`  |
+| `COMMITMENT`     | `"commitment"`     |
+| `DESTRUCTIVE`    | `"destructive"`    |
+
+### `DecisionReason`
+
+Closed set of reasons; each maps to exactly one branch in the
+`enforce()` decision tree. See the mapping table above for the
+branch-to-reason crosswalk.
+
+Members are grouped by outcome (ALLOW / DRAFT / REFUSE). Adding a member
+requires updating the module, this spec, the wrapper tests, and the
+dispatch-path mapping table.
+
+## Audit row shape
+
+The wrapper emits one `audit_log` row per `enforce()` invocation. Columns
+populated (rest left NULL):
+
+| Column          | Value                                                              |
+| --------------- | ------------------------------------------------------------------ |
+| `id`            | ULID (assigned by `AuditLogWriter`)                                |
+| `ts`            | ISO 8601 UTC, ms precision (assigned by writer)                    |
+| `action_type`   | `DRAFT_CREATED` (ALLOW or DRAFT) or `INVARIANT_VIOLATION` (REFUSE) |
+| `actor`         | `"agent"`                                                          |
+| `actor_role`    | `"agent"`                                                          |
+| `skill_name`    | from `skill` argument                                              |
+| `matter_ref`    | from `matter_ref` argument (optional)                              |
+| `trust_ceiling` | from `ceiling_level` argument                                      |
+| `metadata`      | JSON, see below                                                    |
+
+### Why action_type reuses the closed-set vocabulary
+
+`audit_log.py::ACCEPTED_ACTION_TYPES` is closed-set, on main from PR
+#942. This PR's strict file scope (issue #864 brief) forbids modifying
+it. The sticky-stop module (PR #948) made the same call:
+
+> Action types reuse the existing closed-set vocabulary
+> (ACCEPTED_ACTION_TYPES) so this module does not need to extend the
+> audit-log contract.
+
+This module follows the same convention. Mapping:
+
+- `Decision.ALLOW` → `DRAFT_CREATED` (carries `metadata.decision="allow"`)
+- `Decision.DRAFT` → `DRAFT_CREATED` (carries `metadata.decision="draft_for_review"`)
+- `Decision.REFUSE` → `INVARIANT_VIOLATION` (the substrate enforced an invariant)
+
+Downstream readers (dashboard, audit viewer, compliance packet) MUST
+filter on `metadata.trust_ceiling_decision = true` to identify trust-
+ceiling rows, NOT on `action_type` alone. This mirrors the sticky-stop
+convention of `metadata.sticky_stop_transition`.
+
+The trade-off: `action_type` alone does not identify a trust-ceiling
+row. The upside: zero coupling between this module and the closed-set
+vocabulary, and zero risk of dashboard miscount when other emitters use
+the same action_type for unrelated reasons. If a future PR (with the
+right scope) adds a dedicated `TRUST_CEILING_DECISION` action_type to
+`ACCEPTED_ACTION_TYPES`, this module's mapping can flip to the new
+type in one place; the metadata contract stays unchanged.
+
+### `metadata` JSON shape
+
+```json
+{
+  "trust_ceiling_decision": true,
+  "customer": "acme",
+  "skill": "inbox-triage",
+  "action_class": "external_send",
+  "ceiling_level": "draft_for_review",
+  "decision": "draft_for_review",
+  "reason": "external_send_draft_route",
+  "skill_version": "2.1.0",
+  "trace_id": "trace-01HXY..."
+}
+```
+
+All nine keys are canonical. The dashboard aggregations key on these
+field names; they do not change without a coordinated spec + dashboard
+update. `skill_version` and `trace_id` are nullable; the rest are
+populated on every emission.
+
+`extra_metadata` may add fields BUT may NOT collide with canonical keys
+(the wrapper raises `ValueError` on collision). Extra fields are
+opaque to the dashboard aggregations; use them for forensics, not for
+KPIs.
+
+### What does NOT land in the audit row
+
+- The substantive payload (the email body the agent wanted to send,
+  the diff of a memory rule edit, etc.). Substantive content goes to
+  R2 per `r2-vectorize-naming.md`; the audit row carries only the
+  decision and its closed-vocabulary reason.
+- The free-text `EnforcementDecision.reason` string from
+  `adapter/trust_ceiling.py`. The closed-enum `DecisionReason`
+  replaces it for audit purposes; the free-text string may still be
+  surfaced in operator UIs (e.g., a tooltip on the audit row) but
+  must NOT be a basis for aggregation.
+- PII. The reason enum is closed; customer / skill / action_class /
+  ceiling_level are opaque identifiers and closed-vocabulary values.
+
+## Failure modes
+
+- **Audit write fails.** `AuditWriteError` propagates out of
+  `log_decision()`. The caller (dispatch path) MUST treat this as
+  fatal and abort the pending action. Same invariant as the audit
+  log writer (PR #942): a state the substrate cannot evidence is a
+  state the agent does not run.
+- **Free-text reason supplied.** `ValueError` raised before the SQL
+  executes. The dispatch path must map to a `DecisionReason` member;
+  the integration table in this spec is the contract.
+- **Invalid ceiling_level / action_class.** Strings are validated
+  against the closed enums; `ValueError` raised on a typo.
+- **`extra_metadata` collides with a canonical key.** `ValueError`
+  raised. Use a non-canonical key name (e.g., `tool_name`,
+  `recipient_domain`) for caller-side forensics.
+
+## Aggregation
+
+The Captain dashboard's aggregate view and the customer dashboard's
+recent-decisions feed both filter on the `trust_ceiling_decision = true`
+flag in `metadata`. The dashboard implementer (separate issue) uses
+these queries:
+
+### Captain: aggregate decisions over time
+
+```sql
+SELECT
+  json_extract(metadata, '$.decision') AS decision,
+  json_extract(metadata, '$.reason')   AS reason,
+  json_extract(metadata, '$.action_class') AS action_class,
+  COUNT(*) AS count
+FROM audit_log
+WHERE json_extract(metadata, '$.trust_ceiling_decision') = 1
+  AND ts >= ? AND ts < ?
+GROUP BY decision, reason, action_class
+ORDER BY count DESC;
+```
+
+Bucketed by hour / day / week: add
+`strftime('%Y-%m-%d', ts) AS day` to the GROUP BY.
+
+### Customer dashboard: recent decisions for this account
+
+```sql
+SELECT
+  id,
+  ts,
+  skill_name,
+  json_extract(metadata, '$.decision')      AS decision,
+  json_extract(metadata, '$.reason')        AS reason,
+  json_extract(metadata, '$.action_class')  AS action_class,
+  trust_ceiling
+FROM audit_log
+WHERE json_extract(metadata, '$.trust_ceiling_decision') = 1
+ORDER BY ts DESC
+LIMIT 100;
+```
+
+The customer dimension is the D1 binding (one DB per customer per ADRs
+0008 + 0009); no cross-customer JOIN is permitted. Aggregations against
+multiple customers happen at the Captain control-plane layer, summing
+per-customer results.
+
+### Cross-row correlation via `trace_id`
+
+A single dispatch turn may emit:
+
+1. One trust-ceiling decision row (from `log_decision()`)
+2. One action-specific audit row downstream (e.g., the writer's own
+   `DRAFT_CREATED` row when the draft was actually persisted, or the
+   downstream `SENT_DETECTED` row when an autonomous send went out)
+
+Both rows carry the same `metadata.trace_id` so the dashboard can join
+them when rendering the per-turn audit trail. The `trace_id` is set by
+the dispatch path; this module passes it through unchanged.
+
+## Verification
+
+`ai-employee/safety-substrate/tests/test_trust_ceiling_log.py` exercises:
+
+- One happy-path row exercises every canonical metadata key
+- Each of three decisions maps to the correct action_type
+- Each of the 14 `DecisionReason` members emits a correctly-shaped row
+  (parametrized over allow / draft / refuse reason sets)
+- Free-text `decision` and `reason` arguments raise `ValueError`
+- Invalid `ceiling_level` / `action_class` string values raise
+  `ValueError`
+- Missing required `customer` / `skill` arguments raise `ValueError`
+- String-valued `ceiling_level` / `action_class` (the dispatch path's
+  natural shape) pass through and validate
+- The PRD's `disabled` synonym for `refused` is accepted
+- `extra_metadata` merges after canonical keys and may NOT override them
+- Optional fields (`skill_version`, `trace_id`, `matter_ref`) default
+  to `None` and land as JSON nulls in metadata
+- Audit write failure propagates as `AuditWriteError` (caller-abort
+  invariant)
+- Metadata key set is stable (the dashboard aggregation contract)
+- The dashboard's filter predicate
+  (`metadata.trust_ceiling_decision = true`) identifies trust-ceiling
+  rows without false positives against unrelated audit rows
+
+Run locally:
+
+```
+cd ai-employee && uv run --with pytest python -m pytest \
+  safety-substrate/tests/test_trust_ceiling_log.py -v
+```
+
+## Out of scope (filed elsewhere)
+
+- **Dashboard surfaces.** The Captain aggregate view and the customer
+  recent-decisions feed are separate issues. This spec is the emission +
+  audit row contract; the dashboards consume it.
+- **Hermes dispatch integration.** Wiring `log_decision()` to the
+  dispatch path is the adapter team's work and tracked separately. The
+  integration-point mapping table above is the contract.
+- **`TRUST_CEILING_DECISION` action_type promotion.** If a future PR
+  (with the right scope) extends `ACCEPTED_ACTION_TYPES`, this module's
+  mapping can be updated in one place. The metadata contract stays the
+  same, so the dashboard queries continue to work either way.
+
+## Cross-references
+
+- platform-prd.md §11 (trust ceiling model): vocabulary source
+- d1-schema.md §1 (audit_log): column shape and accepted action types
+- sticky-stop.md: precedent for reusing closed-set action_types with
+  metadata-bearing transition details
+- compliance-evidence-packet.md (#802): downstream consumer that
+  groups rows by `metadata.trust_ceiling_decision`
+- PR #942 (audit log persistence): provides `AuditLogWriter`
+- PR #948 (sticky-stop mechanism): convention source
+- ADR 0008 (customer-owned memory artifact)
+- ADR 0009 (cross-machine query prohibition): why the customer
+  dimension is the D1 binding, not a row column


### PR DESCRIPTION
## Summary

Wraps the trust-ceiling `enforce()` decision point with synchronous audit_log emission. Every allow / draft_for_review / refuse decision now lands as a structured audit row with closed-enum reason vocabulary so the Captain dashboard, customer dashboard, and compliance-evidence packet (#802) can aggregate enforcement history.

This PR ships the emission contract only. Dashboard surfaces are filed separately.

## Linked issue

Closes #864

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Every `enforce()` invocation emits an event: timestamp, customer, skill, action class, ceiling level, decision, reason | met | `ai-employee/safety-substrate/trust_ceiling_log.py::log_decision` writes one synchronous audit_log row per call. Tests: `test_log_decision_writes_one_row_with_all_canonical_fields`, `test_metadata_has_stable_keys_for_aggregation` |
| Events persist to per-customer audit log (D1) | met | Wraps `AuditLogWriter` from PR #942. Row lands in the per-customer D1 `audit_log` table per ADR 0008 + 0009. Test: `test_audit_write_failure_propagates_as_auditwriteerror` |
| Captain dashboard shows aggregate decisions over time | deferred | Dashboard surface tracked separately. Aggregation query shape documented in `docs/specs/ai-employee/trust-ceiling-logging.md` §Aggregation so the dashboard implementer has a clean target |
| Customer dashboard shows recent decisions for their account | deferred | Same: dashboard surface tracked separately; per-account query shape documented in spec |

## Deferred ACs (required if `scope-deferred` label is set)

- **AC:** _Captain dashboard shows aggregate decisions over time_
  - **Why deferred:** Per issue brief: "The dashboard surfaces ... are tracked separately." This PR is the emission + audit-row contract; dashboard implementation is a follow-on.
  - **Tracked in:** Dashboard issue per issue brief (not yet filed at time of writing)
- **AC:** _Customer dashboard shows recent decisions for their account_
  - **Why deferred:** Same as above.
  - **Tracked in:** Dashboard issue per issue brief (not yet filed at time of writing)

## Test plan

- [x] `npm run verify` passes
- [x] `cd ai-employee && python -m pytest safety-substrate/tests/ adapter/tests/` passes (120 tests)
- [x] New `test_trust_ceiling_log.py` exercises 32 cases: every (Decision, DecisionReason) combo, closed-enum validation, audit-write failure propagation, dashboard-aggregation contract

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses (closed-enum reasons + opaque identifiers only; substantive payloads stay in R2 per the writer contract)
- [x] Input validation on new endpoints (closed-enum validation rejects free text)
- [x] Parameterized queries for any SQL (writer uses `?`-bound INSERTs from PR #942)
- [x] Auth required on new endpoints (no new endpoints; library module only)
- [x] No internal IDs that enable enumeration

## Feature Impact

**Feature impact:** None

## Deployment Notes

Library module only. No schema migrations. No env var changes. Uses the existing `audit_log` table created in migration 0001 (on main via PR #942).

### Design notes for reviewer

**1. Action_type reuse, not extension.** The strict file scope in the issue brief forbids modifying `ai-employee/adapter/audit_log.py`, including its `ACCEPTED_ACTION_TYPES` constant. Following the sticky-stop precedent (PR #948), this module reuses the closed-set vocabulary and carries trust-ceiling specifics in `metadata.trust_ceiling_decision`. Mapping:

  - `Decision.ALLOW` and `Decision.DRAFT` -> `DRAFT_CREATED`
  - `Decision.REFUSE` -> `INVARIANT_VIOLATION`

  Downstream readers (audit viewer #873, compliance packet #802) filter on `metadata.trust_ceiling_decision = true`, not on `action_type`. The spec doc explicitly calls this out for the audit-viewer and compliance-packet implementers. If a future PR with the right scope adds a dedicated `TRUST_CEILING_DECISION` action type, the wrapper's mapping can flip in one place; the metadata contract stays the same.

**2. The `enforce()` integration point.** The issue says "the actual `trust_ceiling.enforce()` function may not exist yet in code". It does (in `ai-employee/adapter/trust_ceiling.py` on main, as a Phase-A stub). The wrapper accepts the issue's clean `(customer, skill, action_class, level)` decision contract via `log_decision()` and documents the call-site mapping from `EnforcementDecision` to `(Decision, DecisionReason)` in the spec doc's integration table. Wiring `log_decision()` into the Hermes dispatch path is the adapter team's separate PR.

**3. `allow` events and the audit floor.** The AC says "every `enforce()` invocation emits an event". To meet this without changing the action-type vocabulary, allow decisions emit via `DRAFT_CREATED` with `metadata.decision = "allow"`. Downstream action-specific audit rows (the writer's own DRAFT_CREATED on draft persistence, SENT_DETECTED on send, etc.) link to the trust-ceiling row via `metadata.trace_id`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>