### PR TITLE
feat(portal): AI Employee audit log viewer (#873)

### DIFF
--- a/src/components/portal/ai-employee/AuditEntryRow.astro
+++ b/src/components/portal/ai-employee/AuditEntryRow.astro
@@ -1,0 +1,243 @@
+---
+/**
+ * One row in the AI Employee audit log table.
+ *
+ * Used only by AuditLogTable. Lives in its own file so the row's cell
+ * vocabulary (timestamp / actor / action / target / decision / reason)
+ * can be tested and revised independently of the table chrome.
+ *
+ * The row is rendered as a `<details>` block so reviewers can expand a
+ * row to read the full `reason` text without a separate detail page or
+ * client-side JavaScript. Truncated text shows in the row caption; the
+ * expanded body shows the full reason plus the row id and any matter
+ * reference. The summary remains keyboard-actionable via the native
+ * `<details>` behavior.
+ *
+ * Plainspoken aesthetic matching DraftRow.astro (#869): 2px ink
+ * divider between rows, file-style mono numerics for timestamp /
+ * actor / target / action cells, Archivo Narrow uppercase labels for
+ * column captions. The outer 3px ink frame is provided by
+ * AuditLogTable — this component is borderless at the row level so
+ * consecutive rows stitch cleanly.
+ *
+ * Why not PortalListItem? PortalListItem's variants are status (title +
+ * money + meta caption) and document (icon + title + eyebrow). Neither
+ * fits the audit row's six-cell vocabulary. A new primitive is the
+ * honest answer; bending PortalListItem to fit would distort both
+ * surfaces. (Same rationale as DraftRow.astro.)
+ */
+
+import StatusPill from '../StatusPill.astro'
+import {
+  decisionTone,
+  formatAuditAction,
+  formatAuditDecision,
+  formatAuditTimestamp,
+  type AuditEntry,
+} from '../../../lib/portal/ai-employee/audit'
+
+interface Props {
+  entry: AuditEntry
+  /**
+   * Short serial shown in the № cell. The table passes the row index
+   * for stable visual rhythm even when ids change underneath.
+   */
+  serial?: string
+}
+
+const { entry, serial } = Astro.props
+const resolvedSerial = serial ?? entry.id.slice(0, 2).toUpperCase()
+
+const decisionLabel = formatAuditDecision(entry.decision)
+const decisionToneValue = decisionTone(entry.decision)
+
+const actionLabel = formatAuditAction(entry.action)
+const tsLabel = formatAuditTimestamp(entry.ts)
+
+// Truncate the reason in the row caption; the full text is in the
+// expanded body. 120 chars matches the table's column width on
+// desktop without forcing a second visual row in the truncated state.
+const reasonTruncated =
+  entry.reason && entry.reason.length > 120
+    ? entry.reason.slice(0, 117) + '…'
+    : (entry.reason ?? '')
+
+const hasExpandableContent = Boolean(entry.reason ?? entry.matterRef)
+---
+
+<details
+  class="group bg-[color:var(--ss-color-surface)] border-b-[2px] border-[color:var(--ss-color-text-primary)] last:border-b-0 transition-colors hover:bg-[color:var(--ss-color-border-subtle)]"
+>
+  <summary
+    class="cursor-pointer list-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+  >
+    <div
+      class="md:grid md:grid-cols-[56px_minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto_48px] md:items-stretch"
+    >
+      {/* № cell */}
+      <div
+        class="flex md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-primary)] items-center justify-center md:min-h-[96px] py-3 md:py-0 font-['Archivo'] font-black text-num-cell"
+        aria-hidden="true"
+      >
+        № {resolvedSerial}
+      </div>
+
+      {/* Timestamp */}
+      <div
+        class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+      >
+        <span
+          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+        >
+          When
+        </span>
+        <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] truncate">
+          {tsLabel}
+        </span>
+      </div>
+
+      {/* Actor */}
+      <div
+        class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+      >
+        <span
+          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Actor
+        </span>
+        <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] truncate">
+          {entry.actor}
+        </span>
+        {
+          entry.actorRole && (
+            <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]">
+              {entry.actorRole}
+            </span>
+          )
+        }
+      </div>
+
+      {/* Action */}
+      <div
+        class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+      >
+        <span
+          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Action
+        </span>
+        <span class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] truncate">
+          {actionLabel}
+        </span>
+        {
+          entry.skill && (
+            <span class="font-mono text-xs text-[color:var(--ss-color-text-secondary)] truncate">
+              {entry.skill}
+            </span>
+          )
+        }
+      </div>
+
+      {/* Target */}
+      <div
+        class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex flex-col justify-center gap-1 min-w-0"
+      >
+        <span
+          class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-semibold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Target
+        </span>
+        {
+          entry.target ? (
+            <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] truncate">
+              {entry.target}
+            </span>
+          ) : (
+            <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]">
+              None
+            </span>
+          )
+        }
+      </div>
+
+      {/* Decision chip */}
+      <div
+        class="md:border-r-[2px] md:border-[color:var(--ss-color-text-primary)] px-5 py-3 md:py-4 flex items-center justify-start md:justify-center"
+      >
+        {
+          decisionLabel.length > 0 ? (
+            <StatusPill tone={decisionToneValue} label={decisionLabel.toUpperCase()} />
+          ) : (
+            <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]">
+              No decision
+            </span>
+          )
+        }
+      </div>
+
+      {/* Expand indicator */}
+      <div
+        aria-hidden="true"
+        class="hidden md:flex items-center justify-center font-['Archivo'] font-black text-2xl text-[color:var(--ss-color-primary)] transition-transform group-open:rotate-180"
+      >
+        {hasExpandableContent ? '▾' : ''}
+      </div>
+    </div>
+
+    {
+      /* Truncated reason caption — only when reason exists. Sits below
+        the row grid so it remains readable on mobile. */
+    }
+    {
+      entry.reason && (
+        <div class="px-5 pb-3 md:pl-[calc(56px+1.25rem)] md:pr-5 -mt-1 md:-mt-3">
+          <p class="font-mono text-sm text-[color:var(--ss-color-text-secondary)]">
+            {reasonTruncated}
+          </p>
+        </div>
+      )
+    }
+  </summary>
+
+  {
+    hasExpandableContent && (
+      <div class="px-5 pb-5 md:pl-[calc(56px+1.25rem)] md:pr-5 flex flex-col gap-3 border-t-[2px] border-[color:var(--ss-color-border-subtle)] pt-4 mt-2">
+        {entry.reason && entry.reason.length > 120 && (
+          <div>
+            <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+              Full reason
+            </p>
+            <p class="mt-1 font-mono text-sm text-[color:var(--ss-color-text-primary)] whitespace-pre-wrap break-words">
+              {entry.reason}
+            </p>
+          </div>
+        )}
+
+        {entry.matterRef && (
+          <div>
+            <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+              Matter
+            </p>
+            <p class="mt-1 font-mono text-sm">
+              <a
+                href={`?matter=${encodeURIComponent(entry.matterRef)}`}
+                class="text-[color:var(--ss-color-text-primary)] underline hover:text-[color:var(--ss-color-action)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+              >
+                {entry.matterRef}
+              </a>
+            </p>
+          </div>
+        )}
+
+        <div>
+          <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+            Event id
+          </p>
+          <p class="mt-1 font-mono text-xs text-[color:var(--ss-color-text-muted)] break-all">
+            {entry.id}
+          </p>
+        </div>
+      </div>
+    )
+  }
+</details>

