### PR TITLE
feat(book): carry AI Employee interest from marketing CTA through to admin notification

### DIFF
--- a/src/components/booking/IntakeIntroCard.astro
+++ b/src/components/booking/IntakeIntroCard.astro
@@ -16,10 +16,25 @@ interface Props {
     name?: string
     email?: string
     businessName?: string
+    /**
+     * Productized SKU the prospect is inquiring about. Set when /book
+     * is reached via a marketing CTA with `?interest=<sku>`. When set,
+     * the card surfaces an acknowledgment chip in place of the generic
+     * "Intake" eyebrow and the submission carries the value through to
+     * the context metadata + admin notification.
+     *
+     * Allowed values: 'ai-employee' (others are filtered upstream).
+     */
+    interest?: string
   }
 }
 
 const { values = {} } = Astro.props
+
+const INTEREST_LABELS: Record<string, string> = {
+  'ai-employee': 'AI Employee',
+}
+const interestLabel = values.interest ? INTEREST_LABELS[values.interest] : null
 
 // `businessName` is preserved as a hidden field for admin-issued
 // pre-filled links. It is not displayed on the intro card.
@@ -27,7 +42,16 @@ const { values = {} } = Astro.props
 
 <section id="intake-intro" class="ss-intro">
   <header class="mb-stack">
-    <p class="ss-eyebrow">Intake</p>
+    {
+      interestLabel ? (
+        <p class="ss-intent-chip">
+          <span class="ss-intent-chip-label">Inquiring about</span>
+          <span class="ss-intent-chip-value">{interestLabel}</span>
+        </p>
+      ) : (
+        <p class="ss-eyebrow">Intake</p>
+      )
+    }
     <h1 class="ss-headline">Tell us about the business.</h1>
     <p class="ss-lede">
       A short conversation, then a real time on the calendar if it is worth a call.
@@ -88,6 +112,8 @@ const { values = {} } = Astro.props
         <input type="hidden" name="business_name" value={values.businessName} />
       )
     }
+
+    {values.interest && <input type="hidden" name="interest" value={values.interest} />}
 
     <div id="intro-error" class="ss-error" hidden></div>
 

--- a/src/lib/booking/intake-core.ts
+++ b/src/lib/booking/intake-core.ts
@@ -33,6 +33,15 @@ export interface IntakeInput {
   yearsInBusiness?: number | null
   biggestChallenge?: string | null
   howHeard?: string | null
+  /**
+   * Productized SKU the prospect arrived inquiring about (e.g.
+   * 'ai-employee'). Set when /book is reached from a product-detail
+   * marketing CTA. Stored in context metadata and surfaced in the
+   * admin notification so sales can route the lead. Allowed values
+   * are validated at the API boundary; this field accepts the
+   * canonical code, not the display label.
+   */
+  interest?: string | null
 }
 
 /**
@@ -206,8 +215,16 @@ async function resolveMeeting(
   return none
 }
 
+const INTEREST_LABELS: Record<string, string> = {
+  'ai-employee': 'AI Employee',
+}
+
 function buildIntakeLines(input: IntakeInput): string[] {
   const lines: string[] = []
+  if (input.interest) {
+    const label = INTEREST_LABELS[input.interest] ?? input.interest
+    lines.push(`Inquiring about: ${label}`)
+  }
   if (input.vertical) lines.push(`Vertical: ${input.vertical}`)
   if (input.employeeCount) lines.push(`Employees: ${input.employeeCount}`)
   if (input.yearsInBusiness) lines.push(`Years in business: ${input.yearsInBusiness}`)
@@ -261,6 +278,7 @@ export async function processIntakeSubmission(
         years_in_business: input.yearsInBusiness,
         biggest_challenge: input.biggestChallenge,
         how_heard: input.howHeard,
+        interest: input.interest,
       },
     })
     contextId = contextEntry.id

--- a/src/pages/api/intake/send.ts
+++ b/src/pages/api/intake/send.ts
@@ -46,6 +46,18 @@ const MAX_MESSAGE_CHARS = 5000
  */
 const MIN_FORM_FILL_MS = 2000
 
