### PR TITLE
feat(portal): trust-ceiling promotion recommendation card (#811)

### DIFF
--- a/docs/pm/ai-employee/platform-prd.md
+++ b/docs/pm/ai-employee/platform-prd.md
@@ -732,6 +732,8 @@ The customer can promote a `draft_for_review` skill to `autonomous` for skills w
 - Reversible at any time (demotion is one-click)
 - Subject to platform-level guardrails — some skills are non-promotable regardless of customer wishes (see §11.2)
 
+**Promotion is also actively recommended.** Promotion is a hidden Skills-tab action until the principal goes looking for it; without a prompt the §14.3 success metric ("≥2 skills promoted by day 60") slips. The Today tab surfaces a recommendation card for any skill that meets the promotion-ready criteria. See §12.1 for the criteria, card shape, and dismiss + re-surface contract.
+
 ### 11.4 Audit log
 
 Every action at every ceiling is logged. Every promotion/demotion is logged. The audit log is exportable (compliance evidence) and queryable in the dashboard (Activity tab and a dedicated Audit view).
@@ -752,12 +754,30 @@ The full dashboard vision is 16 tabs. **V1 ships 7 tabs**, sized to what a singl
 
 **V1 information views (4 tabs):**
 
-| View       | Primary user      | Content                                                                                                    |
-| ---------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Today**  | Principal         | Headline metrics (drafts pending review, items flagged, recent absorbed corrections), action queue summary |
-| **Queue**  | Operator          | All pending drafts, sortable by skill / age / priority / matter                                            |
-| **Memory** | Both              | What the agent knows (per §10) — read, edit, delete                                                        |
-| **Audit**  | Both + Compliance | Full audit log, exportable, queryable                                                                      |
+| View       | Primary user      | Content                                                                                                                                                         |
+| ---------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Today**  | Principal         | Headline metrics (drafts pending review, items flagged, recent absorbed corrections), action queue summary, trust-ceiling promotion recommendations (see below) |
+| **Queue**  | Operator          | All pending drafts, sortable by skill / age / priority / matter                                                                                                 |
+| **Memory** | Both              | What the agent knows (per §10) — read, edit, delete                                                                                                             |
+| **Audit**  | Both + Compliance | Full audit log, exportable, queryable                                                                                                                           |
+
+**Today tab — trust-ceiling promotion recommendation card.** When a skill has maintained a ≥90% approval rate over 4 consecutive weeks, the Today tab surfaces a "Promotion ready" recommendation card with one-click navigation to the Skills tab. Per §11.3 the actual promotion is a Skills-tab action; this card is the surface that initiates the conversation rather than waiting for the principal to go looking.
+
+Promotion-readiness criteria, evaluated per skill:
+
+- The skill currently sits at `draft_for_review`. Already-autonomous and `refused` skills are not candidates.
+- The skill is promotable per §11.2 — trust accounting, court filing, settlement authority, and other judgment-bearing skills are permanently `draft_for_review` and never surface as candidates regardless of approval rate.
+- Approval rate has been ≥90% in each of the 4 most recent rolling weeks. The threshold is per-week and not an average: a single weak week resets the streak. A week with zero reviewed drafts is not a passing week (silence does not qualify).
+- The card has not been dismissed within the cooldown window (7 days at v1). After the cooldown the card re-surfaces if the criteria still hold — a deferred decision is not a permanent veto.
+
+Card shape:
+
+- Title: "{skill name} ready for promotion?"
+- Body: the actual aggregated approval rate (draft-weighted across the 4-week window), the number of weeks the streak has held, and the total drafts reviewed in the window. Example shape: "92% approval over the last 4 weeks, across 47 drafts. Promote to autonomous?" Numbers are read from the resolver and never fabricated; when the stats bridge is not wired the card does not render at all (per docs/style/empty-state-pattern.md).
+- Actions: \[Review on Skills tab\] navigates to the Skills settings page focused on the candidate skill. \[Dismiss for now\] records the dismissal and suppresses the card for the cooldown.
+- Role gate: principal-only. Operator and compliance do not see the card — the trust-ceiling promotion is a firm-level decision per §11.3.
+
+When no skills qualify, the recommendation section does not render. No empty-state copy, no "all skills are appropriately configured" filler. The section's presence is itself the signal that an action is being recommended; its absence is meaningful by being unremarkable.
 
 **V1 configuration views (3 tabs):**
 

--- a/migrations/0040_promotion_card_dismissals.sql
+++ b/migrations/0040_promotion_card_dismissals.sql
@@ -1,0 +1,49 @@
+-- Trust-ceiling promotion-card dismissals (per #811)
+-- ============================================================================
+--
+-- Adds the `promotion_card_dismissals` table that records when a customer's
+-- principal dismisses a "Skill ready for promotion?" recommendation card on
+-- the AI Employee landing page (Today tab per platform-prd.md §12.1).
+--
+-- The card surfaces a skill once its 4-week approval-rate threshold has been
+-- met (per §11.3 Promotion mechanics). A principal who is not ready to
+-- promote can dismiss the card; the resolver hides it for a cooldown window
+-- (7 days). If the criteria continue to hold past the cooldown, the card
+-- re-surfaces — this is the "dismiss but re-surface" contract called for in
+-- issue #811 so a partner who deferred the conversation eventually sees it
+-- again rather than the recommendation falling on the floor forever.
+--
+-- Identity tuple: (entity_id, skill) is the natural key. A given customer
+-- (entity) has at most one active dismissal per skill at any time. A new
+-- dismissal upserts the row; the resolver compares dismissed_at against the
+-- cooldown window.
+--
+-- The actor (user who clicked dismiss) is recorded for audit but the
+-- cooldown is shared across all principals on the customer — dismissing for
+-- the firm dismisses for everyone, since the trust-ceiling decision is the
+-- firm's, not an individual reviewer's.
+--
+-- Forward-only, additive. No drops.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS promotion_card_dismissals (
+  entity_id     TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+
+  -- Skill name as it appears in customer.yaml's persona.skills[].name.
+  -- Free-form TEXT to track the canonical-config vocabulary without a
+  -- portal-side enum (the vocabulary lives in customer.yaml, not here).
+  skill         TEXT NOT NULL,
+
+  -- The user who dismissed the card. Recorded for audit; the resolver does
+  -- not key off this — the cooldown is per (entity, skill), not per user.
+  dismissed_by  TEXT NOT NULL REFERENCES users(id),
+
+  -- ISO 8601 UTC timestamp. The resolver compares this against the
+  -- cooldown window (7 days at v1) to decide whether to suppress the card.
+  dismissed_at  TEXT NOT NULL DEFAULT (datetime('now')),
+
+  PRIMARY KEY (entity_id, skill)
+);
+
+CREATE INDEX IF NOT EXISTS idx_promotion_card_dismissals_entity
+  ON promotion_card_dismissals(entity_id);

--- a/src/components/portal/ai-employee/PromotionCard.astro
+++ b/src/components/portal/ai-employee/PromotionCard.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * Trust-ceiling promotion recommendation card.
+ *
+ * Surfaces on the AI Employee landing page's Today area when a skill
+ * has met the §11.3 promotion criteria (4 consecutive weeks of ≥90%
+ * approval). Per #811 the card asks the principal whether they'd like
+ * to promote the skill to `autonomous`; the answer is one click to the
+ * Skills tab or one click to dismiss for the cooldown window.
+ *
+ * Renderer only. The card never decides whether it should show — that
+ * decision lives in `listPromotionReadySkills` and the landing page.
+ * If a parent renders this component, a real candidate exists and
+ * fabricated copy ("85% approval" placeholders) is not possible: the
+ * resolver populates the candidate from real bridge data, and the
+ * landing returns empty when no data exists.
+ *
+ * Two CTAs, two distinct intents:
+ *
+ *   [Review on Skills tab] — primary, takes the principal to the
+ *                             Skills settings page focused on this
+ *                             skill so they can see the trust-ceiling
+ *                             dropdown and the surrounding context
+ *                             before changing it.
+ *   [Dismiss for now]      — secondary, suppresses the card for the
+ *                             cooldown window. The card re-surfaces if
+ *                             the criteria still hold past the
+ *                             cooldown.
+ *
+ * Visual language matches DraftRow / NotificationRow conventions: 3px
+ * ink frame, Archivo-Narrow uppercase labels, Archivo Black title,
+ * file-style mono numerics for the percentage. The "Promotion ready"
+ * eyebrow uses the same eyebrow treatment as the section cards on the
+ * landing for visual rhyme.
+ */
+
+import {
+  formatApprovalRate,
+  type PromotionCandidate,
+} from '../../../lib/portal/ai-employee/promotion-cards'
+
+interface Props {
+  candidate: PromotionCandidate
+  /**
+   * URL the dismiss form returns to. Defaults to the AI Employee
+   * landing. Passed by the parent so the redirect lands the principal
+   * back on the page they dismissed from.
+   */
+  returnTo?: string
+}
+
+const { candidate, returnTo = '/portal/products/ai-employee' } = Astro.props
+
+const ratePercent = formatApprovalRate(candidate.approvalRate)
+---
+
+<article
+  class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+  data-promotion-skill={candidate.skillName}
+>
+  <div
+    class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold"
+  >
+    Promotion ready
+  </div>
+  <div class="px-5 md:px-7 py-6 flex flex-col gap-4">
+    <h3
+      class="font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)] m-0"
+    >
+      {candidate.skillName} ready for promotion?
+    </h3>
+    <p class="m-0 text-body text-[color:var(--ss-color-text-secondary)]">
+      <span class="font-mono text-[color:var(--ss-color-text-primary)]">{ratePercent}</span>
+      {' '}approval over the last{' '}
+      <span class="font-mono text-[color:var(--ss-color-text-primary)]">{candidate.weeks}</span>
+      {' '}weeks, across{' '}
+      <span class="font-mono text-[color:var(--ss-color-text-primary)]">
+        {candidate.totalDrafts}
+      </span>
+      {' '}{candidate.totalDrafts === 1 ? 'draft' : 'drafts'}. Promote to autonomous?
+    </p>
+    <div class="flex flex-wrap items-center gap-3">
+      <a
+        href={candidate.reviewUrl}
+        class="inline-flex items-center min-h-11 px-4 py-2 bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold hover:bg-[color:var(--ss-color-action)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+      >
+        Review on Skills tab
+      </a>
+      <form method="POST" action={candidate.dismissUrl} class="contents">
+        <input type="hidden" name="returnTo" value={returnTo} />
+        <button
+          type="submit"
+          class="inline-flex items-center min-h-11 px-4 py-2 border-[2px] border-[color:var(--ss-color-text-primary)] font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 transition-colors"
+        >
+          Dismiss for now
+        </button>
+      </form>
+    </div>
+  </div>
+</article>

--- a/src/components/portal/ai-employee/PromotionCardList.astro
+++ b/src/components/portal/ai-employee/PromotionCardList.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * List wrapper for promotion recommendation cards.
+ *
+ * The AI Employee landing may surface zero, one, or multiple
+ * recommendation cards depending on how many skills meet the §11.3
+ * promotion criteria at once. This wrapper renders a "Recommendations"
+ * section header above the cards and stacks them with consistent
+ * rhythm. When the candidate list is empty the wrapper renders
+ * nothing — there is no empty-state copy because the section's absence
+ * is the empty state (the principal would not miss a section they
+ * didn't expect to exist when nothing qualifies).
+ *
+ * Lives in a sibling file to PromotionCard so the section chrome can
+ * evolve (header copy, sort order, dismissal-of-all affordance)
+ * without touching the per-card renderer.
+ */
+
+import PromotionCard from './PromotionCard.astro'
+import type { PromotionCandidate } from '../../../lib/portal/ai-employee/promotion-cards'
+
+interface Props {
+  candidates: PromotionCandidate[]
+  /**
+   * URL each card's dismiss form returns to. Forwarded as-is to the
+   * child cards. Defaults to the AI Employee landing.
+   */
+  returnTo?: string
+}
+
+const { candidates, returnTo } = Astro.props
+---
+
+{
+  candidates.length > 0 && (
+    <section aria-labelledby="ai-employee-promotion-recommendations" class="flex flex-col gap-4">
+      <p
+        id="ai-employee-promotion-recommendations"
+        class="m-0 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Recommendations
+      </p>
+      <div class="flex flex-col gap-4">
+        {candidates.map((candidate) => (
+          <PromotionCard candidate={candidate} returnTo={returnTo} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/portal/ai-employee/promotion-cards.ts
+++ b/src/lib/portal/ai-employee/promotion-cards.ts
@@ -1,0 +1,372 @@
+/**
+ * Trust-ceiling promotion recommendation cards — typed contract + resolver.
+ *
+ * Per #811, when a `draft_for_review` skill has maintained a sustained high
+ * approval rate, the AI Employee landing page (Today tab per
+ * platform-prd.md §12.1) surfaces a recommendation card prompting the
+ * customer's principal to consider promoting it to `autonomous`. Without
+ * this surface, the §11.3 promotion is a hidden Skills-tab action and the
+ * §14.3 "≥2 skills promoted by day 60" success metric slips.
+ *
+ * The criteria are:
+ *
+ *   - The skill currently sits at `draft_for_review` (already-autonomous
+ *     and refused skills are not candidates).
+ *   - Approval rate has been ≥90% over each of the 4 most recent rolling
+ *     weeks (not just averaged across 4 weeks — every individual week
+ *     must clear the bar, so a single weak week resets the streak).
+ *   - The skill is promotable per §11.2 (trust-accounting / court-filing /
+ *     settlement-authority skills can never promote regardless of stats).
+ *   - The principal has not dismissed the card for this skill within the
+ *     last 7 days. After the cooldown the card re-surfaces if the criteria
+ *     still hold — a deferred decision is not a permanent veto.
+ *
+ * Data sources:
+ *
+ *   - The "currently sits at draft_for_review" check comes from
+ *     `customer.yaml` via the portal projection in `customer-config.ts`.
+ *     This is on the hot path and is the only signal we have today.
+ *   - Per-skill approval-rate stats (the four weekly rates that decide
+ *     whether the streak holds) live in the per-customer Hermes Machine's
+ *     audit_log + draft-review event stream. The portal Worker cannot bind
+ *     directly to a per-customer D1 — reads will go through the same
+ *     Hermes bridge that #821 wires up for notifications, drafts, matters,
+ *     audit, and calendar. Until that bridge ships, the stats fetcher
+ *     returns null and no card surfaces. This is the empty-state pattern
+ *     (docs/style/empty-state-pattern.md): the section simply does not
+ *     render until real data lands. No fake "85% approval" placeholders.
+ *   - Dismissals live in the portal D1 `promotion_card_dismissals` table
+ *     (migration 0040) — read here, written by the dismiss endpoint at
+ *     `src/pages/api/portal/ai-employee/promotion-cards/[skill]/dismiss.ts`.
+ *
+ * When the bridge lands, only `fetchSkillApprovalStatsFromHermes` changes.
+ * The eligibility logic, threshold constants, dismissal lookup, and
+ * candidate shape stay put.
+ */
+
+import { getCustomerConfig, type PersonaConfig } from '../customer-config'
+import { isTrustCeilingLevel } from './settings'
+
+/**
+ * Approval-rate threshold per week for promotion eligibility. Sourced
+ * verbatim from issue #811 ("≥90% approval rate over 4 consecutive
+ * weeks"). Captured as a named constant so the PRD section, the resolver,
+ * and the tests all reference the same number.
+ */
+export const PROMOTION_APPROVAL_RATE_THRESHOLD = 0.9
+
+/**
+ * Number of consecutive weeks the threshold must hold to qualify. Per
+ * #811 the contract is "4 consecutive weeks" — every individual week
+ * must clear the threshold, so a single weak week resets the streak.
+ */
+export const PROMOTION_REQUIRED_WEEKS = 4
+
+/**
+ * Cooldown window after a dismissal. The card re-surfaces past this
+ * window if the criteria still hold. Seven days is short enough that a
+ * principal who deferred the decision sees the prompt again within a
+ * normal review cadence, and long enough that they aren't badgered the
+ * day after dismissing.
+ */
+export const PROMOTION_DISMISSAL_COOLDOWN_DAYS = 7
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Skills that may never be promoted to `autonomous` regardless of stats.
+ * Per platform-prd.md §11.2, anything that touches trust accounting,
+ * court filing, settlement authority, or judgment-bearing work is
+ * permanently held at `draft_for_review`. The list lives here because
+ * this is where eligibility is computed; promoting a name into
+ * customer.yaml does not bypass the gate.
+ *
+ * The vocabulary mirrors the persona-skill names emitted by Hermes; new
+ * non-promotable skills must be added here as they ship.
+ */
+export const NON_PROMOTABLE_SKILLS: readonly string[] = [
+  'trust-accounting',
+  'court-filing',
+  'settlement-authority',
+  'judgment-bearing',
+] as const
+
+/**
+ * Weekly stats for a single skill, as the Hermes bridge will return them
+ * when #821 wires through. Each entry covers one rolling week; the array
+ * is ordered most-recent first (index 0 is the current week, index 3 is
+ * 3 weeks ago).
+ *
+ *   weekStart    — ISO 8601 UTC midnight on Monday of the week.
+ *   approvalRate — Fraction in [0, 1]. NaN/missing weeks are not valid;
+ *                  the bridge guarantees one row per week. A week with
+ *                  no draft activity is null (no signal — does not count
+ *                  as a pass OR a fail). The eligibility check treats
+ *                  null as "streak interrupted" so silence cannot
+ *                  qualify a skill for promotion.
+ *   draftCount   — Total reviewed drafts that week. Surfaced in the card
+ *                  body so the principal can see the volume behind the
+ *                  rate, not just the rate alone.
+ */
+export interface SkillApprovalWeek {
+  weekStart: string
+  approvalRate: number | null
+  draftCount: number
+}
+
+export interface SkillApprovalStats {
+  skillName: string
+  weeks: readonly SkillApprovalWeek[]
+}
+
+/**
+ * One promotion candidate returned by the resolver. Shape is what the
+ * PromotionCard component renders, plus the URL the card's primary CTA
+ * routes to.
+ *
+ *   skillName       — Persona-skill name. Renders in the card title and
+ *                     the dismiss POST URL.
+ *   approvalRate    — Approval rate across the qualifying window
+ *                     (PROMOTION_REQUIRED_WEEKS most-recent weeks),
+ *                     weighted by draft count. Fraction in [0, 1].
+ *                     Renders as a percentage in the card body.
+ *   weeks           — The number of consecutive weeks the threshold has
+ *                     held. Always ≥ PROMOTION_REQUIRED_WEEKS for a
+ *                     candidate (a candidate is only emitted when the
+ *                     streak qualifies).
+ *   totalDrafts     — Total drafts reviewed across the qualifying window.
+ *                     Surfaced so the principal can see "85% of 47
+ *                     drafts" rather than "85%" alone.
+ *   reviewUrl       — Where the [Review on Skills tab] CTA navigates.
+ *                     Resolved here so the card component stays
+ *                     presentational — the URL stays in the data model.
+ *   dismissUrl      — Where the [Dismiss for now] form POSTs. Same
+ *                     rationale: the card is a renderer, not a router.
+ */
+export interface PromotionCandidate {
+  skillName: string
+  approvalRate: number
+  weeks: number
+  totalDrafts: number
+  reviewUrl: string
+  dismissUrl: string
+}
+
+/**
+ * One dismissal row from `promotion_card_dismissals`. Internal shape;
+ * not exported because the resolver is the only consumer.
+ */
+interface DismissalRow {
+  skill: string
+  dismissed_at: string
+}
+
+/**
+ * Resolve which skills currently qualify for a promotion recommendation
+ * card on the given customer's AI Employee landing. Returns an empty
+ * array when:
+ *
+ *   - the customer has no projected customer.yaml config (no signal),
+ *   - no persona is currently active (nothing to evaluate),
+ *   - no skill currently sits at `draft_for_review` (nothing to promote),
+ *   - the Hermes stats bridge returns null (today's case — bridge not
+ *     wired, no fabrication),
+ *   - no skill meets the 4-week ≥90% threshold,
+ *   - every candidate has been dismissed within the cooldown window.
+ *
+ * Anything else returns one candidate per qualifying skill. The page
+ * gates the entire card section on this list being non-empty — no
+ * candidates means no section, no empty-state copy.
+ */
+export async function listPromotionReadySkills(
+  db: D1Database,
+  entityId: string,
+  nowMs: number = Date.now()
+): Promise<PromotionCandidate[]> {
+  const config = await getCustomerConfig(db, entityId)
+  if (!config) return []
+
+  const persona = config.personas.find((p) => p.status === 'active') ?? null
+  if (!persona) return []
+
+  const candidateSkills = listCandidateSkills(persona)
+  if (candidateSkills.length === 0) return []
+
+  const dismissals = await fetchActiveDismissals(db, entityId, nowMs)
+  const dismissedSet = new Set(dismissals.map((d) => d.skill))
+
+  const candidates: PromotionCandidate[] = []
+  for (const skillName of candidateSkills) {
+    if (dismissedSet.has(skillName)) continue
+
+    const stats = await fetchSkillApprovalStatsFromHermes(entityId, skillName)
+    if (!stats) continue
+
+    const evaluation = evaluatePromotionStreak(stats)
+    if (!evaluation) continue
+
+    candidates.push({
+      skillName,
+      approvalRate: evaluation.approvalRate,
+      weeks: evaluation.weeks,
+      totalDrafts: evaluation.totalDrafts,
+      reviewUrl: buildReviewUrl(skillName),
+      dismissUrl: buildDismissUrl(skillName),
+    })
+  }
+
+  return candidates
+}
+
+/**
+ * Project the persona's skill list into the names that are eligible to
+ * become candidates. A skill is eligible when it currently sits at
+ * `draft_for_review` AND is not in the non-promotable list.
+ *
+ * Exported for unit tests; the resolver is the only runtime caller.
+ */
+export function listCandidateSkills(persona: PersonaConfig): string[] {
+  const nonPromotable = new Set(NON_PROMOTABLE_SKILLS)
+  const out: string[] = []
+  for (const skill of persona.skills) {
+    if (nonPromotable.has(skill.name)) continue
+    if (!isTrustCeilingLevel(skill.trust_ceiling)) continue
+    if (skill.trust_ceiling !== 'draft_for_review') continue
+    out.push(skill.name)
+  }
+  return out
+}
+
+/**
+ * Evaluate a skill's weekly stats against the promotion criteria. Returns
+ * null when the criteria are not met; otherwise returns the aggregated
+ * stats the card displays.
+ *
+ * The evaluation walks the most-recent PROMOTION_REQUIRED_WEEKS entries.
+ * Every individual week must:
+ *
+ *   - have non-null approvalRate (silence does not qualify)
+ *   - meet PROMOTION_APPROVAL_RATE_THRESHOLD
+ *
+ * The aggregated approvalRate returned to the card is draft-weighted
+ * across the window — a week with 20 drafts at 100% weighs more than a
+ * week with 2 drafts at 100%. This avoids "100% of 0 drafts" math noise.
+ * When the total draft count across the window is zero, the candidate is
+ * disqualified (no volume = no signal).
+ *
+ * Exported for unit tests.
+ */
+export function evaluatePromotionStreak(
+  stats: SkillApprovalStats
+): { approvalRate: number; weeks: number; totalDrafts: number } | null {
+  const window = stats.weeks.slice(0, PROMOTION_REQUIRED_WEEKS)
+  if (window.length < PROMOTION_REQUIRED_WEEKS) return null
+
+  let totalApprovals = 0
+  let totalDrafts = 0
+  for (const week of window) {
+    if (week.approvalRate === null) return null
+    if (!Number.isFinite(week.approvalRate)) return null
+    if (week.approvalRate < PROMOTION_APPROVAL_RATE_THRESHOLD) return null
+    totalApprovals += week.approvalRate * week.draftCount
+    totalDrafts += week.draftCount
+  }
+
+  if (totalDrafts === 0) return null
+
+  return {
+    approvalRate: totalApprovals / totalDrafts,
+    weeks: window.length,
+    totalDrafts,
+  }
+}
+
+/**
+ * Format an approval rate fraction as a whole-percentage string. Floors
+ * to whole numbers — the issue body's example renders "85% approval",
+ * not "85.4% approval". Inputs outside [0, 1] clamp before formatting so
+ * a malformed bridge value cannot render as "127%". Returns an empty
+ * string for non-finite input rather than fabricating a number.
+ */
+export function formatApprovalRate(rate: number): string {
+  if (!Number.isFinite(rate)) return ''
+  const clamped = Math.max(0, Math.min(1, rate))
+  return `${Math.floor(clamped * 100)}%`
+}
+
+/**
+ * URL the [Review on Skills tab] CTA navigates to. Today the Skills
+ * settings page is shared across all skills — the skill name is passed
+ * as a query string so the page can scroll/focus on the right row when
+ * that affordance lands. The settings page itself does not yet honor
+ * the parameter; surfacing it now keeps the card's link contract stable
+ * across the eventual scroll-to-row change.
+ */
+export function buildReviewUrl(skillName: string): string {
+  return `/portal/products/ai-employee/settings?focus=${encodeURIComponent(skillName)}`
+}
+
+/**
+ * URL the [Dismiss for now] form POSTs to. Per-skill so the endpoint
+ * route is path-driven and the form payload stays empty.
+ */
+export function buildDismissUrl(skillName: string): string {
+  return `/api/portal/ai-employee/promotion-cards/${encodeURIComponent(skillName)}/dismiss`
+}
+
+/**
+ * Fetch the dismissal rows that are still inside the cooldown window
+ * for this entity. Rows past the cooldown are filtered out (they no
+ * longer suppress their card). The resolver uses this to drop
+ * still-suppressed candidates.
+ */
+async function fetchActiveDismissals(
+  db: D1Database,
+  entityId: string,
+  nowMs: number
+): Promise<DismissalRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT skill, dismissed_at FROM promotion_card_dismissals
+        WHERE entity_id = ?`
+    )
+    .bind(entityId)
+    .all<DismissalRow>()
+  const rows = result.results ?? []
+  return rows.filter((row) => !isDismissalExpired(row.dismissed_at, nowMs))
+}
+
+/**
+ * Check whether a dismissal timestamp has aged out of the cooldown
+ * window. Returns true when the dismissal is expired (the card may
+ * re-surface). A malformed timestamp is treated as expired — the
+ * resolver fails open rather than silently suppressing forever.
+ *
+ * Exported for unit tests.
+ */
+export function isDismissalExpired(dismissedAt: string, nowMs: number): boolean {
+  const parsed = Date.parse(dismissedAt)
+  if (!Number.isFinite(parsed)) return true
+  const ageMs = nowMs - parsed
+  return ageMs >= PROMOTION_DISMISSAL_COOLDOWN_DAYS * MS_PER_DAY
+}
+
+/**
+ * Hermes bridge stub for per-skill approval stats. Returns null today
+ * because the bridge that exposes per-customer audit-log aggregations
+ * is tracked under the same Hermes runtime wiring as #821. Returning
+ * null surfaces no card — the empty-state pattern. When the bridge
+ * lands, replace the body with the bridge fetch (the entityId carries
+ * the customer identity needed to route to the right Machine D1) and
+ * leave the rest of the resolver untouched.
+ *
+ * IMPORTANT: do not seed mock stats here. The card body interpolates
+ * the resolved approval rate; a fake "85% of 47 drafts" string is a
+ * Pattern B fabrication violation per CLAUDE.md.
+ */
+function fetchSkillApprovalStatsFromHermes(
+  _entityId: string,
+  _skillName: string
+): Promise<SkillApprovalStats | null> {
+  return Promise.resolve(null)
+}

--- a/src/pages/api/portal/ai-employee/promotion-cards/[skill]/dismiss.ts
+++ b/src/pages/api/portal/ai-employee/promotion-cards/[skill]/dismiss.ts
@@ -1,0 +1,115 @@
+import type { APIRoute } from 'astro'
+import { resolveAiEmployeeAccess } from '../../../../../../lib/portal/ai-employee-access'
+import { env } from 'cloudflare:workers'
+
+/**
+ * POST /api/portal/ai-employee/promotion-cards/[skill]/dismiss
+ *
+ * Dismiss the "Skill ready for promotion?" recommendation card for the
+ * given skill on the caller's AI Employee landing page. Driven by HTML
+ * <form method="POST"> submissions from `PromotionCard.astro`; no JSON
+ * / fetch client.
+ *
+ * Form fields:
+ *   returnTo: TEXT (optional) — server-validated path to redirect back
+ *                                to on success. Defaults to the AI
+ *                                Employee landing when missing or
+ *                                pointing at an unsafe target.
+ *
+ * Authorization:
+ *   - Clerk session required (middleware enforces)
+ *   - Active AI Employee subscription on the entity
+ *   - Caller holds the `principal` role. The trust-ceiling promotion is
+ *     a firm-level decision per platform-prd.md §11.3; only the
+ *     principal can defer it. Operator and compliance get a redirect
+ *     to the landing (which never rendered the card for them anyway,
+ *     but defense in depth at the write path keeps the gate honest).
+ *
+ * Persistence: upserts into `promotion_card_dismissals` keyed by
+ * (entity_id, skill). A second dismissal for the same skill refreshes
+ * the timestamp (extending the cooldown), which matches the user
+ * intent: clicking dismiss again means "keep this hidden a while
+ * longer". The resolver's cooldown comparison is against the most
+ * recent dismissal.
+ *
+ * Contract semantics: this endpoint is intent-idempotent. POSTing for a
+ * skill that is not currently a candidate still records the dismissal
+ * and 303s back — the page resolver decides whether to render anything,
+ * and the dismissal harmlessly ages out if no candidate ever appears.
+ * This keeps the URL contract uniform under racing renders.
+ */
+
+const AI_EMPLOYEE_LANDING = '/portal/products/ai-employee'
+
+/**
+ * Server-side allowlist of return-target paths. POST handlers must not
+ * redirect to caller-supplied absolute URLs — that's an open redirect.
+ * We accept same-origin paths under /portal/products/ai-employee only,
+ * which is the surface set that has a legitimate reason to invoke the
+ * dismissal flow.
+ */
+function resolveReturnTarget(raw: FormDataEntryValue | null): string {
+  if (typeof raw !== 'string') return AI_EMPLOYEE_LANDING
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return AI_EMPLOYEE_LANDING
+  if (!trimmed.startsWith('/portal/products/ai-employee')) {
+    return AI_EMPLOYEE_LANDING
+  }
+  // Defense in depth: reject protocol-relative (`//evil.example`) and
+  // scheme-relative (`javascript:`) inputs.
+  if (trimmed.startsWith('//')) return AI_EMPLOYEE_LANDING
+  if (trimmed.includes(':')) return AI_EMPLOYEE_LANDING
+  return trimmed
+}
+
+function jsonError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const POST: APIRoute = async ({ params, request, locals }) => {
+  const skill = params.skill
+  if (typeof skill !== 'string' || skill.length === 0) {
+    return jsonError(400, 'Missing skill')
+  }
+  // Cap on skill identifier length so a hostile client can't fill the
+  // table with arbitrarily long rows. The persona-skill names emitted
+  // by Hermes are short slugs; 200 is generous and matches what would
+  // round-trip safely in URLs and logs.
+  if (skill.length > 200) {
+    return jsonError(400, 'Skill identifier too long')
+  }
+
+  const access = await resolveAiEmployeeAccess(env.DB, locals, {
+    allowedRoles: ['principal'],
+  })
+  if (access.kind === 'redirect') {
+    return new Response(null, {
+      status: 303,
+      headers: { Location: access.to },
+    })
+  }
+
+  const formData = await request.formData()
+  const returnTarget = resolveReturnTarget(formData.get('returnTo'))
+
+  // Upsert by primary key (entity_id, skill). ON CONFLICT refreshes the
+  // dismissed_at timestamp and the actor, extending the cooldown and
+  // recording the most recent dismisser.
+  await env.DB.prepare(
+    `INSERT INTO promotion_card_dismissals (entity_id, skill, dismissed_by, dismissed_at)
+     VALUES (?, ?, ?, datetime('now'))
+     ON CONFLICT(entity_id, skill) DO UPDATE SET
+       dismissed_by = excluded.dismissed_by,
+       dismissed_at = excluded.dismissed_at`
+  )
+    .bind(access.client.id, skill, access.user.id)
+    .run()
+
+  return new Response(null, {
+    status: 303,
+    headers: { Location: returnTarget },
+  })
+}

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -10,7 +10,12 @@ import {
 import PortalHeader from '../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../components/portal/PortalPageHead.astro'
+import PromotionCardList from '../../../../components/portal/ai-employee/PromotionCardList.astro'
 import SkipToMain from '../../../../components/SkipToMain.astro'
+import {
+  listPromotionReadySkills,
+  type PromotionCandidate,
+} from '../../../../lib/portal/ai-employee/promotion-cards'
 import { SignOutButton } from '@clerk/astro/components'
 import { env } from 'cloudflare:workers'
 
@@ -122,6 +127,19 @@ if (access) {
       'A full record of every action your AI Employee takes: drafts created, sends approved, identity changes.',
   })
 }
+
+// Promotion recommendation cards (per #811). Principal-only because the
+// trust-ceiling promotion is the firm's decision per §11.3 — operator
+// and compliance roles do not see the prompt. The resolver returns an
+// empty list today (Hermes stats bridge not wired); when it does the
+// PromotionCardList wrapper renders nothing, so no fabricated copy
+// reaches the page. The dismissals table is wired so the empty case is
+// honest: even when bridge data lands later, a dismissed card stays
+// suppressed for the cooldown.
+let promotionCandidates: PromotionCandidate[] = []
+if (access?.roles.includes('principal')) {
+  promotionCandidates = await listPromotionReadySkills(env.DB, client.id)
+}
 ---
 
 <!doctype html>
@@ -224,6 +242,7 @@ if (access) {
         surfaceState === 'active' && (
           <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
             <div class="flex flex-col gap-8 min-w-0">
+              <PromotionCardList candidates={promotionCandidates} />
               <section>
                 <p class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
                   Sections

--- a/tests/portal-ai-employee-promotion-cards.test.ts
+++ b/tests/portal-ai-employee-promotion-cards.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Tests for the AI Employee promotion-card resolver
+ * (src/lib/portal/ai-employee/promotion-cards.ts).
+ *
+ * The landing page composes listCandidateSkills → evaluatePromotionStreak →
+ * (db dismissal lookup) → fetch (Hermes bridge stub) and emits zero or
+ * more PromotionCandidate rows. Each piece is exercised independently
+ * so the criteria contract (4-week ≥90%, non-promotable carve-outs,
+ * 7-day cooldown) is regression-protected before the Hermes bridge
+ * starts shipping real stats.
+ *
+ * The runtime resolver `listPromotionReadySkills` returns an empty list
+ * today because `fetchSkillApprovalStatsFromHermes` is the bridge stub
+ * and returns null. That contract is also tested here — if a future
+ * change starts seeding mock stats from this module the build fails
+ * loudly (CLAUDE.md Pattern A/B fabrication violation).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  NON_PROMOTABLE_SKILLS,
+  PROMOTION_APPROVAL_RATE_THRESHOLD,
+  PROMOTION_DISMISSAL_COOLDOWN_DAYS,
+  PROMOTION_REQUIRED_WEEKS,
+  buildDismissUrl,
+  buildReviewUrl,
+  evaluatePromotionStreak,
+  formatApprovalRate,
+  isDismissalExpired,
+  listCandidateSkills,
+  listPromotionReadySkills,
+  type SkillApprovalStats,
+  type SkillApprovalWeek,
+} from '../src/lib/portal/ai-employee/promotion-cards'
+import type { PersonaConfig } from '../src/lib/portal/customer-config'
+
+function makePersona(
+  skills: Array<{ name: string; trust_ceiling: string }>,
+  overrides: Partial<PersonaConfig> = {}
+): PersonaConfig {
+  return {
+    slug: 'p',
+    status: 'active',
+    name: 'Persona',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    channel_bindings: [],
+    skills,
+    ...overrides,
+  }
+}
+
+function makeWeek(overrides: Partial<SkillApprovalWeek> = {}): SkillApprovalWeek {
+  return {
+    weekStart: '2026-05-04T00:00:00.000Z',
+    approvalRate: 0.95,
+    draftCount: 10,
+    ...overrides,
+  }
+}
+
+function makeStats(weeks: SkillApprovalWeek[], skillName = 'conflict-check'): SkillApprovalStats {
+  return { skillName, weeks }
+}
+
+// ---------------------------------------------------------------------------
+// Constants — pin the criteria the PRD §12.1 spec cites
+// ---------------------------------------------------------------------------
+
+describe('promotion criteria constants', () => {
+  it('threshold matches the §12.1 spec (≥90%)', () => {
+    expect(PROMOTION_APPROVAL_RATE_THRESHOLD).toBe(0.9)
+  })
+
+  it('required weeks matches the §12.1 spec (4 consecutive weeks)', () => {
+    expect(PROMOTION_REQUIRED_WEEKS).toBe(4)
+  })
+
+  it('cooldown matches the §12.1 spec (7 days)', () => {
+    expect(PROMOTION_DISMISSAL_COOLDOWN_DAYS).toBe(7)
+  })
+
+  it('non-promotable list includes the §11.2 carve-outs', () => {
+    expect(NON_PROMOTABLE_SKILLS).toContain('trust-accounting')
+    expect(NON_PROMOTABLE_SKILLS).toContain('court-filing')
+    expect(NON_PROMOTABLE_SKILLS).toContain('settlement-authority')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listCandidateSkills — which persona skills are eligible to evaluate
+// ---------------------------------------------------------------------------
+
+describe('listCandidateSkills', () => {
+  it('returns draft_for_review skills only', () => {
+    const persona = makePersona([
+      { name: 'intake-triage', trust_ceiling: 'draft_for_review' },
+      { name: 'conflict-check', trust_ceiling: 'autonomous' },
+      { name: 'refused-skill', trust_ceiling: 'refused' },
+    ])
+    expect(listCandidateSkills(persona)).toEqual(['intake-triage'])
+  })
+
+  it('excludes non-promotable skills regardless of trust ceiling', () => {
+    const persona = makePersona([
+      { name: 'trust-accounting', trust_ceiling: 'draft_for_review' },
+      { name: 'court-filing', trust_ceiling: 'draft_for_review' },
+      { name: 'settlement-authority', trust_ceiling: 'draft_for_review' },
+      { name: 'intake-triage', trust_ceiling: 'draft_for_review' },
+    ])
+    expect(listCandidateSkills(persona)).toEqual(['intake-triage'])
+  })
+
+  it('drops skills with unknown trust ceiling values', () => {
+    const persona = makePersona([
+      { name: 'intake-triage', trust_ceiling: 'auto_send' },
+      { name: 'conflict-check', trust_ceiling: 'draft_for_review' },
+    ])
+    expect(listCandidateSkills(persona)).toEqual(['conflict-check'])
+  })
+
+  it('returns an empty array for an empty persona', () => {
+    expect(listCandidateSkills(makePersona([]))).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluatePromotionStreak — criteria evaluation against weekly stats
+// ---------------------------------------------------------------------------
+
+describe('evaluatePromotionStreak', () => {
+  it('emits a candidate when every week meets the threshold', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.92, draftCount: 12 }),
+      makeWeek({ approvalRate: 0.91, draftCount: 8 }),
+      makeWeek({ approvalRate: 0.93, draftCount: 11 }),
+    ])
+    const result = evaluatePromotionStreak(stats)
+    expect(result).not.toBeNull()
+    expect(result?.weeks).toBe(4)
+    expect(result?.totalDrafts).toBe(41)
+    // Draft-weighted: (0.95*10 + 0.92*12 + 0.91*8 + 0.93*11) / 41 = 38.05/41 ≈ 0.9280
+    expect(result?.approvalRate).toBeCloseTo(0.928, 3)
+  })
+
+  it('disqualifies when any single week is below threshold', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.92, draftCount: 12 }),
+      makeWeek({ approvalRate: 0.85, draftCount: 8 }), // weak
+      makeWeek({ approvalRate: 0.95, draftCount: 11 }),
+    ])
+    expect(evaluatePromotionStreak(stats)).toBeNull()
+  })
+
+  it('disqualifies on exactly the threshold boundary minus epsilon', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.89, draftCount: 10 }), // just below
+    ])
+    expect(evaluatePromotionStreak(stats)).toBeNull()
+  })
+
+  it('accepts exactly on the threshold (90.0%)', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.9, draftCount: 10 }),
+    ])
+    const result = evaluatePromotionStreak(stats)
+    expect(result).not.toBeNull()
+    expect(result?.approvalRate).toBeCloseTo(0.9, 5)
+  })
+
+  it('disqualifies when fewer than 4 weeks are available', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95 }),
+      makeWeek({ approvalRate: 0.95 }),
+      makeWeek({ approvalRate: 0.95 }),
+    ])
+    expect(evaluatePromotionStreak(stats)).toBeNull()
+  })
+
+  it('disqualifies when a week has null approvalRate (silence does not qualify)', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95 }),
+      makeWeek({ approvalRate: null, draftCount: 0 }),
+      makeWeek({ approvalRate: 0.95 }),
+      makeWeek({ approvalRate: 0.95 }),
+    ])
+    expect(evaluatePromotionStreak(stats)).toBeNull()
+  })
+
+  it('disqualifies when total draft count across the window is zero', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95, draftCount: 0 }),
+      makeWeek({ approvalRate: 0.95, draftCount: 0 }),
+      makeWeek({ approvalRate: 0.95, draftCount: 0 }),
+      makeWeek({ approvalRate: 0.95, draftCount: 0 }),
+    ])
+    expect(evaluatePromotionStreak(stats)).toBeNull()
+  })
+
+  it('evaluates only the most recent 4 weeks even if more are supplied', () => {
+    // Older weeks (indices 4+) should be ignored — they could be weak
+    // without breaking the streak. This proves the resolver does not
+    // average across an unbounded history.
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.95, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.95, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.95, draftCount: 10 }),
+      makeWeek({ approvalRate: 0.2, draftCount: 100 }),
+      makeWeek({ approvalRate: 0.1, draftCount: 100 }),
+    ])
+    const result = evaluatePromotionStreak(stats)
+    expect(result).not.toBeNull()
+    expect(result?.totalDrafts).toBe(40)
+  })
+
+  it('disqualifies on non-finite approvalRate values', () => {
+    const stats = makeStats([
+      makeWeek({ approvalRate: 0.95 }),
+      makeWeek({ approvalRate: Number.NaN }),
+      makeWeek({ approvalRate: 0.95 }),
+      makeWeek({ approvalRate: 0.95 }),
+    ])
+    expect(evaluatePromotionStreak(stats)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatApprovalRate
+// ---------------------------------------------------------------------------
+
+describe('formatApprovalRate', () => {
+  it('floors to whole percentages', () => {
+    expect(formatApprovalRate(0.85)).toBe('85%')
+    expect(formatApprovalRate(0.857)).toBe('85%')
+    expect(formatApprovalRate(0.9)).toBe('90%')
+    expect(formatApprovalRate(1)).toBe('100%')
+  })
+
+  it('clamps values outside [0, 1]', () => {
+    expect(formatApprovalRate(1.27)).toBe('100%')
+    expect(formatApprovalRate(-0.5)).toBe('0%')
+  })
+
+  it('returns empty string for non-finite input rather than fabricating', () => {
+    expect(formatApprovalRate(Number.NaN)).toBe('')
+    expect(formatApprovalRate(Number.POSITIVE_INFINITY)).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isDismissalExpired
+// ---------------------------------------------------------------------------
+
+describe('isDismissalExpired', () => {
+  const nowMs = Date.UTC(2026, 4, 21, 12, 0, 0)
+  const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+  it('returns false within the cooldown window', () => {
+    const ts = new Date(nowMs - 3 * MS_PER_DAY).toISOString()
+    expect(isDismissalExpired(ts, nowMs)).toBe(false)
+  })
+
+  it('returns true past the cooldown window', () => {
+    const ts = new Date(nowMs - 8 * MS_PER_DAY).toISOString()
+    expect(isDismissalExpired(ts, nowMs)).toBe(true)
+  })
+
+  it('returns true at exactly the cooldown boundary', () => {
+    const ts = new Date(nowMs - PROMOTION_DISMISSAL_COOLDOWN_DAYS * MS_PER_DAY).toISOString()
+    expect(isDismissalExpired(ts, nowMs)).toBe(true)
+  })
+
+  it('treats malformed timestamps as expired (fail open)', () => {
+    expect(isDismissalExpired('not-a-date', nowMs)).toBe(true)
+    expect(isDismissalExpired('', nowMs)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+describe('buildReviewUrl', () => {
+  it('points at the Skills settings page with the skill focused', () => {
+    expect(buildReviewUrl('conflict-check')).toBe(
+      '/portal/products/ai-employee/settings?focus=conflict-check'
+    )
+  })
+
+  it('URL-encodes skill names containing special characters', () => {
+    expect(buildReviewUrl('intake triage')).toBe(
+      '/portal/products/ai-employee/settings?focus=intake%20triage'
+    )
+  })
+})
+
+describe('buildDismissUrl', () => {
+  it('routes the dismiss POST to the per-skill endpoint', () => {
+    expect(buildDismissUrl('conflict-check')).toBe(
+      '/api/portal/ai-employee/promotion-cards/conflict-check/dismiss'
+    )
+  })
+
+  it('URL-encodes skill names containing slashes or spaces', () => {
+    expect(buildDismissUrl('a/b')).toBe('/api/portal/ai-employee/promotion-cards/a%2Fb/dismiss')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listPromotionReadySkills — empty list contract until bridge wires in
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal D1 stub. Captures the most recent statement so we can assert
+ * the dismissals query shape even though we don't run real SQL here.
+ * Returns no config row by default (entity has no customer.yaml
+ * projection) so the resolver short-circuits to an empty list.
+ */
+function makeDbStub(options: {
+  customerConfigRow?: Record<string, unknown> | null
+  dismissalRows?: Array<{ skill: string; dismissed_at: string }>
+}) {
+  return {
+    prepare(_sql: string) {
+      return {
+        bind(..._args: unknown[]) {
+          return this
+        },
+        async first() {
+          if (_sql.includes('FROM customer_configs')) {
+            return options.customerConfigRow ?? null
+          }
+          return null
+        },
+        async all() {
+          if (_sql.includes('FROM promotion_card_dismissals')) {
+            return { results: options.dismissalRows ?? [], success: true, meta: {} }
+          }
+          return { results: [], success: true, meta: {} }
+        },
+        async run() {
+          return { success: true, meta: {} }
+        },
+      }
+    },
+    // Compat with D1Database type — these are unused by the resolver but
+    // satisfy the structural type check at call sites.
+    batch: async () => [],
+    dump: async () => new ArrayBuffer(0),
+    exec: async () => ({ count: 0, duration: 0 }),
+  } as unknown as D1Database
+}
+
+describe('listPromotionReadySkills', () => {
+  it('returns an empty list when the customer has no projected config', async () => {
+    const db = makeDbStub({ customerConfigRow: null })
+    const result = await listPromotionReadySkills(db, 'ent-1')
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty list when no persona is active', async () => {
+    const db = makeDbStub({
+      customerConfigRow: {
+        entity_id: 'ent-1',
+        org_id: 'org-1',
+        customer_slug: 'firm',
+        schema_version: '1',
+        personas_json: JSON.stringify([
+          {
+            slug: 'archived',
+            status: 'archived',
+            name: 'Old',
+            title: null,
+            signature_html: null,
+            tone: [],
+            send_as: null,
+            skills: [{ name: 'conflict-check', trust_ceiling: 'draft_for_review' }],
+            channel_bindings: [],
+          },
+        ]),
+        voice_library_json: null,
+        escalation_json: null,
+        business_hours_json: null,
+        connectors_json: null,
+        scope_json: null,
+        git_sha: 'abc',
+        synced_at: '2026-05-21T00:00:00Z',
+      },
+    })
+    const result = await listPromotionReadySkills(db, 'ent-1')
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty list when the active persona has no candidate skills', async () => {
+    const db = makeDbStub({
+      customerConfigRow: {
+        entity_id: 'ent-1',
+        org_id: 'org-1',
+        customer_slug: 'firm',
+        schema_version: '1',
+        personas_json: JSON.stringify([
+          {
+            slug: 'p',
+            status: 'active',
+            name: 'P',
+            title: null,
+            signature_html: null,
+            tone: [],
+            send_as: null,
+            skills: [
+              { name: 'conflict-check', trust_ceiling: 'autonomous' },
+              { name: 'trust-accounting', trust_ceiling: 'draft_for_review' },
+            ],
+            channel_bindings: [],
+          },
+        ]),
+        voice_library_json: null,
+        escalation_json: null,
+        business_hours_json: null,
+        connectors_json: null,
+        scope_json: null,
+        git_sha: 'abc',
+        synced_at: '2026-05-21T00:00:00Z',
+      },
+    })
+    const result = await listPromotionReadySkills(db, 'ent-1')
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty list even with candidates while the Hermes bridge is stubbed', async () => {
+    // No fabrication contract: even when the customer has eligible
+    // skills and no dismissals, the bridge stub returns null and no
+    // cards surface. If a future change starts seeding mock stats from
+    // fetchSkillApprovalStatsFromHermes this test fails loudly
+    // (CLAUDE.md Pattern A/B violation).
+    const db = makeDbStub({
+      customerConfigRow: {
+        entity_id: 'ent-1',
+        org_id: 'org-1',
+        customer_slug: 'firm',
+        schema_version: '1',
+        personas_json: JSON.stringify([
+          {
+            slug: 'p',
+            status: 'active',
+            name: 'P',
+            title: null,
+            signature_html: null,
+            tone: [],
+            send_as: null,
+            skills: [{ name: 'intake-triage', trust_ceiling: 'draft_for_review' }],
+            channel_bindings: [],
+          },
+        ]),
+        voice_library_json: null,
+        escalation_json: null,
+        business_hours_json: null,
+        connectors_json: null,
+        scope_json: null,
+        git_sha: 'abc',
+        synced_at: '2026-05-21T00:00:00Z',
+      },
+    })
+    const result = await listPromotionReadySkills(db, 'ent-1')
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Surfaces a "Promotion ready" recommendation card on the AI Employee landing page when a skill has held a >=90% approval rate over 4 consecutive weeks. The card asks the principal whether to promote the skill to autonomous, with [Review on Skills tab] and [Dismiss for now] actions; dismissed cards re-surface past a 7-day cooldown if the criteria continue to hold.

Extends `platform-prd.md` §12.1 (V1 Today tab) with the full criteria, card shape, and dismiss/re-surface contract, plus a cross-reference from §11.3 Promotion mechanics. Trust-ceiling promotion was a hidden Skills-tab action; without this surface, the §14.3 "≥2 skills promoted by day 60" success metric slips.

The Hermes per-skill stats bridge is the same runtime wiring tracked under #821; until that ships, `fetchSkillApprovalStatsFromHermes` returns null and no cards surface. Empty-state pattern, no fabrication. The dismissals table is already wired so the suppression contract is honest when real stats land.

## Linked issue

Closes #811

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| platform-prd.md §12.1 Today tab content extended | met | `docs/pm/ai-employee/platform-prd.md` §12.1 new "Today tab — trust-ceiling promotion recommendation card" block |
| Promotion-readiness criteria documented (≥90% approval rate over 4 weeks) | met | `docs/pm/ai-employee/platform-prd.md` §12.1 (per-week threshold, silence does not qualify, non-promotable carve-outs from §11.2) |
| Card shape and CTAs specified | met | `docs/pm/ai-employee/platform-prd.md` §12.1 (title / body / actions / role gate) and the `PromotionCard.astro` renderer |
| Dismiss + re-surface logic defined | met | `docs/pm/ai-employee/platform-prd.md` §12.1 + 7-day cooldown constant in `src/lib/portal/ai-employee/promotion-cards.ts` + `promotion_card_dismissals` table (migration 0040) + tests in `tests/portal-ai-employee-promotion-cards.test.ts` |
| Cross-reference from §11 Trust Ceiling Model | met | `docs/pm/ai-employee/platform-prd.md` §11.3 forward-references §12.1 for the recommendation surface |

## Test plan

- [x] `npm run verify` passes (typecheck, lint, prettier, unit tests across app + 5 workers)
- [x] New unit tests in `tests/portal-ai-employee-promotion-cards.test.ts` (32 tests) cover: criteria constants, `listCandidateSkills` carve-outs, `evaluatePromotionStreak` boundary + null-week + zero-volume cases, `formatApprovalRate` clamping + non-finite handling, `isDismissalExpired` window + malformed-timestamp behavior, URL builders, and the empty-list contract from `listPromotionReadySkills` while the Hermes bridge is stubbed
- [x] Existing `tests/forbidden-strings.test.ts` and `tests/portal-list-consistency.test.ts` remain green (em-dash and list-row registry guardrails)

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints (skill id length cap, allowlisted `returnTo` redirect target)
- [x] Parameterized queries for any SQL (use `.bind()`)
- [x] Auth required on new endpoints (`resolveAiEmployeeAccess` gate, principal-only)
- [x] No internal IDs that enable enumeration (skill identifiers are persona-defined slugs, dismissal table keyed by (entity, skill))

## Feature Impact

**Feature impact:** None. New surface (recommendation card section) renders nothing when no candidates qualify, which is today's universal state until the Hermes stats bridge wires in.

## Deployment Notes

- Schema migration `0040_promotion_card_dismissals.sql` adds a new table; forward-only, additive
- No new env vars or secrets
- No runtime impact while the Hermes stats bridge stub (`fetchSkillApprovalStatsFromHermes`) returns null; resolver short-circuits before hitting the dismissals table

🤖 Generated with [Claude Code](https://claude.com/claude-code)