### PR TITLE
feat(ai-employee): no-PM-system demo configuration (#853)

### DIFF
--- a/ai-employee/connectors/no_pm/README.md
+++ b/ai-employee/connectors/no_pm/README.md
@@ -1,0 +1,133 @@
+# no_pm connector -- synthetic PracticeManagement adapter for customers without an external PM system
+
+Status: v1 (issue [#853](https://github.com/venturecrane/ss-console/issues/853)). Most target-buyer firms operate without a working practice-management vendor (paper + Outlook + OneDrive + QuickBooks for billing). The PI PRDs assume Filevine / Clio / CASEpeer; this adapter is the matching capability binding for the no-PM-system reality. The capability-adapter pattern itself is locked in [ADR 0006](../../../docs/adr/0006-capability-adapter-pattern.md).
+
+## What this connector covers
+
+| Capability         | Methods implemented                                                                                                                               | TypeScript contract                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| PracticeManagement | `search_matters`, `get_matter`, `create_matter`, `update_matter`, `list_matter_documents`, `create_note`, `describe_capabilities`, `health_check` | [`src/lib/ai-employee/capabilities/practice-management.ts`](../../../src/lib/ai-employee/capabilities/practice-management.ts) |
+
+The adapter implements the full read + create/update matter surface plus matter-scoped note + document listings -- the minimum needed to drive the demo flow without an external PM vendor. Methods the synthetic store cannot honestly serve (`search_contacts`, `get_contact`, `create_contact`, `list_time_entries`, `create_time_entry_draft`, `upload_matter_document`) are declared in `unsupported_methods` and raise `AdapterError(code="capability_not_supported")` if invoked. This satisfies the UNSUPPORTED_METHODS_THROW conformance invariant -- there are no silent stubs.
+
+The adapter binds to PracticeManagement only. Document storage, email, calendar, signatures, and accounting are bound to their own first-class capability adapters (OneDrive, Microsoft Graph, DocuSign, QuickBooks) in the same `customer.yaml`.
+
+## Cross-language contract mapping
+
+The capability interfaces are TypeScript; the runtime adapter is Python (lives in the Hermes Machine per [ADR 0007](../../../docs/adr/0007-per-customer-machine-isolation.md) / [ADR 0009](../../../docs/adr/0009-cross-machine-query-prohibition.md)). Both sides agree on:
+
+| Concept              | TypeScript (`src/lib/ai-employee/capabilities/`)   | Python (`ai-employee/connectors/no_pm/`)             |
+| -------------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| Capability interface | `interface PracticeManagement extends AdapterBase` | `class NoPmPracticeManagement`                       |
+| Method names         | snake_case (`search_matters`, `create_note`)       | snake_case (identical)                               |
+| Return shape         | `interface Matter { id, client_name, ... }`        | `@dataclass(frozen=True) class Matter`               |
+| Error contract       | `class AdapterError` + `type AdapterErrorCode`     | `class AdapterError` + `Literal[...]` in `errors.py` |
+| Capability set       | `interface CapabilitySet`                          | `@dataclass(frozen=True) class CapabilitySet`        |
+| Error codes          | Closed union of 9 strings                          | `frozenset` of identical 9 strings (pinned by test)  |
+| Capability names     | Closed union of 11 strings                         | `frozenset` of identical 11 strings (pinned by test) |
+
+Drift between the two languages is a P0. `tests/test_errors.py` pins the closed unions; if anyone changes `types.ts`, that test fails immediately on the Python side and forces a paired update -- the same shape Filevine uses.
+
+## Storage seam
+
+The no_pm adapter persists matters, notes, and matter-document indexes to a `MatterStore`:
+
+```python
+class MatterStore(Protocol):
+    async def list_matters(self, *, client_name=None, matter_type=None,
+                           status=None, limit=50, offset=0) -> list[StoredMatter]: ...
+    async def get_matter(self, matter_id: str) -> Optional[StoredMatter]: ...
+    async def create_matter(self, matter: StoredMatter) -> StoredMatter: ...
+    async def update_matter(self, matter_id, *, client_name=None,
+                            matter_type=None, status=None,
+                            custom_fields=None) -> StoredMatter: ...
+    async def list_matter_documents(self, matter_id) -> list[StoredMatterDocument]: ...
+    async def create_matter_note(self, note: StoredMatterNote) -> StoredMatterNote: ...
+```
+
+- **Production wiring (planned).** A `D1MatterStore` implementation is the follow-on issue. It maps onto per-customer D1 tables `no_pm_matters` and `no_pm_matter_notes`; documents live in the per-customer R2 vault at `vaults/{customer_id}/no_pm/matters/{matter_id}/documents/`. Per [ADR 0008](../../../docs/adr/0008-customer-owned-memory-artifact.md), every artifact the adapter writes lands in customer-owned storage that decommission can drain. Per [ADR 0009](../../../docs/adr/0009-cross-machine-query-prohibition.md), no tenant ID is ever passed in -- isolation is structural via the per-Machine binding.
+- **Test wiring (today).** `InMemoryMatterStore` is a dict-backed reference implementation; tests inject it directly. The adapter's `__init__` defaults to `InMemoryMatterStore()` so a no-arg `NoPmPracticeManagement()` boots cleanly for the conformance harness.
+
+## customer.yaml binding
+
+The connector is bound per-customer via the `connectors:` map in `customer.yaml` ([schema spec](../../../docs/specs/ai-employee/customer-yaml-schema.md)):
+
+```yaml
+connectors:
+  PracticeManagement:
+    adapter: no_pm
+    backend: build:no_pm
+    enabled: true
+    # No token_ref -- the synthetic store has no external OAuth surface.
+    # Persistence binds to the per-customer D1 + R2 wiring at provision time.
+```
+
+Notes on the binding shape:
+
+- `adapter: no_pm` -- the SMD-internal slug. The validator (`src/lib/ai-employee/customer-yaml/validator.ts`) treats it as opaque; the boot-time conformance harness asserts `NoPmPracticeManagement` satisfies the interface.
+- `backend: build:no_pm` -- `build:` prefix means SMD-owned implementation (this connector). There is no `composio:` alternative because there is no vendor.
+- No `token_ref` -- the synthetic store does not authenticate against an external API. The per-customer D1 + R2 binding is wired at provision time (see `bin/provision-customer.sh`).
+- The companion `customer-no-pm-system.yaml` template at `ai-employee/templates/customer-no-pm-system.yaml` ships the full default binding set (MS Graph for email + calendar, DocuSign for signatures, OneDrive for documents, QuickBooks for accounting, no_pm for practice management).
+
+## ADR 0005 -- reviewer-as-sender attribution
+
+`create_note` is the only mutating method that produces user-visible content. Per [ADR 0005](../../../docs/adr/0005-reviewer-as-sender.md):
+
+- The note's `author_account_id` is the reviewer's account, not "AI Employee" and not the persona name.
+- The note body is the drafted content verbatim. No "[Drafted by Marcus]" prefix.
+- The `drafted_by_skill` field rides on the note for the dashboard sourcing block.
+- There is no autonomous-send method anywhere in this connector. The synthetic store writes only to per-customer storage; nothing leaves the Machine.
+
+The `tests/test_capabilities.py::test_adapter_has_no_banned_method_names` test asserts the adapter exposes no method name from the banned-method-name list.
+
+## Fabrication discipline
+
+Per the no-fabrication rule (Platform PRD invariant #8 + CLAUDE.md project policy):
+
+- The store-to-capability translation is 1:1. Field values from `StoredMatter` are copied to `Matter` without invention; missing optional fields stay as `None`.
+- The adapter synthesizes two fields when the caller omits them on `create_matter`: a fresh `matter_id` (`mat_<hex>`) and a current ISO `opened_at`. Both are disclosed in `describe_capabilities().field_coverage["create_matter"].derived` so the dashboard sourcing block can show "synthesized by no_pm adapter".
+- Same for `create_note`: `id` and `created_at` are derived; both are disclosed.
+- Unknown matter statuses raise `validation_failed` rather than silently falling back to `"open"`.
+
+## Per-customer isolation
+
+Per [ADR 0007](../../../docs/adr/0007-per-customer-machine-isolation.md) and [ADR 0009](../../../docs/adr/0009-cross-machine-query-prohibition.md):
+
+- The connector is instantiated per-customer in the Hermes Machine.
+- No tenant ID appears on any row; isolation is enforced at the deployment layer (one Machine per customer, one `MatterStore` per Machine).
+- The `MatterStore` instance is scoped to one customer's D1 + R2 binding; the adapter cannot accidentally read another customer's matters.
+
+## Demo flow this adapter enables
+
+| Demo scene                                                 | What it exercises                                                                           |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Operator creates a new matter from an Outlook intake email | `create_matter` writes to the synthetic store; matter shows up in the dashboard matters tab |
+| Marcus drafts a status-update note                         | `create_note` records reviewer attribution + drafted-by-skill metadata                      |
+| Matter is closed                                           | `update_matter(status="closed")` records `closed_at` from the server clock                  |
+| Dashboard matters tab                                      | `search_matters` lists local matters; `list_matter_documents` lists per-matter R2 docs      |
+
+The spec at [`docs/specs/ai-employee/no-pm-system-mode.md`](../../../docs/specs/ai-employee/no-pm-system-mode.md) walks each demo scene through the full no-PM-system binding set.
+
+## Testing
+
+Unit tests live in `tests/`. From the repo root:
+
+```bash
+cd ai-employee && python -m pytest connectors/no_pm/tests/ -v
+```
+
+Coverage:
+
+| File                         | Asserts                                                                                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `tests/test_errors.py`       | AdapterError code + capability union pinned against the TypeScript contract                                                           |
+| `tests/test_store.py`        | `InMemoryMatterStore` honors the `MatterStore` protocol (list / get / create / update / docs / notes)                                 |
+| `tests/test_capabilities.py` | `NoPmPracticeManagement` happy paths; unsupported-method behavior; ADR 0005 attribution; no banned method names; end-to-end demo flow |
+
+There is no live-sandbox smoke test -- the no_pm adapter has no external vendor to smoke against. The in-memory store IS the smoke test.
+
+## What ships next
+
+- A `D1MatterStore` implementation backed by the per-customer D1 + R2 substrate (follow-on issue against this PR).
+- Boot-time wiring in `bin/provision-customer.sh` so customers with `adapter: no_pm` get the D1 schema applied and the store wired automatically.
+- If the customer later signs with a real PM vendor, the binding flips in `customer.yaml` -- no skill code changes.

--- a/ai-employee/connectors/no_pm/__init__.py
+++ b/ai-employee/connectors/no_pm/__init__.py
@@ -1,0 +1,57 @@
+"""no_pm connector -- synthetic PracticeManagement adapter for customers
+without an external PM system.
+
+Most target-buyer firms operate without a working practice-management
+system (paper + Outlook + OneDrive + QuickBooks for billing). The PI
+PRDs assume Filevine / Clio / CASEpeer; this adapter is the matching
+capability binding for the no-PM-system reality.
+
+Per ADR 0006, skills bind to capability interfaces, not vendors. This
+adapter satisfies the same ``PracticeManagement`` contract Filevine
+does, so the skill catalog runs unchanged. Storage is per-customer D1
+(matters, notes) + per-customer R2 (matter documents) via the existing
+memory pipeline substrate (PR #944); this adapter does not introduce a
+new persistence layer.
+
+This package exposes:
+
+* ``MatterStore`` -- Protocol the adapter binds to. Production wires
+  it to per-customer D1 + R2; tests use ``InMemoryMatterStore``.
+* ``InMemoryMatterStore`` -- reference implementation used by tests
+  and local dev.
+* ``NoPmPracticeManagement`` -- ``PracticeManagement`` capability
+  adapter. Implements the read + create/update matter surface against
+  ``MatterStore``; no autonomous send paths.
+
+The TypeScript capability contract is the source of truth
+(``src/lib/ai-employee/capabilities/practice-management.ts``); this
+Python adapter conforms to that contract -- method names, parameter
+shape, return shape, and error codes. The cross-language mapping is
+documented in README.md.
+"""
+
+from __future__ import annotations
+
+from .capabilities import ADAPTER_SLUG, NoPmMatterNoteRef, NoPmPracticeManagement
+from .errors import AdapterError, AdapterErrorCode, CAPABILITY_NAMES
+from .store import (
+    InMemoryMatterStore,
+    MatterStore,
+    StoredMatter,
+    StoredMatterDocument,
+    StoredMatterNote,
+)
+
+__all__ = [
+    "ADAPTER_SLUG",
+    "AdapterError",
+    "AdapterErrorCode",
+    "CAPABILITY_NAMES",
+    "InMemoryMatterStore",
+    "MatterStore",
+    "NoPmMatterNoteRef",
+    "NoPmPracticeManagement",
+    "StoredMatter",
+    "StoredMatterDocument",
+    "StoredMatterNote",
+]

--- a/ai-employee/connectors/no_pm/capabilities.py
+++ b/ai-employee/connectors/no_pm/capabilities.py
@@ -1,0 +1,586 @@
+"""Capability adapter -- ``PracticeManagement`` for customers with no
+external PM system.
+
+Conforms to the ``PracticeManagement`` interface locked in
+``src/lib/ai-employee/capabilities/practice-management.ts``. Storage is
+the per-customer ``MatterStore`` (D1 + R2 in production, in-memory in
+tests).
+
+The adapter supports the read + create/update matter surface plus
+matter-scoped note + document listings. Methods that no synthetic
+store can faithfully serve (contacts, time entries, document uploads
+into a PM system that does not exist) are declared in
+``unsupported_methods`` and raise ``capability_not_supported`` at call
+time -- per the UNSUPPORTED_METHODS_THROW conformance invariant. There
+are no silent stubs and no autonomous send paths anywhere in this
+module.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from .errors import AdapterError
+from .store import (
+    InMemoryMatterStore,
+    MatterStore,
+    StoredMatter,
+    StoredMatterDocument,
+    StoredMatterNote,
+)
+
+
+ADAPTER_SLUG = "no_pm"
+
+_VALID_MATTER_STATUSES = frozenset({"open", "closed", "pending", "intake"})
+
+
+# ---------------------------------------------------------------------------
+# Capability data shapes -- Python mirrors of the TypeScript interfaces
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CapabilitySet:
+    """Python mirror of ``CapabilitySet`` from
+    ``src/lib/ai-employee/capabilities/types.ts``."""
+
+    capability: str
+    adapter: str
+    version: str
+    supported_methods: tuple[str, ...]
+    unsupported_methods: tuple[str, ...]
+    field_coverage: dict[str, dict[str, tuple[str, ...]]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HealthStatus:
+    status: str  # "healthy" | "degraded" | "unhealthy"
+    last_ok_at: Optional[str] = None
+    message: Optional[str] = None
+    details: Optional[dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class Matter:
+    """Python mirror of ``Matter`` from ``practice-management.ts``."""
+
+    id: str
+    client_name: str
+    matter_type: str
+    status: str  # "open" | "closed" | "pending" | "intake"
+    opened_at: str
+    closed_at: Optional[str]
+    custom_fields: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DocumentRef:
+    """Python mirror of ``DocumentRef`` from ``practice-management.ts``."""
+
+    id: str
+    matter_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    uploaded_at: str
+    uploaded_by: Optional[str]
+
+
+@dataclass(frozen=True)
+class NoPmMatterNoteRef:
+    """Return shape for ``create_note``.
+
+    The TypeScript interface does not yet declare a typed note shape;
+    the Filevine adapter uses the same workaround. If the TypeScript
+    interface grows a typed note shape later, both adapters converge.
+    """
+
+    id: str
+    matter_id: str
+    body: str
+    created_at: str
+    author_account_id: str
+    drafted_by_skill: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso_utc() -> str:
+    dt = datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def _gen_matter_id() -> str:
+    return f"mat_{secrets.token_hex(8)}"
+
+
+def _gen_note_id() -> str:
+    return f"note_{secrets.token_hex(8)}"
+
+
+def _matter_from_stored(stored: StoredMatter) -> Matter:
+    """1:1 translate from store shape to capability shape.
+
+    The store shape mirrors the capability shape, so this is a copy
+    rather than a translation. Listed explicitly because the
+    NO_FIELD_FABRICATION invariant says adapters declare what they
+    populate; the test suite asserts no fields are invented here.
+    """
+    return Matter(
+        id=stored.id,
+        client_name=stored.client_name,
+        matter_type=stored.matter_type,
+        status=stored.status,
+        opened_at=stored.opened_at,
+        closed_at=stored.closed_at,
+        custom_fields=dict(stored.custom_fields),
+    )
+
+
+def _docref_from_stored(stored: StoredMatterDocument) -> DocumentRef:
+    return DocumentRef(
+        id=stored.id,
+        matter_id=stored.matter_id,
+        filename=stored.filename,
+        mime_type=stored.mime_type,
+        size_bytes=stored.size_bytes,
+        uploaded_at=stored.uploaded_at,
+        uploaded_by=stored.uploaded_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PracticeManagement adapter
+# ---------------------------------------------------------------------------
+
+
+_PM_SUPPORTED = (
+    "describe_capabilities",
+    "health_check",
+    "search_matters",
+    "get_matter",
+    "create_matter",
+    "update_matter",
+    "list_matter_documents",
+    "create_note",
+)
+
+
+# Methods the synthetic store cannot honestly serve. Contacts and time
+# entries are first-class records in an external PM vendor; here, the
+# customer keeps them in Outlook contacts and a billing system (e.g.
+# QuickBooks). Surfacing a fake contacts list from the no_pm adapter
+# would invite drift; skills that need contacts should bind to the
+# ``IntakeCRM`` capability instead.
+_PM_UNSUPPORTED = (
+    "search_contacts",
+    "get_contact",
+    "create_contact",
+    "list_time_entries",
+    "create_time_entry_draft",
+    "upload_matter_document",
+)
+
+
+class NoPmPracticeManagement:
+    """PracticeManagement capability adapter for customers without a PM
+    system.
+
+    Conforms to ``PracticeManagement`` from
+    ``src/lib/ai-employee/capabilities/practice-management.ts``. Storage
+    is injected via ``MatterStore``; defaults to ``InMemoryMatterStore``
+    so local-dev and the conformance tests work without wiring a real
+    D1 + R2 binding.
+    """
+
+    capability = "PracticeManagement"
+    adapter = ADAPTER_SLUG
+    version = "0.1.0"
+
+    def __init__(self, store: Optional[MatterStore] = None) -> None:
+        self._store: MatterStore = store if store is not None else InMemoryMatterStore()
+
+    # ----- AdapterBase -----
+
+    def describe_capabilities(self) -> CapabilitySet:
+        return CapabilitySet(
+            capability=self.capability,
+            adapter=self.adapter,
+            version=self.version,
+            supported_methods=_PM_SUPPORTED,
+            unsupported_methods=_PM_UNSUPPORTED,
+            field_coverage={
+                "search_matters": {
+                    "populated": (
+                        "id",
+                        "client_name",
+                        "matter_type",
+                        "status",
+                        "opened_at",
+                        "closed_at",
+                        "custom_fields",
+                    ),
+                    "not_populated": (),
+                    "derived": (),
+                },
+                "create_matter": {
+                    "populated": (
+                        "id",
+                        "client_name",
+                        "matter_type",
+                        "status",
+                        "opened_at",
+                        "closed_at",
+                        "custom_fields",
+                    ),
+                    "not_populated": (),
+                    # ``id`` is generated by the adapter when the caller does
+                    # not supply one; ``opened_at`` is the create timestamp.
+                    # Both are disclosed so the dashboard sourcing block can
+                    # show "synthesized by no_pm adapter".
+                    "derived": ("id", "opened_at"),
+                },
+                "create_note": {
+                    "populated": (
+                        "id",
+                        "matter_id",
+                        "body",
+                        "created_at",
+                        "author_account_id",
+                        "drafted_by_skill",
+                    ),
+                    "not_populated": (),
+                    "derived": ("id", "created_at"),
+                },
+            },
+        )
+
+    async def health_check(self) -> HealthStatus:
+        # The synthetic store is always reachable -- it lives in the
+        # same Machine. Issue a no-arg list to confirm the store is
+        # responsive; convert any failure into the unhealthy state.
+        try:
+            await self._store.list_matters(limit=1)
+            return HealthStatus(status="healthy", last_ok_at=_iso_utc())
+        except Exception as exc:  # pragma: no cover -- defensive
+            return HealthStatus(
+                status="unhealthy",
+                last_ok_at=None,
+                message=f"no_pm store ping raised {type(exc).__name__}",
+            )
+
+    # ----- Supported methods -----
+
+    async def search_matters(
+        self,
+        *,
+        client_name: Optional[str] = None,
+        matter_type: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Matter]:
+        if status is not None and status not in _VALID_MATTER_STATUSES:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"Unknown matter status {status!r}; "
+                    f"expected one of {sorted(_VALID_MATTER_STATUSES)}"
+                ),
+            )
+        rows = await self._store.list_matters(
+            client_name=client_name,
+            matter_type=matter_type,
+            status=status,
+            limit=limit,
+            offset=offset,
+        )
+        return [_matter_from_stored(r) for r in rows]
+
+    async def get_matter(self, matter_id: str) -> Optional[Matter]:
+        if not matter_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="get_matter requires a non-empty matter_id",
+            )
+        stored = await self._store.get_matter(matter_id)
+        if stored is None:
+            return None
+        return _matter_from_stored(stored)
+
+    async def create_matter(
+        self,
+        *,
+        client_name: str,
+        matter_type: str,
+        status: Optional[str] = None,
+        custom_fields: Optional[dict[str, Any]] = None,
+        matter_id: Optional[str] = None,
+        opened_at: Optional[str] = None,
+    ) -> Matter:
+        if not client_name:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_matter requires client_name",
+            )
+        if not matter_type:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_matter requires matter_type",
+            )
+        effective_status = status if status is not None else "open"
+        if effective_status not in _VALID_MATTER_STATUSES:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"create_matter status {effective_status!r} not in "
+                    f"valid set {sorted(_VALID_MATTER_STATUSES)}"
+                ),
+            )
+        stored = StoredMatter(
+            id=matter_id or _gen_matter_id(),
+            client_name=client_name,
+            matter_type=matter_type,
+            status=effective_status,
+            opened_at=opened_at or _iso_utc(),
+            closed_at=None,
+            custom_fields=dict(custom_fields or {}),
+        )
+        try:
+            saved = await self._store.create_matter(stored)
+        except ValueError as exc:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=str(exc),
+                cause=exc,
+            ) from exc
+        return _matter_from_stored(saved)
+
+    async def update_matter(
+        self,
+        matter_id: str,
+        *,
+        client_name: Optional[str] = None,
+        matter_type: Optional[str] = None,
+        status: Optional[str] = None,
+        custom_fields: Optional[dict[str, Any]] = None,
+    ) -> Matter:
+        if not matter_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="update_matter requires a non-empty matter_id",
+            )
+        if status is not None and status not in _VALID_MATTER_STATUSES:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"update_matter status {status!r} not in valid set "
+                    f"{sorted(_VALID_MATTER_STATUSES)}"
+                ),
+            )
+        try:
+            saved = await self._store.update_matter(
+                matter_id,
+                client_name=client_name,
+                matter_type=matter_type,
+                status=status,
+                custom_fields=custom_fields,
+            )
+        except KeyError as exc:
+            raise AdapterError(
+                code="not_found",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=f"matter {matter_id!r} not found",
+                cause=exc,
+            ) from exc
+        except ValueError as exc:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=str(exc),
+                cause=exc,
+            ) from exc
+        return _matter_from_stored(saved)
+
+    async def list_matter_documents(self, matter_id: str) -> list[DocumentRef]:
+        if not matter_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="list_matter_documents requires a non-empty matter_id",
+            )
+        rows = await self._store.list_matter_documents(matter_id)
+        return [_docref_from_stored(r) for r in rows]
+
+    async def create_note(
+        self,
+        matter_id: str,
+        *,
+        content: str,
+        reviewer_account_id: str,
+        drafted_by_skill: str,
+    ) -> NoPmMatterNoteRef:
+        """Create a matter note attributed to the reviewer.
+
+        Per ADR 0005, the note's author is the reviewer, not the
+        persona. The body is the drafted content verbatim. The
+        ``drafted_by_skill`` is recorded for the dashboard sourcing
+        block.
+        """
+        if not matter_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires a non-empty matter_id",
+            )
+        if not content:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires non-empty content",
+            )
+        if not reviewer_account_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires reviewer_account_id",
+            )
+        if not drafted_by_skill:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_note requires drafted_by_skill",
+            )
+        note = StoredMatterNote(
+            id=_gen_note_id(),
+            matter_id=matter_id,
+            body=content,
+            created_at=_iso_utc(),
+            author_account_id=reviewer_account_id,
+            drafted_by_skill=drafted_by_skill,
+        )
+        try:
+            saved = await self._store.create_matter_note(note)
+        except KeyError as exc:
+            raise AdapterError(
+                code="not_found",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=f"matter {matter_id!r} not found",
+                cause=exc,
+            ) from exc
+        return NoPmMatterNoteRef(
+            id=saved.id,
+            matter_id=saved.matter_id,
+            body=saved.body,
+            created_at=saved.created_at,
+            author_account_id=saved.author_account_id,
+            drafted_by_skill=saved.drafted_by_skill,
+        )
+
+    # ----- Unsupported methods raise capability_not_supported -----
+
+    async def search_contacts(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message=(
+                "search_contacts is not supported in the no_pm adapter; "
+                "bind to the IntakeCRM capability for contact records"
+            ),
+        )
+
+    async def get_contact(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="get_contact is not supported in the no_pm adapter",
+        )
+
+    async def create_contact(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message="create_contact is not supported in the no_pm adapter",
+        )
+
+    async def list_time_entries(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message=(
+                "list_time_entries is not supported in the no_pm adapter; "
+                "bind to the Accounting capability (e.g. QuickBooks) for "
+                "billing records"
+            ),
+        )
+
+    async def create_time_entry_draft(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message=(
+                "create_time_entry_draft is not supported in the no_pm "
+                "adapter; bind to the Accounting capability for time "
+                "entries"
+            ),
+        )
+
+    async def upload_matter_document(self, *args: Any, **kwargs: Any) -> None:
+        raise AdapterError(
+            code="capability_not_supported",
+            capability=self.capability,
+            adapter=self.adapter,
+            message=(
+                "upload_matter_document is not supported in the no_pm "
+                "adapter; bind to the DocumentStorage capability (e.g. "
+                "OneDrive) to upload bytes, then attach the link via "
+                "create_note"
+            ),
+        )
+
+
+__all__ = [
+    "ADAPTER_SLUG",
+    "CapabilitySet",
+    "DocumentRef",
+    "HealthStatus",
+    "Matter",
+    "NoPmMatterNoteRef",
+    "NoPmPracticeManagement",
+]

--- a/ai-employee/connectors/no_pm/errors.py
+++ b/ai-employee/connectors/no_pm/errors.py
@@ -1,0 +1,109 @@
+"""Adapter error contract -- Python mirror of ``AdapterError`` from
+``src/lib/ai-employee/capabilities/types.ts``.
+
+Mirrors the Filevine connector's ``errors.py`` so the no_pm adapter
+satisfies the same closed unions. The capability-set and error-code
+unions are pinned by the TypeScript-side conformance harness; drift
+between the two languages is a P0.
+
+Per ADR 0006 invariant TYPED_ERRORS: adapters only raise ``AdapterError``
+with codes drawn from the closed ``AdapterErrorCode`` union. Internal
+exceptions are wrapped in ``cause``, never re-raised raw. Skill code
+switches on ``code``, not on ``message``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+
+AdapterErrorCode = Literal[
+    "not_found",
+    "unauthorized",
+    "rate_limited",
+    "transient",
+    "capability_not_supported",
+    "scope_violation",
+    "fabrication_blocked",
+    "validation_failed",
+    "unknown",
+]
+
+
+ADAPTER_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "not_found",
+        "unauthorized",
+        "rate_limited",
+        "transient",
+        "capability_not_supported",
+        "scope_violation",
+        "fabrication_blocked",
+        "validation_failed",
+        "unknown",
+    }
+)
+
+
+CAPABILITY_NAMES: frozenset[str] = frozenset(
+    {
+        "PracticeManagement",
+        "Email",
+        "Calendar",
+        "DocumentStorage",
+        "ESign",
+        "CourtAccess",
+        "Payments",
+        "Accounting",
+        "IntakeCRM",
+        "CallTracking",
+        "InternalComms",
+    }
+)
+
+
+class AdapterError(Exception):
+    """Canonical error raised by the no_pm capability adapter.
+
+    Mirrors ``class AdapterError extends Error`` in
+    ``src/lib/ai-employee/capabilities/types.ts``. Skill code switches
+    on ``.code`` rather than ``.message`` or the exception type chain.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        capability: str,
+        adapter: str,
+        message: str,
+        cause: Optional[BaseException] = None,
+    ) -> None:
+        if code not in ADAPTER_ERROR_CODES:
+            raise ValueError(
+                f"AdapterError code {code!r} not in closed union; "
+                "update both this constant and "
+                "src/lib/ai-employee/capabilities/types.ts"
+            )
+        if capability not in CAPABILITY_NAMES:
+            raise ValueError(
+                f"AdapterError capability {capability!r} not in CapabilityName union"
+            )
+        super().__init__(message)
+        self.code = code
+        self.capability = capability
+        self.adapter = adapter
+        self.cause = cause
+
+    def __repr__(self) -> str:  # pragma: no cover -- debug helper
+        return (
+            f"AdapterError(code={self.code!r}, capability={self.capability!r}, "
+            f"adapter={self.adapter!r}, message={self.args[0]!r})"
+        )
+
+
+__all__ = [
+    "ADAPTER_ERROR_CODES",
+    "CAPABILITY_NAMES",
+    "AdapterError",
+    "AdapterErrorCode",
+]

--- a/ai-employee/connectors/no_pm/store.py
+++ b/ai-employee/connectors/no_pm/store.py
@@ -1,0 +1,302 @@
+"""Synthetic matter store -- the persistence seam for the no_pm adapter.
+
+The no-PM-system adapter needs somewhere to keep matters, matter notes,
+and matter document references for customers who do not have an
+external practice-management vendor. Per ADR 0008 (customer-owned
+memory artifact), that storage lives in the per-customer D1 + R2
+substrate that the memory pipeline (PR #944) already owns.
+
+This module defines the storage seam as a Protocol -- ``MatterStore``
+-- so the adapter never touches D1 or R2 directly. Production wires an
+implementation backed by the per-customer ``D1Executor`` and R2
+binding; tests use ``InMemoryMatterStore``. The conformance harness
+verifies the adapter satisfies the capability interface regardless of
+which store backs it.
+
+Storage layout (production -- planned)
+--------------------------------------
+
+The production ``D1MatterStore`` implementation (follow-on issue) maps
+onto two per-customer D1 tables:
+
+* ``no_pm_matters`` -- one row per matter
+* ``no_pm_matter_notes`` -- one row per note, linked by ``matter_id``
+
+Per-matter documents live in the per-customer R2 vault at
+``vaults/{customer_id}/no_pm/matters/{matter_id}/documents/`` -- the
+same naming convention the memory pipeline already uses. The store
+records the R2 key in the matter document index; the adapter exposes
+``list_matter_documents`` against that index.
+
+Per ADR 0009, no tenant ID is ever passed in -- the D1 + R2 bindings
+are scoped at the per-customer Machine boundary, so isolation is
+structural rather than per-row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional, Protocol
+
+
+# Closed enum mirroring the capability's ``MatterStatus`` union.
+_VALID_STATUSES = frozenset({"open", "closed", "pending", "intake"})
+
+
+def _iso_utc(now: Optional[datetime] = None) -> str:
+    dt = now if now is not None else datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+# ---------------------------------------------------------------------------
+# Data shapes -- vendor-neutral, mirror capability fields
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StoredMatter:
+    """Matter row as the store sees it.
+
+    Field set matches the capability ``Matter`` shape so the adapter's
+    translation step is a 1:1 copy. Custom fields are an open dict so
+    the synthetic-tracker UI (or a future operator surface) can record
+    free-form metadata (e.g. "Outlook thread ref", "Dropbox folder ref")
+    without forcing a schema change.
+    """
+
+    id: str
+    client_name: str
+    matter_type: str
+    status: str
+    opened_at: str
+    closed_at: Optional[str]
+    custom_fields: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StoredMatterNote:
+    """Note attached to a matter, attributed to the reviewer per ADR 0005."""
+
+    id: str
+    matter_id: str
+    body: str
+    created_at: str
+    author_account_id: str
+    drafted_by_skill: str
+
+
+@dataclass(frozen=True)
+class StoredMatterDocument:
+    """Pointer to a document associated with a matter.
+
+    The synthetic store records the document metadata (filename, size,
+    upload time) plus an ``r2_key`` pointing at the per-customer vault
+    where the bytes live. The DocumentStorage capability binding is the
+    one customers should use to read the bytes -- the no_pm adapter
+    exposes only matter-scoped listings.
+    """
+
+    id: str
+    matter_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    uploaded_at: str
+    uploaded_by: Optional[str]
+    r2_key: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Protocol -- the seam the adapter binds to
+# ---------------------------------------------------------------------------
+
+
+class MatterStore(Protocol):
+    """Storage seam for the no_pm adapter.
+
+    All methods are async so the production D1 + R2 implementation can
+    do real I/O; the in-memory test fake's methods are async-no-ops
+    that satisfy the protocol.
+    """
+
+    async def list_matters(
+        self,
+        *,
+        client_name: Optional[str] = None,
+        matter_type: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[StoredMatter]: ...
+
+    async def get_matter(self, matter_id: str) -> Optional[StoredMatter]: ...
+
+    async def create_matter(self, matter: StoredMatter) -> StoredMatter: ...
+
+    async def update_matter(
+        self,
+        matter_id: str,
+        *,
+        client_name: Optional[str] = None,
+        matter_type: Optional[str] = None,
+        status: Optional[str] = None,
+        custom_fields: Optional[dict[str, Any]] = None,
+    ) -> StoredMatter: ...
+
+    async def list_matter_documents(
+        self, matter_id: str
+    ) -> list[StoredMatterDocument]: ...
+
+    async def create_matter_note(self, note: StoredMatterNote) -> StoredMatterNote: ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory implementation -- used by tests + local dev
+# ---------------------------------------------------------------------------
+
+
+class InMemoryMatterStore:
+    """Reference implementation of ``MatterStore`` backed by Python dicts.
+
+    The conformance + capability tests use this implementation. Local
+    dev with the no_pm template wires it as well; production swaps in
+    a D1 + R2 implementation that satisfies the same protocol.
+
+    Records are stored in insertion order; queries iterate in that
+    order and apply substring matches on string fields. The store does
+    not invent values -- if a caller asks for a matter that does not
+    exist, ``get_matter`` returns ``None`` per the capability contract.
+    """
+
+    def __init__(
+        self,
+        matters: Optional[Iterable[StoredMatter]] = None,
+        notes: Optional[Iterable[StoredMatterNote]] = None,
+        documents: Optional[Iterable[StoredMatterDocument]] = None,
+        clock: Optional["object"] = None,
+    ) -> None:
+        self._matters: dict[str, StoredMatter] = {}
+        self._notes: dict[str, StoredMatterNote] = {}
+        self._documents: dict[str, StoredMatterDocument] = {}
+        # Insertion-order index for documents per matter so list calls
+        # return them in the order the store recorded them.
+        self._docs_by_matter: dict[str, list[str]] = {}
+        for m in matters or ():
+            self._matters[m.id] = m
+        for n in notes or ():
+            self._notes[n.id] = n
+        for d in documents or ():
+            self._documents[d.id] = d
+            self._docs_by_matter.setdefault(d.matter_id, []).append(d.id)
+        # ``clock`` is a callable that returns the current ISO timestamp;
+        # tests override it for deterministic ``created_at`` values.
+        self._clock = clock if clock is not None else _iso_utc
+
+    # ---------------------------------------------------------------- reads
+
+    async def list_matters(
+        self,
+        *,
+        client_name: Optional[str] = None,
+        matter_type: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[StoredMatter]:
+        rows = list(self._matters.values())
+        if client_name is not None:
+            needle = client_name.lower()
+            rows = [m for m in rows if needle in m.client_name.lower()]
+        if matter_type is not None:
+            rows = [m for m in rows if m.matter_type == matter_type]
+        if status is not None:
+            rows = [m for m in rows if m.status == status]
+        return rows[offset : offset + limit]
+
+    async def get_matter(self, matter_id: str) -> Optional[StoredMatter]:
+        return self._matters.get(matter_id)
+
+    async def list_matter_documents(
+        self, matter_id: str
+    ) -> list[StoredMatterDocument]:
+        doc_ids = self._docs_by_matter.get(matter_id, ())
+        return [self._documents[doc_id] for doc_id in doc_ids if doc_id in self._documents]
+
+    # --------------------------------------------------------------- writes
+
+    async def create_matter(self, matter: StoredMatter) -> StoredMatter:
+        if matter.status not in _VALID_STATUSES:
+            raise ValueError(
+                f"create_matter status {matter.status!r} not in valid set "
+                f"{sorted(_VALID_STATUSES)}"
+            )
+        if matter.id in self._matters:
+            raise ValueError(f"matter_id {matter.id!r} already exists")
+        self._matters[matter.id] = matter
+        return matter
+
+    async def update_matter(
+        self,
+        matter_id: str,
+        *,
+        client_name: Optional[str] = None,
+        matter_type: Optional[str] = None,
+        status: Optional[str] = None,
+        custom_fields: Optional[dict[str, Any]] = None,
+    ) -> StoredMatter:
+        existing = self._matters.get(matter_id)
+        if existing is None:
+            raise KeyError(matter_id)
+        if status is not None and status not in _VALID_STATUSES:
+            raise ValueError(
+                f"update_matter status {status!r} not in valid set "
+                f"{sorted(_VALID_STATUSES)}"
+            )
+        merged_custom = dict(existing.custom_fields)
+        if custom_fields is not None:
+            merged_custom.update(custom_fields)
+        new_closed_at = existing.closed_at
+        if status == "closed" and existing.closed_at is None:
+            new_closed_at = self._clock()
+        updated = replace(
+            existing,
+            client_name=client_name if client_name is not None else existing.client_name,
+            matter_type=matter_type if matter_type is not None else existing.matter_type,
+            status=status if status is not None else existing.status,
+            closed_at=new_closed_at,
+            custom_fields=merged_custom,
+        )
+        self._matters[matter_id] = updated
+        return updated
+
+    async def create_matter_note(self, note: StoredMatterNote) -> StoredMatterNote:
+        if note.matter_id not in self._matters:
+            raise KeyError(note.matter_id)
+        if note.id in self._notes:
+            raise ValueError(f"note_id {note.id!r} already exists")
+        self._notes[note.id] = note
+        return note
+
+    # ----------------------------------------------------------- test seams
+
+    def add_document(self, doc: StoredMatterDocument) -> None:
+        """Insert a document row.
+
+        Tests use this seam to populate a matter with documents the
+        adapter can list; production wires the same shape from the
+        memory pipeline's R2 + index path.
+        """
+        if doc.matter_id not in self._matters:
+            raise KeyError(doc.matter_id)
+        self._documents[doc.id] = doc
+        self._docs_by_matter.setdefault(doc.matter_id, []).append(doc.id)
+
+
+__all__ = [
+    "InMemoryMatterStore",
+    "MatterStore",
+    "StoredMatter",
+    "StoredMatterDocument",
+    "StoredMatterNote",
+]

--- a/ai-employee/connectors/no_pm/tests/conftest.py
+++ b/ai-employee/connectors/no_pm/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest config -- extend sys.path so ``connectors.no_pm`` is importable
+when the suite is invoked from either ``ai-employee/`` or the repo
+root.
+
+Mirrors the Filevine connector's ``conftest.py`` so the two suites can
+be run together with one ``pytest`` invocation from ``ai-employee/``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+# Make ``ai-employee/`` importable -> ``from connectors.no_pm import ...``
+sys.path.insert(0, str(_HERE.parents[3]))

--- a/ai-employee/connectors/no_pm/tests/test_capabilities.py
+++ b/ai-employee/connectors/no_pm/tests/test_capabilities.py
@@ -1,0 +1,486 @@
+"""Unit tests for the no_pm capability adapter.
+
+Covers:
+
+* CapabilitySet shape -- capability name, supported/unsupported method
+  declarations, field_coverage disclosure
+* Matter.Read + Matter.Write happy paths (search, get, create, update)
+* Note.Write attribution (reviewer, not "AI Employee")
+* Unsupported methods raise ``capability_not_supported``
+  (UNSUPPORTED_METHODS_THROW)
+* ``get_matter`` returns None on unknown id (NULL_FOR_ABSENT)
+* No banned methods on the adapter (NO_AUTONOMOUS_EXTERNAL_SEND)
+* No field fabrication -- the 1:1 store-to-capability mapping
+  preserves the store's values without invention
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from connectors.no_pm import (  # type: ignore[import-not-found]
+    AdapterError,
+    InMemoryMatterStore,
+    NoPmPracticeManagement,
+    StoredMatter,
+    StoredMatterDocument,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _seed_store_with_smith_matter() -> InMemoryMatterStore:
+    store = InMemoryMatterStore()
+    asyncio.run(
+        store.create_matter(
+            StoredMatter(
+                id="mat-smith",
+                client_name="Smith, John",
+                matter_type="PI-Auto",
+                status="open",
+                opened_at="2026-01-15T10:30:00.000Z",
+                closed_at=None,
+                custom_fields={"outlook_thread_ref": "thr-101"},
+            )
+        )
+    )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# describe_capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_describe_capabilities_is_honest():
+    pm = NoPmPracticeManagement()
+    cs = pm.describe_capabilities()
+
+    assert cs.capability == "PracticeManagement"
+    assert cs.adapter == "no_pm"
+    # The required read + write surface for the demo flow.
+    for method in (
+        "search_matters",
+        "get_matter",
+        "create_matter",
+        "update_matter",
+        "list_matter_documents",
+        "create_note",
+        "describe_capabilities",
+        "health_check",
+    ):
+        assert method in cs.supported_methods
+
+    # The synthetic store cannot honestly serve these.
+    for method in (
+        "search_contacts",
+        "get_contact",
+        "create_contact",
+        "list_time_entries",
+        "create_time_entry_draft",
+        "upload_matter_document",
+    ):
+        assert method in cs.unsupported_methods
+
+    # Supported and unsupported are disjoint -- the conformance harness
+    # asserts this; restating here so a regression fails locally first.
+    assert set(cs.supported_methods).isdisjoint(set(cs.unsupported_methods))
+
+
+def test_describe_capabilities_discloses_derived_fields_on_writes():
+    pm = NoPmPracticeManagement()
+    cs = pm.describe_capabilities()
+    # ``create_matter`` synthesizes id + opened_at if the caller omits
+    # them. The dashboard sourcing block needs this declared.
+    create_coverage = cs.field_coverage["create_matter"]
+    assert "id" in create_coverage["derived"]
+    assert "opened_at" in create_coverage["derived"]
+    # ``create_note`` synthesizes id + created_at.
+    note_coverage = cs.field_coverage["create_note"]
+    assert "id" in note_coverage["derived"]
+    assert "created_at" in note_coverage["derived"]
+
+
+# ---------------------------------------------------------------------------
+# search_matters / get_matter
+# ---------------------------------------------------------------------------
+
+
+def test_search_matters_returns_typed_matters():
+    store = _seed_store_with_smith_matter()
+    pm = NoPmPracticeManagement(store=store)
+    matters = asyncio.run(pm.search_matters())
+    assert len(matters) == 1
+    m = matters[0]
+    assert m.id == "mat-smith"
+    assert m.client_name == "Smith, John"
+    assert m.matter_type == "PI-Auto"
+    assert m.status == "open"
+    assert m.custom_fields == {"outlook_thread_ref": "thr-101"}
+
+
+def test_search_matters_validation_failed_on_unknown_status():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.search_matters(status="bogus"))
+    assert exc.value.code == "validation_failed"
+    assert exc.value.capability == "PracticeManagement"
+
+
+def test_search_matters_filters_by_status():
+    store = _seed_store_with_smith_matter()
+    asyncio.run(
+        store.create_matter(
+            StoredMatter(
+                id="mat-closed",
+                client_name="Doe, Jane",
+                matter_type="PI-Slip",
+                status="closed",
+                opened_at="2025-12-01T08:00:00.000Z",
+                closed_at="2026-04-01T08:00:00.000Z",
+                custom_fields={},
+            )
+        )
+    )
+    pm = NoPmPracticeManagement(store=store)
+    closed = asyncio.run(pm.search_matters(status="closed"))
+    assert [m.id for m in closed] == ["mat-closed"]
+
+
+def test_get_matter_returns_none_on_unknown_id():
+    pm = NoPmPracticeManagement(store=_seed_store_with_smith_matter())
+    assert asyncio.run(pm.get_matter("mat-missing")) is None
+
+
+def test_get_matter_happy_path():
+    pm = NoPmPracticeManagement(store=_seed_store_with_smith_matter())
+    m = asyncio.run(pm.get_matter("mat-smith"))
+    assert m is not None
+    assert m.id == "mat-smith"
+
+
+def test_get_matter_validates_empty_id():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.get_matter(""))
+    assert exc.value.code == "validation_failed"
+
+
+# ---------------------------------------------------------------------------
+# create_matter / update_matter
+# ---------------------------------------------------------------------------
+
+
+def test_create_matter_persists_and_returns_typed_record():
+    pm = NoPmPracticeManagement()
+    m = asyncio.run(
+        pm.create_matter(client_name="Roe, Richard", matter_type="PI-Premises")
+    )
+    assert m.client_name == "Roe, Richard"
+    assert m.matter_type == "PI-Premises"
+    assert m.status == "open"
+    # Adapter-synthesized id + opened_at are populated.
+    assert m.id.startswith("mat_")
+    assert m.opened_at  # non-empty ISO string
+    assert m.closed_at is None
+
+
+def test_create_matter_accepts_caller_supplied_id():
+    pm = NoPmPracticeManagement()
+    m = asyncio.run(
+        pm.create_matter(
+            client_name="Smith, John",
+            matter_type="PI-Auto",
+            matter_id="custom-id",
+        )
+    )
+    assert m.id == "custom-id"
+
+
+def test_create_matter_validation_failed_on_missing_fields():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.create_matter(client_name="", matter_type="PI-Auto"))
+    assert exc.value.code == "validation_failed"
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.create_matter(client_name="Smith", matter_type=""))
+    assert exc.value.code == "validation_failed"
+
+
+def test_create_matter_validation_failed_on_unknown_status():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            pm.create_matter(
+                client_name="Smith", matter_type="PI-Auto", status="archived"
+            )
+        )
+    assert exc.value.code == "validation_failed"
+
+
+def test_create_matter_duplicate_id_surfaces_as_validation_failed():
+    pm = NoPmPracticeManagement()
+    asyncio.run(
+        pm.create_matter(
+            client_name="Smith", matter_type="PI-Auto", matter_id="dup"
+        )
+    )
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            pm.create_matter(
+                client_name="Roe", matter_type="PI-Auto", matter_id="dup"
+            )
+        )
+    assert exc.value.code == "validation_failed"
+
+
+def test_update_matter_changes_status_and_merges_custom_fields():
+    pm = NoPmPracticeManagement(store=_seed_store_with_smith_matter())
+    updated = asyncio.run(
+        pm.update_matter(
+            "mat-smith",
+            status="pending",
+            custom_fields={"deposition_date": "2026-06-10"},
+        )
+    )
+    assert updated.status == "pending"
+    assert updated.custom_fields["outlook_thread_ref"] == "thr-101"
+    assert updated.custom_fields["deposition_date"] == "2026-06-10"
+
+
+def test_update_matter_not_found_on_unknown_id():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.update_matter("mat-missing", status="closed"))
+    assert exc.value.code == "not_found"
+
+
+def test_update_matter_validation_failed_on_unknown_status():
+    pm = NoPmPracticeManagement(store=_seed_store_with_smith_matter())
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.update_matter("mat-smith", status="archived"))
+    assert exc.value.code == "validation_failed"
+
+
+def test_update_matter_validates_empty_id():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.update_matter("", status="closed"))
+    assert exc.value.code == "validation_failed"
+
+
+# ---------------------------------------------------------------------------
+# list_matter_documents
+# ---------------------------------------------------------------------------
+
+
+def test_list_matter_documents_returns_typed_docrefs():
+    store = _seed_store_with_smith_matter()
+    store.add_document(
+        StoredMatterDocument(
+            id="doc-1",
+            matter_id="mat-smith",
+            filename="police-report.pdf",
+            mime_type="application/pdf",
+            size_bytes=184320,
+            uploaded_at="2026-01-18T14:22:00.000Z",
+            uploaded_by="paralegal-12",
+            r2_key="vaults/example/no_pm/matters/mat-smith/documents/police-report.pdf",
+        )
+    )
+    pm = NoPmPracticeManagement(store=store)
+    docs = asyncio.run(pm.list_matter_documents("mat-smith"))
+    assert len(docs) == 1
+    d = docs[0]
+    assert d.id == "doc-1"
+    assert d.matter_id == "mat-smith"
+    assert d.filename == "police-report.pdf"
+    assert d.size_bytes == 184320
+    assert d.uploaded_by == "paralegal-12"
+
+
+def test_list_matter_documents_validates_empty_id():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(pm.list_matter_documents(""))
+    assert exc.value.code == "validation_failed"
+
+
+def test_list_matter_documents_returns_empty_for_unknown_matter():
+    pm = NoPmPracticeManagement()
+    assert asyncio.run(pm.list_matter_documents("mat-missing")) == []
+
+
+# ---------------------------------------------------------------------------
+# create_note -- ADR 0005 attribution
+# ---------------------------------------------------------------------------
+
+
+def test_create_note_attributes_to_reviewer_not_persona():
+    pm = NoPmPracticeManagement(store=_seed_store_with_smith_matter())
+    note = asyncio.run(
+        pm.create_note(
+            "mat-smith",
+            content="Status update: deposition scheduled 2026-06-10.",
+            reviewer_account_id="reviewer-attorney-99",
+            drafted_by_skill="law-client-status-update",
+        )
+    )
+    assert note.matter_id == "mat-smith"
+    assert note.author_account_id == "reviewer-attorney-99"
+    assert note.drafted_by_skill == "law-client-status-update"
+    # Body is the drafted content verbatim. The persona is NOT in the body.
+    assert note.body == "Status update: deposition scheduled 2026-06-10."
+    assert "AI Employee" not in note.body
+    assert "Marcus" not in note.body
+
+
+def test_create_note_not_found_on_unknown_matter():
+    pm = NoPmPracticeManagement()
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            pm.create_note(
+                "mat-missing",
+                content="hi",
+                reviewer_account_id="r",
+                drafted_by_skill="s",
+            )
+        )
+    assert exc.value.code == "not_found"
+
+
+def test_create_note_validates_required_fields():
+    pm = NoPmPracticeManagement(store=_seed_store_with_smith_matter())
+    invalid_calls = (
+        {"content": "", "reviewer_account_id": "r", "drafted_by_skill": "s"},
+        {"content": "x", "reviewer_account_id": "", "drafted_by_skill": "s"},
+        {"content": "x", "reviewer_account_id": "r", "drafted_by_skill": ""},
+    )
+    for kwargs in invalid_calls:
+        with pytest.raises(AdapterError) as exc:
+            asyncio.run(pm.create_note("mat-smith", **kwargs))
+        assert exc.value.code == "validation_failed"
+
+    with pytest.raises(AdapterError) as exc:
+        asyncio.run(
+            pm.create_note(
+                "",
+                content="x",
+                reviewer_account_id="r",
+                drafted_by_skill="s",
+            )
+        )
+    assert exc.value.code == "validation_failed"
+
+
+# ---------------------------------------------------------------------------
+# Unsupported methods + conformance invariants
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_methods_raise_capability_not_supported():
+    pm = NoPmPracticeManagement()
+    for method in (
+        "search_contacts",
+        "get_contact",
+        "create_contact",
+        "list_time_entries",
+        "create_time_entry_draft",
+        "upload_matter_document",
+    ):
+        fn = getattr(pm, method)
+        with pytest.raises(AdapterError) as exc:
+            asyncio.run(fn())
+        assert exc.value.code == "capability_not_supported", (
+            f"{method} did not raise capability_not_supported"
+        )
+
+
+# Banned method names -- the conformance harness rejects adapters that
+# expose autonomous send paths. The no_pm adapter is read+write-to-store
+# only; this test asserts none of the banned names slip in.
+_BANNED_METHOD_NAMES = frozenset(
+    {
+        "send",
+        "send_email",
+        "send_message",
+        "send_invoice",
+        "post_invoice",
+        "publish",
+        "submit_filing",
+        "schedule_meeting",
+        "rsvp",
+        "share_externally",
+    }
+)
+
+
+def test_adapter_has_no_banned_method_names():
+    pm = NoPmPracticeManagement()
+    for name in dir(pm):
+        assert name not in _BANNED_METHOD_NAMES, (
+            f"NoPmPracticeManagement exposes banned method name {name!r}; "
+            "the no_pm adapter must not expose autonomous send paths"
+        )
+
+
+# ---------------------------------------------------------------------------
+# health_check
+# ---------------------------------------------------------------------------
+
+
+def test_health_check_is_healthy_when_store_is_reachable():
+    pm = NoPmPracticeManagement()
+    h = asyncio.run(pm.health_check())
+    assert h.status == "healthy"
+    assert h.last_ok_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Cross-method demo flow -- end-to-end through the synthetic substrate
+# ---------------------------------------------------------------------------
+
+
+def test_demo_flow_create_then_note_then_close():
+    """End-to-end exercise of the no_pm adapter against an in-memory
+    store -- the demo flow that the spec promises works without an
+    external PM vendor.
+    """
+    pm = NoPmPracticeManagement()
+
+    # 1. Operator creates a synthetic matter from an Outlook intake.
+    matter = asyncio.run(
+        pm.create_matter(
+            client_name="Smith, John",
+            matter_type="PI-Auto",
+            custom_fields={"outlook_thread_ref": "thr-101"},
+        )
+    )
+    assert matter.status == "open"
+
+    # 2. The agent drafts a status-update note; reviewer signs off.
+    note = asyncio.run(
+        pm.create_note(
+            matter.id,
+            content="Deposition scheduled 2026-06-10.",
+            reviewer_account_id="reviewer-attorney-99",
+            drafted_by_skill="law-client-status-update",
+        )
+    )
+    assert note.author_account_id == "reviewer-attorney-99"
+    assert note.body == "Deposition scheduled 2026-06-10."
+
+    # 3. Matter is closed; closed_at is recorded.
+    closed = asyncio.run(pm.update_matter(matter.id, status="closed"))
+    assert closed.status == "closed"
+    assert closed.closed_at is not None
+
+    # 4. List confirms the matter is searchable as closed.
+    rows = asyncio.run(pm.search_matters(status="closed"))
+    assert [m.id for m in rows] == [matter.id]

--- a/ai-employee/connectors/no_pm/tests/test_errors.py
+++ b/ai-employee/connectors/no_pm/tests/test_errors.py
@@ -1,0 +1,108 @@
+"""Pin the AdapterError code + capability union against the TypeScript
+contract.
+
+If anyone changes ``src/lib/ai-employee/capabilities/types.ts`` without
+updating ``ai-employee/connectors/no_pm/errors.py``, these tests fail
+and force a paired update. The same shape is asserted in the Filevine
+connector; both adapters share the closed unions by design.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from connectors.no_pm import (  # type: ignore[import-not-found]
+    ADAPTER_SLUG,
+    AdapterError,
+    CAPABILITY_NAMES,
+)
+from connectors.no_pm.errors import ADAPTER_ERROR_CODES  # type: ignore[import-not-found]
+
+
+# Closed unions pinned against ``src/lib/ai-employee/capabilities/types.ts``.
+EXPECTED_ERROR_CODES = frozenset(
+    {
+        "not_found",
+        "unauthorized",
+        "rate_limited",
+        "transient",
+        "capability_not_supported",
+        "scope_violation",
+        "fabrication_blocked",
+        "validation_failed",
+        "unknown",
+    }
+)
+
+EXPECTED_CAPABILITIES = frozenset(
+    {
+        "PracticeManagement",
+        "Email",
+        "Calendar",
+        "DocumentStorage",
+        "ESign",
+        "CourtAccess",
+        "Payments",
+        "Accounting",
+        "IntakeCRM",
+        "CallTracking",
+        "InternalComms",
+    }
+)
+
+
+def test_adapter_error_codes_match_typescript_union():
+    assert ADAPTER_ERROR_CODES == EXPECTED_ERROR_CODES
+
+
+def test_capability_names_match_typescript_union():
+    assert CAPABILITY_NAMES == EXPECTED_CAPABILITIES
+
+
+def test_adapter_error_rejects_unknown_code():
+    with pytest.raises(ValueError):
+        AdapterError(
+            code="not_a_real_code",
+            capability="PracticeManagement",
+            adapter=ADAPTER_SLUG,
+            message="should reject",
+        )
+
+
+def test_adapter_error_rejects_unknown_capability():
+    with pytest.raises(ValueError):
+        AdapterError(
+            code="unknown",
+            capability="NotARealCapability",
+            adapter=ADAPTER_SLUG,
+            message="should reject",
+        )
+
+
+def test_adapter_error_records_code_capability_adapter_message():
+    err = AdapterError(
+        code="validation_failed",
+        capability="PracticeManagement",
+        adapter=ADAPTER_SLUG,
+        message="example message",
+    )
+    assert err.code == "validation_failed"
+    assert err.capability == "PracticeManagement"
+    assert err.adapter == ADAPTER_SLUG
+    assert err.args[0] == "example message"
+    assert err.cause is None
+
+
+def test_adapter_error_carries_cause_distinct_from_python_chain():
+    inner = RuntimeError("vendor blew up")
+    err = AdapterError(
+        code="unknown",
+        capability="PracticeManagement",
+        adapter=ADAPTER_SLUG,
+        message="wrapped",
+        cause=inner,
+    )
+    # ``cause`` is a distinct attribute from Python's ``__cause__``; the
+    # audit-log reads ``cause``, the user-facing chain reads ``__cause__``.
+    assert err.cause is inner
+    assert err.__cause__ is None

--- a/ai-employee/connectors/no_pm/tests/test_store.py
+++ b/ai-employee/connectors/no_pm/tests/test_store.py
@@ -1,0 +1,194 @@
+"""Unit tests for ``InMemoryMatterStore``.
+
+Covers the reference implementation of the ``MatterStore`` protocol the
+no_pm adapter binds to. Production swaps in a D1 + R2-backed
+implementation that satisfies the same protocol; these tests assert
+the in-memory variant honors the contract the adapter expects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from connectors.no_pm.store import (  # type: ignore[import-not-found]
+    InMemoryMatterStore,
+    StoredMatter,
+    StoredMatterDocument,
+    StoredMatterNote,
+)
+
+
+def _matter(
+    matter_id: str = "mat-1",
+    *,
+    client_name: str = "Smith, John",
+    matter_type: str = "PI-Auto",
+    status: str = "open",
+) -> StoredMatter:
+    return StoredMatter(
+        id=matter_id,
+        client_name=client_name,
+        matter_type=matter_type,
+        status=status,
+        opened_at="2026-01-15T10:30:00.000Z",
+        closed_at=None,
+        custom_fields={},
+    )
+
+
+def test_list_matters_returns_empty_for_fresh_store():
+    store = InMemoryMatterStore()
+    assert asyncio.run(store.list_matters()) == []
+
+
+def test_create_matter_persists_and_can_be_read():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter()))
+    matters = asyncio.run(store.list_matters())
+    assert len(matters) == 1
+    assert matters[0].id == "mat-1"
+    assert matters[0].client_name == "Smith, John"
+
+
+def test_create_matter_rejects_duplicate_id():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter()))
+    with pytest.raises(ValueError):
+        asyncio.run(store.create_matter(_matter()))
+
+
+def test_create_matter_rejects_invalid_status():
+    store = InMemoryMatterStore()
+    with pytest.raises(ValueError):
+        asyncio.run(store.create_matter(_matter(status="archived")))
+
+
+def test_get_matter_returns_none_for_unknown_id():
+    store = InMemoryMatterStore()
+    assert asyncio.run(store.get_matter("mat-missing")) is None
+
+
+def test_list_matters_filters_by_client_name_substring():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter("mat-1", client_name="Smith, John")))
+    asyncio.run(store.create_matter(_matter("mat-2", client_name="Doe, Jane")))
+    smiths = asyncio.run(store.list_matters(client_name="smith"))
+    assert [m.id for m in smiths] == ["mat-1"]
+
+
+def test_list_matters_filters_by_status():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter("mat-1", status="open")))
+    asyncio.run(store.create_matter(_matter("mat-2", status="closed")))
+    closed = asyncio.run(store.list_matters(status="closed"))
+    assert [m.id for m in closed] == ["mat-2"]
+
+
+def test_list_matters_paginates_by_limit_offset():
+    store = InMemoryMatterStore()
+    for i in range(5):
+        asyncio.run(store.create_matter(_matter(f"mat-{i}")))
+    page = asyncio.run(store.list_matters(limit=2, offset=1))
+    assert [m.id for m in page] == ["mat-1", "mat-2"]
+
+
+def test_update_matter_merges_custom_fields():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter()))
+    asyncio.run(
+        store.update_matter("mat-1", custom_fields={"outlook_thread": "thr-99"})
+    )
+    asyncio.run(store.update_matter("mat-1", custom_fields={"dropbox_folder": "f1"}))
+    m = asyncio.run(store.get_matter("mat-1"))
+    assert m is not None
+    assert m.custom_fields == {"outlook_thread": "thr-99", "dropbox_folder": "f1"}
+
+
+def test_update_matter_records_closed_at_when_status_flips_to_closed():
+    store = InMemoryMatterStore(clock=lambda: "2026-05-21T12:00:00.000Z")
+    asyncio.run(store.create_matter(_matter()))
+    m = asyncio.run(store.update_matter("mat-1", status="closed"))
+    assert m.status == "closed"
+    assert m.closed_at == "2026-05-21T12:00:00.000Z"
+
+
+def test_update_matter_rejects_unknown_status():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter()))
+    with pytest.raises(ValueError):
+        asyncio.run(store.update_matter("mat-1", status="archived"))
+
+
+def test_update_matter_raises_keyerror_for_unknown_id():
+    store = InMemoryMatterStore()
+    with pytest.raises(KeyError):
+        asyncio.run(store.update_matter("mat-missing", status="open"))
+
+
+def test_create_matter_note_requires_matter_to_exist():
+    store = InMemoryMatterStore()
+    note = StoredMatterNote(
+        id="note-1",
+        matter_id="mat-missing",
+        body="hi",
+        created_at="2026-05-21T12:00:00.000Z",
+        author_account_id="reviewer-1",
+        drafted_by_skill="law-client-status-update",
+    )
+    with pytest.raises(KeyError):
+        asyncio.run(store.create_matter_note(note))
+
+
+def test_add_document_lists_in_insertion_order():
+    store = InMemoryMatterStore()
+    asyncio.run(store.create_matter(_matter()))
+    store.add_document(
+        StoredMatterDocument(
+            id="doc-1",
+            matter_id="mat-1",
+            filename="intake.pdf",
+            mime_type="application/pdf",
+            size_bytes=100,
+            uploaded_at="2026-01-15T10:30:00.000Z",
+            uploaded_by=None,
+            r2_key="vaults/example/no_pm/matters/mat-1/documents/intake.pdf",
+        )
+    )
+    store.add_document(
+        StoredMatterDocument(
+            id="doc-2",
+            matter_id="mat-1",
+            filename="medical-records.pdf",
+            mime_type="application/pdf",
+            size_bytes=200,
+            uploaded_at="2026-01-16T10:30:00.000Z",
+            uploaded_by=None,
+            r2_key="vaults/example/no_pm/matters/mat-1/documents/medical-records.pdf",
+        )
+    )
+    docs = asyncio.run(store.list_matter_documents("mat-1"))
+    assert [d.id for d in docs] == ["doc-1", "doc-2"]
+
+
+def test_list_matter_documents_returns_empty_for_unknown_matter():
+    store = InMemoryMatterStore()
+    assert asyncio.run(store.list_matter_documents("mat-missing")) == []
+
+
+def test_add_document_rejects_unknown_matter():
+    store = InMemoryMatterStore()
+    with pytest.raises(KeyError):
+        store.add_document(
+            StoredMatterDocument(
+                id="doc-1",
+                matter_id="mat-missing",
+                filename="x.pdf",
+                mime_type="application/pdf",
+                size_bytes=1,
+                uploaded_at="2026-01-15T10:30:00.000Z",
+                uploaded_by=None,
+                r2_key=None,
+            )
+        )

--- a/ai-employee/templates/README.md
+++ b/ai-employee/templates/README.md
@@ -1,0 +1,26 @@
+# ai-employee/templates
+
+Templates an operator copies during provisioning. Each file is read once at provision time and never imported by runtime code -- runtime configuration lives under `ai-employee/customers/{firm-slug}/`.
+
+## Runtime templates
+
+| File                | Used by                       | Purpose                                                              |
+| ------------------- | ----------------------------- | -------------------------------------------------------------------- |
+| `Dockerfile`        | `bin/provision-customer.sh`   | Hermes Machine image; per-customer Fly app builds from this          |
+| `fly.toml.template` | `bin/provision-customer.sh`   | Fly app config; placeholders resolved per-customer at provision time |
+| `bootstrap.sh`      | Per-customer Fly Machine boot | First-run substrate setup inside the Machine                         |
+
+## Customer.yaml templates
+
+Two starter templates for the most common buyer states. Each is copied into `ai-employee/customers/{firm-slug}/customer.yaml`, then the bracketed values are filled in. The reserved `_template` directory is never a real customer slug.
+
+| File                                                                           | When to use                                                                                                                                                                                                                  |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`../customers/_template/customer.yaml`](../customers/_template/customer.yaml) | The fully bracketed default. Use when the customer's capability bindings are not yet known -- the assessment call fills them in.                                                                                             |
+| [`customer-no-pm-system.yaml`](customer-no-pm-system.yaml)                     | The customer has no working practice-management system (paper + Outlook + OneDrive + QuickBooks for billing). Ships with `no_pm` PracticeManagement + Microsoft Graph + DocuSign + QuickBooks + OneDrive bindings pre-wired. |
+
+Both pass through the same validator (`src/lib/ai-employee/customer-yaml/validator.ts`); the bracketed-field shape rejects an unedited template at validation time, forcing the operator to substitute real values before provisioning.
+
+### no-PM-system mode
+
+The most common state at the target-buyer profile is no working PM system at all. The `customer-no-pm-system.yaml` template is the matching capability binding set -- see the spec at [`docs/specs/ai-employee/no-pm-system-mode.md`](../../docs/specs/ai-employee/no-pm-system-mode.md) for the scene-by-scene demo flow and the `no_pm` adapter README at [`../connectors/no_pm/README.md`](../connectors/no_pm/README.md) for the synthetic matter store. Issue [#853](https://github.com/venturecrane/ss-console/issues/853).

--- a/ai-employee/templates/customer-no-pm-system.yaml
+++ b/ai-employee/templates/customer-no-pm-system.yaml
@@ -1,0 +1,160 @@
+schema_version: 1
+
+# TEMPLATE customer.yaml for a firm with NO external practice-management
+# system (paper + Outlook + OneDrive + QuickBooks for billing). This is
+# the most common state at the target-buyer profile -- the PI PRDs assume
+# Filevine / Clio, but most prospects we meet have no working PM system
+# at all.
+#
+# Default capability bindings (the stack assumption for this template):
+#
+#   PracticeManagement -> no_pm  (synthetic matter tracker; per-customer
+#                                 D1 + R2 substrate from PR #944)
+#   Email              -> microsoft_graph        (Outlook)
+#   Calendar           -> microsoft_graph        (Outlook calendar)
+#   DocumentStorage    -> onedrive               (Microsoft Graph drive API)
+#   ESign              -> docusign
+#   Accounting         -> quickbooks             (QuickBooks Online)
+#
+# Adapter implementations referenced above either ship (no_pm) or are
+# tracked under named adapter-build issues. The bindings are wire
+# contracts; flipping any binding to a real vendor later is a
+# customer.yaml edit, not a skill rewrite (per ADR 0006).
+#
+# Copy this file to ai-employee/customers/{firm-slug}/customer.yaml, then
+# replace every bracketed value. Validate with:
+#
+#   uv run --quiet --with pyyaml python3 \
+#     ai-employee/adapter/validate_customer_yaml.py \
+#     ai-employee/customers/{firm-slug}/customer.yaml \
+#     --skills-dir ai-employee/skills \
+#     --connectors-dir ai-employee/connectors \
+#     --fixtures-dir ai-employee/fixtures
+#
+# The reserved `_template` directory is never a real customer slug.
+# customer_id must equal the directory name and match ^[a-z0-9][a-z0-9-]{0,31}$.
+
+# ---- IDENTITY ----
+customer_id: '[FIRM-SLUG]'
+customer_name: '[LEGAL NAME]'
+vertical: law-firm
+practice_areas:
+  - '[PRIMARY PRACTICE AREA, e.g., personal-injury-plaintiff]'
+fly_region: '[FLY REGION SLUG, e.g., iad / lax / ord]'
+
+# ---- RUNTIME ----
+model: claude-opus-4-7
+hermes_ref: '[HERMES REF, e.g., v2026.5.7]'
+
+machine:
+  size: shared-cpu-1x
+  memory_mb: 1024
+
+# ---- HUMANS WITH PORTAL ACCESS ----
+users:
+  - email: '[PRINCIPAL EMAIL]'
+    role: principal
+    full_name: '[PRINCIPAL FULL NAME]'
+
+# ---- PERSONAS (length >= 1) ----
+personas:
+  - slug: '[PERSONA SLUG, e.g., marcus]'
+    status: active
+    name: '[PERSONA FIRST NAME]'
+    title: AI Associate
+    tone:
+      - plainspoken
+      - warm-but-professional
+      - concise
+    skills:
+      - name: '[LEAD PI SKILL, e.g., law-pi-demand-letter-draft]'
+        version: pending
+        trust_ceiling: draft_for_review
+        enabled: true
+
+# ---- CONNECTORS ----
+# No-PM-system stack. Replace any binding with a real vendor adapter
+# during the assessment call if the firm uses one (e.g. swap
+# accounting.adapter to xero if the firm is on Xero, not QuickBooks).
+connectors:
+  PracticeManagement:
+    adapter: no_pm
+    backend: build:no_pm
+    enabled: true
+    # No token_ref -- the synthetic store has no external OAuth surface.
+    # Per-customer D1 + R2 wiring is applied at provision time.
+
+  Email:
+    adapter: microsoft_graph
+    backend: build:microsoft_graph
+    enabled: true
+    scopes:
+      - 'Mail.Read'
+      - 'Mail.ReadWrite'
+    token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/email/microsoft-graph-oauth-refresh'
+
+  Calendar:
+    adapter: microsoft_graph
+    backend: build:microsoft_graph
+    enabled: true
+    scopes:
+      - 'Calendars.Read'
+      - 'Calendars.ReadWrite'
+    # Calendar reuses the Email OAuth token; provision-customer.sh wires
+    # both bindings to the same auth provider when the adapter slug matches.
+    token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/email/microsoft-graph-oauth-refresh'
+
+  DocumentStorage:
+    adapter: onedrive
+    backend: build:onedrive
+    enabled: true
+    scopes:
+      - 'Files.Read'
+      - 'Files.ReadWrite'
+    # OneDrive is a Microsoft Graph surface too; same token refresh path
+    # the Email + Calendar bindings use. Provisioning wires the shared
+    # auth provider.
+    token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/email/microsoft-graph-oauth-refresh'
+
+  ESign:
+    adapter: docusign
+    backend: build:docusign
+    enabled: true
+    scopes:
+      - 'signature'
+      - 'impersonation'
+    token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/e-sign/docusign-oauth-refresh'
+
+  Accounting:
+    adapter: quickbooks
+    backend: build:quickbooks
+    enabled: true
+    scopes:
+      - 'com.intuit.quickbooks.accounting'
+    token_ref: 'infisical:/ai-employee/[FIRM-SLUG]/accounting/quickbooks-oauth-refresh'
+
+# ---- SCOPE ----
+scope:
+  email_folders_visible:
+    - Inbox
+    - Sent
+  email_folders_blind: []
+  email_keyword_blocks: []
+  domain_blocks: []
+
+# ---- ESCALATION ----
+escalation:
+  red_flag_recipients:
+    - '[PRINCIPAL EMAIL]'
+  failure_recipients:
+    - '[PRINCIPAL EMAIL]'
+
+# ---- VOICE LIBRARY ----
+voice_library:
+  samples_path: 'r2://vaults/[FIRM-SLUG]/voice/samples/'
+
+# ---- MEMORY (isolation invariants; must match customer_id) ----
+memory:
+  d1_namespace: '[FIRM-SLUG]'
+  r2_vault_path: 'vaults/[FIRM-SLUG]/'
+  vectorize_index: 'hermes-[FIRM-SLUG]-vault'

--- a/docs/specs/ai-employee/index.md
+++ b/docs/specs/ai-employee/index.md
@@ -32,6 +32,7 @@ Build agents consuming these specs should treat the PRDs as **vision/doctrine** 
 | [refusal-handling.md](refusal-handling.md)                     | [#866](https://github.com/venturecrane/ss-console/issues/866) | Runtime semantics when `trust_ceiling.enforce()` returns `refuse` (abort + notification + cascade alert) |
 | [calibration-session.md](calibration-session.md)               | [#867](https://github.com/venturecrane/ss-console/issues/867) | Four 90-minute calibration sessions over two weeks; portal surface + integration seams                   |
 | [audit-log-immutability.md](audit-log-immutability.md)         | [#892](https://github.com/venturecrane/ss-console/issues/892) | Worker-layer enforcement, Logpush mirror protocol, integrity check, Captain exception process            |
+| [no-pm-system-mode.md](no-pm-system-mode.md)                   | [#853](https://github.com/venturecrane/ss-console/issues/853) | Customer.yaml + capability bindings for customers without an external practice-management vendor         |
 
 ## Open ambiguities requiring Captain decision
 

--- a/docs/specs/ai-employee/index.md
+++ b/docs/specs/ai-employee/index.md
@@ -33,6 +33,7 @@ Build agents consuming these specs should treat the PRDs as **vision/doctrine** 
 | [calibration-session.md](calibration-session.md)               | [#867](https://github.com/venturecrane/ss-console/issues/867) | Four 90-minute calibration sessions over two weeks; portal surface + integration seams                   |
 | [audit-log-immutability.md](audit-log-immutability.md)         | [#892](https://github.com/venturecrane/ss-console/issues/892) | Worker-layer enforcement, Logpush mirror protocol, integrity check, Captain exception process            |
 | [aie-adapter-register.md](aie-adapter-register.md)             | [#841](https://github.com/venturecrane/ss-console/issues/841) | Adapter-side hook surface for the SMD overlay on Hermes; pre/post/refusal/compaction hooks               |
+| [no-pm-system-mode.md](no-pm-system-mode.md)                   | [#853](https://github.com/venturecrane/ss-console/issues/853) | Customer.yaml + capability bindings for customers without an external practice-management vendor         |
 
 ## Open ambiguities requiring Captain decision
 

--- a/docs/specs/ai-employee/no-pm-system-mode.md
+++ b/docs/specs/ai-employee/no-pm-system-mode.md
@@ -1,0 +1,195 @@
+# No-PM-System Mode
+
+**Spec for issue [#853](https://github.com/venturecrane/ss-console/issues/853).** The "no practice-management system" capability binding set -- a `customer.yaml` template + capability-adapter configuration that runs the demo flow for customers without an external PM vendor (Filevine, Clio, CASEpeer, SmartAdvocate, etc.).
+
+## Source
+
+- **Business-analyst finding.** The most common state at the target-buyer profile is no working PM system at all -- paper + Outlook + Dropbox + PracticeMaster for billing, or Clio bought-but-unused. The platform PRD and law-firm PRD assume Filevine/Clio; reality differs.
+- **Capability-adapter pattern.** [ADR 0006](../../adr/0006-capability-adapter-pattern.md) -- skills bind to capability interfaces, not vendors. The no-PM-system mode is implemented by swapping the `PracticeManagement` adapter, not by rewriting skills.
+- **Customer-owned memory artifact.** [ADR 0008](../../adr/0008-customer-owned-memory-artifact.md) -- every artifact the synthetic store persists is per-customer and drains on decommission, the same as memory ingestion artifacts from PR #944.
+
+## What this spec covers
+
+- The default capability-binding set for a no-PM-system customer.
+- The `no_pm` PracticeManagement adapter and its synthetic matter store.
+- The demo flow scene-by-scene: how each surface that the dry-run #889 expects works without an external PM vendor.
+
+## What this spec does not cover
+
+- The vendor adapters this template binds to outside `PracticeManagement` (Microsoft Graph, DocuSign, QuickBooks, OneDrive). Each ships under its own adapter-build issue and follows the same shape Filevine does. This spec assumes those adapters exist or are clearly named TBD; the template references them by capability slug.
+- The per-customer D1 schema for the synthetic store tables (`no_pm_matters`, `no_pm_matter_notes`). The schema follow-on lands against the same issue once Captain approves this spec.
+- Switching a customer from `no_pm` to a real vendor mid-engagement. Per ADR 0006 that is a `customer.yaml` edit; the migration runbook is a separate spec.
+
+## Stack assumption
+
+The target-buyer reality the no-PM-system template assumes:
+
+| Capability         | Adapter slug      | Vendor / source                         |
+| ------------------ | ----------------- | --------------------------------------- |
+| PracticeManagement | `no_pm`           | synthetic store -- per-customer D1 + R2 |
+| Email              | `microsoft_graph` | Microsoft Graph (Outlook)               |
+| Calendar           | `microsoft_graph` | Microsoft Graph (Outlook calendar)      |
+| DocumentStorage    | `onedrive`        | Microsoft Graph drive API               |
+| ESign              | `docusign`        | DocuSign                                |
+| Accounting         | `quickbooks`      | QuickBooks Online                       |
+
+If a specific firm uses Xero instead of QuickBooks, or Gmail instead of Outlook, the assessment-call flow swaps the binding in their `customer.yaml`. The skill catalog runs unchanged either way.
+
+## The `no_pm` PracticeManagement adapter
+
+Implementation: [`ai-employee/connectors/no_pm/`](../../../ai-employee/connectors/no_pm/). Conforms to the `PracticeManagement` interface from [`src/lib/ai-employee/capabilities/practice-management.ts`](../../../src/lib/ai-employee/capabilities/practice-management.ts) via the same Python-mirrors-TypeScript shape Filevine uses.
+
+### Supported methods
+
+| Method                  | Behavior                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `describe_capabilities` | Returns capability + supported / unsupported method declarations and per-method `field_coverage` (with `id` + `opened_at` disclosed as derived on `create_matter`) |
+| `health_check`          | Pings the underlying `MatterStore` -- healthy when the store responds                                                                                              |
+| `search_matters`        | Filters by `client_name` (substring), `matter_type` (exact), `status` (enum); paginates by `limit` / `offset`                                                      |
+| `get_matter`            | Returns the matter row or `null` (per NULL_FOR_ABSENT); raises `validation_failed` on empty id                                                                     |
+| `create_matter`         | Persists a new matter; synthesizes `mat_<hex>` id and ISO `opened_at` when omitted; defaults `status` to `"open"`                                                  |
+| `update_matter`         | Merges `custom_fields`; auto-records `closed_at` from server clock when status flips to `"closed"`; `not_found` if id is unknown                                   |
+| `list_matter_documents` | Returns the matter's per-customer R2 document index entries in insertion order                                                                                     |
+| `create_note`           | Records a reviewer-attributed note per [ADR 0005](../../adr/0005-reviewer-as-sender.md); `drafted_by_skill` rides on the row for the dashboard sourcing block      |
+
+### Unsupported methods (raise `capability_not_supported`)
+
+| Method                                             | Why                                                                                                                                                           |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `search_contacts`, `get_contact`, `create_contact` | The customer keeps contacts in Outlook. Skills that need contacts bind to the `IntakeCRM` capability (or read the Outlook contacts surface via `Email`).      |
+| `list_time_entries`, `create_time_entry_draft`     | The customer keeps time + billing in QuickBooks. Skills that need billing bind to the `Accounting` capability.                                                |
+| `upload_matter_document`                           | The synthetic store does not own document bytes. Skills upload to OneDrive via the `DocumentStorage` capability and reference the file by R2 / OneDrive path. |
+
+There are no silent stubs. Every unsupported method raises `AdapterError(code="capability_not_supported")` with a message that points at the capability the caller should bind to instead.
+
+### Storage seam
+
+The adapter binds to a `MatterStore` Protocol that abstracts persistence:
+
+- **Tests + local dev:** `InMemoryMatterStore` -- dict-backed reference implementation. The conformance + capability tests use this directly; `NoPmPracticeManagement()` with no args defaults to it so the boot-time conformance harness boots cleanly.
+- **Production (planned):** `D1MatterStore` -- backed by per-customer D1 tables `no_pm_matters` and `no_pm_matter_notes`. Documents live in the per-customer R2 vault at `vaults/{customer_id}/no_pm/matters/{matter_id}/documents/` (same naming convention the memory pipeline already uses per [`r2-vectorize-naming.md`](r2-vectorize-naming.md)). The store records the R2 key in the matter document index; `list_matter_documents` reads against that index. Per [ADR 0009](../../adr/0009-cross-machine-query-prohibition.md), no tenant id is ever passed in -- isolation is structural via the per-Machine binding.
+
+## Demo flow
+
+How each demo scene from the dry-run [#889](https://github.com/venturecrane/ss-console/issues/889) plays through the no-PM-system stack. The scenes are pulled from the dashboard tab layout the Captain dashboard renders today.
+
+### Scene 1: Drafts list shows real drafts written from real Outlook emails
+
+| Component      | Binding                                                                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inbound        | `Email.list_threads()` -> Microsoft Graph -> Outlook Inbox. The agent reads incoming threads.                                                                                                           |
+| Reasoning      | Persona skill runs against the thread + relevant matter context (read from the synthetic store via `get_matter` if the thread is linked to a matter).                                                   |
+| Outbound       | `Email.create_draft()` -> Microsoft Graph -> reviewer's Outlook Drafts folder. Per [ADR 0005](../../adr/0005-reviewer-as-sender.md), the agent never sends; the reviewer opens Outlook and clicks Send. |
+| Sourcing block | Dashboard renders "what Marcus used to write this" by reading `field_coverage` from each adapter the skill touched, including the no_pm adapter when matter context was used.                           |
+
+No `no_pm` write happens in this scene -- the synthetic store is read-only for draft creation. The drafts list is the same surface a Filevine customer sees.
+
+### Scene 2: Matters tab shows synthetic matters created locally
+
+| Component | Binding                                                                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Read      | `PracticeManagement.search_matters()` -> `NoPmPracticeManagement` -> the customer's D1 `no_pm_matters` table.                                          |
+| Create    | Operator clicks "New matter" -> dashboard calls `PracticeManagement.create_matter()` -> the synthetic store persists the row.                          |
+| Detail    | `PracticeManagement.get_matter()` + `list_matter_documents()` populate the matter detail view. Documents are listed from the per-customer R2 vault.    |
+| Update    | Status changes (close, intake -> open) hit `PracticeManagement.update_matter()`; `closed_at` is set from the server clock when status flips to closed. |
+
+A Filevine customer's matters tab calls the same capability methods against `FilevinePracticeManagement` -- skills and dashboard code are untouched. The only difference is the adapter binding.
+
+### Scene 3: Calendar tab shows real Outlook events
+
+| Component | Binding                                                                                          |
+| --------- | ------------------------------------------------------------------------------------------------ |
+| Read      | `Calendar.list_events()` -> Microsoft Graph -> Outlook calendar. Same auth as the Email binding. |
+| Draft     | `Calendar.create_invitation_draft()` -> Microsoft Graph -> reviewer's draft event surface.       |
+
+No `no_pm` involvement -- calendar is its own capability and the binding is real. Matter context for calendar events is read from the synthetic store when relevant (e.g. "deposition for Smith matter, opened 2026-01-15" is enriched from `get_matter`).
+
+### Scene 4: Documents tab shows OneDrive folders + matter-attached files
+
+| Component          | Binding                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Browse             | `DocumentStorage.list_folder()` -> OneDrive (Microsoft Graph drive API). Renders the customer's actual OneDrive folder tree.                                                                            |
+| Per-matter listing | `PracticeManagement.list_matter_documents()` -> the synthetic store's per-matter index. Documents linked to a matter are returned here, with the OneDrive / R2 path.                                    |
+| Upload             | `DocumentStorage.upload_document()` -> OneDrive. The synthetic store records the resulting OneDrive path in the matter document index (operator action wires this -- the adapter does not auto-attach). |
+
+The per-matter view and the global folder view both work; they are two different capability bindings serving two different surfaces.
+
+### Scene 5: Signatures tab shows DocuSign envelopes + status
+
+| Component | Binding                                                                                                                                                  |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Read      | `ESign.list_envelopes()` -> DocuSign API. Status (sent / delivered / partial_signed / completed) renders in the dashboard.                               |
+| Draft     | `ESign.create_reminder_draft()` -> reviewer's Outlook Drafts folder via the `Email` capability. Per ADR 0005, the agent does not chase signers directly. |
+| Match     | The dashboard cross-references envelope `matter_ref` against the synthetic store's matter ids when possible. When not, the envelope renders standalone.  |
+
+### Scene 6: Billing tab shows QuickBooks invoices + AR
+
+| Component  | Binding                                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Read       | `Accounting.list_invoices()` -> QuickBooks Online API.                                                                     |
+| Draft      | `Accounting.create_invoice_draft()` -> QuickBooks draft surface. Per ADR 0005 + invariant #3, the agent never posts to GL. |
+| Per-matter | The dashboard cross-references invoice `matter_ref` against the synthetic store's matter ids.                              |
+
+## Validation
+
+The template is validated by the same runtime validator every `customer.yaml` runs through (`src/lib/ai-employee/customer-yaml/validator.ts`). The bracketed-fields shape means an unedited template fails validation -- the customer slug pattern, infisical token_ref pattern, and memory invariants will all reject the placeholder values. This is intentional: the validator forces the operator to fill in real values before provisioning.
+
+To validate after copying + filling:
+
+```bash
+uv run --quiet --with pyyaml python3 \
+  ai-employee/adapter/validate_customer_yaml.py \
+  ai-employee/customers/{firm-slug}/customer.yaml \
+  --skills-dir ai-employee/skills \
+  --connectors-dir ai-employee/connectors \
+  --fixtures-dir ai-employee/fixtures
+```
+
+## Failure modes
+
+| Condition                                                                        | Adapter behavior                                                                                                      |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Caller invokes an unsupported method                                             | `AdapterError(code="capability_not_supported")` with message pointing at the right capability binding                 |
+| `search_matters` with unknown status                                             | `AdapterError(code="validation_failed")` listing the valid status enum                                                |
+| `get_matter` with unknown id                                                     | Returns `null` (NULL_FOR_ABSENT)                                                                                      |
+| `update_matter` / `create_note` with unknown matter id                           | `AdapterError(code="not_found")`                                                                                      |
+| `create_matter` with duplicate id                                                | `AdapterError(code="validation_failed")` (the store rejects; the adapter translates)                                  |
+| Underlying `MatterStore` raises                                                  | `health_check` returns `"unhealthy"`; reads bubble the error wrapped in `AdapterError(code="unknown", cause=exc)`     |
+| Caller invokes a banned method name (`send`, `publish`, `share_externally`, ...) | Test `test_adapter_has_no_banned_method_names` asserts none exist on the adapter class -- conformance failure at boot |
+
+## Verification
+
+### Adapter tests
+
+`ai-employee/connectors/no_pm/tests/` -- run via:
+
+```bash
+cd ai-employee && python -m pytest connectors/no_pm/tests/ -v
+```
+
+Coverage:
+
+| File                         | Asserts                                                                                                                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tests/test_errors.py`       | AdapterError code + capability union pinned against the TypeScript contract                                                                                                       |
+| `tests/test_store.py`        | `InMemoryMatterStore` honors the `MatterStore` protocol (list / get / create / update / docs / notes); status enum enforced                                                       |
+| `tests/test_capabilities.py` | `NoPmPracticeManagement` happy paths; unsupported-method behavior; ADR 0005 attribution; no banned method names; end-to-end demo flow exercises the create -> note -> close cycle |
+
+### Template
+
+The template at [`ai-employee/templates/customer-no-pm-system.yaml`](../../../ai-employee/templates/customer-no-pm-system.yaml) is the wire shape an operator copies into `ai-employee/customers/{firm-slug}/customer.yaml`. The bracketed fields force the operator to fill in real values before the validator passes; the connector bindings ship pre-wired so the operator never has to hand-author them.
+
+## Cross-references
+
+- [`customer-yaml-schema.md`](customer-yaml-schema.md) -- the schema this template instantiates
+- [`r2-vectorize-naming.md`](r2-vectorize-naming.md) -- the per-customer R2 path convention the synthetic store reuses
+- [`memory-ingestion.md`](memory-ingestion.md) -- the memory pipeline whose substrate the no_pm store rides on
+- [`day-1-onboarding.md`](day-1-onboarding.md) -- the first-hour dashboard walkthrough each demo scene above renders into
+- [ADR 0005](../../adr/0005-reviewer-as-sender.md) -- reviewer-as-sender (the `create_note` attribution rule)
+- [ADR 0006](../../adr/0006-capability-adapter-pattern.md) -- capability-adapter pattern (why this adapter swap works without skill rewrites)
+- [ADR 0007](../../adr/0007-per-customer-machine-isolation.md) -- per-customer Machine isolation (the deployment boundary the synthetic store inherits)
+- [ADR 0008](../../adr/0008-customer-owned-memory-artifact.md) -- customer-owned memory artifact (decommission drains the synthetic store like any other per-customer artifact)
+- [ADR 0009](../../adr/0009-cross-machine-query-prohibition.md) -- cross-Machine query prohibition (the isolation invariant the synthetic store relies on)
+- [ADR 0014](../../adr/0014-pi-vertical-adapter-build-priority.md) -- PI-vertical adapter build priority (the Filevine / CASEpeer / SmartAdvocate ladder this template runs alongside)
+- [`ai-employee/connectors/no_pm/README.md`](../../../ai-employee/connectors/no_pm/README.md) -- adapter implementation notes
+- [`ai-employee/connectors/filevine/README.md`](../../../ai-employee/connectors/filevine/README.md) -- the real-PM-vendor analogue


### PR DESCRIPTION
## Summary

Most target-buyer firms operate without a working practice-management vendor (paper + Outlook + OneDrive + QuickBooks for billing). The PI PRDs assume Filevine/Clio; reality differs. This PR adds the matching capability binding set so the dry-run #889 demo flow works against the actual buyer state.

- **Template**: `ai-employee/templates/customer-no-pm-system.yaml` -- bracketed-fields `customer.yaml` pre-wired with `no_pm` + Microsoft Graph + DocuSign + QuickBooks + OneDrive bindings. Passes through the same validator every customer.yaml runs through.
- **Connector**: `ai-employee/connectors/no_pm/` -- synthetic `PracticeManagement` capability adapter conforming to the same TypeScript contract Filevine does. Implements `search_matters`, `get_matter`, `create_matter`, `update_matter`, `list_matter_documents`, `create_note` (reviewer-attributed per ADR 0005), `describe_capabilities`, `health_check`. Unsupported methods (contacts, time entries, matter-document uploads) raise `capability_not_supported` and point at the right capability binding.
- **Storage seam**: `MatterStore` Protocol with `InMemoryMatterStore` reference implementation. Production `D1MatterStore` (per-customer D1 `no_pm_matters` + `no_pm_matter_notes` tables, R2 vault for documents) lands as a follow-on; substrate piggybacks on the memory pipeline from PR #944.
- **Spec**: `docs/specs/ai-employee/no-pm-system-mode.md` -- scene-by-scene demo flow showing how each #889 dry-run surface works without an external PM vendor.
- **Tests**: 49 unit tests, all passing (`connectors/no_pm/tests/`).

No autonomous send paths. No em dashes. No fabrication -- the adapter discloses `id` and `opened_at` as derived fields when synthesized.

Closes #853.

## Test plan

- [ ] CI green
- [ ] `cd ai-employee && python -m pytest connectors/no_pm/tests/ -v` -- 49 passing locally
- [ ] `npm run verify` -- passing locally
- [ ] Captain spot-check: bracketed-field validator rejection of unedited template (intentional -- forces operator to fill in real values before provisioning)
- [ ] Captain spot-check: scene-by-scene demo flow in the spec matches the dry-run #889 expectations

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)