### PR TITLE
feat(portal): calibration session workflow (#867)

### DIFF
--- a/docs/runbooks/ai-employee-calibration.md
+++ b/docs/runbooks/ai-employee-calibration.md
@@ -1,0 +1,259 @@
+# AI Employee calibration runbook
+
+**Audience:** Captain.
+**Scope:** Conducting one calibration cycle (four 90-minute sessions over two
+weeks) with a customer's partner. Covers what each session is for, what
+Captain prepares, what the partner does, and what gets written to the
+substrate after each session.
+**Source:** Spec at `docs/specs/ai-employee/calibration-session.md`. Backed
+by platform PRD §9.6 and law-firm PRD §11.9.
+**Companion surface:** `portal.smd.services/portal/products/ai-employee/calibration`
+(principal-only).
+
+> The PRD's 4-6 hour single-block calibration collapses at firms that sign.
+> The four 90-minute sessions are the canonical structure. Do not attempt to
+> condense them back into a single block — the business-analyst critique
+> documented that path's failure mode.
+
+---
+
+## Overview
+
+One calibration cycle has four sessions, in scheduling order:
+
+| #   | Session                  | Duration | Output to substrate                                         |
+| --- | ------------------------ | -------- | ----------------------------------------------------------- |
+| 1   | Voice calibration        | 90 min   | Structural-diffs to voice ingestion (seam 1)                |
+| 2   | Skill calibration        | 90 min   | Memory rules to the memory ingestion writer (seam 2)        |
+| 3   | Trust-ceiling refinement | 90 min   | Trust-ceiling decisions to `audit_log` via `log_decision()` |
+| 4   | Integration and handoff  | 90 min   | Sign-off marker; cycle marked `completed`                   |
+
+Schedule two sessions per week. The partner's calendar drives spacing;
+fourteen days is the typical envelope.
+
+Captain may run a calibration cycle on demand by starting a new cycle from
+the portal: principal opens
+`portal.smd.services/portal/products/ai-employee/calibration` and clicks
+"Start new calibration cycle." Starting a new cycle archives any prior cycle.
+
+## Required framing in every session
+
+Every session opens with the assistant-not-replacement framing:
+
+> "{persona name} assists the partner; {persona name} never replaces them."
+
+The persona name is the active persona from `customer.yaml`. The framing
+is also rendered on the portal calibration surface; the partner sees the
+same words there.
+
+This is not a marketing line. It is the load-bearing posture for every
+calibration decision: the partner is the judge of every voice correction,
+every rule addition, every ceiling change. The agent does not self-grade.
+
+---
+
+## Session 1: voice calibration (90 minutes)
+
+**Purpose.** Surface the writing voice across recipient cohorts. Capture
+10-15 representative drafts edited by the partner, feeding the voice
+ingestion seam.
+
+**Prep (Captain, 30 minutes before the session).**
+
+- Confirm the customer has ≥30 voice samples on disk (per platform-prd
+  §9.6 gate #1). If under 30, run the dossier voice scrape (see
+  `docs/runbooks/pi-firm-demo-prep.md` §3) to top up before the session.
+- Open the demo flow at the customer's Hermes Machine.
+- Stage 10-15 scenarios across cohorts (anxious client, opposing
+  counsel, internal staff, vendor). The mix matches the cohort
+  distribution in `customer.yaml.scope`.
+
+**Walkthrough (with the partner, 90 minutes).**
+
+1. Open the calibration surface and read the framing line aloud to the
+   partner. Confirm the partner accepts the posture.
+2. For each staged scenario:
+   - Generate a draft.
+   - Hand the keyboard to the partner.
+   - Partner edits the draft until it reads as theirs.
+   - Captain saves the `(draft, sent)` pair to the voice ingestion
+     queue with `source=calibration_session`.
+3. After the last scenario, walk the partner through the structural-diff
+   for one sample. Confirm the diff matches what the partner expected.
+
+**Substrate output.** 10-15 structural-diff entries written under
+`{customer_slug}/voice/cohort/{cohort}/` per
+`docs/specs/ai-employee/voice-ingestion.md`. The voice gate counter
+advances; the dashboard's voice histogram updates on next render.
+
+**Failure modes.**
+
+- Partner is uncomfortable editing in front of Captain. Pause. Switch to
+  the partner editing alone for the next scenario; Captain reviews after.
+- Drafts are too far off. Confirm the persona's `tone` array in
+  `customer.yaml` matches the partner's stated voice. Adjust if needed.
+  Do not silently soften scenarios; the partner needs to see the worst
+  cases.
+- Partner runs out of time. Stop at the 90-minute mark. The session
+  ends `completed` only when ≥5 scenarios produced structural-diffs.
+  Below 5: session ends `skipped` and the cycle re-runs session 1 in
+  the next available slot.
+
+## Session 2: skill calibration (90 minutes)
+
+**Purpose.** Walk every enabled skill against a representative scenario.
+Capture per-skill approve / edit / refuse decisions, feeding memory rules.
+
+**Prep (Captain, 30 minutes before the session).**
+
+- List every skill with a non-`refused` trust ceiling from
+  `customer.yaml.personas[0].skills`.
+- For each skill, stage one realistic scenario. PI law-firm starts with
+  `law-pi-intake-triage`, `law-pi-discovery-response`,
+  `law-pi-demand-letter-evidence-packet`, etc.
+- Open the memory tab so the partner can see the rule writer landing.
+
+**Walkthrough (with the partner, 90 minutes).**
+
+1. Open the calibration surface; re-read the framing line.
+2. For each skill:
+   - Run the staged scenario.
+   - Partner approves, edits, or refuses the outcome.
+   - If the partner stated a new rule ("we don't take medmal under $1M"),
+     Captain writes the rule to the memory rule writer with the partner
+     watching. The rule appears in the memory tab immediately.
+3. After the last skill, walk the partner through the memory tab. Confirm
+   every rule the partner stated is visible and correctly categorized
+   (rule / voice / process / person).
+
+**Substrate output.** Per-skill calibration outcomes recorded for
+session-2 of the cycle. Memory rules written via the memory ingestion
+writer per `docs/specs/ai-employee/memory-ingestion.md`.
+
+**Failure modes.**
+
+- Partner wants to change a skill's behavior more than the rule writer
+  supports. Note the request, file a follow-on issue against the skill's
+  source. Do not promise a turnaround.
+- Partner refuses every skill outcome. This is the strongest signal a
+  re-scoping is needed; defer session 3 and convene with Captain and
+  the partner on which skills should be disabled outright.
+
+## Session 3: trust-ceiling refinement (90 minutes)
+
+**Purpose.** Refine the per-skill trust ceiling based on the first two
+sessions. The principal sets the autonomy boundary. Every ceiling change
+writes to `audit_log` via the `log_decision()` emission contract.
+
+**Prep (Captain, 30 minutes before the session).**
+
+- Open the trust-ceiling section on the AI Employee settings page.
+- Review the cumulative voice ingestion stats from session 1 and the
+  skill calibration outcomes from session 2. Identify skills that look
+  ready for promotion and skills that should drop.
+
+**Walkthrough (with the principal, 90 minutes).**
+
+1. Open the calibration surface; re-read the framing line.
+2. For each skill:
+   - Show the cumulative signal from sessions 1 and 2.
+   - The principal sets the ceiling.
+   - The ceiling change writes one row to `audit_log` per the emission
+     contract; the row carries `metadata.calibration_cycle_id` and
+     `metadata.calibration_session_kind=trust_ceiling` so the compliance
+     evidence packet can group the rows.
+3. After the last skill, confirm the principal has reviewed every skill's
+   ceiling. The session ends `completed` when every enabled skill has a
+   ceiling decision logged.
+
+**Substrate output.** One `audit_log` row per ceiling change per
+`docs/specs/ai-employee/trust-ceiling-logging.md`.
+
+**Failure modes.**
+
+- Principal is hesitant on every skill. The default is
+  `draft_for_review`. Set every uncertain skill to the default; promotion
+  can land later via the promotion recommendation card (#811).
+- Principal wants `autonomous` on every skill. Read the §11.3 promotion
+  mechanics paragraph aloud. Promote one skill, observe for a week,
+  promote the next.
+
+## Session 4: integration and handoff (90 minutes)
+
+**Purpose.** Live workflow at the partner's keyboard. Final sign-off
+before the blind-test gate (§9.6 gate #3) fires.
+
+**Prep (Captain, 30 minutes before the session).**
+
+- Open the partner's actual inbox in the demo flow.
+- Have the blind-test materials ready: 10 reviewer-written + 10
+  agent-drafted communications, unlabeled.
+
+**Walkthrough (with the partner, 90 minutes).**
+
+1. Open the calibration surface; re-read the framing line.
+2. Partner works through their actual inbox for 45 minutes with the
+   AI Employee active. Captain observes; intervenes only on request.
+3. Switch to the blind-test materials for the remaining 45 minutes.
+   Run the blind test per platform-prd §9.6 gate #3. Document the
+   indistinguishability rate.
+4. If the blind-test rate is ≥80%, the partner signs off and the
+   first external draft is unblocked.
+5. If the blind-test rate is below 80%, the cycle does not end
+   `completed`. Schedule a new cycle for the next available window;
+   document the failure mode in the dossier.
+
+**Substrate output.** Cycle marked `completed`. Sign-off marker recorded
+under the (customer, cycle) tuple.
+
+**Failure modes.**
+
+- Blind-test rate ≥80% but partner is uncomfortable. The partner's
+  judgment overrides the rate. Defer first external draft until the
+  partner is ready; document the gap.
+- Partner cannot make the 90-minute slot. Reschedule the session;
+  do not run it remote-async. Session 4 is in-person by default.
+
+---
+
+## Recovery paths
+
+**A session ran out of time.** Sessions 1 and 2 may end `skipped` if
+fewer than 5 / fewer than half the enabled skills got coverage. The
+cycle re-runs the skipped session in the next available slot. Sessions
+3 and 4 cannot be `skipped` — they must run to `completed` for the
+blind-test gate to fire.
+
+**A session produced bad signal.** The partner is the judge. If the
+partner says session 2 went badly, do not write the rules collected in
+that session. Mark session 2 `skipped`, reschedule, repeat with a fresh
+set of scenarios.
+
+**A cycle stalled mid-way.** The principal may start a new cycle from
+the portal at any time. Starting a new cycle archives the stalled one
+and resets the four-session schedule to `pending`. Document the stall
+in the dossier so the next cycle's prep accounts for it.
+
+**The customer has no active persona.** The calibration surface renders
+the empty state per `docs/style/empty-state-pattern.md`. Calibration
+cannot run; provision a persona through `customer.yaml` first (see
+`docs/specs/ai-employee/customer-yaml-schema.md`).
+
+**The customer has no AI Employee subscription.** The calibration
+surface redirects to the AI Employee landing per
+`resolveProductAccess()`. No calibration is possible until the
+subscription is provisioned.
+
+## Cross-references
+
+- spec: `docs/specs/ai-employee/calibration-session.md`
+- demo prep: `docs/runbooks/pi-firm-demo-prep.md`
+- voice ingestion: `docs/specs/ai-employee/voice-ingestion.md`
+- memory ingestion: `docs/specs/ai-employee/memory-ingestion.md`
+- trust-ceiling logging: `docs/specs/ai-employee/trust-ceiling-logging.md`
+- platform PRD §9.6 (voice quality gates), §10 (memory model), §11
+  (trust ceilings)
+- law-firm PRD §11.9 (calibration session split)
+- issue [#867](https://github.com/venturecrane/ss-console/issues/867)
+- issue [#821](https://github.com/venturecrane/ss-console/issues/821)
+  (data-capture mechanics unblock)

--- a/docs/specs/ai-employee/calibration-session.md
+++ b/docs/specs/ai-employee/calibration-session.md
@@ -1,0 +1,201 @@
+# Calibration session workflow
+
+**Spec for issue [#867](https://github.com/venturecrane/ss-console/issues/867).**
+Defines the calibration cycle structure (four 90-minute sessions over two weeks),
+the portal surface that exposes it, and the integration seams that connect
+calibration findings back to voice ingestion, memory rules, and trust-ceiling
+logging.
+
+The platform PRD §9.6 names a 4-6 hour Captain-led calibration session as
+gate #2 before any external draft ships. The business-analyst critique (carried
+into law-firm PRD §11.9) flagged that the single 4-6 hour block collapses at
+firms that actually sign — partner calendars do not support it. This spec
+adopts the four-session split as the canonical structure for every
+calibration cycle (PI law-firm and beyond).
+
+## Source
+
+- platform-prd.md §9.6 — voice quality gates (sample minimum, calibration
+  session, blind-test gate)
+- platform-prd.md §10 — memory model + learning loop (rule additions, voice
+  corrections, edit-then-send signal)
+- platform-prd.md §11 — trust ceiling model (approvals feed audit log)
+- law-firm-prd.md §11.9 — calibration session split (partner + paralegal)
+- `docs/specs/ai-employee/voice-ingestion.md` — structural-diff storage
+- `docs/specs/ai-employee/memory-ingestion.md` — memory rule writer
+- `docs/specs/ai-employee/trust-ceiling-logging.md` — `log_decision()`
+  emission contract
+- `docs/style/empty-state-pattern.md` — no fabrication; render nothing or
+  an explicit marker when authored data is missing
+
+## Why four sessions
+
+A 90-minute block fits inside a partner's calendar in a way that a 4-6 hour
+block does not. The cycle keeps the same total Captain time (six hours
+spread, not four-to-six condensed) but moves the partner's involvement onto
+a cadence the partner can actually keep. Each session has a single output:
+
+| #   | Session                  | Duration | Output                                                             |
+| --- | ------------------------ | -------- | ------------------------------------------------------------------ |
+| 1   | Voice calibration        | 90 min   | 10-15 partner-edited drafts feeding the voice ingestion seam       |
+| 2   | Skill calibration        | 90 min   | Per-skill approve / edit / refuse decisions feeding memory rules   |
+| 3   | Trust-ceiling refinement | 90 min   | Per-skill ceiling set by the principal; approval rows in audit_log |
+| 4   | Integration and handoff  | 90 min   | Live workflow at the partner keyboard; sign-off for the blind-test |
+
+Cycles are scheduled across two weeks. Two sessions per week is the
+recommended cadence; the spec does not enforce a per-session calendar offset
+because the partner's schedule drives the spacing.
+
+## Required framing
+
+Every surface that names the AI Employee inside the calibration workflow
+must include the assistant framing:
+
+> `{persona name} assists the partner; {persona name} never replaces them.`
+
+The persona name comes from `getActivePersona()` (see
+`src/lib/portal/customer-config.ts`). When no active persona exists, the
+framing is suppressed and the empty-state branch fires per
+`docs/style/empty-state-pattern.md`. No fallback persona name is permitted.
+
+## Portal surface
+
+URL: `portal.smd.services/portal/products/ai-employee/calibration`
+
+Access gate (principal-only via `resolveProductAccess()`):
+
+- Clerk session present (middleware)
+- Local entity bound to the active Clerk organization
+- Active AI Employee subscription on the entity
+- Caller holds the `principal` role on (user, entity, 'ai-employee')
+
+Operators and compliance users redirect to the AI Employee landing page.
+The page does not render a half-locked view; the role gate is binary.
+
+### States the page renders
+
+The page renders exactly one of four states, per
+`docs/style/empty-state-pattern.md`. No fabrication; no placeholder cycle.
+
+| State         | When                                                   | What renders                                                  |
+| ------------- | ------------------------------------------------------ | ------------------------------------------------------------- |
+| `no_persona`  | Customer config has no active persona                  | Empty state: "No active persona configured. Contact Captain." |
+| `not_started` | Persona exists; no calibration cycle has been created  | Empty state plus a "Start new calibration cycle" action       |
+| `active`      | A calibration cycle exists and at least one session is | Full cycle: four-session schedule with per-session state      |
+|               | `pending` or `in_progress`                             |                                                               |
+| `completed`   | All four sessions completed                            | Read-only summary plus a "Start new calibration cycle" action |
+
+The "Start new calibration cycle" action is the explicit way to (re-)run
+calibration on demand. It posts to
+`/api/portal/ai-employee/calibration/start` (endpoint lands under #821 with
+the D1 writer; the form action is the contract today).
+
+### Sections on the page
+
+The page composes three sections, in order:
+
+1. **Cycle header.** Cycle ID (when present), state badge, planning-window
+   length, persona name, the required assistant framing.
+2. **Session schedule.** A four-row grid in `CALIBRATION_SESSION_KINDS`
+   order: position number, label, description, state badge.
+3. **Seams documentation.** A read-only block naming the three integration
+   seams (voice, memory, trust ceiling) so the principal sees what each
+   session connects to downstream. Links to `docs/specs/ai-employee/`
+   sibling specs.
+
+The "Start new calibration cycle" action appears under the cycle header
+when the state is `not_started` or `completed`. It is not present in
+`active` (a cycle is already running) or `no_persona` (no persona to
+calibrate against).
+
+## Data-capture mechanics (deferred to #821)
+
+This spec documents the seams; the actual D1 tables, writer wiring, and
+emission contract land when the Hermes runtime scoping (issue #821) is
+resolved. Until then, the portal surface is read-only on every seam.
+
+### Seam 1: voice corrections → voice ingestion
+
+During session 1, the partner edits 10-15 representative drafts. Each
+edit produces a `(draft, sent)` pair that the voice ingestion pipeline
+consumes — see `docs/specs/ai-employee/voice-ingestion.md`. The
+structural-diff is stored under `{customer_slug}/voice/cohort/{cohort}/`
+per the existing ingestion contract; the calibration session does not
+introduce a new R2 prefix.
+
+When #821 ships, the calibration session writer posts each `(draft, sent)`
+pair to the voice ingestion runner with `source=calibration_session` so
+downstream consumers (compliance evidence packet, dashboard) can
+distinguish calibration-derived structural-diffs from live edit-then-send
+signals.
+
+### Seam 2: rule additions → memory rules
+
+During session 2, the partner walks each enabled skill against a real
+scenario and either approves the outcome, edits it, or marks it refused.
+"Edited" outcomes plus any newly stated rules ("we don't take medmal
+under $1M") feed the memory rules writer per
+`docs/specs/ai-employee/memory-ingestion.md`. The rule writer enforces
+the closed memory categories (rule / voice / process / person) from
+platform-prd.md §10.
+
+### Seam 3: approvals → trust-ceiling logging
+
+During session 3, the principal sets the per-skill ceiling (autonomous,
+draft_for_review, refused). Each ceiling change writes one row to
+`audit_log` via the `log_decision()` emission contract in
+`docs/specs/ai-employee/trust-ceiling-logging.md`. The
+`action_type` is `CEILING_PROMOTED` or `CEILING_DEMOTED` from the
+closed-set vocabulary (see `audit_log.py`); the `metadata` JSON includes
+`calibration_cycle_id` and `calibration_session_kind` so the compliance
+evidence packet can group calibration-derived audit rows together.
+
+## Non-goals
+
+- **No autonomous calibration.** The agent never schedules, conducts,
+  or self-grades a calibration session. Every session is a Captain-led
+  90-minute walkthrough with the partner. The portal exposes the cycle
+  structure; it does not run sessions.
+- **No fabricated session outcomes.** When no cycle has been authored,
+  the page renders the empty state. The portal does not synthesize
+  placeholder sessions, sample drafts, or projected timelines.
+- **No retry-pressure copy.** The action is "Start new calibration
+  cycle." It is not "Recalibrate now" or "Your calibration is overdue."
+  The cadence is the partner's decision.
+- **No fixed dates in marketing copy.** Per `CLAUDE.md` §3, scope-based
+  pricing engagements do not publish fixed timeframes externally. The
+  `CALIBRATION_WINDOW_DAYS` constant (14) governs internal scheduling;
+  the portal renders "two weeks" as descriptive text, not as a
+  commitment.
+
+## Customer.yaml shape (under #821)
+
+Calibration cycles persist in a per-customer D1 table once #821 lands.
+The expected shape lives in `customer.yaml` under a new
+`calibration_state` block (schema not yet defined; ADR pending). Until
+then, the portal reads from the projection only when the resolver
+returns a non-null cycle — today the resolver always returns null and
+the empty-state branch fires.
+
+## Verification
+
+- `tests/portal-ai-employee-calibration.test.ts` exercises the closed
+  vocabulary helpers (`isCalibrationSessionKind`,
+  `isCalibrationSessionState`, formatters), the framing builder
+  (`buildAssistantFraming`), and the cycle projection
+  (`buildDefaultSessionRows`, `getActiveCalibrationCycle`).
+- The portal page is unit-tested through the lib helpers it consumes
+  (Astro page rendering is not in the test surface for portal AI
+  Employee surfaces, consistent with the existing settings test set).
+
+## Cross-references
+
+- `docs/runbooks/ai-employee-calibration.md` — Captain-facing runbook
+  for conducting the four sessions
+- `docs/specs/ai-employee/voice-ingestion.md` — seam 1 consumer
+- `docs/specs/ai-employee/memory-ingestion.md` — seam 2 consumer
+- `docs/specs/ai-employee/trust-ceiling-logging.md` — seam 3 consumer
+- platform-prd.md §9.6 — gate #2 contract
+- law-firm-prd.md §11.9 — session-split rationale
+- issue [#821](https://github.com/venturecrane/ss-console/issues/821) —
+  Hermes runtime scoping that unblocks the D1 writer paths

--- a/docs/specs/ai-employee/index.md
+++ b/docs/specs/ai-employee/index.md
@@ -30,6 +30,7 @@ Build agents consuming these specs should treat the PRDs as **vision/doctrine** 
 | [sticky-stop.md](sticky-stop.md)                               | [#843](https://github.com/venturecrane/ss-console/issues/843) | System-initiated circuit breaker for runaway agent loops (WARN/SOFT/HARD)                                |
 | [safety-invariants.md](safety-invariants.md)                   | [#865](https://github.com/venturecrane/ss-console/issues/865) | Invariants #6 (citation enforcement on fact-bearing fields) and #7 (cross-Machine query prohibition)     |
 | [refusal-handling.md](refusal-handling.md)                     | [#866](https://github.com/venturecrane/ss-console/issues/866) | Runtime semantics when `trust_ceiling.enforce()` returns `refuse` (abort + notification + cascade alert) |
+| [calibration-session.md](calibration-session.md)               | [#867](https://github.com/venturecrane/ss-console/issues/867) | Four 90-minute calibration sessions over two weeks; portal surface + integration seams                   |
 
 ## Open ambiguities requiring Captain decision
 

--- a/src/components/portal/ai-employee/calibration/CycleHeader.astro
+++ b/src/components/portal/ai-employee/calibration/CycleHeader.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * Cycle header for the AI Employee calibration surface.
+ *
+ * Renders the cycle state, persona name, planning window, and the
+ * required assistant-not-replacement framing per the issue acceptance
+ * criteria. The framing is built in `src/lib/portal/ai-employee/calibration.ts`
+ * (`buildAssistantFraming`) so the literal text lives in one place.
+ *
+ * When `cycle` is null (state is `not_started` or `no_persona`), the
+ * component still renders the framing and the planning-window meta —
+ * the partner needs the posture before the empty-state action below.
+ */
+
+import {
+  buildAssistantFraming,
+  CALIBRATION_SESSION_MINUTES,
+  CALIBRATION_SESSIONS_PER_CYCLE,
+  CALIBRATION_WINDOW_DAYS,
+  formatCalibrationCycleState,
+  type CalibrationCycle,
+} from '../../../../lib/portal/ai-employee/calibration'
+
+interface Props {
+  /** Active persona name from `customer.yaml`. Null when no persona is configured. */
+  personaName: string | null
+  /** Active cycle, or null when not started / no persona. */
+  cycle: CalibrationCycle | null
+}
+
+const { personaName, cycle } = Astro.props
+
+const framing = personaName ? buildAssistantFraming(personaName) : null
+---
+
+<section
+  class="mt-stack border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)] p-card"
+>
+  <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+    <div class="min-w-0 flex-1">
+      <p
+        class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-text-secondary)]"
+      >
+        Calibration cycle
+      </p>
+      <h2
+        class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]"
+      >
+        {
+          cycle
+            ? formatCalibrationCycleState(cycle.state)
+            : formatCalibrationCycleState('not_started')
+        }
+      </h2>
+      {
+        cycle && (
+          <p class="mt-2 font-['JetBrains_Mono'] text-xs text-[color:var(--ss-color-text-muted)] break-all">
+            {cycle.id}
+          </p>
+        )
+      }
+    </div>
+    <dl class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm md:text-right">
+      {
+        personaName && (
+          <>
+            <dt class="font-['Archivo_Narrow'] uppercase tracking-[0.14em] text-xs text-[color:var(--ss-color-text-muted)] md:order-1">
+              Persona
+            </dt>
+            <dd class="text-[color:var(--ss-color-text-primary)] md:order-2">{personaName}</dd>
+          </>
+        )
+      }
+      <dt
+        class="font-['Archivo_Narrow'] uppercase tracking-[0.14em] text-xs text-[color:var(--ss-color-text-muted)] md:order-3"
+      >
+        Window
+      </dt>
+      <dd class="text-[color:var(--ss-color-text-primary)] md:order-4">
+        {CALIBRATION_SESSIONS_PER_CYCLE} sessions over {CALIBRATION_WINDOW_DAYS} days
+      </dd>
+      <dt
+        class="font-['Archivo_Narrow'] uppercase tracking-[0.14em] text-xs text-[color:var(--ss-color-text-muted)] md:order-5"
+      >
+        Length
+      </dt>
+      <dd class="text-[color:var(--ss-color-text-primary)] md:order-6">
+        {CALIBRATION_SESSION_MINUTES} minutes each
+      </dd>
+    </dl>
+  </div>
+
+  {
+    framing && (
+      <p class="mt-6 pt-6 border-t-[2px] border-[color:var(--ss-color-border-subtle)] text-body text-[color:var(--ss-color-text-primary)]">
+        {framing}
+      </p>
+    )
+  }
+</section>

--- a/src/components/portal/ai-employee/calibration/SeamsBlock.astro
+++ b/src/components/portal/ai-employee/calibration/SeamsBlock.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * Seams documentation block for the AI Employee calibration surface.
+ *
+ * Read-only block naming the three integration seams between
+ * calibration findings and the downstream substrate:
+ *
+ *   1. Voice corrections    → voice ingestion
+ *   2. Rule additions       → memory rules
+ *   3. Approvals            → trust-ceiling logging
+ *
+ * Per the issue acceptance criteria and the spec at
+ * `docs/specs/ai-employee/calibration-session.md`, the seams are
+ * documented on the portal so the principal sees what each session
+ * connects to. The actual data-capture mechanics depend on issue
+ * #821 (Hermes runtime scoping); until that ships, this block is the
+ * contract that downstream work hangs off.
+ *
+ * No fabricated runtime state. The block describes the seam, not the
+ * volume of data flowing through it. Volume is a downstream concern
+ * that lands when the writers wire up.
+ */
+
+interface Seam {
+  label: string
+  description: string
+}
+
+const SEAMS: Seam[] = [
+  {
+    label: 'Voice corrections to voice ingestion',
+    description:
+      'Edits the partner makes during session 1 feed the voice ingestion pipeline. Structural-diffs land in R2 per the voice-ingestion spec.',
+  },
+  {
+    label: 'Rule additions to memory rules',
+    description:
+      'Rules the partner states during session 2 are written to the memory rule writer. New rules appear in the memory tab on the next render.',
+  },
+  {
+    label: 'Approvals to trust-ceiling logging',
+    description:
+      'Ceiling changes the principal makes in session 3 write one row per change to the audit log via the log_decision emission contract.',
+  },
+]
+---
+
+<section class="mt-section">
+  <p
+    class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+  >
+    What each session connects to
+  </p>
+  <div
+    class="grid grid-cols-1 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]"
+  >
+    {
+      SEAMS.map((seam) => (
+        <article class="bg-[color:var(--ss-color-background)] p-6 md:p-8">
+          <h3 class="font-['Archivo'] text-base md:text-lg font-black uppercase tracking-[-0.01em] text-[color:var(--ss-color-text-primary)]">
+            {seam.label}
+          </h3>
+          <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">{seam.description}</p>
+        </article>
+      ))
+    }
+  </div>
+</section>

--- a/src/components/portal/ai-employee/calibration/SessionScheduleTable.astro
+++ b/src/components/portal/ai-employee/calibration/SessionScheduleTable.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * Four-row session schedule for the AI Employee calibration surface.
+ *
+ * Renders the cycle's session list in `CALIBRATION_SESSION_KINDS` order:
+ * position number, label, description, state badge. The list is always
+ * four rows (`CALIBRATION_SESSIONS_PER_CYCLE`); the closed vocabulary
+ * is asserted at the lib boundary (see
+ * `src/lib/portal/ai-employee/calibration.ts`).
+ *
+ * When `sessions` is empty (state is `not_started` or `no_persona`),
+ * the page passes the default row set from `buildDefaultSessionRows()`
+ * so the partner can see what a calibration cycle will look like even
+ * before one is started.
+ */
+
+import {
+  formatCalibrationSessionState,
+  type CalibrationSessionRow,
+} from '../../../../lib/portal/ai-employee/calibration'
+
+interface Props {
+  /** Four-row session schedule. */
+  sessions: CalibrationSessionRow[]
+}
+
+const { sessions } = Astro.props
+---
+
+<section class="mt-section">
+  <p
+    class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+  >
+    Sessions
+  </p>
+  <div
+    class="grid grid-cols-1 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]"
+  >
+    {
+      sessions.map((session) => {
+        const positionLabel = `§ ${String(session.position).padStart(2, '0')}`
+        return (
+          <article class="bg-[color:var(--ss-color-background)] p-6 md:p-8">
+            <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+              <div class="min-w-0 flex-1">
+                <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
+                  {positionLabel}
+                </p>
+                <h3 class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                  {session.label}
+                </h3>
+                <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+                  {session.description}
+                </p>
+              </div>
+              <span class="self-start md:self-auto inline-flex items-center bg-[color:var(--ss-color-border-subtle)] text-[color:var(--ss-color-text-primary)] px-3 py-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold whitespace-nowrap">
+                {formatCalibrationSessionState(session.state)}
+              </span>
+            </div>
+          </article>
+        )
+      })
+    }
+  </div>
+</section>

--- a/src/components/portal/ai-employee/calibration/StartCycleAction.astro
+++ b/src/components/portal/ai-employee/calibration/StartCycleAction.astro
@@ -1,0 +1,47 @@
+---
+/**
+ * "Start new calibration cycle" action for the AI Employee
+ * calibration surface.
+ *
+ * Renders an HTML form POSTing to
+ * `/api/portal/ai-employee/calibration/start`. The endpoint lands
+ * under issue #821 with the D1 writer; the form action is the
+ * contract today. Until the endpoint ships, the form submits and
+ * receives a 404 — the URL is the part downstream work hooks into.
+ *
+ * Per the issue acceptance criteria the action is always available
+ * to the principal: it appears in `not_started` and `completed`
+ * states, and is suppressed in the `active` state (a cycle is
+ * already running) and the `no_persona` state (no persona to
+ * calibrate against).
+ */
+
+interface Props {
+  /** Label that varies by state ("Start" for first run, "Start new" thereafter). */
+  label: string
+  /** Optional secondary copy that explains the action's effect. */
+  helperText?: string | null
+}
+
+const { label, helperText = null } = Astro.props
+---
+
+<form
+  method="POST"
+  action="/api/portal/ai-employee/calibration/start"
+  class="mt-section flex flex-col sm:flex-row gap-3 items-stretch sm:items-center justify-end border-t-[3px] border-[color:var(--ss-color-text-primary)] pt-6"
+>
+  {
+    helperText && (
+      <p class="flex-1 text-sm text-[color:var(--ss-color-text-secondary)] m-0 sm:text-right">
+        {helperText}
+      </p>
+    )
+  }
+  <button
+    type="submit"
+    class="inline-flex items-center justify-center px-5 py-2 font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold text-sm border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] hover:bg-[color:var(--ss-color-primary)] hover:border-[color:var(--ss-color-primary)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+  >
+    {label}
+  </button>
+</form>

--- a/src/lib/portal/ai-employee/calibration.ts
+++ b/src/lib/portal/ai-employee/calibration.ts
@@ -1,0 +1,321 @@
+/**
+ * AI Employee — calibration session workflow.
+ *
+ * Backs the portal surface at
+ * `/portal/products/ai-employee/calibration/*` and the runbook at
+ * `docs/runbooks/ai-employee-calibration.md`.
+ *
+ * Source: platform PRD §9.6 (voice quality gates) + law-firm PRD §11.9
+ * (calibration session split). The business-analyst critique
+ * collapsed the 4-6 hour Captain-led session into four 90-minute
+ * sessions spaced over two weeks because the 4-6 hour single block
+ * fails at firms that actually sign — partner calendars do not
+ * support it.
+ *
+ * What this module does today vs later:
+ *
+ *   - Today: declares the four-session schema, the planning window,
+ *     the closed vocabulary of session kinds + states, and projects
+ *     a cycle from a customer config row. No D1 writes. The portal
+ *     renders the cycle so a principal can see the structure and
+ *     start a new cycle when they are ready.
+ *
+ *   - Later (issue #821, Hermes runtime scoping): the data-capture
+ *     mechanics. Voice corrections flow into voice ingestion, rule
+ *     additions flow into memory rules, approvals flow into
+ *     trust-ceiling logging. The seams are named here so the
+ *     downstream work has a stable contract; the actual D1 tables
+ *     and writer wiring land under #821.
+ *
+ * No fabricated content. Per `docs/style/empty-state-pattern.md`,
+ * the resolver returns null when no cycle has been authored — the
+ * page renders the empty state with the explicit "Start new
+ * calibration cycle" action rather than a placeholder cycle.
+ */
+
+import type { PersonaConfig } from '../customer-config'
+
+// ---------------------------------------------------------------------------
+// Session kinds — closed vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * The four 90-minute sessions that make up one calibration cycle, in
+ * scheduling order. The vocabulary is closed because adding or
+ * renaming a session changes the runbook contract on
+ * `docs/runbooks/ai-employee-calibration.md`. New session kinds
+ * require a runbook revision.
+ *
+ *   voice_calibration       — session 1; surface the writing voice
+ *                             across recipient cohorts. Partner edits
+ *                             10-15 representative drafts. Corrections
+ *                             feed the voice ingestion seam.
+ *
+ *   skill_calibration       — session 2; walk through each enabled
+ *                             skill against real-shaped (synthetic at
+ *                             demo, customer-data at production)
+ *                             scenarios. Outcomes feed memory rules.
+ *
+ *   trust_ceiling           — session 3; refine the per-skill ceiling
+ *                             based on how the first two sessions
+ *                             went. Approvals feed trust-ceiling
+ *                             logging.
+ *
+ *   integration_handoff     — session 4; live workflow at the
+ *                             partner's keyboard. Final sign-off
+ *                             before the blind-test gate fires.
+ */
+export type CalibrationSessionKind =
+  | 'voice_calibration'
+  | 'skill_calibration'
+  | 'trust_ceiling'
+  | 'integration_handoff'
+
+export const CALIBRATION_SESSION_KINDS: readonly CalibrationSessionKind[] = [
+  'voice_calibration',
+  'skill_calibration',
+  'trust_ceiling',
+  'integration_handoff',
+] as const
+
+export function isCalibrationSessionKind(value: unknown): value is CalibrationSessionKind {
+  return (
+    typeof value === 'string' && (CALIBRATION_SESSION_KINDS as readonly string[]).includes(value)
+  )
+}
+
+/**
+ * Human label for a CalibrationSessionKind. Closed vocabulary; the
+ * switch is exhaustive so a typo upstream surfaces at compile time.
+ */
+export function formatCalibrationSessionKind(kind: CalibrationSessionKind): string {
+  switch (kind) {
+    case 'voice_calibration':
+      return 'Voice calibration'
+    case 'skill_calibration':
+      return 'Skill calibration'
+    case 'trust_ceiling':
+      return 'Trust-ceiling refinement'
+    case 'integration_handoff':
+      return 'Integration and handoff'
+  }
+}
+
+/**
+ * One-sentence description of what the session is for. Used on the
+ * portal card and in the runbook section anchors. Closed vocabulary;
+ * the descriptions are authored copy, not template strings.
+ */
+export function describeCalibrationSessionKind(kind: CalibrationSessionKind): string {
+  switch (kind) {
+    case 'voice_calibration':
+      return 'Surface the writing voice across recipient cohorts. The partner edits 10-15 representative drafts.'
+    case 'skill_calibration':
+      return 'Walk through every enabled skill against representative scenarios. The partner approves, edits, or refuses each outcome.'
+    case 'trust_ceiling':
+      return 'Refine the per-skill ceiling based on the first two sessions. The principal sets the autonomy boundary.'
+    case 'integration_handoff':
+      return 'Live workflow at the partner keyboard. Final sign-off before the blind-test gate.'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session state — closed vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * The lifecycle state of a single 90-minute session inside a cycle.
+ * Forward-only by default; the portal does not support moving a
+ * session backwards. A cancelled session may be re-scheduled by
+ * starting a new cycle.
+ *
+ *   pending     — session is on the schedule; not yet conducted
+ *   in_progress — Captain is conducting the session right now
+ *   completed   — session has been conducted and its findings logged
+ *   skipped     — session was intentionally not conducted (rare;
+ *                 documented in the runbook recovery path)
+ */
+export type CalibrationSessionState = 'pending' | 'in_progress' | 'completed' | 'skipped'
+
+export const CALIBRATION_SESSION_STATES: readonly CalibrationSessionState[] = [
+  'pending',
+  'in_progress',
+  'completed',
+  'skipped',
+] as const
+
+export function isCalibrationSessionState(value: unknown): value is CalibrationSessionState {
+  return (
+    typeof value === 'string' && (CALIBRATION_SESSION_STATES as readonly string[]).includes(value)
+  )
+}
+
+export function formatCalibrationSessionState(state: CalibrationSessionState): string {
+  switch (state) {
+    case 'pending':
+      return 'Scheduled'
+    case 'in_progress':
+      return 'In progress'
+    case 'completed':
+      return 'Completed'
+    case 'skipped':
+      return 'Skipped'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cycle state — closed vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * The overall lifecycle state of a calibration cycle (a set of four
+ * sessions). One cycle is active at a time. Starting a new cycle
+ * archives the prior one.
+ *
+ *   not_started — no cycle has been started for this customer
+ *   active      — a cycle is in progress; at least one session is
+ *                 pending or in_progress
+ *   completed   — all four sessions completed
+ *   archived    — a newer cycle was started; this one is read-only
+ */
+export type CalibrationCycleState = 'not_started' | 'active' | 'completed' | 'archived'
+
+export function formatCalibrationCycleState(state: CalibrationCycleState): string {
+  switch (state) {
+    case 'not_started':
+      return 'Not started'
+    case 'active':
+      return 'In progress'
+    case 'completed':
+      return 'Completed'
+    case 'archived':
+      return 'Archived'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cycle + session row shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * One row in the four-session schedule for a calibration cycle. The
+ * ordering matches CALIBRATION_SESSION_KINDS so callers can render
+ * the list without sorting.
+ */
+export interface CalibrationSessionRow {
+  /** Position in the cycle, 1-indexed (1, 2, 3, 4). */
+  position: 1 | 2 | 3 | 4
+  /** Session kind; see CalibrationSessionKind for the vocabulary. */
+  kind: CalibrationSessionKind
+  /** Lifecycle state of this individual session. */
+  state: CalibrationSessionState
+  /** Display label. */
+  label: string
+  /** One-sentence description of the session's purpose. */
+  description: string
+}
+
+/**
+ * A complete calibration cycle as projected for the portal. Cycle
+ * rows are derived, not authored — given the four session kinds and
+ * a planning window, the cycle structure is deterministic. The state
+ * of each session is what changes over time (and lives in D1 once
+ * the data-capture mechanics land per #821).
+ */
+export interface CalibrationCycle {
+  /** Cycle identifier; unique per (customer, cycle attempt). */
+  id: string
+  /** Active persona this cycle is calibrating. */
+  personaSlug: string
+  /** Overall lifecycle state. */
+  state: CalibrationCycleState
+  /** Four-session schedule, in CALIBRATION_SESSION_KINDS order. */
+  sessions: CalibrationSessionRow[]
+  /** Total length of the planning window, in days. */
+  windowDays: number
+}
+
+// ---------------------------------------------------------------------------
+// Framing constant — assistant, not replacement
+// ---------------------------------------------------------------------------
+
+/**
+ * The required framing sentence per the issue acceptance criteria.
+ * Composed at render time using the active persona name resolved
+ * from `customer-config.getActivePersona()`. The sentence is
+ * authored copy; the variable is the persona name, sourced from
+ * customer.yaml. No fallback persona name is permitted — when no
+ * active persona exists, the portal renders the empty state per
+ * `docs/style/empty-state-pattern.md` and the framing line is
+ * suppressed entirely.
+ *
+ * The shape is deliberately small. A longer template here invites
+ * Pattern A drift (committed sentences that describe uncontracted
+ * business behavior). The promise is bounded: assist, not replace.
+ */
+export function buildAssistantFraming(personaName: string): string {
+  return `${personaName} assists the partner; ${personaName} never replaces them.`
+}
+
+// ---------------------------------------------------------------------------
+// Window planning
+// ---------------------------------------------------------------------------
+
+/** Total length of a calibration cycle, per business-analyst recommendation. */
+export const CALIBRATION_WINDOW_DAYS = 14
+
+/** Length of each session in minutes, per business-analyst recommendation. */
+export const CALIBRATION_SESSION_MINUTES = 90
+
+/** Number of sessions per cycle. Closed vocabulary; do not loosen. */
+export const CALIBRATION_SESSIONS_PER_CYCLE = 4
+
+// ---------------------------------------------------------------------------
+// Cycle resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the default four-session structure for a cycle. Used both
+ * when starting a new cycle and when projecting a session-stateless
+ * cycle for the empty state.
+ *
+ * Every session starts as `pending`. The runbook governs which
+ * Captain action moves a session through `in_progress -> completed`.
+ */
+export function buildDefaultSessionRows(): CalibrationSessionRow[] {
+  return CALIBRATION_SESSION_KINDS.map((kind, idx) => {
+    const position = (idx + 1) as 1 | 2 | 3 | 4
+    const row: CalibrationSessionRow = {
+      position,
+      kind,
+      state: 'pending',
+      label: formatCalibrationSessionKind(kind),
+      description: describeCalibrationSessionKind(kind),
+    }
+    return row
+  })
+}
+
+/**
+ * Resolve the calibration cycle for a customer. Returns null when
+ * no cycle has been started — the page renders the empty state.
+ *
+ * Today this always returns null because the calibration_cycles
+ * D1 table lands under issue #821 (Hermes runtime scoping). Once
+ * the data-capture mechanics ship, this resolver reads the active
+ * row from D1 and projects it into the CalibrationCycle shape.
+ * The portal does not change when the resolver starts returning
+ * non-null values; the empty-state branch falls away naturally.
+ */
+export function getActiveCalibrationCycle(
+  _db: D1Database,
+  _entityId: string,
+  persona: PersonaConfig | null
+): Promise<CalibrationCycle | null> {
+  // No D1 reads today. When #821 lands the persona is the key into
+  // the per-(customer, persona) row in `calibration_cycles`; this
+  // function will gain an `await` then. The Promise return shape is
+  // stable across the wiring change so callers do not move.
+  void persona
+  return Promise.resolve(null)
+}

--- a/src/pages/portal/products/ai-employee/calibration/index.astro
+++ b/src/pages/portal/products/ai-employee/calibration/index.astro
@@ -1,0 +1,172 @@
+---
+import '../../../../../styles/global.css'
+import { BRAND_NAME } from '../../../../../lib/config/brand'
+import { resolveAiEmployeeAccess } from '../../../../../lib/portal/ai-employee-access'
+import { getActivePersona } from '../../../../../lib/portal/customer-config'
+import {
+  buildDefaultSessionRows,
+  getActiveCalibrationCycle,
+  type CalibrationCycle,
+  type CalibrationSessionRow,
+} from '../../../../../lib/portal/ai-employee/calibration'
+import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
+import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
+import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
+import SkipToMain from '../../../../../components/SkipToMain.astro'
+import CycleHeader from '../../../../../components/portal/ai-employee/calibration/CycleHeader.astro'
+import SessionScheduleTable from '../../../../../components/portal/ai-employee/calibration/SessionScheduleTable.astro'
+import SeamsBlock from '../../../../../components/portal/ai-employee/calibration/SeamsBlock.astro'
+import StartCycleAction from '../../../../../components/portal/ai-employee/calibration/StartCycleAction.astro'
+import { SignOutButton } from '@clerk/astro/components'
+import { env } from 'cloudflare:workers'
+
+/**
+ * AI Employee — Calibration session workflow (principal-only).
+ *
+ * URL: portal.smd.services/portal/products/ai-employee/calibration
+ *
+ * Four 90-minute sessions over two weeks, per the business-analyst
+ * critique carried into law-firm PRD §11.9 and the spec at
+ * `docs/specs/ai-employee/calibration-session.md`. The page is
+ * read-only at v1; the "Start new calibration cycle" action posts to
+ * an endpoint that lands with the data-capture mechanics under issue
+ * #821 (Hermes runtime scoping).
+ *
+ * Access gate (principal-only — operators and compliance redirect to
+ * the AI Employee landing):
+ *   - Clerk session (middleware)
+ *   - Local entity bound to the active Clerk organization
+ *   - Active AI Employee subscription on this customer
+ *   - Caller holds the `principal` role
+ *
+ * States the page renders (per docs/style/empty-state-pattern.md):
+ *   - no_persona  — customer.yaml has no active persona; empty state
+ *                   with explicit contact-Captain copy
+ *   - not_started — persona exists; no cycle yet; empty state plus
+ *                   the "Start new calibration cycle" action
+ *   - active      — a cycle exists with at least one pending session
+ *   - completed   — all four sessions completed; read-only summary
+ *                   plus the "Start new calibration cycle" action
+ *
+ * No fabricated cycle. No placeholder sessions. The default session
+ * rows (from `buildDefaultSessionRows()`) are rendered in the
+ * `not_started` state so the principal sees the cycle structure
+ * before starting one — but every row is `pending` and the rows are
+ * a visual preview of the schema, not a fake history.
+ */
+
+const access = await resolveAiEmployeeAccess(env.DB, Astro.locals, {
+  allowedRoles: ['principal'],
+})
+if (access.kind === 'redirect') {
+  return Astro.redirect(access.to)
+}
+const { client } = access
+
+const persona = await getActivePersona(env.DB, client.id)
+const cycle: CalibrationCycle | null = await getActiveCalibrationCycle(env.DB, client.id, persona)
+
+type SurfaceState = 'no_persona' | 'not_started' | 'active' | 'completed'
+
+let surfaceState: SurfaceState
+if (!persona) {
+  surfaceState = 'no_persona'
+} else if (!cycle) {
+  surfaceState = 'not_started'
+} else if (cycle.state === 'completed' || cycle.state === 'archived') {
+  surfaceState = 'completed'
+} else {
+  surfaceState = 'active'
+}
+
+// The session rows the page renders. Empty when there is no persona;
+// the default preview rows when no cycle exists; the cycle's own rows
+// otherwise. The default-preview rows are explicitly typed `pending`
+// so the partner can see what a real cycle will look like.
+const sessionRows: CalibrationSessionRow[] = (() => {
+  if (surfaceState === 'no_persona') return []
+  if (cycle) return cycle.sessions
+  return buildDefaultSessionRows()
+})()
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;900&family=Archivo+Narrow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <title>AI Employee · Calibration | {BRAND_NAME}</title>
+  </head>
+  <body class="min-h-screen bg-[color:var(--ss-color-background)]">
+    <SkipToMain />
+    <PortalHeader clientName={client.name}>
+      <SignOutButton asChild redirectUrl="/auth/portal-sign-in?status=signed_out">
+        <button
+          type="button"
+          class="inline-flex items-center min-h-11 px-2 -mx-2 text-sm text-[color:var(--ss-color-text-muted)] hover:text-[color:var(--ss-color-text-primary)] active:text-[color:var(--ss-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded transition-colors"
+        >
+          Sign out
+        </button>
+      </SignOutButton>
+    </PortalHeader>
+
+    <PortalTabs pathname={Astro.url.pathname} aiEmployeeActive={true} />
+
+    <main id="main" role="main" class="max-w-5xl mx-auto px-4 md:px-6 pb-24 md:pb-12">
+      <PortalPageHead
+        crumbHref="/portal/products/ai-employee"
+        crumbLabel="AI Employee"
+        tag="Section"
+        h1="Calibration"
+        meta={null}
+      />
+
+      {
+        surfaceState === 'no_persona' && (
+          <section class="mt-stack">
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-8 md:p-12 text-center">
+              <p class="font-['Archivo'] text-2xl md:text-3xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                No active persona
+              </p>
+              <p class="mt-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)]">
+                Calibration runs against an active persona. Contact Captain to provision one.
+              </p>
+            </div>
+          </section>
+        )
+      }
+
+      {
+        surfaceState !== 'no_persona' && persona && (
+          <>
+            <CycleHeader personaName={persona.name} cycle={cycle} />
+            <SessionScheduleTable sessions={sessionRows} />
+            <SeamsBlock />
+            {surfaceState === 'not_started' && (
+              <StartCycleAction
+                label="Start new calibration cycle"
+                helperText="Four 90-minute sessions over two weeks. The principal drives the cadence."
+              />
+            )}
+            {surfaceState === 'completed' && (
+              <StartCycleAction
+                label="Start new calibration cycle"
+                helperText="Starting a new cycle archives this one."
+              />
+            )}
+          </>
+        )
+      }
+    </main>
+  </body>
+</html>

--- a/tests/portal-ai-employee-calibration.test.ts
+++ b/tests/portal-ai-employee-calibration.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for the AI Employee calibration session workflow
+ * (src/lib/portal/ai-employee/calibration.ts).
+ *
+ * The lib declares the four-session schema, the closed vocabulary of
+ * session kinds + states, and projects a calibration cycle from a
+ * customer config row. The data-capture mechanics are deferred to
+ * issue #821; today's resolver always returns null and the page
+ * renders the empty state. The tests cover the closed vocabulary
+ * helpers, the framing builder, the default session row builder, and
+ * the resolver contract (returns null today, will return a cycle
+ * when the writer lands).
+ *
+ * Per the issue acceptance criteria the required framing is
+ * "AI Employee assists [Partner from getActivePersona()]; never
+ * replaces them." The framing is built in `buildAssistantFraming`
+ * which takes a persona name (the resolved active persona) and
+ * returns the literal sentence. No fabrication; no fallback persona
+ * name — null persona means the page renders the empty state and
+ * suppresses the framing entirely.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildAssistantFraming,
+  buildDefaultSessionRows,
+  CALIBRATION_SESSION_KINDS,
+  CALIBRATION_SESSION_MINUTES,
+  CALIBRATION_SESSION_STATES,
+  CALIBRATION_SESSIONS_PER_CYCLE,
+  CALIBRATION_WINDOW_DAYS,
+  describeCalibrationSessionKind,
+  formatCalibrationCycleState,
+  formatCalibrationSessionKind,
+  formatCalibrationSessionState,
+  getActiveCalibrationCycle,
+  isCalibrationSessionKind,
+  isCalibrationSessionState,
+  type CalibrationCycleState,
+  type CalibrationSessionKind,
+  type CalibrationSessionState,
+} from '../src/lib/portal/ai-employee/calibration'
+import type { PersonaConfig } from '../src/lib/portal/customer-config'
+
+function makePersona(overrides?: Partial<PersonaConfig>): PersonaConfig {
+  return {
+    slug: 'marcus',
+    status: 'active',
+    name: 'Marcus',
+    title: null,
+    signature_html: null,
+    tone: [],
+    send_as: null,
+    skills: [],
+    channel_bindings: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Closed vocabulary: session kinds
+// ---------------------------------------------------------------------------
+
+describe('CALIBRATION_SESSION_KINDS', () => {
+  it('exposes the four canonical session kinds in scheduling order', () => {
+    expect(CALIBRATION_SESSION_KINDS).toEqual([
+      'voice_calibration',
+      'skill_calibration',
+      'trust_ceiling',
+      'integration_handoff',
+    ])
+  })
+
+  it('declares CALIBRATION_SESSIONS_PER_CYCLE equal to its length', () => {
+    expect(CALIBRATION_SESSIONS_PER_CYCLE).toBe(CALIBRATION_SESSION_KINDS.length)
+    expect(CALIBRATION_SESSIONS_PER_CYCLE).toBe(4)
+  })
+})
+
+describe('isCalibrationSessionKind', () => {
+  it('accepts the four canonical values', () => {
+    expect(isCalibrationSessionKind('voice_calibration')).toBe(true)
+    expect(isCalibrationSessionKind('skill_calibration')).toBe(true)
+    expect(isCalibrationSessionKind('trust_ceiling')).toBe(true)
+    expect(isCalibrationSessionKind('integration_handoff')).toBe(true)
+  })
+
+  it('rejects anything else', () => {
+    expect(isCalibrationSessionKind('VOICE_CALIBRATION')).toBe(false)
+    expect(isCalibrationSessionKind('handoff')).toBe(false)
+    expect(isCalibrationSessionKind('')).toBe(false)
+    expect(isCalibrationSessionKind(null)).toBe(false)
+    expect(isCalibrationSessionKind(undefined)).toBe(false)
+    expect(isCalibrationSessionKind(0)).toBe(false)
+    expect(isCalibrationSessionKind(['voice_calibration'])).toBe(false)
+  })
+})
+
+describe('formatCalibrationSessionKind', () => {
+  it('maps every kind to a friendly label', () => {
+    const cases: Array<[CalibrationSessionKind, string]> = [
+      ['voice_calibration', 'Voice calibration'],
+      ['skill_calibration', 'Skill calibration'],
+      ['trust_ceiling', 'Trust-ceiling refinement'],
+      ['integration_handoff', 'Integration and handoff'],
+    ]
+    for (const [kind, expected] of cases) {
+      expect(formatCalibrationSessionKind(kind)).toBe(expected)
+    }
+  })
+})
+
+describe('describeCalibrationSessionKind', () => {
+  it('returns a non-empty description for every kind', () => {
+    for (const kind of CALIBRATION_SESSION_KINDS) {
+      const description = describeCalibrationSessionKind(kind)
+      expect(description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('mentions the partner in voice and skill sessions', () => {
+    expect(describeCalibrationSessionKind('voice_calibration')).toMatch(/partner/i)
+    expect(describeCalibrationSessionKind('skill_calibration')).toMatch(/partner/i)
+  })
+
+  it('mentions the principal in the trust-ceiling session', () => {
+    expect(describeCalibrationSessionKind('trust_ceiling')).toMatch(/principal/i)
+  })
+
+  it('descriptions are short single sentences (under 160 chars)', () => {
+    for (const kind of CALIBRATION_SESSION_KINDS) {
+      const description = describeCalibrationSessionKind(kind)
+      expect(description.length).toBeLessThanOrEqual(160)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Closed vocabulary: session state
+// ---------------------------------------------------------------------------
+
+describe('CALIBRATION_SESSION_STATES', () => {
+  it('exposes the four canonical states in lifecycle order', () => {
+    expect(CALIBRATION_SESSION_STATES).toEqual(['pending', 'in_progress', 'completed', 'skipped'])
+  })
+})
+
+describe('isCalibrationSessionState', () => {
+  it('accepts every canonical state', () => {
+    for (const state of CALIBRATION_SESSION_STATES) {
+      expect(isCalibrationSessionState(state)).toBe(true)
+    }
+  })
+
+  it('rejects anything else', () => {
+    expect(isCalibrationSessionState('PENDING')).toBe(false)
+    expect(isCalibrationSessionState('archived')).toBe(false)
+    expect(isCalibrationSessionState('')).toBe(false)
+    expect(isCalibrationSessionState(null)).toBe(false)
+    expect(isCalibrationSessionState(undefined)).toBe(false)
+  })
+})
+
+describe('formatCalibrationSessionState', () => {
+  it('maps every state to a friendly label', () => {
+    const cases: Array<[CalibrationSessionState, string]> = [
+      ['pending', 'Scheduled'],
+      ['in_progress', 'In progress'],
+      ['completed', 'Completed'],
+      ['skipped', 'Skipped'],
+    ]
+    for (const [state, expected] of cases) {
+      expect(formatCalibrationSessionState(state)).toBe(expected)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle state
+// ---------------------------------------------------------------------------
+
+describe('formatCalibrationCycleState', () => {
+  it('maps every cycle state to a friendly label', () => {
+    const cases: Array<[CalibrationCycleState, string]> = [
+      ['not_started', 'Not started'],
+      ['active', 'In progress'],
+      ['completed', 'Completed'],
+      ['archived', 'Archived'],
+    ]
+    for (const [state, expected] of cases) {
+      expect(formatCalibrationCycleState(state)).toBe(expected)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Required framing
+// ---------------------------------------------------------------------------
+
+describe('buildAssistantFraming', () => {
+  it('uses the persona name on both sides of the sentence', () => {
+    const framing = buildAssistantFraming('Marcus')
+    expect(framing).toBe('Marcus assists the partner; Marcus never replaces them.')
+  })
+
+  it('names the assist relationship before naming the not-replace one', () => {
+    const framing = buildAssistantFraming('Marcus')
+    const assistsAt = framing.indexOf('assists')
+    const neverAt = framing.indexOf('never')
+    expect(assistsAt).toBeGreaterThan(-1)
+    expect(neverAt).toBeGreaterThan(-1)
+    expect(assistsAt).toBeLessThan(neverAt)
+  })
+
+  it('uses the literal persona name passed in (no normalization)', () => {
+    expect(buildAssistantFraming('Karen Chen')).toMatch(/^Karen Chen assists/)
+  })
+
+  it('never contains em dashes (per CLAUDE.md tone standard)', () => {
+    const framing = buildAssistantFraming('Marcus')
+    expect(framing).not.toMatch(/—/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Window planning constants
+// ---------------------------------------------------------------------------
+
+describe('window planning constants', () => {
+  it('CALIBRATION_WINDOW_DAYS is fourteen days', () => {
+    expect(CALIBRATION_WINDOW_DAYS).toBe(14)
+  })
+
+  it('CALIBRATION_SESSION_MINUTES is ninety minutes', () => {
+    expect(CALIBRATION_SESSION_MINUTES).toBe(90)
+  })
+
+  it('CALIBRATION_SESSIONS_PER_CYCLE is four', () => {
+    expect(CALIBRATION_SESSIONS_PER_CYCLE).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Default session rows
+// ---------------------------------------------------------------------------
+
+describe('buildDefaultSessionRows', () => {
+  it('returns exactly four rows', () => {
+    const rows = buildDefaultSessionRows()
+    expect(rows).toHaveLength(CALIBRATION_SESSIONS_PER_CYCLE)
+  })
+
+  it('rows are in CALIBRATION_SESSION_KINDS order with 1-indexed positions', () => {
+    const rows = buildDefaultSessionRows()
+    expect(rows.map((r) => r.kind)).toEqual([...CALIBRATION_SESSION_KINDS])
+    expect(rows.map((r) => r.position)).toEqual([1, 2, 3, 4])
+  })
+
+  it('every row starts pending', () => {
+    const rows = buildDefaultSessionRows()
+    expect(rows.every((r) => r.state === 'pending')).toBe(true)
+  })
+
+  it('row labels match the formatter output for the kind', () => {
+    const rows = buildDefaultSessionRows()
+    for (const row of rows) {
+      expect(row.label).toBe(formatCalibrationSessionKind(row.kind))
+    }
+  })
+
+  it('row descriptions match the description helper for the kind', () => {
+    const rows = buildDefaultSessionRows()
+    for (const row of rows) {
+      expect(row.description).toBe(describeCalibrationSessionKind(row.kind))
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Resolver contract
+// ---------------------------------------------------------------------------
+
+describe('getActiveCalibrationCycle', () => {
+  // The resolver is the seam between the portal and the per-customer
+  // D1 writer. Today it returns null on every call — the writer lands
+  // under issue #821 (Hermes runtime scoping). These tests pin the
+  // contract so an accidental fabrication does not slip into the
+  // portal under the empty-state branch.
+
+  // A stub D1Database — the resolver does not touch it today.
+  const stubDb = {} as unknown as D1Database
+
+  it('returns null when persona is null', async () => {
+    const result = await getActiveCalibrationCycle(stubDb, 'entity-1', null)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when persona exists but no cycle is on file', async () => {
+    const persona = makePersona()
+    const result = await getActiveCalibrationCycle(stubDb, 'entity-1', persona)
+    expect(result).toBeNull()
+  })
+
+  it('does not fabricate a cycle for an entity that has none', async () => {
+    // Belt-and-suspenders: independent of input, the resolver does
+    // not return a synthesized cycle. The empty-state branch on the
+    // portal is the load-bearing rule per
+    // docs/style/empty-state-pattern.md.
+    const persona = makePersona({ slug: 'anything', name: 'Anyone' })
+    const result = await getActiveCalibrationCycle(stubDb, 'whatever', persona)
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Adds the calibration session workflow per platform PRD §9.6 + law-firm PRD §11.9: four 90-minute sessions over two weeks (the business-analyst critique flagged the single 4-6 hour block as a collapse risk at firms that actually sign).

- Spec at `docs/specs/ai-employee/calibration-session.md` + runbook at `docs/runbooks/ai-employee-calibration.md`. Spec registered in the AI Employee specs index.
- Portal surface at `portal.smd.services/portal/products/ai-employee/calibration` (principal-only via `resolveProductAccess`). Renders one of four states (`no_persona`, `not_started`, `active`, `completed`) per `docs/style/empty-state-pattern.md` — no fabricated cycle, no placeholder sessions.
- Required framing per AC: `{persona name} assists the partner; {persona name} never replaces them.` Persona name resolved from `getActivePersona()`; suppressed when no active persona.
- "Start new calibration cycle" action posts to `/api/portal/ai-employee/calibration/start` (endpoint lands under #821 with the D1 writer; the URL is the contract today).
- Three integration seams documented as deferred to #821: voice corrections → voice ingestion, rule additions → memory rules, approvals → trust-ceiling logging.
- 29 lib tests covering closed vocabulary helpers, framing builder, default session row builder, and the null-returning resolver contract.

Closes #867.

## Test plan

- [x] `npm test -- portal-ai-employee-calibration` — 29 tests pass
- [x] `npm test -- forbidden-strings` — 74 tests pass (no allowlist row needed)
- [x] `npm run verify` — 0 errors, 0 new warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)