### PR TITLE
fix(book): rewrite /book/manage in Plainspoken + SlotPicker

### DIFF
--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -1,9 +1,37 @@
 ---
+/**
+ * /book/manage/[token] — Guest-facing manage UI for a booked call.
+ *
+ * Authenticated by the raw manage token in the URL — no session needed.
+ * Hydrates against GET /api/booking/manage/[token], drives reschedule
+ * and cancel flows against the matching POST endpoints.
+ *
+ * Visible shell follows the same Plainspoken three-state pattern as
+ * /book: a single section frame with multiple sibling state blocks,
+ * one visible at a time. Five states:
+ *
+ *   loading     : initial fetch in progress.
+ *   details     : current booking + Reschedule / Cancel actions.
+ *   reschedule  : SlotPicker + selected-slot banner + Confirm.
+ *                 Same component, same shape as /book — so the
+ *                 reschedule calendar matches the original calendar.
+ *   cancel      : inline reason textarea + Confirm/Keep.
+ *   result      : terminal acknowledgment (success after reschedule,
+ *                 success after cancel, or a fatal load error —
+ *                 not_found / expired / network). Configurable copy.
+ *
+ * Previous bespoke implementation (Tailwind rounded tiles, native
+ * confirm()/alert() dialogs, modal cancel dialog, SVG icons) replaced
+ * here. The script logic for cancel and reschedule API calls is
+ * preserved; only the UI was non-conforming.
+ */
+
 export const prerender = false
 
 import Base from '../../../layouts/Base.astro'
 import Nav from '../../../components/Nav.astro'
 import Footer from '../../../components/Footer.astro'
+import SlotPicker from '../../../components/booking/SlotPicker.astro'
 ---
 
 <Base
@@ -13,264 +41,105 @@ import Footer from '../../../components/Footer.astro'
 >
   <Nav />
   <main id="main" role="main">
-    <section class="bg-[color:var(--ss-color-background)] px-6 py-16 sm:py-24">
-      <div class="mx-auto max-w-2xl">
-        <!-- Loading state -->
-        <div id="loading" class="text-center">
-          <div
-            class="mx-auto h-8 w-8 animate-spin rounded-[var(--ss-radius-card)] border-4 border-[color:var(--ss-color-border)] border-t-primary"
-          >
-          </div>
-          <p class="mt-4 text-sm text-[color:var(--ss-color-text-secondary)]">
-            Loading your booking...
-          </p>
-        </div>
+    <section class="ss-section">
+      <div id="manage-shell" class="ss-book-frame" data-state="loading">
+        <section id="manage-loading" class="ss-loading">
+          <p class="ss-lede">Loading your booking...</p>
+        </section>
 
-        <!-- Error state -->
-        <div id="error-state" class="hidden text-center">
-          <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-error)]/10"
-          >
-            <svg
-              class="h-8 w-8 text-[color:var(--ss-color-error)]"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-              stroke="currentColor"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"></path>
-            </svg>
-          </div>
-          <h1
-            class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]"
-            id="error-title"
-          >
-            Something went wrong
-          </h1>
-          <p class="mt-3 text-[color:var(--ss-color-text-secondary)]" id="error-message">
-            Please try again or contact us directly.
-          </p>
-          <a
-            href="/book"
-            class="mt-6 inline-block rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
-          >
-            Book a new time
-          </a>
-        </div>
+        <section id="manage-details" class="ss-closed-card" hidden>
+          <header class="mb-stack">
+            <p class="ss-eyebrow">Confirmed</p>
+            <h1 id="details-slot" class="ss-headline-sm"></h1>
+            <p id="details-meeting-label" class="ss-lede mt-row"></p>
+          </header>
 