--- a/src/components/portal/ai-employee/AuditFilterBar.astro
+++ b/src/components/portal/ai-employee/AuditFilterBar.astro
@@ -1,0 +1,266 @@
+---
+/**
+ * Audit log filter bar.
+ *
+ * Renders six controls — skill multi-select, action-class multi-select,
+ * date-range pair (from / to), per-matter drill-down indicator, and
+ * free-text search. Submits as a plain GET form to the surrounding
+ * page so server-side params drive the list. No client-side
+ * JavaScript: the page re-renders with the new query string and the
+ * data resolver re-runs against the new params.
+ *
+ * Plainspoken aesthetic matching FilterBar.astro (#869). 3px ink
+ * border, Archivo Narrow uppercase labels, no shadowy form chrome.
+ *
+ * Drift guard: every input `name` here matches a field on
+ * `AuditListParams` in src/lib/portal/ai-employee/audit.ts. If you
+ * rename one here, rename both — the URL is the contract between the
+ * form and the resolver.
+ *
+ * Per-matter drill-down: when a `matter=<id>` param is set, the form
+ * surfaces it as a hidden input plus a visible read-only chip so the
+ * reviewer sees the active drill-down and can clear it. We do not
+ * render a free-text matter input; the typical entry vector is a link
+ * from the matter detail page, not a typed query.
+ */
+
+import {
+  AUDIT_ACTION_TYPES,
+  AUDIT_SORTS,
+  type AuditSort,
+} from '../../../lib/portal/ai-employee/audit'
+
+interface Props {
+  /**
+   * The currently-applied filter / sort state. Comes from the page's
+   * parsed URLSearchParams so the form re-hydrates after a submit.
+   */
+  skills: readonly string[]
+  actions: readonly string[]
+  from: string | null
+  to: string | null
+  matter: string | null
+  q: string | null
+  sort: AuditSort
+  /**
+   * The set of skills observed across the current customer's audit
+   * page. Drives the skill multi-select. Empty array → the control is
+   * rendered disabled with a "No skills yet" hint so the bar structure
+   * stays visible in the empty state.
+   */
+  availableSkills: readonly string[]
+}
+
+const { skills, actions, from, to, matter, q, sort, availableSkills } = Astro.props
+
+const SORT_LABELS: Record<AuditSort, string> = {
+  ts_desc: 'Newest first',
+  ts_asc: 'Oldest first',
+}
+
+const selectedSkills = new Set(skills)
+const selectedActions = new Set(actions)
+
+// Strip time component from an ISO datetime for the `<input type="date">`
+// re-hydration. The resolver accepts both ISO date and ISO datetime so
+// surfacing the date alone keeps the control honest about what it
+// actually filters on (whole-day windows).
+function toDateValue(value: string | null): string {
+  if (value === null) return ''
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) return ''
+  return new Date(parsed).toISOString().slice(0, 10)
+}
+---
+
+<form
+  method="get"
+  class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-4 md:p-5 flex flex-col gap-3 md:gap-4"
+  aria-label="Filter and sort audit log"
+>
+  {
+    /* Active matter drill-down: visible chip + hidden input so the
+      reviewer sees the active filter and can clear it from the bar. */
+  }
+  {
+    matter !== null && (
+      <div class="flex items-center gap-3 border-b-[2px] border-[color:var(--ss-color-text-primary)] pb-3">
+        <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+          Matter
+        </span>
+        <span class="font-mono text-sm text-[color:var(--ss-color-text-primary)] break-all">
+          {matter}
+        </span>
+        <input type="hidden" name="matter" value={matter} />
+        <a
+          href="?"
+          class="inline-flex items-center min-h-9 px-3 py-1 border-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+        >
+          Clear matter
+        </a>
+      </div>
+    )
+  }
+
+  <div
+    class="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto_auto_auto_auto] gap-3 md:gap-4 md:items-end"
+  >
+    {/* Skill multi-select */}
+    <div class="flex flex-col gap-1.5 min-w-0">
+      <label
+        for="audit-filter-skill"
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Skill
+      </label>
+      <select
+        id="audit-filter-skill"
+        name="skill"
+        multiple
+        size={Math.min(Math.max(availableSkills.length, 1), 4)}
+        disabled={availableSkills.length === 0}
+        class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] disabled:bg-[color:var(--ss-color-border-subtle)] disabled:text-[color:var(--ss-color-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+        aria-describedby={availableSkills.length === 0 ? 'audit-filter-skill-empty' : undefined}
+      >
+        {
+          availableSkills.length === 0 ? (
+            <option value="" disabled>
+              No skills yet
+            </option>
+          ) : (
+            availableSkills.map((skill) => (
+              <option value={skill} selected={selectedSkills.has(skill)}>
+                {skill}
+              </option>
+            ))
+          )
+        }
+      </select>
+      {
+        availableSkills.length === 0 && (
+          <span
+            id="audit-filter-skill-empty"
+            class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-muted)]"
+          >
+            Skills appear as your AI Employee acts
+          </span>
+        )
+      }
+    </div>
+
+    {/* Action class multi-select */}
+    <div class="flex flex-col gap-1.5 min-w-0">
+      <label
+        for="audit-filter-action"
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Action class
+      </label>
+      <select
+        id="audit-filter-action"
+        name="action"
+        multiple
+        size="4"
+        class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-xs text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      >
+        {
+          AUDIT_ACTION_TYPES.map((action) => (
+            <option value={action} selected={selectedActions.has(action)}>
+              {action}
+            </option>
+          ))
+        }
+      </select>
+    </div>
+
+    {/* From date */}
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="audit-filter-from"
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        From
+      </label>
+      <input
+        type="date"
+        id="audit-filter-from"
+        name="from"
+        value={toDateValue(from)}
+        class="w-40 border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      />
+    </div>
+
+    {/* To date */}
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="audit-filter-to"
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        To
+      </label>
+      <input
+        type="date"
+        id="audit-filter-to"
+        name="to"
+        value={toDateValue(to)}
+        class="w-40 border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      />
+    </div>
+
+    {/* Sort */}
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="audit-filter-sort"
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Sort
+      </label>
+      <select
+        id="audit-filter-sort"
+        name="sort"
+        class="border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+      >
+        {
+          AUDIT_SORTS.map((option) => (
+            <option value={option} selected={option === sort}>
+              {SORT_LABELS[option]}
+            </option>
+          ))
+        }
+      </select>
+    </div>
+
+    {/* Submit */}
+    <div class="flex flex-row gap-2 md:items-end">
+      <button
+        type="submit"
+        class="inline-flex items-center justify-center min-h-11 px-5 py-2 bg-[color:var(--ss-color-primary)] text-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-opacity"
+      >
+        Apply
+      </button>
+    </div>
+  </div>
+
+  {
+    /* Free-text search occupies its own row so the recipient field's
+      sibling-bar shape doesn't crowd it. Search hits reason + actor +
+      target per the AC. */
+  }
+  <div class="flex flex-col gap-1.5 min-w-0">
+    <label
+      for="audit-filter-q"
+      class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+    >
+      Search
+    </label>
+    <input
+      type="search"
+      id="audit-filter-q"
+      name="q"
+      value={q ?? ''}
+      placeholder="reason, actor, or target"
+      autocomplete="off"
+      class="w-full border-[2px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] px-3 py-2 font-mono text-sm text-[color:var(--ss-color-text-primary)] placeholder:text-[color:var(--ss-color-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+    />
+  </div>
+</form>

--- a/src/components/portal/ai-employee/AuditLogTable.astro
+++ b/src/components/portal/ai-employee/AuditLogTable.astro
@@ -1,0 +1,126 @@
+---
+/**
+ * AI Employee audit log table.
+ *
+ * Wraps a list of AuditEntryRow components in a 3px ink frame and
+ * renders pagination controls below when there are more entries than
+ * fit on one page. The empty state is owned by the surrounding page
+ * (so the page can use the standard portal empty-state block); this
+ * component only renders when `rows.length > 0`.
+ *
+ * Pagination is server-side: the prev/next links carry the current
+ * filter / sort params plus the new `page` so a deep link to a
+ * filtered page-N stays linkable. The form GET in AuditFilterBar
+ * resets pagination by omitting `page` — explicit, no surprise jumps.
+ *
+ * Mirrors DraftsListTable.astro deliberately so the two list views
+ * share a pagination contract and visual rhythm; reviewers moving
+ * between drafts and audit don't lose orientation.
+ */
+
+import AuditEntryRow from './AuditEntryRow.astro'
+import type { AuditEntry } from '../../../lib/portal/ai-employee/audit'
+
+interface Props {
+  rows: readonly AuditEntry[]
+  totalCount: number
+  page: number
+  pageSize: number
+  pageCount: number
+  /**
+   * Search params currently applied (filter + sort). The component
+   * threads these through prev/next links so paging preserves
+   * filters. Pass `Astro.url.searchParams` from the page.
+   */
+  searchParams: URLSearchParams
+}
+
+const { rows, totalCount, page, pageSize, pageCount, searchParams } = Astro.props
+
+function buildHref(targetPage: number): string {
+  const next = new URLSearchParams(searchParams)
+  next.set('page', String(targetPage))
+  // The form omits empty params; mirror that here so the URL is the
+  // minimal form for back/forward navigation.
+  for (const [key, value] of Array.from(next.entries())) {
+    if (value === '') next.delete(key)
+  }
+  const query = next.toString()
+  return query.length > 0 ? `?${query}` : ''
+}
+
+const hasPrev = page > 1
+const hasNext = page < pageCount
+
+const rangeStart = totalCount === 0 ? 0 : (page - 1) * pageSize + 1
+const rangeEnd = Math.min(page * pageSize, totalCount)
+---
+
+<section aria-label="Audit log">
+  <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
+    {
+      rows.map((entry, index) => (
+        <AuditEntryRow
+          entry={entry}
+          serial={String(index + 1 + (page - 1) * pageSize).padStart(2, '0')}
+        />
+      ))
+    }
+  </div>
+
+  {
+    pageCount > 1 && (
+      <nav
+        aria-label="Audit log pagination"
+        class="mt-4 flex flex-col md:flex-row md:items-center md:justify-between gap-3"
+      >
+        <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+          Showing {rangeStart} to {rangeEnd} of {totalCount}
+        </p>
+        <ul class="flex items-center gap-2" role="list">
+          <li>
+            {hasPrev ? (
+              <a
+                href={buildHref(page - 1)}
+                rel="prev"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+              >
+                Previous
+              </a>
+            ) : (
+              <span
+                aria-disabled="true"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-border)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-muted)]"
+              >
+                Previous
+              </span>
+            )}
+          </li>
+          <li>
+            <span class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)] px-2">
+              Page {page} of {pageCount}
+            </span>
+          </li>
+          <li>
+            {hasNext ? (
+              <a
+                href={buildHref(page + 1)}
+                rel="next"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+              >
+                Next
+              </a>
+            ) : (
+              <span
+                aria-disabled="true"
+                class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-border)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-muted)]"
+              >
+                Next
+              </span>
+            )}
+          </li>
+        </ul>
+      </nav>
+    )
+  }
+</section>

