### PR TITLE
feat(portal): AI Employee calendar tab (#872)

### DIFF
--- a/src/components/portal/ai-employee/CalendarAgenda.astro
+++ b/src/components/portal/ai-employee/CalendarAgenda.astro
@@ -1,0 +1,139 @@
+---
+/**
+ * AI Employee calendar agenda.
+ *
+ * Wraps a list of CalendarItemRow components in a 3px ink frame and
+ * renders pagination controls below when there are more items than fit
+ * on one page. The empty state is owned by the surrounding page (so the
+ * page can use the standard portal empty-state block); this component
+ * only renders when `rows.length > 0`.
+ *
+ * Conflict detection is computed once at the page level via
+ * `detectConflicts(rows)` and passed in as a Map<id, conflictingIds>.
+ * The agenda translates that into a per-row `conflictCount` integer
+ * for the row component. Centralizing the computation here (rather
+ * than at the row level) means the conflict graph is a single source
+ * of truth — the row never thinks about its neighbors.
+ *
+ * Pagination mirrors DraftsListTable so the URL contract is consistent
+ * across AI Employee sub-surfaces: prev/next links carry the current
+ * filter / sort params plus the new `page`, so a deep link to a
+ * filtered page-N stays linkable. The form GET in FilterBar would
+ * reset pagination by omitting `page` — same convention as drafts.
+ */
+
+import CalendarItemRow from './CalendarItemRow.astro'
+import type { CalendarItem } from '../../../lib/portal/ai-employee/calendar'
+
+interface Props {
+  rows: readonly CalendarItem[]
+  totalCount: number
+  page: number
+  pageSize: number
+  pageCount: number
+  /**
+   * Conflict graph keyed by item id; value is the list of OTHER ids
+   * that overlap with the keyed item. Items not in the map have zero
+   * conflicts. Computed once by the page via detectConflicts so the
+   * row component stays a pure render of one item.
+   */
+  conflictMap: Map<string, string[]>
+  /**
+   * Search params currently applied (filter + sort). The component
+   * threads these through prev/next links so paging preserves
+   * filters. Pass `Astro.url.searchParams` from the page.
+   */
+  searchParams: URLSearchParams
+}
+
+const { rows, totalCount, page, pageSize, pageCount, conflictMap, searchParams } = Astro.props
+
+function buildHref(targetPage: number): string {
+  const next = new URLSearchParams(searchParams)
+  next.set('page', String(targetPage))
+  for (const [key, value] of Array.from(next.entries())) {
+    if (value === '') next.delete(key)
+  }
+  const query = next.toString()
+  return query.length > 0 ? `?${query}` : ''
+}
+
+const hasPrev = page > 1
+const hasNext = page < pageCount
+
+const rangeStart = totalCount === 0 ? 0 : (page - 1) * pageSize + 1
+const rangeEnd = Math.min(page * pageSize, totalCount)
+---
+
+<section aria-label="Calendar agenda">
+  <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
+    {
+      rows.map((item, index) => {
+        const conflictCount = conflictMap.get(item.id)?.length ?? 0
+        return (
+          <CalendarItemRow
+            item={item}
+            conflictCount={conflictCount}
+            serial={String(index + 1 + (page - 1) * pageSize).padStart(2, '0')}
+          />
+        )
+      })
+    }
+  </div>
+
+  {
+    pageCount > 1 && (
+      <nav
+        aria-label="Calendar pagination"
+        class="mt-4 flex flex-col md:flex-row md:items-center md:justify-between gap-3"
+      >
+        <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+          Showing {rangeStart} to {rangeEnd} of {totalCount}
+        </p>
+        <ul class="flex items-center gap-2" role="list">
+          <li>
+            {hasPrev ? (
+              <a
+                href={buildHref(page - 1)}
+                rel="prev"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+              >
+                Previous
+              </a>
+            ) : (
+              <span
+                aria-disabled="true"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-border)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-muted)]"
+              >
+                Previous
+              </span>
+            )}
+          </li>
+          <li>
+            <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)] px-2">
+              Page {page} of {pageCount}
+            </span>
+          </li>
+          <li>
+            {hasNext ? (
+              <a
+                href={buildHref(page + 1)}
+                rel="next"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+              >
+                Next
+              </a>
+            ) : (
+              <span
+                aria-disabled="true"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-border)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-muted)]"
+              >
+                Next
+              </span>
+            )}
+          </li>
+        </ul>
+      </nav>
+    )
+  }
+</section>

--- a/src/components/portal/ai-employee/CalendarItemRow.astro
+++ b/src/components/portal/ai-employee/CalendarItemRow.astro
@@ -1,0 +1,176 @@
+---
+/**
+ * One row in the AI Employee calendar agenda.
+ *
+ * Used only by CalendarAgenda. Lives in its own file so the row's
+ * cell vocabulary (time / title / type / source / matter / conflict)
+ * can be tested and revised independently of the agenda chrome.
+ *
+ * Per #872 (and PortalListItem precedent), the row is a link to the
+ * item detail page at `/portal/products/ai-employee/calendar/[id]` —
+ * that page lands in a follow-on issue alongside the drag-drop
+ * reschedule machinery; this PR provides the working link target.
+ *
+ * Plainspoken aesthetic (mirrors DraftRow): 2px ink divider between
+ * rows, file-style mono numerics for the time range, Archivo Narrow
+ * uppercase labels for column captions, type chip on the right. The
+ * outer 3px ink frame is provided by CalendarAgenda — this component
+ * is borderless at the row level so consecutive rows stitch cleanly.
+ *
+ * Why not PortalListItem? PortalListItem's variants are status (title +
+ * money + meta) and document (icon + title + eyebrow). Neither fits
+ * the calendar's six-cell vocabulary (time-range / title / type /
+ * source-skill / related-matter / conflict). A new primitive is the
+ * honest answer — bending PortalListItem to fit would distort both
+ * surfaces. Same justification DraftRow already records.
+ *
+ * Conflict signal: the row carries `aria-describedby` referencing the
+ * conflict indicator id when the item has conflicts, so screen-reader
+ * users hear "2 time conflicts" as part of the row context.
+ */
+
+import StatusPill from '../StatusPill.astro'
+import ConflictIndicator from './ConflictIndicator.astro'
+import {
+  formatCalendarItemType,
+  formatTimeRange,
+  type CalendarItem,
+} from '../../../lib/portal/ai-employee/calendar'
+
+interface Props {
+  item: CalendarItem
+  /**
+   * Number of OTHER items in the same agenda that overlap with this
+   * one in time. Computed by detectConflicts in the host page and
+   * passed through. Zero = no conflict.
+   */
+  conflictCount: number
+  /**
+   * Short serial shown in the № cell. Defaults to the first two
+   * uppercase characters of the id. The agenda passes the row index
+   * for stable visual rhythm even when ids change underneath.
+   */
+  serial?: string
+}
+
+const { item, conflictCount, serial } = Astro.props
+const resolvedSerial = serial ?? item.id.slice(0, 2).toUpperCase()
+
+// `ai_scheduled` is the higher-trust state — already on the customer's
+// calendar. Render with the success tone so reviewers can spot the
+// already-committed items at scan time. `ai_proposed` is the
+// review-needed state and uses the warning tone to mirror DraftRow's
+// pattern for "needs human action" rows.
+const typeTone = item.type === 'ai_scheduled' ? 'success' : 'warning'
+const typeLabel = formatCalendarItemType(item.type).toUpperCase()
+
+const time = formatTimeRange(item.startsAt, item.endsAt)
+const conflictId = conflictCount > 0 ? `conflict-${item.id}` : undefined
+---
+
+<a
+  href={`/portal/products/ai-employee/calendar/${item.id}`}
+  aria-describedby={conflictId}
+  class="group block bg-[color:var(--ss-color-surface)] border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 transition-colors hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+>
+  <div
+    class="md:grid md:grid-cols-[56px_minmax(0,1.4fr)_minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_48px] md:items-stretch"
+  >
+    {/* № cell */}
+    <div
+      class="flex md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)] items-center justify-center md:min-h-[96px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell"
+      aria-hidden="true"
+    >
+      № {resolvedSerial}
+    </div>
+
+    {/* When / time range */}
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+    >
+      <span
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+      >
+        When
+      </span>
+      <span class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] truncate">
+        {time.datePart}
+      </span>
+      <span class="font-mono text-sm text-[color:var(--ss-color-text-secondary)] truncate">
+        {time.timePart}
+        {time.tzPart && ` ${time.tzPart}`}
+      </span>
+    </div>
+
+    {/* Title + location */}
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+    >
+      <span
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Title
+      </span>
+      <span class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] truncate">
+        {item.title}
+      </span>
+      {
+        item.location && (
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-secondary)] truncate">
+            {item.location}
+          </span>
+        )
+      }
+    </div>
+
+    {/* Source skill */}
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+    >
+      <span
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Source
+      </span>
+      <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] truncate">
+        {item.skill}
+      </span>
+    </div>
+
+    {/* Related matter */}
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+    >
+      <span
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Matter
+      </span>
+      {
+        item.relatedMatterTitle ? (
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] truncate">
+            {item.relatedMatterTitle}
+          </span>
+        ) : (
+          <span class="font-mono text-sm text-[color:var(--ss-color-text-muted)]">None</span>
+        )
+      }
+    </div>
+
+    {/* Type chip + conflict indicator */}
+    <div
+      class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col items-start md:items-end justify-center gap-1.5"
+    >
+      <StatusPill tone={typeTone} label={typeLabel} />
+      <ConflictIndicator conflictCount={conflictCount} id={conflictId} />
+    </div>
+
+    {/* Arrow */}
+    <div
+      aria-hidden="true"
+      class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-2xl text-[color:var(--ss-color-primary)] transition-transform group-hover:translate-x-0.5"
+    >
+      →
+    </div>
+  </div>
+</a>

