### PR TITLE
fix(booking): drop required business_name and phone from reserve validation

### DIFF
--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -69,6 +69,11 @@ interface ValidatedInput {
   prefillTokenRaw: string | null
 }
 
+function deriveBusinessNameFromEmail(email: string): string {
+  const domain = email.split('@')[1] ?? ''
+  return domain || 'Unknown'
+}
+
 function validateSlotTiming(slotStartUtc: string): { slotEndUtc: string } | Response {
   const slotStart = new Date(slotStartUtc)
   if (isNaN(slotStart.getTime())) {
@@ -89,32 +94,28 @@ function validateSlotTiming(slotStartUtc: string): { slotEndUtc: string } | Resp
 function validateReserveInput(body: Record<string, unknown>): ValidatedInput | Response {
   const name = trimString(body.name)
   const email = trimString(body.email)
-  const businessName = trimString(body.business_name)
+  const businessNameRaw = trimString(body.business_name)
   const phone = trimString(body.phone)
   const slotStartUtc = trimString(body.slot_start_utc)
 
-  if (!name || !email || !businessName || !slotStartUtc) {
+  if (!name || !email || !slotStartUtc) {
     return jsonResponse(400, {
       error: 'validation_failed',
-      message: 'name, email, business_name, and slot_start_utc are required',
-    })
-  }
-
-  // Phone is required for new website-driven bookings (the unified intake
-  // collects it). Admin "Send booking link" flow may still come through
-  // without phone — those carry a prefill_token and we don't want to break
-  // pre-existing booking-link campaigns.
-  if (!phone && !body.prefill_token) {
-    return jsonResponse(400, {
-      error: 'validation_failed',
-      message: 'Phone is required.',
-      field_errors: { phone: 'Phone is required.' },
+      message: 'name, email, and slot_start_utc are required',
     })
   }
 
   if (!isValidEmail(email)) {
     return jsonResponse(400, { error: 'validation_failed', message: 'Invalid email address' })
   }
+
+  // business_name and phone are optional for web intakes. The V3 unified
+  // intake form drops both fields in favor of a simpler "email + name +
+  // message" shape. When business_name is absent we derive it from the
+  // email domain so downstream entity rows and email/calendar templates
+  // still have something to render. The admin "Send booking link" flow
+  // continues to bypass all of this via prefill_token + PreSeededIntake.
+  const businessName = businessNameRaw ?? deriveBusinessNameFromEmail(email)
 
   const slotTiming = validateSlotTiming(slotStartUtc)
   if (slotTiming instanceof Response) return slotTiming

--- a/tests/booking/reserve.test.ts
+++ b/tests/booking/reserve.test.ts
@@ -243,19 +243,26 @@ describe('POST /api/booking/reserve', () => {
       expect(json.error).toBe('slot_unavailable')
     })
 
-    it('rejects bookings missing phone (no prefill_token) with 400', async () => {
+    it('accepts bookings without phone (V3 intake form drops the phone field)', async () => {
+      // Phone was historically required for non-prefill-token bookings, but
+      // the V3 unified intake form no longer collects it. Reserve treats
+      // phone as optional; admin send-link flows continue to work
+      // unchanged via prefill_token.
       const res = await POST(
         buildContext({
           body: validBody({ phone: '' }),
         })
       )
-      expect(res.status).toBe(400)
-      const json = await parseJson<{
-        error: string
-        field_errors?: { phone?: string }
-      }>(res)
-      expect(json.error).toBe('validation_failed')
-      expect(json.field_errors?.phone).toBe('Phone is required.')
+      expect(res.status).toBe(201)
+    })
+
+    it('accepts bookings without business_name and derives it from the email domain', async () => {
+      const res = await POST(
+        buildContext({
+          body: validBody({ business_name: '', email: 'jane@acme.com' }),
+        })
+      )
+      expect(res.status).toBe(201)
     })
   })
 


### PR DESCRIPTION
## Summary

Hotfix for the booking flow. The V3 unified intake form dropped business_name and phone from the form months ago in favor of an email + name + message shape, but \`/api/booking/reserve\` was still rejecting submissions without them. Every organic web booking has been failing with \`"name, email, business_name, and slot_start_utc are required"\` at the confirm-time step.

- \`/api/booking/reserve\` now requires only \`name\`, \`email\`, \`slot_start_utc\`.
- \`business_name\` is derived from the email domain when absent (matches \`/api/intake/send\` pattern).
- \`phone\` is optional for web intakes.
- Admin send-link flow via \`prefill_token + PreSeededIntake\` is untouched.

This is PR1 of a two-PR series. PR2 will rewrite the intake UX (chat → fast booking, AI moves backstage). Shipping this first because the booking blocker is bleeding leads.

## Test plan
- [x] \`npm run verify\` passes
- [x] Existing reserve test \`rejects bookings missing phone\` replaced with \`accepts bookings without phone\` (V3-aligned)
- [x] New test \`accepts bookings without business_name and derives it from the email domain\`
- [x] All 11 reserve tests pass
- [ ] Curl test on production after merge: POST to \`/api/booking/reserve\` with \`{name, email, slot_start_utc}\` only → expect 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)