--- a/src/lib/portal/ai-employee/audit.ts
+++ b/src/lib/portal/ai-employee/audit.ts
@@ -1,0 +1,637 @@
+/**
+ * AI Employee audit log viewer — typed contract + read resolver.
+ *
+ * Per PRD §13 and #873, every safety-relevant action the AI Employee
+ * takes (draft created, sent approved, trust ceiling promoted,
+ * connector bound, invariant violation, etc.) writes an `audit_log` row
+ * on the per-customer Hermes Machine D1. The audit_log writer landed
+ * in PR #942 (`ai-employee/adapter/audit_log.py`); the row schema and
+ * accepted action_type vocabulary are the source of truth there.
+ *
+ * This module owns the read side: typed `AuditEntry` shape, URL
+ * search-params parsing (filters / pagination), in-memory filter +
+ * sort + paginate helpers, friendly formatters for action class and
+ * actor role, and the resolver the page invokes.
+ *
+ * Data source: per-customer Hermes Machine D1 (ADR 0007 + 0009). The
+ * portal Worker cannot bind directly to a per-customer D1; reads go
+ * through an internal Hermes bridge (PR #907 architecture, runtime
+ * wiring tracked in #821). Until that bridge ships, this resolver
+ * returns an empty list with the correct typed shape so the page
+ * machinery (filter bar, table, pagination) works end-to-end without
+ * fabricating rows. No mock data. No placeholder copy. See
+ * docs/style/empty-state-pattern.md.
+ *
+ * When the bridge lands, only `fetchAuditEntriesFromHermes` changes.
+ * Filter parsing, validation, formatters, and the page UI stay put.
+ *
+ * Mirrors the shape of `src/lib/portal/ai-employee/drafts.ts` deliberately
+ * (sibling list view, same pagination contract). Differences:
+ *
+ *   - Audit rows are immutable history, not a triage queue: default sort
+ *     is `ts_desc` (newest first), no priority bucket, no "max age"
+ *     window. Instead the date range filter (`from` / `to`) is the
+ *     primary temporal filter, defaulting to the last 7 days per AC.
+ *   - The free-text `q` filter does substring match over
+ *     `reason` + `actor` + `target` — these are the three fields a
+ *     compliance reviewer scans for "what happened around X".
+ *   - Action class is a multi-select over the closed
+ *     `ACCEPTED_ACTION_TYPES` vocabulary mirrored from the writer.
+ *   - Per-matter drill-down piggy-backs on the same params: `?matter=<id>`
+ *     filters rows whose `target` is that matter ref.
+ */
+
+import type { SubscriptionRow } from '../product-access'
+
+/**
+ * Accepted `action_type` values for audit rows, mirrored from
+ * `ai-employee/adapter/audit_log.py::ACCEPTED_ACTION_TYPES`. The
+ * vocabulary is closed — additions require updating both this list and
+ * the Python constant in lockstep (see writer-side doc reference for
+ * the spec at docs/specs/ai-employee/d1-schema.md §1).
+ *
+ * Listed here as a TypeScript const so the filter bar can render
+ * options from a single source and the resolver can validate incoming
+ * params against the vocabulary.
+ */
+export const AUDIT_ACTION_TYPES = [
+  // Draft lifecycle
+  'DRAFT_CREATED',
+  'DRAFT_APPROVED',
+  'DRAFT_REJECTED',
+  'DRAFT_EXPIRED',
+  // Memory rules
+  'MEMORY_RULE_ADDED',
+  'MEMORY_RULE_EDITED',
+  'MEMORY_RULE_DELETED',
+  // Trust ceiling
+  'TRUST_PROMOTED',
+  'TRUST_DEMOTED',
+  // Skill activation
+  'SKILL_ENABLED',
+  'SKILL_DISABLED',
+  // Agent lifecycle
+  'AGENT_STOPPED',
+  'AGENT_RESUMED',
+  // Connector lifecycle
+  'CONNECTOR_BOUND',
+  'CONNECTOR_UNBOUND',
+  'CONNECTOR_AUTH_EXPIRED',
+  'CONNECTOR_AUTH_RESTORED',
+  'CONNECTOR_TOKEN_REFRESHED',
+  'CONNECTOR_HEALTH_PROBE_FAILED',
+  // Scope changes
+  'SCOPE_CHANGED',
+  // Sent-folder watching
+  'SENT_DETECTED',
+  'SENT_DIFF_INDEXED',
+  // Safety substrate
+  'INVARIANT_VIOLATION',
+  'INVARIANT_BOOT_CHECK_FAILED',
+  // RBAC and compliance
+  'RBAC_EVENT',
+  'COMPLIANCE_PACKET_EXPORTED',
+  // Voice gate
+  'VOICE_GATE_PASSED',
+  'VOICE_GATE_NEAR_PASS',
+  'VOICE_GATE_FAILED',
+  // Fabrication and escalation
+  'FABRICATION_FILTER_TRIGGERED',
+  'ESCALATION_FIRED',
+  'ESCALATION_ACKNOWLEDGED',
+  // Decommission lifecycle
+  'DECOMMISSION_INITIATED',
+  'DECOMMISSION_DRAIN_COMPLETE',
+  'DECOMMISSION_FINAL',
+] as const
+
+export type AuditActionType = (typeof AUDIT_ACTION_TYPES)[number]
+
+const AUDIT_ACTION_TYPE_SET: ReadonlySet<string> = new Set(AUDIT_ACTION_TYPES)
+
+/**
+ * The effective decision the writer recorded for an action. Mirrors the
+ * trust-ceiling outcomes the agent emits per ADR 0005. The vocabulary is
+ * closed — unknown values surface as the raw string rather than a
+ * fabricated friendly label.
+ *
+ *   allow            — Action proceeded without reviewer gate.
+ *   draft_for_review — Default. The AI Employee proposed; a reviewer must
+ *                      approve before the effect lands.
+ *   refuse           — The action was refused (trust ceiling, invariant,
+ *                      voice gate, fabrication filter).
+ */
+export type AuditDecision = 'allow' | 'draft_for_review' | 'refuse'
+
+export const AUDIT_DECISIONS: readonly AuditDecision[] = [
+  'allow',
+  'draft_for_review',
+  'refuse',
+] as const
+
+/**
+ * Closed vocabulary for the actor's role at the time of the audited
+ * action. Mirrors `ai-employee/adapter/audit_log.py::ActorRole`. The
+ * column itself is nullable in the writer; null surfaces as `null` here.
+ */
+export type AuditActorRole = 'principal' | 'operator' | 'compliance' | 'agent' | 'captain'
+
+export const AUDIT_ACTOR_ROLES: readonly AuditActorRole[] = [
+  'principal',
+  'operator',
+  'compliance',
+  'agent',
+  'captain',
+] as const
+
+/**
+ * Sort options exposed via `?sort=`. Default is `ts_desc` (newest
+ * first) — audit history is a "what just happened" surface for
+ * compliance reviewers. `ts_asc` is the chronological reading order
+ * for incident reconstruction.
+ */
+export type AuditSort = 'ts_desc' | 'ts_asc'
+
+export const AUDIT_SORTS: readonly AuditSort[] = ['ts_desc', 'ts_asc'] as const
+
+/**
+ * One row in the audit log viewer. Shape mirrors what the Hermes
+ * bridge will return when #821 lands — fields map to `audit_log`
+ * columns one-for-one. Field semantics:
+ *
+ *   id        — ULID written by the audit writer. Stable identifier
+ *               used as the row key and for the optional expand
+ *               affordance.
+ *   ts        — ISO 8601 UTC with millisecond precision. The writer
+ *               always emits this; the renderer formats it for display.
+ *   actor     — Caller identity (`'agent'`, `'captain'`, or a
+ *               `person_mappings.id`). Renders verbatim in the actor
+ *               cell; the table never fabricates a friendly name.
+ *   actorRole — Optional role at action time (see AuditActorRole).
+ *   action    — Action class. Validated against AUDIT_ACTION_TYPES;
+ *               unknown values render verbatim so we never silently
+ *               drop a row whose class drifted ahead of this constant.
+ *   target    — Free-form target reference (matter id, draft id,
+ *               connector slug). `null` when the action has no
+ *               specific target (e.g., `INVARIANT_BOOT_CHECK_FAILED`).
+ *   decision  — Effective decision (see AuditDecision). `null` when
+ *               the writer did not attach one (the schema field is
+ *               nullable in some action classes).
+ *   reason    — Short human-readable explanation of the decision /
+ *               action. Renders truncated by default with an expand
+ *               affordance on the row; full text lives in the row's
+ *               `<details>` block. May be null if the writer did not
+ *               attach a reason.
+ *   skill     — Optional skill slug that originated the action.
+ *               Powers the skill multi-select; mirrors
+ *               `audit_log.skill_name`.
+ *   matterRef — Optional matter reference for cross-skill drill-down.
+ *               Mirrors `audit_log.matter_ref` and is the field the
+ *               `?matter=<id>` query string filters against.
+ */
+export interface AuditEntry {
+  id: string
+  ts: string
+  actor: string
+  actorRole: AuditActorRole | null
+  action: string
+  target: string | null
+  decision: AuditDecision | null
+  reason: string | null
+  skill: string | null
+  matterRef: string | null
+}
+
+/**
+ * Parameters parsed from the page's URLSearchParams. All optional — the
+ * page renders an unfiltered list when nothing is passed, except for the
+ * date-range default below.
+ *
+ *   skills      — Multi-select skill filter. Empty array = all skills.
+ *   actions     — Multi-select action-class filter. Empty array = all
+ *                 actions. Values outside AUDIT_ACTION_TYPES are
+ *                 dropped (defensive against bookmark drift).
+ *   from        — Inclusive lower bound on `ts` as an ISO date or
+ *                 ISO datetime. null = no lower bound. Empty / invalid
+ *                 input falls back to null so a typo doesn't blank the
+ *                 list silently.
+ *   to          — Inclusive upper bound on `ts`. Same semantics as
+ *                 `from`. When both are null and `defaultDateRange` is
+ *                 true (the page contract), the resolver lets the page
+ *                 supply a "last 7 days" window.
+ *   matter      — Per-matter drill-down. Substring/equality match on
+ *                 `matterRef` (canonicalized lowercase). null = no
+ *                 filter.
+ *   q           — Free-text search applied over `reason` + `actor` +
+ *                 `target` (case-insensitive substring). null = no
+ *                 filter.
+ *   sort        — One of AUDIT_SORTS. Defaults to 'ts_desc'.
+ *   page        — 1-indexed page number. Defaults to 1. Out-of-range
+ *                 values clamp to 1.
+ *   pageSize    — Defaults to 100 per AC. Capped at MAX_AUDIT_PAGE_SIZE.
+ */
+export interface AuditListParams {
+  skills: readonly string[]
+  actions: readonly string[]
+  from: string | null
+  to: string | null
+  matter: string | null
+  q: string | null
+  sort: AuditSort
+  page: number
+  pageSize: number
+}
+
+export const DEFAULT_AUDIT_PAGE_SIZE = 100
+export const MAX_AUDIT_PAGE_SIZE = 500
+
+/**
+ * Default date-range window for the audit viewer. Compliance reviewers
+ * scanning "what happened today / this week" want a tight default so
+ * the page is responsive even when the customer has months of history.
+ * Seven days is the AC default; reviewers widen via the filter bar.
+ */
+export const DEFAULT_AUDIT_RANGE_DAYS = 7
+
+/**
+ * Validate that a string is a parsable ISO date or datetime. Returns
+ * the input verbatim when valid (preserves the user's representation
+ * for the form's re-hydration) and null when not. Defensive: rejects
+ * NaN, empty strings, and obvious typos so the resolver never silently
+ * filters out everything because a single character is wrong.
+ */
+function normalizeIsoTimestamp(raw: string | null): string | null {
+  if (raw === null) return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  const parsed = Date.parse(trimmed)
+  if (!Number.isFinite(parsed)) return null
+  return trimmed
+}
+
+/**
+ * Parse params from URLSearchParams. Defensive — every field is
+ * validated against the closed vocabularies above; unknown values fall
+ * back to safe defaults instead of throwing. This keeps the surface
+ * stable under user-typed URLs and bookmark drift.
+ *
+ * Multi-select fields accept both repeated params
+ * (`?skill=intake&skill=deadline`) and comma-separated values
+ * (`?skill=intake,deadline`).
+ */
+export function parseAuditListParams(searchParams: URLSearchParams): AuditListParams {
+  // Multi-select skill: union of repeated params and comma-separated values.
+  const rawSkillParams = searchParams.getAll('skill')
+  const skills = Array.from(
+    new Set(
+      rawSkillParams
+        .flatMap((value) => value.split(','))
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    )
+  )
+
+  // Multi-select action: same shape as skill, validated against the
+  // closed vocabulary. Unknown values are dropped (we never want to
+  // silently filter the whole list because a stale bookmark named an
+  // action class that no longer exists).
+  const rawActionParams = searchParams.getAll('action')
+  const actions = Array.from(
+    new Set(
+      rawActionParams
+        .flatMap((value) => value.split(','))
+        .map((value) => value.trim())
+        .filter((value) => AUDIT_ACTION_TYPE_SET.has(value))
+    )
+  )
+
+  const from = normalizeIsoTimestamp(searchParams.get('from'))
+  const to = normalizeIsoTimestamp(searchParams.get('to'))
+
+  const rawMatter = searchParams.get('matter')?.trim() ?? ''
+  const matter = rawMatter.length > 0 ? rawMatter.toLowerCase() : null
+
+  const rawQ = searchParams.get('q')?.trim() ?? ''
+  const q = rawQ.length > 0 ? rawQ.toLowerCase() : null
+
+  const rawSort = searchParams.get('sort')
+  const sort: AuditSort = AUDIT_SORTS.includes(rawSort as AuditSort)
+    ? (rawSort as AuditSort)
+    : 'ts_desc'
+
+  const rawPage = Number(searchParams.get('page'))
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? Math.floor(rawPage) : 1
+
+  const rawPageSize = Number(searchParams.get('pageSize'))
+  const pageSize =
+    Number.isFinite(rawPageSize) && rawPageSize >= 1
+      ? Math.min(Math.floor(rawPageSize), MAX_AUDIT_PAGE_SIZE)
+      : DEFAULT_AUDIT_PAGE_SIZE
+
+  return { skills, actions, from, to, matter, q, sort, page, pageSize }
+}
+
+/**
+ * Compute the default date-range window the page applies when neither
+ * `from` nor `to` is in the URL. Lower bound is `nowMs - days * 86400e3`;
+ * upper bound is `nowMs`. Returned as ISO strings to match what
+ * normalizeIsoTimestamp would have produced from URL input — keeps the
+ * downstream filter path uniform.
+ *
+ * `nowMs` is injectable so tests can pin the window deterministically.
+ */
+export function defaultAuditDateRange(
+  days: number = DEFAULT_AUDIT_RANGE_DAYS,
+  nowMs: number = Date.now()
+): { from: string; to: string } {
+  const upper = new Date(nowMs).toISOString()
+  const lower = new Date(nowMs - days * 86400_000).toISOString()
+  return { from: lower, to: upper }
+}
+
+/**
+ * Apply filters to an AuditEntry list in-memory. Exposed for the
+ * resolver below and for unit tests. The Hermes bridge will eventually
+ * push filtering server-side and this function will only run for
+ * in-page post-filtering (or be replaced entirely). For now it is the
+ * source of truth so the empty-list contract has tested filter
+ * semantics.
+ *
+ * `q` matches the lowercase substring against `reason || ''`,
+ * `actor || ''`, and `target || ''`. Empty strings never match, which
+ * is the desired behavior — searching for the empty string is treated
+ * as "no search" upstream, so a row whose `reason` is null is included
+ * unless filtered out by some other clause.
+ */
+export function applyAuditFilters(
+  rows: readonly AuditEntry[],
+  params: AuditListParams
+): AuditEntry[] {
+  let result = rows.slice()
+
+  if (params.skills.length > 0) {
+    const wanted = new Set(params.skills)
+    result = result.filter((row) => row.skill !== null && wanted.has(row.skill))
+  }
+
+  if (params.actions.length > 0) {
+    const wanted = new Set(params.actions)
+    result = result.filter((row) => wanted.has(row.action))
+  }
+
+  if (params.from !== null) {
+    const lowerMs = Date.parse(params.from)
+    if (Number.isFinite(lowerMs)) {
+      result = result.filter((row) => {
+        const rowMs = Date.parse(row.ts)
+        return Number.isFinite(rowMs) && rowMs >= lowerMs
+      })
+    }
+  }
+
+  if (params.to !== null) {
+    const upperMs = Date.parse(params.to)
+    if (Number.isFinite(upperMs)) {
+      result = result.filter((row) => {
+        const rowMs = Date.parse(row.ts)
+        return Number.isFinite(rowMs) && rowMs <= upperMs
+      })
+    }
+  }
+
+  if (params.matter !== null) {
+    const needle = params.matter
+    result = result.filter(
+      (row) => row.matterRef !== null && row.matterRef.toLowerCase() === needle
+    )
+  }
+
+  if (params.q !== null) {
+    const needle = params.q
+    result = result.filter((row) => {
+      const reason = (row.reason ?? '').toLowerCase()
+      const actor = row.actor.toLowerCase()
+      const target = (row.target ?? '').toLowerCase()
+      return reason.includes(needle) || actor.includes(needle) || target.includes(needle)
+    })
+  }
+
+  return result
+}
+
+/**
+ * Sort a (pre-filtered) AuditEntry list by timestamp. ISO 8601 strings
+ * sort lexicographically the same way as their underlying instants for
+ * any well-formed value, but the writer is the only authority on
+ * timestamp formatting and a malformed value would shift the sort.
+ * `Date.parse` keeps the comparison numeric and stable across that
+ * edge.
+ */
+export function applyAuditSort(rows: readonly AuditEntry[], sort: AuditSort): AuditEntry[] {
+  const sorted = rows.slice()
+  switch (sort) {
+    case 'ts_desc':
+      sorted.sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))
+      return sorted
+    case 'ts_asc':
+      sorted.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts))
+      return sorted
+  }
+}
+
+/**
+ * Pagination return value. Same shape as the drafts resolver so the
+ * page can share the table primitive's pagination contract. `pageCount`
+ * is floored at 1 even when there are zero rows so "Page 1 of 1" reads
+ * sensibly in the empty state.
+ */
+export interface AuditListPage {
+  rows: AuditEntry[]
+  totalCount: number
+  page: number
+  pageSize: number
+  pageCount: number
+}
+
+/**
+ * Apply offset-based pagination to a sorted+filtered list. Page is
+ * 1-indexed, clamped to [1, pageCount]. Out-of-range pages return the
+ * last page rather than an empty result.
+ */
+export function paginateAuditEntries(
+  rows: readonly AuditEntry[],
+  page: number,
+  pageSize: number
+): AuditListPage {
+  const totalCount = rows.length
+  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize))
+  const clampedPage = Math.min(Math.max(1, Math.floor(page)), pageCount)
+  const start = (clampedPage - 1) * pageSize
+  return {
+    rows: rows.slice(start, start + pageSize),
+    totalCount,
+    page: clampedPage,
+    pageSize,
+    pageCount,
+  }
+}
+
+/**
+ * Compose filter → sort → paginate over an in-memory AuditEntry list.
+ * Useful for unit tests; the page calls listAuditEntries below.
+ */
+export function buildAuditListPage(
+  rows: readonly AuditEntry[],
+  params: AuditListParams
+): AuditListPage {
+  const filtered = applyAuditFilters(rows, params)
+  const sorted = applyAuditSort(filtered, params.sort)
+  return paginateAuditEntries(sorted, params.page, params.pageSize)
+}
+
+/**
+ * Format an ISO timestamp as a compact human-readable string for the
+ * audit table's `ts` cell. Returns the input verbatim when it cannot be
+ * parsed — never fabricates a "just now" or "unknown" label for a
+ * malformed value (the writer is the authority on this field; surfacing
+ * the raw value lets reviewers see exactly what the system recorded).
+ *
+ * Pure function: takes the timestamp string, not a Date, so rendered
+ * HTML is deterministic for snapshot tests. Uses Intl.DateTimeFormat in
+ * UTC so output does not depend on the rendering machine's locale.
+ */
+export function formatAuditTimestamp(ts: string): string {
+  const parsedMs = Date.parse(ts)
+  if (!Number.isFinite(parsedMs)) return ts
+  const dt = new Date(parsedMs)
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  })
+  return fmt.format(dt)
+}
+
+/**
+ * Human label for an AuditDecision value. Closed vocabulary; unknown
+ * values fall through to the raw value rather than fabricating a
+ * friendly label.
+ */
+export function formatAuditDecision(decision: AuditDecision | null): string {
+  if (decision === null) return ''
+  switch (decision) {
+    case 'allow':
+      return 'Allowed'
+    case 'draft_for_review':
+      return 'Drafted for review'
+    case 'refuse':
+      return 'Refused'
+  }
+}
+
+/**
+ * Human label for an audit action_type. Splits the SCREAMING_SNAKE
+ * vocabulary into Title-cased words so the table reads as English
+ * without a giant switch statement. Unknown values render verbatim.
+ */
+export function formatAuditAction(action: string): string {
+  if (!action) return ''
+  return action
+    .split('_')
+    .map((word) =>
+      word.length === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )
+    .join(' ')
+}
+
+/**
+ * Tone for the decision chip in the row. `refuse` is danger (the action
+ * was blocked), `draft_for_review` is the neutral default (reviewer
+ * gate is the standard posture), `allow` is the neutral success tone
+ * because allowed actions are the unremarkable bulk of the log.
+ *
+ * The return values are the `Tone` vocabulary from
+ * `src/lib/portal/status.ts` — kept as a string here to avoid a hard
+ * import dependency at the resolver layer.
+ */
+export function decisionTone(decision: AuditDecision | null): 'danger' | 'neutral' | 'success' {
+  switch (decision) {
+    case 'refuse':
+      return 'danger'
+    case 'allow':
+      return 'success'
+    case 'draft_for_review':
+    case null:
+      return 'neutral'
+  }
+}
+
+/**
+ * Collect the distinct skills present in an audit list, sorted
+ * alphabetically and excluding null. Used by the page to populate the
+ * skill multi-select in the filter bar from whatever rows the current
+ * page returned.
+ */
+export function distinctAuditSkills(rows: readonly AuditEntry[]): string[] {
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (row.skill !== null && row.skill.length > 0) {
+      seen.add(row.skill)
+    }
+  }
+  return Array.from(seen).sort()
+}
+
+/**
+ * Collect the distinct action classes present in an audit list. Used by
+ * the page to populate the action multi-select. The full vocabulary
+ * lives in AUDIT_ACTION_TYPES; this helper narrows to "what's actually
+ * shown on the current page" so reviewers don't see options that would
+ * filter the page to zero. Sorted alphabetically.
+ */
+export function distinctAuditActions(rows: readonly AuditEntry[]): string[] {
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (row.action.length > 0) {
+      seen.add(row.action)
+    }
+  }
+  return Array.from(seen).sort()
+}
+
+/**
+ * Server-side resolver invoked by the audit list page. Today this
+ * returns an empty list with the correct shape — the per-customer
+ * Hermes bridge that feeds real audit rows is tracked in #821. When the
+ * bridge lands, swap `fetchAuditEntriesFromHermes` for the bridge call
+ * and leave the rest of the page machinery in place.
+ *
+ * IMPORTANT: do not seed mock rows here. The empty-state pattern is the
+ * design contract (docs/style/empty-state-pattern.md) — the page must
+ * render its empty state until real data lands, never fabricated
+ * placeholders.
+ */
+export async function listAuditEntries(
+  _subscription: SubscriptionRow,
+  params: AuditListParams
+): Promise<AuditListPage> {
+  const rows = await fetchAuditEntriesFromHermes(_subscription)
+  return buildAuditListPage(rows, params)
+}
+
+/**
+ * Hermes bridge stub. Returns an empty list. When #821 (Hermes runtime
+ * wiring) lands, replace the body with the bridge fetch — the
+ * subscription row carries the customer identity needed to route to the
+ * right Machine D1. Promise.resolve keeps the call shape async so the
+ * future swap is body-only.
+ */
+function fetchAuditEntriesFromHermes(_subscription: SubscriptionRow): Promise<AuditEntry[]> {
+  return Promise.resolve([])
+}