--- a/src/components/portal/ai-employee/ConflictIndicator.astro
+++ b/src/components/portal/ai-employee/ConflictIndicator.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * Conflict indicator for the AI Employee calendar agenda.
+ *
+ * Renders a small inline marker on a row whose time range overlaps one
+ * or more other items in the same agenda. Computed by
+ * `detectConflicts(items)` in src/lib/portal/ai-employee/calendar.ts;
+ * this component is the visual surface only.
+ *
+ * Two cases:
+ *   - `conflictCount === 0` → render nothing. The caller can pass the
+ *     value unconditionally without needing to gate at the call site.
+ *   - `conflictCount > 0` → render an inline marker with a count and an
+ *     accessible label. The marker is styled with the `danger` tone
+ *     vocabulary (red fill, white text) so it pulls scanner attention
+ *     immediately; conflicts are the highest-signal datum on the row.
+ *
+ * Why not StatusPill with tone='danger'? StatusPill is a status tag —
+ * the calendar row already carries one for type (scheduled / proposed).
+ * Stacking two same-shape tags creates visual confusion (UI-PATTERNS R2
+ * — one signal per fact). The conflict marker uses a tag + count
+ * affordance (badge-style, e.g., "Conflicts 2") so the scanner knows
+ * it's a different kind of signal at a glance.
+ *
+ * Accessibility: the inner text describes the conflict count in plain
+ * language. screen-reader users hear "2 time conflicts" rather than
+ * just the number. The host row carries `aria-describedby` so the
+ * marker is announced as part of the row context.
+ */
+
+interface Props {
+  /**
+   * Number of OTHER items that overlap with this one in time. Computed
+   * by detectConflicts and passed through by the row. Zero means
+   * "no conflicts" and the component returns null.
+   */
+  conflictCount: number
+  /**
+   * Stable id used to wire `aria-describedby` from the parent row, if
+   * the parent wants the screen-reader to read the conflict label as
+   * part of the row. Optional.
+   */
+  id?: string
+}
+
+const { conflictCount, id } = Astro.props
+const visible = conflictCount > 0
+const label = conflictCount === 1 ? '1 time conflict' : `${conflictCount} time conflicts`
+---
+
+{
+  visible && (
+    <span
+      id={id}
+      class="inline-flex items-center gap-1.5 px-2 py-1 bg-[color:var(--ss-color-error)] text-white font-mono uppercase tracking-[var(--ss-text-letter-spacing-label)] text-label font-semibold rounded-[var(--ss-radius-badge)] whitespace-nowrap"
+      role="status"
+      aria-label={label}
+    >
+      <span aria-hidden="true">⚠</span>
+      <span aria-hidden="true">
+        {conflictCount === 1 ? 'Conflict' : `Conflicts ${conflictCount}`}
+      </span>
+    </span>
+  )
+}