+/**
+ * Productized SKU codes that may be carried through /book?interest=<sku>
+ * from a marketing CTA. Strict allow-list: values not in this set are
+ * silently dropped to null rather than rejected, so a stale URL or
+ * cached link cannot break a legitimate submission. Extending this list
+ * requires an explicit code change.
+ */
+const ALLOWED_INTERESTS = new Set<string>(['ai-employee'])
+const INTEREST_LABELS: Record<string, string> = {
+  'ai-employee': 'AI Employee',
+}
+
 interface ValidatedSendBody {
   name: string
   email: string
@@ -53,6 +65,7 @@ interface ValidatedSendBody {
   phone: string | null
   website: string | null
   messageRaw: string
+  interest: string | null
 }
 
 /**
@@ -92,6 +105,9 @@ function validateSendBody(body: Record<string, unknown>): ValidatedSendBody | Re
     })
   }
 
+  const interestRaw = trimString(body.interest)
+  const interest = interestRaw && ALLOWED_INTERESTS.has(interestRaw) ? interestRaw : null
+
   return {
     name: name!,
     email: email!,
@@ -99,6 +115,7 @@ function validateSendBody(body: Record<string, unknown>): ValidatedSendBody | Re
     phone,
     website: trimString(body.website),
     messageRaw,
+    interest,
   }
 }
 
@@ -207,6 +224,7 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
         phone: validated.phone ?? '',
         website: validated.website,
         userMessage: validated.messageRaw || null,
+        interest: validated.interest,
       },
       { source: 'website_intake_send' }
     )
@@ -233,23 +251,32 @@ async function handlePost({ request, clientAddress }: APIContext): Promise<Respo
     console.error('[api/intake/send] Admin notification failed:', emailErr)
   }
 
-  // Issue a signed conversation cookie so /api/intake/continue can
-  // authenticate follow-up turns. Only set the cookie when we actually
-  // started a conversation (i.e. there was a non-empty message that
-  // produced an AI reply).
+  return buildIntakeSendResponse(intakeResult.entityId, conversationId, aiReply)
+}
+
+/**
+ * Build the success response for /api/intake/send. Issues a signed
+ * conversation cookie so /api/intake/continue can authenticate follow-up
+ * turns, but only when we actually started a conversation (non-empty
+ * message → AI reply).
+ */
+async function buildIntakeSendResponse(
+  entityId: string,
+  conversationId: string,
+  aiReply: string | null
+): Promise<Response> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (aiReply) {
     const token = await signConversationToken({
       conversation_id: conversationId,
-      entity_id: intakeResult.entityId,
+      entity_id: entityId,
     })
     headers['Set-Cookie'] = buildConversationCookieHeader(token, DEFAULT_CONVERSATION_TTL_SECONDS)
   }
-
   return new Response(
     JSON.stringify({
       ok: true,
-      entity_id: intakeResult.entityId,
+      entity_id: entityId,
       ai_reply: aiReply,
       can_continue: aiReply !== null,
     }),
@@ -268,6 +295,7 @@ interface AdminNotificationParams {
   message: string
   aiReply: string | null
   entityId: string
+  interest: string | null
 }
 
 async function sendAdminNotification(
@@ -282,9 +310,12 @@ async function sendAdminNotification(
   const escapedWebsite = params.website ? escapeHtml(params.website) : null
   const escapedMessage = params.message ? escapeHtml(params.message) : null
   const escapedAiReply = params.aiReply ? escapeHtml(params.aiReply) : null
+  const interestLabel = params.interest ? INTEREST_LABELS[params.interest] : null
+  const escapedInterest = interestLabel ? escapeHtml(interestLabel) : null
 
   const html = [
     `<p><strong>${escapedName}</strong> &lt;${escapedEmail}&gt; from <strong>${escapedBusiness}</strong> sent a message via the Send path on /book.</p>`,
+    escapedInterest ? `<p><strong>Inquiring about:</strong> ${escapedInterest}</p>` : '',
     escapedPhone ? `<p>Phone: ${escapedPhone}</p>` : '',
     escapedWebsite ? `<p>Website: <a href="${escapedWebsite}">${escapedWebsite}</a></p>` : '',
     '<hr>',
@@ -300,10 +331,11 @@ async function sendAdminNotification(
     .filter(Boolean)
     .join('')
 
+  const subjectPrefix = interestLabel ? `[${interestLabel}] ` : ''
   await sendEmail(workerEnv.RESEND_API_KEY, {
     to: NOTIFY_EMAIL,
     reply_to: params.email,
-    subject: `[Send-path lead] ${params.businessName}`,
+    subject: `${subjectPrefix}[Send-path lead] ${params.businessName}`,
     html,
   })
 }

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -25,6 +25,16 @@ let prefillContactName: string | null = null
 let prefillTokenValid = false
 let prefillTokenError: 'expired' | 'invalid' | null = null
 
+// Productized SKU interest carried from a marketing CTA (e.g.
+// /ai-employee → /book?interest=ai-employee). Strict allow-list: unknown
+// values are silently dropped so a stale URL or cached link does not
+// pollute the form. The same allow-list is enforced again at the API
+// boundary in /api/intake/send.ts.
+const ALLOWED_INTERESTS = new Set<string>(['ai-employee'])
+const interestParam = Astro.url.searchParams.get('interest')
+const interest =
+  interestParam && ALLOWED_INTERESTS.has(interestParam) ? interestParam : undefined
+
 if (prefillToken) {
   const verify = await verifyBookingLink(prefillToken)
   if (!verify.ok) {
@@ -87,6 +97,7 @@ if (prefillToken) {
               name: prefillContactName ?? undefined,
               email: prefillEmail ?? undefined,
               businessName: prefillBusinessName ?? undefined,
+              interest,
             }}
           />
 

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -32,8 +32,7 @@ let prefillTokenError: 'expired' | 'invalid' | null = null
 // boundary in /api/intake/send.ts.
 const ALLOWED_INTERESTS = new Set<string>(['ai-employee'])
 const interestParam = Astro.url.searchParams.get('interest')
-const interest =
-  interestParam && ALLOWED_INTERESTS.has(interestParam) ? interestParam : undefined
+const interest = interestParam && ALLOWED_INTERESTS.has(interestParam) ? interestParam : undefined
 
 if (prefillToken) {
   const verify = await verifyBookingLink(prefillToken)

--- a/src/scripts/book.ts
+++ b/src/scripts/book.ts
@@ -75,14 +75,17 @@ function readIntroFormPayload(els: BookElements): {
   email: string
   message: string
   business_name: string | null
+  interest: string | null
 } {
   const fd = new FormData(els.introForm)
   const business = readStringField(fd, 'business_name')
+  const interest = readStringField(fd, 'interest')
   return {
     name: readStringField(fd, 'name'),
     email: readStringField(fd, 'email'),
     message: readStringField(fd, 'message'),
     business_name: business.length > 0 ? business : null,
+    interest: interest.length > 0 ? interest : null,
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -235,6 +235,35 @@
   margin-bottom: 0.75rem;
 }
 
+/*
+ * Filled chip used in place of the generic "Intake" eyebrow when a
+ * prospect arrives on /book from a productized-SKU marketing CTA
+ * (e.g. /ai-employee → /book?interest=ai-employee). Confirms to the
+ * prospect that we know what they are here for. The label/value
+ * split lets the product name pop while the "Inquiring about" prefix
+ * stays softer.
+ */
+.ss-intent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: var(--ss-color-text-primary);
+  color: var(--ss-color-background);
+  font-family: var(--ss-font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.ss-intent-chip-label {
+  opacity: 0.7;
+  font-weight: 500;
+}
+.ss-intent-chip-value {
+  font-weight: 700;
+}
+
 .ss-headline {
   font-family: var(--ss-font-display);
   font-weight: 900;


### PR DESCRIPTION
## Summary

PR2 of the AI Employee marketing launch (see #994 for PR1). Wires the `?interest=ai-employee` query param end-to-end so a prospect arriving on /book from the AI Employee detail page is acknowledged on the page and the interest reaches the admin inbox.

- **/book.astro** reads `?interest=<sku>`, validates against the SKU allow-list, threads the value to `IntakeIntroCard`.
- **IntakeIntroCard.astro** renders a filled chip ("Inquiring about: AI Employee") in place of the generic "Intake" eyebrow, plus a hidden input that carries the value through form submission. New `.ss-intent-chip` style added to `global.css` with the Plainspoken treatment (mono, uppercase, label/value split, filled).
- **book.ts** form-payload reader picks up the hidden `interest` field and includes it in the POST body to `/api/intake/send`.
- **/api/intake/send.ts** validates the field against a strict allow-list (silent drop to null on unknown values), passes it to `processIntakeSubmission`, threads it into `sendAdminNotification`. Admin email gets a subject-line tag (`[AI Employee] [Send-path lead] …`) and a body line so the lead is visible at inbox-triage time.
- **intake-core.ts** extends `IntakeInput` with `interest`, surfaces it as the first line of the admin intake summary (most actionable signal), persists it into the context metadata JSON blob alongside `vertical`, `employee_count`, `how_heard`, etc.

## Schema migration: not needed

The approved plan called for `ALTER TABLE intakes ADD COLUMN interest TEXT;` — but the `intakes` table does not exist. Intake submissions persist via the `context` table's `metadata` JSON blob via `appendContext()`. The existing intake fields (`vertical`, `employeeCount`, `howHeard`) all live there. Interest fits the same pattern. No schema change.

## Strict allow-list, silently dropping unknown values

Only `'ai-employee'` is honored in v1. Unknown values are dropped to null at both the page layer (`book.astro`) and the API layer (`/api/intake/send.ts`) rather than rejected with a 400. Reasoning: there is no security benefit to a 400 (unknown values are never stored as the value anyway), and silent drop is more user-forgiving — a stale URL or cached link cannot break a legitimate submission. The page CTA only ever emits known values; the server is just defending against pollution.

Extending the allow-list for a future product requires touching three lines (one Set, one label map per layer).

## What admin sees

- Email subject: `[AI Employee] [Send-path lead] {businessName}`
- Email body: prominent "**Inquiring about:** AI Employee" line above the message
- Admin entity view (via context metadata): `interest: "ai-employee"` alongside other intake fields

## Test plan

- [x] `npm test` — 2534 tests pass
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `/book?interest=ai-employee` — chip renders, hidden input present, "Intake" eyebrow replaced
- [x] `/book` (no param) — no chip, no hidden input, "Intake" eyebrow renders (no regression)
- [x] `/book?interest=garbage` — no chip, no hidden input (strict allow-list dropped it)
- [ ] End-to-end submit test in a deployed preview: confirm `context.metadata.interest === 'ai-employee'` in D1 and confirm admin email subject + body line render correctly through Resend

## Refactor note

`handlePost` in `/api/intake/send.ts` was 75 lines (the eslint max). My one-line addition pushed it to 76. Extracted the cookie + response-building block into a dedicated `buildIntakeSendResponse` helper, which is a real coherent unit ("build the success response"), not just a lint shim. handlePost is now 56 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)