-        <!-- Cancelled state -->
-        <div id="cancelled-state" class="hidden text-center">
-          <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-border-subtle)]"
-          >
-            <svg
-              class="h-8 w-8 text-[color:var(--ss-color-text-muted)]"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-              stroke="currentColor"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-          </div>
-          <h1 class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
-            This booking was cancelled
-          </h1>
-          <p class="mt-3 text-[color:var(--ss-color-text-secondary)]">
-            Whenever you're ready, you can book a new time.
-          </p>
-          <a
-            href="/book"
-            class="mt-6 inline-block rounded-[var(--ss-radius-card)] bg-primary px-6 py-3 text-sm font-medium text-white hover:bg-primary/90"
-          >
-            Book a new time
-          </a>
-        </div>
-
-        <!-- Booking details -->
-        <div id="booking-details" class="hidden">
-          <div class="text-center">
-            <div
-              class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-primary)]/10"
-            >
-              <svg
-                class="h-8 w-8 text-[color:var(--ss-color-primary)]"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="2"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
-                ></path>
-              </svg>
+          <dl class="ss-detail-list">
+            <div>
+              <dt class="ss-eyebrow">Guest</dt>
+              <dd id="details-guest" class="ss-detail-value"></dd>
             </div>
-            <h1 class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
-              Your Booking
-            </h1>
-            <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]" id="meeting-label">
-            </p>
-          </div>
-
-          <div class="mt-8 rounded-[var(--ss-radius-card)] bg-white p-card">
-            <div class="space-y-stack">
-              <div>
-                <p
-                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)]"
-                >
-                  When
-                </p>
-                <p
-                  class="mt-1 text-lg font-semibold text-[color:var(--ss-color-text-primary)]"
-                  id="slot-label"
-                >
-                </p>
-              </div>
-              <div>
-                <p
-                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)]"
-                >
-                  Guest
-                </p>
-                <p class="mt-1 text-[color:var(--ss-color-text-primary)]" id="guest-name"></p>
-              </div>
-              <div id="meet-link-container" class="hidden">
-                <p
-                  class="text-xs font-medium uppercase tracking-wide text-[color:var(--ss-color-text-muted)]"
-                >
-                  Video call
-                </p>
+            <div id="details-meet-row" hidden>
+              <dt class="ss-eyebrow">Video call</dt>
+              <dd class="ss-detail-value">
                 <a
-                  id="meet-link"
-                  href=""
-                  class="mt-1 inline-block text-sm text-[color:var(--ss-color-primary)] hover:text-blue-800"
+                  id="details-meet-link"
+                  href="#"
+                  class="ss-quiet-link"
                   target="_blank"
                   rel="noopener"></a>
-              </div>
+              </dd>
             </div>
+          </dl>
 
-            <div class="mt-8 flex flex-col gap-row sm:flex-row">
-              <button
-                id="reschedule-btn"
-                class="flex-1 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--ss-color-text-primary)] transition-colors hover:bg-[color:var(--ss-color-background)]"
-              >
-                Reschedule
-              </button>
-              <button
-                id="cancel-btn"
-                class="flex-1 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)]/30 bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--ss-color-error)] transition-colors hover:bg-[color:var(--ss-color-error)]/5"
-              >
-                Cancel Booking
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Reschedule panel -->
-        <div id="reschedule-panel" class="hidden">
-          <div class="text-center">
-            <h2 class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
-              Pick a new time
-            </h2>
-            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
-              Choose an available slot below.
-            </p>
-          </div>
-
-          <div id="slots-loading" class="mt-8 text-center">
-            <div
-              class="mx-auto h-6 w-6 animate-spin rounded-[var(--ss-radius-card)] border-4 border-[color:var(--ss-color-border)] border-t-primary"
-            >
-            </div>
-            <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
-              Loading available times...
-            </p>
-          </div>
-
-          <div id="slots-container" class="mt-8 hidden space-y-card"></div>
-
-          <div id="slots-empty" class="mt-8 hidden text-center">
-            <p class="text-[color:var(--ss-color-text-secondary)]">
-              No available times found. Please check back later or contact us.
-            </p>
-          </div>
-
-          <div class="mt-6 text-center">
-            <button
-              id="back-to-details-btn"
-              class="text-sm text-[color:var(--ss-color-text-secondary)] hover:text-[color:var(--ss-color-text-primary)]"
-            >
-              Back to booking details
+          <div class="ss-form-actions mt-stack">
+            <button type="button" id="details-cancel-btn" class="ss-quiet-link">
+              Cancel booking
+            </button>
+            <button type="button" id="details-reschedule-btn" class="ss-primary">
+              Reschedule
             </button>
           </div>