--- a/src/lib/portal/ai-employee/calendar.ts
+++ b/src/lib/portal/ai-employee/calendar.ts
@@ -1,0 +1,482 @@
+/**
+ * AI Employee calendar list — typed contract + read resolver.
+ *
+ * Per #872, the calendar surface shows two kinds of items the AI Employee
+ * is tracking against the customer's external calendar (MS Graph / Google
+ * Calendar via the connector tracked in #822):
+ *
+ *   ai_scheduled — committed events the AI added to calendar
+ *                  (already sync'd to the customer's external calendar)
+ *   ai_proposed  — drafts the AI suggests for scheduling; awaiting
+ *                  reviewer approval before they sync out
+ *
+ * Both kinds render in a single chronological agenda. The reviewer sees
+ * at a glance what is already on the calendar vs. what is waiting on a
+ * decision, plus any time-conflicts the AI surfaced.
+ *
+ * Data source: per-customer Hermes Machine D1 (ADR 0007 + 0009). The
+ * portal Worker can NOT bind to a per-customer D1 directly; reads go
+ * through an internal Hermes bridge (PR #907 architecture, runtime
+ * wiring tracked in #821). Until that bridge ships AND the MS Graph /
+ * Google Calendar connector lands (#822), this resolver returns an
+ * empty list with the correct typed shape so the page machinery
+ * (filter bar, agenda render, conflict detection) works end-to-end
+ * without fabricating events. No mock data. No placeholder copy. See
+ * docs/style/empty-state-pattern.md.
+ *
+ * Drag-drop reschedule is deferred to a follow-on issue. This module
+ * owns the read path only — it does not (yet) expose mutation helpers.
+ *
+ * This module owns:
+ *   - The CalendarItem row shape consumed by the agenda UI
+ *   - The CalendarItemType vocabulary (ai_scheduled / ai_proposed)
+ *   - Filter / sort / pagination parameter parsing from URLSearchParams
+ *   - The pure detectConflicts function over an item list
+ *   - The (currently empty) data fetch
+ *
+ * When the bridge lands, only `fetchCalendarItemsFromHermes` changes.
+ * Filter parsing, conflict detection, formatters, and the page UI
+ * stay put.
+ */
+
+import type { SubscriptionRow } from '../product-access'
+
+/**
+ * The two kinds of items that land in the calendar surface. The
+ * vocabulary is closed; adding a third value requires a PRD amendment
+ * and matching label/tone updates in the row component.
+ *
+ *   ai_scheduled — Already on the customer's external calendar via the
+ *                  connector. Reviewer's job: confirm it stays.
+ *   ai_proposed  — Awaiting reviewer approval. Reviewer's job: approve
+ *                  or reject before the AI syncs it out.
+ */
+export type CalendarItemType = 'ai_scheduled' | 'ai_proposed'
+
+export const CALENDAR_ITEM_TYPES: readonly CalendarItemType[] = [
+  'ai_scheduled',
+  'ai_proposed',
+] as const
+
+/**
+ * Sort options exposed via `?sort=`. Default is `start_asc` (chronological,
+ * earliest first) — agenda surfaces read top-to-bottom as "what's next."
+ * `start_desc` is for reviewing recent / past scheduling activity. The
+ * Drafts surface defaults to `age_desc`; we deliberately diverge because
+ * the calendar question is "what's coming up," not "what's new."
+ */
+export type CalendarSort = 'start_asc' | 'start_desc'
+
+export const CALENDAR_SORTS: readonly CalendarSort[] = ['start_asc', 'start_desc'] as const
+
+/**
+ * One row in the calendar agenda. Shape mirrors what the Hermes bridge
+ * will return when #821 + #822 land. Field semantics:
+ *
+ *   id              — Stable item identifier. Forms the detail-page URL.
+ *   type            — ai_scheduled vs ai_proposed. Drives the tone of
+ *                     the chip and the action affordances.
+ *   title           — Short title of the calendar entry (e.g.,
+ *                     "Deposition: Acme v. Beta").
+ *   startsAt        — ISO 8601 timestamp (UTC) of the item's start. The
+ *                     UI converts to the customer's tz at render time.
+ *   endsAt          — ISO 8601 timestamp (UTC) of the item's end. Must
+ *                     be > startsAt; the resolver validates.
+ *   skill           — Slug of the capability that produced the item
+ *                     (e.g., "deposition-scheduling", "hearing-prep").
+ *                     Drives the source label and skill filter.
+ *   relatedMatterId — Optional link to a matter (per #871). When set,
+ *                     the row renders a "Matter" cell linking out to
+ *                     the matter detail page. null when the item has
+ *                     no matter context.
+ *   relatedMatterTitle — Optional display title for the matter cell.
+ *                     null when relatedMatterId is null.
+ *   location        — Optional free-text location (room, address, video
+ *                     link). null when not applicable.
+ */
+export interface CalendarItem {
+  id: string
+  type: CalendarItemType
+  title: string
+  startsAt: string
+  endsAt: string
+  skill: string
+  relatedMatterId: string | null
+  relatedMatterTitle: string | null
+  location: string | null
+}
+
+/**
+ * Filter / sort / pagination parameters parsed from URLSearchParams.
+ * All optional — the page renders an unfiltered list when nothing is
+ * passed. Mirrors the contract used in drafts.ts so reviewers who learn
+ * one surface know the other.
+ *
+ * types         — Multi-select of CalendarItemType. Empty array means
+ *                 "all types".
+ * fromIso       — Lower bound (inclusive) on item start. null = no lower
+ *                 bound. Validated as a finite ISO date string; invalid
+ *                 values fall back to null rather than throwing.
+ * toIso         — Upper bound (inclusive) on item start. null = no upper
+ *                 bound. Validated as a finite ISO date string.
+ * sort          — One of CALENDAR_SORTS. Defaults to 'start_asc'.
+ * page          — 1-indexed page number. Defaults to 1.
+ * pageSize      — Defaults to 50 (matches drafts). Capped at 200 so a
+ *                 hostile query string can't drag a Worker over CPU limit.
+ */
+export interface CalendarListParams {
+  types: readonly CalendarItemType[]
+  fromIso: string | null
+  toIso: string | null
+  sort: CalendarSort
+  page: number
+  pageSize: number
+}
+
+export const DEFAULT_CALENDAR_PAGE_SIZE = 50
+export const MAX_CALENDAR_PAGE_SIZE = 200
+
+function isValidIsoDate(value: string): boolean {
+  const ms = Date.parse(value)
+  return Number.isFinite(ms)
+}
+
+/**
+ * Parse params from URLSearchParams. Defensive — every field is
+ * validated against the closed vocabularies and date semantics above;
+ * unknown values fall back to safe defaults instead of throwing. Keeps
+ * the surface stable under user-typed URLs and bookmark drift.
+ *
+ * `type` supports comma-separated values for multi-select
+ * (`?type=ai_scheduled,ai_proposed`) and repeated params
+ * (`?type=ai_scheduled&type=ai_proposed`). Any unknown value in the set
+ * is silently dropped — the page falls back to "all types" rather than
+ * 400-ing on a typo'd bookmark.
+ */
+export function parseCalendarListParams(searchParams: URLSearchParams): CalendarListParams {
+  const knownTypes = new Set<CalendarItemType>(CALENDAR_ITEM_TYPES)
+  const rawTypeParams = searchParams.getAll('type')
+  const types = Array.from(
+    new Set(
+      rawTypeParams
+        .flatMap((value) => value.split(','))
+        .map((value) => value.trim())
+        .filter((value): value is CalendarItemType => knownTypes.has(value as CalendarItemType))
+    )
+  )
+
+  const rawFrom = searchParams.get('from')?.trim() ?? ''
+  const fromIso = rawFrom.length > 0 && isValidIsoDate(rawFrom) ? rawFrom : null
+
+  const rawTo = searchParams.get('to')?.trim() ?? ''
+  const toIso = rawTo.length > 0 && isValidIsoDate(rawTo) ? rawTo : null
+
+  const rawSort = searchParams.get('sort')
+  const sort: CalendarSort = CALENDAR_SORTS.includes(rawSort as CalendarSort)
+    ? (rawSort as CalendarSort)
+    : 'start_asc'
+
+  const rawPage = Number(searchParams.get('page'))
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? Math.floor(rawPage) : 1
+
+  const rawPageSize = Number(searchParams.get('pageSize'))
+  const pageSize =
+    Number.isFinite(rawPageSize) && rawPageSize >= 1
+      ? Math.min(Math.floor(rawPageSize), MAX_CALENDAR_PAGE_SIZE)
+      : DEFAULT_CALENDAR_PAGE_SIZE
+
+  return { types, fromIso, toIso, sort, page, pageSize }
+}
+
+/**
+ * Apply filters to a CalendarItem list in-memory. Exposed for the
+ * resolver below and for unit tests. The Hermes bridge will eventually
+ * push filtering server-side; for now this is the source of truth so
+ * the empty-list contract has tested filter semantics.
+ */
+export function applyCalendarFilters(
+  rows: readonly CalendarItem[],
+  params: CalendarListParams
+): CalendarItem[] {
+  let result = rows.slice()
+
+  if (params.types.length > 0) {
+    const wanted = new Set(params.types)
+    result = result.filter((row) => wanted.has(row.type))
+  }
+
+  if (params.fromIso !== null) {
+    const fromMs = Date.parse(params.fromIso)
+    result = result.filter((row) => {
+      const startMs = Date.parse(row.startsAt)
+      return Number.isFinite(startMs) && startMs >= fromMs
+    })
+  }
+
+  if (params.toIso !== null) {
+    const toMs = Date.parse(params.toIso)
+    result = result.filter((row) => {
+      const startMs = Date.parse(row.startsAt)
+      return Number.isFinite(startMs) && startMs <= toMs
+    })
+  }
+
+  return result
+}
+
+/**
+ * Sort a (pre-filtered) CalendarItem list according to params.sort.
+ * Items with unparseable startsAt sort last (their parse result is NaN
+ * — Number comparisons return false either way, so they end up at the
+ * tail of either direction). That matches the empty-state design: the
+ * resolver should never emit unparseable dates, and if it ever does
+ * (bridge bug, future schema drift), the visual signal is "this row is
+ * out of place" rather than "this row is silently first."
+ */
+export function applyCalendarSort(
+  rows: readonly CalendarItem[],
+  sort: CalendarSort
+): CalendarItem[] {
+  const sorted = rows.slice()
+  sorted.sort((a, b) => {
+    const aMs = Date.parse(a.startsAt)
+    const bMs = Date.parse(b.startsAt)
+    const aFinite = Number.isFinite(aMs)
+    const bFinite = Number.isFinite(bMs)
+    if (!aFinite && !bFinite) return 0
+    if (!aFinite) return 1
+    if (!bFinite) return -1
+    return sort === 'start_asc' ? aMs - bMs : bMs - aMs
+  })
+  return sorted
+}
+
+/**
+ * Pagination return value. Same shape as Drafts. `totalCount` is the
+ * count after filtering but before pagination; `pageCount` is floored
+ * at 1 even when there are zero rows so "Page 1 of 1" reads sensibly
+ * in the empty state.
+ */
+export interface CalendarListPage {
+  rows: CalendarItem[]
+  totalCount: number
+  page: number
+  pageSize: number
+  pageCount: number
+}
+
+/**
+ * Apply offset-based pagination to a sorted+filtered list. Page is
+ * 1-indexed, clamped to [1, pageCount]. Out-of-range pages return the
+ * last page rather than an empty result — keeps deep links from
+ * rendering as "no events" when the list shifted underneath.
+ */
+export function paginateCalendarItems(
+  rows: readonly CalendarItem[],
+  page: number,
+  pageSize: number
+): CalendarListPage {
+  const totalCount = rows.length
+  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
+  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
+  const start = (clampedPage - 1) * pageSize
+  return {
+    rows: rows.slice(start, start + pageSize),
+    totalCount,
+    page: clampedPage,
+    pageSize,
+    pageCount,
+  }
+}
+
+/**
+ * Compose filter → sort → paginate over an in-memory CalendarItem list.
+ * Useful for unit tests; the page calls listCalendarItems below.
+ */
+export function buildCalendarListPage(
+  rows: readonly CalendarItem[],
+  params: CalendarListParams
+): CalendarListPage {
+  const filtered = applyCalendarFilters(rows, params)
+  const sorted = applyCalendarSort(filtered, params.sort)
+  return paginateCalendarItems(sorted, params.page, params.pageSize)
+}
+
+/**
+ * Detect time-conflicts across a CalendarItem list.
+ *
+ * Returns a Map keyed by item id; each value is the list of OTHER item
+ * ids that overlap with the keyed item in time. An item with no
+ * conflicts is omitted from the map (the caller should treat a missing
+ * key as "no conflicts" — same shape as a Set/Map of "violators").
+ *
+ * Overlap rule: two items conflict if their half-open intervals
+ * [startsAt, endsAt) overlap. Touching at a single instant
+ * (a.endsAt === b.startsAt) does NOT count as a conflict — that's a
+ * back-to-back schedule, which is intentional, not a clash.
+ *
+ * Items with malformed or zero-length ranges (NaN starts / ends, or
+ * start >= end) are silently excluded from conflict checks rather than
+ * matched against everything. The empty-state contract guarantees the
+ * resolver never emits such rows; this is a defensive zero-impact path
+ * if the bridge ever does.
+ *
+ * Algorithmic note: this runs in O(n log n + k) where n is the input
+ * length and k is the number of overlapping pairs — sort by start,
+ * sweep, keep a min-heap-of-ends would be the textbook O(n log n)
+ * version. For agenda surfaces with n in the dozens-to-hundreds, the
+ * simpler O(n²) sweep below is faster in practice (no allocator
+ * pressure, tight loop) and easier to read. If the calendar ever
+ * surfaces thousands of items on one page, swap this for the sweep.
+ */
+export function detectConflicts(items: readonly CalendarItem[]): Map<string, string[]> {
+  const ranges = items
+    .map((item) => {
+      const start = Date.parse(item.startsAt)
+      const end = Date.parse(item.endsAt)
+      return { id: item.id, start, end }
+    })
+    .filter(
+      (range) =>
+        Number.isFinite(range.start) && Number.isFinite(range.end) && range.start < range.end
+    )
+
+  const conflicts = new Map<string, Set<string>>()
+  for (let i = 0; i < ranges.length; i++) {
+    for (let j = i + 1; j < ranges.length; j++) {
+      const a = ranges[i]
+      const b = ranges[j]
+      // Half-open overlap: a.start < b.end AND b.start < a.end. Touching
+      // (a.end === b.start) is NOT overlap by this rule.
+      if (a.start < b.end && b.start < a.end) {
+        const aSet = conflicts.get(a.id) ?? new Set<string>()
+        aSet.add(b.id)
+        conflicts.set(a.id, aSet)
+        const bSet = conflicts.get(b.id) ?? new Set<string>()
+        bSet.add(a.id)
+        conflicts.set(b.id, bSet)
+      }
+    }
+  }
+
+  // Materialize as Map<string, string[]> per the public signature.
+  // Sort each list so the order is deterministic for tests / hashing.
+  const result = new Map<string, string[]>()
+  for (const [id, set] of conflicts) {
+    result.set(id, Array.from(set).sort())
+  }
+  return result
+}
+
+/**
+ * Human label for a CalendarItemType value. Closed vocabulary; see
+ * CalendarItemType. Used by the row component's type chip.
+ */
+export function formatCalendarItemType(type: CalendarItemType): string {
+  switch (type) {
+    case 'ai_scheduled':
+      return 'Scheduled'
+    case 'ai_proposed':
+      return 'Proposed'
+  }
+}
+
+/**
+ * Format an ISO datetime as a compact "date · time range" string for
+ * the agenda row, given an end timestamp. Falls back to the raw value
+ * if the date cannot be parsed (defensive — empty-state contract says
+ * this should never happen, but a bridge bug shouldn't crash the page).
+ *
+ * Returns three independently-renderable strings so the row component
+ * can place them in distinct typography cells. The shape:
+ *
+ *   datePart — "Tue, May 21"
+ *   timePart — "9:00 AM – 10:30 AM"
+ *   tzPart   — "PDT" (the resolved tz abbreviation)
+ *
+ * Time-zone resolution is the runtime's default tz (the customer's
+ * local time when rendered on their device — Astro is SSR, so the
+ * server renders the AI Employee's configured business tz once
+ * customer-tz is plumbed through; for now we render UTC for stability).
+ */
+export interface FormattedTimeRange {
+  datePart: string
+  timePart: string
+  tzPart: string
+}
+
+export function formatTimeRange(startsAt: string, endsAt: string): FormattedTimeRange {
+  const startMs = Date.parse(startsAt)
+  const endMs = Date.parse(endsAt)
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    return { datePart: startsAt, timePart: endsAt, tzPart: '' }
+  }
+  const start = new Date(startMs)
+  const end = new Date(endMs)
+  // Render in UTC for SSR determinism. When customer-tz is plumbed
+  // through the subscription settings (#822 follow-on), thread the
+  // resolved tz into Intl options below.
+  const dateFmt = new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+  const timeFmt = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  })
+  return {
+    datePart: dateFmt.format(start),
+    timePart: `${timeFmt.format(start)} to ${timeFmt.format(end)}`,
+    tzPart: 'UTC',
+  }
+}
+
+/**
+ * Collect the distinct skills present in a calendar item list, sorted
+ * alphabetically. Mirrors `distinctSkills` in drafts.ts for parity
+ * across the two surfaces — both use the same shape so the filter
+ * machinery can be lifted into a shared util later without churn.
+ */
+export function distinctCalendarSkills(rows: readonly CalendarItem[]): string[] {
+  const seen = new Set<string>()
+  for (const row of rows) {
+    seen.add(row.skill)
+  }
+  return Array.from(seen).sort()
+}
+
+/**
+ * Server-side resolver invoked by the calendar list page. Today this
+ * returns an empty list with the correct shape — the per-customer
+ * Hermes bridge that feeds real items is tracked in #821, and the
+ * MS Graph / Google Calendar connector that feeds Hermes is #822. When
+ * both land, swap fetchCalendarItemsFromHermes for the bridge call and
+ * leave the rest of the page machinery in place.
+ *
+ * IMPORTANT: do not seed mock rows here. The empty-state pattern is
+ * the design contract (docs/style/empty-state-pattern.md) — the page
+ * must render its empty state until real data lands, never fabricated
+ * placeholders.
+ */
+export async function listCalendarItems(
+  _subscription: SubscriptionRow,
+  params: CalendarListParams
+): Promise<CalendarListPage> {
+  const rows = await fetchCalendarItemsFromHermes(_subscription)
+  return buildCalendarListPage(rows, params)
+}
+
+/**
+ * Hermes bridge stub. Returns an empty list. When #821 (Hermes runtime
+ * wiring) and #822 (MS Graph / Google Calendar connector) land, replace
+ * the body with the bridge fetch — the subscription row carries the
+ * customer identity needed to route to the right Machine D1.
+ * Promise.resolve keeps the call shape async so the future swap is
+ * body-only.
+ */
+function fetchCalendarItemsFromHermes(_subscription: SubscriptionRow): Promise<CalendarItem[]> {
+  return Promise.resolve([])
+}

