### PR TITLE
feat(ai-employee): per-customer cost attribution rollup (#884)

### DIFF
--- a/ai-employee/adapter/cost_rollup.py
+++ b/ai-employee/adapter/cost_rollup.py
@@ -1,0 +1,398 @@
+"""Per-customer cost attribution rollup (issue #884).
+
+Aggregates rows from the per-customer `cost_telemetry` D1 table into a
+monthly view broken down by cost driver. The §17.1 COGS/MRR margin gate
+in platform-prd.md reads from the totals computed here.
+
+Design notes
+------------
+
+* The rollup is per-customer because the `cost_telemetry` table is
+  per-customer (ADR 0009: one D1 binding per customer; no cross-customer
+  table). The caller passes an `Executor` already bound to the customer's
+  database. There is no `customer_id` argument and no row-level customer
+  column.
+
+* Drivers are grouped into nine `DriverCategory` buckets that match the
+  platform-prd §15.1 cost-driver enumeration. Several raw drivers
+  (`claude_api_input_tokens` + `claude_api_output_tokens`,
+  `r2_storage_gb_hours` + `r2_class_a_ops` + `r2_class_b_ops`, etc.)
+  roll up into a single category so the COGS line items match the
+  pricing model in docs/strategy/ai-employee-pricing-2026-05-13.md.
+
+* Anything emitted under a driver name that is not in the closed
+  category map lands in `DriverCategory.OTHER`. New drivers are added by
+  extending `_DRIVER_TO_CATEGORY` in the same PR that adds the emitter,
+  not silently bucketed.
+
+* The query computes monthly totals by `(year_month, driver)` and the
+  module folds those rows into per-category sums + a grand total + a
+  per-category percentage breakdown. Percentages are computed in integer
+  basis points (1/100 of a percent) to avoid float drift in the
+  COGS/MRR ratio downstream.
+
+* Aggregation cadence: real-time per-event INSERT via the emitter
+  (cost-telemetry-events.md). The rollup is computed on-demand by this
+  module. A future nightly cron seam is documented but not implemented
+  here — `compute_monthly_rollup` is callable from a Worker cron or from
+  the Captain dashboard handler equally.
+
+* No autonomous send. This module produces values; it does not trigger
+  alerts or notifications. The §17.1 alert seam is the Captain
+  dashboard's responsibility.
+
+Failure modes
+-------------
+
+* `cost_telemetry` empty for the requested month: returns a
+  `MonthlyRollup` with zero totals and an empty per-driver breakdown.
+  This is not an error — a brand-new customer has no rows yet.
+
+* Database error: surfaces as the underlying executor exception. The
+  module does not swallow database failures.
+
+* Driver value not in the closed enum: bucketed into
+  `DriverCategory.OTHER` with the raw driver name preserved in the
+  per-driver detail map. Captain dashboard can surface the unknown
+  driver name for triage.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Protocol, Sequence
+
+log = logging.getLogger("aie.cost_rollup")
+
+
+# ---------------------------------------------------------------------------
+# Driver categories
+#
+# Source of truth: docs/pm/ai-employee/platform-prd.md §15.1 (nine cost
+# drivers) + docs/specs/ai-employee/cost-telemetry-events.md (raw driver
+# enum that emitters write).
+# ---------------------------------------------------------------------------
+
+
+class DriverCategory(str, enum.Enum):
+    """High-level COGS categories that the pricing model groups by.
+
+    The pricing model in docs/strategy/ai-employee-pricing-2026-05-13.md
+    has nine line items per profile per month; these are the same nine.
+    """
+
+    ANTHROPIC_LLM = "anthropic_llm"
+    COMPOSIO_ACTION = "composio_action"
+    FLY_COMPUTE = "fly_compute"
+    CLOUDFLARE_D1 = "cloudflare_d1"
+    CLOUDFLARE_R2 = "cloudflare_r2"
+    CLOUDFLARE_VECTORIZE = "cloudflare_vectorize"
+    AGENTMAIL = "agentmail"
+    CAPTAIN_TIME = "captain_time"
+    OTHER = "other"
+
+
+# Raw driver -> category. Drivers not present here fall through to OTHER.
+# Sourced from cost-telemetry-events.md "Drivers + emission sources" table.
+_DRIVER_TO_CATEGORY: Mapping[str, DriverCategory] = {
+    # Anthropic LLM
+    "claude_api_input_tokens": DriverCategory.ANTHROPIC_LLM,
+    "claude_api_output_tokens": DriverCategory.ANTHROPIC_LLM,
+    # Composio
+    "composio_actions": DriverCategory.COMPOSIO_ACTION,
+    # Fly
+    "fly_machine_minutes": DriverCategory.FLY_COMPUTE,
+    # Cloudflare D1
+    "d1_reads": DriverCategory.CLOUDFLARE_D1,
+    "d1_writes": DriverCategory.CLOUDFLARE_D1,
+    # Cloudflare R2
+    "r2_storage_gb_hours": DriverCategory.CLOUDFLARE_R2,
+    "r2_class_a_ops": DriverCategory.CLOUDFLARE_R2,
+    "r2_class_b_ops": DriverCategory.CLOUDFLARE_R2,
+    # Cloudflare Vectorize
+    "vectorize_queries": DriverCategory.CLOUDFLARE_VECTORIZE,
+    "vectorize_dimensions_stored": DriverCategory.CLOUDFLARE_VECTORIZE,
+    # AgentMail
+    "agentmail_messages": DriverCategory.AGENTMAIL,
+    "agentmail_mailbox_days": DriverCategory.AGENTMAIL,
+    # Captain time
+    "captain_time": DriverCategory.CAPTAIN_TIME,
+}
+
+
+def category_for_driver(driver: str) -> DriverCategory:
+    """Map a raw `cost_telemetry.driver` value to a `DriverCategory`.
+
+    Unknown drivers bucket into OTHER. The raw driver name is preserved
+    by the caller in the `per_driver_detail_cents` map so the dashboard
+    can surface the unmapped driver for triage.
+    """
+    return _DRIVER_TO_CATEGORY.get(driver, DriverCategory.OTHER)
+
+
+# ---------------------------------------------------------------------------
+# Year-month validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_year_month(year_month: str) -> tuple[int, int]:
+    """Parse a `YYYY-MM` string into `(year, month)`. Raises `ValueError`.
+
+    The rollup is monthly-grained; the input is the calendar month in
+    UTC. The format matches the `cost_telemetry.date` column's leading
+    7 chars so the SQL filter is a simple prefix match.
+    """
+    if not isinstance(year_month, str):
+        raise ValueError(f"year_month must be str, got {type(year_month).__name__}")
+    if len(year_month) != 7 or year_month[4] != "-":
+        raise ValueError(
+            f"year_month must be 'YYYY-MM' (got {year_month!r})"
+        )
+    try:
+        year = int(year_month[:4])
+        month = int(year_month[5:7])
+    except ValueError as e:
+        raise ValueError(
+            f"year_month must be 'YYYY-MM' (got {year_month!r})"
+        ) from e
+    if not (1 <= month <= 12):
+        raise ValueError(f"month must be 1..12 (got {month} in {year_month!r})")
+    if year < 2026 or year > 2100:
+        # Defensive bound; cost_telemetry only exists post-launch.
+        raise ValueError(
+            f"year must be 2026..2100 (got {year} in {year_month!r})"
+        )
+    return year, month
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MonthlyRollup:
+    """Per-customer monthly cost rollup.
+
+    Fields
+    ------
+    year_month : str
+        'YYYY-MM' of the rollup month (UTC).
+    total_cents : int
+        Sum of `amount_cents` across every row in the month.
+    by_category_cents : Mapping[DriverCategory, int]
+        Per-category sum. Every `DriverCategory` is present even when
+        zero so consumers can render a stable column set.
+    by_category_basis_points : Mapping[DriverCategory, int]
+        Per-category share as basis points (1/100 of a percent). The
+        sum of the values is 10000 when `total_cents > 0`; the dict is
+        all zeros when `total_cents == 0`. Integer math avoids float
+        drift in the §17.1 COGS/MRR ratio computation.
+    per_driver_detail_cents : Mapping[str, int]
+        Raw `cost_telemetry.driver` -> sum-of-cents. Preserves the
+        underlying driver names so a dashboard can drill in and so
+        unmapped drivers in the OTHER bucket can be surfaced by name.
+    row_count : int
+        Number of `cost_telemetry` rows that fed the rollup. Useful for
+        sanity-checking that the query actually returned data.
+    """
+
+    year_month: str
+    total_cents: int
+    by_category_cents: Mapping[DriverCategory, int]
+    by_category_basis_points: Mapping[DriverCategory, int]
+    per_driver_detail_cents: Mapping[str, int]
+    row_count: int = 0
+
+    def category_dollars(self, category: DriverCategory) -> float:
+        """Return the category total in dollars (float). Convenience for
+        rendering; the source of truth remains `by_category_cents`."""
+        return self.by_category_cents.get(category, 0) / 100.0
+
+    def total_dollars(self) -> float:
+        """Return total in dollars (float). Convenience for rendering."""
+        return self.total_cents / 100.0
+
+    def cogs_mrr_basis_points(self, mrr_cents: int) -> Optional[int]:
+        """Compute `total_cents / mrr_cents` as basis points.
+
+        Returns None when `mrr_cents <= 0` (an unpriced customer; the
+        ratio is undefined). The §17.1 kill criterion in
+        platform-prd.md is `ratio > 0.40` for two consecutive months,
+        which is 4000 basis points; the dashboard reads this value and
+        applies the threshold.
+        """
+        if mrr_cents <= 0:
+            return None
+        return (self.total_cents * 10_000) // mrr_cents
+
+
+# ---------------------------------------------------------------------------
+# Executor protocol
+#
+# The reader uses a Protocol so tests can swap a sqlite executor for the
+# production D1 HTTP executor. Same shape as audit_log.py's `Executor`.
+# ---------------------------------------------------------------------------
+
+
+class RowReader(Protocol):
+    """Async row reader. Returns a list of (driver, total_cents) tuples."""
+
+    async def fetch_rows(
+        self, sql: str, params: list
+    ) -> Sequence[tuple]: ...
+
+
+# ---------------------------------------------------------------------------
+# SQL
+#
+# The query is a straight aggregate on the `(date, driver)` PK. SQLite
+# and D1 both plan this as an index scan with on-the-fly aggregation.
+# ---------------------------------------------------------------------------
+
+
+# Use a leading-substring match on `date` so the (date, driver) PK index
+# can serve the scan. cost_telemetry.date is 'YYYY-MM-DD'; the year_month
+# prefix is 'YYYY-MM' followed by '-'.
+_AGGREGATE_SQL = (
+    "SELECT driver, COALESCE(SUM(amount_cents), 0) AS cents, "
+    "COUNT(*) AS rowcount "
+    "FROM cost_telemetry "
+    "WHERE date >= ? AND date < ? AND amount_cents >= 0 "
+    "GROUP BY driver "
+    "ORDER BY driver"
+)
+
+
+def _month_bounds(year: int, month: int) -> tuple[str, str]:
+    """Return ('YYYY-MM-01', 'YYYY-MM+1-01') half-open range.
+
+    Using a half-open range over the lexicographically-ordered date
+    string lets SQLite/D1 plan an index range scan on the (date, driver)
+    PK without a function call per row.
+    """
+    start = f"{year:04d}-{month:02d}-01"
+    if month == 12:
+        end = f"{year + 1:04d}-01-01"
+    else:
+        end = f"{year:04d}-{month + 1:02d}-01"
+    return start, end
+
+
+# ---------------------------------------------------------------------------
+# Rollup entry point
+# ---------------------------------------------------------------------------
+
+
+async def compute_monthly_rollup(
+    reader: RowReader,
+    year_month: str,
+) -> MonthlyRollup:
+    """Compute the monthly cost rollup for the bound customer.
+
+    Parameters
+    ----------
+    reader : RowReader
+        An executor already bound to the per-customer D1 database. The
+        caller is responsible for picking the right binding per ADR 0009.
+    year_month : str
+        Calendar month in 'YYYY-MM' (UTC).
+
+    Returns
+    -------
+    MonthlyRollup
+        Total cents, per-category cents, per-category basis-points share,
+        and a per-driver detail map of the raw `driver` values seen.
+    """
+    year, month = _validate_year_month(year_month)
+    start, end = _month_bounds(year, month)
+
+    rows = await reader.fetch_rows(_AGGREGATE_SQL, [start, end])
+
+    per_driver: dict[str, int] = {}
+    by_category: dict[DriverCategory, int] = {cat: 0 for cat in DriverCategory}
+    total = 0
+    row_count = 0
+
+    for row in rows:
+        # rows are (driver, cents, rowcount) tuples
+        driver = row[0]
+        cents = int(row[1]) if row[1] is not None else 0
+        rowcount = int(row[2]) if len(row) > 2 and row[2] is not None else 0
+
+        if cents < 0:
+            # Per cost-telemetry-events.md, amounts are always integer cents
+            # >= 0. A negative value indicates a corrupted row; log and skip
+            # rather than poison the rollup.
+            log.warning(
+                "cost_rollup: negative amount_cents for driver=%r in %s; skipping",
+                driver,
+                year_month,
+            )
+            continue
+
+        per_driver[driver] = per_driver.get(driver, 0) + cents
+        category = category_for_driver(driver)
+        by_category[category] = by_category.get(category, 0) + cents
+        total += cents
+        row_count += rowcount
+
+    by_category_bps: dict[DriverCategory, int] = {cat: 0 for cat in DriverCategory}
+    if total > 0:
+        for cat, cents in by_category.items():
+            # Integer basis points; floor division. Sum may be off by 1-2 bps
+            # from rounding; the dashboard reconciles by reading total_cents
+            # directly rather than summing per-category bps.
+            by_category_bps[cat] = (cents * 10_000) // total
+
+    return MonthlyRollup(
+        year_month=year_month,
+        total_cents=total,
+        by_category_cents=by_category,
+        by_category_basis_points=by_category_bps,
+        per_driver_detail_cents=per_driver,
+        row_count=row_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sqlite reader (tests + local dev)
+#
+# Backs the rollup with a `sqlite3.Connection` whose schema matches the
+# `cost_telemetry` table from migration 0001. Production wiring would
+# use a `HttpD1Reader` that calls the Cloudflare D1 HTTP API; that
+# wrapper lives outside this module and is configured by bootstrap.sh.
+# ---------------------------------------------------------------------------
+
+
+class SqliteRowReader:
+    """Sqlite3-backed RowReader for tests and local dev.
+
+    The caller supplies a `sqlite3.Connection` with the `cost_telemetry`
+    schema applied (via migration 0001 or a hand-built CREATE TABLE in
+    test setup). The reader runs the aggregate query synchronously
+    inside the async method; sqlite calls are non-blocking enough for
+    test scope.
+    """
+
+    def __init__(self, connection) -> None:
+        self._conn = connection
+
+    async def fetch_rows(
+        self, sql: str, params: list
+    ) -> Sequence[tuple]:
+        cur = self._conn.cursor()
+        cur.execute(sql, params)
+        return cur.fetchall()
+
+
+__all__ = [
+    "DriverCategory",
+    "MonthlyRollup",
+    "RowReader",
+    "SqliteRowReader",
+    "category_for_driver",
+    "compute_monthly_rollup",
+]

--- a/ai-employee/adapter/tests/test_cost_rollup.py
+++ b/ai-employee/adapter/tests/test_cost_rollup.py
@@ -1,0 +1,610 @@
+"""Tests for ai-employee/adapter/cost_rollup.py (issue #884).
+
+Exercises the per-customer monthly cost rollup against a sqlite-backed
+executor that mirrors the `cost_telemetry` schema from migration 0001
+and the `captain_time_events` schema from migration 0006.
+
+Coverage:
+  - Year-month input validation
+  - Empty month returns a zero rollup
+  - Aggregation across multiple drivers in one month
+  - Per-category bucketing (Anthropic in/out tokens roll to one bucket;
+    R2 storage + class A + class B all roll to one bucket; D1 reads +
+    writes; Vectorize queries + dimensions; AgentMail messages + days)
+  - Unknown drivers bucket into OTHER and preserve their raw name in
+    per_driver_detail_cents
+  - Basis points sum approximates 10000; bps == 0 when total == 0
+  - COGS/MRR ratio helper: returns None for unpriced customer, bps for
+    priced
+  - Month-bound filter excludes adjacent months
+  - Negative amount_cents rows are skipped with a warning
+  - SqliteRowReader exercises the full read path
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_cost_rollup.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow running from repo root or from ai-employee/.
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from adapter.cost_rollup import (  # noqa: E402
+    DriverCategory,
+    MonthlyRollup,
+    SqliteRowReader,
+    _month_bounds,
+    _validate_year_month,
+    category_for_driver,
+    compute_monthly_rollup,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema setup — exact copy of cost_telemetry + captain_time_events from
+# migrations 0001 and 0006. Mirrored by hand so the test does not depend
+# on shelling out to wrangler.
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """
+CREATE TABLE cost_telemetry (
+  date         TEXT NOT NULL,
+  driver       TEXT NOT NULL,
+  amount_cents INTEGER NOT NULL,
+  units        REAL,
+  unit_type    TEXT,
+  PRIMARY KEY (date, driver)
+);
+CREATE INDEX idx_cost_telemetry_date ON cost_telemetry(date);
+
+CREATE TABLE captain_time_events (
+  id            TEXT PRIMARY KEY,
+  ts            TEXT NOT NULL,
+  date          TEXT NOT NULL,
+  activity      TEXT NOT NULL,
+  minutes       INTEGER NOT NULL,
+  amount_cents  INTEGER NOT NULL,
+  note          TEXT
+);
+CREATE INDEX idx_captain_time_date ON captain_time_events(date);
+CREATE INDEX idx_captain_time_activity ON captain_time_events(activity, date);
+"""
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_SCHEMA_SQL)
+    return conn
+
+
+def _seed(conn: sqlite3.Connection, rows: list[tuple]) -> None:
+    """Insert (date, driver, amount_cents) rows; UPSERT on conflict."""
+    cur = conn.cursor()
+    for date, driver, cents in rows:
+        cur.execute(
+            "INSERT INTO cost_telemetry (date, driver, amount_cents) "
+            "VALUES (?, ?, ?) "
+            "ON CONFLICT (date, driver) DO UPDATE SET "
+            "  amount_cents = amount_cents + excluded.amount_cents",
+            (date, driver, cents),
+        )
+    conn.commit()
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Year-month validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_year_month_happy_path():
+    assert _validate_year_month("2026-05") == (2026, 5)
+    assert _validate_year_month("2026-12") == (2026, 12)
+
+
+def test_validate_year_month_rejects_bad_shape():
+    with pytest.raises(ValueError):
+        _validate_year_month("2026/05")
+    with pytest.raises(ValueError):
+        _validate_year_month("2026-5")
+    with pytest.raises(ValueError):
+        _validate_year_month("26-05")
+    with pytest.raises(ValueError):
+        _validate_year_month("not-a-date")
+
+
+def test_validate_year_month_rejects_bad_month():
+    with pytest.raises(ValueError):
+        _validate_year_month("2026-00")
+    with pytest.raises(ValueError):
+        _validate_year_month("2026-13")
+
+
+def test_validate_year_month_rejects_out_of_range_year():
+    with pytest.raises(ValueError):
+        _validate_year_month("2020-05")
+    with pytest.raises(ValueError):
+        _validate_year_month("3000-05")
+
+
+def test_validate_year_month_rejects_non_string():
+    with pytest.raises(ValueError):
+        _validate_year_month(202605)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Month bounds
+# ---------------------------------------------------------------------------
+
+
+def test_month_bounds_mid_year():
+    assert _month_bounds(2026, 5) == ("2026-05-01", "2026-06-01")
+
+
+def test_month_bounds_december_rolls_year():
+    assert _month_bounds(2026, 12) == ("2026-12-01", "2027-01-01")
+
+
+def test_month_bounds_january():
+    assert _month_bounds(2026, 1) == ("2026-01-01", "2026-02-01")
+
+
+# ---------------------------------------------------------------------------
+# Driver -> category mapping
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_drivers_map_to_anthropic_llm():
+    assert category_for_driver("claude_api_input_tokens") == DriverCategory.ANTHROPIC_LLM
+    assert category_for_driver("claude_api_output_tokens") == DriverCategory.ANTHROPIC_LLM
+
+
+def test_r2_drivers_all_map_to_cloudflare_r2():
+    assert category_for_driver("r2_storage_gb_hours") == DriverCategory.CLOUDFLARE_R2
+    assert category_for_driver("r2_class_a_ops") == DriverCategory.CLOUDFLARE_R2
+    assert category_for_driver("r2_class_b_ops") == DriverCategory.CLOUDFLARE_R2
+
+
+def test_d1_drivers_map_to_cloudflare_d1():
+    assert category_for_driver("d1_reads") == DriverCategory.CLOUDFLARE_D1
+    assert category_for_driver("d1_writes") == DriverCategory.CLOUDFLARE_D1
+
+
+def test_vectorize_drivers_map_to_cloudflare_vectorize():
+    assert category_for_driver("vectorize_queries") == DriverCategory.CLOUDFLARE_VECTORIZE
+    assert (
+        category_for_driver("vectorize_dimensions_stored")
+        == DriverCategory.CLOUDFLARE_VECTORIZE
+    )
+
+
+def test_fly_machine_minutes_maps_to_fly_compute():
+    assert category_for_driver("fly_machine_minutes") == DriverCategory.FLY_COMPUTE
+
+
+def test_agentmail_drivers_map_to_agentmail():
+    assert category_for_driver("agentmail_messages") == DriverCategory.AGENTMAIL
+    assert category_for_driver("agentmail_mailbox_days") == DriverCategory.AGENTMAIL
+
+
+def test_captain_time_maps_to_captain_time():
+    assert category_for_driver("captain_time") == DriverCategory.CAPTAIN_TIME
+
+
+def test_composio_actions_maps_to_composio():
+    assert category_for_driver("composio_actions") == DriverCategory.COMPOSIO_ACTION
+
+
+def test_unknown_driver_maps_to_other():
+    assert category_for_driver("third_party_api_lawpay") == DriverCategory.OTHER
+    assert category_for_driver("totally-novel-driver") == DriverCategory.OTHER
+
+
+# ---------------------------------------------------------------------------
+# Rollup — empty
+# ---------------------------------------------------------------------------
+
+
+def test_empty_month_returns_zero_rollup():
+    conn = _make_conn()
+    reader = SqliteRowReader(conn)
+
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert isinstance(rollup, MonthlyRollup)
+    assert rollup.year_month == "2026-05"
+    assert rollup.total_cents == 0
+    assert rollup.total_dollars() == 0.0
+    assert rollup.row_count == 0
+    assert rollup.per_driver_detail_cents == {}
+    # Every category present, all zero
+    for cat in DriverCategory:
+        assert rollup.by_category_cents[cat] == 0
+        assert rollup.by_category_basis_points[cat] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rollup — single driver, single day
+# ---------------------------------------------------------------------------
+
+
+def test_single_driver_single_day():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "claude_api_input_tokens", 250),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.total_cents == 250
+    assert rollup.by_category_cents[DriverCategory.ANTHROPIC_LLM] == 250
+    assert rollup.by_category_basis_points[DriverCategory.ANTHROPIC_LLM] == 10_000
+    assert rollup.per_driver_detail_cents == {"claude_api_input_tokens": 250}
+    assert rollup.row_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Rollup — multiple drivers + multiple days
+# ---------------------------------------------------------------------------
+
+
+def test_multi_driver_multi_day_aggregation():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            # Anthropic across two days
+            ("2026-05-01", "claude_api_input_tokens", 100),
+            ("2026-05-01", "claude_api_output_tokens", 200),
+            ("2026-05-02", "claude_api_input_tokens", 150),
+            ("2026-05-02", "claude_api_output_tokens", 250),
+            # R2 across three sub-drivers
+            ("2026-05-01", "r2_storage_gb_hours", 50),
+            ("2026-05-01", "r2_class_a_ops", 30),
+            ("2026-05-01", "r2_class_b_ops", 20),
+            # Fly
+            ("2026-05-01", "fly_machine_minutes", 500),
+            # Captain time
+            ("2026-05-15", "captain_time", 6000),
+            # AgentMail
+            ("2026-05-01", "agentmail_messages", 40),
+            ("2026-05-01", "agentmail_mailbox_days", 60),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.total_cents == 100 + 200 + 150 + 250 + 50 + 30 + 20 + 500 + 6000 + 40 + 60
+    assert rollup.total_cents == 7400
+    # Anthropic: 100 + 200 + 150 + 250 = 700
+    assert rollup.by_category_cents[DriverCategory.ANTHROPIC_LLM] == 700
+    # R2: 50 + 30 + 20 = 100
+    assert rollup.by_category_cents[DriverCategory.CLOUDFLARE_R2] == 100
+    # Fly: 500
+    assert rollup.by_category_cents[DriverCategory.FLY_COMPUTE] == 500
+    # Captain time: 6000
+    assert rollup.by_category_cents[DriverCategory.CAPTAIN_TIME] == 6000
+    # AgentMail: 40 + 60 = 100
+    assert rollup.by_category_cents[DriverCategory.AGENTMAIL] == 100
+    # No D1, Vectorize, Composio or OTHER
+    assert rollup.by_category_cents[DriverCategory.CLOUDFLARE_D1] == 0
+    assert rollup.by_category_cents[DriverCategory.CLOUDFLARE_VECTORIZE] == 0
+    assert rollup.by_category_cents[DriverCategory.COMPOSIO_ACTION] == 0
+    assert rollup.by_category_cents[DriverCategory.OTHER] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rollup — basis points
+# ---------------------------------------------------------------------------
+
+
+def test_basis_points_sum_to_within_one_per_category():
+    # 4000 / 6000 / 0 split -> 6666 / 3333 / 0; sum = 9999 due to floor rounding
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "fly_machine_minutes", 4000),
+            ("2026-05-01", "captain_time", 6000),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.total_cents == 10000
+    assert rollup.by_category_basis_points[DriverCategory.FLY_COMPUTE] == 4000
+    assert rollup.by_category_basis_points[DriverCategory.CAPTAIN_TIME] == 6000
+    # Other categories at 0
+    total_bps = sum(rollup.by_category_basis_points.values())
+    assert total_bps == 10_000
+
+
+def test_basis_points_zero_when_total_zero():
+    conn = _make_conn()
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    for cat in DriverCategory:
+        assert rollup.by_category_basis_points[cat] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rollup — month-bound isolation
+# ---------------------------------------------------------------------------
+
+
+def test_month_bound_excludes_prior_month():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-04-30", "fly_machine_minutes", 999),  # outside
+            ("2026-05-01", "fly_machine_minutes", 100),  # inside
+            ("2026-05-31", "fly_machine_minutes", 200),  # inside
+            ("2026-06-01", "fly_machine_minutes", 888),  # outside
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    # Only the two May rows count
+    assert rollup.total_cents == 300
+    assert rollup.by_category_cents[DriverCategory.FLY_COMPUTE] == 300
+
+
+def test_month_bound_handles_december_year_roll():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-12-01", "fly_machine_minutes", 50),
+            ("2026-12-31", "fly_machine_minutes", 70),
+            ("2027-01-01", "fly_machine_minutes", 999),  # next year, excluded
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-12"))
+
+    assert rollup.total_cents == 120
+
+
+# ---------------------------------------------------------------------------
+# Rollup — unknown drivers bucket into OTHER but preserve their name
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_drivers_land_in_other_with_name_preserved():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "third_party_api_docusign", 75),
+            ("2026-05-02", "totally-novel-driver", 25),
+            ("2026-05-03", "fly_machine_minutes", 100),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.total_cents == 200
+    assert rollup.by_category_cents[DriverCategory.OTHER] == 100
+    assert rollup.by_category_cents[DriverCategory.FLY_COMPUTE] == 100
+    # Per-driver detail map preserves the raw names so Captain dashboard can
+    # surface unknown drivers for triage
+    assert rollup.per_driver_detail_cents["third_party_api_docusign"] == 75
+    assert rollup.per_driver_detail_cents["totally-novel-driver"] == 25
+    assert rollup.per_driver_detail_cents["fly_machine_minutes"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Rollup — negative amounts are skipped, not poisoning the rollup
+# ---------------------------------------------------------------------------
+
+
+def test_negative_amount_rows_are_filtered_out():
+    """Defense in depth: the SQL filter excludes negative amount_cents at the
+    row level so a corrupt row cannot poison the rollup via SUM."""
+    conn = _make_conn()
+    cur = conn.cursor()
+    # Two same-driver rows; the negative must not contribute.
+    cur.execute(
+        "INSERT INTO cost_telemetry (date, driver, amount_cents) "
+        "VALUES ('2026-05-01', 'fly_machine_minutes', -500)"
+    )
+    cur.execute(
+        "INSERT INTO cost_telemetry (date, driver, amount_cents) "
+        "VALUES ('2026-05-02', 'fly_machine_minutes', 200)"
+    )
+    conn.commit()
+
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    # The negative row is filtered at the SQL layer; only the positive row counts.
+    assert rollup.total_cents == 200
+    assert rollup.by_category_cents[DriverCategory.FLY_COMPUTE] == 200
+
+
+def test_module_level_negative_guard_also_skips(monkeypatch):
+    """The module's row-level negative guard is a belt-and-braces backstop
+    in case a non-SQL row source (e.g. a future in-memory reader) supplies
+    a negative. Feed the rollup a synthetic reader and assert the guard
+    skips the row + warns."""
+    from adapter import cost_rollup
+
+    class _StubReader:
+        def __init__(self, rows):
+            self._rows = rows
+
+        async def fetch_rows(self, sql, params):
+            return self._rows
+
+    reader = _StubReader(
+        [
+            ("fly_machine_minutes", -500, 1),
+            ("fly_machine_minutes", 200, 1),
+        ]
+    )
+    rollup = _run(cost_rollup.compute_monthly_rollup(reader, "2026-05"))
+    # Negative is dropped by the row-level guard; the positive row is kept.
+    assert rollup.total_cents == 200
+    assert rollup.by_category_cents[DriverCategory.FLY_COMPUTE] == 200
+
+
+# ---------------------------------------------------------------------------
+# Rollup — COGS/MRR ratio
+# ---------------------------------------------------------------------------
+
+
+def test_cogs_mrr_basis_points_priced_customer():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "fly_machine_minutes", 30_000),
+            ("2026-05-01", "claude_api_input_tokens", 20_000),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    # 50_000 cents COGS against 200_000 cents MRR ($2k) = 25% = 2500 bps
+    assert rollup.cogs_mrr_basis_points(mrr_cents=200_000) == 2500
+
+
+def test_cogs_mrr_basis_points_above_kill_threshold():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "fly_machine_minutes", 50_000),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    # 50_000 / 100_000 = 50% = 5000 bps; > 4000 bps kill threshold
+    bps = rollup.cogs_mrr_basis_points(mrr_cents=100_000)
+    assert bps == 5000
+    assert bps is not None and bps > 4000
+
+
+def test_cogs_mrr_basis_points_unpriced_returns_none():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "fly_machine_minutes", 100),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.cogs_mrr_basis_points(mrr_cents=0) is None
+    assert rollup.cogs_mrr_basis_points(mrr_cents=-1) is None
+
+
+# ---------------------------------------------------------------------------
+# MonthlyRollup helpers
+# ---------------------------------------------------------------------------
+
+
+def test_category_dollars_helper():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "claude_api_input_tokens", 1234),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.category_dollars(DriverCategory.ANTHROPIC_LLM) == 12.34
+    assert rollup.category_dollars(DriverCategory.CLOUDFLARE_D1) == 0.0
+
+
+def test_total_dollars_helper():
+    conn = _make_conn()
+    _seed(
+        conn,
+        [
+            ("2026-05-01", "fly_machine_minutes", 1000),
+            ("2026-05-02", "captain_time", 1234),
+        ],
+    )
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+
+    assert rollup.total_dollars() == 22.34
+
+
+# ---------------------------------------------------------------------------
+# Rollup result immutability
+# ---------------------------------------------------------------------------
+
+
+def test_rollup_is_frozen():
+    rollup = MonthlyRollup(
+        year_month="2026-05",
+        total_cents=0,
+        by_category_cents={},
+        by_category_basis_points={},
+        per_driver_detail_cents={},
+    )
+    with pytest.raises(Exception):
+        rollup.total_cents = 100  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Compose with cost_telemetry UPSERT pattern used by emitters
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_pattern_accumulates_then_rollup_reads_total():
+    """Same-day same-driver INSERTs should accumulate via UPSERT, and the
+    rollup should read the accumulated total — matching the emitter
+    pattern in cost-telemetry-events.md."""
+    conn = _make_conn()
+    cur = conn.cursor()
+    # Emit three same-day same-driver events; UPSERT accumulates.
+    upsert_sql = (
+        "INSERT INTO cost_telemetry (date, driver, amount_cents, units, unit_type) "
+        "VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT (date, driver) DO UPDATE SET "
+        "  amount_cents = amount_cents + excluded.amount_cents, "
+        "  units = units + excluded.units"
+    )
+    for cents, tokens in [(100, 10_000), (200, 20_000), (300, 30_000)]:
+        cur.execute(
+            upsert_sql,
+            ("2026-05-15", "claude_api_input_tokens", cents, tokens, "input_tokens"),
+        )
+    conn.commit()
+
+    # One row in the table, accumulated cents
+    row = cur.execute(
+        "SELECT amount_cents, units FROM cost_telemetry "
+        "WHERE date='2026-05-15' AND driver='claude_api_input_tokens'"
+    ).fetchone()
+    assert row == (600, 60_000.0)
+
+    reader = SqliteRowReader(conn)
+    rollup = _run(compute_monthly_rollup(reader, "2026-05"))
+    assert rollup.total_cents == 600
+    assert rollup.by_category_cents[DriverCategory.ANTHROPIC_LLM] == 600