--- a/src/pages/portal/products/ai-employee/audit/index.astro
+++ b/src/pages/portal/products/ai-employee/audit/index.astro
@@ -1,11 +1,22 @@
 ---
 import '../../../../../styles/global.css'
 import { BRAND_NAME } from '../../../../../lib/config/brand'
-import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import {
+  resolveAiEmployeeAccess,
+  AI_EMPLOYEE_LANDING_PATH,
+} from '../../../../../lib/portal/ai-employee-access'
+import {
+  defaultAuditDateRange,
+  distinctAuditSkills,
+  listAuditEntries,
+  parseAuditListParams,
+} from '../../../../../lib/portal/ai-employee/audit'
 import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
 import SkipToMain from '../../../../../components/SkipToMain.astro'
+import AuditFilterBar from '../../../../../components/portal/ai-employee/AuditFilterBar.astro'
+import AuditLogTable from '../../../../../components/portal/ai-employee/AuditLogTable.astro'
 import { SignOutButton } from '@clerk/astro/components'
 import { env } from 'cloudflare:workers'
 
@@ -14,39 +25,96 @@ import { env } from 'cloudflare:workers'
  *
  * URL: portal.smd.services/portal/products/ai-employee/audit
  *
- * Per #873 and #895, every action the AI Employee takes — drafts
- * created, sends approved, identity attributions, trust-ceiling
- * decisions, memory access — emits an audit event. This surface is the
- * read-only viewer over those events. Persistence and writer modules
- * land separately (#891, #842, #864).
+ * Per #873 and PRD §13, every safety-relevant action the AI Employee
+ * takes emits an audit event. This surface is the read-only viewer
+ * over those events. The audit writer landed in PR #942
+ * (`ai-employee/adapter/audit_log.py`).
  *
- * Audit events live on the per-customer Hermes Machine D1 (ADR 0007 +
- * 0009). The portal Worker cannot bind directly to a per-customer D1;
- * the read path is pending Hermes runtime wiring (#821) and the
- * compliance evidence pipeline (#892, #894).
+ * Data source: per-customer Hermes Machine D1 (ADR 0007 + 0009). The
+ * portal Worker cannot bind directly to a per-customer D1; the read
+ * path is pending Hermes runtime wiring (#821). Until that bridge
+ * ships, `listAuditEntries` returns an empty typed list and the page
+ * renders the empty-state block per docs/style/empty-state-pattern.md
+ * — no fabricated events, no synthetic trace, no "coming soon" copy.
  *
- * Until the read path lands, this surface renders the empty state per
- * docs/style/empty-state-pattern.md — no fabricated events, no synthetic
- * trace, no "coming soon" copy.
+ * Filter / sort / pagination machinery is wired today so the URL
+ * contract is stable when the bridge lands.
  *
  * Access gate (see resolveAiEmployeeAccess):
  *   - Clerk session (middleware)
  *   - Local entity bound to the active Clerk organization
  *   - Active AI Employee subscription on this customer
- *   - Caller holds principal OR operator OR compliance role
+ *   - Caller holds principal OR compliance role
  *
- * Compliance is the dedicated viewer for this surface (#895), but
- * audit transparency is for the whole team — operators see what they
- * acted on, principals see firm-wide activity.
+ * Note: operators are NOT granted access. Audit transparency for the
+ * operator's own actions is delivered through the drafts queue
+ * (their direct surface). The audit viewer is org-wide and sensitive
+ * — restricted to principal and compliance per the issue contract.
+ *
+ * Per-matter drill-down: a `?matter=<id>` query string filters the
+ * table to rows whose `matterRef` matches that id. The empty-state
+ * messaging acknowledges the active filter so the reviewer knows the
+ * page is honestly empty under the filter rather than empty overall.
+ *
+ * Default date range: when neither `from` nor `to` is set, the page
+ * resolves a "last N days" window (DEFAULT_AUDIT_RANGE_DAYS = 7) so
+ * the page is fast even for customers with months of history. The
+ * window appears in the form's date inputs so reviewers see exactly
+ * what is being filtered.
+ *
+ * Evidence packet export is a follow-on (#878 in the audit/compliance
+ * issue cluster); this PR ships the viewer only.
  */
 
 const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
-  allowedRoles: ['principal', 'operator', 'compliance'],
+  allowedRoles: ['principal', 'compliance'],
 })
 if (access.kind === 'redirect') {
   return Astro.redirect(access.to)
 }
-const { client } = access
+const { client, subscription, roles } = access
+
+// Belt-and-braces role check per the issue's explicit requirement: the
+// audit log is sensitive and the surface must verify the resolved role
+// is principal OR compliance even though resolveAiEmployeeAccess
+// already enforces this via allowedRoles. The failure mode (operator
+// or a future role accidentally seeing org-wide audit) is bad enough
+// that the redundant assertion is worth keeping.
+const hasAuditRole = roles.includes('principal') || roles.includes('compliance')
+if (!hasAuditRole) {
+  return Astro.redirect(AI_EMPLOYEE_LANDING_PATH)
+}
+
+const params = parseAuditListParams(Astro.url.searchParams)
+
+// Apply the default "last 7 days" window when no explicit range was
+// requested. The form re-hydrates from the resolved range so reviewers
+// see the window the page actually filtered on.
+const resolvedParams = (() => {
+  if (params.from === null && params.to === null) {
+    const range = defaultAuditDateRange()
+    return { ...params, from: range.from, to: range.to }
+  }
+  return params
+})()
+
+const auditPage = await listAuditEntries(subscription, resolvedParams)
+
+// availableSkills is derived from the current page of audit rows; the
+// Hermes bridge will replace this with a customer-wide summary when
+// #821 lands. Empty list today is honest — there are no skills to
+// surface until rows arrive.
+const availableSkills = distinctAuditSkills(auditPage.rows)
+
+// Empty-state copy varies based on whether a matter filter is active.
+// The base copy is the same shape as the drafts page; the matter
+// variant acknowledges the filter so the reviewer doesn't think the
+// log is empty overall.
+const matterFilter = resolvedParams.matter
+const emptyHeading = matterFilter ? 'No audit events for this matter' : 'No audit events yet'
+const emptyBody = matterFilter
+  ? 'No actions in the selected window have this matter reference. Clear the matter filter to see firm-wide audit activity.'
+  : 'Every action your AI Employee takes is recorded here: drafts created, sends approved, identity changes, memory access.'
 ---
 
 <!doctype html>
@@ -87,26 +155,46 @@ const { client } = access
         crumbLabel="AI Employee"
         tag="Section"
         h1="Audit"
-        meta={null}
+        meta={auditPage.totalCount > 0 ? `${auditPage.totalCount} total` : null}
       />
 
-      <section class="mt-10">
-        <div
-          class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
-        >
-          <p
-            class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
-          >
-            No audit events yet
-          </p>
-          <p
-            class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]"
-          >
-            Every action your AI Employee takes is recorded here: drafts created, sends approved,
-            identity changes, memory access.
-          </p>
-        </div>
-      </section>
+      <div class="mt-8 flex flex-col gap-6">
+        <AuditFilterBar
+          skills={resolvedParams.skills}
+          actions={resolvedParams.actions}
+          from={resolvedParams.from}
+          to={resolvedParams.to}
+          matter={resolvedParams.matter}
+          q={resolvedParams.q}
+          sort={resolvedParams.sort}
+          availableSkills={availableSkills}
+        />
+
+        {
+          auditPage.totalCount === 0 ? (
+            <section
+              aria-label="No audit events"
+              class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center"
+            >
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                {emptyHeading}
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                {emptyBody}
+              </p>
+            </section>
+          ) : (
+            <AuditLogTable
+              rows={auditPage.rows}
+              totalCount={auditPage.totalCount}
+              page={auditPage.page}
+              pageSize={auditPage.pageSize}
+              pageCount={auditPage.pageCount}
+              searchParams={Astro.url.searchParams}
+            />
+          )
+        }
+      </div>
     </main>
   </body>
 </html>

--- a/tests/portal-ai-employee-audit.test.ts
+++ b/tests/portal-ai-employee-audit.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for the AI Employee audit log resolver
+ * (src/lib/portal/ai-employee/audit.ts).
+ *
+ * The page surface composes parseAuditListParams →
+ * applyAuditFilters → applyAuditSort → paginateAuditEntries. Each
+ * piece is independently exercised here so the URL contract
+ * (filter / sort / pagination) is regression-protected against drift
+ * before the Hermes bridge (#821) lands and starts shipping real rows.
+ *
+ * The page-rendering resolver `listAuditEntries` returns an empty list
+ * today (no bridge). That contract is also tested here — we want the
+ * build to fail loudly if a future change starts seeding mock rows
+ * from this module, since that would be a Pattern A/B fabrication
+ * violation per CLAUDE.md.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  AUDIT_ACTION_TYPES,
+  AUDIT_DECISIONS,
+  AUDIT_SORTS,
+  DEFAULT_AUDIT_PAGE_SIZE,
+  DEFAULT_AUDIT_RANGE_DAYS,
+  MAX_AUDIT_PAGE_SIZE,
+  applyAuditFilters,
+  applyAuditSort,
+  buildAuditListPage,
+  decisionTone,
+  defaultAuditDateRange,
+  distinctAuditActions,
+  distinctAuditSkills,
+  formatAuditAction,
+  formatAuditDecision,
+  formatAuditTimestamp,
+  listAuditEntries,
+  paginateAuditEntries,
+  parseAuditListParams,
+  type AuditEntry,
+  type AuditListParams,
+} from '../src/lib/portal/ai-employee/audit'
+import type { SubscriptionRow } from '../src/lib/portal/product-access'
+
+function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    id: '01HX5N3K2A',
+    ts: '2026-05-20T10:00:00.000Z',
+    actor: 'person-1',
+    actorRole: 'operator',
+    action: 'DRAFT_CREATED',
+    target: 'draft-9',
+    decision: 'draft_for_review',
+    reason: 'Routine intake follow-up.',
+    skill: 'client-intake',
+    matterRef: 'matter-1',
+    ...overrides,
+  }
+}
+
+const baseParams: AuditListParams = {
+  skills: [],
+  actions: [],
+  from: null,
+  to: null,
+  matter: null,
+  q: null,
+  sort: 'ts_desc',
+  page: 1,
+  pageSize: DEFAULT_AUDIT_PAGE_SIZE,
+}
+
+describe('AUDIT_ACTION_TYPES vocabulary', () => {
+  it('contains the writer-side core action classes', () => {
+    // Sanity check against the audit_log.py constant. If new action
+    // types ship on the writer side, this list must update in lockstep
+    // (see ACCEPTED_ACTION_TYPES in ai-employee/adapter/audit_log.py).
+    expect(AUDIT_ACTION_TYPES).toContain('DRAFT_CREATED')
+    expect(AUDIT_ACTION_TYPES).toContain('DRAFT_APPROVED')
+    expect(AUDIT_ACTION_TYPES).toContain('TRUST_PROMOTED')
+    expect(AUDIT_ACTION_TYPES).toContain('INVARIANT_VIOLATION')
+    expect(AUDIT_ACTION_TYPES).toContain('FABRICATION_FILTER_TRIGGERED')
+  })
+
+  it('has no duplicate entries', () => {
+    const set = new Set(AUDIT_ACTION_TYPES)
+    expect(set.size).toBe(AUDIT_ACTION_TYPES.length)
+  })
+})
+
+describe('parseAuditListParams', () => {
+  it('returns defaults for an empty query string', () => {
+    const params = parseAuditListParams(new URLSearchParams())
+    expect(params).toEqual(baseParams)
+  })
+
+  it('parses repeated skill params and comma-separated skill values', () => {
+    const params = parseAuditListParams(
+      new URLSearchParams('skill=intake&skill=deadline,reminder&skill=intake')
+    )
+    expect(params.skills.slice().sort()).toEqual(['deadline', 'intake', 'reminder'])
+  })
+
+  it('drops action values outside the closed vocabulary', () => {
+    const params = parseAuditListParams(
+      new URLSearchParams('action=DRAFT_CREATED&action=NOT_A_REAL_ACTION,DRAFT_APPROVED')
+    )
+    expect(params.actions.slice().sort()).toEqual(['DRAFT_APPROVED', 'DRAFT_CREATED'])
+  })
+
+  it('accepts every value in AUDIT_ACTION_TYPES via the action filter', () => {
+    // Defensive: if any vocabulary entry would silently get dropped by
+    // the parser, this test catches it before users hit it.
+    for (const action of AUDIT_ACTION_TYPES) {
+      const params = parseAuditListParams(new URLSearchParams(`action=${action}`))
+      expect(params.actions).toEqual([action])
+    }
+  })
+
+  it('normalizes from/to into ISO-parseable strings, dropping invalid', () => {
+    expect(parseAuditListParams(new URLSearchParams('from=2026-05-01')).from).toBe('2026-05-01')
+    expect(parseAuditListParams(new URLSearchParams('from=2026-05-01T00:00:00Z')).from).toBe(
+      '2026-05-01T00:00:00Z'
+    )
+    expect(parseAuditListParams(new URLSearchParams('from=not-a-date')).from).toBeNull()
+    expect(parseAuditListParams(new URLSearchParams('from=')).from).toBeNull()
+  })
+
+  it('lowercases matter and q', () => {
+    expect(parseAuditListParams(new URLSearchParams('matter=Matter-9')).matter).toBe('matter-9')
+    expect(parseAuditListParams(new URLSearchParams('q=Foo')).q).toBe('foo')
+  })
+
+  it('treats empty matter and q as no filter', () => {
+    expect(parseAuditListParams(new URLSearchParams('matter=')).matter).toBeNull()
+    expect(parseAuditListParams(new URLSearchParams('q=   ')).q).toBeNull()
+  })
+
+  it('falls back to ts_desc on unknown sort values', () => {
+    expect(parseAuditListParams(new URLSearchParams('sort=random')).sort).toBe('ts_desc')
+  })
+
+  it('clamps page to 1 when below 1', () => {
+    expect(parseAuditListParams(new URLSearchParams('page=0')).page).toBe(1)
+    expect(parseAuditListParams(new URLSearchParams('page=-2')).page).toBe(1)
+  })
+
+  it('caps pageSize at MAX_AUDIT_PAGE_SIZE', () => {
+    expect(parseAuditListParams(new URLSearchParams('pageSize=10000')).pageSize).toBe(
+      MAX_AUDIT_PAGE_SIZE
+    )
+  })
+
+  it('uses DEFAULT_AUDIT_PAGE_SIZE for invalid pageSize values', () => {
+    expect(parseAuditListParams(new URLSearchParams('pageSize=abc')).pageSize).toBe(
+      DEFAULT_AUDIT_PAGE_SIZE
+    )
+    expect(parseAuditListParams(new URLSearchParams('pageSize=0')).pageSize).toBe(
+      DEFAULT_AUDIT_PAGE_SIZE
+    )
+  })
+})
+
+describe('defaultAuditDateRange', () => {
+  it('returns a window N days wide ending at nowMs', () => {
+    const now = Date.UTC(2026, 4, 21, 12, 0, 0)
+    const range = defaultAuditDateRange(7, now)
+    expect(range.to).toBe(new Date(now).toISOString())
+    expect(range.from).toBe(new Date(now - 7 * 86400_000).toISOString())
+  })
+
+  it('defaults to DEFAULT_AUDIT_RANGE_DAYS when not specified', () => {
+    const now = Date.UTC(2026, 4, 21, 12, 0, 0)
+    const range = defaultAuditDateRange(undefined, now)
+    expect(Date.parse(range.to) - Date.parse(range.from)).toBe(DEFAULT_AUDIT_RANGE_DAYS * 86400_000)
+  })
+})
+
+describe('applyAuditFilters', () => {
+  const rows: AuditEntry[] = [
+    makeEntry({
+      id: 'a',
+      ts: '2026-05-20T10:00:00.000Z',
+      skill: 'intake',
+      action: 'DRAFT_CREATED',
+      target: 'draft-1',
+      matterRef: 'matter-1',
+      reason: 'Routine intake follow up.',
+      actor: 'pat',
+    }),
+    makeEntry({
+      id: 'b',
+      ts: '2026-05-19T10:00:00.000Z',
+      skill: 'deadline',
+      action: 'DRAFT_APPROVED',
+      target: 'draft-2',
+      matterRef: 'matter-2',
+      reason: 'Approved by reviewer.',
+      actor: 'jordan',
+    }),
+    makeEntry({
+      id: 'c',
+      ts: '2026-05-10T10:00:00.000Z',
+      skill: 'intake',
+      action: 'TRUST_PROMOTED',
+      target: null,
+      matterRef: 'matter-1',
+      reason: null,
+      actor: 'agent',
+    }),
+  ]
+
+  it('returns all rows when no filters are set', () => {
+    expect(applyAuditFilters(rows, baseParams)).toHaveLength(3)
+  })
+
+  it('filters by single skill', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, skills: ['intake'] })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'c'])
+  })
+
+  it('filters by multiple actions (union)', () => {
+    const result = applyAuditFilters(rows, {
+      ...baseParams,
+      actions: ['DRAFT_CREATED', 'TRUST_PROMOTED'],
+    })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'c'])
+  })
+
+  it('filters by from (inclusive lower bound)', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, from: '2026-05-19T00:00:00Z' })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('filters by to (inclusive upper bound)', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, to: '2026-05-19T23:59:59Z' })
+    expect(result.map((r) => r.id).sort()).toEqual(['b', 'c'])
+  })
+
+  it('filters by matter ref (exact, case-insensitive)', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, matter: 'matter-1' })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'c'])
+  })
+
+  it('matter filter is exact match, not substring', () => {
+    // matter-1 should NOT match matter-10 or any other partial; this
+    // mirrors the resolver semantic so a drill-down from a matter detail
+    // page lands on exactly that matter's rows.
+    const extras: AuditEntry[] = [...rows, makeEntry({ id: 'd', matterRef: 'matter-10' })]
+    const result = applyAuditFilters(extras, { ...baseParams, matter: 'matter-1' })
+    expect(result.map((r) => r.id).sort()).toEqual(['a', 'c'])
+  })
+
+  it('q matches against reason (case-insensitive)', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, q: 'approved' })
+    expect(result.map((r) => r.id)).toEqual(['b'])
+  })
+
+  it('q matches against actor', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, q: 'jordan' })
+    expect(result.map((r) => r.id)).toEqual(['b'])
+  })
+
+  it('q matches against target', () => {
+    const result = applyAuditFilters(rows, { ...baseParams, q: 'draft-1' })
+    expect(result.map((r) => r.id)).toEqual(['a'])
+  })
+
+  it('q on rows with null reason still matches actor / target', () => {
+    // Row c has reason=null; q='agent' should still match via actor.
+    const result = applyAuditFilters(rows, { ...baseParams, q: 'agent' })
+    expect(result.map((r) => r.id)).toEqual(['c'])
+  })
+
+  it('combines all filters', () => {
+    const result = applyAuditFilters(rows, {
+      ...baseParams,
+      skills: ['intake'],
+      actions: ['DRAFT_CREATED'],
+      from: '2026-05-19T00:00:00Z',
+      matter: 'matter-1',
+    })
+    expect(result.map((r) => r.id)).toEqual(['a'])
+  })
+})
+
+describe('applyAuditSort', () => {
+  const rows: AuditEntry[] = [
+    makeEntry({ id: 'oldest', ts: '2026-05-01T10:00:00.000Z' }),
+    makeEntry({ id: 'newest', ts: '2026-05-21T10:00:00.000Z' }),
+    makeEntry({ id: 'middle', ts: '2026-05-10T10:00:00.000Z' }),
+  ]
+
+  it('ts_desc puts newest first', () => {
+    const result = applyAuditSort(rows, 'ts_desc')
+    expect(result.map((r) => r.id)).toEqual(['newest', 'middle', 'oldest'])
+  })
+
+  it('ts_asc puts oldest first', () => {
+    const result = applyAuditSort(rows, 'ts_asc')
+    expect(result.map((r) => r.id)).toEqual(['oldest', 'middle', 'newest'])
+  })
+
+  it('covers every member of AUDIT_SORTS', () => {
+    // Defensive: if the AUDIT_SORTS vocabulary grows, this test fails
+    // until applyAuditSort gets a matching case branch (the switch is
+    // exhaustive in TS; this catches the runtime side).
+    for (const sort of AUDIT_SORTS) {
+      expect(() => applyAuditSort(rows, sort)).not.toThrow()
+    }
+  })
+})
+
+describe('paginateAuditEntries', () => {
+  const rows: AuditEntry[] = Array.from({ length: 250 }, (_, i) =>
+    makeEntry({ id: `e-${i}`, ts: new Date(Date.UTC(2026, 4, 1) + i * 60_000).toISOString() })
+  )
+
+  it('returns one page when totalCount <= pageSize', () => {
+    const page = paginateAuditEntries(rows.slice(0, 10), 1, 100)
+    expect(page.rows).toHaveLength(10)
+    expect(page.pageCount).toBe(1)
+  })
+
+  it('paginates correctly across multiple pages', () => {
+    const page1 = paginateAuditEntries(rows, 1, 100)
+    expect(page1.rows).toHaveLength(100)
+    expect(page1.rows[0].id).toBe('e-0')
+    expect(page1.pageCount).toBe(3)
+
+    const page2 = paginateAuditEntries(rows, 2, 100)
+    expect(page2.rows[0].id).toBe('e-100')
+
+    const page3 = paginateAuditEntries(rows, 3, 100)
+    expect(page3.rows).toHaveLength(50)
+    expect(page3.rows[49].id).toBe('e-249')
+  })
+
+  it('clamps out-of-range page to last page', () => {
+    const page = paginateAuditEntries(rows, 999, 100)
+    expect(page.page).toBe(3)
+    expect(page.rows[0].id).toBe('e-200')
+  })
+
+  it('clamps below-range page to page 1', () => {
+    const page = paginateAuditEntries(rows, -5, 100)
+    expect(page.page).toBe(1)
+  })
+
+  it('returns pageCount=1 for empty input', () => {
+    const page = paginateAuditEntries([], 1, 100)
+    expect(page.rows).toEqual([])
+    expect(page.totalCount).toBe(0)
+    expect(page.pageCount).toBe(1)
+  })
+})
+
+describe('buildAuditListPage', () => {
+  it('composes filter → sort → paginate (default page size 100)', () => {
+    const rows: AuditEntry[] = [
+      makeEntry({ id: 'a', skill: 'intake', ts: '2026-05-20T10:00:00.000Z' }),
+      makeEntry({ id: 'b', skill: 'intake', ts: '2026-05-19T10:00:00.000Z' }),
+      makeEntry({ id: 'c', skill: 'deadline', ts: '2026-05-18T10:00:00.000Z' }),
+    ]
+
+    const page = buildAuditListPage(rows, {
+      ...baseParams,
+      skills: ['intake'],
+      sort: 'ts_desc',
+    })
+
+    expect(page.rows.map((r) => r.id)).toEqual(['a', 'b'])
+    expect(page.totalCount).toBe(2)
+    expect(page.pageSize).toBe(DEFAULT_AUDIT_PAGE_SIZE)
+  })
+})
+
+describe('formatAuditTimestamp', () => {
+  it('renders a parsable ISO timestamp in UTC', () => {
+    const out = formatAuditTimestamp('2026-05-20T10:30:45.000Z')
+    // We don't assert exact locale spacing (Intl output drifts across
+    // Node releases), but the year, month, and the UTC marker should
+    // all be present.
+    expect(out).toContain('2026')
+    expect(out).toContain('May')
+    expect(out).toMatch(/UTC|Z/)
+  })
+
+  it('returns the raw value when the timestamp cannot be parsed', () => {
+    // Never fabricate a "just now" or "unknown" for malformed input —
+    // the raw value lets reviewers see what the system actually recorded.
+    expect(formatAuditTimestamp('not-a-date')).toBe('not-a-date')
+    expect(formatAuditTimestamp('')).toBe('')
+  })
+})
+
+describe('formatAuditAction', () => {
+  it('title-cases SCREAMING_SNAKE values', () => {
+    expect(formatAuditAction('DRAFT_CREATED')).toBe('Draft Created')
+    expect(formatAuditAction('CONNECTOR_AUTH_RESTORED')).toBe('Connector Auth Restored')
+    expect(formatAuditAction('FABRICATION_FILTER_TRIGGERED')).toBe('Fabrication Filter Triggered')
+  })
+
+  it('returns the empty string for empty input', () => {
+    expect(formatAuditAction('')).toBe('')
+  })
+})
+
+describe('formatAuditDecision / decisionTone', () => {
+  it('maps every decision value to a friendly label', () => {
+    expect(formatAuditDecision('allow')).toBe('Allowed')
+    expect(formatAuditDecision('draft_for_review')).toBe('Drafted for review')
+    expect(formatAuditDecision('refuse')).toBe('Refused')
+  })
+
+  it('returns the empty string for null', () => {
+    expect(formatAuditDecision(null)).toBe('')
+  })
+
+  it('covers every member of AUDIT_DECISIONS', () => {
+    for (const decision of AUDIT_DECISIONS) {
+      expect(formatAuditDecision(decision)).not.toBe('')
+    }
+  })
+
+  it('decisionTone returns the expected tone per decision', () => {
+    expect(decisionTone('refuse')).toBe('danger')
+    expect(decisionTone('allow')).toBe('success')
+    expect(decisionTone('draft_for_review')).toBe('neutral')
+    expect(decisionTone(null)).toBe('neutral')
+  })
+})
+
+describe('distinctAuditSkills / distinctAuditActions', () => {
+  it('returns empty array for empty input', () => {
+    expect(distinctAuditSkills([])).toEqual([])
+    expect(distinctAuditActions([])).toEqual([])
+  })
+
+  it('returns unique skills sorted alphabetically, dropping null', () => {
+    const rows: AuditEntry[] = [
+      makeEntry({ id: 'a', skill: 'deadline' }),
+      makeEntry({ id: 'b', skill: 'intake' }),
+      makeEntry({ id: 'c', skill: null }),
+      makeEntry({ id: 'd', skill: 'deadline' }),
+    ]
+    expect(distinctAuditSkills(rows)).toEqual(['deadline', 'intake'])
+  })
+
+  it('returns unique actions sorted alphabetically', () => {
+    const rows: AuditEntry[] = [
+      makeEntry({ id: 'a', action: 'DRAFT_CREATED' }),
+      makeEntry({ id: 'b', action: 'TRUST_PROMOTED' }),
+      makeEntry({ id: 'c', action: 'DRAFT_CREATED' }),
+    ]
+    expect(distinctAuditActions(rows)).toEqual(['DRAFT_CREATED', 'TRUST_PROMOTED'])
+  })
+})
+
+describe('listAuditEntries', () => {
+  it('returns an empty page until the Hermes bridge wires in (#821)', async () => {
+    // No fabrication: the bridge stub returns []. If a future change
+    // adds mock rows in fetchAuditEntriesFromHermes this test fails
+    // loudly (CLAUDE.md Pattern A/B violation).
+    const stubSubscription: SubscriptionRow = {
+      id: 'sub-test',
+      org_id: 'org-test',
+      entity_id: 'ent-test',
+      product_slug: 'ai-employee',
+      status: 'active',
+      started_at: '2026-05-21T00:00:00Z',
+      ended_at: null,
+      settings_json: null,
+      created_at: '2026-05-21T00:00:00Z',
+      updated_at: '2026-05-21T00:00:00Z',
+    }
+    const page = await listAuditEntries(stubSubscription, baseParams)
+    expect(page.rows).toEqual([])
+    expect(page.totalCount).toBe(0)
+    expect(page.page).toBe(1)
+    expect(page.pageCount).toBe(1)
+    expect(page.pageSize).toBe(DEFAULT_AUDIT_PAGE_SIZE)
+  })
+})