--- a/src/pages/portal/products/ai-employee/calendar/index.astro
+++ b/src/pages/portal/products/ai-employee/calendar/index.astro
@@ -2,45 +2,94 @@
 import '../../../../../styles/global.css'
 import { BRAND_NAME } from '../../../../../lib/config/brand'
 import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import {
+  CALENDAR_ITEM_TYPES,
+  CALENDAR_SORTS,
+  detectConflicts,
+  formatCalendarItemType,
+  listCalendarItems,
+  parseCalendarListParams,
+  type CalendarItemType,
+  type CalendarSort,
+} from '../../../../../lib/portal/ai-employee/calendar'
 import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
 import SkipToMain from '../../../../../components/SkipToMain.astro'
+import CalendarAgenda from '../../../../../components/portal/ai-employee/CalendarAgenda.astro'
 import { SignOutButton } from '@clerk/astro/components'
 import { env } from 'cloudflare:workers'
 
 /**
- * AI Employee — Calendar.
+ * AI Employee — Calendar list / agenda.
  *
  * URL: portal.smd.services/portal/products/ai-employee/calendar
  *
- * Per #872, the calendar surfaces deadlines, hearings, depositions, and
- * scheduled follow-ups the AI Employee is tracking. Connector wiring for
- * Google Calendar / Outlook / case-management deadlines lands as part of
- * the per-customer Hermes Machine runtime (#821, #923 connector
- * addressing) — none of that data is reachable from the portal Worker
- * directly per ADR 0009.
+ * Per #872 (and PRD calendar awareness), the surface shows both
+ * `ai_scheduled` items (already on the customer's external calendar
+ * via the connector) and `ai_proposed` items (drafts the AI suggests
+ * for scheduling, waiting on a reviewer). Conflict detection runs
+ * server-side via `detectConflicts(items)` and is surfaced per-row.
  *
- * Until the read path lands, this surface renders the empty state per
- * docs/style/empty-state-pattern.md — no fabricated events, no fake
- * deadlines, no "coming soon" copy.
+ * Drag-drop reschedule is a separate, complex interaction and is
+ * tracked in a follow-on issue (filed at PR open). This surface is
+ * the LIST + DETAIL pattern only; rescheduling happens via the future
+ * detail page's actions or the drag-drop machinery shipped in the
+ * follow-on.
+ *
+ * Data source: per-customer Hermes Machine D1 (ADR 0007 + 0009). The
+ * portal Worker cannot bind directly to a per-customer D1; the read
+ * path is pending Hermes runtime wiring (#821) AND the MS Graph /
+ * Google Calendar connector (#822). Until both land,
+ * listCalendarItems returns an empty list with the correct typed
+ * shape — the page renders the empty state per
+ * docs/style/empty-state-pattern.md, no fabricated events, no fake
+ * counts, no "coming soon" copy.
+ *
+ * Filter / sort / pagination machinery is wired today so the URL
+ * contract is stable when the connector + bridge land. See
+ * src/lib/portal/ai-employee/calendar.ts.
  *
  * Access gate (see resolveAiEmployeeAccess):
  *   - Clerk session (middleware)
  *   - Local entity bound to the active Clerk organization
  *   - Active AI Employee subscription on this customer
- *   - Caller holds operator OR principal role
+ *   - Caller holds principal OR operator OR compliance role
  *
- * Compliance-only users are redirected to the AI Employee landing.
+ * Unlike drafts, calendar grants access to compliance because the
+ * calendar is a read surface — viewing what the AI scheduled is part
+ * of the audit posture, not a doer surface that changes state.
  */
 
 const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
