### PR TITLE
fix(book): polish intake — explicit business name, just-send alt CTA, layout fixes

### DIFF
--- a/src/components/booking/IntakeClosed.astro
+++ b/src/components/booking/IntakeClosed.astro
@@ -1,15 +1,19 @@
 ---
 /**
- * V4 /book closed-state acknowledgment card. Single flavor: 'booked'.
+ * V4 /book closed-state acknowledgment card. Two flavors:
  *
- * Replaces the slot picker after the prospect confirms a time. Shows
- * the confirmed slot label and (optional) Google Meet link / reschedule
- * link. The V3 'done' flavor was retired with the chat surface; there
- * is no longer a path that lands in this state without a confirmed
- * booking.
+ *   - 'booked' — replaces the slot picker after the prospect confirms
+ *                a time. Shows the confirmed slot label and (optional)
+ *                reschedule link. The Google Meet join link is no
+ *                longer surfaced here — it lives on the calendar
+ *                invite and confirmation email where it belongs.
  *
- * Pre-rendered hidden; book.ts reveals the card via data-state and
- * populates fields (slot text, meet link).
+ *   - 'sent'   — replaces the intro card after the prospect uses the
+ *                "Just send a note" path. Short acknowledgment with
+ *                no fabricated follow-up promise.
+ *
+ * Pre-rendered hidden; book.ts reveals the appropriate flavor and
+ * populates the slot text for the booked variant.
  */
 ---
 
@@ -17,13 +21,13 @@
   <div id="closed-booked" class="ss-closed-card" hidden data-flavor="booked">
     <p class="ss-eyebrow">Confirmed</p>
     <p id="closed-booked-slot" class="ss-headline-sm"></p>
-    <div id="closed-booked-meet-row" class="ss-stack" hidden>
-      <a id="closed-booked-meet-link" href="#" target="_blank" rel="noopener" class="ss-link">
-        Join the call
-      </a>
-    </div>
     <div id="closed-booked-manage-row" class="ss-stack" hidden>
       <a id="closed-booked-manage-link" href="#" class="ss-quiet-link"> Reschedule or cancel </a>
     </div>
+  </div>
+
+  <div id="closed-sent" class="ss-closed-card" hidden data-flavor="sent">
+    <p class="ss-eyebrow">Got it</p>
+    <p class="ss-headline-sm">Thanks for the message.</p>
   </div>
 </section>