### PR DESCRIPTION
## Summary

Thickens the AI Employee audit log scaffold from PR #932 into a working viewer at `portal.smd.services/portal/products/ai-employee/audit`. Adds the typed `AuditEntry` contract, URL-driven filter/sort/pagination resolver, and three new components (`AuditFilterBar`, `AuditLogTable`, `AuditEntryRow`). Surface is role-gated to principal and compliance only (operators do not get org-wide audit access). Renders empty state until the Hermes bridge (#821) wires real rows.

## Linked issue

Closes #873

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Page at `/ai-employee/audit` (role-gated to Compliance + Principal) | met | `src/pages/portal/products/ai-employee/audit/index.astro` (`allowedRoles: ['principal', 'compliance']` + explicit belt-and-braces role assertion) |
| Searchable table: timestamp, actor, action, target, decision, reason | met | `src/components/portal/ai-employee/AuditEntryRow.astro` renders all six cells; free-text `q` filter in `applyAuditFilters` matches reason+actor+target |
| Filter by skill, by date range, by action class | met | `parseAuditListParams` + `AuditFilterBar.astro`: multi-select skill (from current-page distinct values), `from`/`to` date inputs (default last 7 days), multi-select action class over the closed `AUDIT_ACTION_TYPES` vocabulary mirrored from `audit_log.py` |
| Per-matter cross-skill drill-down | met | `?matter=<id>` query string filters via `applyAuditFilters`; filter bar surfaces an active-matter chip with "Clear matter" affordance; empty state acknowledges the filter |
| Evidence packet export per matter / per period | deferred | Per issue text: "Evidence packet export per matter / per period (separate issue)" — viewer-only scope per the task brief; the export pipeline lives elsewhere in the audit/compliance cluster |

## Test plan

- [x] `npm run verify` passes (120 test files / 2281 tests, 0 errors)
- [x] 48 unit tests added covering vocabulary, params parsing, filter/sort/paginate, formatters, and the empty-resolver contract
- [ ] Manual verification deferred until Hermes bridge (#821) ships real rows; today the page renders the empty-state block honestly

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses (resolver returns typed empty list until bridge lands)
- [x] Input validation on new endpoints (`parseAuditListParams` defensive validation; closed-vocabulary checks drop unknown action values silently rather than throwing)
- [x] Parameterized queries for any SQL (no SQL in this PR; Hermes bridge owns the read query)
- [x] Auth required on new endpoints (`resolveAiEmployeeAccess` enforces Clerk session, entity binding, subscription, and role allowlist; audit page additionally re-checks resolved role)
- [x] No internal IDs that enable enumeration (audit row id is a ULID written by the writer; only the customer's own rows ever reach the page via the Hermes bridge scope)

## Feature Impact

**Feature impact:** None

## Deployment Notes

Standard deploy. No schema, env, or secret changes. Hermes-side D1 bridge work is tracked in #821 and lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)