-        </div>
+        </section>
 
-        <!-- Cancel dialog -->
-        <div
-          id="cancel-dialog"
-          class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50 p-stack"
-        >
-          <div class="w-full max-w-md rounded-[var(--ss-radius-card)] bg-white p-card">
-            <h3 class="text-lg font-bold text-[color:var(--ss-color-text-primary)]">
-              Cancel your booking?
-            </h3>
-            <p class="mt-2 text-sm text-[color:var(--ss-color-text-secondary)]">
-              This will cancel your assessment call. You can always book a new time later.
+        <section id="manage-reschedule" class="ss-slots" hidden>
+          <header class="mb-stack">
+            <p class="ss-eyebrow">Pick a new time</p>
+            <h2 class="ss-headline">When works instead?</h2>
+            <p class="ss-lede">
+              Currently booked for <span id="reschedule-current"></span>.
             </p>
-            <div class="mt-4">
-              <label
-                for="cancel-reason"
-                class="block text-sm font-medium text-[color:var(--ss-color-text-primary)]"
-                >Reason (optional)</label
-              >
-              <textarea
-                id="cancel-reason"
-                rows="2"
-                class="mt-1 w-full rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] focus:border-primary focus:ring-1 focus:ring-primary"
-                placeholder="Let us know why you're cancelling..."></textarea>
-            </div>
-            <div class="mt-6 flex gap-row">
-              <button
-                id="cancel-dialog-dismiss"
-                class="flex-1 rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-4 py-2.5 text-sm font-medium text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-background)]"
-                >Keep Booking</button
-              >
-              <button
-                id="cancel-dialog-confirm"
-                class="flex-1 rounded-[var(--ss-radius-card)] bg-red-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-red-700"
-                >Yes, Cancel</button
-              >
-            </div>
-          </div>
-        </div>
+          </header>
 
-        <!-- Success state -->
-        <div id="success-state" class="hidden text-center">
-          <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-[var(--ss-radius-card)] bg-[color:var(--ss-color-complete)]/10"
-          >
-            <svg
-              class="h-8 w-8 text-[color:var(--ss-color-complete)]"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-              stroke="currentColor"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path>
-            </svg>
+          <SlotPicker />
+
+          <div id="reschedule-selected" class="ss-selected-slot" hidden>
+            <span id="reschedule-selected-text"></span>
+            <button type="button" id="reschedule-change-btn" class="ss-quiet-link">Change</button>
           </div>
-          <h1
-            class="mt-6 text-2xl font-bold text-[color:var(--ss-color-text-primary)]"
-            id="success-title"
-          >
-          </h1>
-          <p class="mt-3 text-[color:var(--ss-color-text-secondary)]" id="success-message"></p>
-        </div>
+
+          <div id="reschedule-error" class="ss-error mt-row" hidden></div>
+
+          <div class="ss-form-actions mt-stack">
+            <button type="button" id="reschedule-back-btn" class="ss-quiet-link">Back</button>
+            <button id="reschedule-confirm-btn" type="button" disabled class="ss-primary">
+              Confirm new time
+            </button>
+          </div>
+        </section>
+
+        <section id="manage-cancel" class="ss-intro" hidden>
+          <header class="mb-stack">
+            <p class="ss-eyebrow">Cancel</p>
+            <h2 class="ss-headline">Cancel your call?</h2>
+            <p class="ss-lede">You can book a new time later if you change your mind.</p>
+          </header>
+
+          <div class="ss-field">
+            <label for="cancel-reason" class="ss-field-label">Reason (optional)</label>
+            <div class="ss-textarea-wrap">
+              <textarea id="cancel-reason" rows="3" class="ss-textarea"></textarea>
+            </div>
+          </div>
+
+          <div id="cancel-error" class="ss-error mt-row" hidden></div>
+
+          <div class="ss-form-actions mt-stack">
+            <button type="button" id="cancel-back-btn" class="ss-quiet-link">
+              Keep my booking
+            </button>
+            <button id="cancel-confirm-btn" type="button" class="ss-primary">Cancel call</button>
+          </div>
+        </section>
+
+        <section id="manage-result" class="ss-closed-card" hidden>
+          <p id="result-eyebrow" class="ss-eyebrow"></p>
+          <h1 id="result-headline" class="ss-headline-sm"></h1>
+          <p id="result-message" class="ss-lede mt-row"></p>
+          <div id="result-cta-row" class="mt-stack" hidden>
+            <a id="result-cta" href="/book" class="ss-primary">Book a new time</a>
+          </div>
+        </section>
       </div>
     </section>
   </main>
