### PR TITLE
fix(book): drop Intake eyebrow, allow booking from sent state, surface reschedule in invite

### DIFF
--- a/src/components/booking/IntakeClosed.astro
+++ b/src/components/booking/IntakeClosed.astro
@@ -29,5 +29,11 @@
   <div id="closed-sent" class="ss-closed-card" hidden data-flavor="sent">
     <p class="ss-eyebrow">Got it</p>
     <p class="ss-headline-sm">Thanks for the message.</p>
+    <p class="ss-lede mt-stack">
+      Want to put time on the calendar too? We already have your details.
+    </p>
+    <button type="button" id="closed-sent-book-btn" class="ss-primary mt-stack">
+      Pick a time to talk
+    </button>
   </div>
 </section>

--- a/src/components/booking/IntakeIntroCard.astro
+++ b/src/components/booking/IntakeIntroCard.astro
@@ -48,13 +48,11 @@ const interestLabel = values.interest ? INTEREST_LABELS[values.interest] : null
 <section id="intake-intro" class="ss-intro">
   <header class="mb-stack">
     {
-      interestLabel ? (
+      interestLabel && (
         <p class="ss-intent-chip">
           <span class="ss-intent-chip-label">Inquiring about</span>
           <span class="ss-intent-chip-value">{interestLabel}</span>
         </p>
-      ) : (
-        <p class="ss-eyebrow">Intake</p>
       )
     }
     <h1 class="ss-headline">Tell us about the business.</h1>

--- a/src/pages/api/booking/reserve-helpers.ts
+++ b/src/pages/api/booking/reserve-helpers.ts
@@ -75,11 +75,15 @@ export function buildEventDescription(
   name: string,
   email: string,
   businessName: string,
-  intakeLines: string[]
+  intakeLines: string[],
+  manageUrl?: string
 ): string {
   const lines = [`Guest: ${name} <${email}>`, `Business: ${businessName}`]
   if (intakeLines.length > 0) {
     lines.push('', '--- Intake ---', ...intakeLines)
+  }
+  if (manageUrl) {
+    lines.push('', `Reschedule or cancel: ${manageUrl}`)
   }
   return lines.join('\n')
 }

--- a/src/pages/api/booking/reserve.ts
+++ b/src/pages/api/booking/reserve.ts
@@ -327,10 +327,11 @@ interface GoogleSyncArgs {
   dbResult: DbCommitResult
   holdId: string
   preSeeded: PreSeededIntake | null
+  manageUrl: string
 }
 
 async function syncGoogleCalendarAndPromote(args: GoogleSyncArgs): Promise<string | Response> {
-  const { accessToken, calendarId, input, dbResult, holdId, preSeeded } = args
+  const { accessToken, calendarId, input, dbResult, holdId, preSeeded, manageUrl } = args
   const { name, email, businessName, slotStartUtc, slotEndUtc } = input
   // prettier-ignore
   const { assessmentId, meetingId, entityId, scheduleId, meetingScheduleId, entityCreated, contactCreated, contactId, contextId, previousAssessmentScheduledAt, previousMeetingScheduledAt } = dbResult
@@ -340,7 +341,13 @@ async function syncGoogleCalendarAndPromote(args: GoogleSyncArgs): Promise<strin
   try {
     const eventResult = await createGoogleCalendarEvent(accessToken, calendarId, {
       summary: `Assessment: ${businessName} (${name})`,
-      description: buildEventDescription(name, email, businessName, dbResult.intakeLines),
+      description: buildEventDescription(
+        name,
+        email,
+        businessName,
+        dbResult.intakeLines,
+        manageUrl
+      ),
       startUtc: slotStartUtc,
       endUtc: slotEndUtc,
       guestEmail: email,
@@ -535,6 +542,17 @@ async function handlePost({ request }: APIContext): Promise<Response> {
     return jsonResponse(500, { error: 'Internal server error' })
   }
 
+  // Build the manage URL once, up front, so we can thread it through the
+  // calendar event description (where reschedule needs to be findable from
+  // the calendar app, not just the confirmation email).
+  let appBaseUrl: string
+  try {
+    appBaseUrl = requireAppBaseUrl(env)
+  } catch {
+    appBaseUrl = 'https://smd.services'
+  }
+  const manageUrl = `${appBaseUrl}/book/manage?token=${dbResult.manageToken}`
+
   // Phase 3: Google Calendar sync + entity stage promotion
   const calendarId = integration.calendar_id || BOOKING_CONFIG.consultant.calendar_id
   const googleSyncResult = await syncGoogleCalendarAndPromote({
@@ -544,6 +562,7 @@ async function handlePost({ request }: APIContext): Promise<Response> {
     dbResult,
     holdId: holdResult.id!,
     preSeeded,
+    manageUrl,
   })
   if (googleSyncResult instanceof Response) return googleSyncResult
   const googleMeetUrl = googleSyncResult
@@ -552,16 +571,8 @@ async function handlePost({ request }: APIContext): Promise<Response> {
   await releaseHold(env.DB, holdResult.id!)
 
   const { slotStartUtc, slotEndUtc, guestTimezone } = validated
-  const { assessmentId, meetingId, scheduleId, meetingScheduleId, manageToken } = dbResult
+  const { assessmentId, meetingId, scheduleId, meetingScheduleId } = dbResult
   const displayTz = guestTimezone || BOOKING_CONFIG.consultant.timezone
-
-  let appBaseUrl: string
-  try {
-    appBaseUrl = requireAppBaseUrl(env)
-  } catch {
-    appBaseUrl = 'https://smd.services'
-  }
-  const manageUrl = `${appBaseUrl}/book/manage?token=${manageToken}`
 
   // Phase 4: Confirmation emails (best-effort)
   await sendConfirmationEmails({ input: validated, dbResult, googleMeetUrl, manageUrl })

--- a/src/scripts/book-elements.ts
+++ b/src/scripts/book-elements.ts
@@ -34,6 +34,7 @@ export interface BookElements {
   closedBookedManageRow: HTMLElement
   closedBookedManageLink: HTMLAnchorElement
   closedSent: HTMLElement
+  closedSentBookBtn: HTMLButtonElement
   prefillTokenStore: HTMLInputElement | null
 }
 
@@ -100,6 +101,7 @@ interface ClosedParts {
   closedBookedManageRow: HTMLElement | null
   closedBookedManageLink: HTMLAnchorElement | null
   closedSent: HTMLElement | null
+  closedSentBookBtn: HTMLButtonElement | null
 }
 
 function locateClosedParts(): ClosedParts {
@@ -110,6 +112,7 @@ function locateClosedParts(): ClosedParts {
     closedBookedManageRow: el('closed-booked-manage-row', HTMLElement),
     closedBookedManageLink: el('closed-booked-manage-link', HTMLAnchorElement),
     closedSent: el('closed-sent', HTMLElement),
+    closedSentBookBtn: el('closed-sent-book-btn', HTMLButtonElement),
   }
 }
 
@@ -137,6 +140,7 @@ const REQUIRED_KEYS: ReadonlyArray<keyof BookElements> = [
   'closedBookedManageRow',
   'closedBookedManageLink',
   'closedSent',
+  'closedSentBookBtn',
 ]
 
 export function locateElements(): BookElements | null {

--- a/src/scripts/book.ts
+++ b/src/scripts/book.ts
@@ -237,6 +237,15 @@ function bindSlots(els: BookElements, state: BookState): void {
   })
 }
 
+function bindClosedSent(els: BookElements, state: BookState): void {
+  // After "Just send a note" lands in the sent state, give the prospect
+  // a way to pick a time without re-entering identity. State already
+  // carries name/email/businessName from the intake submission.
+  els.closedSentBookBtn.addEventListener('click', () => {
+    showSlots(els, state)
+  })
+}
+
 ;(() => {
   const els = locateElements()
   if (!els) return
@@ -251,6 +260,7 @@ function bindSlots(els: BookElements, state: BookState): void {
   showIntro(els, state)
   bindIntro(els, state)
   bindSlots(els, state)
+  bindClosedSent(els, state)
 })()
 
 export {}


### PR DESCRIPTION
## Summary

Three more polish items from Captain's audit on the V4 /book flow.

1. **"Intake" eyebrow removed.** When no marketing interest is set, the form now goes straight from headline to body — no "INTAKE" jargon. The interest chip ("Inquiring about: AI Employee") still renders when a productized SKU is in the URL.

2. **"Just send a note" no longer dead-ends.** The closed-sent variant gets a "Pick a time to talk" CTA that transitions back into the slot picker, reusing the in-memory state. The prospect doesn't have to re-enter email/name/business — we already have it from the intake submission.

3. **Reschedule findable from the calendar event.** Added the manage URL to the Google Calendar event description via \`buildEventDescription\`. Previously it was only in the confirmation email body — Captain reported never having seen it. Now it's surfaced anywhere the calendar event is rendered (Gmail event view, Google Calendar mobile, etc.).

## Out of scope

The \`/book/manage\` page has a different visual register than the V4 intake (different inputs, different button styling, different layout). Bringing it in line with the Plainspoken treatment is a real chunk of work and lives in a follow-up PR. The reschedule action *works*; it just doesn't *look* consistent.

## Test plan
- [x] \`npm run verify\` clean
- [x] Visual: \`/book\` (no interest) renders without "INTAKE" eyebrow
- [x] Visual: \`/book?interest=ai-employee\` still renders the chip
- [x] Visual: closed-sent state shows "Pick a time to talk" button
- [ ] End-to-end on production: submit "Just send a note", verify the post-sent CTA transitions to the slot picker with name/email/business prefilled in state
- [ ] End-to-end on production: book a slot, open the resulting Google Calendar invite event, confirm the description has \`Reschedule or cancel: …\` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)