-  allowedRoles: ['operator', 'principal'],
+  allowedRoles: ['principal', 'operator', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)
 }
-const { client } = access
+const { client, subscription } = access
+
+const params = parseCalendarListParams(Astro.url.searchParams)
+const calendarPage = await listCalendarItems(subscription, params)
+
+// Conflict graph: computed once over the page rows so the agenda
+// doesn't ask each row to look at its neighbors. Map<id, otherIds[]>.
+const conflictMap = detectConflicts(calendarPage.rows)
+
+// Filter form selection state (re-hydrated from parsed params on
+// re-submit). Sets give the template fast `has()` lookups for
+// pre-checking option states.
+const selectedTypes = new Set<CalendarItemType>(params.types)
+
+const TYPE_LABELS: Record<CalendarItemType, string> = {
+  ai_scheduled: formatCalendarItemType('ai_scheduled'),
+  ai_proposed: formatCalendarItemType('ai_proposed'),
+}
+
+const SORT_LABELS: Record<CalendarSort, string> = {
+  start_asc: 'Earliest first',
+  start_desc: 'Latest first',
+}
 ---
 
 <!doctype html>
@@ -81,25 +130,137 @@ const { client } = access
         crumbLabel="AI Employee"
         tag="Section"
         h1="Calendar"
-        meta={null}
+        meta={calendarPage.totalCount > 0 ? `${calendarPage.totalCount} total` : null}
       />
 
-      <section class="mt-10">
-        <div
-          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+      <div class="mt-8 flex flex-col gap-6">
+        {
+          /* Filter form: by type + date range + sort. GET-form shape
+            mirrors the FilterBar pattern used on the drafts surface so
+            the URL contract is consistent across AI Employee sub-surfaces.
+            Calendar-specific so it stays inline; the drafts FilterBar
+            component is left untouched per #872 file-scope. */
+        }
+        <form
+          method="get"
+          class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-4 md:p-5 grid grid-cols-1 md:grid-cols-[1fr_1fr_1fr_auto_auto] gap-3 md:gap-4 md:items-end"
+          aria-label="Filter and sort calendar items"
         >