@@ -280,217 +149,264 @@ import Footer from '../../../components/Footer.astro'
     const token =
       new URLSearchParams(window.location.search).get('token') ||
       window.location.pathname.split('/').pop()
-    if (!token) {
-      showError('Invalid link', 'This booking link appears to be broken.')
-    } else {
-      loadBooking(token)
-    }
 
     let bookingData = null
+    let currentSlot = null
 
-    async function loadBooking(tkn) {
+    const STATES = ['loading', 'details', 'reschedule', 'cancel', 'result']
+
+    function setState(next) {
+      const shell = document.getElementById('manage-shell')
+      shell.dataset.state = next
+      STATES.forEach(function (s) {
+        const el = document.getElementById('manage-' + s)
+        if (el) el.hidden = s !== next
+      })
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+
+    function showResult(eyebrow, headline, message, opts) {
+      document.getElementById('result-eyebrow').textContent = eyebrow
+      document.getElementById('result-headline').textContent = headline
+      document.getElementById('result-message').textContent = message
+      const ctaRow = document.getElementById('result-cta-row')
+      const hideCta = opts && opts.hideCta === true
+      ctaRow.hidden = hideCta
+      setState('result')
+    }
+
+    function setError(id, message) {
+      const el = document.getElementById(id)
+      el.textContent = message
+      el.hidden = false
+    }
+
+    async function loadBooking() {
+      if (!token) {
+        showResult(
+          'Invalid link',
+          'This booking link looks broken.',
+          'Check the link in your confirmation email.'
+        )
+        return
+      }
       try {
-        const res = await fetch('/api/booking/manage/' + tkn)
+        const res = await fetch('/api/booking/manage/' + token)
         const data = await res.json()
-
-        hide('loading')
         if (res.status === 404) {
-          showError('Booking not found', data.message || 'This link is not valid.')
+          showResult('Not found', 'Booking not found.', data.message || 'This link is not valid.')
           return
         }
         if (res.status === 410) {
-          showError('Link expired', data.message || 'This manage link has expired.')
+          showResult(
+            'Expired',
+            'This link has expired.',
+            data.message || 'Please contact us if you need to make changes.'
+          )
           return
         }
         if (res.status >= 400) {
-          showError('Something went wrong', data.message || 'Please try again.')
+          showResult(
+            'Something went wrong',
+            'We could not load your booking.',
+            data.message || 'Please try again.'
+          )
           return
         }
-
         bookingData = data
-        if (bookingData.cancelled_at) {
-          show('cancelled-state')
+        if (data.cancelled_at) {
+          showResult(
+            'Cancelled',
+            'This booking was cancelled.',
+            'You can book a new time whenever you are ready.'
+          )
           return
         }
-
-        document.getElementById('meeting-label').textContent = bookingData.meeting_label
-        document.getElementById('slot-label').textContent = bookingData.slot_label
-        document.getElementById('guest-name').textContent = bookingData.guest_name
-        if (bookingData.google_meet_url) {
-          const ml = document.getElementById('meet-link')
-          ml.href = bookingData.google_meet_url
-          ml.textContent = bookingData.google_meet_url
-          show('meet-link-container')
+        document.getElementById('details-slot').textContent = data.slot_label
+        document.getElementById('details-meeting-label').textContent = data.meeting_label
+        document.getElementById('details-guest').textContent = data.guest_name
+        if (data.google_meet_url) {
+          const link = document.getElementById('details-meet-link')
+          link.href = data.google_meet_url
+          link.textContent = 'Open meeting link'
+          document.getElementById('details-meet-row').hidden = false
         }
-        show('booking-details')
-      } catch {
-        hide('loading')
-        showError('Something went wrong', "We couldn't load your booking. Please try again.")
+        setState('details')
+      } catch (err) {
+        showResult(
+          'Something went wrong',
+          'We could not load your booking.',
+          'Check your connection and try again.'
+        )
       }
     }
 
-    document.getElementById('cancel-btn').addEventListener('click', function () {
-      const d = document.getElementById('cancel-dialog')
-      d.classList.remove('hidden')
-      d.classList.add('flex')
+    // ---------- Reschedule ----------
+
+    document.getElementById('details-reschedule-btn').addEventListener('click', function () {
+      if (!bookingData) return
+      document.getElementById('reschedule-current').textContent = bookingData.slot_label
+      setState('reschedule')
     })
-    document.getElementById('cancel-dialog-dismiss').addEventListener('click', function () {
-      const d = document.getElementById('cancel-dialog')
-      d.classList.add('hidden')
-      d.classList.remove('flex')
+
+    document.getElementById('reschedule-back-btn').addEventListener('click', function () {
+      currentSlot = null
+      document.getElementById('reschedule-selected').hidden = true
+      const confirmBtn = document.getElementById('reschedule-confirm-btn')
+      confirmBtn.disabled = true
+      confirmBtn.textContent = 'Confirm new time'
+      document.getElementById('reschedule-error').hidden = true
+      setState('details')
     })
-    document.getElementById('cancel-dialog-confirm').addEventListener('click', function () {
-      const btn = document.getElementById('cancel-dialog-confirm')
+
+    document.getElementById('slot-picker').addEventListener('slot-selected', function (event) {
+      currentSlot = event.detail
+      if (!currentSlot) return
+      const d = new Date(currentSlot.start_utc)
+      const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+      const months = [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ]
+      document.getElementById('reschedule-selected-text').textContent =
+        days[d.getDay()] +
+        ', ' +
+        months[d.getMonth()] +
+        ' ' +
+        d.getDate() +
+        ' at ' +
+        currentSlot.label
+      document.getElementById('reschedule-selected').hidden = false
+      document.getElementById('reschedule-error').hidden = true
+      const confirmBtn = document.getElementById('reschedule-confirm-btn')
+      confirmBtn.disabled = false
+      confirmBtn.textContent = 'Confirm ' + currentSlot.label
+      confirmBtn.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    })
+
+    document.getElementById('reschedule-change-btn').addEventListener('click', function () {
+      document.getElementById('slot-picker').scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+
+    document.getElementById('reschedule-confirm-btn').addEventListener('click', async function () {
+      if (!currentSlot) return
+      const btn = document.getElementById('reschedule-confirm-btn')
+      const orig = btn.textContent
       btn.disabled = true
-      btn.textContent = 'Cancelling...'
-      const reason = document.getElementById('cancel-reason').value.trim()
-      fetch('/api/booking/manage/' + token + '/cancel', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: reason ? JSON.stringify({ reason: reason }) : '{}',
-      })
-        .then(function (r) {
-          return r.json()
-        })
-        .then(function (d) {
-          if (d.ok) {
-            hide('cancel-dialog')
-            hide('booking-details')
-            showSuccess(
-              'Booking cancelled',
-              "Your assessment call has been cancelled. We'll send a confirmation email shortly."
-            )
-          } else {
-            btn.disabled = false
-            btn.textContent = 'Yes, Cancel'
-            alert(d.message || 'Failed to cancel.')
-          }
-        })
-        .catch(function () {
-          btn.disabled = false
-          btn.textContent = 'Yes, Cancel'
-          alert('Something went wrong.')
-        })
-    })
-
-    document.getElementById('reschedule-btn').addEventListener('click', function () {
-      hide('booking-details')
-      show('reschedule-panel')
-      loadSlots()
-    })
-    document.getElementById('back-to-details-btn').addEventListener('click', function () {
-      hide('reschedule-panel')
-      show('booking-details')
-    })
-
-    function loadSlots() {
-      show('slots-loading')
-      hide('slots-container')
-      hide('slots-empty')
-      const tz = bookingData.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
-      fetch('/api/booking/slots?tz=' + encodeURIComponent(tz))
-        .then(function (r) {
-          return r.json()
-        })
-        .then(function (data) {
-          hide('slots-loading')
-          if (!data.days || data.days.length === 0) {
-            show('slots-empty')
-            return
-          }
-          const c = document.getElementById('slots-container')
-          c.innerHTML = ''
-          data.days.forEach(function (day) {
-            const div = document.createElement('div')
-            const dateObj = new Date(day.date + 'T12:00:00')
-            const lbl = dateObj.toLocaleDateString('en-US', {
-              weekday: 'long',
-              month: 'long',
-              day: 'numeric',
-            })
-            const h = document.createElement('h3')
-            h.className = 'text-sm font-semibold text-[color:var(--ss-color-text-primary)]'
-            h.textContent = lbl
-            div.appendChild(h)
-            const g = document.createElement('div')
-            g.className = 'mt-2 grid grid-cols-3 gap-2 sm:grid-cols-4'
-            day.slots.forEach(function (slot) {
-              const b = document.createElement('button')
-              b.className =
-                'rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] bg-white px-3 py-2 text-sm text-[color:var(--ss-color-text-primary)] transition-colors hover:border-primary hover:bg-primary/5 hover:text-primary'
-              b.textContent = slot.label
-              b.dataset.startUtc = slot.start_utc
-              b.addEventListener('click', function () {
-                confirmReschedule(slot.start_utc, slot.label, lbl)
-              })
-              g.appendChild(b)
-            })
-            div.appendChild(g)
-            c.appendChild(div)
-          })
-          show('slots-container')
-        })
-        .catch(function () {
-          hide('slots-loading')
-          show('slots-empty')
-        })
-    }
-
-    async function confirmReschedule(startUtc, timeLabel, dayLabel) {
-      if (!confirm('Reschedule to ' + dayLabel + ' at ' + timeLabel + '?')) return
-      const btns = document.querySelectorAll('#slots-container button')
-      btns.forEach(function (b) {
-        b.disabled = true
-        b.classList.add('opacity-50')
-      })
+      btn.textContent = 'Rescheduling...'
       try {
-        const r = await fetch('/api/booking/manage/' + token + '/reschedule', {
+        const res = await fetch('/api/booking/manage/' + token + '/reschedule', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ slot_start_utc: startUtc }),
+          body: JSON.stringify({ slot_start_utc: currentSlot.start_utc }),
         })
-        const data = await r.json()
+        const data = await res.json()
         if (data.ok) {
-          hide('reschedule-panel')
-          showSuccess(
-            'Booking rescheduled',
-            'Your call has been moved to ' +
-              data.slot_label +
-              ". We'll send a confirmation email with the updated details."
+          showResult(
+            'Rescheduled',
+            'Your call has been moved.',
+            'It is now on ' + data.slot_label + '. We sent a calendar update.',
+            { hideCta: true }
           )
-        } else {
-          btns.forEach(function (b) {
-            b.disabled = false
-            b.classList.remove('opacity-50')
-          })
-          alert(data.message || 'Failed to reschedule.')
+          return
         }
-      } catch {
-        btns.forEach(function (b) {
-          b.disabled = false
-          b.classList.remove('opacity-50')
-        })
-        alert('Something went wrong.')
+        setError(
+          'reschedule-error',
+          data.message || 'Could not reschedule. Please try a different time.'
+        )
+        btn.disabled = false
+        btn.textContent = orig
+      } catch (err) {
+        setError(
+          'reschedule-error',
+          'Could not reach the server. Check your connection and try again.'
+        )
+        btn.disabled = false
+        btn.textContent = orig
       }
-    }
+    })
 
-    function show(id) {
-      const e = document.getElementById(id)
-      if (e) e.classList.remove('hidden')
-    }
-    function hide(id) {
-      const e = document.getElementById(id)
-      if (e) e.classList.add('hidden')
-    }
-    function showError(t, m) {
-      document.getElementById('error-title').textContent = t
-      document.getElementById('error-message').textContent = m
-      show('error-state')
-    }
-    function showSuccess(t, m) {
-      document.getElementById('success-title').textContent = t
-      document.getElementById('success-message').textContent = m
-      show('success-state')
-    }
+    // ---------- Cancel ----------
+
+    document.getElementById('details-cancel-btn').addEventListener('click', function () {
+      setState('cancel')
+    })
+
+    document.getElementById('cancel-back-btn').addEventListener('click', function () {
+      document.getElementById('cancel-error').hidden = true
+      setState('details')
+    })
+
+    document.getElementById('cancel-confirm-btn').addEventListener('click', async function () {
+      const reason = document.getElementById('cancel-reason').value.trim()
+      const btn = document.getElementById('cancel-confirm-btn')
+      const orig = btn.textContent
+      btn.disabled = true
+      btn.textContent = 'Cancelling...'
+      try {
+        const res = await fetch('/api/booking/manage/' + token + '/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: reason ? JSON.stringify({ reason: reason }) : '{}',
+        })
+        const data = await res.json()
+        if (data.ok) {
+          showResult(
+            'Cancelled',
+            'Your call has been cancelled.',
+            'You can book a new time whenever you are ready.'
+          )
+          return
+        }
+        setError('cancel-error', data.message || 'Could not cancel. Please try again.')
+        btn.disabled = false
+        btn.textContent = orig
+      } catch (err) {
+        setError('cancel-error', 'Could not reach the server. Check your connection and try again.')
+        btn.disabled = false
+        btn.textContent = orig
+      }
+    })
+
+    loadBooking()
   </script>
+
+  <style>
+    .ss-section {
+      padding: 4rem 1.5rem 6rem;
+    }
+    .ss-loading {
+      text-align: center;
+      padding: 3rem 0;
+    }
+    .ss-detail-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.875rem;
+      margin: 1.25rem 0 0;
+    }
+    .ss-detail-list > div {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+    .ss-detail-list dt {
+      margin-bottom: 0;
+    }
+    .ss-detail-value {
+      margin: 0;
+      font-size: 1rem;
+      color: var(--ss-color-text-primary);
+    }
+  </style>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -362,6 +362,9 @@
 .mt-stack {
   margin-top: 1.25rem;
 }
+.mb-stack {
+  margin-bottom: 1.25rem;
+}
 
 /* ---------- Intro card ---------- */
 .ss-intro {


### PR DESCRIPTION
## Summary

The reschedule UI on `/book/manage/<token>` was a bespoke Tailwind-rounded slot grid that did not match the V4 `/book` calendar. The rest of the manage page was the same: SVG icons, native `confirm()/alert()` dialogs, a modal cancel dialog, white-tile buttons — none of it Plainspoken Sign Shop.

Rewrites the manage page as a single shell with five sibling states (loading, details, reschedule, cancel, result) mirroring the `/book` three-state pattern. The reschedule state now imports the **same SlotPicker component** `/book` uses, so the calendar, time-button styling, and selected-slot banner match the original booking flow exactly.

## Changes

- `src/pages/book/manage/[token].astro` — full rewrite. Single shell + five states. Imports SlotPicker. Inline cancel surface replaces modal dialog. Inline `.ss-error` messages replace `confirm()/alert()` popups. Success / cancelled / not-found / expired states all collapse into one configurable `result` surface.
- `src/styles/global.css` — promote `.mb-stack` from `.ss-intro`-scoped to a global utility. The existing `.ss-intro .mb-stack` rule (1.5rem) still wins via specificity within `/book`, so the intro card stacks identically.

## Verified

- [x] `npm run verify` — green
- [ ] On prod: open a manage link → details state renders in Plainspoken
- [ ] Click Reschedule → SlotPicker calendar matches /book exactly (cream paper, thick borders, no rounded tiles)
- [ ] Pick a slot → selected-slot banner appears → Confirm new time → result state shows "Rescheduled" eyebrow + headline
- [ ] Click Cancel booking → inline cancel surface with reason textarea (no modal) → Cancel call → result state shows "Cancelled"
- [ ] Already-cancelled booking → result state shows "Cancelled" without going through details
- [ ] Expired token → result state shows "Expired"

🤖 Generated with [Claude Code](https://claude.com/claude-code)