### PR TITLE
feat(ai-employee): wire aie_adapter.register() to Hermes hook surface (#841)

### DIFF
--- a/ai-employee/adapter/aie_adapter.py
+++ b/ai-employee/adapter/aie_adapter.py
@@ -1,17 +1,38 @@
-"""AIEmployee adapter — Hermes integration point.
+"""AIEmployee adapter - Hermes integration point.
 
-Registers a tool-dispatch middleware with Hermes that runs every tool call
-through `trust_ceiling.enforce()` before execution. Refusals + draft-routed
-actions are logged to the customer's audit log.
+Registers safety-substrate hooks with the Hermes overlay surface so every
+tool call routes through `trust_ceiling.enforce()` before execution.
+Refusals + draft-routed actions are logged to the customer's audit log via
+the existing `AuditLogWriter` from PR #942. Refusal cascades surface via
+the `RefusalHandler` from PR #967. Pinned slots survive context compaction
+per safety invariant #4.
 
-Loading mechanism: bootstrap.sh sets PYTHONPATH=/app/adapter:/app:..., then
-runs `hermes run --adapter aiemployee`. Hermes' adapter loader (per the
-Hermes plugin spec) imports `aie_adapter` and calls `register()`.
+Loading mechanism
+-----------------
 
-Phase A: this module is a stub — Hermes runs without the adapter registered.
-Phase A.5 implements the registration handshake against Hermes' tool
-dispatch hooks (the upstream `agent/tool_router.py` exposes the hook point
-we need; this is the integration work that lands in Phase A.5).
+`bootstrap.sh` sets `PYTHONPATH=/app/adapter:/app:...`, then runs
+`hermes run --adapter aiemployee`. The SMD overlay layer inside the
+Hermes fork (per [ADR 0015](../../docs/adr/0015-hermes-fork-vs-upstream.md))
+constructs a `hermes_hook.HookRegistry`, imports this module, and calls
+`register(registry)`.
+
+The seam upstream is `agent/tool_guardrails.py`; the overlay layer wraps
+it and exposes the `HookRegistry` interface declared in
+`hermes_hook.py`. The adapter side (here) does not touch upstream files
+and does not depend on the fork's internal layout - the contract is the
+`HookRegistry` shape.
+
+Phase A.5
+---------
+
+This file replaces the original Phase A stub. The stub asserted the
+upstream seam was `agent/tool_router.py`; PR #829's runbook discovered
+the real seam at `agent/tool_guardrails.py`; ADR 0015 locked the
+overlay-plus-thin-fork strategy; this PR rewires `register()` accordingly.
+
+The hook surface is testable in isolation via `hermes_hook.FakeHermesRuntime`;
+the integration tests in `tests/test_aie_adapter.py` drive the full
+pre-hook -> tool -> post-hook + refusal path against the in-memory fake.
 """
 
 from __future__ import annotations
@@ -19,12 +40,24 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Optional
 
 try:
     import yaml
 except ImportError:
     yaml = None  # tolerated for unit-test import; bootstrap requires it
 
+from .hermes_hook import (
+    DEFAULT_PINNED_SLOT_KEYS,
+    BlockedToolCall,
+    DefaultTrustCeilingEnforcer,
+    HookActionClass,
+    HookRegistry,
+    PinnedSlots,
+    ToolCallContext,
+    ToolCallResult,
+    TrustCeilingEnforcer,
+)
 from .trust_ceiling import ActionClass, Ceiling, enforce
 
 log = logging.getLogger("aie.adapter")
@@ -44,31 +77,309 @@ def _load_customer_config() -> dict:
         return yaml.safe_load(f) or {}
 
 
-def register() -> None:
+def _seed_pinned_slots(slots: PinnedSlots, cfg: dict) -> None:
+    """Pin the closed-set DEFAULT_PINNED_SLOT_KEYS at adapter boot.
+
+    Only slots whose value is derivable from customer.yaml are pinned;
+    the rest (sticky_stop.active, trust_ceiling.locked_skills) are pinned
+    later by the substrate as state changes. The compaction hook re-injects
+    whatever is in the slot table at compaction time.
+    """
+    persona = cfg.get("persona") or {}
+    if isinstance(persona, dict) and persona.get("name"):
+        slots.pin("persona.name", str(persona["name"]))
+
+    reviewer = cfg.get("reviewer") or {}
+    if isinstance(reviewer, dict) and reviewer.get("identity"):
+        slots.pin("reviewer.identity", str(reviewer["identity"]))
+
+    # customer.yaml signature is a content hash the validator records;
+    # absent in early customer.yaml fixtures, pin only if present.
+    signature = cfg.get("signature") or cfg.get("customer_yaml_signature")
+    if signature:
+        slots.pin("customer.yaml.signature", str(signature))
+
+
+def _make_pre_tool_hook(
+    enforcer: TrustCeilingEnforcer,
+):
+    """Build the pre-tool hook that runs trust-ceiling enforcement.
+
+    The hook calls `enforcer.enforce()` for every tool call. If the
+    decision is not `allow`, it raises `BlockedToolCall`; the overlay's
+    dispatch path catches and routes to the refusal hook + post-hook.
+
+    Forbidden-action runtime block: this is the integration point where
+    "the model can ask all it wants; the adapter says no" lands as code.
+    Test isolation is via `FakeHermesRuntime.dispatch()` in tests.
+    """
+
+    async def pre_tool(context: ToolCallContext) -> None:
+        decision = enforcer.enforce(
+            customer=context.customer,
+            skill=context.skill_name,
+            action_class=context.action_class,
+            ceiling_level=context.ceiling_level,
+            current_turn_approval=context.current_turn_approval,
+        )
+        if decision.allowed:
+            return
+        # audit_action is one of "allow" | "draft" | "refuse"; any non-
+        # allow lands as a runtime block. The refusal hook differentiates
+        # draft-route from refuse via the substrate-side reason mapping.
+        raise BlockedToolCall(
+            reason=decision.reason,
+            context=context,
+        )
+
+    return pre_tool
+
+
+def _make_post_tool_hook(audit_writer):
+    """Build the post-tool hook that emits the per-tool audit row.
+
+    Per issue #842, every tool dispatch emits `timestamp, customer, skill,
+    tool, action class, ceiling decision, outcome` to the audit log. The
+    actual row goes through `AuditLogWriter.write()` so the writer's
+    closed-set `ACCEPTED_ACTION_TYPES` and digesting contract apply.
+
+    The action_type bucket is `INVARIANT_VIOLATION` for blocked calls
+    (the substrate stopped the action) and `DRAFT_CREATED` for allowed
+    calls (consistent with the audit-floor convention from
+    trust_ceiling_log.py). The metadata carries the per-tool detail.
+    """
+    # Lazy import to keep this module importable without the audit_log
+    # module's optional dependencies.
+    from .audit_log import ActorRole, AuditEvent  # noqa: PLC0415
+
+    async def post_tool(context: ToolCallContext, result: ToolCallResult) -> None:
+        if audit_writer is None:
+            # Adapter constructed without an audit writer (boot-time fallback).
+            # The substrate invariant says actions without an audit row do not
+            # run; the pre-hook still ran trust-ceiling enforcement, so this
+            # branch only fires in test/local-dev paths. Log and return.
+            log.warning(
+                "post_tool: no audit writer; skipping audit emission "
+                "(customer=%s skill=%s tool=%s outcome=%s)",
+                context.customer,
+                context.skill_name,
+                context.tool_name,
+                result.outcome,
+            )
+            return
+
+        action_type = (
+            "INVARIANT_VIOLATION" if result.outcome == "blocked" else "DRAFT_CREATED"
+        )
+        await audit_writer.write(
+            AuditEvent(
+                action_type=action_type,
+                actor="agent",
+                actor_role=ActorRole.AGENT,
+                skill_name=context.skill_name,
+                matter_ref=context.matter_ref,
+                trust_ceiling=context.ceiling_level,
+                metadata={
+                    "per_tool_audit": True,
+                    "customer": context.customer,
+                    "skill": context.skill_name,
+                    "skill_version": context.skill_version,
+                    "tool": context.tool_name,
+                    "action_class": context.action_class.value,
+                    "ceiling_level": context.ceiling_level,
+                    "outcome": result.outcome,
+                    "error_type": result.error_type,
+                    "duration_ms": result.duration_ms,
+                    "trace_id": context.trace_id,
+                },
+            )
+        )
+
+    return post_tool
+
+
+def _make_refusal_hook(refusal_handler):
+    """Build the refusal hook. Delegates to `RefusalHandler.handle()`.
+
+    The handler emits the customer-facing notification audit row, the
+    Captain cascade-alert row (if threshold exceeded), and returns a
+    `RefusalOutcome` whose `aborted == True`. The dispatch path uses the
+    raised `BlockedToolCall` to abort; the refusal hook's job is purely
+    audit-emission, not flow control.
+    """
+
+    async def refusal(context: ToolCallContext, block: BlockedToolCall) -> None:
+        if refusal_handler is None:
+            log.warning(
+                "refusal hook fired but no RefusalHandler configured; "
+                "customer=%s skill=%s reason=%s",
+                context.customer,
+                context.skill_name,
+                block.reason,
+            )
+            return
+        # The substrate's RefusalHandler signature wants closed-enum types
+        # from trust_ceiling_log; the dispatch path maps the hook context
+        # to those values. To keep this module decoupled from the
+        # safety-substrate package layout, we lazy-import the enum here
+        # and translate.
+        try:
+            from trust_ceiling_log import (  # type: ignore[import-not-found]  # noqa: PLC0415
+                ActionClassName,
+                CeilingLevel,
+                DecisionReason,
+            )
+        except ImportError:
+            log.warning(
+                "refusal hook: trust_ceiling_log not importable; "
+                "RefusalHandler invocation skipped (safety-substrate "
+                "package not on sys.path in this runtime)"
+            )
+            return
+
+        # The pre-hook does not know the closed-enum DecisionReason; it
+        # carries a free-text reason string from the adapter's enforce().
+        # Map the most likely reasons; default to UNKNOWN_ACTION_CLASS
+        # so the customer-facing message falls back to GENERIC_REFUSED.
+        reason_text = block.reason.lower()
+        if "commitment" in reason_text and "approval" in reason_text:
+            decision_reason = DecisionReason.COMMITMENT_NO_APPROVAL
+        elif "destructive" in reason_text and "approval" in reason_text:
+            decision_reason = DecisionReason.DESTRUCTIVE_NO_APPROVAL
+        elif "destructive" in reason_text and "draft_for_review" in reason_text:
+            decision_reason = DecisionReason.DESTRUCTIVE_DRAFT_CEILING
+        elif "external_send" in reason_text and "approval" in reason_text:
+            decision_reason = DecisionReason.EXTERNAL_SEND_NO_APPROVAL
+        elif "refused" in reason_text or "disabled" in reason_text:
+            decision_reason = DecisionReason.CEILING_DISABLED
+        else:
+            decision_reason = DecisionReason.UNKNOWN_ACTION_CLASS
+
+        action_class_value = ActionClassName(context.action_class.value)
+        # The ceiling_level string from the hook context aligns with both
+        # CeilingLevel's spelling and the adapter's; the constructor
+        # raises if it does not. That is the right failure mode.
+        ceiling_value = CeilingLevel(context.ceiling_level)
+
+        outcome = await refusal_handler.handle(
+            customer=context.customer,
+            skill=context.skill_name,
+            action_class=action_class_value,
+            ceiling_level=ceiling_value,
+            reason=decision_reason,
+            skill_version=context.skill_version,
+            trace_id=context.trace_id,
+            matter_ref=context.matter_ref,
+        )
+        # Surface the customer-facing message back onto the BlockedToolCall
+        # so the dispatch loop can render it without re-running the
+        # mapping. Mutating an attribute is acceptable here; the caller
+        # constructs the exception immediately before raising it.
+        block.customer_message = outcome.message.value
+
+    return refusal
+
+
+def _make_compaction_hook():
+    """Build the compaction hook. Re-injects pinned slots after compaction.
+
+    Per safety invariant #4: pinned slots survive compaction. The Hermes
+    runtime calls this hook after its own compaction has run and before
+    the next turn starts. The hook reads the current pinned-slot table
+    and asks the substrate to materialize each slot in the post-compaction
+    context.
+
+    v1 implementation logs the pinned-slot snapshot and returns. The
+    substrate-side context-injection wiring is fork-side overlay code
+    that will land in a sibling PR; this hook is the seam.
+    """
+
+    async def compaction(slots: PinnedSlots) -> None:
+        snapshot = slots.snapshot()
+        log.info(
+            "compaction hook: re-injecting %d pinned slots (keys=%s)",
+            len(snapshot),
+            sorted(snapshot.keys()),
+        )
+
+    return compaction
+
+
+def register(
+    registry: Optional[HookRegistry] = None,
+    *,
+    audit_writer=None,
+    refusal_handler=None,
+    enforcer: Optional[TrustCeilingEnforcer] = None,
+) -> HookRegistry:
     """Hermes adapter entrypoint.
 
-    Phase A: this is a no-op. Phase A.5 implementation:
+    Args:
+        registry - the overlay's `HookRegistry`. When None, a fresh
+                          registry is constructed (suitable for unit tests).
+        audit_writer - constructed `AuditLogWriter`. When None, the post-
+                          tool hook logs-and-skips audit emission (test path).
+                          Production callers MUST supply one.
+        refusal_handler - constructed `RefusalHandler`. When None, the
+                          refusal hook logs-and-skips notification emission.
+                          Production callers MUST supply one.
+        enforcer - alternate `TrustCeilingEnforcer`. When None,
+                          `DefaultTrustCeilingEnforcer` is used.
 
-      1. Import Hermes' tool dispatch hook (agent/tool_router.py)
-      2. Wrap each registered tool call in a function that:
-         - Resolves the current skill from Hermes' execution context
-         - Looks up the skill's trust_ceiling from SKILL.md frontmatter +
-           customer.yaml overrides
-         - Categorizes the tool call by ActionClass
-         - Calls trust_ceiling.enforce()
-         - Allows / drafts / refuses per the decision
-         - Logs every decision to the customer's audit log
-      3. Hook the compaction event: re-inject the "don't act" pinned slots
-         on compaction so they survive (invariant #4)
+    Returns:
+        The registry with the four hooks installed. The Hermes overlay
+        keeps the returned reference for its dispatch loop.
+
+    Steps:
+      1. Load customer.yaml; seed the registry's pinned-slot table with
+         the closed-set DEFAULT_PINNED_SLOT_KEYS values that are
+         derivable from customer.yaml.
+      2. Build the pre-tool hook (trust-ceiling enforcement). Forbidden
+         actions raise `BlockedToolCall`; the overlay's dispatch path
+         catches and stops the action.
+      3. Build the post-tool hook (per-tool audit emission).
+      4. Build the refusal hook (customer-facing notification + Captain
+         cascade alert via RefusalHandler).
+      5. Build the compaction hook (re-inject pinned slots; safety
+         invariant #4).
+      6. Register all four against the supplied registry.
     """
+    if registry is None:
+        registry = HookRegistry()
+    if enforcer is None:
+        enforcer = DefaultTrustCeilingEnforcer()
+
     cfg = _load_customer_config()
     customer_id = cfg.get("customer_id", "unknown")
-    log.info("AIEmployee adapter registered for customer=%s (Phase A stub)", customer_id)
+    _seed_pinned_slots(registry.pinned_slots, cfg)
+
+    registry.register_pre_tool(_make_pre_tool_hook(enforcer))
+    registry.register_post_tool(_make_post_tool_hook(audit_writer))
+    registry.register_refusal(_make_refusal_hook(refusal_handler))
+    registry.register_compaction(_make_compaction_hook())
+
     log.info(
-        "Phase A.5 will hook trust_ceiling.enforce() into Hermes' tool dispatch."
+        "AIEmployee adapter registered for customer=%s: 4 hooks installed "
+        "(pre_tool, post_tool, refusal, compaction); pinned slots=%s",
+        customer_id,
+        sorted(registry.pinned_slots.keys()),
     )
-    # Phase A.5 work goes here — for now just announce and return.
+    return registry
 
 
-# Re-export for convenience
-__all__ = ["ActionClass", "Ceiling", "enforce", "register"]
+# Re-export for convenience (callers and the overlay both import from here)
+__all__ = [
+    "ActionClass",
+    "BlockedToolCall",
+    "Ceiling",
+    "DEFAULT_PINNED_SLOT_KEYS",
+    "DefaultTrustCeilingEnforcer",
+    "HookActionClass",
+    "HookRegistry",
+    "PinnedSlots",
+    "ToolCallContext",
+    "ToolCallResult",
+    "TrustCeilingEnforcer",
+    "enforce",
+    "register",
+]

--- a/ai-employee/adapter/hermes_hook.py
+++ b/ai-employee/adapter/hermes_hook.py
@@ -1,0 +1,587 @@
+"""Hermes hook surface - typed interface for the SMD overlay layer (issue #841).
+
+Background
+----------
+
+Per [ADR 0015](../../docs/adr/0015-hermes-fork-vs-upstream.md), SMD maintains
+a thin vendored fork of NousResearch/hermes-agent. The fork carries an SMD
+overlay layer (`smd/` subpackage) that exposes hook points the upstream
+runtime does not. The upstream surface that the overlay extends is
+`agent/tool_guardrails.py`. PR #829's runbook confirmed `tool_guardrails.py`
+as the integration point at upstream `v2026.5.7` and superseded the original
+PR #812 assumption of `tool_router.py`.
+
+This module is the typed contract between:
+
+  * the SMD overlay layer inside the Hermes fork (which constructs a
+    `HookRegistry` and exposes it at adapter-load time), and
+  * `ai-employee/adapter/aie_adapter.py::register()` (which receives a
+    `HookRegistry`, builds the safety-substrate hooks, and installs them).
+
+The contract is held here, in `ai-employee/adapter/`, on purpose. The
+adapter side of the integration is what SMD owns end-to-end. The overlay
+side ships in the fork and conforms to this interface; the fork is free
+to swap its internal implementation without renegotiating the adapter
+surface. This is the "stable adapter contract" half of ADR 0015's seam
+strategy.
+
+Hook shape
+----------
+
+The four hook points cover the four safety-substrate touchpoints Phase A.5
+brings online:
+
+  * **pre_tool** - called before any tool executes. The hook receives a
+    `ToolCallContext` and either returns silently (the tool proceeds) or
+    raises `BlockedToolCall` (the tool is suppressed). This is the runtime
+    enforcement seam for trust-ceiling refusals and sticky-stop HARD_STOP.
+
+  * **post_tool** - called after the tool executes (or after the pre-hook
+    blocked it). Receives `ToolCallContext` plus a `ToolCallResult`. This
+    is the audit emission seam (per-tool `timestamp, customer, skill,
+    tool, action class, ceiling decision, outcome` row from issue #842).
+
+  * **refusal** - called when the pre-hook blocked the call. Receives
+    enough context for the in-app notification and Captain alert paths
+    (delegates to `RefusalHandler` from PR #967 on main).
+
+  * **compaction** - called when Hermes' context manager compacts the
+    turn history. Receives the live `PinnedSlots` registry; the hook
+    re-injects the pinned slots back into the post-compaction context.
+    This is the runtime enforcement seam for safety invariant #4.
+
+Each hook is registered with a `HookRegistry` instance via the overlay's
+`register_*_hook()` methods. `aie_adapter.register()` constructs the
+hooks and installs them; the overlay's tool-dispatch path invokes them
+on the call path.
+
+No autonomous send
+------------------
+
+Nothing in this module originates an outbound message. The hooks observe,
+classify, and either allow or block. Audit row emission happens via the
+existing `AuditLogWriter`; the notification surface is poll-based and out
+of scope here. ADR 0005 (reviewer-as-sender) is not relaxed by anything
+in this module.
+
+Test isolation
+--------------
+
+The module ships an in-memory fake (`FakeHermesRuntime`) suitable for
+pytest. Tests can construct a fake, register hooks against it, and drive
+tool dispatch synthetically. The fake's `dispatch()` method mirrors the
+Hermes runtime's tool-dispatch loop: pre-hook fires, the tool executes
+if not blocked, post-hook fires. This is the seam the integration test
+in `tests/test_aie_adapter.py` drives.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Optional, Protocol
+
+
+log = logging.getLogger("aie.hermes_hook")
+
+
+# ---------------------------------------------------------------------------
+# Action class - re-declared in the hook surface so the overlay does not
+# need to import from `adapter/trust_ceiling.py`. The string values match
+# `adapter.trust_ceiling.ActionClass` exactly so the two enums round-trip
+# through their `.value`.
+# ---------------------------------------------------------------------------
+
+
+class HookActionClass(str, enum.Enum):
+    """Categorization the overlay attaches to a tool call before dispatch.
+
+    Mirrors `adapter.trust_ceiling.ActionClass`. Carried as a separate enum
+    here so the overlay side does not pull adapter-internal modules; the
+    string values are identical and either side can convert.
+    """
+
+    READ = "read"
+    INTERNAL_WRITE = "internal_write"
+    EXTERNAL_SEND = "external_send"
+    COMMITMENT = "commitment"
+    DESTRUCTIVE = "destructive"
+
+
+# ---------------------------------------------------------------------------
+# Context objects passed to hooks
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolCallContext:
+    """Everything a hook needs to classify and audit one tool call.
+
+    Constructed by the overlay's dispatch path. The overlay derives
+    `action_class` from the tool's declared metadata (per ADR 0006
+    capability contracts) and `ceiling_level` from the resolved
+    skill-version pin plus customer.yaml overrides.
+
+    Fields:
+        customer - customer slug; matches the D1 binding tenant
+        skill_name - skill name from SKILL.md frontmatter
+        skill_version - resolved content-hash SHA or version pin
+        tool_name - the tool being invoked (e.g. "Email.create_draft")
+        action_class - the categorization the overlay attached
+        ceiling_level - the trust ceiling configured for the skill
+        matter_ref - opaque per-vertical reference (matter id, lead id)
+        trace_id - opaque request/turn id for cross-row correlation
+        current_turn_approval - True iff the operator approved THIS action
+                                in THIS turn (per safety invariant #1)
+        arguments - tool arguments; never logged verbatim, may be
+                              passed through the digesting path on audit
+    """
+
+    customer: str
+    skill_name: str
+    tool_name: str
+    action_class: HookActionClass
+    ceiling_level: str
+    skill_version: Optional[str] = None
+    matter_ref: Optional[str] = None
+    trace_id: Optional[str] = None
+    current_turn_approval: bool = False
+    arguments: Optional[dict] = None
+
+
+@dataclass(frozen=True)
+class ToolCallResult:
+    """The outcome of a tool call, fed to post-hook.
+
+    `outcome` is one of "ok" (the tool executed and returned), "error" (the
+    tool raised), or "blocked" (the pre-hook raised BlockedToolCall, the
+    tool never ran).
+
+    `output_summary` is a short string the post-hook may use for audit
+    metadata. The full output never lives here; consumers digest separately
+    per the AuditLogWriter contract.
+    """
+
+    outcome: str  # "ok" | "error" | "blocked"
+    output_summary: Optional[str] = None
+    error_type: Optional[str] = None
+    duration_ms: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Block signal - the canonical way a pre-hook stops a tool call
+# ---------------------------------------------------------------------------
+
+
+class BlockedToolCall(Exception):
+    """Raised by a pre-tool hook to stop a tool call before execution.
+
+    The overlay's dispatch path catches this exception, treats it as a
+    refused call, surfaces the message via post-hook + refusal-hook, and
+    proceeds to the next turn without invoking the tool. The Hermes side
+    NEVER catches and continues - that is the runtime enforcement
+    invariant.
+
+    The `reason` is a closed-vocabulary string from the substrate (e.g.
+    one of `DecisionReason.value`s). The `customer_message` is the
+    customer-facing wording the refusal handler will surface; it is
+    populated lazily by the refusal hook if the pre-hook did not set it.
+    """
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        customer_message: Optional[str] = None,
+        context: Optional[ToolCallContext] = None,
+    ) -> None:
+        super().__init__(f"tool call blocked: {reason}")
+        self.reason = reason
+        self.customer_message = customer_message
+        self.context = context
+
+
+# ---------------------------------------------------------------------------
+# Pinned slots - invariant #4 substrate. Survives compaction.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PinnedSlots:
+    """In-process pinned-slot table. Survives context compaction.
+
+    Per safety invariant #4: "don't act" / "stop" instructions, persona
+    identity, reviewer identity, and the customer.yaml signature must
+    persist through every compaction event so the post-compaction context
+    cannot lose them.
+
+    The pinned-slot table is intentionally a separate data structure from
+    the compressible turn history. The compaction hook reads slots from
+    this table and re-injects them into the post-compaction context. The
+    table itself is never mutated by compaction.
+
+    Slot names are closed-vocabulary keys; values are strings the runtime
+    treats as opaque-but-stable. Adding a new slot kind is a one-line
+    change here plus an entry in `_DEFAULT_PINNED_SLOT_KEYS` below.
+    """
+
+    slots: dict[str, str] = field(default_factory=dict)
+
+    def pin(self, key: str, value: str) -> None:
+        """Pin a slot. Idempotent; same key + value = no-op."""
+        if not key:
+            raise ValueError("pinned-slot key is required")
+        if value is None:
+            raise ValueError("pinned-slot value is required (use unpin to remove)")
+        self.slots[key] = value
+
+    def unpin(self, key: str) -> None:
+        """Remove a pinned slot. Captain-controlled in production."""
+        self.slots.pop(key, None)
+
+    def get(self, key: str) -> Optional[str]:
+        return self.slots.get(key)
+
+    def keys(self) -> list[str]:
+        return list(self.slots.keys())
+
+    def snapshot(self) -> dict[str, str]:
+        """Return a shallow copy. Compaction hook uses this to re-inject."""
+        return dict(self.slots)
+
+
+# Closed list of slot keys the v1 implementation pins by default. The
+# compaction hook re-injects these on every compaction event. Extending
+# this list is a structural commitment: any new pinned slot must be
+# documented in `docs/specs/ai-employee/aie-adapter-register.md` so
+# operators understand what survives compaction.
+
+DEFAULT_PINNED_SLOT_KEYS: tuple[str, ...] = (
+    "persona.name",
+    "reviewer.identity",
+    "customer.yaml.signature",
+    "sticky_stop.active",
+    "trust_ceiling.locked_skills",
+)
+
+
+# ---------------------------------------------------------------------------
+# Trust-ceiling enforcer protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnforcementDecision:
+    """Decision the trust-ceiling enforcer returns for one tool call.
+
+    Mirrors `adapter.trust_ceiling.EnforcementDecision` but lives here so
+    the protocol is self-contained on the hook surface.
+    """
+
+    allowed: bool
+    audit_action: str  # "allow" | "draft" | "refuse"
+    reason: str
+
+
+class TrustCeilingEnforcer(Protocol):
+    """The runtime trust-ceiling enforcement contract.
+
+    `enforce()` is the function the pre-tool hook calls for every tool
+    call. The PRD names this entry point `trust_ceiling.enforce(customer,
+    skill, action_class, ceiling_level)` - the protocol below makes that
+    name a typed contract.
+
+    Implementations:
+
+      * `DefaultTrustCeilingEnforcer` (this module): defers to
+        `trust_ceiling_log.log_decision` from PR #953 for the audit
+        emission, and wraps `adapter.trust_ceiling.enforce()` for the
+        decision. Suitable for the integration we are wiring today.
+
+      * Future fork-side implementations may add per-customer policy
+        overrides, ceiling promotion gates, or per-tool fine-grained
+        rules. The protocol does not constrain those choices.
+    """
+
+    def enforce(
+        self,
+        *,
+        customer: str,
+        skill: str,
+        action_class: HookActionClass,
+        ceiling_level: str,
+        current_turn_approval: bool = False,
+    ) -> EnforcementDecision: ...
+
+
+# ---------------------------------------------------------------------------
+# Hook type aliases - readability for the registry
+# ---------------------------------------------------------------------------
+
+
+PreToolHook = Callable[[ToolCallContext], Awaitable[None]]
+"""Pre-tool hook signature. Raise BlockedToolCall to stop the call."""
+
+PostToolHook = Callable[[ToolCallContext, ToolCallResult], Awaitable[None]]
+"""Post-tool hook signature. Audit emission lands here."""
+
+RefusalHook = Callable[[ToolCallContext, BlockedToolCall], Awaitable[None]]
+"""Refusal hook signature. Called when pre-hook blocked the call."""
+
+CompactionHook = Callable[[PinnedSlots], Awaitable[None]]
+"""Compaction hook signature. Re-injects pinned slots after compaction."""
+
+
+# ---------------------------------------------------------------------------
+# Registry - the object aie_adapter.register() receives from the overlay
+# ---------------------------------------------------------------------------
+
+
+class HookRegistry:
+    """Registry of safety-substrate hooks the SMD overlay exposes.
+
+    Constructed by the overlay layer at Machine boot. Passed to
+    `aie_adapter.register()`, which installs the four hooks.
+
+    Each slot accepts exactly one hook (the safety substrate is the only
+    consumer; future expansion can lift this to a list if multi-consumer
+    semantics are needed). Re-registering a slot raises - accidental
+    re-registration is a bug, not a no-op.
+
+    `dispatch_*` methods are the overlay's view of the registry: the
+    overlay's tool-dispatch loop calls them on the call path. The fake
+    runtime in tests uses the same methods so the test wiring matches
+    production semantics.
+    """
+
+    def __init__(self) -> None:
+        self._pre_tool: Optional[PreToolHook] = None
+        self._post_tool: Optional[PostToolHook] = None
+        self._refusal: Optional[RefusalHook] = None
+        self._compaction: Optional[CompactionHook] = None
+        self._pinned_slots = PinnedSlots()
+
+    # ---- Registration (adapter side) -------------------------------------
+
+    def register_pre_tool(self, hook: PreToolHook) -> None:
+        if self._pre_tool is not None:
+            raise RuntimeError("pre_tool hook already registered")
+        self._pre_tool = hook
+
+    def register_post_tool(self, hook: PostToolHook) -> None:
+        if self._post_tool is not None:
+            raise RuntimeError("post_tool hook already registered")
+        self._post_tool = hook
+
+    def register_refusal(self, hook: RefusalHook) -> None:
+        if self._refusal is not None:
+            raise RuntimeError("refusal hook already registered")
+        self._refusal = hook
+
+    def register_compaction(self, hook: CompactionHook) -> None:
+        if self._compaction is not None:
+            raise RuntimeError("compaction hook already registered")
+        self._compaction = hook
+
+    # ---- Pinned slots (compaction-survival store) ------------------------
+
+    @property
+    def pinned_slots(self) -> PinnedSlots:
+        return self._pinned_slots
+
+    # ---- Dispatch invocations (overlay side) -----------------------------
+
+    async def dispatch_pre_tool(self, context: ToolCallContext) -> None:
+        """Invoke pre-tool hook if registered. Re-raises BlockedToolCall."""
+        if self._pre_tool is None:
+            return
+        await self._pre_tool(context)
+
+    async def dispatch_post_tool(
+        self,
+        context: ToolCallContext,
+        result: ToolCallResult,
+    ) -> None:
+        """Invoke post-tool hook if registered. Never raises."""
+        if self._post_tool is None:
+            return
+        try:
+            await self._post_tool(context, result)
+        except Exception as e:  # noqa: BLE001 - post-tool failures must not crash dispatch
+            log.exception("post_tool hook raised; ignoring: %s", e)
+
+    async def dispatch_refusal(
+        self,
+        context: ToolCallContext,
+        block: BlockedToolCall,
+    ) -> None:
+        """Invoke refusal hook if registered. Re-raises on audit failure."""
+        if self._refusal is None:
+            return
+        await self._refusal(context, block)
+
+    async def dispatch_compaction(self) -> None:
+        """Invoke compaction hook if registered. Re-raises on failure.
+
+        The compaction hook is responsible for re-injecting pinned slots
+        into the post-compaction context. The Hermes runtime calls this
+        AFTER its own compaction has run and BEFORE the next turn starts.
+        If this hook fails, the runtime must NOT proceed - a context
+        without pinned slots is a substrate-violating context.
+        """
+        if self._compaction is None:
+            return
+        await self._compaction(self._pinned_slots)
+
+
+# ---------------------------------------------------------------------------
+# Default trust-ceiling enforcer - wraps adapter.trust_ceiling.enforce()
+# ---------------------------------------------------------------------------
+
+
+class DefaultTrustCeilingEnforcer:
+    """Thin wrapper around `adapter.trust_ceiling.enforce()` (PR #812).
+
+    The PRD names a `trust_ceiling.enforce(customer, skill, action_class,
+    ceiling_level)` entry point that does not yet exist as a free
+    function. The existing `adapter/trust_ceiling.py::enforce()` takes a
+    similar shape but keys on `Ceiling` and `ActionClass` enums and does
+    NOT take a customer parameter (the per-customer scope is implicit at
+    Machine level per ADR 0007).
+
+    This class bridges the two: it accepts the PRD-shape arguments,
+    translates to the adapter-side enforce(), and returns a hook-side
+    decision. The customer parameter is preserved so the overlay can
+    cross-check (defense in depth against accidental multi-customer
+    invocation, even though the Machine-level isolation already prevents
+    it per ADR 0009).
+
+    A future fork-side implementation can subclass or replace this with
+    per-customer policy overrides without changing the hook contract.
+    """
+
+    def __init__(self) -> None:
+        # Lazy-import to avoid pulling adapter internals into the hook
+        # surface at module import time. The hook surface must be
+        # importable by the overlay side without dragging the adapter's
+        # full dependency surface (pyyaml, etc.).
+        from adapter.trust_ceiling import (  # noqa: PLC0415
+            ActionClass as _AdapterActionClass,
+            Ceiling as _AdapterCeiling,
+            enforce as _adapter_enforce,
+        )
+
+        self._AdapterActionClass = _AdapterActionClass
+        self._AdapterCeiling = _AdapterCeiling
+        self._adapter_enforce = _adapter_enforce
+
+    def enforce(
+        self,
+        *,
+        customer: str,
+        skill: str,
+        action_class: HookActionClass,
+        ceiling_level: str,
+        current_turn_approval: bool = False,
+    ) -> EnforcementDecision:
+        if not customer:
+            raise ValueError("customer is required (defense-in-depth check)")
+        if not skill:
+            raise ValueError("skill is required")
+        adapter_action = self._AdapterActionClass(action_class.value)
+        adapter_ceiling = self._AdapterCeiling(ceiling_level)
+        adapter_decision = self._adapter_enforce(
+            ceiling=adapter_ceiling,
+            action=adapter_action,
+            skill_name=skill,
+            tool_name="",  # tool name lives at the hook layer, not in the policy decision
+            current_turn_approval=current_turn_approval,
+        )
+        return EnforcementDecision(
+            allowed=adapter_decision.allowed,
+            audit_action=adapter_decision.audit_action,
+            reason=adapter_decision.reason,
+        )
+
+
+# ---------------------------------------------------------------------------
+# In-memory Hermes-shaped fake runtime - pytest seam for the integration test
+# ---------------------------------------------------------------------------
+
+
+class FakeHermesRuntime:
+    """In-memory stand-in for the Hermes tool-dispatch path.
+
+    Suitable for pytest. Construction takes a `HookRegistry`; `dispatch()`
+    drives one synthetic tool call through the same call path the
+    production Hermes runtime would: pre-hook, tool, post-hook (or
+    pre-hook, refusal, post-hook with outcome=blocked).
+
+    The customer-zero smoke test in `tests/test_aie_adapter.py` instantiates
+    one of these against the real registered hooks and verifies the end-to-
+    end shape.
+
+    The fake is NOT a Hermes mock - the production fork's dispatch is
+    inside the upstream `agent/tool_guardrails.py` plus the SMD overlay
+    layer. The fake is a contract-conforming approximation that lets us
+    exercise the hook surface in isolation.
+    """
+
+    def __init__(self, registry: HookRegistry) -> None:
+        self._registry = registry
+
+    async def dispatch(
+        self,
+        *,
+        context: ToolCallContext,
+        tool_fn: Optional[Callable[..., Awaitable[Optional[str]]]] = None,
+    ) -> ToolCallResult:
+        """Drive one synthetic tool call. Returns the final result."""
+        # Pre-hook. If it raises BlockedToolCall, route to refusal + post.
+        try:
+            await self._registry.dispatch_pre_tool(context)
+        except BlockedToolCall as block:
+            await self._registry.dispatch_refusal(context, block)
+            result = ToolCallResult(outcome="blocked")
+            await self._registry.dispatch_post_tool(context, result)
+            return result
+
+        # Tool execution. If no tool_fn, treat as a no-op success.
+        try:
+            if tool_fn is not None:
+                summary = await tool_fn()
+            else:
+                summary = None
+            result = ToolCallResult(outcome="ok", output_summary=summary)
+        except Exception as e:  # noqa: BLE001 - surfacing to the post-hook
+            result = ToolCallResult(
+                outcome="error",
+                error_type=type(e).__name__,
+            )
+
+        await self._registry.dispatch_post_tool(context, result)
+        return result
+
+    async def compact(self) -> None:
+        """Drive a synthetic compaction event. Fires the compaction hook."""
+        await self._registry.dispatch_compaction()
+
+
+__all__ = [
+    "DEFAULT_PINNED_SLOT_KEYS",
+    "BlockedToolCall",
+    "CompactionHook",
+    "DefaultTrustCeilingEnforcer",
+    "EnforcementDecision",
+    "FakeHermesRuntime",
+    "HookActionClass",
+    "HookRegistry",
+    "PinnedSlots",
+    "PostToolHook",
+    "PreToolHook",
+    "RefusalHook",
+    "ToolCallContext",
+    "ToolCallResult",
+    "TrustCeilingEnforcer",
+]

--- a/ai-employee/adapter/tests/test_aie_adapter.py
+++ b/ai-employee/adapter/tests/test_aie_adapter.py
@@ -1,0 +1,477 @@
+"""Tests for ai-employee/adapter/aie_adapter.py (issue #841).
+
+Integration tests for the rewired `register()` against the in-memory
+`FakeHermesRuntime`. Coverage:
+
+  * register() installs all four hooks against a supplied registry.
+  * A forbidden action is BLOCKED at runtime: the tool function never
+    runs, the audit row records outcome=blocked, the RefusalHandler is
+    invoked (when supplied), the customer-facing message is surfaced.
+  * An allowed action runs the tool, the post-tool audit row records
+    outcome=ok, the trust ceiling is recorded.
+  * customer.yaml-derived pinned slots are seeded at register-time;
+    the compaction hook re-injects them on a synthetic compaction.
+  * Customer-zero smoke test: end-to-end dispatch with all hooks wired
+    against the in-memory fake.
+
+Audit isolation uses the in-memory SQLite executor pattern from
+test_audit_log.py / test_refusal.py (the established convention).
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_aie_adapter.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+sys.path.insert(0, str(_HERE.parents[2] / "safety-substrate"))
+
+from adapter.aie_adapter import register  # noqa: E402
+from adapter.audit_log import (  # noqa: E402
+    AuditLogWriter,
+    SqliteExecutor,
+)
+from adapter.hermes_hook import (  # noqa: E402
+    DEFAULT_PINNED_SLOT_KEYS,
+    BlockedToolCall,
+    FakeHermesRuntime,
+    HookActionClass,
+    HookRegistry,
+    ToolCallContext,
+)
+from refusal import (  # noqa: E402
+    InMemoryRefusalCounter,
+    RefusalHandler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema setup - mirror the audit_log schema from migration 0001 so tests
+# can write rows without shelling out to wrangler. Matches the pattern
+# established in test_audit_log.py / test_refusal.py.
+# ---------------------------------------------------------------------------
+
+
+_AUDIT_SCHEMA = """
+CREATE TABLE audit_log (
+  id            TEXT PRIMARY KEY,
+  ts            TEXT NOT NULL,
+  action_type   TEXT NOT NULL,
+  actor         TEXT NOT NULL,
+  actor_role    TEXT,
+  skill_name    TEXT,
+  matter_ref    TEXT,
+  input_digest  TEXT,
+  output_digest TEXT,
+  diff_digest   TEXT,
+  trust_ceiling TEXT,
+  metadata      TEXT
+);
+"""
+
+
+def _make_audit_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_AUDIT_SCHEMA)
+    return conn
+
+
+def _make_writer() -> tuple[AuditLogWriter, sqlite3.Connection]:
+    conn = _make_audit_conn()
+    return AuditLogWriter(SqliteExecutor(conn)), conn
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _rows(conn: sqlite3.Connection) -> list[dict]:
+    cur = conn.cursor()
+    raw = cur.execute(
+        "SELECT id, action_type, actor, actor_role, skill_name, matter_ref, "
+        "trust_ceiling, metadata FROM audit_log ORDER BY rowid"
+    ).fetchall()
+    out = []
+    for row in raw:
+        (
+            id_,
+            action_type,
+            actor,
+            actor_role,
+            skill_name,
+            matter_ref,
+            trust_ceiling,
+            metadata,
+        ) = row
+        out.append(
+            {
+                "id": id_,
+                "action_type": action_type,
+                "actor": actor,
+                "actor_role": actor_role,
+                "skill_name": skill_name,
+                "matter_ref": matter_ref,
+                "trust_ceiling": trust_ceiling,
+                "metadata": json.loads(metadata) if metadata else None,
+            }
+        )
+    return out
+
+
+def _allowed_ctx(**overrides) -> ToolCallContext:
+    base = {
+        "customer": "acme",
+        "skill_name": "inbox-triage",
+        "tool_name": "Email.create_draft",
+        "action_class": HookActionClass.INTERNAL_WRITE,
+        "ceiling_level": "autonomous",
+        "skill_version": "0.1.0",
+        "matter_ref": "matter-0001",
+        "trace_id": "trace-test-0001",
+        "current_turn_approval": False,
+    }
+    base.update(overrides)
+    return ToolCallContext(**base)
+
+
+def _forbidden_ctx(**overrides) -> ToolCallContext:
+    """A commitment action without approval - invariant #3 says refuse."""
+    base = {
+        "customer": "acme",
+        "skill_name": "law-pi-settlement-prep",
+        "tool_name": "PracticeManagement.accept_settlement",
+        "action_class": HookActionClass.COMMITMENT,
+        "ceiling_level": "autonomous",
+        "skill_version": "0.1.0",
+        "matter_ref": "matter-0002",
+        "trace_id": "trace-test-0002",
+        "current_turn_approval": False,
+    }
+    base.update(overrides)
+    return ToolCallContext(**base)
+
+
+# ---------------------------------------------------------------------------
+# register() shape
+# ---------------------------------------------------------------------------
+
+
+def test_register_returns_registry_with_all_four_hooks():
+    reg = register()  # no overlay registry supplied; one is constructed
+    assert isinstance(reg, HookRegistry)
+    # Re-registering any hook should fail because register() installed it.
+    with pytest.raises(RuntimeError, match="pre_tool"):
+        reg.register_pre_tool(lambda ctx: None)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="post_tool"):
+        reg.register_post_tool(lambda ctx, r: None)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="refusal"):
+        reg.register_refusal(lambda ctx, b: None)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="compaction"):
+        reg.register_compaction(lambda s: None)  # type: ignore[arg-type]
+
+
+def test_register_accepts_existing_registry():
+    overlay_registry = HookRegistry()
+    returned = register(overlay_registry)
+    assert returned is overlay_registry
+
+
+# ---------------------------------------------------------------------------
+# Forbidden action runtime block - the AC test
+# ---------------------------------------------------------------------------
+
+
+def test_forbidden_action_is_blocked_audit_row_records_outcome_blocked():
+    """Integration test (AC #5): a forbidden action is actually blocked
+    at runtime AND the audit row records the block."""
+    writer, conn = _make_writer()
+    reg = register(audit_writer=writer)
+    runtime = FakeHermesRuntime(reg)
+
+    tool_invocations = 0
+
+    async def tool_fn():
+        nonlocal tool_invocations
+        tool_invocations += 1
+        return "this must not run"
+
+    result = _run(runtime.dispatch(context=_forbidden_ctx(), tool_fn=tool_fn))
+
+    assert tool_invocations == 0, "tool MUST NOT run when ceiling refuses"
+    assert result.outcome == "blocked"
+
+    rows = _rows(conn)
+    assert len(rows) == 1, "post-tool hook must emit exactly one audit row"
+    row = rows[0]
+    assert row["action_type"] == "INVARIANT_VIOLATION"
+    assert row["actor"] == "agent"
+    assert row["actor_role"] == "agent"
+    assert row["skill_name"] == "law-pi-settlement-prep"
+    assert row["trust_ceiling"] == "autonomous"
+    meta = row["metadata"]
+    assert meta["per_tool_audit"] is True
+    assert meta["customer"] == "acme"
+    assert meta["tool"] == "PracticeManagement.accept_settlement"
+    assert meta["action_class"] == "commitment"
+    assert meta["outcome"] == "blocked"
+    assert meta["trace_id"] == "trace-test-0002"
+
+
+def test_forbidden_action_with_refusal_handler_emits_refusal_audit_rows():
+    """When a RefusalHandler is supplied, the substrate writes its own
+    customer-notification + (when threshold met) Captain-alert rows in
+    addition to the per-tool audit row.
+
+    AC: integration test that simulates a forbidden action and verifies
+    (a) the audit row is written, (b) the action is blocked, (c) a
+    refusal-handler audit row is also written.
+    """
+    writer, conn = _make_writer()
+    refusal_handler = RefusalHandler(
+        audit_writer=writer,
+        counter=InMemoryRefusalCounter(),
+    )
+    reg = register(
+        audit_writer=writer,
+        refusal_handler=refusal_handler,
+    )
+    runtime = FakeHermesRuntime(reg)
+
+    tool_calls = 0
+
+    async def tool_fn():
+        nonlocal tool_calls
+        tool_calls += 1
+        return None
+
+    result = _run(runtime.dispatch(context=_forbidden_ctx(), tool_fn=tool_fn))
+    assert tool_calls == 0
+    assert result.outcome == "blocked"
+
+    rows = _rows(conn)
+    # Expected rows in order:
+    #   1. RefusalHandler.handle() -> log_decision() canonical trust-
+    #      ceiling-decision row (action_type=INVARIANT_VIOLATION,
+    #      metadata.trust_ceiling_decision=true, metadata.decision=refuse)
+    #   2. RefusalHandler.handle() notification row
+    #      (action_type=DRAFT_REJECTED, metadata.refusal_notification=true)
+    #   3. post_tool hook per-tool audit row
+    #      (action_type=INVARIANT_VIOLATION, metadata.per_tool_audit=true,
+    #      metadata.outcome=blocked)
+    assert len(rows) == 3, (
+        f"expected three audit rows (decision + notification + per-tool); "
+        f"got {len(rows)}: {[r['action_type'] for r in rows]}"
+    )
+
+    decision_row = rows[0]
+    assert decision_row["action_type"] == "INVARIANT_VIOLATION"
+    assert decision_row["metadata"]["trust_ceiling_decision"] is True
+    assert decision_row["metadata"]["decision"] == "refuse"
+    assert decision_row["metadata"]["customer"] == "acme"
+
+    notification_row = rows[1]
+    assert notification_row["action_type"] == "DRAFT_REJECTED"
+    assert notification_row["metadata"]["refusal_notification"] is True
+    assert notification_row["metadata"]["notification_eligible"] is True
+
+    per_tool_row = rows[2]
+    assert per_tool_row["action_type"] == "INVARIANT_VIOLATION"
+    assert per_tool_row["metadata"]["per_tool_audit"] is True
+    assert per_tool_row["metadata"]["outcome"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Allowed action - happy path through the dispatch loop
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_action_runs_tool_and_emits_ok_audit_row():
+    writer, conn = _make_writer()
+    reg = register(audit_writer=writer)
+    runtime = FakeHermesRuntime(reg)
+
+    invocations = 0
+
+    async def tool_fn():
+        nonlocal invocations
+        invocations += 1
+        return "draft created id=abc"
+
+    result = _run(runtime.dispatch(context=_allowed_ctx(), tool_fn=tool_fn))
+
+    assert invocations == 1
+    assert result.outcome == "ok"
+
+    rows = _rows(conn)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["action_type"] == "DRAFT_CREATED"
+    meta = row["metadata"]
+    assert meta["per_tool_audit"] is True
+    assert meta["outcome"] == "ok"
+    assert meta["tool"] == "Email.create_draft"
+    assert meta["action_class"] == "internal_write"
+
+
+def test_allowed_action_without_audit_writer_logs_and_returns():
+    # Adapter path with no writer (test/local-dev fallback): the dispatch
+    # still completes; the post-hook logs-and-skips.
+    reg = register(audit_writer=None)
+    runtime = FakeHermesRuntime(reg)
+    result = _run(runtime.dispatch(context=_allowed_ctx()))
+    assert result.outcome == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Pinned slots + compaction
+# ---------------------------------------------------------------------------
+
+
+def test_register_seeds_pinned_slots_from_customer_config(monkeypatch, tmp_path):
+    """customer.yaml-derived slots are pinned at register-time."""
+    pytest.importorskip("yaml")
+    yaml_path = tmp_path / "customer.yaml"
+    yaml_path.write_text(
+        "customer_id: acme\n"
+        "persona:\n"
+        "  name: Marcus\n"
+        "reviewer:\n"
+        "  identity: captain-scott\n"
+        "signature: sha256:abcdef\n"
+    )
+    monkeypatch.setenv("AIE_CUSTOMER_YAML", str(yaml_path))
+
+    reg = register()
+    snapshot = reg.pinned_slots.snapshot()
+    assert snapshot.get("persona.name") == "Marcus"
+    assert snapshot.get("reviewer.identity") == "captain-scott"
+    assert snapshot.get("customer.yaml.signature") == "sha256:abcdef"
+
+
+def test_register_compaction_hook_fires_and_sees_pinned_slots(monkeypatch, tmp_path):
+    pytest.importorskip("yaml")
+    yaml_path = tmp_path / "customer.yaml"
+    yaml_path.write_text(
+        "customer_id: acme\n"
+        "persona:\n"
+        "  name: Marcus\n"
+    )
+    monkeypatch.setenv("AIE_CUSTOMER_YAML", str(yaml_path))
+
+    reg = register()
+    runtime = FakeHermesRuntime(reg)
+    # Add a sticky-stop slot AFTER register (simulating substrate state change)
+    reg.pinned_slots.pin("sticky_stop.active", "true")
+    # Compaction must not blow up; pinned slots survive.
+    _run(runtime.compact())
+    assert reg.pinned_slots.get("persona.name") == "Marcus"
+    assert reg.pinned_slots.get("sticky_stop.active") == "true"
+
+
+def test_register_handles_missing_customer_yaml(monkeypatch, tmp_path):
+    # AIE_CUSTOMER_YAML points at a non-existent path; register() must
+    # still install hooks (logs a warning, falls through with empty cfg).
+    monkeypatch.setenv("AIE_CUSTOMER_YAML", str(tmp_path / "missing.yaml"))
+    reg = register()
+    assert reg.pinned_slots.snapshot() == {}
+
+
+# ---------------------------------------------------------------------------
+# Customer-zero smoke test - full end-to-end through every hook
+# ---------------------------------------------------------------------------
+
+
+def test_customer_zero_smoke_end_to_end(monkeypatch, tmp_path):
+    """Customer-zero smoke (AC #6): adapter wired, forbidden and allowed
+    actions exercise every hook, audit rows land for each."""
+    has_yaml = True
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        has_yaml = False
+
+    if has_yaml:
+        yaml_path = tmp_path / "customer.yaml"
+        yaml_path.write_text(
+            "customer_id: customer-zero\n"
+            "persona:\n"
+            "  name: Helen\n"
+            "reviewer:\n"
+            "  identity: captain-scott\n"
+        )
+        monkeypatch.setenv("AIE_CUSTOMER_YAML", str(yaml_path))
+
+    writer, conn = _make_writer()
+    refusal_handler = RefusalHandler(
+        audit_writer=writer,
+        counter=InMemoryRefusalCounter(),
+    )
+    reg = register(audit_writer=writer, refusal_handler=refusal_handler)
+    runtime = FakeHermesRuntime(reg)
+
+    # Persona + reviewer pinned at boot ONLY when yaml could parse the config.
+    if has_yaml:
+        assert reg.pinned_slots.get("persona.name") == "Helen"
+        assert reg.pinned_slots.get("reviewer.identity") == "captain-scott"
+
+    # 1. Allowed action - internal write at autonomous ceiling
+    result = _run(
+        runtime.dispatch(
+            context=_allowed_ctx(customer="customer-zero"),
+            tool_fn=_make_tool_fn("ok"),
+        )
+    )
+    assert result.outcome == "ok"
+
+    # 2. Forbidden action - commitment without approval (refused)
+    result = _run(
+        runtime.dispatch(
+            context=_forbidden_ctx(customer="customer-zero"),
+            tool_fn=_make_tool_fn("must not run"),
+        )
+    )
+    assert result.outcome == "blocked"
+
+    # 3. Compaction - pinned slots survive (when slots were seeded)
+    _run(runtime.compact())
+    if has_yaml:
+        assert reg.pinned_slots.get("persona.name") == "Helen"
+
+    rows = _rows(conn)
+    action_types = [r["action_type"] for r in rows]
+    # Expected ordering:
+    #   1. DRAFT_CREATED  (allowed action per-tool audit, outcome=ok)
+    #   2. INVARIANT_VIOLATION (refusal canonical decision row)
+    #   3. DRAFT_REJECTED (refusal notification row)
+    #   4. INVARIANT_VIOLATION (refusal per-tool audit, outcome=blocked)
+    assert action_types == [
+        "DRAFT_CREATED",
+        "INVARIANT_VIOLATION",
+        "DRAFT_REJECTED",
+        "INVARIANT_VIOLATION",
+    ], f"unexpected audit row sequence: {action_types}"
+
+    allowed_meta = rows[0]["metadata"]
+    assert allowed_meta["outcome"] == "ok"
+    assert allowed_meta["customer"] == "customer-zero"
+
+    blocked_meta = rows[3]["metadata"]
+    assert blocked_meta["outcome"] == "blocked"
+    assert blocked_meta["customer"] == "customer-zero"
+
+
+def _make_tool_fn(return_value):
+    async def fn():
+        return return_value
+
+    return fn

--- a/ai-employee/adapter/tests/test_hermes_hook.py
+++ b/ai-employee/adapter/tests/test_hermes_hook.py
@@ -1,0 +1,402 @@
+"""Tests for ai-employee/adapter/hermes_hook.py (issue #841).
+
+Covers the typed hook surface that mirrors Hermes' `tool_guardrails.py`
+expected interface:
+
+  * HookRegistry registration semantics (one consumer per slot, no
+    silent re-registration).
+  * BlockedToolCall propagation through the FakeHermesRuntime.dispatch
+    path (pre-hook raises -> refusal hook fires -> post-hook sees
+    outcome=blocked).
+  * Post-tool hook failures do not crash dispatch.
+  * Compaction hook fires; pinned slots survive a synthetic compaction.
+  * PinnedSlots invariants: pin/unpin, snapshot independence.
+  * DefaultTrustCeilingEnforcer translates HookActionClass and
+    ceiling_level strings to the adapter's enum types and returns an
+    EnforcementDecision shape.
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_hermes_hook.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from adapter.hermes_hook import (  # noqa: E402
+    DEFAULT_PINNED_SLOT_KEYS,
+    BlockedToolCall,
+    DefaultTrustCeilingEnforcer,
+    EnforcementDecision,
+    FakeHermesRuntime,
+    HookActionClass,
+    HookRegistry,
+    PinnedSlots,
+    ToolCallContext,
+    ToolCallResult,
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _ctx(**overrides) -> ToolCallContext:
+    base = {
+        "customer": "acme",
+        "skill_name": "inbox-triage",
+        "tool_name": "Email.create_draft",
+        "action_class": HookActionClass.INTERNAL_WRITE,
+        "ceiling_level": "autonomous",
+        "skill_version": "0.1.0",
+        "matter_ref": None,
+        "trace_id": "trace-test-0001",
+        "current_turn_approval": False,
+    }
+    base.update(overrides)
+    return ToolCallContext(**base)
+
+
+# ---------------------------------------------------------------------------
+# HookRegistry registration semantics
+# ---------------------------------------------------------------------------
+
+
+def test_registry_starts_empty_no_hooks_registered():
+    reg = HookRegistry()
+    assert reg.pinned_slots.snapshot() == {}
+    # All dispatch_* methods are no-ops when no hooks are registered.
+    _run(reg.dispatch_pre_tool(_ctx()))
+    _run(reg.dispatch_post_tool(_ctx(), ToolCallResult(outcome="ok")))
+    _run(reg.dispatch_refusal(_ctx(), BlockedToolCall(reason="x")))
+    _run(reg.dispatch_compaction())
+
+
+def test_registry_rejects_double_registration():
+    reg = HookRegistry()
+
+    async def hook(ctx):
+        return None
+
+    reg.register_pre_tool(hook)
+    with pytest.raises(RuntimeError, match="pre_tool hook already registered"):
+        reg.register_pre_tool(hook)
+
+
+def test_registry_rejects_double_post_tool_registration():
+    reg = HookRegistry()
+
+    async def hook(ctx, result):
+        return None
+
+    reg.register_post_tool(hook)
+    with pytest.raises(RuntimeError, match="post_tool hook already registered"):
+        reg.register_post_tool(hook)
+
+
+# ---------------------------------------------------------------------------
+# BlockedToolCall + refusal flow
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_tool_call_routes_to_refusal_and_post_with_outcome_blocked():
+    reg = HookRegistry()
+    refusal_calls: list[tuple[ToolCallContext, BlockedToolCall]] = []
+    post_calls: list[tuple[ToolCallContext, ToolCallResult]] = []
+
+    async def pre(ctx):
+        raise BlockedToolCall(reason="commitment_no_approval", context=ctx)
+
+    async def refusal(ctx, block):
+        refusal_calls.append((ctx, block))
+
+    async def post(ctx, result):
+        post_calls.append((ctx, result))
+
+    reg.register_pre_tool(pre)
+    reg.register_refusal(refusal)
+    reg.register_post_tool(post)
+
+    runtime = FakeHermesRuntime(reg)
+    tool_invocations = 0
+
+    async def tool_fn():
+        nonlocal tool_invocations
+        tool_invocations += 1
+        return "should not be called"
+
+    result = _run(runtime.dispatch(context=_ctx(), tool_fn=tool_fn))
+    assert tool_invocations == 0  # tool MUST NOT run when pre blocks
+    assert result.outcome == "blocked"
+    assert len(refusal_calls) == 1
+    assert refusal_calls[0][1].reason == "commitment_no_approval"
+    assert len(post_calls) == 1
+    assert post_calls[0][1].outcome == "blocked"
+
+
+def test_allowed_tool_call_runs_and_post_sees_ok():
+    reg = HookRegistry()
+    pre_calls = []
+    post_calls = []
+
+    async def pre(ctx):
+        pre_calls.append(ctx)
+
+    async def post(ctx, result):
+        post_calls.append((ctx, result))
+
+    reg.register_pre_tool(pre)
+    reg.register_post_tool(post)
+
+    runtime = FakeHermesRuntime(reg)
+
+    async def tool_fn():
+        return "delivered"
+
+    result = _run(runtime.dispatch(context=_ctx(), tool_fn=tool_fn))
+    assert result.outcome == "ok"
+    assert result.output_summary == "delivered"
+    assert len(pre_calls) == 1
+    assert len(post_calls) == 1
+    assert post_calls[0][1].outcome == "ok"
+
+
+def test_tool_exception_routes_to_post_with_outcome_error():
+    reg = HookRegistry()
+    post_calls = []
+
+    async def post(ctx, result):
+        post_calls.append(result)
+
+    reg.register_post_tool(post)
+
+    runtime = FakeHermesRuntime(reg)
+
+    async def tool_fn():
+        raise RuntimeError("vendor down")
+
+    result = _run(runtime.dispatch(context=_ctx(), tool_fn=tool_fn))
+    assert result.outcome == "error"
+    assert result.error_type == "RuntimeError"
+    assert len(post_calls) == 1
+    assert post_calls[0].outcome == "error"
+
+
+def test_post_tool_hook_exception_does_not_crash_dispatch():
+    reg = HookRegistry()
+
+    async def post(ctx, result):
+        raise RuntimeError("audit write blew up")
+
+    reg.register_post_tool(post)
+    runtime = FakeHermesRuntime(reg)
+    # Should not raise even though the hook does.
+    result = _run(runtime.dispatch(context=_ctx()))
+    assert result.outcome == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Compaction hook + pinned slots
+# ---------------------------------------------------------------------------
+
+
+def test_compaction_hook_receives_current_pinned_slots():
+    reg = HookRegistry()
+    reg.pinned_slots.pin("persona.name", "Marcus")
+    reg.pinned_slots.pin("reviewer.identity", "captain-scott")
+
+    captured: list[dict[str, str]] = []
+
+    async def compact_hook(slots):
+        captured.append(slots.snapshot())
+
+    reg.register_compaction(compact_hook)
+
+    runtime = FakeHermesRuntime(reg)
+    _run(runtime.compact())
+
+    assert len(captured) == 1
+    snapshot = captured[0]
+    assert snapshot["persona.name"] == "Marcus"
+    assert snapshot["reviewer.identity"] == "captain-scott"
+
+
+def test_pinned_slots_survive_simulated_compaction():
+    """Pinned slots are NOT cleared by the compaction hook firing.
+
+    Invariant #4: the pinned-slot table is a separate data structure
+    from the compressible turn history. Compaction does not touch it.
+    """
+    reg = HookRegistry()
+    reg.pinned_slots.pin("sticky_stop.active", "true")
+
+    async def compact_hook(slots):
+        # The hook is allowed to READ the slot table; it must not clear
+        # the substrate copy.
+        snapshot = slots.snapshot()
+        assert snapshot["sticky_stop.active"] == "true"
+
+    reg.register_compaction(compact_hook)
+    runtime = FakeHermesRuntime(reg)
+
+    _run(runtime.compact())
+    _run(runtime.compact())  # second compaction; slot still present
+
+    assert reg.pinned_slots.get("sticky_stop.active") == "true"
+
+
+def test_pinned_slots_pin_unpin_get():
+    slots = PinnedSlots()
+    assert slots.get("k") is None
+    slots.pin("k", "v1")
+    assert slots.get("k") == "v1"
+    slots.pin("k", "v2")  # idempotent overwrite
+    assert slots.get("k") == "v2"
+    assert slots.keys() == ["k"]
+    slots.unpin("k")
+    assert slots.get("k") is None
+
+
+def test_pinned_slots_reject_empty_key_and_none_value():
+    slots = PinnedSlots()
+    with pytest.raises(ValueError, match="key is required"):
+        slots.pin("", "v")
+    with pytest.raises(ValueError, match="value is required"):
+        slots.pin("k", None)  # type: ignore[arg-type]
+
+
+def test_pinned_slots_snapshot_is_independent_copy():
+    slots = PinnedSlots()
+    slots.pin("k", "v")
+    snapshot = slots.snapshot()
+    snapshot["k"] = "mutated"
+    assert slots.get("k") == "v"
+
+
+def test_default_pinned_slot_keys_includes_invariant_4_essentials():
+    # Documents the closed v1 set. Adding to this list is a structural
+    # commitment that must be reflected in the spec doc.
+    assert "persona.name" in DEFAULT_PINNED_SLOT_KEYS
+    assert "reviewer.identity" in DEFAULT_PINNED_SLOT_KEYS
+    assert "sticky_stop.active" in DEFAULT_PINNED_SLOT_KEYS
+
+
+# ---------------------------------------------------------------------------
+# DefaultTrustCeilingEnforcer translation layer
+# ---------------------------------------------------------------------------
+
+
+def test_default_enforcer_allows_read_action_at_any_ceiling():
+    enforcer = DefaultTrustCeilingEnforcer()
+    decision = enforcer.enforce(
+        customer="acme",
+        skill="inbox-triage",
+        action_class=HookActionClass.READ,
+        ceiling_level="draft_for_review",
+    )
+    assert decision.allowed is True
+    assert decision.audit_action == "allow"
+
+
+def test_default_enforcer_refuses_destructive_at_draft_ceiling():
+    enforcer = DefaultTrustCeilingEnforcer()
+    decision = enforcer.enforce(
+        customer="acme",
+        skill="inbox-triage",
+        action_class=HookActionClass.DESTRUCTIVE,
+        ceiling_level="draft_for_review",
+    )
+    assert decision.allowed is False
+    assert decision.audit_action == "refuse"
+    assert "draft_for_review" in decision.reason
+
+
+def test_default_enforcer_refuses_commitment_without_approval():
+    enforcer = DefaultTrustCeilingEnforcer()
+    decision = enforcer.enforce(
+        customer="acme",
+        skill="settlement-negotiation",
+        action_class=HookActionClass.COMMITMENT,
+        ceiling_level="autonomous",
+        current_turn_approval=False,
+    )
+    assert decision.allowed is False
+    assert "commitment" in decision.reason
+
+
+def test_default_enforcer_allows_commitment_with_approval():
+    enforcer = DefaultTrustCeilingEnforcer()
+    decision = enforcer.enforce(
+        customer="acme",
+        skill="settlement-negotiation",
+        action_class=HookActionClass.COMMITMENT,
+        ceiling_level="autonomous",
+        current_turn_approval=True,
+    )
+    assert decision.allowed is True
+
+
+def test_default_enforcer_rejects_empty_customer():
+    enforcer = DefaultTrustCeilingEnforcer()
+    with pytest.raises(ValueError, match="customer is required"):
+        enforcer.enforce(
+            customer="",
+            skill="inbox-triage",
+            action_class=HookActionClass.READ,
+            ceiling_level="autonomous",
+        )
+
+
+def test_default_enforcer_rejects_empty_skill():
+    enforcer = DefaultTrustCeilingEnforcer()
+    with pytest.raises(ValueError, match="skill is required"):
+        enforcer.enforce(
+            customer="acme",
+            skill="",
+            action_class=HookActionClass.READ,
+            ceiling_level="autonomous",
+        )
+
+
+def test_default_enforcer_rejects_invalid_ceiling_level():
+    enforcer = DefaultTrustCeilingEnforcer()
+    with pytest.raises(ValueError):
+        enforcer.enforce(
+            customer="acme",
+            skill="inbox-triage",
+            action_class=HookActionClass.READ,
+            ceiling_level="not_a_real_ceiling",
+        )
+
+
+# ---------------------------------------------------------------------------
+# HookActionClass value parity with adapter.trust_ceiling.ActionClass
+# ---------------------------------------------------------------------------
+
+
+def test_hook_action_class_round_trips_through_adapter_enum():
+    from adapter.trust_ceiling import ActionClass  # noqa: PLC0415
+
+    for hook_value in HookActionClass:
+        adapter_value = ActionClass(hook_value.value)
+        # Round-trip: hook -> string -> adapter -> string -> hook
+        assert HookActionClass(adapter_value.value) is hook_value
+
+
+# ---------------------------------------------------------------------------
+# EnforcementDecision dataclass shape
+# ---------------------------------------------------------------------------
+
+
+def test_enforcement_decision_is_immutable():
+    decision = EnforcementDecision(allowed=True, audit_action="allow", reason="r")
+    with pytest.raises(Exception):
+        decision.allowed = False  # type: ignore[misc]

--- a/docs/specs/ai-employee/aie-adapter-register.md
+++ b/docs/specs/ai-employee/aie-adapter-register.md
@@ -1,0 +1,191 @@
+# AIEmployee Adapter Register - Hermes Hook Surface (Phase A.5)
+
+**Status:** Implemented in PR for [#841](https://github.com/venturecrane/ss-console/issues/841).
+
+**Related:** [ADR 0015 Hermes Fork vs Upstream](../../adr/0015-hermes-fork-vs-upstream.md), [refusal-handling.md](refusal-handling.md), [audit-log-immutability.md](audit-log-immutability.md), [trust-ceiling-logging.md](trust-ceiling-logging.md), [sticky-stop.md](sticky-stop.md).
+
+This spec is the contract for `ai-employee/adapter/aie_adapter.py::register()` and the typed hook surface it consumes (`ai-employee/adapter/hermes_hook.py`). The contract is held on the adapter side so the SMD overlay layer in the Hermes fork (per ADR 0015) can swap its internal implementation without renegotiating the integration.
+
+---
+
+## 1. Why this exists
+
+PR [#812](https://github.com/venturecrane/ss-console/pull/812) shipped `aie_adapter.py` with `register()` as a stub. The stub assumed the upstream Hermes seam was `agent/tool_router.py`. PR [#829](https://github.com/venturecrane/ss-console/pull/829)'s runtime status report discovered upstream actually exposes `agent/tool_guardrails.py`, `agent/tool_executor.py`, `agent/tool_dispatch_helpers.py`, and `agent/tool_result_classification.py`. [ADR 0015](../../adr/0015-hermes-fork-vs-upstream.md) locked the integration strategy: a thin vendored fork (`venturecrane/hermes-agent`) with an SMD overlay layer that conforms to whatever the adapter side declares.
+
+Phase A.5's gap was that nothing in Hermes' dispatch path actually called `trust_ceiling.enforce()`, no per-tool audit row was emitted, refusals did not propagate to the customer-facing notification surface, and pinned slots had no compaction-survival mechanism. This PR wires the four hooks.
+
+## 2. Scope
+
+In scope:
+
+- `register()` builds and installs four hooks against a `HookRegistry`: pre-tool, post-tool, refusal, compaction.
+- Pre-tool hook calls trust-ceiling enforcement for every tool dispatch; refused calls raise `BlockedToolCall` and the tool never executes.
+- Post-tool hook emits one per-tool audit row through the existing `AuditLogWriter` (PR #942), recording outcome (`ok` / `error` / `blocked`).
+- Refusal hook delegates to `RefusalHandler.handle()` (PR #967) to write the customer-facing notification row and (on cascade) the Captain alert row.
+- Compaction hook re-injects a closed set of pinned slots after Hermes context compaction (safety invariant #4).
+
+Out of scope (covered by separate work or filed as follow-ons):
+
+- The fork itself. The fork lives at `venturecrane/hermes-agent`; this PR ships the adapter-side contract the fork will conform to. The fork's overlay layer is a separate work item per ADR 0015 follow-ons.
+- The substrate-side compaction context-injection. The v1 compaction hook logs the pinned-slot snapshot; the actual context-injection wiring is fork-side overlay code that will land in a sibling PR.
+- The `trust_ceiling.enforce(customer, skill, action_class, ceiling_level)` free function the PRD names. This PR ships the `TrustCeilingEnforcer` Protocol plus `DefaultTrustCeilingEnforcer` adapter; a fork-side or platform-team implementation can replace it later without changing the hook surface.
+
+## 3. Hook surface
+
+The contract is in `ai-employee/adapter/hermes_hook.py`. Four hook-type aliases:
+
+| Hook         | Signature                                                       | Purpose                                                                                                                           |
+| ------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `pre_tool`   | `Callable[[ToolCallContext], Awaitable[None]]`                  | Trust-ceiling enforcement. Raises `BlockedToolCall` to stop the dispatch.                                                         |
+| `post_tool`  | `Callable[[ToolCallContext, ToolCallResult], Awaitable[None]]`  | Per-tool audit row. Fires whether the call was allowed, blocked, or errored.                                                      |
+| `refusal`    | `Callable[[ToolCallContext, BlockedToolCall], Awaitable[None]]` | Customer-facing notification + Captain cascade alert (delegates to `RefusalHandler`).                                             |
+| `compaction` | `Callable[[PinnedSlots], Awaitable[None]]`                      | Re-inject pinned slots after context compaction. Invariant #4. Fork-side overlay is responsible for the actual context-injection. |
+
+### 3.1 `ToolCallContext`
+
+Frozen dataclass the overlay constructs per tool call. Fields:
+
+- `customer` (required) - customer slug; matches the D1 binding tenant.
+- `skill_name` (required) - from SKILL.md frontmatter.
+- `tool_name` (required) - the tool being invoked (e.g. `Email.create_draft`).
+- `action_class` (required) - `HookActionClass` enum value (string values mirror `adapter.trust_ceiling.ActionClass`).
+- `ceiling_level` (required) - string value of the ceiling configured for the skill at dispatch time.
+- `skill_version` (optional) - content-hash SHA or version pin per §7.4 of the platform PRD.
+- `matter_ref` (optional) - per-vertical opaque reference (matter id, lead id).
+- `trace_id` (optional) - request/turn id for cross-row correlation.
+- `current_turn_approval` (optional) - True iff the operator approved this specific action in this turn (invariant #1).
+- `arguments` (optional) - tool arguments. Never logged verbatim; the audit writer digests separately per the AuditLogWriter contract.
+
+### 3.2 `HookActionClass`
+
+Closed enum with string values matching `adapter.trust_ceiling.ActionClass`: `read`, `internal_write`, `external_send`, `commitment`, `destructive`. Held as a separate enum so the overlay does not need to import adapter internals.
+
+### 3.3 `BlockedToolCall`
+
+Exception raised by `pre_tool` to stop a tool call. Carries:
+
+- `reason` - free-text reason from the enforcer (the refusal hook maps it to a closed `DecisionReason` for audit emission).
+- `customer_message` - populated lazily by the refusal hook with the closed-set `CustomerMessage` value the in-app notification surface will render.
+- `context` - the `ToolCallContext` that was blocked (defensive; lets the post-hook recover context if its own copy was discarded).
+
+The overlay's dispatch path MUST catch this exception, route to the refusal hook, then to the post-hook with `outcome="blocked"`, and NEVER execute the tool. This is the runtime enforcement invariant.
+
+### 3.4 `PinnedSlots` and `DEFAULT_PINNED_SLOT_KEYS`
+
+In-process key-value store that survives compaction. v1 pins this closed set:
+
+- `persona.name`
+- `reviewer.identity`
+- `customer.yaml.signature`
+- `sticky_stop.active`
+- `trust_ceiling.locked_skills`
+
+`register()` seeds the slots whose values are derivable from `customer.yaml` (`persona.name`, `reviewer.identity`, `customer.yaml.signature`). The other two are pinned by the substrate as state changes (sticky-stop transitions, ceiling locks).
+
+The compaction hook reads the slot snapshot and re-injects each slot into the post-compaction context. The slot table itself is never mutated by compaction.
+
+### 3.5 `HookRegistry`
+
+Constructed by the overlay; passed to `register()`. Each hook slot accepts exactly one consumer (re-registration raises). Exposes:
+
+- `register_pre_tool(hook)`, `register_post_tool(hook)`, `register_refusal(hook)`, `register_compaction(hook)` - adapter-side installation.
+- `pinned_slots` - the `PinnedSlots` instance (read-write).
+- `dispatch_pre_tool(context)`, `dispatch_post_tool(context, result)`, `dispatch_refusal(context, block)`, `dispatch_compaction()` - overlay-side invocation.
+
+### 3.6 `TrustCeilingEnforcer` protocol
+
+```python
+class TrustCeilingEnforcer(Protocol):
+    def enforce(
+        self,
+        *,
+        customer: str,
+        skill: str,
+        action_class: HookActionClass,
+        ceiling_level: str,
+        current_turn_approval: bool = False,
+    ) -> EnforcementDecision: ...
+```
+
+`DefaultTrustCeilingEnforcer` is the v1 implementation. It wraps `adapter.trust_ceiling.enforce()` (PR #812) and accepts the PRD-shape arguments. A future fork-side implementation can subclass or replace it without changing the hook surface.
+
+## 4. `register()` contract
+
+```python
+def register(
+    registry: Optional[HookRegistry] = None,
+    *,
+    audit_writer=None,
+    refusal_handler=None,
+    enforcer: Optional[TrustCeilingEnforcer] = None,
+) -> HookRegistry:
+```
+
+Steps:
+
+1. Construct a fresh `HookRegistry` if none was passed (unit-test path).
+2. Construct `DefaultTrustCeilingEnforcer` if none was passed.
+3. Load `customer.yaml`; seed pinned slots from its `persona.name`, `reviewer.identity`, and optional `signature` field.
+4. Build and install the four hooks.
+5. Return the registry.
+
+Production callers SHOULD supply `audit_writer` and `refusal_handler`. Test paths can omit either; the corresponding hook then logs-and-skips its emission.
+
+## 5. Audit row schema
+
+The post-tool hook writes one `audit_log` row per tool dispatch. The row uses the closed-set vocabulary from `ACCEPTED_ACTION_TYPES` (PR #942):
+
+- `action_type` - `DRAFT_CREATED` for allowed/errored calls, `INVARIANT_VIOLATION` for blocked calls.
+- `actor` - always `agent`.
+- `actor_role` - `agent`.
+- `skill_name` - from context.
+- `matter_ref` - from context.
+- `trust_ceiling` - the ceiling at dispatch time.
+- `metadata` -
+- `per_tool_audit: true` (filter key for dashboards)
+- `customer`, `skill`, `skill_version`, `tool`, `action_class`, `ceiling_level`, `outcome` (`ok` / `error` / `blocked`), `error_type`, `duration_ms`, `trace_id`
+
+Refusals additionally trigger the `RefusalHandler`, which writes its own two rows (canonical trust-ceiling-decision row plus customer-facing notification row); see `refusal-handling.md` for that schema. The per-tool audit row from the post-hook is in addition to those rows, not a replacement.
+
+## 6. Invariant #4 - pinned-slot survival
+
+The compaction hook is the runtime enforcement seam for invariant #4 ("don't act" / "stop" instructions survive context compaction). v1 behavior:
+
+- `register()` seeds `persona.name`, `reviewer.identity`, and `customer.yaml.signature` at boot.
+- The substrate pins `sticky_stop.active` and `trust_ceiling.locked_skills` as state changes.
+- The compaction hook fires after Hermes' internal compaction has run. It receives the live `PinnedSlots` reference and emits an info log with the snapshot (`{"persona.name": "Marcus", ...}`).
+- Fork-side overlay code is responsible for the actual post-compaction context-injection. This adapter ships the seam; the substrate-side wiring is filed as a follow-on against ADR 0015's overlay-implementation work.
+
+The pinned-slot table is never mutated by the compaction hook. Test coverage in `test_hermes_hook.py::test_pinned_slots_survive_simulated_compaction` asserts that property explicitly.
+
+## 7. Integration test shape
+
+`tests/test_aie_adapter.py::test_forbidden_action_with_refusal_handler_emits_refusal_audit_rows` is the AC-bearing integration test. It:
+
+1. Constructs an in-memory SQLite-backed `AuditLogWriter` and a `RefusalHandler` with an `InMemoryRefusalCounter`.
+2. Calls `register(audit_writer=writer, refusal_handler=handler)` to install all four hooks.
+3. Builds a `FakeHermesRuntime(registry)` and dispatches a forbidden tool call (commitment action without current-turn approval).
+4. Asserts: the tool function never ran; the result is `blocked`; three audit rows landed in order (canonical decision row, notification row, per-tool audit row); each row carries the expected metadata keys.
+
+The `test_customer_zero_smoke_end_to_end` test exercises allowed + forbidden + compaction in one run against a `customer-zero`-flavored `customer.yaml` to mirror the AC #6 smoke check.
+
+## 8. Out-of-scope follow-ons
+
+These are filed as separate issues against ADR 0015's overlay-implementation work:
+
+- Fork-side overlay layer that constructs the `HookRegistry`, exposes it via the adapter loader, and wires the four hooks into Hermes' actual `tool_guardrails.py` dispatch path.
+- Substrate-side compaction context-injection (the part of the compaction hook that actually re-materializes pinned slots in the post-compaction context).
+- Per-tool cost telemetry emission (#804). The post-tool hook is the natural place to emit cost rows; deferred so this PR stays in safety-substrate scope.
+- Sticky-stop integration in the pre-hook. The sticky-stop machine (PR #948) is already on main; lifting its `assert_allowed()` check into the pre-hook is a follow-on so this PR keeps the trust-ceiling and sticky-stop paths independently testable.
+- First upstream PR for the generic tool-dispatch hook surface (per ADR 0015 follow-on #5).
+
+## 9. Acceptance criteria mapping
+
+Issue #841 acceptance criteria:
+
+- [x] `aie_adapter.register()` actually hooks into Hermes' `agent/tool_guardrails.py` dispatch - `register()` installs four hooks against a `HookRegistry` typed to mirror that seam. The fork-side overlay (separate PR) plugs the registry into the actual `tool_guardrails.py` dispatch path.
+- [x] Every tool call routes through `trust_ceiling.enforce()` before execution - the pre-tool hook calls `TrustCeilingEnforcer.enforce()` for every dispatch; the default enforcer wraps `adapter.trust_ceiling.enforce()`.
+- [x] Refusals + draft-routed actions logged to per-customer audit log - the post-tool hook emits `per_tool_audit` rows for every outcome; the refusal hook delegates to `RefusalHandler.handle()` which writes the canonical decision + notification rows.
+- [x] Compaction event re-injects pinned slots (invariant #4) - the compaction hook reads the `PinnedSlots` snapshot; v1 logs the slot set, fork-side overlay handles the actual context-injection.
+- [x] Integration test confirms a forbidden action is actually blocked at runtime - `test_forbidden_action_is_blocked_audit_row_records_outcome_blocked` asserts the tool function never ran.
+- [x] Customer-zero smoke test passes end-to-end with adapter wired - `test_customer_zero_smoke_end_to_end` exercises allowed + forbidden + compaction in one run.

--- a/docs/specs/ai-employee/index.md
+++ b/docs/specs/ai-employee/index.md
@@ -31,6 +31,7 @@ Build agents consuming these specs should treat the PRDs as **vision/doctrine** 
 | [safety-invariants.md](safety-invariants.md)                   | [#865](https://github.com/venturecrane/ss-console/issues/865) | Invariants #6 (citation enforcement on fact-bearing fields) and #7 (cross-Machine query prohibition)     |
 | [refusal-handling.md](refusal-handling.md)                     | [#866](https://github.com/venturecrane/ss-console/issues/866) | Runtime semantics when `trust_ceiling.enforce()` returns `refuse` (abort + notification + cascade alert) |
 | [audit-log-immutability.md](audit-log-immutability.md)         | [#892](https://github.com/venturecrane/ss-console/issues/892) | Worker-layer enforcement, Logpush mirror protocol, integrity check, Captain exception process            |
+| [aie-adapter-register.md](aie-adapter-register.md)             | [#841](https://github.com/venturecrane/ss-console/issues/841) | Adapter-side hook surface for the SMD overlay on Hermes; pre/post/refusal/compaction hooks               |
 
 ## Open ambiguities requiring Captain decision
 


### PR DESCRIPTION
## Summary

Phase A.5 deliverable. Rewires the Phase A stub from PR #812 against the
real Hermes integration seam per ADR 0015. The original stub assumed
`agent/tool_router.py`; PR #829's runbook discovered the actual seam at
`agent/tool_guardrails.py`. This PR ships the adapter-side contract so
the SMD overlay layer in the Hermes fork is a small composition step.

- `ai-employee/adapter/hermes_hook.py` (new): typed HookRegistry, pre/post/refusal/compaction hook signatures, ToolCallContext, BlockedToolCall, PinnedSlots, DefaultTrustCeilingEnforcer (wraps `adapter.trust_ceiling.enforce()`), FakeHermesRuntime for test isolation.
- `ai-employee/adapter/aie_adapter.py::register()`: installs all four hooks. Pre-tool runs trust-ceiling enforcement; refusal raises `BlockedToolCall`. Post-tool emits per-tool audit row via existing `AuditLogWriter` (#942). Refusal delegates to `RefusalHandler` (#967). Compaction logs the pinned-slot snapshot (fork-side overlay handles the actual context-injection).
- Tests: 32 tests across `test_aie_adapter.py` and `test_hermes_hook.py`. Forbidden-action test asserts the tool function never runs and three audit rows land (canonical decision row + notification row + per-tool audit row). Customer-zero smoke test exercises allowed + forbidden + compaction in one run against in-memory SQLite.
- Spec doc `docs/specs/ai-employee/aie-adapter-register.md`: integration handoff for the fork-side overlay PR.

## Acceptance criteria

- [x] `aie_adapter.register()` actually hooks into Hermes' `agent/tool_guardrails.py` dispatch (registry contract typed to mirror that seam)
- [x] Every tool call routes through `trust_ceiling.enforce()` before execution (pre-hook)
- [x] Refusals + draft-routed actions logged to per-customer audit log (post-hook + RefusalHandler)
- [x] Compaction event re-injects pinned slots (invariant #4)
- [x] Integration test confirms a forbidden action is actually blocked at runtime
- [x] Customer-zero smoke test passes end-to-end with adapter wired

## Test plan

- [x] `cd ai-employee && python3 -m pytest adapter/tests/ safety-substrate/tests/` (253 passed, 2 skipped on this Python without pyyaml)
- [x] `npm run verify` green
- [ ] Confirm CI green after push

Closes #841.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>