--- a/src/components/booking/IntakeIntroCard.astro
+++ b/src/components/booking/IntakeIntroCard.astro
@@ -1,12 +1,15 @@
 ---
 /**
- * V4 /book intro card. Three fields (email, name, message) plus a mic
- * button on the message textarea. Single primary "Pick a time" button.
+ * V4 /book intro card. Four fields (email, name, business, message)
+ * plus a mic button on the message textarea. Two CTAs: primary
+ * "Pick a time" lands on the slot picker; secondary "Just send a
+ * note" submits the message without booking and shows a short
+ * acknowledgment.
  *
  * On submit, the page controller (src/scripts/book.ts) POSTs the form
- * to /api/intake/send and transitions directly to the slot picker
- * state. No chat conversation; AI runs backstage to prepare a brief
- * for the call.
+ * to /api/intake/send. Where it transitions next (slot picker vs sent
+ * confirmation) depends on which button was clicked. AI runs backstage
+ * to prepare a brief for the call.
  *
  * Plainspoken Sign Shop register: cream paper, ink, thick borders,
  * zero radius.
@@ -37,8 +40,9 @@ const INTEREST_LABELS: Record<string, string> = {
 }
 const interestLabel = values.interest ? INTEREST_LABELS[values.interest] : null
 
-// `businessName` is preserved as a hidden field for admin-issued
-// pre-filled links. It is not displayed on the intro card.
+// `businessName` from prefill is rendered as the initial value of the
+// visible Business field so an admin-issued prefill link doesn't ask
+// the user to retype what we already know.
 ---
 
 <section id="intake-intro" class="ss-intro">
@@ -85,6 +89,19 @@ const interestLabel = values.interest ? INTEREST_LABELS[values.interest] : null
     </div>
 
     <div class="ss-field">
+      <label for="intro-business-name" class="ss-field-label">Business</label>
+      <input
+        id="intro-business-name"
+        name="business_name"
+        type="text"
+        autocomplete="organization"
+        required
+        class="ss-input"
+        value={values.businessName ?? ''}
+      />
+    </div>
+
+    <div class="ss-field">
       <label for="intro-message" class="ss-field-label">What is going on?</label>
       <div class="ss-textarea-wrap">
         <textarea
@@ -106,17 +123,12 @@ const interestLabel = values.interest ? INTEREST_LABELS[values.interest] : null
       </div>
     </div>
 
-    {
-      values.businessName && (
-        <input type="hidden" name="business_name" value={values.businessName} />
-      )
-    }
-
     {values.interest && <input type="hidden" name="interest" value={values.interest} />}
 
-    <div id="intro-error" class="ss-error" hidden></div>
+    <div id="intro-error" class="ss-error" aria-live="polite"></div>
 
     <div class="ss-form-actions">
+      <button type="button" id="intro-send-btn" class="ss-quiet-link">Just send a note</button>
       <button type="submit" id="intro-start-btn" class="ss-primary">Pick a time</button>
     </div>
 

--- a/src/pages/api/intake/send.ts
+++ b/src/pages/api/intake/send.ts
@@ -67,6 +67,7 @@ function validateSendBody(body: Record<string, unknown>): ValidatedSendBody | Re
   if (!name) fieldErrors.name = 'Name is required.'
   if (!email) fieldErrors.email = 'Email is required.'
   else if (!isValidEmail(email)) fieldErrors.email = 'Email looks invalid.'
+  if (!businessName) fieldErrors.business_name = 'Business name is required.'
   if (!messageRaw) fieldErrors.message = 'Tell us a bit about the business.'
 
   if (Object.keys(fieldErrors).length > 0) {
@@ -90,17 +91,12 @@ function validateSendBody(body: Record<string, unknown>): ValidatedSendBody | Re
   return {
     name: name!,
     email: email!,
-    businessName: businessName ?? deriveBusinessNameFromEmail(email!),
+    businessName: businessName!,
     phone,
     website: trimString(body.website),
     messageRaw,
     interest,
   }
-}
-
-function deriveBusinessNameFromEmail(email: string): string {
-  const domain = email.split('@')[1] ?? ''
-  return domain || 'Unknown'
 }
 
 async function handlePost({ request, clientAddress, locals }: APIContext): Promise<Response> {

--- a/src/scripts/book-elements.ts
+++ b/src/scripts/book-elements.ts
@@ -15,10 +15,11 @@ export interface BookElements {
   introForm: HTMLFormElement
   introError: HTMLElement
   introStartBtn: HTMLButtonElement
+  introSendBtn: HTMLButtonElement
   introEmail: HTMLInputElement
   introName: HTMLInputElement
+  introBusinessName: HTMLInputElement
   introMessage: HTMLTextAreaElement
-  introBusinessNameHidden: HTMLInputElement | null
   slots: HTMLElement
   slotPicker: HTMLElement & { refetchSlots?: () => void }
   selectedSlotBanner: HTMLElement
@@ -30,10 +31,9 @@ export interface BookElements {
   closed: HTMLElement
   closedBooked: HTMLElement
   closedBookedSlot: HTMLElement
-  closedBookedMeetRow: HTMLElement
-  closedBookedMeetLink: HTMLAnchorElement
   closedBookedManageRow: HTMLElement
   closedBookedManageLink: HTMLAnchorElement
+  closedSent: HTMLElement
   prefillTokenStore: HTMLInputElement | null
 }
 
@@ -47,26 +47,24 @@ interface IntroParts {
   introForm: HTMLFormElement | null
   introError: HTMLElement | null
   introStartBtn: HTMLButtonElement | null
+  introSendBtn: HTMLButtonElement | null
   introEmail: HTMLInputElement | null
   introName: HTMLInputElement | null
+  introBusinessName: HTMLInputElement | null
   introMessage: HTMLTextAreaElement | null
-  introBusinessNameHidden: HTMLInputElement | null
 }
 
 function locateIntroParts(): IntroParts {
-  const introForm = el('intro-form', HTMLFormElement)
-  const introBusinessNameHidden = introForm
-    ? introForm.querySelector<HTMLInputElement>('input[name="business_name"]')
-    : null
   return {
     intro: el('intake-intro', HTMLElement),
-    introForm,
+    introForm: el('intro-form', HTMLFormElement),
     introError: el('intro-error', HTMLElement),
     introStartBtn: el('intro-start-btn', HTMLButtonElement),
+    introSendBtn: el('intro-send-btn', HTMLButtonElement),
     introEmail: el('intro-email', HTMLInputElement),
     introName: el('intro-name', HTMLInputElement),
+    introBusinessName: el('intro-business-name', HTMLInputElement),
     introMessage: el('intro-message', HTMLTextAreaElement),
-    introBusinessNameHidden,
   }
 }
 
@@ -99,10 +97,9 @@ interface ClosedParts {
   closed: HTMLElement | null
   closedBooked: HTMLElement | null
   closedBookedSlot: HTMLElement | null
-  closedBookedMeetRow: HTMLElement | null
-  closedBookedMeetLink: HTMLAnchorElement | null
   closedBookedManageRow: HTMLElement | null
   closedBookedManageLink: HTMLAnchorElement | null
+  closedSent: HTMLElement | null
 }
 
 function locateClosedParts(): ClosedParts {
@@ -110,10 +107,9 @@ function locateClosedParts(): ClosedParts {
     closed: el('intake-closed', HTMLElement),
     closedBooked: el('closed-booked', HTMLElement),
     closedBookedSlot: el('closed-booked-slot', HTMLElement),
-    closedBookedMeetRow: el('closed-booked-meet-row', HTMLElement),
-    closedBookedMeetLink: el('closed-booked-meet-link', HTMLAnchorElement),
     closedBookedManageRow: el('closed-booked-manage-row', HTMLElement),
     closedBookedManageLink: el('closed-booked-manage-link', HTMLAnchorElement),
+    closedSent: el('closed-sent', HTMLElement),
   }
 }
 
@@ -122,8 +118,10 @@ const REQUIRED_KEYS: ReadonlyArray<keyof BookElements> = [
   'introForm',
   'introError',
   'introStartBtn',
+  'introSendBtn',
   'introEmail',
   'introName',
+  'introBusinessName',
   'introMessage',
   'slots',
   'slotPicker',
@@ -136,10 +134,9 @@ const REQUIRED_KEYS: ReadonlyArray<keyof BookElements> = [
   'closed',
   'closedBooked',
   'closedBookedSlot',
-  'closedBookedMeetRow',
-  'closedBookedMeetLink',
   'closedBookedManageRow',
   'closedBookedManageLink',
+  'closedSent',
 ]
 
 export function locateElements(): BookElements | null {

--- a/src/scripts/book-render.ts
+++ b/src/scripts/book-render.ts
@@ -15,6 +15,7 @@ export interface BookState {
   shellState: ShellState
   email: string | null
   name: string | null
+  businessName: string | null
   currentSlot: BookingSlot | null
   slotsFetched: boolean
 }
@@ -37,7 +38,11 @@ export interface BookingResponse {
 // ---------- State transitions ----------
 
 function scrollShellTop(els: BookElements): void {
-  els.shell.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  // Scroll the whole window to the top so the new state's heading
+  // lands below the sticky nav rather than behind it. element.scrollIntoView
+  // doesn't know about the sticky-nav offset; resetting window scroll does.
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+  void els
 }
 
 export function showIntro(els: BookElements, state: BookState): void {
@@ -47,6 +52,7 @@ export function showIntro(els: BookElements, state: BookState): void {
   els.slots.hidden = true
   els.closed.hidden = true
   els.closedBooked.hidden = true
+  els.closedSent.hidden = true
 }
 
 export function showSlots(els: BookElements, state: BookState): void {
@@ -70,16 +76,24 @@ export function showClosedBooked(els: BookElements, state: BookState, body: Book
   els.slots.hidden = true
   els.closed.hidden = false
   els.closedBooked.hidden = false
+  els.closedSent.hidden = true
 
   els.closedBookedSlot.textContent = body.slot_label ?? 'Your call is booked.'
-  if (body.meet_url) {
-    els.closedBookedMeetRow.hidden = false
-    els.closedBookedMeetLink.href = body.meet_url
-  }
   if (body.manage_url) {
     els.closedBookedManageRow.hidden = false
     els.closedBookedManageLink.href = body.manage_url
   }
+  scrollShellTop(els)
+}
+
+export function showClosedSent(els: BookElements, state: BookState): void {
+  state.shellState = 'closed'
+  els.shell.dataset.state = 'closed'
+  els.intro.hidden = true
+  els.slots.hidden = true
+  els.closed.hidden = false
+  els.closedBooked.hidden = true
+  els.closedSent.hidden = false
   scrollShellTop(els)
 }
 
@@ -118,11 +132,12 @@ export function handleSlotSelected(event: Event, els: BookElements, state: BookS
 // ---------- Helpers ----------
 
 export function showIntroError(els: BookElements, message: string): void {
+  // Set textContent without toggling `hidden`; the .ss-error CSS reserves
+  // min-height so showing or clearing the error does not reflow the form
+  // actions row below it.
   els.introError.textContent = message
-  els.introError.hidden = false
 }
 
 export function clearIntroError(els: BookElements): void {
-  els.introError.hidden = true
   els.introError.textContent = ''
 }

--- a/src/scripts/book.ts
+++ b/src/scripts/book.ts
@@ -1,15 +1,20 @@
 /**
  * V4 /book client controller.
  *
- * Three-state shell: intro → slots → closed (booked).
+ * Three-state shell: intro → (slots | sent) → closed.
  *
- *   intro   : IntakeIntroCard form. Submit POSTs /api/intake/send,
- *             which creates the entity and fires backstage enrichment.
- *             On success, transition straight to slots.
+ *   intro   : IntakeIntroCard form. Two CTAs:
+ *               - "Pick a time" submits via /api/intake/send and
+ *                 transitions to the slot picker.
+ *               - "Just send a note" submits via /api/intake/send and
+ *                 transitions straight to the sent acknowledgment.
+ *             Both paths create the entity and fire backstage enrichment.
  *   slots   : IntakeSlots wrapping SlotPicker + selected-slot banner +
  *             confirm button. Pick a time, hit confirm, POST /api/booking/reserve.
- *   closed  : IntakeClosed acknowledgment card showing the booked slot
- *             plus the Google Meet + manage links.
+ *   closed  : IntakeClosed acknowledgment card. Two variants — booked
+ *             (confirmed slot) and sent (message-only path). The Google
+ *             Meet join link is no longer surfaced here; it lives on
+ *             the calendar invite and confirmation email.
  *
  * DOM location lives in book-elements.ts. State transitions and slot-
  * selected handling live in book-render.ts. This file owns network
@@ -21,6 +26,7 @@ import {
   clearIntroError,
   handleSlotSelected,
   showClosedBooked,
+  showClosedSent,
   showIntro,
   showIntroError,
   showSlots,
@@ -36,6 +42,8 @@ interface IntakeSendResponse {
   field_errors?: Record<string, string>
 }
 
+type IntakeIntent = 'book' | 'send'
+
 const RENDERED_AT = Date.now()
 
 // ---------------------------------------------------------------------------
@@ -50,24 +58,23 @@ function readStringField(fd: FormData, key: string): string {
 function readIntroFormPayload(els: BookElements): {
   name: string
   email: string
+  business_name: string
   message: string
-  business_name: string | null
   interest: string | null
 } {
   const fd = new FormData(els.introForm)
-  const business = readStringField(fd, 'business_name')
   const interest = readStringField(fd, 'interest')
   return {
     name: readStringField(fd, 'name'),
     email: readStringField(fd, 'email'),
+    business_name: readStringField(fd, 'business_name'),
     message: readStringField(fd, 'message'),
-    business_name: business.length > 0 ? business : null,
     interest: interest.length > 0 ? interest : null,
   }
 }
 
 // ---------------------------------------------------------------------------
-// Network: Start (POST /api/intake/send) → slot picker
+// Network: submit intake (POST /api/intake/send)
 // ---------------------------------------------------------------------------
 
 function extractSendErrorMessage(res: Response, body: IntakeSendResponse): string {
@@ -80,20 +87,28 @@ function extractSendErrorMessage(res: Response, body: IntakeSendResponse): strin
   return body.message ?? body.error ?? 'Something went wrong. Try again.'
 }
 
-async function handleStart(els: BookElements, state: BookState): Promise<void> {
+async function submitIntake(
+  els: BookElements,
+  state: BookState,
+  intent: IntakeIntent
+): Promise<void> {
   clearIntroError(els)
   const payload = readIntroFormPayload(els)
   const missing: string[] = []
   if (!payload.name) missing.push('name')
   if (!payload.email) missing.push('email')
+  if (!payload.business_name) missing.push('business')
   if (!payload.message) missing.push('a message')
   if (missing.length > 0) {
     showIntroError(els, `Please add ${missing.join(', ')}.`)
     return
   }
 
+  const activeBtn = intent === 'book' ? els.introStartBtn : els.introSendBtn
+  const originalLabel = activeBtn.textContent
   els.introStartBtn.disabled = true
-  els.introStartBtn.textContent = 'Loading...'
+  els.introSendBtn.disabled = true
+  activeBtn.textContent = intent === 'book' ? 'Loading...' : 'Sending...'
 
   try {
     const res = await fetch('/api/intake/send', {
@@ -106,18 +121,25 @@ async function handleStart(els: BookElements, state: BookState): Promise<void> {
     if (!res.ok || !body.ok) {
       showIntroError(els, extractSendErrorMessage(res, body))
       els.introStartBtn.disabled = false
-      els.introStartBtn.textContent = 'Pick a time'
+      els.introSendBtn.disabled = false
+      activeBtn.textContent = originalLabel
       return
     }
 
     state.email = payload.email
     state.name = payload.name
-    showSlots(els, state)
+    state.businessName = payload.business_name
+    if (intent === 'book') {
+      showSlots(els, state)
+    } else {
+      showClosedSent(els, state)
+    }
   } catch (err) {
     console.error('[book] /api/intake/send error:', err)
     showIntroError(els, 'Could not reach the server. Check your connection and try again.')
     els.introStartBtn.disabled = false
-    els.introStartBtn.textContent = 'Pick a time'
+    els.introSendBtn.disabled = false
+    activeBtn.textContent = originalLabel
   }
 }
 
@@ -126,7 +148,7 @@ async function handleStart(els: BookElements, state: BookState): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleConfirmSlot(els: BookElements, state: BookState): Promise<void> {
-  if (!state.currentSlot || !state.email || !state.name) return
+  if (!state.currentSlot || !state.email || !state.name || !state.businessName) return
 
   els.confirmSlotBtn.disabled = true
   const originalText = els.confirmSlotBtn.textContent
@@ -137,7 +159,7 @@ async function handleConfirmSlot(els: BookElements, state: BookState): Promise<v
   const payload: Record<string, unknown> = {
     name: state.name,
     email: state.email,
-    business_name: els.introBusinessNameHidden?.value ?? '',
+    business_name: state.businessName,
     slot_start_utc: state.currentSlot.start_utc,
     timezone: state.currentSlot.timezone,
   }
@@ -196,7 +218,10 @@ async function handleConfirmSlot(els: BookElements, state: BookState): Promise<v
 function bindIntro(els: BookElements, state: BookState): void {
   els.introForm.addEventListener('submit', (e) => {
     e.preventDefault()
-    void handleStart(els, state)
+    void submitIntake(els, state, 'book')
+  })
+  els.introSendBtn.addEventListener('click', () => {
+    void submitIntake(els, state, 'send')
   })
 }
 
@@ -219,6 +244,7 @@ function bindSlots(els: BookElements, state: BookState): void {
     shellState: 'intro',
     email: null,
     name: null,
+    businessName: null,
     currentSlot: null,
     slotsFetched: false,
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -298,6 +298,7 @@
 .ss-error {
   color: var(--ss-color-error, #7c1d1d);
   font-size: 0.8125rem;
+  min-height: 1.25rem;
 }
 
 .ss-quiet-link {


### PR DESCRIPTION
## Summary

Polish pass on the V4 /book flow. Five fixes from Captain's audit:

1. **Error doesn't bounce the button anymore.** Reserved \`min-height\` on \`.ss-error\` so the form-actions row holds steady whether the error is empty or populated. Stopped toggling \`hidden\` on intro-error — just clearing textContent now.

2. **Business name is captured explicitly.** New Business field on the intro form, required both client- and server-side. \`/api/intake/send\` no longer derives \`business_name\` from the email domain — Captain flagged that as unnecessary risk. Admin prefill-token flow continues to work unchanged via \`PreSeededIntake\`.

3. **Get in touch without booking is possible again.** Secondary "Just send a note" link next to "Pick a time". Both submit the same payload to \`/api/intake/send\`; the client decides whether to transition to the slot picker (book) or to a sent-acknowledgment closed state (send). Restored \`closed-sent\` variant in \`IntakeClosed\`.

4. **Confirmation no longer scrolls behind the nav.** Switched \`scrollShellTop\` from \`element.scrollIntoView\` (which doesn't know about the sticky-nav offset) to \`window.scrollTo({ top: 0 })\`. The new state's heading lands cleanly below the nav on every transition.

5. **"Join the call" link removed from the confirmation.** Useless — the call is a future event, the join URL belongs on the calendar invite and email where it surfaces at the right time. Dropped \`closed-booked-meet-row\` from \`IntakeClosed\` and from \`book-elements\` / \`book-render\`.

## Test plan
- [x] \`npm run verify\` clean (typecheck + format:check + lint + build + test + test:workers, 2426 tests pass)
- [x] Visual: \`/book?interest=ai-employee\` renders with Business field + dual CTAs
- [ ] End-to-end on production after merge: submit "Pick a time" → calendar confirms cleanly; submit "Just send a note" → sent acknowledgment appears with no fabricated follow-up promise

🤖 Generated with [Claude Code](https://claude.com/claude-code)