--- a/ai-employee/migrations/0006_cost_attribution_rollup.sql
+++ b/ai-employee/migrations/0006_cost_attribution_rollup.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- Migration 0006: cost attribution rollup support (issue #884)
+-- ============================================================================
+--
+-- Per-customer cost attribution rollup. The daily-roll `cost_telemetry` table
+-- already exists from migration 0001 with the shape
+-- `(date, driver, amount_cents, units, unit_type) PRIMARY KEY (date, driver)`
+-- per the cost-telemetry-events.md spec on main. This migration adds the
+-- per-event Captain time table referenced by that spec but not yet created,
+-- and supporting indexes that accelerate the monthly rollup query in
+-- ai-employee/adapter/cost_rollup.py.
+--
+-- Two changes:
+--
+--   1. captain_time_events — per-event row written by the
+--      `crane ai-employee log-time` CLI. The CLI also UPSERTs a same-day
+--      summary into cost_telemetry under driver='captain_time' so the
+--      §17.1 COGS/MRR rollup reads from a single source. Per-event detail
+--      (activity, note) lives here for Captain-only audit and per-activity
+--      cost reporting. Schema is the authoritative copy from
+--      d1-schema.md §6 (cost telemetry).
+--
+--   2. cost_telemetry index on (date) — the rollup query reads a month
+--      range across all drivers; the (date, driver) PK already covers
+--      single-day point reads but the monthly scan benefits from a
+--      stand-alone date index.
+--
+-- Privacy posture (ADR 0009):
+--   Both objects live in the per-customer D1 database. No cross-customer
+--   table. Isolation enforced by the binding layer, not a row-level
+--   customer_id column.
+--
+-- Compatibility:
+--   New objects only. No drops, no column changes, no constraint changes.
+--   Existing cost_telemetry rows are untouched and remain readable by the
+--   rollup module without further migration.
+--
+-- Source spec: docs/specs/ai-employee/cost-attribution-rollup.md (issue #884)
+-- Refers to:   docs/specs/ai-employee/cost-telemetry-events.md (issue #804)
+--              docs/specs/ai-employee/d1-schema.md (issue #800)
+--              docs/strategy/ai-employee-pricing-2026-05-13.md (issue #794)
+-- ============================================================================
+
+-- ---------- 1. Captain time events (per-event audit) ----------
+-- One row per `crane ai-employee log-time` invocation. The CLI computes
+-- amount_cents as (minutes * 200 * 100) / 60 using the $200/hr loaded rate
+-- defined in platform-prd.md §15.1 and CLAUDE.md.
+--
+-- The CLI pairs this INSERT with an UPSERT into cost_telemetry for the same
+-- (date, 'captain_time') key. Re-running the same command writes a second
+-- row here and accumulates in cost_telemetry — by design. See
+-- cost-telemetry-events.md "Captain time logging".
+CREATE TABLE captain_time_events (
+  id            TEXT PRIMARY KEY,           -- ULID, sortable
+  ts            TEXT NOT NULL,              -- ISO 8601 UTC of CLI invocation
+  date          TEXT NOT NULL,              -- YYYY-MM-DD; --date flag, defaults to today UTC
+  activity      TEXT NOT NULL,              -- enum from platform-prd.md §15.2 activity-tag taxonomy
+  minutes       INTEGER NOT NULL,           -- > 0 and <= 600
+  amount_cents  INTEGER NOT NULL,           -- (minutes * 200 * 100) / 60 at $200/hr Captain rate
+  note          TEXT                        -- optional free text, <= 280 chars
+);
+CREATE INDEX idx_captain_time_date ON captain_time_events(date);
+CREATE INDEX idx_captain_time_activity ON captain_time_events(activity, date);
+
+-- ---------- 2. Cost telemetry monthly-scan index ----------
+-- The PRIMARY KEY (date, driver) on cost_telemetry already covers exact
+-- (date, driver) reads and ordered (date, driver) range scans. The monthly
+-- rollup query scans a date range across every driver — the leading-date
+-- PK is sufficient, but a stand-alone date index gives the planner the
+-- option of an index-only scan when only date and the aggregate cents are
+-- needed. Cheap to add, prevents a regression if the PK ordering changes.
+CREATE INDEX IF NOT EXISTS idx_cost_telemetry_date
+  ON cost_telemetry(date);
+
+-- ---------- Schema version ----------
+-- 0001 set 1, 0002 set 2, 0003 set 3, 0004 set 4, 0005 set 5; this is 6.
+PRAGMA user_version = 6;

--- a/docs/specs/ai-employee/cost-attribution-rollup.md
+++ b/docs/specs/ai-employee/cost-attribution-rollup.md
@@ -1,0 +1,158 @@
+# Cost Attribution Rollup
+
+**Spec for issue [#884](https://github.com/venturecrane/ss-console/issues/884).** Per-customer monthly rollup over the `cost_telemetry` table that the [cost-telemetry-events.md](cost-telemetry-events.md) emitters write. The §17.1 COGS/MRR margin gate in `platform-prd.md` reads its totals from the function defined here.
+
+## Source
+
+- [platform-prd.md](../../pm/ai-employee/platform-prd.md) §15.1 (cost drivers), §17.1 (COGS/MRR kill criterion)
+- [cost-telemetry-events.md](cost-telemetry-events.md) — emitter spec; the row source this rollup reads
+- [d1-schema.md](d1-schema.md) §6 — `cost_telemetry` shape; §6 also defines `captain_time_events`
+- [docs/strategy/ai-employee-pricing-2026-05-13.md](../../strategy/ai-employee-pricing-2026-05-13.md) — per-driver COGS lines and the nine cost categories this rollup groups by
+- [ADR 0009](../../adr/0009-cross-machine-query-prohibition.md) — per-customer database binding
+
+## Why this exists
+
+Emitters produce per-`(date, driver)` rows in `cost_telemetry`. The dashboard, the §17.1 COGS/MRR ratio computation, the decommission-final cost export, and the Captain control plane all need the same view: a single month, rolled up per customer, with totals grouped into the nine platform-prd §15.1 cost categories.
+
+Without a single rollup module, every consumer reimplements the GROUP BY and the driver-to-category mapping. That is how the driver enum drifts: two consumers map `r2_class_a_ops` differently and the COGS/MRR ratio gate stops being falsifiable.
+
+This module is the single authoritative reader. Every consumer calls it.
+
+## Contract
+
+### Inputs
+
+```python
+async def compute_monthly_rollup(
+    reader: RowReader,
+    year_month: str,
+) -> MonthlyRollup
+```
+
+- `reader` is an executor already bound to one customer's per-customer D1 database. The caller is responsible for picking the binding per ADR 0009. There is no `customer_id` parameter — isolation is the binding, not a row-level column.
+- `year_month` is `YYYY-MM` UTC. The function validates the shape and rejects months outside `[2026-01, 2100-12]`.
+
+### Output
+
+```python
+@dataclass(frozen=True)
+class MonthlyRollup:
+    year_month: str
+    total_cents: int
+    by_category_cents: Mapping[DriverCategory, int]
+    by_category_basis_points: Mapping[DriverCategory, int]
+    per_driver_detail_cents: Mapping[str, int]
+    row_count: int
+```
+
+- `total_cents` is the sum of `amount_cents` across every `cost_telemetry` row in the month with `amount_cents >= 0`. Negative rows are filtered at the SQL layer and skipped at the Python layer (defense in depth).
+- `by_category_cents` carries every `DriverCategory` key, even at zero, so consumers can render a stable column set.
+- `by_category_basis_points` is the integer-basis-point share per category. Basis points are 1/100 of a percent; the §17.1 `> 0.40` kill threshold is 4000 bps. Integer arithmetic prevents float drift in the ratio gate.
+- `per_driver_detail_cents` preserves the raw `cost_telemetry.driver` values so the Captain dashboard can drill into a category and surface unknown drivers from the `OTHER` bucket.
+- `row_count` lets a consumer sanity-check that data was actually present.
+
+### Driver categories
+
+The nine categories match platform-prd §15.1 and the pricing model in docs/strategy/ai-employee-pricing-2026-05-13.md:
+
+| `DriverCategory`       | Raw drivers (from cost-telemetry-events.md)               |
+| ---------------------- | --------------------------------------------------------- |
+| `ANTHROPIC_LLM`        | `claude_api_input_tokens`, `claude_api_output_tokens`     |
+| `COMPOSIO_ACTION`      | `composio_actions`                                        |
+| `FLY_COMPUTE`          | `fly_machine_minutes`                                     |
+| `CLOUDFLARE_D1`        | `d1_reads`, `d1_writes`                                   |
+| `CLOUDFLARE_R2`        | `r2_storage_gb_hours`, `r2_class_a_ops`, `r2_class_b_ops` |
+| `CLOUDFLARE_VECTORIZE` | `vectorize_queries`, `vectorize_dimensions_stored`        |
+| `AGENTMAIL`            | `agentmail_messages`, `agentmail_mailbox_days`            |
+| `CAPTAIN_TIME`         | `captain_time`                                            |
+| `OTHER`                | anything not in the explicit map above                    |
+
+Adding a new driver requires editing `_DRIVER_TO_CATEGORY` in `ai-employee/adapter/cost_rollup.py` in the same PR that adds the emitter. Drivers that arrive without a category land in `OTHER`; their raw name is preserved in `per_driver_detail_cents` so they surface in the dashboard for triage.
+
+### COGS/MRR ratio
+
+```python
+rollup.cogs_mrr_basis_points(mrr_cents=200_000)  # returns Optional[int]
+```
+
+Returns `None` when `mrr_cents <= 0` (an unpriced customer; the ratio is undefined). Otherwise returns `(total_cents * 10_000) // mrr_cents`. The §17.1 alert seam is the Captain dashboard's responsibility — this module computes the value but does not fire notifications.
+
+### Aggregation cadence
+
+V1 implementation is **on-demand only**. Every call recomputes the rollup. A daily cron seam is documented for the future:
+
+- A Cloudflare Worker scheduled cron could call `compute_monthly_rollup` per active customer and persist the result for the dashboard to read without recomputing.
+- The persisted shape would mirror `MonthlyRollup` as a JSON blob or a per-`(customer, year_month, category)` table.
+- The current contract does not write — adding a writer happens in a follow-on PR, not here.
+
+On-demand is sufficient for v1 because `cost_telemetry` rows are bounded by `30 days × ~16 drivers = ~500 rows/customer/month`. A full-month aggregate on D1 takes single-digit milliseconds.
+
+## Storage shape
+
+`cost_telemetry` already exists from migration 0001:
+
+```sql
+CREATE TABLE cost_telemetry (
+  date         TEXT NOT NULL,               -- YYYY-MM-DD (UTC)
+  driver       TEXT NOT NULL,
+  amount_cents INTEGER NOT NULL,
+  units        REAL,
+  unit_type    TEXT,
+  PRIMARY KEY (date, driver)
+);
+```
+
+Migration `0006_cost_attribution_rollup.sql` adds:
+
+1. `captain_time_events` — the per-event Captain time table referenced by cost-telemetry-events.md "Captain time logging" but not present in migration 0001. The `crane ai-employee log-time` CLI writes one row here per invocation and pairs that with a same-day UPSERT into `cost_telemetry` under `driver='captain_time'`.
+2. `idx_cost_telemetry_date` — a stand-alone date index for monthly-scan queries. The existing `(date, driver)` PK already covers exact-date reads; this index gives the planner an alternative for date-only scans.
+
+Neither change touches existing rows. The migration is additive.
+
+## Privacy posture
+
+Per [ADR 0009](../../adr/0009-cross-machine-query-prohibition.md), `cost_telemetry` and `captain_time_events` live in the per-customer D1 database. No row-level `customer_id` column. No cross-customer aggregate query is possible at the database layer. The rollup module accepts a single executor bound to one customer's database; computing a cross-customer total requires N calls and an aggregation in the Captain control plane.
+
+## Failure modes
+
+- **Empty month.** Returns a zero `MonthlyRollup`. Not an error — a brand-new customer has no rows yet.
+- **Negative `amount_cents`.** Filtered at the SQL layer (`WHERE amount_cents >= 0`). The Python layer also skips negative rows from non-SQL sources (a future in-memory reader) and logs a warning. A persistently-negative row signals a corrupt emitter and is a Captain triage item.
+- **Unknown driver.** Bucketed into `DriverCategory.OTHER`. The raw driver name survives in `per_driver_detail_cents` so the dashboard can render it for triage.
+- **Year out of `[2026, 2100]`.** `ValueError` raised before SQL executes. Defensive bound; the substrate did not exist before 2026.
+- **Database error.** Surfaces as the underlying executor exception. The module does not swallow database failures.
+
+## Verification
+
+Unit tests at `ai-employee/adapter/tests/test_cost_rollup.py` cover:
+
+1. Year-month input validation (shape, month bounds, year bounds, non-string).
+2. Empty-month rollup returns zero totals with every category key present.
+3. Aggregation across multiple drivers + multiple days.
+4. Per-category bucketing for all nine categories.
+5. Unknown drivers bucket into `OTHER` and preserve their raw name in the per-driver detail map.
+6. Basis-point shares sum to 10,000 for a non-empty month and are zero for an empty month.
+7. Month-bound filter excludes adjacent months, including the December year roll.
+8. Negative `amount_cents` is filtered at the SQL layer (positive-only sum) and skipped at the Python layer (warning).
+9. `cogs_mrr_basis_points` returns `None` for unpriced customers and basis points for priced.
+10. The UPSERT accumulation pattern from the emitter spec lands correctly when the rollup reads.
+
+Run from repo root:
+
+```
+cd ai-employee && python -m pytest adapter/tests/test_cost_rollup.py -v
+```
+
+## Implementation notes
+
+- Module: `ai-employee/adapter/cost_rollup.py`.
+- Migration: `ai-employee/migrations/0006_cost_attribution_rollup.sql`.
+- The aggregate query uses a half-open date range (`date >= 'YYYY-MM-01' AND date < 'YYYY-MM+1-01'`) so the `(date, driver)` PK serves the scan without a function call per row.
+- A production D1 HTTP reader is not implemented here. The `RowReader` Protocol accepts any async `fetch_rows(sql, params)`. The `SqliteRowReader` implementation ships for tests and local dev; the production wrapper around `HttpD1Executor` is a small wiring exercise that lives outside this module's scope.
+- Cross-references:
+  - [cost-telemetry-events.md](cost-telemetry-events.md) — the emitter side
+  - [d1-schema.md](d1-schema.md) — the table shape this reads
+  - [decommission-drain.md](decommission-drain.md) — final rollup before D1 deletion
+
+[AMBIGUITY: Cron seam — should the on-demand rollup be paired with a nightly persist into a `cost_summary` table, or is on-demand sufficient through Phase 4? Captain decision.]
+
+[AMBIGUITY: Cross-customer aggregation surface — the Captain control plane needs a portfolio-level COGS view across all customers. ADR 0009 forbids a cross-Machine query at the database layer. The control plane will fan out N rollups and aggregate in process; the API shape for this fan-out lives in a follow-on issue.]

--- a/docs/specs/ai-employee/index.md
+++ b/docs/specs/ai-employee/index.md
@@ -25,6 +25,7 @@ Build agents consuming these specs should treat the PRDs as **vision/doctrine** 
 | [compliance-evidence-packet.md](compliance-evidence-packet.md) | [#802](https://github.com/venturecrane/ss-console/issues/802) | Susan-readable compliance packet contents                                                                |
 | [day-1-onboarding.md](day-1-onboarding.md)                     | [#803](https://github.com/venturecrane/ss-console/issues/803) | First-hour dashboard walkthrough screens                                                                 |
 | [cost-telemetry-events.md](cost-telemetry-events.md)           | [#804](https://github.com/venturecrane/ss-console/issues/804) | Per-customer cost emission for all 9+ drivers                                                            |
+| [cost-attribution-rollup.md](cost-attribution-rollup.md)       | [#884](https://github.com/venturecrane/ss-console/issues/884) | Per-customer monthly rollup over cost_telemetry; nine category buckets; §17.1 COGS/MRR ratio computation |
 | [decommission-drain.md](decommission-drain.md)                 | [#805](https://github.com/venturecrane/ss-console/issues/805) | 60s drain window before substrate deletion                                                               |
 | [decommission-customer.md](decommission-customer.md)           | [#820](https://github.com/venturecrane/ss-console/issues/820) | Full per-customer off-boarding pipeline; 9 idempotent steps                                              |
 | [sticky-stop.md](sticky-stop.md)                               | [#843](https://github.com/venturecrane/ss-console/issues/843) | System-initiated circuit breaker for runaway agent loops (WARN/SOFT/HARD)                                |
@@ -82,6 +83,10 @@ mobile-approval-flow ─► fabrication-filter    (flag banner rendering)
 
 cost-telemetry       ─► d1-schema             (cost_telemetry table)
 cost-telemetry       ─► decommission-drain    (final rollup before D1 delete)
+
+cost-attribution-rollup ─► cost-telemetry-events (row source the rollup reads)
+cost-attribution-rollup ─► d1-schema             (cost_telemetry + captain_time_events)
+cost-attribution-rollup ─► decommission-drain    (final cost export before D1 delete)
 
 decommission-drain   ─► compliance-evidence-packet (final export contents)
 decommission-drain   ─► r2-vectorize-naming   (retention bucket)


### PR DESCRIPTION
## Summary

Implements the per-customer monthly cost rollup that aggregates `cost_telemetry` rows into the nine platform-prd §15.1 cost categories. This is the single authoritative reader used by the §17.1 COGS/MRR margin gate, the Captain dashboard, the decommission-final cost export, and the control plane.

- `ai-employee/adapter/cost_rollup.py` exposes `compute_monthly_rollup(reader, year_month) -> MonthlyRollup` with a frozen result carrying total cents, per-category cents, per-category basis points, a per-driver detail map, and a `cogs_mrr_basis_points` helper.
- `DriverCategory` is a closed enum (anthropic_llm, composio_action, fly_compute, cloudflare_d1, cloudflare_r2, cloudflare_vectorize, agentmail, captain_time, other) matching the nine cost lines in `docs/strategy/ai-employee-pricing-2026-05-13.md`. Unknown drivers bucket into `OTHER` with their raw name preserved in the per-driver detail map for Captain triage.
- Migration `0006_cost_attribution_rollup.sql` adds the per-event `captain_time_events` table (referenced by `cost-telemetry-events.md` but not present in migration 0001) and a stand-alone `(date)` index on `cost_telemetry` for monthly-scan queries. Additive only.
- `docs/specs/ai-employee/cost-attribution-rollup.md` is the new spec, registered in the index.

Privacy posture: rollup is per-customer; both tables live in the per-customer D1 database per ADR 0009. No row-level customer_id. Cross-customer aggregation requires N rollups + a control-plane fan-out.

Aggregation cadence: on-demand only in v1. A nightly cron seam is documented; the persistence layer ships in a follow-on PR.

## Test plan

- [x] `cd ai-employee && python -m pytest adapter/tests/` — 182 passed, 2 skipped, 0 failed.
- [x] `npm run verify` — exit 0 (lint, typecheck, prettier, vitest, worker typechecks).
- [x] 34 new tests cover year-month validation, empty-month zero rollup, multi-driver multi-day aggregation, all nine category buckets, month-bound isolation including December year roll, basis-point share math, COGS/MRR ratio (priced + unpriced), unknown-driver fallthrough, defense-in-depth negative-amount filtering at both SQL and Python layers, frozen result immutability, and the UPSERT accumulation pattern emitters use.

Closes #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)