-          <p
-            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-          >
-            No upcoming events
-          </p>
-          <p
-            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
-          >
-            Hearings, depositions, and deadlines your AI Employee is tracking will appear here.
-          </p>
-        </div>
-      </section>
+          <fieldset class="flex flex-col gap-1.5 min-w-0">
+            <legend
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)] mb-1"
+            >
+              Type
+            </legend>
+            <div class="flex flex-col gap-1">
+              {
+                CALENDAR_ITEM_TYPES.map((type) => (
+                  <label class="inline-flex items-center gap-2 font-mono text-sm text-[color:var(--ss-color-text-primary)]">
+                    <input
+                      type="checkbox"
+                      name="type"
+                      value={type}
+                      checked={selectedTypes.has(type)}
+                      class="border-[2px] border-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+                    />
+                    {TYPE_LABELS[type]}
+                  </label>
+                ))
+              }
+            </div>
+          </fieldset>
+
+          <div class="flex flex-col gap-1.5 min-w-0">
+            <label
+              for="filter-from"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+            >
+              From
+            </label>
+            <input
+              type="date"
+              id="filter-from"
+              name="from"
+              value={params.fromIso ?? ''}
+              class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+            />
+          </div>
+
+          <div class="flex flex-col gap-1.5 min-w-0">
+            <label
+              for="filter-to"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+            >
+              To
+            </label>
+            <input
+              type="date"
+              id="filter-to"
+              name="to"
+              value={params.toIso ?? ''}
+              class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+            />
+          </div>
+
+          <div class="flex flex-col gap-1.5">
+            <label
+              for="filter-sort"
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+            >
+              Sort
+            </label>
+            <select
+              id="filter-sort"
+              name="sort"
+              class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+            >
+              {
+                CALENDAR_SORTS.map((option) => (
+                  <option value={option} selected={option === params.sort}>
+                    {SORT_LABELS[option]}
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+
+          <div class="flex flex-row gap-2 md:items-end">
+            <button
+              type="submit"
+              class="inline-flex items-center justify-center min-h-11 px-5 py-2 bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-opacity"
+            >
+              Apply
+            </button>
+          </div>
+        </form>
+
+        {
+          calendarPage.totalCount === 0 ? (
+            <section
+              aria-label="No calendar items"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+            >
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                No calendar items yet
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                Items your AI Employee schedules or proposes appear here once your calendar
+                connector is active.
+              </p>
+            </section>
+          ) : (
+            <CalendarAgenda
+              rows={calendarPage.rows}
+              totalCount={calendarPage.totalCount}
+              page={calendarPage.page}
+              pageSize={calendarPage.pageSize}
+              pageCount={calendarPage.pageCount}
+              conflictMap={conflictMap}
+              searchParams={Astro.url.searchParams}
+            />
+          )
+        }
+      </div>
     </main>
   </body>
 </html>

--- a/tests/forbidden-strings.test.ts
+++ b/tests/forbidden-strings.test.ts
@@ -357,6 +357,16 @@ const LIST_INDEX_ALLOWLIST: string[] = [
   // /portal/products/ai-employee/drafts/index.astro and matters/index.astro
   // and WILL use PortalListItem.
   resolve('src/pages/portal/products/ai-employee/index.astro'),
+  // `products/ai-employee/calendar/index.astro` is the AI Employee
+  // calendar agenda (#872). It renders list rows through the
+  // dedicated <CalendarItemRow> primitive (mirrors DraftRow's
+  // justification — the six-cell calendar vocabulary, time-range /
+  // title / type / source / matter / conflict, does not fit
+  // PortalListItem's status or document variants). The .map( hits on
+  // this page render the filter form's type checkboxes and sort
+  // <option>s, not list rows. The agenda itself is rendered through
+  // <CalendarAgenda>, which iterates via <CalendarItemRow>.
+  resolve('src/pages/portal/products/ai-employee/calendar/index.astro'),
 ]
 
 /** Collect every `index.astro` under `src/pages/portal/` EXCEPT the home. */

--- a/tests/portal-ai-employee-calendar.test.ts
+++ b/tests/portal-ai-employee-calendar.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Tests for the AI Employee calendar list helper
+ * (src/lib/portal/ai-employee/calendar.ts).
+ *
+ * The page surface composes parseCalendarListParams → applyCalendarFilters
+ * → applyCalendarSort → paginateCalendarItems, plus a separate
+ * `detectConflicts` over the page rows. Each piece is independently
+ * exercised here so the URL contract and the conflict semantics are
+ * regression-protected against drift before the Hermes bridge (#821)
+ * and the calendar connector (#822) land and start shipping real rows.
+ *
+ * The page-rendering resolver `listCalendarItems` returns an empty list
+ * today (no bridge, no connector). That contract is also tested here —
+ * the build must fail loudly if a future change starts seeding mock
+ * rows from this module, since that would be a Pattern A/B fabrication
+ * violation per CLAUDE.md.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  CALENDAR_ITEM_TYPES,
+  DEFAULT_CALENDAR_PAGE_SIZE,
+  MAX_CALENDAR_PAGE_SIZE,
+  applyCalendarFilters,
+  applyCalendarSort,
+  buildCalendarListPage,
+  detectConflicts,
+  distinctCalendarSkills,
+  formatCalendarItemType,
+  formatTimeRange,
+  listCalendarItems,
+  paginateCalendarItems,
+  parseCalendarListParams,
+  type CalendarItem,
+  type CalendarListParams,
+} from '../src/lib/portal/ai-employee/calendar'
+import type { SubscriptionRow } from '../src/lib/portal/product-access'
+
+function makeItem(overrides: Partial<CalendarItem> = {}): CalendarItem {
+  return {
+    id: 'c-1',
+    type: 'ai_scheduled',
+    title: 'Deposition: Acme v. Beta',
+    startsAt: '2026-05-21T09:00:00Z',
+    endsAt: '2026-05-21T10:30:00Z',
+    skill: 'deposition-scheduling',
+    relatedMatterId: 'm-1',
+    relatedMatterTitle: 'Acme v. Beta',
+    location: 'Conference Room B',
+    ...overrides,
+  }
+}
+
+const baseParams: CalendarListParams = {
+  types: [],
+  fromIso: null,
+  toIso: null,
+  sort: 'start_asc',
+  page: 1,
+  pageSize: DEFAULT_CALENDAR_PAGE_SIZE,
+}
+
+describe('parseCalendarListParams', () => {
+  it('returns defaults for an empty query string', () => {
+    const params = parseCalendarListParams(new URLSearchParams())
+    expect(params).toEqual(baseParams)
+  })
+
+  it('parses repeated type params and comma-separated type values', () => {
+    const params = parseCalendarListParams(
+      new URLSearchParams('type=ai_scheduled&type=ai_proposed,ai_scheduled')
+    )
+    expect(params.types.slice().sort()).toEqual(['ai_proposed', 'ai_scheduled'])
+  })
+
+  it('silently drops unknown type values rather than throwing', () => {
+    const params = parseCalendarListParams(new URLSearchParams('type=ai_scheduled,bogus,deleted'))
+    expect(params.types).toEqual(['ai_scheduled'])
+  })
+
+  it('accepts a valid from/to ISO date pair', () => {
+    const params = parseCalendarListParams(
+      new URLSearchParams('from=2026-05-01&to=2026-05-31T23:59:59Z')
+    )
+    expect(params.fromIso).toBe('2026-05-01')
+    expect(params.toIso).toBe('2026-05-31T23:59:59Z')
+  })
+
+  it('rejects unparseable from/to values', () => {
+    const params = parseCalendarListParams(new URLSearchParams('from=nope&to=alsonope'))
+    expect(params.fromIso).toBeNull()
+    expect(params.toIso).toBeNull()
+  })
+
+  it('treats empty from/to as null', () => {
+    const params = parseCalendarListParams(new URLSearchParams('from=&to=  '))
+    expect(params.fromIso).toBeNull()
+    expect(params.toIso).toBeNull()
+  })
+
+  it('falls back to start_asc on unknown sort values', () => {
+    expect(parseCalendarListParams(new URLSearchParams('sort=random')).sort).toBe('start_asc')
+  })
+
+  it('accepts the valid sort vocabulary', () => {
+    expect(parseCalendarListParams(new URLSearchParams('sort=start_desc')).sort).toBe('start_desc')
+    expect(parseCalendarListParams(new URLSearchParams('sort=start_asc')).sort).toBe('start_asc')
+  })
+
+  it('clamps page to 1 when below 1', () => {
+    expect(parseCalendarListParams(new URLSearchParams('page=0')).page).toBe(1)
+    expect(parseCalendarListParams(new URLSearchParams('page=-2')).page).toBe(1)
+  })
+
+  it('caps pageSize at MAX_CALENDAR_PAGE_SIZE', () => {
+    expect(parseCalendarListParams(new URLSearchParams('pageSize=10000')).pageSize).toBe(
+      MAX_CALENDAR_PAGE_SIZE
+    )
+  })
+
+  it('uses DEFAULT_CALENDAR_PAGE_SIZE for invalid pageSize values', () => {
+    expect(parseCalendarListParams(new URLSearchParams('pageSize=abc')).pageSize).toBe(
+      DEFAULT_CALENDAR_PAGE_SIZE
+    )
+    expect(parseCalendarListParams(new URLSearchParams('pageSize=0')).pageSize).toBe(
+      DEFAULT_CALENDAR_PAGE_SIZE
+    )
+  })
+})
+
+describe('applyCalendarFilters', () => {
+  const rows: CalendarItem[] = [
+    makeItem({
+      id: 'a',
+      type: 'ai_scheduled',
+      startsAt: '2026-05-01T10:00:00Z',
+      endsAt: '2026-05-01T11:00:00Z',
+    }),
+    makeItem({
+      id: 'b',
+      type: 'ai_proposed',
+      startsAt: '2026-05-15T10:00:00Z',
+      endsAt: '2026-05-15T11:00:00Z',
+    }),
+    makeItem({
+      id: 'c',
+      type: 'ai_scheduled',
+      startsAt: '2026-05-30T10:00:00Z',
+      endsAt: '2026-05-30T11:00:00Z',
+    }),
+  ]
+
+  it('returns all rows when no filters are set', () => {
+    expect(applyCalendarFilters(rows, baseParams)).toHaveLength(3)
+  })
+
+  it('filters by single type', () => {
+    const result = applyCalendarFilters(rows, { ...baseParams, types: ['ai_proposed'] })
+    expect(result.map((r) => r.id)).toEqual(['b'])
+  })
+
+  it('filters by multiple types (union)', () => {
+    const result = applyCalendarFilters(rows, {
+      ...baseParams,
+      types: ['ai_scheduled', 'ai_proposed'],
+    })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('filters by fromIso (drops anything before)', () => {
+    const result = applyCalendarFilters(rows, { ...baseParams, fromIso: '2026-05-10' })
+    expect(result.map((r) => r.id).sort()).toEqual(['b', 'c'])
+  })
+
+  it('filters by toIso (drops anything after)', () => {
+    const result = applyCalendarFilters(rows, { ...baseParams, toIso: '2026-05-20' })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('combines from + to into a window', () => {
+    const result = applyCalendarFilters(rows, {
+      ...baseParams,
+      fromIso: '2026-05-10',
+      toIso: '2026-05-20',
+    })
+    expect(result.map((r) => r.id)).toEqual(['b'])
+  })
+
+  it('combines all filters', () => {
+    const result = applyCalendarFilters(rows, {
+      ...baseParams,
+      types: ['ai_scheduled'],
+      fromIso: '2026-05-10',
+    })
+    expect(result.map((r) => r.id)).toEqual(['c'])
+  })
+})
+
+describe('applyCalendarSort', () => {
+  const rows: CalendarItem[] = [
+    makeItem({ id: 'mid', startsAt: '2026-05-15T10:00:00Z', endsAt: '2026-05-15T11:00:00Z' }),
+    makeItem({ id: 'late', startsAt: '2026-05-30T10:00:00Z', endsAt: '2026-05-30T11:00:00Z' }),
+    makeItem({ id: 'early', startsAt: '2026-05-01T10:00:00Z', endsAt: '2026-05-01T11:00:00Z' }),
+  ]
+
+  it('start_asc puts earliest first', () => {
+    const result = applyCalendarSort(rows, 'start_asc')
+    expect(result.map((r) => r.id)).toEqual(['early', 'mid', 'late'])
+  })
+
+  it('start_desc puts latest first', () => {
+    const result = applyCalendarSort(rows, 'start_desc')
+    expect(result.map((r) => r.id)).toEqual(['late', 'mid', 'early'])
+  })
+
+  it('sorts unparseable startsAt to the end (not the start)', () => {
+    const rowsWithBad: CalendarItem[] = [
+      ...rows,
+      makeItem({ id: 'bad', startsAt: 'not-a-date', endsAt: 'also-not' }),
+    ]
+    const result = applyCalendarSort(rowsWithBad, 'start_asc')
+    expect(result[result.length - 1].id).toBe('bad')
+  })
+})
+
+describe('paginateCalendarItems', () => {
+  const rows: CalendarItem[] = Array.from({ length: 125 }, (_, i) =>
+    makeItem({
+      id: `c-${i}`,
+      startsAt: `2026-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`,
+      endsAt: `2026-05-${String((i % 28) + 1).padStart(2, '0')}T11:00:00Z`,
+    })
+  )
+
+  it('returns one page when totalCount <= pageSize', () => {
+    const page = paginateCalendarItems(rows.slice(0, 10), 1, 50)
+    expect(page.rows).toHaveLength(10)
+    expect(page.pageCount).toBe(1)
+  })
+
+  it('paginates correctly across multiple pages', () => {
+    const page1 = paginateCalendarItems(rows, 1, 50)
+    expect(page1.rows).toHaveLength(50)
+    expect(page1.pageCount).toBe(3)
+
+    const page3 = paginateCalendarItems(rows, 3, 50)
+    expect(page3.rows).toHaveLength(25)
+  })
+
+  it('clamps out-of-range page to last page', () => {
+    const page = paginateCalendarItems(rows, 999, 50)
+    expect(page.page).toBe(3)
+  })
+
+  it('clamps below-range page to page 1', () => {
+    const page = paginateCalendarItems(rows, -5, 50)
+    expect(page.page).toBe(1)
+  })
+
+  it('returns pageCount=1 for empty input', () => {
+    const page = paginateCalendarItems([], 1, 50)
+    expect(page.rows).toEqual([])
+    expect(page.totalCount).toBe(0)
+    expect(page.pageCount).toBe(1)
+  })
+})
+
+describe('buildCalendarListPage', () => {
+  it('composes filter → sort → paginate', () => {
+    const rows: CalendarItem[] = [
+      makeItem({
+        id: 'a',
+        type: 'ai_scheduled',
+        startsAt: '2026-05-01T10:00:00Z',
+        endsAt: '2026-05-01T11:00:00Z',
+      }),
+      makeItem({
+        id: 'b',
+        type: 'ai_scheduled',
+        startsAt: '2026-05-30T10:00:00Z',
+        endsAt: '2026-05-30T11:00:00Z',
+      }),
+      makeItem({
+        id: 'c',
+        type: 'ai_proposed',
+        startsAt: '2026-05-15T10:00:00Z',
+        endsAt: '2026-05-15T11:00:00Z',
+      }),
+    ]
+
+    const page = buildCalendarListPage(rows, {
+      ...baseParams,
+      types: ['ai_scheduled'],
+      sort: 'start_desc',
+      page: 1,
+      pageSize: 50,
+    })
+
+    expect(page.rows.map((r) => r.id)).toEqual(['b', 'a'])
+    expect(page.totalCount).toBe(2)
+  })
+})
+
+describe('detectConflicts', () => {
+  it('returns an empty map when there are no items', () => {
+    expect(detectConflicts([])).toEqual(new Map())
+  })
+
+  it('returns an empty map when items do not overlap', () => {
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'a', startsAt: '2026-05-01T09:00:00Z', endsAt: '2026-05-01T10:00:00Z' }),
+      makeItem({ id: 'b', startsAt: '2026-05-01T11:00:00Z', endsAt: '2026-05-01T12:00:00Z' }),
+      makeItem({ id: 'c', startsAt: '2026-05-02T09:00:00Z', endsAt: '2026-05-02T10:00:00Z' }),
+    ]
+    expect(detectConflicts(rows)).toEqual(new Map())
+  })
+
+  it('treats edge-touching items as non-conflicting (back-to-back schedule)', () => {
+    // a ends exactly when b starts. By half-open interval semantics
+    // this is NOT a conflict — it's a tight schedule, not a clash.
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'a', startsAt: '2026-05-01T09:00:00Z', endsAt: '2026-05-01T10:00:00Z' }),
+      makeItem({ id: 'b', startsAt: '2026-05-01T10:00:00Z', endsAt: '2026-05-01T11:00:00Z' }),
+    ]
+    expect(detectConflicts(rows)).toEqual(new Map())
+  })
+
+  it('reports overlapping items in both directions', () => {
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'a', startsAt: '2026-05-01T09:00:00Z', endsAt: '2026-05-01T10:30:00Z' }),
+      makeItem({ id: 'b', startsAt: '2026-05-01T10:00:00Z', endsAt: '2026-05-01T11:00:00Z' }),
+    ]
+    const result = detectConflicts(rows)
+    expect(result.get('a')).toEqual(['b'])
+    expect(result.get('b')).toEqual(['a'])
+  })
+
+  it('reports multi-way overlaps', () => {
+    // All three overlap in the 10:00-10:30 window.
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'a', startsAt: '2026-05-01T09:00:00Z', endsAt: '2026-05-01T10:30:00Z' }),
+      makeItem({ id: 'b', startsAt: '2026-05-01T10:00:00Z', endsAt: '2026-05-01T11:00:00Z' }),
+      makeItem({ id: 'c', startsAt: '2026-05-01T10:15:00Z', endsAt: '2026-05-01T10:45:00Z' }),
+    ]
+    const result = detectConflicts(rows)
+    expect(result.get('a')).toEqual(['b', 'c'])
+    expect(result.get('b')).toEqual(['a', 'c'])
+    expect(result.get('c')).toEqual(['a', 'b'])
+  })
+
+  it('silently excludes items with malformed time ranges', () => {
+    // Bad item should not conflict with anything, even when its
+    // partial fields look like they might overlap. Empty-state
+    // contract: the resolver never emits malformed rows; this is the
+    // defensive path.
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'good', startsAt: '2026-05-01T09:00:00Z', endsAt: '2026-05-01T10:00:00Z' }),
+      makeItem({ id: 'bad', startsAt: 'not-a-date', endsAt: 'also-not' }),
+      makeItem({
+        id: 'zero',
+        startsAt: '2026-05-01T09:00:00Z',
+        endsAt: '2026-05-01T09:00:00Z',
+      }),
+    ]
+    expect(detectConflicts(rows)).toEqual(new Map())
+  })
+
+  it('returns deterministic sort of conflicting ids', () => {
+    // Insertion order would otherwise leak; the public contract is a
+    // sorted list per id so tests / hashing stay stable.
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'z', startsAt: '2026-05-01T09:00:00Z', endsAt: '2026-05-01T11:00:00Z' }),
+      makeItem({ id: 'a', startsAt: '2026-05-01T09:30:00Z', endsAt: '2026-05-01T10:00:00Z' }),
+      makeItem({ id: 'm', startsAt: '2026-05-01T09:45:00Z', endsAt: '2026-05-01T10:15:00Z' }),
+    ]
+    const result = detectConflicts(rows)
+    expect(result.get('z')).toEqual(['a', 'm'])
+  })
+})
+
+describe('formatCalendarItemType', () => {
+  it('maps every type value to a friendly label', () => {
+    expect(formatCalendarItemType('ai_scheduled')).toBe('Scheduled')
+    expect(formatCalendarItemType('ai_proposed')).toBe('Proposed')
+  })
+
+  it('every type vocabulary entry has a label (exhaustiveness)', () => {
+    for (const type of CALENDAR_ITEM_TYPES) {
+      const label = formatCalendarItemType(type)
+      expect(label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('formatTimeRange', () => {
+  it('formats a valid ISO start/end pair', () => {
+    const formatted = formatTimeRange('2026-05-21T09:00:00Z', '2026-05-21T10:30:00Z')
+    expect(formatted.datePart).toContain('May')
+    expect(formatted.datePart).toContain('21')
+    expect(formatted.timePart).toContain('9:00')
+    expect(formatted.timePart).toContain('10:30')
+    expect(formatted.tzPart).toBe('UTC')
+  })
+
+  it('passes through unparseable values without throwing', () => {
+    const formatted = formatTimeRange('not-a-date', 'also-not')
+    expect(formatted.datePart).toBe('not-a-date')
+    expect(formatted.timePart).toBe('also-not')
+    expect(formatted.tzPart).toBe('')
+  })
+})
+
+describe('distinctCalendarSkills', () => {
+  it('returns empty array for empty input', () => {
+    expect(distinctCalendarSkills([])).toEqual([])
+  })
+
+  it('returns unique skills sorted alphabetically', () => {
+    const rows: CalendarItem[] = [
+      makeItem({ id: 'a', skill: 'hearing-prep' }),
+      makeItem({ id: 'b', skill: 'deposition-scheduling' }),
+      makeItem({ id: 'c', skill: 'hearing-prep' }),
+      makeItem({ id: 'd', skill: 'deadline-tracking' }),
+    ]
+    expect(distinctCalendarSkills(rows)).toEqual([
+      'deadline-tracking',
+      'deposition-scheduling',
+      'hearing-prep',
+    ])
+  })
+})
+
+describe('listCalendarItems', () => {
+  it('returns an empty page until the Hermes bridge (#821) and connector (#822) land', async () => {
+    // No fabrication: the bridge stub returns []. If a future change
+    // adds mock rows in fetchCalendarItemsFromHermes this test fails
+    // loudly — that would be a Pattern A/B fabrication violation per
+    // CLAUDE.md.
+    const stubSubscription: SubscriptionRow = {
+      id: 'sub-test',
+      org_id: 'org-test',
+      entity_id: 'ent-test',
+      product_slug: 'ai-employee',
+      status: 'active',
+      started_at: '2026-05-21T00:00:00Z',
+      ended_at: null,
+      settings_json: null,
+      created_at: '2026-05-21T00:00:00Z',
+      updated_at: '2026-05-21T00:00:00Z',
+    }
+    const page = await listCalendarItems(stubSubscription, baseParams)
+    expect(page.rows).toEqual([])
+    expect(page.totalCount).toBe(0)
+    expect(page.page).toBe(1)
+    expect(page.pageCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Builds the LIST + DETAIL view for the AI Employee calendar agenda at `portal.smd.services/portal/products/ai-employee/calendar`, mirroring the drafts (#945) and matters (#950) sibling patterns.

The surface shows two kinds of items — `ai_scheduled` (committed to the customer's external calendar) and `ai_proposed` (waiting on reviewer approval) — in a single chronological agenda with per-row time-conflict indicators. Filter by type, date range, and sort.

Empty state today (no fabricated events). Page renders the no-items block until the Hermes bridge (#821) and the MS Graph / Google Calendar connector (#822) wire in real data. Filter / sort / pagination machinery and the conflict detector are exercised by 41 unit tests so the URL contract and conflict semantics are stable when items arrive.

## Linked issue

Closes #872

Follow-on (drag-drop reschedule): #952

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| ------------------------ | ------ | -------- |
| Page at `/ai-employee/calendar` | met | `src/pages/portal/products/ai-employee/calendar/index.astro` (route resolves at `portal.smd.services/portal/products/ai-employee/calendar` per the PR #907 / subdomain routing decision) |
| Shows AI-scheduled items + AI-proposed items | met | `CalendarItemType = 'ai_scheduled' \| 'ai_proposed'` in `src/lib/portal/ai-employee/calendar.ts`; row renders both with distinct tones in `src/components/portal/ai-employee/CalendarItemRow.astro` |
| Drag-drop to reschedule (AI re-syncs dependent items) | deferred | Tracked in #952 — drag-drop is a complex interaction whose scope and persistence path are gated on the Hermes bridge (#821) and calendar connector (#822). |
| Conflict detection | met | `detectConflicts(items: CalendarItem[]): Map<string, string[]>` in `src/lib/portal/ai-employee/calendar.ts` (half-open interval semantics, edge-touching is back-to-back not conflict); 7 unit tests in `tests/portal-ai-employee-calendar.test.ts`; surfaced per-row by `ConflictIndicator.astro` |
| Integration with MS Graph / Google Calendar connector | deferred | Connector lands in #822 (per ADR 0007 + 0009, portal Worker can't bind directly to the per-customer Hermes Machine D1; bridge work is #821). Resolver shape is wired today so the swap is body-only. |

## Deferred ACs

- **AC:** Drag-drop to reschedule (AI re-syncs dependent items)
  - **Why deferred:** Complex interaction with chained-update semantics; depends on real items in the agenda (so it needs #821 + #822 first). Per the issue task notes: "Drag-drop is deferred to a follow-on issue — link it from the PR body, do NOT block this issue on it."
  - **Tracked in:** #952

- **AC:** Integration with MS Graph / Google Calendar connector
  - **Why deferred:** Per ADR 0007 + 0009, the portal Worker can't bind directly to the per-customer Hermes Machine D1. The connector work is the #822 slice; this PR ships the read-path contract so the connector hand-off is body-only.
  - **Tracked in:** #822 (connector) and #821 (Hermes runtime wiring)

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, build, all unit tests including 41 new calendar tests and the updated forbidden-strings registry test)
- [x] Empty state renders with no fabricated events (page-level conditional gates on `calendarPage.totalCount === 0`)
- [x] Conflict detection: non-overlapping, edge-touching back-to-back, two-way overlap, multi-way overlap, and malformed-range exclusion all covered by `detectConflicts` tests
- [x] Filter form re-hydrates from URL params (types as repeated `?type=` and comma-separated; from / to ISO dates; sort vocabulary closed)
- [x] Role gate: `principal | operator | compliance` (calendar is a read surface — compliance gets access because viewing scheduled items is part of the audit posture)

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints (URL param parsing in `parseCalendarListParams` is defensive — unknown values fall back to safe defaults, no throws)
- [x] Parameterized queries for any SQL (use `.bind()`) — N/A, no SQL touched
- [x] Auth required on new endpoints (`resolveAiEmployeeAccess` enforces session + subscription + role)
- [x] No internal IDs that enable enumeration (item ids come from per-customer Hermes; no cross-customer enumeration possible)

## Feature Impact

**Feature impact:** None

## Deployment Notes

Standard deploy. No schema migrations, no env vars, no secret rotations.

The empty-state contract ensures that even after this lands on prod, the page renders "No calendar items yet" until the Hermes bridge (#821) and calendar connector (#822) ship — there is no fabrication path that could leak to the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)