### PR TITLE
feat(ai-employee): MS Graph OAuth — Mail/Calendar/Drive read (#822)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,11 @@ docs/style/UI-PATTERNS.md
 # Pytest cache directories (gitignored locally; never authored)
 .pytest_cache/
 **/.pytest_cache/
+# Python virtualenvs created under ai-employee/connectors/*/ for local
+# adapter test loops. Site-packages docs (LICENSE.md, etc.) trip prettier
+# on whitespace/markdown rules we have no business enforcing on
+# vendored content. Gitignored separately in ai-employee/.gitignore.
+**/.venv/
 # Git worktrees — checked-out copies of other branches owned by parallel
 # work. The branch that owns the source is responsible for formatting it,
 # not whichever branch happens to have a worktree on disk right now.

--- a/ai-employee/.gitignore
+++ b/ai-employee/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 .pytest_cache/
+.venv/
+*.egg-info/

--- a/ai-employee/connectors/ms_graph/README.md
+++ b/ai-employee/connectors/ms_graph/README.md
@@ -1,0 +1,89 @@
+# ai-employee-ms-graph
+
+Microsoft Graph adapter for SMD's AI Employee. Implements three capability interfaces from `docs/specs/ai-employee/capability-contracts.md`:
+
+| Capability        | Adapter class     | Graph surface                                                |
+| ----------------- | ----------------- | ------------------------------------------------------------ |
+| `Email`           | `MSGraphMailbox`  | `/me/messages` + `/me/mailFolders` (read + draft)            |
+| `Calendar`        | `MSGraphCalendar` | `/me/calendarView`, `/me/events`, `/me/calendar/getSchedule` |
+| `DocumentStorage` | `MSGraphDrive`    | `/me/drive` (read) + `/me/drive/special/approot` (write)     |
+
+## Phase 1 scope
+
+Read + draft only. **No `Mail.Send`.** Programmatic send is wave-2 stream [#881](https://github.com/venturecrane/ss-console/issues/881) under a separate delegated scope and a distinct adapter method. The `MSGraphOAuth` constructor refuses to ship with `Mail.Send` in its scope list — defense-in-depth against accidental drift.
+
+Delegated scopes requested at consent time (see `oauth.PHASE_1_SCOPES`):
+
+- `offline_access` — required for a refresh token
+- `User.Read`
+- `Mail.Read`, `Mail.ReadWrite`, `MailboxSettings.Read`
+- `Calendars.ReadWrite`
+- `Files.Read`, `Files.ReadWrite.AppFolder`
+
+Write into OneDrive is confined to the agent's AppFolder (Microsoft provisions `/Apps/SMD Services AI Employee/` on the customer's drive). Drive-wide write would require `Files.ReadWrite` which is intentionally out of Phase 1.
+
+## Token storage
+
+Per [ADR 0010](../../../docs/adr/0010-per-customer-oauth-token-storage.md), tokens live on the per-customer Fly volume at `/opt/data/oauth/microsoft.json`. Never in Infisical. The `TokenStore` class enforces atomic writes (tempfile + rename) and `0600` mode.
+
+```text
+/opt/data/oauth/microsoft.json   chmod 0600, owned by uid 10000 (hermes)
+```
+
+JSON shape on disk matches [ADR 0010 §Storage shape](../../../docs/adr/0010-per-customer-oauth-token-storage.md):
+
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "scopes": ["Mail.Read", "Calendars.ReadWrite", "..."],
+  "expires_at": "2026-05-23T12:34:56.000Z",
+  "obtained_at": "2026-05-23T11:34:56.000Z",
+  "provider": "microsoft",
+  "token_type": "Bearer"
+}
+```
+
+## Refresh policy
+
+10-minute safety margin per [oauth-lifecycle.md](../../../docs/specs/ai-employee/oauth-lifecycle.md). Refresh happens transparently inside `MSGraphOAuth.get_valid_tokens()`. `invalid_grant` upstream is mapped to `AdapterError(code="auth_expired", ...)` which the runtime uses to drive the re-consent flow (see `bin/reauth-connector.sh`).
+
+## customer.yaml binding
+
+```yaml
+connectors:
+  Email:
+    adapter: microsoft-graph
+    backend: build:ms-graph
+    scopes:
+      - https://graph.microsoft.com/Mail.Read
+      - https://graph.microsoft.com/Mail.ReadWrite
+      - https://graph.microsoft.com/MailboxSettings.Read
+  Calendar:
+    adapter: microsoft-graph
+    backend: build:ms-graph
+    scopes:
+      - https://graph.microsoft.com/Calendars.ReadWrite
+  DocumentStorage:
+    adapter: microsoft-graph
+    backend: build:ms-graph
+    scopes:
+      - https://graph.microsoft.com/Files.Read
+      - https://graph.microsoft.com/Files.ReadWrite.AppFolder
+```
+
+No token reference — token storage is per-Machine, not per-customer.yaml.
+
+## Setup
+
+See [docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md](../../../docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md) for the Azure AD app registration steps (one-time, by Captain) and per-customer consent via `bin/reauth-connector.sh`.
+
+## Tests
+
+```bash
+cd ai-employee/connectors/ms_graph
+pip install -e .[dev]
+pytest
+```
+
+The suite covers the lifecycle spec's verification list: storage round-trip, refresh on expiry, invalid_grant → auth_expired, file mode 0600, scope-set integrity, no Mail.Send leakage.

--- a/ai-employee/connectors/ms_graph/__init__.py
+++ b/ai-employee/connectors/ms_graph/__init__.py
@@ -1,0 +1,44 @@
+"""Microsoft Graph connector — Phase 1 Email / Calendar / DocumentStorage.
+
+Implements the capability interfaces locked in
+`docs/specs/ai-employee/capability-contracts.md` against the Microsoft
+Graph REST API (https://graph.microsoft.com/v1.0/). Phase 1 scope is
+read + draft only: `Mail.Send` is intentionally NOT requested. The
+programmatic-send surface ships in wave-2 (issue #881) under a separate
+delegated scope and a distinct adapter method.
+
+Public surface:
+
+* `MSGraphOAuth` -- per-customer OAuth refresh + atomic Fly-volume
+  storage at `/opt/data/oauth/microsoft.json` per ADR 0010.
+* `MSGraphMailbox` -- `Email` capability adapter (list threads, get
+  thread, create draft, update draft, apply label, move folder).
+* `MSGraphCalendar` -- `Calendar` capability adapter (list events, get
+  event, create event draft, suggest times, RSVP draft).
+* `MSGraphDrive` -- `DocumentStorage` capability adapter (list folder,
+  get document, put document into the app folder).
+
+The OAuth layer is intentionally vendor-agnostic at the wire level: it
+talks to `https://login.microsoftonline.com/common/oauth2/v2.0/token`
+and returns a `TokenSet` shape identical to the LawPay and Filevine
+connectors so the conformance harness reads the same surface across
+adapters.
+"""
+
+from __future__ import annotations
+
+from .oauth import MSGraphOAuth, TokenSet, TokenStore
+from ._types import (
+    AdapterError,
+    CapabilitySet,
+    HealthStatus,
+)
+
+__all__ = [
+    "AdapterError",
+    "CapabilitySet",
+    "HealthStatus",
+    "MSGraphOAuth",
+    "TokenSet",
+    "TokenStore",
+]

--- a/ai-employee/connectors/ms_graph/_client.py
+++ b/ai-employee/connectors/ms_graph/_client.py
@@ -1,0 +1,143 @@
+"""Thin async HTTP wrapper around https://graph.microsoft.com/v1.0/.
+
+Centralizes the auth-header injection, 401-retry-once-after-refresh
+pattern, and translation of Graph-layer errors into ``AdapterError``.
+The capability adapters in ``mailbox.py``, ``calendar_adapter.py``, and
+``drive.py`` consume this client; no adapter speaks httpx directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+from .oauth import MSGraphOAuth
+from ._types import AdapterError
+
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+
+
+class GraphClient:
+    """Per-customer async client. One instance per Hermes Machine."""
+
+    def __init__(
+        self,
+        oauth: MSGraphOAuth,
+        *,
+        http: Optional[httpx.AsyncClient] = None,
+        capability: str = "Email",
+    ) -> None:
+        self.oauth = oauth
+        self._http = http or httpx.AsyncClient(base_url=GRAPH_BASE, timeout=30.0)
+        self._owned_http = http is None
+        # Stamped on AdapterError so logs disambiguate which surface tripped.
+        self._capability = capability
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json: Optional[dict[str, Any]] = None,
+        content: Optional[bytes] = None,
+        content_type: Optional[str] = None,
+        accept: str = "application/json",
+        capability: Optional[str] = None,
+    ) -> httpx.Response:
+        cap = capability or self._capability
+        tokens = await self.oauth.get_valid_tokens()
+        headers = {
+            "Authorization": tokens.authorization_header(),
+            "Accept": accept,
+        }
+        if content_type:
+            headers["Content-Type"] = content_type
+
+        resp = await self._http.request(
+            method,
+            path,
+            params=params,
+            json=json,
+            content=content,
+            headers=headers,
+        )
+        # If the upstream says the token is no good, refresh and retry once.
+        if resp.status_code == 401:
+            # Force a refresh by calling refresh() directly; if the refresh
+            # itself fails the auth_expired AdapterError surfaces.
+            tokens = await self.oauth.refresh(tokens)
+            headers["Authorization"] = tokens.authorization_header()
+            resp = await self._http.request(
+                method,
+                path,
+                params=params,
+                json=json,
+                content=content,
+                headers=headers,
+            )
+        if not resp.is_success:
+            self._raise_from_response(resp, capability=cap)
+        return resp
+
+    def _raise_from_response(self, resp: httpx.Response, *, capability: str) -> None:
+        status = resp.status_code
+        # Microsoft Graph error envelope is `{ "error": { "code": ..., "message": ... } }`.
+        graph_code = ""
+        graph_message = ""
+        try:
+            body = resp.json()
+            if isinstance(body, dict):
+                err = body.get("error")
+                if isinstance(err, dict):
+                    graph_code = str(err.get("code") or "")
+                    graph_message = str(err.get("message") or "")
+        except ValueError:
+            graph_message = (resp.text or "")[:200]
+
+        if status == 401 or graph_code.lower() == "invalidauthenticationtoken":
+            raise AdapterError(
+                code="auth_expired",
+                capability=capability,
+                adapter=self.oauth.adapter,
+                message=f"Microsoft Graph returned 401 ({graph_code or 'unauthenticated'}): {graph_message[:200]}",
+            )
+        if status == 403:
+            raise AdapterError(
+                code="forbidden",
+                capability=capability,
+                adapter=self.oauth.adapter,
+                message=f"Microsoft Graph returned 403 ({graph_code}): {graph_message[:200]}",
+            )
+        if status == 404:
+            raise AdapterError(
+                code="not_found",
+                capability=capability,
+                adapter=self.oauth.adapter,
+                message=f"Microsoft Graph returned 404: {graph_message[:200]}",
+            )
+        if status == 429:
+            raise AdapterError(
+                code="rate_limited",
+                capability=capability,
+                adapter=self.oauth.adapter,
+                message=f"Microsoft Graph rate-limited: {graph_message[:200]}",
+            )
+        raise AdapterError(
+            code="upstream_error",
+            capability=capability,
+            adapter=self.oauth.adapter,
+            message=f"Microsoft Graph HTTP {status} ({graph_code}): {graph_message[:200]}",
+        )
+
+    async def aclose(self) -> None:
+        if self._owned_http:
+            await self._http.aclose()
+
+
+__all__ = [
+    "GRAPH_BASE",
+    "GraphClient",
+]

--- a/ai-employee/connectors/ms_graph/_types.py
+++ b/ai-employee/connectors/ms_graph/_types.py
@@ -1,0 +1,227 @@
+"""Shared types for the Microsoft Graph connector.
+
+Python mirrors of the TypeScript capability shapes locked in
+`docs/specs/ai-employee/capability-contracts.md`. The connector emits
+these dataclasses; skills consume them via the capability interface.
+The error type mirrors the canonical `AdapterError` in
+`ai-employee/connectors/filevine/errors.py` -- code names are drawn
+from the closed `AdapterErrorCode` union so audit-log routing and
+runtime backoff stay vendor-neutral.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+
+AdapterErrorCode = Literal[
+    "not_found",
+    "unauthorized",
+    "auth_expired",
+    "rate_limited",
+    "transient",
+    "capability_not_supported",
+    "scope_violation",
+    "fabrication_blocked",
+    "validation_failed",
+    "forbidden",
+    "upstream_error",
+    "unknown",
+]
+
+
+ADAPTER_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "not_found",
+        "unauthorized",
+        "auth_expired",
+        "rate_limited",
+        "transient",
+        "capability_not_supported",
+        "scope_violation",
+        "fabrication_blocked",
+        "validation_failed",
+        "forbidden",
+        "upstream_error",
+        "unknown",
+    }
+)
+
+
+CAPABILITY_NAMES: frozenset[str] = frozenset(
+    {
+        "Email",
+        "Calendar",
+        "DocumentStorage",
+    }
+)
+
+
+class AdapterError(Exception):
+    """Canonical adapter error.
+
+    Skill code switches on ``code``, not on message text or exception
+    class chain. ``auth_expired`` is the signal the OAuth lifecycle
+    spec uses to trigger the re-consent flow per
+    `docs/specs/ai-employee/oauth-lifecycle.md`.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        capability: str,
+        adapter: str,
+        message: str,
+        cause: Optional[BaseException] = None,
+    ) -> None:
+        if code not in ADAPTER_ERROR_CODES:
+            raise ValueError(
+                f"AdapterError code {code!r} not in closed union; update both "
+                "ai-employee/connectors/ms_graph/types.py and the TypeScript "
+                "doctrine in src/lib/ai-employee/capabilities/types.ts"
+            )
+        if capability not in CAPABILITY_NAMES:
+            raise ValueError(
+                f"MS Graph adapter only supports {sorted(CAPABILITY_NAMES)}; "
+                f"got capability={capability!r}"
+            )
+        super().__init__(message)
+        self.code = code
+        self.capability = capability
+        self.adapter = adapter
+        self.cause = cause
+
+
+@dataclass(frozen=True)
+class CapabilitySet:
+    """Python mirror of ``CapabilitySet`` from capability-contracts.md."""
+
+    capability: str
+    adapter: str
+    version: str
+    supported_methods: tuple[str, ...]
+    unsupported_methods: tuple[str, ...]
+    features: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class HealthStatus:
+    """Python mirror of ``HealthStatus`` from capability-contracts.md."""
+
+    healthy: bool
+    last_ok_at: str  # ISO 8601 UTC
+    last_error: Optional[dict[str, Any]] = None
+
+
+# ---------------------------------------------------------------------------
+# Email domain shapes -- minimum surface for v1 per Pattern A
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmailParticipant:
+    name: Optional[str]
+    address: str
+
+
+@dataclass(frozen=True)
+class EmailMessage:
+    id: str
+    thread_id: str
+    subject: str
+    received_at: str  # ISO 8601 UTC
+    from_addr: EmailParticipant
+    to: tuple[EmailParticipant, ...]
+    cc: tuple[EmailParticipant, ...]
+    body_preview: str
+    is_read: bool
+    folder: str
+
+
+@dataclass(frozen=True)
+class EmailThread:
+    id: str
+    subject: str
+    last_message_at: str  # ISO 8601 UTC
+    message_count: int
+    messages: tuple[EmailMessage, ...]
+
+
+@dataclass(frozen=True)
+class DraftRef:
+    id: str
+    storage_uri: str
+    created_at: str  # ISO 8601 UTC
+
+
+# ---------------------------------------------------------------------------
+# Calendar domain shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TimeSlot:
+    start: str  # ISO 8601 UTC
+    end: str  # ISO 8601 UTC
+
+
+@dataclass(frozen=True)
+class CalendarAttendee:
+    address: str
+    name: Optional[str]
+    response_status: Optional[str]  # accepted | declined | tentative | none
+
+
+@dataclass(frozen=True)
+class CalendarEvent:
+    id: str
+    subject: str
+    start: str  # ISO 8601 UTC
+    end: str  # ISO 8601 UTC
+    location: Optional[str]
+    body_preview: Optional[str]
+    organizer: Optional[EmailParticipant]
+    attendees: tuple[CalendarAttendee, ...]
+    is_all_day: bool
+
+
+# ---------------------------------------------------------------------------
+# DocumentStorage domain shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DocumentRef:
+    id: str
+    path: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    created_at: str  # ISO 8601 UTC
+    modified_at: str  # ISO 8601 UTC
+
+
+@dataclass(frozen=True)
+class DocumentContent:
+    ref: DocumentRef
+    bytes_: bytes
+
+
+__all__ = [
+    "ADAPTER_ERROR_CODES",
+    "CAPABILITY_NAMES",
+    "AdapterError",
+    "AdapterErrorCode",
+    "CalendarAttendee",
+    "CalendarEvent",
+    "CapabilitySet",
+    "DocumentContent",
+    "DocumentRef",
+    "DraftRef",
+    "EmailMessage",
+    "EmailParticipant",
+    "EmailThread",
+    "HealthStatus",
+    "TimeSlot",
+]

--- a/ai-employee/connectors/ms_graph/calendar_adapter.py
+++ b/ai-employee/connectors/ms_graph/calendar_adapter.py
@@ -1,0 +1,572 @@
+"""``Calendar`` capability adapter -- Microsoft Graph calendar surface.
+
+Implements the Calendar interface from
+`docs/specs/ai-employee/capability-contracts.md`. Pattern A discipline
+applies to invites and RSVPs too: the agent creates event drafts and
+RSVP drafts; the reviewer confirms before any commitment is recorded
+on their behalf (see capability-contracts.md "Resolved decisions"
+``Calendar.respond_to_invitation_draft shape``).
+
+Graph endpoints used (delegated, Phase 1 scopes only):
+
+* ``GET /me/calendarView`` -- list events in a time window
+* ``GET /me/events/{id}`` -- single event
+* ``POST /me/events`` -- create event (subject + start + end + attendees)
+* ``POST /me/calendar/getSchedule`` -- find free/busy windows
+* Draft RSVPs are stored as local DraftRefs -- the actual
+  ``accept``/``decline``/``tentativelyAccept`` call only fires after
+  the reviewer taps in the dashboard.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from ._client import GraphClient
+from ._types import (
+    AdapterError,
+    CalendarAttendee,
+    CalendarEvent,
+    CapabilitySet,
+    DraftRef,
+    EmailParticipant,
+    HealthStatus,
+    TimeSlot,
+)
+
+
+_SUPPORTED: tuple[str, ...] = (
+    "describe_capabilities",
+    "health_check",
+    "list_events",
+    "get_event",
+    "create_event_draft",
+    "update_event_draft",
+    "suggest_times",
+    "respond_to_invitation_draft",
+)
+
+_UNSUPPORTED: tuple[str, ...] = ()
+
+
+class MSGraphCalendar:
+    """``Calendar`` capability adapter."""
+
+    capability = "Calendar"
+    adapter = "microsoft-graph"
+    version = "0.1.0"
+
+    def __init__(self, client: GraphClient) -> None:
+        self._client = client
+
+    def describe_capabilities(self) -> CapabilitySet:
+        return CapabilitySet(
+            capability=self.capability,
+            adapter=self.adapter,
+            version=self.version,
+            supported_methods=_SUPPORTED,
+            unsupported_methods=_UNSUPPORTED,
+            features=("free-busy", "rsvp-draft"),
+        )
+
+    async def health_check(self) -> HealthStatus:
+        try:
+            await self._client.request(
+                "GET",
+                "/me/calendar",
+                capability=self.capability,
+            )
+            return HealthStatus(healthy=True, last_ok_at=_now_iso())
+        except AdapterError as exc:
+            return HealthStatus(
+                healthy=False,
+                last_ok_at="",
+                last_error={
+                    "kind": exc.code,
+                    "capability": self.capability,
+                    "adapter": self.adapter,
+                },
+            )
+
+    async def list_events(
+        self,
+        *,
+        start: str,
+        end: str,
+        top: int = 50,
+    ) -> list[CalendarEvent]:
+        """Events in the half-open window ``[start, end)``.
+
+        ``start`` and ``end`` MUST be ISO 8601 UTC strings; Graph's
+        ``calendarView`` enforces a sane upper bound (currently 5
+        years) and we let it surface its own error if exceeded.
+        """
+        if not start or not end:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="list_events requires start and end (ISO 8601 UTC)",
+            )
+        params = {
+            "startDateTime": start,
+            "endDateTime": end,
+            "$top": min(max(top, 1), 100),
+            "$orderby": "start/dateTime",
+            "$select": ",".join(
+                (
+                    "id",
+                    "subject",
+                    "start",
+                    "end",
+                    "location",
+                    "bodyPreview",
+                    "organizer",
+                    "attendees",
+                    "isAllDay",
+                )
+            ),
+        }
+        resp = await self._client.request(
+            "GET",
+            "/me/calendarView",
+            params=params,
+            capability=self.capability,
+        )
+        payload = resp.json()
+        rows = payload.get("value") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            return []
+        return [_event_from_graph(r) for r in rows if isinstance(r, dict)]
+
+    async def get_event(self, event_id: str) -> Optional[CalendarEvent]:
+        if not event_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="get_event requires event_id",
+            )
+        try:
+            resp = await self._client.request(
+                "GET",
+                f"/me/events/{event_id}",
+                capability=self.capability,
+            )
+        except AdapterError as exc:
+            if exc.code == "not_found":
+                return None
+            raise
+        return _event_from_graph(resp.json())
+
+    async def create_event_draft(
+        self,
+        *,
+        subject: str,
+        start: str,
+        end: str,
+        attendees: Optional[list[str]] = None,
+        location: Optional[str] = None,
+        body_text: Optional[str] = None,
+        matter_ref: Optional[str] = None,
+    ) -> DraftRef:
+        """Create an unsent event on the reviewer's calendar.
+
+        Microsoft Graph does not expose a first-class "calendar draft"
+        concept -- the closest thing is creating an event with
+        ``responseRequested: false`` and no attendees pre-invited.
+        Per Pattern A discipline, the v1 adapter creates the event
+        with ``responseRequested: false`` and an attendee list, so it
+        appears in the reviewer's calendar; the dashboard surfaces it
+        as a draft and the reviewer manually fires the invite. This
+        avoids the agent inadvertently sending invitations.
+        """
+        if not subject:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_event_draft requires subject",
+            )
+        if not start or not end:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_event_draft requires start and end (ISO 8601 UTC)",
+            )
+        body: dict[str, Any] = {
+            "subject": subject,
+            "start": {"dateTime": start, "timeZone": "UTC"},
+            "end": {"dateTime": end, "timeZone": "UTC"},
+            "responseRequested": False,
+            "isReminderOn": False,
+        }
+        if location:
+            body["location"] = {"displayName": location}
+        if body_text:
+            body["body"] = {"contentType": "Text", "content": body_text}
+        if attendees:
+            body["attendees"] = [
+                {
+                    "emailAddress": {"address": a},
+                    "type": "required",
+                }
+                for a in attendees
+            ]
+        if matter_ref:
+            body["categories"] = [f"matter:{matter_ref}"]
+
+        resp = await self._client.request(
+            "POST",
+            "/me/events",
+            json=body,
+            capability=self.capability,
+        )
+        created = resp.json()
+        event_id = str(created.get("id") or "")
+        if not event_id:
+            raise AdapterError(
+                code="upstream_error",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="Microsoft Graph returned an event without an id",
+            )
+        return DraftRef(
+            id=event_id,
+            storage_uri=f"msgraph://me/events/{event_id}",
+            created_at=str(created.get("createdDateTime") or _now_iso()),
+        )
+
+    async def update_event_draft(
+        self,
+        draft_id: str,
+        updates: dict[str, Any],
+    ) -> DraftRef:
+        if not draft_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="update_event_draft requires draft_id",
+            )
+        if not updates:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="update_event_draft requires at least one update field",
+            )
+        body: dict[str, Any] = {}
+        if "subject" in updates:
+            body["subject"] = updates["subject"]
+        if "start" in updates:
+            body["start"] = {"dateTime": updates["start"], "timeZone": "UTC"}
+        if "end" in updates:
+            body["end"] = {"dateTime": updates["end"], "timeZone": "UTC"}
+        if "location" in updates:
+            body["location"] = {"displayName": updates["location"]}
+        if "body_text" in updates:
+            body["body"] = {"contentType": "Text", "content": updates["body_text"]}
+        if "attendees" in updates and isinstance(updates["attendees"], list):
+            body["attendees"] = [
+                {"emailAddress": {"address": a}, "type": "required"}
+                for a in updates["attendees"]
+            ]
+        resp = await self._client.request(
+            "PATCH",
+            f"/me/events/{draft_id}",
+            json=body,
+            capability=self.capability,
+        )
+        updated = resp.json()
+        return DraftRef(
+            id=draft_id,
+            storage_uri=f"msgraph://me/events/{draft_id}",
+            created_at=str(updated.get("createdDateTime") or _now_iso()),
+        )
+
+    async def suggest_times(
+        self,
+        *,
+        attendees: list[str],
+        start: str,
+        end: str,
+        duration_minutes: int,
+    ) -> list[TimeSlot]:
+        """Return free-busy windows in the [start, end) range.
+
+        Uses Graph's ``/me/calendar/getSchedule`` endpoint, which
+        returns busy/tentative/oof intervals per attendee. We invert
+        the merged busy set to derive free slots of the requested
+        minimum duration.
+        """
+        if not attendees:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="suggest_times requires at least one attendee",
+            )
+        if duration_minutes <= 0:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="suggest_times requires positive duration_minutes",
+            )
+        body = {
+            "schedules": attendees,
+            "startTime": {"dateTime": start, "timeZone": "UTC"},
+            "endTime": {"dateTime": end, "timeZone": "UTC"},
+            "availabilityViewInterval": 30,
+        }
+        resp = await self._client.request(
+            "POST",
+            "/me/calendar/getSchedule",
+            json=body,
+            capability=self.capability,
+        )
+        payload = resp.json()
+        rows = payload.get("value") if isinstance(payload, dict) else []
+        # Merge busy intervals across all attendees.
+        busy_intervals: list[tuple[float, float]] = []
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            for item in row.get("scheduleItems") or []:
+                if not isinstance(item, dict):
+                    continue
+                status = str(item.get("status") or "")
+                if status not in ("busy", "tentative", "oof", "workingElsewhere"):
+                    continue
+                s = item.get("start")
+                e = item.get("end")
+                if not (isinstance(s, dict) and isinstance(e, dict)):
+                    continue
+                s_iso = str(s.get("dateTime") or "")
+                e_iso = str(e.get("dateTime") or "")
+                if not (s_iso and e_iso):
+                    continue
+                try:
+                    s_ts = _iso_to_ts(s_iso)
+                    e_ts = _iso_to_ts(e_iso)
+                except ValueError:
+                    continue
+                if e_ts > s_ts:
+                    busy_intervals.append((s_ts, e_ts))
+        try:
+            window_start = _iso_to_ts(start)
+            window_end = _iso_to_ts(end)
+        except ValueError as exc:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=f"suggest_times start/end could not be parsed: {exc}",
+            ) from exc
+        free = _merge_free(busy_intervals, window_start, window_end, duration_minutes * 60)
+        return [
+            TimeSlot(start=_ts_to_iso(s), end=_ts_to_iso(e)) for s, e in free
+        ]
+
+    async def respond_to_invitation_draft(
+        self,
+        event_id: str,
+        response: str,
+        comment: Optional[str] = None,
+    ) -> DraftRef:
+        """Draft an RSVP -- does NOT actually accept/decline.
+
+        Per capability-contracts.md resolved decision: the API call to
+        accept/decline is partner-fired from the dashboard. The
+        adapter returns a DraftRef the dashboard renders. The
+        ``response`` argument is validated here so the dashboard layer
+        can't drift the vocabulary.
+        """
+        if response not in ("accept", "decline", "tentative"):
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=f"response must be accept | decline | tentative, got {response!r}",
+            )
+        if not event_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="respond_to_invitation_draft requires event_id",
+            )
+        # No upstream call is made here -- the draft lives in the
+        # dashboard until the reviewer taps. The storage_uri encodes
+        # the response so the dashboard can fire the right Graph
+        # endpoint when the reviewer confirms.
+        draft_id = f"rsvp-{event_id}-{response}"
+        storage_uri = f"msgraph-draft://rsvp/{event_id}/{response}"
+        if comment:
+            storage_uri += f"?comment={_safe_qs(comment)}"
+        return DraftRef(
+            id=draft_id,
+            storage_uri=storage_uri,
+            created_at=_now_iso(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Translation helpers
+# ---------------------------------------------------------------------------
+
+
+def _event_from_graph(raw: dict[str, Any]) -> CalendarEvent:
+    organizer = raw.get("organizer")
+    organizer_p: Optional[EmailParticipant] = None
+    if isinstance(organizer, dict):
+        email_addr = organizer.get("emailAddress")
+        if isinstance(email_addr, dict):
+            address = email_addr.get("address")
+            if isinstance(address, str) and address:
+                organizer_p = EmailParticipant(
+                    name=str(email_addr.get("name") or "") or None,
+                    address=address,
+                )
+
+    raw_attendees = raw.get("attendees") or []
+    attendees: list[CalendarAttendee] = []
+    if isinstance(raw_attendees, list):
+        for a in raw_attendees:
+            if not isinstance(a, dict):
+                continue
+            email_addr = a.get("emailAddress")
+            if not isinstance(email_addr, dict):
+                continue
+            address = email_addr.get("address")
+            if not isinstance(address, str) or not address:
+                continue
+            status = a.get("status")
+            response = ""
+            if isinstance(status, dict):
+                response = str(status.get("response") or "")
+            attendees.append(
+                CalendarAttendee(
+                    address=address,
+                    name=str(email_addr.get("name") or "") or None,
+                    response_status=response or None,
+                )
+            )
+    start = ""
+    end = ""
+    raw_start = raw.get("start")
+    raw_end = raw.get("end")
+    if isinstance(raw_start, dict):
+        start = str(raw_start.get("dateTime") or "")
+    if isinstance(raw_end, dict):
+        end = str(raw_end.get("dateTime") or "")
+    location_text: Optional[str] = None
+    raw_location = raw.get("location")
+    if isinstance(raw_location, dict):
+        loc_name = raw_location.get("displayName")
+        if isinstance(loc_name, str) and loc_name:
+            location_text = loc_name
+    return CalendarEvent(
+        id=str(raw.get("id") or ""),
+        subject=str(raw.get("subject") or ""),
+        start=start,
+        end=end,
+        location=location_text,
+        body_preview=str(raw.get("bodyPreview") or "") or None,
+        organizer=organizer_p,
+        attendees=tuple(attendees),
+        is_all_day=bool(raw.get("isAllDay", False)),
+    )
+
+
+def _merge_free(
+    busy: list[tuple[float, float]],
+    window_start: float,
+    window_end: float,
+    min_duration_seconds: int,
+) -> list[tuple[float, float]]:
+    """Return free intervals of at least ``min_duration_seconds`` inside the window.
+
+    Busy intervals are coalesced (sorted, overlapping merged); the
+    complement inside ``[window_start, window_end)`` is split into
+    intervals long enough to satisfy the requested duration.
+    """
+    if window_end <= window_start:
+        return []
+    if not busy:
+        if window_end - window_start >= min_duration_seconds:
+            return [(window_start, window_end)]
+        return []
+    sorted_busy = sorted(busy, key=lambda iv: iv[0])
+    merged: list[tuple[float, float]] = []
+    cur_s, cur_e = sorted_busy[0]
+    for s, e in sorted_busy[1:]:
+        if s <= cur_e:
+            cur_e = max(cur_e, e)
+        else:
+            merged.append((cur_s, cur_e))
+            cur_s, cur_e = s, e
+    merged.append((cur_s, cur_e))
+
+    free: list[tuple[float, float]] = []
+    cursor = window_start
+    for s, e in merged:
+        if e <= cursor:
+            continue
+        if s >= window_end:
+            break
+        if s > cursor:
+            gap_end = min(s, window_end)
+            if gap_end - cursor >= min_duration_seconds:
+                free.append((cursor, gap_end))
+        cursor = max(cursor, e)
+        if cursor >= window_end:
+            break
+    if cursor < window_end and window_end - cursor >= min_duration_seconds:
+        free.append((cursor, window_end))
+    return free
+
+
+def _iso_to_ts(iso: str) -> float:
+    """Parse ISO 8601 to a UNIX timestamp.
+
+    Graph returns timestamps as 'YYYY-MM-DDTHH:MM:SS.fffffff' WITHOUT
+    a zone designator inside the ``dateTime`` field (the zone is in
+    the sibling ``timeZone`` field). We treat the bare timestamp as
+    UTC, which matches our request shape (``timeZone: "UTC"``).
+    """
+    cleaned = iso.replace("Z", "")
+    # Truncate fractional seconds to 6 digits (Python's strptime limit).
+    if "." in cleaned:
+        head, frac = cleaned.split(".", 1)
+        frac = frac[:6]
+        cleaned = f"{head}.{frac}"
+    try:
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"cannot parse ISO timestamp {iso!r}") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _ts_to_iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _safe_qs(value: str) -> str:
+    from urllib.parse import quote
+
+    return quote(value, safe="")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+__all__ = [
+    "MSGraphCalendar",
+]

--- a/ai-employee/connectors/ms_graph/drive.py
+++ b/ai-employee/connectors/ms_graph/drive.py
@@ -1,0 +1,273 @@
+"""``DocumentStorage`` capability adapter -- Microsoft Graph OneDrive surface.
+
+Implements the DocumentStorage interface from
+`docs/specs/ai-employee/capability-contracts.md`. Phase 1 scope is
+``Files.Read`` + ``Files.ReadWrite.AppFolder``: the agent reads from
+the entire drive but writes ONLY into its own AppFolder subtree.
+This is intentional containment -- `Files.ReadWrite` (drive-wide
+write) is out of Phase 1 because it expands the blast radius far
+beyond what Pattern A discipline requires for a v1 demo.
+
+Graph endpoints used (delegated, Phase 1 scopes only):
+
+* ``GET /me/drive/root:/{path}:/children`` -- list folder contents
+* ``GET /me/drive/items/{id}`` -- item metadata
+* ``GET /me/drive/items/{id}/content`` -- raw bytes
+* ``PUT /me/drive/special/approot:/{path}:/content`` -- upload into the
+  app folder (Files.ReadWrite.AppFolder scope)
+
+Delete, copy across folders, and version listing are declared
+unsupported in v1 -- they require either ``Files.ReadWrite`` (out of
+Phase 1) or a thicker consent model than Pattern A provides.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from ._client import GraphClient
+from ._types import (
+    AdapterError,
+    CapabilitySet,
+    DocumentContent,
+    DocumentRef,
+    HealthStatus,
+)
+
+
+_SUPPORTED: tuple[str, ...] = (
+    "describe_capabilities",
+    "health_check",
+    "list_folder",
+    "get_document",
+    "put_document",
+)
+
+# Methods declared by DocumentStorage interface but not shipped in v1.
+_UNSUPPORTED: tuple[str, ...] = (
+    "copy_document",
+    "delete_document",
+    "list_versions",
+)
+
+
+class MSGraphDrive:
+    """``DocumentStorage`` capability adapter for OneDrive."""
+
+    capability = "DocumentStorage"
+    adapter = "microsoft-graph"
+    version = "0.1.0"
+
+    def __init__(self, client: GraphClient) -> None:
+        self._client = client
+
+    def describe_capabilities(self) -> CapabilitySet:
+        return CapabilitySet(
+            capability=self.capability,
+            adapter=self.adapter,
+            version=self.version,
+            supported_methods=_SUPPORTED,
+            unsupported_methods=_UNSUPPORTED,
+            features=("app-folder-write", "drive-read"),
+        )
+
+    async def health_check(self) -> HealthStatus:
+        try:
+            await self._client.request(
+                "GET",
+                "/me/drive",
+                capability=self.capability,
+            )
+            return HealthStatus(healthy=True, last_ok_at=_now_iso())
+        except AdapterError as exc:
+            return HealthStatus(
+                healthy=False,
+                last_ok_at="",
+                last_error={
+                    "kind": exc.code,
+                    "capability": self.capability,
+                    "adapter": self.adapter,
+                },
+            )
+
+    async def list_folder(self, path: str) -> list[DocumentRef]:
+        """List immediate children of the folder at ``path``.
+
+        ``path`` is a OneDrive-relative path like ``/Documents`` or
+        ``/Documents/2026/Q1``. Use the empty string or ``/`` to list
+        the drive root.
+        """
+        normalized = _normalize_path(path)
+        graph_path = (
+            "/me/drive/root/children"
+            if normalized in ("", "/")
+            else f"/me/drive/root:/{normalized.lstrip('/')}:/children"
+        )
+        resp = await self._client.request(
+            "GET",
+            graph_path,
+            capability=self.capability,
+        )
+        payload = resp.json()
+        rows = payload.get("value") if isinstance(payload, dict) else []
+        if not isinstance(rows, list):
+            return []
+        return [_docref_from_drive_item(r, parent_path=normalized) for r in rows if isinstance(r, dict)]
+
+    async def get_document(self, id_: str) -> DocumentContent:
+        """Return the document metadata + raw bytes."""
+        if not id_:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="get_document requires id",
+            )
+        meta_resp = await self._client.request(
+            "GET",
+            f"/me/drive/items/{id_}",
+            capability=self.capability,
+        )
+        meta = meta_resp.json()
+        ref = _docref_from_drive_item(meta, parent_path=_parent_path_from_item(meta))
+        content_resp = await self._client.request(
+            "GET",
+            f"/me/drive/items/{id_}/content",
+            accept="*/*",
+            capability=self.capability,
+        )
+        return DocumentContent(ref=ref, bytes_=content_resp.content)
+
+    async def put_document(
+        self,
+        path: str,
+        *,
+        content: bytes,
+        mime_type: str,
+    ) -> DocumentRef:
+        """Upload bytes into the agent's AppFolder.
+
+        Phase 1 uses ``Files.ReadWrite.AppFolder``; the write path is
+        confined to ``/Apps/SMD Services AI Employee/...`` (the
+        AppFolder Microsoft provisions on the customer's drive). The
+        ``path`` argument is interpreted as a path RELATIVE to the
+        AppFolder root, not the drive root, to make this containment
+        explicit.
+        """
+        if not path:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="put_document requires path",
+            )
+        if not content:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="put_document requires non-empty content",
+            )
+        if not mime_type:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="put_document requires mime_type",
+            )
+        normalized = _normalize_path(path).lstrip("/")
+        if not normalized:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="put_document path cannot resolve to AppFolder root",
+            )
+        graph_path = f"/me/drive/special/approot:/{normalized}:/content"
+        resp = await self._client.request(
+            "PUT",
+            graph_path,
+            content=content,
+            content_type=mime_type,
+            capability=self.capability,
+        )
+        return _docref_from_drive_item(resp.json(), parent_path=_parent_path_from_path(normalized))
+
+
+# ---------------------------------------------------------------------------
+# Translation helpers
+# ---------------------------------------------------------------------------
+
+
+def _docref_from_drive_item(raw: dict[str, Any], *, parent_path: str) -> DocumentRef:
+    item_id = str(raw.get("id") or "")
+    filename = str(raw.get("name") or "")
+    size_bytes = raw.get("size")
+    file = raw.get("file") if isinstance(raw, dict) else None
+    mime_type = "inode/directory"
+    if isinstance(file, dict):
+        mime_type = str(file.get("mimeType") or "application/octet-stream")
+    created_at = str(raw.get("createdDateTime") or "")
+    modified_at = str(raw.get("lastModifiedDateTime") or "")
+    # Prefer Graph's parentReference.path when present (more accurate than the
+    # caller-supplied parent_path for queries that traversed elsewhere).
+    parent_ref = raw.get("parentReference")
+    full_path = ""
+    if isinstance(parent_ref, dict):
+        graph_path = parent_ref.get("path")
+        if isinstance(graph_path, str) and graph_path:
+            # Graph paths look like "/drive/root:/Documents/2026"; strip the prefix.
+            head, sep, tail = graph_path.partition(":")
+            full_path = f"{tail}/{filename}" if sep else f"{head}/{filename}"
+    if not full_path:
+        joined = parent_path.rstrip("/")
+        full_path = f"{joined}/{filename}" if joined else f"/{filename}"
+    return DocumentRef(
+        id=item_id,
+        path=full_path,
+        filename=filename,
+        mime_type=mime_type,
+        size_bytes=int(size_bytes) if isinstance(size_bytes, int) else 0,
+        created_at=created_at,
+        modified_at=modified_at,
+    )
+
+
+def _normalize_path(path: str) -> str:
+    if not path:
+        return ""
+    # Strip the protocol scheme if the caller passed a storage_uri.
+    if path.startswith("msgraph://"):
+        path = path[len("msgraph://") :]
+    # Collapse duplicate slashes; preserve leading slash semantics.
+    parts = [p for p in path.split("/") if p]
+    leading = "/" if path.startswith("/") else ""
+    return leading + "/".join(parts)
+
+
+def _parent_path_from_item(item: dict[str, Any]) -> str:
+    parent_ref = item.get("parentReference") if isinstance(item, dict) else None
+    if not isinstance(parent_ref, dict):
+        return ""
+    raw_path = parent_ref.get("path")
+    if not isinstance(raw_path, str):
+        return ""
+    _, sep, tail = raw_path.partition(":")
+    return tail if sep else raw_path
+
+
+def _parent_path_from_path(path: str) -> str:
+    parts = path.rstrip("/").split("/")
+    if len(parts) <= 1:
+        return "/"
+    return "/" + "/".join(parts[:-1])
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+__all__ = [
+    "MSGraphDrive",
+]

--- a/ai-employee/connectors/ms_graph/mailbox.py
+++ b/ai-employee/connectors/ms_graph/mailbox.py
@@ -1,0 +1,526 @@
+"""``Email`` capability adapter -- Microsoft Graph mailbox surface.
+
+Implements the Email interface from
+`docs/specs/ai-employee/capability-contracts.md` Pattern A: read
+threads, create drafts in the reviewer's drafts folder, apply labels,
+move folders. **No ``send`` method.** Mail.Send is wave-2 (issue #881).
+
+Graph endpoints used (delegated, Phase 1 scopes only):
+
+* ``GET /me/messages`` -- list messages (filtered by conversationId
+  in get_thread)
+* ``GET /me/messages/{id}`` -- single message
+* ``POST /me/messages`` -- create draft (the resulting message has
+  ``isDraft: true`` and lives in the Drafts folder)
+* ``PATCH /me/messages/{id}`` -- update draft
+* ``POST /me/messages/{id}/move`` -- move to a named folder
+* ``PATCH /me/messages/{id}`` -- categories edit (mapped to apply_label)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from ._client import GraphClient
+from ._types import (
+    AdapterError,
+    CapabilitySet,
+    DraftRef,
+    EmailMessage,
+    EmailParticipant,
+    EmailThread,
+    HealthStatus,
+)
+
+
+_SUPPORTED: tuple[str, ...] = (
+    "describe_capabilities",
+    "health_check",
+    "list_threads",
+    "get_thread",
+    "create_draft",
+    "update_draft",
+    "apply_label",
+    "move_to_folder",
+    "get_scoped_folders",
+)
+
+# Methods declared by the Email interface but not shipped in v1 MS Graph adapter.
+_UNSUPPORTED: tuple[str, ...] = (
+    # `send` is intentionally excluded -- Pattern B / wave-2 issue #881.
+    "list_sent_since",
+    "get_sent_item",
+)
+
+
+class MSGraphMailbox:
+    """``Email`` capability adapter."""
+
+    capability = "Email"
+    adapter = "microsoft-graph"
+    version = "0.1.0"
+
+    def __init__(
+        self,
+        client: GraphClient,
+        *,
+        scoped_folders: tuple[str, ...] = (),
+    ) -> None:
+        self._client = client
+        self._scoped_folders = tuple(scoped_folders)
+
+    # ----- AdapterBase -----
+
+    def describe_capabilities(self) -> CapabilitySet:
+        return CapabilitySet(
+            capability=self.capability,
+            adapter=self.adapter,
+            version=self.version,
+            supported_methods=_SUPPORTED,
+            unsupported_methods=_UNSUPPORTED,
+            features=("drafts", "categories", "folders"),
+        )
+
+    async def health_check(self) -> HealthStatus:
+        try:
+            await self._client.request("GET", "/me", capability=self.capability)
+            return HealthStatus(
+                healthy=True,
+                last_ok_at=_now_iso(),
+            )
+        except AdapterError as exc:
+            return HealthStatus(
+                healthy=False,
+                last_ok_at="",
+                last_error={
+                    "kind": exc.code,
+                    "capability": self.capability,
+                    "adapter": self.adapter,
+                },
+            )
+
+    def get_scoped_folders(self) -> list[str]:
+        """Folders the customer has authored as visible to the agent."""
+        return list(self._scoped_folders)
+
+    # ----- Supported methods -----
+
+    async def list_threads(
+        self,
+        *,
+        folder: Optional[str] = None,
+        unread_only: bool = False,
+        top: int = 50,
+    ) -> list[EmailThread]:
+        """Return one EmailThread per conversation in the named folder.
+
+        Microsoft Graph models a thread as a ``conversationId``. The
+        Phase 1 surface is "give me the most recent N messages in a
+        folder grouped by conversation" -- adequate for inbox triage
+        and reply drafting; deeper threading semantics ship in vertical
+        extensions.
+        """
+        self._guard_folder(folder)
+        params: dict[str, Any] = {
+            "$top": min(max(top, 1), 100),
+            "$orderby": "receivedDateTime desc",
+            "$select": ",".join(
+                (
+                    "id",
+                    "conversationId",
+                    "subject",
+                    "receivedDateTime",
+                    "from",
+                    "toRecipients",
+                    "ccRecipients",
+                    "bodyPreview",
+                    "isRead",
+                    "parentFolderId",
+                )
+            ),
+        }
+        if unread_only:
+            params["$filter"] = "isRead eq false"
+        path = "/me/messages"
+        if folder:
+            path = f"/me/mailFolders/{folder}/messages"
+        resp = await self._client.request("GET", path, params=params, capability=self.capability)
+        payload = resp.json()
+        messages = payload.get("value") if isinstance(payload, dict) else None
+        if not isinstance(messages, list):
+            return []
+        grouped: dict[str, list[EmailMessage]] = {}
+        for raw in messages:
+            if not isinstance(raw, dict):
+                continue
+            msg = _message_from_graph(raw, folder=folder or "")
+            grouped.setdefault(msg.thread_id, []).append(msg)
+        threads: list[EmailThread] = []
+        for conv_id, msgs in grouped.items():
+            msgs_sorted = tuple(sorted(msgs, key=lambda m: m.received_at, reverse=True))
+            threads.append(
+                EmailThread(
+                    id=conv_id,
+                    subject=msgs_sorted[0].subject,
+                    last_message_at=msgs_sorted[0].received_at,
+                    message_count=len(msgs_sorted),
+                    messages=msgs_sorted,
+                )
+            )
+        threads.sort(key=lambda t: t.last_message_at, reverse=True)
+        return threads
+
+    async def get_thread(self, thread_id: str) -> EmailThread:
+        """Return all messages in the given conversation."""
+        if not thread_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="get_thread requires non-empty thread_id",
+            )
+        # Microsoft Graph $filter on conversationId with $orderby requires
+        # the orderby field to appear in the filter clause set; using
+        # receivedDateTime as the secondary sort matches the inbox semantic.
+        params: dict[str, Any] = {
+            "$filter": f"conversationId eq '{_escape_odata(thread_id)}'",
+            "$orderby": "receivedDateTime desc",
+            "$top": 100,
+            "$select": ",".join(
+                (
+                    "id",
+                    "conversationId",
+                    "subject",
+                    "receivedDateTime",
+                    "from",
+                    "toRecipients",
+                    "ccRecipients",
+                    "bodyPreview",
+                    "isRead",
+                    "parentFolderId",
+                )
+            ),
+        }
+        resp = await self._client.request(
+            "GET", "/me/messages", params=params, capability=self.capability
+        )
+        payload = resp.json()
+        raw_messages = payload.get("value") if isinstance(payload, dict) else None
+        if not isinstance(raw_messages, list) or not raw_messages:
+            raise AdapterError(
+                code="not_found",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=f"no messages found for conversationId={thread_id!r}",
+            )
+        messages = tuple(
+            _message_from_graph(r, folder="") for r in raw_messages if isinstance(r, dict)
+        )
+        first = messages[0]
+        return EmailThread(
+            id=thread_id,
+            subject=first.subject,
+            last_message_at=first.received_at,
+            message_count=len(messages),
+            messages=messages,
+        )
+
+    async def create_draft(
+        self,
+        *,
+        reviewer_account_id: str,
+        to: list[str],
+        subject: str,
+        body_html: str,
+        body_text: str,
+        cc: Optional[list[str]] = None,
+        bcc: Optional[list[str]] = None,
+        thread_id: Optional[str] = None,
+        matter_ref: Optional[str] = None,
+    ) -> DraftRef:
+        """Create a draft in the reviewer's Drafts folder.
+
+        Pattern A invariant: the draft is created via the customer's
+        delegated token. The reviewer sees it natively in Outlook /
+        Outlook on the web and edits + sends from there. ``matter_ref``
+        is recorded as a category so dashboards can correlate the
+        draft to the originating matter.
+        """
+        if not reviewer_account_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_draft requires reviewer_account_id",
+            )
+        if not to or any(not addr for addr in to):
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_draft requires at least one valid 'to' address",
+            )
+        if not subject:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_draft requires non-empty subject",
+            )
+        if not body_html and not body_text:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="create_draft requires at least one of body_html or body_text",
+            )
+        body: dict[str, Any] = {
+            "subject": subject,
+            "body": {
+                "contentType": "HTML" if body_html else "Text",
+                "content": body_html or body_text,
+            },
+            "toRecipients": [_recipient(a) for a in to],
+        }
+        if cc:
+            body["ccRecipients"] = [_recipient(a) for a in cc]
+        if bcc:
+            body["bccRecipients"] = [_recipient(a) for a in bcc]
+        if thread_id:
+            # Microsoft uses conversationId for thread association; setting
+            # it on the draft is honored on POST.
+            body["conversationId"] = thread_id
+        if matter_ref:
+            body["categories"] = [f"matter:{matter_ref}"]
+
+        resp = await self._client.request(
+            "POST",
+            "/me/messages",
+            json=body,
+            capability=self.capability,
+        )
+        created = resp.json()
+        draft_id = str(created.get("id") or "")
+        if not draft_id:
+            raise AdapterError(
+                code="upstream_error",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="Microsoft Graph returned a draft without an id",
+            )
+        created_at = str(created.get("createdDateTime") or _now_iso())
+        return DraftRef(
+            id=draft_id,
+            storage_uri=f"msgraph://me/messages/{draft_id}",
+            created_at=created_at,
+        )
+
+    async def update_draft(
+        self,
+        draft_id: str,
+        updates: dict[str, Any],
+    ) -> DraftRef:
+        """Patch a draft's content."""
+        if not draft_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="update_draft requires draft_id",
+            )
+        if not updates:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="update_draft requires at least one update field",
+            )
+        body: dict[str, Any] = {}
+        if "subject" in updates:
+            body["subject"] = updates["subject"]
+        if "body_html" in updates or "body_text" in updates:
+            body_html = updates.get("body_html")
+            body_text = updates.get("body_text")
+            body["body"] = {
+                "contentType": "HTML" if body_html else "Text",
+                "content": body_html or body_text or "",
+            }
+        if "to" in updates and isinstance(updates["to"], list):
+            body["toRecipients"] = [_recipient(a) for a in updates["to"]]
+        if "cc" in updates and isinstance(updates["cc"], list):
+            body["ccRecipients"] = [_recipient(a) for a in updates["cc"]]
+        if "bcc" in updates and isinstance(updates["bcc"], list):
+            body["bccRecipients"] = [_recipient(a) for a in updates["bcc"]]
+
+        resp = await self._client.request(
+            "PATCH",
+            f"/me/messages/{draft_id}",
+            json=body,
+            capability=self.capability,
+        )
+        updated = resp.json()
+        return DraftRef(
+            id=draft_id,
+            storage_uri=f"msgraph://me/messages/{draft_id}",
+            created_at=str(updated.get("createdDateTime") or _now_iso()),
+        )
+
+    async def apply_label(self, thread_id: str, label: str) -> None:
+        """Apply a category to every message in a thread.
+
+        Microsoft Graph has no native "label" concept; categories are
+        the closest equivalent and are visible in Outlook UI. We patch
+        the most recent message in the conversation (Graph does not
+        offer a thread-scoped category edit).
+        """
+        if not thread_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="apply_label requires thread_id",
+            )
+        if not label:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="apply_label requires non-empty label",
+            )
+        thread = await self.get_thread(thread_id)
+        target = thread.messages[0]
+        # Read current categories so we don't blow away ones already applied
+        # to the message by the reviewer.
+        existing_resp = await self._client.request(
+            "GET",
+            f"/me/messages/{target.id}",
+            params={"$select": "categories"},
+            capability=self.capability,
+        )
+        existing = existing_resp.json()
+        existing_cats = list(existing.get("categories") or [])
+        if label in existing_cats:
+            return
+        existing_cats.append(label)
+        await self._client.request(
+            "PATCH",
+            f"/me/messages/{target.id}",
+            json={"categories": existing_cats},
+            capability=self.capability,
+        )
+
+    async def move_to_folder(self, thread_id: str, folder: str) -> None:
+        """Move every message in a thread to the named folder.
+
+        ``folder`` is a Graph mail-folder id (well-known names like
+        ``archive``, ``inbox``, ``deleteditems`` resolve via the
+        well-known-name aliasing Microsoft supports). The folder must
+        appear in ``scoped_folders`` if the customer has authored a
+        scope envelope.
+        """
+        if not thread_id:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="move_to_folder requires thread_id",
+            )
+        if not folder:
+            raise AdapterError(
+                code="validation_failed",
+                capability=self.capability,
+                adapter=self.adapter,
+                message="move_to_folder requires folder",
+            )
+        self._guard_folder(folder)
+        thread = await self.get_thread(thread_id)
+        for msg in thread.messages:
+            await self._client.request(
+                "POST",
+                f"/me/messages/{msg.id}/move",
+                json={"destinationId": folder},
+                capability=self.capability,
+            )
+
+    # ----- Internal helpers -----
+
+    def _guard_folder(self, folder: Optional[str]) -> None:
+        """Raise scope_violation if the folder is outside the visible envelope."""
+        if folder is None or not self._scoped_folders:
+            return
+        if folder not in self._scoped_folders:
+            raise AdapterError(
+                code="scope_violation",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"folder {folder!r} is not in the customer's scoped_folders "
+                    "envelope; refusing to traverse outside authored scope"
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Translation helpers -- Graph JSON -> typed shapes (no fabrication)
+# ---------------------------------------------------------------------------
+
+
+def _participant(raw: Any) -> Optional[EmailParticipant]:
+    if not isinstance(raw, dict):
+        return None
+    email_addr = raw.get("emailAddress")
+    if not isinstance(email_addr, dict):
+        return None
+    address = email_addr.get("address")
+    if not isinstance(address, str) or not address:
+        return None
+    name = email_addr.get("name")
+    return EmailParticipant(
+        name=str(name) if isinstance(name, str) and name else None,
+        address=address,
+    )
+
+
+def _recipient(address: str) -> dict[str, Any]:
+    return {"emailAddress": {"address": address}}
+
+
+def _message_from_graph(raw: dict[str, Any], *, folder: str) -> EmailMessage:
+    msg_id = str(raw.get("id") or "")
+    thread_id = str(raw.get("conversationId") or msg_id)
+    subject = str(raw.get("subject") or "")
+    received_at = str(raw.get("receivedDateTime") or "")
+    from_addr = _participant(raw.get("from")) or EmailParticipant(name=None, address="")
+    to = tuple(
+        p for p in (_participant(t) for t in (raw.get("toRecipients") or [])) if p is not None
+    )
+    cc = tuple(
+        p for p in (_participant(t) for t in (raw.get("ccRecipients") or [])) if p is not None
+    )
+    return EmailMessage(
+        id=msg_id,
+        thread_id=thread_id,
+        subject=subject,
+        received_at=received_at,
+        from_addr=from_addr,
+        to=to,
+        cc=cc,
+        body_preview=str(raw.get("bodyPreview") or ""),
+        is_read=bool(raw.get("isRead", False)),
+        folder=folder or str(raw.get("parentFolderId") or ""),
+    )
+
+
+def _escape_odata(value: str) -> str:
+    """Escape single quotes in an OData filter literal per Graph docs."""
+    return value.replace("'", "''")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+__all__ = [
+    "MSGraphMailbox",
+]

--- a/ai-employee/connectors/ms_graph/oauth.py
+++ b/ai-employee/connectors/ms_graph/oauth.py
@@ -1,0 +1,418 @@
+"""OAuth 2.0 token management for Microsoft Graph.
+
+Implements the per-customer Fly-volume storage shape from
+[ADR 0010](../../../../docs/adr/0010-per-customer-oauth-token-storage.md):
+tokens live at ``/opt/data/oauth/microsoft.json`` (chmod 0600), atomic
+write on refresh, the 10-minute safety margin from
+[oauth-lifecycle.md](../../../../docs/specs/ai-employee/oauth-lifecycle.md).
+
+The class shape mirrors the LawPay reference implementation at
+``ai-employee/connectors/lawpay/src/ai_employee_lawpay/oauth.py``, with
+two differences:
+
+1. Refresh-token-revoked is surfaced as
+   ``AdapterError(code="auth_expired", ...)`` per the
+   ``capability-contracts.md`` ``CapabilityError`` mapping, so the
+   runtime can drive the re-consent flow.
+2. The token file lives at the canonical ADR-0010 path
+   (``/opt/data/oauth/microsoft.json``), one file per provider in a
+   single shared directory, rather than the LawPay
+   ``<base>/<customer>/tokens.json`` layout. The customer scope is
+   per-Machine (ADR 0007) so the per-customer subdirectory is
+   redundant.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+from ._types import AdapterError
+
+
+# Microsoft Graph delegated OAuth endpoints (multi-tenant).
+AUTHORIZE_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+
+# Fly-volume token storage path per ADR 0010.
+DEFAULT_TOKEN_PATH = Path("/opt/data/oauth/microsoft.json")
+
+# 10-minute safety margin from oauth-lifecycle.md.
+REFRESH_MARGIN_SECONDS = 600
+
+# Phase 1 delegated scopes per oauth-lifecycle.md. `offline_access` is
+# required to receive a refresh token. `Mail.Send` is intentionally
+# excluded -- wave-2 issue #881.
+PHASE_1_SCOPES: tuple[str, ...] = (
+    "offline_access",
+    "User.Read",
+    "Mail.Read",
+    "Mail.ReadWrite",
+    "MailboxSettings.Read",
+    "Calendars.ReadWrite",
+    "Files.Read",
+    "Files.ReadWrite.AppFolder",
+)
+
+
+@dataclass
+class TokenSet:
+    """OAuth token pair plus expiry metadata.
+
+    Shape matches the JSON-on-disk format described in ADR 0010 §
+    "Storage shape": ``{ access_token, refresh_token, scopes,
+    expires_at (iso8601), obtained_at (iso8601), provider }``.
+    Internally we keep ``expires_at`` as epoch seconds (the LawPay
+    pattern) and translate at the disk boundary.
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at: float  # epoch seconds when access_token expires
+    scopes: tuple[str, ...] = ()
+    obtained_at: float = 0.0
+    token_type: str = "Bearer"
+
+    @classmethod
+    def from_token_response(
+        cls, payload: dict[str, Any], previous: Optional["TokenSet"] = None
+    ) -> "TokenSet":
+        """Build a TokenSet from a Microsoft Graph token-endpoint response.
+
+        Microsoft Graph returns ``access_token``, ``expires_in``, ``scope``
+        (space-separated), and ``refresh_token`` (only when
+        ``offline_access`` is in the requested scopes). When a refresh
+        call returns no new ``refresh_token`` we carry the previous one
+        forward -- Microsoft refresh tokens are long-lived and only
+        rotated occasionally.
+        """
+        access_token = str(payload.get("access_token") or "")
+        if not access_token:
+            raise ValueError("token response missing access_token")
+        expires_in = float(payload.get("expires_in", 3600))
+        refresh_token = payload.get("refresh_token")
+        if not refresh_token and previous is not None:
+            refresh_token = previous.refresh_token
+        if not refresh_token:
+            raise ValueError(
+                "token response missing refresh_token and no previous token "
+                "to carry forward (was offline_access requested?)"
+            )
+        scope_raw = payload.get("scope") or ""
+        scopes = tuple(s for s in scope_raw.split(" ") if s) if isinstance(scope_raw, str) else ()
+        return cls(
+            access_token=access_token,
+            refresh_token=str(refresh_token),
+            expires_at=time.time() + expires_in,
+            scopes=scopes,
+            obtained_at=time.time(),
+            token_type=str(payload.get("token_type") or "Bearer"),
+        )
+
+    def is_expired(self, *, margin_seconds: int = REFRESH_MARGIN_SECONDS) -> bool:
+        """True if the access token expires within the refresh margin."""
+        return time.time() + margin_seconds >= self.expires_at
+
+    def authorization_header(self) -> str:
+        return f"{self.token_type} {self.access_token}"
+
+    def to_json_bytes(self) -> bytes:
+        """Serialize to the ADR 0010 on-disk JSON shape."""
+        payload = {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "scopes": list(self.scopes),
+            "expires_at": _epoch_to_iso(self.expires_at),
+            "obtained_at": _epoch_to_iso(self.obtained_at or time.time()),
+            "provider": "microsoft",
+            "token_type": self.token_type,
+        }
+        # Sort keys + newline for deterministic on-disk content.
+        return (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+    @classmethod
+    def from_json_bytes(cls, raw: bytes) -> "TokenSet":
+        data = json.loads(raw.decode("utf-8"))
+        scopes = data.get("scopes") or []
+        if not isinstance(scopes, list):
+            raise ValueError("scopes must be a list of strings on disk")
+        expires_at_raw = data.get("expires_at")
+        if isinstance(expires_at_raw, (int, float)):
+            expires_at = float(expires_at_raw)
+        else:
+            expires_at = _iso_to_epoch(str(expires_at_raw))
+        obtained_at_raw = data.get("obtained_at")
+        if isinstance(obtained_at_raw, (int, float)):
+            obtained_at = float(obtained_at_raw)
+        elif obtained_at_raw:
+            obtained_at = _iso_to_epoch(str(obtained_at_raw))
+        else:
+            obtained_at = 0.0
+        return cls(
+            access_token=str(data["access_token"]),
+            refresh_token=str(data["refresh_token"]),
+            expires_at=expires_at,
+            scopes=tuple(str(s) for s in scopes),
+            obtained_at=obtained_at,
+            token_type=str(data.get("token_type") or "Bearer"),
+        )
+
+
+def _epoch_to_iso(epoch_seconds: float) -> str:
+    """Format epoch seconds as ISO 8601 UTC with trailing Z."""
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.000Z"
+    )
+
+
+def _iso_to_epoch(iso: str) -> float:
+    """Parse ISO 8601 UTC to epoch seconds. Accepts 'Z' or '+00:00' suffix."""
+    from datetime import datetime
+
+    cleaned = iso.replace("Z", "+00:00")
+    return datetime.fromisoformat(cleaned).timestamp()
+
+
+class TokenStore:
+    """File-backed token storage on the per-customer Fly volume.
+
+    The path defaults to ``/opt/data/oauth/microsoft.json`` per ADR 0010.
+    Writes are atomic (tempfile + rename) and the resulting file is
+    forced to mode 0600. Reads return ``None`` when no token has been
+    saved yet -- that is the signal customer-zero has not completed
+    initial OAuth consent.
+    """
+
+    def __init__(self, path: Path = DEFAULT_TOKEN_PATH) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load(self) -> Optional[TokenSet]:
+        if not self.path.exists():
+            return None
+        raw = self.path.read_bytes()
+        return TokenSet.from_json_bytes(raw)
+
+    def save(self, tokens: TokenSet) -> None:
+        """Atomic write: write to a sibling tempfile then rename.
+
+        The temp file is created in the same directory as the target
+        so the rename is on the same filesystem (POSIX atomic rename
+        guarantee). Mode is forced to 0600 BEFORE the rename so the
+        file is never world-readable, even briefly, on the volume.
+        """
+        directory = self.path.parent
+        # NamedTemporaryFile with delete=False so we can rename it.
+        fd, tmp_path_str = tempfile.mkstemp(
+            prefix=self.path.name + ".",
+            suffix=".tmp",
+            dir=str(directory),
+        )
+        tmp_path = Path(tmp_path_str)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(tokens.to_json_bytes())
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, self.path)
+        except Exception:
+            # Best-effort cleanup if the rename never happened.
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+
+class MSGraphOAuth:
+    """Microsoft Graph OAuth client.
+
+    Owns the Fly-volume token store, the refresh-on-expiry loop, the
+    initial authorization-code exchange, and the authorize-URL builder
+    used by `bin/reauth-connector.sh`.
+    """
+
+    capability = "Email"  # informational; the same OAuth backs all three capabilities
+    adapter = "microsoft-graph"
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        scopes: tuple[str, ...] = PHASE_1_SCOPES,
+        token_store: Optional[TokenStore] = None,
+        http: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        if not client_id:
+            raise ValueError("client_id is required")
+        if not client_secret:
+            raise ValueError("client_secret is required")
+        if not redirect_uri:
+            raise ValueError("redirect_uri is required")
+        # Defense-in-depth: refuse to ship with Mail.Send scope -- wave-2 only.
+        if any(scope.lower() == "mail.send" for scope in scopes):
+            raise ValueError(
+                "Mail.Send is a wave-2 scope (issue #881); Phase 1 ships read + draft only"
+            )
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.scopes = scopes
+        self.token_store = token_store or TokenStore()
+        self._http = http or httpx.AsyncClient(timeout=30.0)
+        self._owned_http = http is None
+
+    def authorize_url(self, *, state: str, login_hint: Optional[str] = None) -> str:
+        """Build the Entra ID authorize URL for the initial consent flow.
+
+        The ``state`` value MUST be the signed token produced by
+        ``src/lib/oauth/state.ts`` so the portal callback can verify
+        provenance. Microsoft requires the scopes to be space-separated
+        in the URL; ``offline_access`` MUST be present for a refresh
+        token to be issued.
+        """
+        from urllib.parse import urlencode
+
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+            "response_mode": "query",
+            "scope": " ".join(self.scopes),
+            "state": state,
+        }
+        if login_hint:
+            params["login_hint"] = login_hint
+        return f"{AUTHORIZE_URL}?{urlencode(params, safe=' :/.')}"
+
+    async def exchange_auth_code(self, code: str) -> TokenSet:
+        """Trade an authorization code for the initial token pair."""
+        resp = await self._http.post(
+            TOKEN_URL,
+            data={
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "code": code,
+                "redirect_uri": self.redirect_uri,
+                "grant_type": "authorization_code",
+                # Re-send scopes so the resulting token's scope claim is
+                # explicit even when the consent prompt elided some.
+                "scope": " ".join(self.scopes),
+            },
+        )
+        self._raise_for_status(resp, operation="exchange_auth_code")
+        tokens = TokenSet.from_token_response(resp.json())
+        self.token_store.save(tokens)
+        return tokens
+
+    async def refresh(self, current: TokenSet) -> TokenSet:
+        """Exchange a refresh token for a fresh access token.
+
+        On ``invalid_grant`` (refresh token revoked or expired) raises
+        ``AdapterError(code="auth_expired", ...)`` so the runtime can
+        drive the re-consent flow per oauth-lifecycle.md § "Re-
+        authorization (re-consent) flow".
+        """
+        resp = await self._http.post(
+            TOKEN_URL,
+            data={
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "refresh_token": current.refresh_token,
+                "grant_type": "refresh_token",
+                "scope": " ".join(self.scopes),
+            },
+        )
+        self._raise_for_status(resp, operation="refresh")
+        tokens = TokenSet.from_token_response(resp.json(), previous=current)
+        self.token_store.save(tokens)
+        return tokens
+
+    async def get_valid_tokens(self) -> TokenSet:
+        """Return non-expired tokens, refreshing transparently.
+
+        Raises ``AdapterError(code="auth_expired")`` if no tokens exist
+        (initial consent not completed) or if the refresh attempt is
+        rejected upstream.
+        """
+        tokens = self.token_store.load()
+        if tokens is None:
+            raise AdapterError(
+                code="auth_expired",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"No Microsoft Graph tokens stored at {self.token_store.path}; "
+                    "customer must complete initial OAuth consent"
+                ),
+            )
+        if tokens.is_expired():
+            tokens = await self.refresh(tokens)
+        return tokens
+
+    def _raise_for_status(self, resp: httpx.Response, *, operation: str) -> None:
+        """Translate non-2xx token-endpoint responses into AdapterError.
+
+        Microsoft Entra returns ``invalid_grant`` for revoked, expired,
+        or otherwise unusable refresh tokens -- we map that to
+        ``auth_expired`` per the capability contract. Everything else
+        non-2xx becomes ``upstream_error`` with the HTTP status
+        preserved.
+        """
+        if resp.is_success:
+            return
+        body_text = resp.text if resp.text else "(no body)"
+        error_code = ""
+        try:
+            body = resp.json()
+            if isinstance(body, dict):
+                error_code = str(body.get("error") or "")
+        except (ValueError, json.JSONDecodeError):
+            pass
+        if error_code == "invalid_grant":
+            raise AdapterError(
+                code="auth_expired",
+                capability=self.capability,
+                adapter=self.adapter,
+                message=(
+                    f"Microsoft Graph refresh rejected with invalid_grant "
+                    f"({operation}); re-consent required"
+                ),
+            )
+        raise AdapterError(
+            code="upstream_error",
+            capability=self.capability,
+            adapter=self.adapter,
+            message=(
+                f"Microsoft Graph token endpoint returned HTTP {resp.status_code} "
+                f"({operation}): {body_text[:200]}"
+            ),
+        )
+
+    async def aclose(self) -> None:
+        if self._owned_http:
+            await self._http.aclose()
+
+
+__all__ = [
+    "AUTHORIZE_URL",
+    "DEFAULT_TOKEN_PATH",
+    "MSGraphOAuth",
+    "PHASE_1_SCOPES",
+    "REFRESH_MARGIN_SECONDS",
+    "TOKEN_URL",
+    "TokenSet",
+    "TokenStore",
+]

--- a/ai-employee/connectors/ms_graph/pyproject.toml
+++ b/ai-employee/connectors/ms_graph/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "ai-employee-ms-graph"
+version = "0.1.0"
+description = "Microsoft Graph adapter for SMD's AI Employee — Email, Calendar, OneDrive (DocumentStorage) capabilities. Phase 1 read + draft only; Mail.Send deferred to wave 2 (#881)."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "SMD Services" }]
+license = { text = "MIT" }
+dependencies = [
+  "httpx>=0.28.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+  "pytest-asyncio>=0.23.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ms_graph*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/ai-employee/connectors/ms_graph/tests/conftest.py
+++ b/ai-employee/connectors/ms_graph/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest config -- extend sys.path so ``connectors.ms_graph`` is importable
+when the suite is invoked from either ``ai-employee/`` or the repo root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve()
+# Make ``ai-employee/`` importable -> ``from connectors.ms_graph import ...``
+sys.path.insert(0, str(_HERE.parents[3]))

--- a/ai-employee/connectors/ms_graph/tests/test_oauth.py
+++ b/ai-employee/connectors/ms_graph/tests/test_oauth.py
@@ -1,0 +1,497 @@
+"""Unit tests for the Microsoft Graph OAuth lifecycle.
+
+Coverage targets (from `docs/specs/ai-employee/oauth-lifecycle.md`
+§Verification "Unit tests"):
+
+* Token storage round-trip (atomic write + 0600 mode + JSON shape)
+* Refresh on expiry within the 10-minute safety margin
+* Refresh failure (invalid_grant) -> AdapterError(auth_expired)
+* Re-consent URL generation (authorize URL includes signed state +
+  every Phase-1 scope; no Mail.Send)
+* AppFolder-only write scope is enforced via PHASE_1_SCOPES (the
+  client refuses to construct with Mail.Send)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+# When invoked from the package directory the import path is the
+# package itself; when invoked from ai-employee/ via the conftest
+# sys.path hook it's ``connectors.ms_graph``. Try both.
+try:
+    from connectors.ms_graph.oauth import (
+        AUTHORIZE_URL,
+        MSGraphOAuth,
+        PHASE_1_SCOPES,
+        REFRESH_MARGIN_SECONDS,
+        TOKEN_URL,
+        TokenSet,
+        TokenStore,
+    )
+    from connectors.ms_graph._types import AdapterError
+except ModuleNotFoundError:
+    from ms_graph.oauth import (  # type: ignore[no-redef]
+        AUTHORIZE_URL,
+        MSGraphOAuth,
+        PHASE_1_SCOPES,
+        REFRESH_MARGIN_SECONDS,
+        TOKEN_URL,
+        TokenSet,
+        TokenStore,
+    )
+    from ms_graph._types import AdapterError  # type: ignore[no-redef]
+
+
+def _token_payload(
+    *,
+    access: str = "access1",
+    refresh: str | None = "refresh1",
+    expires_in: int = 3600,
+    scope: str = " ".join(PHASE_1_SCOPES),
+) -> dict:
+    payload = {
+        "access_token": access,
+        "expires_in": expires_in,
+        "token_type": "Bearer",
+        "scope": scope,
+    }
+    if refresh is not None:
+        payload["refresh_token"] = refresh
+    return payload
+
+
+# ----- TokenSet -----
+
+
+def test_token_set_is_expired_within_safety_margin() -> None:
+    tokens = TokenSet(
+        access_token="a",
+        refresh_token="r",
+        expires_at=time.time() + REFRESH_MARGIN_SECONDS // 2,
+    )
+    assert tokens.is_expired() is True
+
+
+def test_token_set_not_expired_outside_safety_margin() -> None:
+    tokens = TokenSet(
+        access_token="a",
+        refresh_token="r",
+        expires_at=time.time() + REFRESH_MARGIN_SECONDS * 2,
+    )
+    assert tokens.is_expired() is False
+
+
+def test_token_set_from_token_response_carries_refresh_forward() -> None:
+    previous = TokenSet(
+        access_token="old-access",
+        refresh_token="long-lived-refresh",
+        expires_at=time.time() - 1,
+    )
+    new = TokenSet.from_token_response(
+        _token_payload(access="new-access", refresh=None),
+        previous=previous,
+    )
+    assert new.access_token == "new-access"
+    assert new.refresh_token == "long-lived-refresh"
+
+
+def test_token_set_rejects_missing_access_token() -> None:
+    with pytest.raises(ValueError, match="missing access_token"):
+        TokenSet.from_token_response({"expires_in": 100})
+
+
+def test_token_set_rejects_missing_refresh_with_no_previous() -> None:
+    with pytest.raises(ValueError, match="missing refresh_token"):
+        TokenSet.from_token_response(_token_payload(refresh=None))
+
+
+# ----- TokenStore -----
+
+
+def test_token_store_round_trip(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    original = TokenSet(
+        access_token="abc",
+        refresh_token="def",
+        expires_at=time.time() + 3600,
+        scopes=("Mail.Read", "Calendars.ReadWrite"),
+        obtained_at=time.time(),
+    )
+    store.save(original)
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.access_token == "abc"
+    assert loaded.refresh_token == "def"
+    assert loaded.scopes == ("Mail.Read", "Calendars.ReadWrite")
+
+
+def test_token_store_returns_none_when_no_tokens(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    assert store.load() is None
+
+
+def test_token_store_enforces_0600_permissions(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    store.save(TokenSet(access_token="a", refresh_token="r", expires_at=time.time() + 3600))
+    mode = store.path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_token_store_writes_adr_0010_json_shape(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    now = time.time()
+    store.save(
+        TokenSet(
+            access_token="a",
+            refresh_token="r",
+            expires_at=now + 3600,
+            scopes=("Mail.Read",),
+            obtained_at=now,
+        )
+    )
+    on_disk = json.loads(store.path.read_bytes())
+    # Required fields per ADR 0010 §Storage shape
+    assert set(on_disk.keys()) >= {
+        "access_token",
+        "refresh_token",
+        "scopes",
+        "expires_at",
+        "obtained_at",
+        "provider",
+    }
+    assert on_disk["provider"] == "microsoft"
+    assert on_disk["scopes"] == ["Mail.Read"]
+    # ISO 8601 UTC, trailing Z
+    assert on_disk["expires_at"].endswith("Z")
+    assert on_disk["obtained_at"].endswith("Z")
+
+
+def test_token_store_atomic_replace(tmp_path: Path) -> None:
+    """A second write replaces atomically; no .tmp files left behind."""
+    store = TokenStore(tmp_path / "microsoft.json")
+    store.save(TokenSet(access_token="v1", refresh_token="r", expires_at=time.time() + 3600))
+    store.save(TokenSet(access_token="v2", refresh_token="r", expires_at=time.time() + 3600))
+    loaded = store.load()
+    assert loaded is not None and loaded.access_token == "v2"
+    leftover = list(tmp_path.glob("microsoft.json.*.tmp"))
+    assert leftover == []
+
+
+# ----- MSGraphOAuth construction -----
+
+
+def test_oauth_rejects_mail_send_scope(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Mail.Send is a wave-2 scope"):
+        MSGraphOAuth(
+            client_id="x",
+            client_secret="y",
+            redirect_uri="https://portal.example/ai-employee/oauth/microsoft-graph/callback",
+            scopes=("Mail.Read", "Mail.Send"),
+            token_store=TokenStore(tmp_path / "microsoft.json"),
+        )
+
+
+def test_oauth_requires_client_id(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="client_id is required"):
+        MSGraphOAuth(
+            client_id="",
+            client_secret="y",
+            redirect_uri="https://example/cb",
+            token_store=TokenStore(tmp_path / "microsoft.json"),
+        )
+
+
+def test_oauth_requires_client_secret(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="client_secret is required"):
+        MSGraphOAuth(
+            client_id="x",
+            client_secret="",
+            redirect_uri="https://example/cb",
+            token_store=TokenStore(tmp_path / "microsoft.json"),
+        )
+
+
+def test_oauth_requires_redirect_uri(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="redirect_uri is required"):
+        MSGraphOAuth(
+            client_id="x",
+            client_secret="y",
+            redirect_uri="",
+            token_store=TokenStore(tmp_path / "microsoft.json"),
+        )
+
+
+# ----- Authorize URL generation -----
+
+
+def test_authorize_url_includes_state_and_phase_1_scopes(tmp_path: Path) -> None:
+    oauth = MSGraphOAuth(
+        client_id="abc-123",
+        client_secret="secret",
+        redirect_uri="https://portal.smd.services/ai-employee/oauth/microsoft-graph/callback",
+        token_store=TokenStore(tmp_path / "microsoft.json"),
+    )
+    url = oauth.authorize_url(state="signed-state-token")
+    assert url.startswith(AUTHORIZE_URL)
+    assert "client_id=abc-123" in url
+    assert "state=signed-state-token" in url
+    assert "response_type=code" in url
+    assert "redirect_uri=" in url
+    # Every Phase-1 scope must be in the URL
+    for scope in PHASE_1_SCOPES:
+        assert scope in url
+    # Mail.Send must NOT be in the URL
+    assert "Mail.Send" not in url
+    assert "mail.send" not in url
+
+
+def test_authorize_url_optional_login_hint(tmp_path: Path) -> None:
+    oauth = MSGraphOAuth(
+        client_id="abc",
+        client_secret="secret",
+        redirect_uri="https://example/cb",
+        token_store=TokenStore(tmp_path / "microsoft.json"),
+    )
+    url = oauth.authorize_url(state="s", login_hint="user@example.com")
+    assert "login_hint=user%40example.com" in url or "login_hint=user@example.com" in url
+
+
+# ----- Auth code exchange -----
+
+
+@pytest.mark.asyncio
+async def test_exchange_auth_code_hits_token_endpoint(tmp_path: Path) -> None:
+    captured_request: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_request["url"] = str(request.url)
+        captured_request["method"] = request.method
+        captured_request["body"] = request.read().decode()
+        return httpx.Response(200, json=_token_payload(access="A1", refresh="R1"))
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        oauth = MSGraphOAuth(
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://portal.example/cb",
+            token_store=TokenStore(tmp_path / "microsoft.json"),
+            http=http,
+        )
+        tokens = await oauth.exchange_auth_code("CODE123")
+
+    assert tokens.access_token == "A1"
+    assert tokens.refresh_token == "R1"
+    assert captured_request["url"] == TOKEN_URL
+    assert captured_request["method"] == "POST"
+    body = str(captured_request["body"])
+    assert "grant_type=authorization_code" in body
+    assert "code=CODE123" in body
+    # Persisted to disk
+    persisted = TokenStore(tmp_path / "microsoft.json").load()
+    assert persisted is not None and persisted.access_token == "A1"
+
+
+# ----- Refresh -----
+
+
+@pytest.mark.asyncio
+async def test_get_valid_tokens_refreshes_within_safety_margin(tmp_path: Path) -> None:
+    """A token that expires inside the 10-minute window triggers refresh."""
+    store = TokenStore(tmp_path / "microsoft.json")
+    # Expires in 5 minutes -- well inside the 10-minute margin.
+    store.save(
+        TokenSet(
+            access_token="OLD",
+            refresh_token="REFRESH_OLD",
+            expires_at=time.time() + 300,
+        )
+    )
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.read().decode()
+        calls.append(body)
+        return httpx.Response(200, json=_token_payload(access="NEW", refresh="REFRESH_NEW"))
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        oauth = MSGraphOAuth(
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://portal.example/cb",
+            token_store=store,
+            http=http,
+        )
+        tokens = await oauth.get_valid_tokens()
+
+    assert tokens.access_token == "NEW"
+    assert tokens.refresh_token == "REFRESH_NEW"
+    assert len(calls) == 1
+    assert "grant_type=refresh_token" in calls[0]
+    assert "refresh_token=REFRESH_OLD" in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_get_valid_tokens_skips_refresh_when_well_in_future(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    store.save(
+        TokenSet(
+            access_token="STILL_GOOD",
+            refresh_token="r",
+            expires_at=time.time() + 3600,
+        )
+    )
+    calls = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json=_token_payload())
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        oauth = MSGraphOAuth(
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://portal.example/cb",
+            token_store=store,
+            http=http,
+        )
+        tokens = await oauth.get_valid_tokens()
+
+    assert tokens.access_token == "STILL_GOOD"
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_translates_invalid_grant_to_auth_expired(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    store.save(
+        TokenSet(access_token="OLD", refresh_token="REVOKED", expires_at=time.time() - 1)
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": "invalid_grant",
+                "error_description": "AADSTS70008: refresh token expired",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        oauth = MSGraphOAuth(
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://portal.example/cb",
+            token_store=store,
+            http=http,
+        )
+        with pytest.raises(AdapterError) as excinfo:
+            await oauth.get_valid_tokens()
+    assert excinfo.value.code == "auth_expired"
+    assert excinfo.value.adapter == "microsoft-graph"
+
+
+@pytest.mark.asyncio
+async def test_refresh_translates_other_errors_to_upstream_error(tmp_path: Path) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    store.save(
+        TokenSet(access_token="OLD", refresh_token="r", expires_at=time.time() - 1)
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="Service Unavailable")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        oauth = MSGraphOAuth(
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://portal.example/cb",
+            token_store=store,
+            http=http,
+        )
+        with pytest.raises(AdapterError) as excinfo:
+            await oauth.get_valid_tokens()
+    assert excinfo.value.code == "upstream_error"
+
+
+@pytest.mark.asyncio
+async def test_get_valid_tokens_raises_auth_expired_without_initial_consent(
+    tmp_path: Path,
+) -> None:
+    oauth = MSGraphOAuth(
+        client_id="cid",
+        client_secret="csecret",
+        redirect_uri="https://portal.example/cb",
+        token_store=TokenStore(tmp_path / "microsoft.json"),
+    )
+    with pytest.raises(AdapterError) as excinfo:
+        await oauth.get_valid_tokens()
+    assert excinfo.value.code == "auth_expired"
+    assert "customer must complete initial OAuth consent" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_carries_previous_refresh_token_when_response_omits_it(
+    tmp_path: Path,
+) -> None:
+    store = TokenStore(tmp_path / "microsoft.json")
+    store.save(
+        TokenSet(
+            access_token="OLD",
+            refresh_token="LONG_LIVED",
+            expires_at=time.time() - 1,
+        )
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Graph sometimes returns a refreshed token without a new refresh_token
+        # when it elects not to rotate.
+        return httpx.Response(200, json=_token_payload(access="NEW", refresh=None))
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        oauth = MSGraphOAuth(
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://portal.example/cb",
+            token_store=store,
+            http=http,
+        )
+        tokens = await oauth.get_valid_tokens()
+
+    assert tokens.access_token == "NEW"
+    assert tokens.refresh_token == "LONG_LIVED"
+
+
+# ----- Phase-1 scopes -----
+
+
+def test_phase_1_scopes_have_no_mail_send() -> None:
+    assert "Mail.Send" not in PHASE_1_SCOPES
+    assert all(s.lower() != "mail.send" for s in PHASE_1_SCOPES)
+
+
+def test_phase_1_scopes_match_lifecycle_spec() -> None:
+    """The scope set must match oauth-lifecycle.md §"Per-connector OAuth scope inventory"."""
+    required = {
+        "offline_access",
+        "User.Read",
+        "Mail.Read",
+        "Mail.ReadWrite",
+        "MailboxSettings.Read",
+        "Calendars.ReadWrite",
+        "Files.Read",
+        "Files.ReadWrite.AppFolder",
+    }
+    assert set(PHASE_1_SCOPES) == required

--- a/bin/reauth-connector.sh
+++ b/bin/reauth-connector.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# reauth-connector.sh CUSTOMER_SLUG CONNECTOR_SLUG
+#
+# Captain-invoked. Generates a signed OAuth authorize URL for the given
+# customer + connector and emails it to the customer's principal user
+# per oauth-lifecycle.md § "Re-authorization (re-consent) flow":
+#
+#   1. Issue a signed state parameter (HMAC-SHA256, 10-minute TTL)
+#      bound to the customer slug + provider + reviewer id.
+#   2. Build the provider's authorize URL with that state.
+#   3. Email the link to the customer's principal user via Resend.
+#
+# Phase 1 supports CONNECTOR_SLUG = microsoft-graph. Other providers
+# layer in once their registry entry lands in src/lib/oauth/providers/.
+#
+# Required env (Infisical export OR sourced from .dev.vars):
+#   ADMIN_BASE_URL                e.g. https://admin.smd.services
+#   PORTAL_BASE_URL               e.g. https://portal.smd.services
+#   OAUTH_STATE_SIGNING_KEY       32 bytes, base64-encoded
+#   MICROSOFT_GRAPH_CLIENT_ID     Entra ID app registration client id
+#   RESEND_API_KEY                Resend API key for outbound email
+#   REAUTH_FROM_ADDRESS           verified sender, e.g. captain@smd.services
+#   REAUTH_REVIEWER_ID            Captain's Clerk user id (matches state)
+#
+# Optional:
+#   REAUTH_CUSTOMER_EMAIL         override the principal user email
+#                                 lookup; useful for dry-run testing
+#   DRY_RUN=1                     print the URL + would-be email body,
+#                                 don't actually send
+#
+# This script is intentionally a thin Bash wrapper around a Node
+# one-shot. The signing key + URL builders live in TypeScript so a
+# single source of truth governs every URL the platform emits.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: reauth-connector.sh CUSTOMER_SLUG CONNECTOR_SLUG
+
+Arguments:
+  CUSTOMER_SLUG     customer.yaml customer_id (e.g. acme-law)
+  CONNECTOR_SLUG    provider slug; supported: microsoft-graph
+
+Environment:
+  See script header.
+
+Exit codes:
+  0  success
+  1  argument error
+  2  missing env
+  3  email send failed
+USAGE
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+fi
+
+CUSTOMER_SLUG="$1"
+CONNECTOR_SLUG="$2"
+
+case "$CONNECTOR_SLUG" in
+  microsoft-graph) ;;
+  *)
+    echo "FATAL: connector '$CONNECTOR_SLUG' not supported in Phase 1." >&2
+    echo "       Currently shipping: microsoft-graph" >&2
+    exit 1
+    ;;
+esac
+
+REQUIRED_VARS=(
+  ADMIN_BASE_URL
+  PORTAL_BASE_URL
+  OAUTH_STATE_SIGNING_KEY
+  MICROSOFT_GRAPH_CLIENT_ID
+  REAUTH_REVIEWER_ID
+)
+MISSING=()
+for var in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!var:-}" ]; then
+    MISSING+=("$var")
+  fi
+done
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo "FATAL: missing required env vars: ${MISSING[*]}" >&2
+  echo "       Source from Infisical: infisical export --env=prod --path=/ss --format=dotenv > .env.reauth" >&2
+  exit 2
+fi
+
+# Locate the repo root from this script's location so the call works
+# from any cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Single node invocation: signs state, builds URL, prints it. We pipe
+# only the URL out so the Bash wrapper can use it without parsing.
+URL="$(
+  CUSTOMER_SLUG="$CUSTOMER_SLUG" \
+  CONNECTOR_SLUG="$CONNECTOR_SLUG" \
+  REVIEWER_ID="$REAUTH_REVIEWER_ID" \
+  CLIENT_ID="$MICROSOFT_GRAPH_CLIENT_ID" \
+  REDIRECT_URI="${PORTAL_BASE_URL%/}/portal/products/ai-employee/oauth/${CONNECTOR_SLUG}/callback" \
+  SIGNING_KEY="$OAUTH_STATE_SIGNING_KEY" \
+  node --input-type=module -e '
+    import { createHmac } from "node:crypto";
+
+    const customer_id = process.env.CUSTOMER_SLUG;
+    const provider = process.env.CONNECTOR_SLUG;
+    const reviewer_id = process.env.REVIEWER_ID;
+    const client_id = process.env.CLIENT_ID;
+    const redirect_uri = process.env.REDIRECT_URI;
+    const signingKeyB64 = process.env.SIGNING_KEY;
+
+    function b64UrlEncode(buf) {
+      return Buffer.from(buf).toString("base64")
+        .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    }
+
+    const exp = Math.floor(Date.now() / 1000) + 600; // 10-minute TTL
+    const nonce = crypto.randomUUID();
+    const payload = JSON.stringify({
+      v: 1,
+      customer_id,
+      provider,
+      reviewer_id,
+      nonce,
+      exp,
+    });
+    const payloadB64 = b64UrlEncode(payload);
+
+    const keyBytes = Buffer.from(signingKeyB64, "base64");
+    const sig = createHmac("sha256", keyBytes).update(payloadB64).digest();
+    const sigB64 = b64UrlEncode(sig);
+
+    const state = `${payloadB64}.${sigB64}`;
+
+    // Phase-1 scopes — must match
+    // ai-employee/connectors/ms_graph/oauth.py PHASE_1_SCOPES and
+    // src/lib/oauth/providers/ms-graph.ts MS_GRAPH_PHASE_1_SCOPES.
+    const scopes = [
+      "offline_access",
+      "User.Read",
+      "Mail.Read",
+      "Mail.ReadWrite",
+      "MailboxSettings.Read",
+      "Calendars.ReadWrite",
+      "Files.Read",
+      "Files.ReadWrite.AppFolder",
+    ];
+
+    const params = new URLSearchParams({
+      client_id,
+      response_type: "code",
+      redirect_uri,
+      response_mode: "query",
+      scope: scopes.join(" "),
+      state,
+    });
+    process.stdout.write(
+      `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}\n`
+    );
+  '
+)"
+
+if [ -z "$URL" ]; then
+  echo "FATAL: state-signing step produced no URL" >&2
+  exit 1
+fi
+
+CUSTOMER_EMAIL="${REAUTH_CUSTOMER_EMAIL:-}"
+if [ -z "$CUSTOMER_EMAIL" ]; then
+  # Look up principal user from the canonical customer.yaml. In
+  # production this lives in the configs repo; for now we read from
+  # ai-employee/customers/<slug>/customer.yaml when present and fall
+  # back to printing the URL only.
+  CUSTOMER_YAML="$REPO_ROOT/ai-employee/customers/$CUSTOMER_SLUG/customer.yaml"
+  if [ -f "$CUSTOMER_YAML" ]; then
+    CUSTOMER_EMAIL="$(
+      awk '
+        /^users:/ { in_users = 1; next }
+        in_users && /^[^ -]/ { in_users = 0 }
+        in_users && /role:[[:space:]]*principal/ { found = 1 }
+        in_users && /^[[:space:]]*-/ {
+          if (found && email) { print email; exit }
+          email = ""; found = 0
+        }
+        in_users && /email:[[:space:]]*/ {
+          sub(/^[^:]*:[[:space:]]*/, "")
+          gsub(/^["[:space:]]+|["[:space:]]+$/, "")
+          email = $0
+        }
+        END {
+          if (found && email) print email
+        }
+      ' "$CUSTOMER_YAML"
+    )"
+  fi
+fi
+
+cat <<EOF
+
+Customer slug:    $CUSTOMER_SLUG
+Connector:        $CONNECTOR_SLUG
+Principal email:  ${CUSTOMER_EMAIL:-(not resolved; pass REAUTH_CUSTOMER_EMAIL)}
+Authorize URL:    $URL
+
+EOF
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN=1 set; not sending email."
+  exit 0
+fi
+
+if [ -z "$CUSTOMER_EMAIL" ]; then
+  echo "FATAL: cannot send — principal email not resolved." >&2
+  echo "       Set REAUTH_CUSTOMER_EMAIL or populate users[].role: principal in customer.yaml." >&2
+  exit 1
+fi
+
+if [ -z "${RESEND_API_KEY:-}" ] || [ -z "${REAUTH_FROM_ADDRESS:-}" ]; then
+  echo "FATAL: RESEND_API_KEY or REAUTH_FROM_ADDRESS missing." >&2
+  exit 2
+fi
+
+# Send via Resend. The URL is the only customer-specific data; we keep
+# the body terse and free of marketing.
+BODY_TEXT=$(cat <<MSG
+Hello,
+
+We need you to re-authorize the SMD Services AI Employee connection to
+your Microsoft 365 account. Click the link below to sign in and grant
+access. The link expires in 10 minutes.
+
+$URL
+
+If you did not expect this email, please ignore it and contact SMD
+Services directly.
+
+— SMD Services
+MSG
+)
+
+JSON_PAYLOAD=$(
+  CUSTOMER_EMAIL="$CUSTOMER_EMAIL" \
+  BODY_TEXT="$BODY_TEXT" \
+  REAUTH_FROM_ADDRESS="$REAUTH_FROM_ADDRESS" \
+  python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "from": os.environ["REAUTH_FROM_ADDRESS"],
+    "to": [os.environ["CUSTOMER_EMAIL"]],
+    "subject": "Re-authorize Microsoft 365 access for the AI Employee",
+    "text": os.environ["BODY_TEXT"],
+}))
+PY
+)
+
+HTTP_STATUS=$(
+  curl -sS -o /tmp/reauth-resp.json -w "%{http_code}" \
+    -X POST "https://api.resend.com/emails" \
+    -H "Authorization: Bearer $RESEND_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$JSON_PAYLOAD"
+)
+
+if [ "$HTTP_STATUS" != "200" ] && [ "$HTTP_STATUS" != "202" ]; then
+  echo "FATAL: Resend send failed (HTTP $HTTP_STATUS)" >&2
+  cat /tmp/reauth-resp.json >&2
+  exit 3
+fi
+
+echo "OK: re-consent email sent to $CUSTOMER_EMAIL"

--- a/docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md
+++ b/docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md
@@ -1,0 +1,99 @@
+# Microsoft Graph Azure AD app registration
+
+How to register the SMD Services AI Employee app in Microsoft Entra ID (Azure AD), obtain the client credentials used by the OAuth callback, and grant the Phase-1 scopes that the MS Graph adapter requires.
+
+This runbook is performed **once** by Captain. The resulting `client_id` and `client_secret` are stored in Infisical at `/ai-employee/shared/microsoft-graph/` and pushed to the ss-web Worker as `MICROSOFT_GRAPH_CLIENT_ID` / `MICROSOFT_GRAPH_CLIENT_SECRET`. Per-customer consent (and the resulting per-tenant tokens) is collected separately during customer provisioning — see "Customer onboarding" below.
+
+## Prerequisites
+
+- Azure subscription with rights to register applications in the SMD Services Entra ID tenant.
+- `ADMIN_BASE_URL` set in production (`https://admin.smd.services`) and `PORTAL_BASE_URL` set (`https://portal.smd.services`).
+- Access to Infisical for the SMD Services workspace.
+
+## App registration steps
+
+1. Sign in to <https://entra.microsoft.com> as a global admin on the SMD Services tenant.
+2. Navigate to **Identity → Applications → App registrations** → **+ New registration**.
+3. Configure:
+   - **Name:** `SMD Services AI Employee`
+   - **Supported account types:** _Accounts in any organizational directory (Any Microsoft Entra ID tenant — multitenant)_.
+     - Multi-tenant is required because each customer law-firm tenant will consent independently.
+   - **Redirect URI:** `Web` → `https://portal.smd.services/ai-employee/oauth/microsoft-graph/callback`
+     - This is the customer-facing portal subdomain per [oauth-lifecycle.md](../../specs/ai-employee/oauth-lifecycle.md) "Re-consent callback URL". The admin-subdomain endpoint at `https://admin.smd.services/api/oauth/callback` from PR #936 stays in place as the v1 backstop and may be added as a second registered URI during the transition window.
+4. Click **Register**. Record the **Application (client) ID** — this becomes `MICROSOFT_GRAPH_CLIENT_ID`.
+
+## Configure API permissions (Phase 1)
+
+Phase 1 ships read + draft only. `Mail.Send` is intentionally excluded — programmatic send is wave-2 stream #881.
+
+1. **Manage → API permissions → + Add a permission → Microsoft Graph → Delegated permissions**.
+2. Add exactly the following delegated scopes:
+   - `User.Read` _(default; keep)_
+   - `Mail.Read`
+   - `Mail.ReadWrite`
+   - `MailboxSettings.Read`
+   - `Calendars.ReadWrite`
+   - `Files.Read`
+   - `Files.ReadWrite.AppFolder`
+   - `offline_access` _(required to issue refresh tokens)_
+3. Do **not** add `Mail.Send`, `Files.ReadWrite`, `Files.ReadWrite.All`, or any `.All` application permission. If one is added by mistake, remove it before saving — leaving it on the registration broadens the consent prompt the customer sees, even if the adapter does not exercise it.
+4. Click **Grant admin consent for SMD Services** to pre-consent on the SMD Services tenant only. Customer tenants grant their own consent during onboarding (see below).
+
+## Create a client secret
+
+1. **Manage → Certificates & secrets → + New client secret**.
+2. **Description:** `prod-<YYYYMM>` (e.g. `prod-202605`).
+3. **Expires:** 12 months.
+4. Click **Add** and immediately copy the secret **Value** (not the Secret ID). This value is shown only once.
+5. Store the secret in Infisical:
+   ```bash
+   # Run from a machine with Infisical CLI already authenticated
+   pbpaste | infisical secrets set MICROSOFT_GRAPH_CLIENT_SECRET --env=prod --path=/ai-employee/shared/microsoft-graph --plain
+   ```
+6. Add the client ID to Infisical the same way under `MICROSOFT_GRAPH_CLIENT_ID`.
+7. Push to Workers env:
+   ```bash
+   infisical export --env=prod --path=/ai-employee/shared/microsoft-graph --format=dotenv \
+     | npx wrangler secret bulk
+   ```
+
+Rotation: schedule the next rotation 30 days before the expiry date. Replace the secret value in Infisical, re-push to Workers, then delete the old secret in Entra after a 24-hour overlap window so in-flight customer consent flows are not interrupted.
+
+## Customer onboarding (per-tenant consent)
+
+When a new customer is provisioned, Captain runs `bin/reauth-connector.sh <customer-slug> microsoft-graph`, which:
+
+1. Issues a signed OAuth state parameter bound to the customer slug and Captain's reviewer ID.
+2. Generates an authorize URL of the form `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...&state=<signed>`.
+3. Emails the URL to the customer's principal user listed in `customer.yaml` under `users[].role: principal`.
+
+The customer signs in to their own Microsoft 365 tenant, reviews the requested scopes, and consents. Microsoft Entra redirects to the portal callback at `https://portal.smd.services/ai-employee/oauth/microsoft-graph/callback?code=...&state=...`. The portal handler verifies the state, exchanges the code for tokens via the registered token endpoint, and proxies the resulting `{ access_token, refresh_token, expires_at, scopes }` payload to the per-customer Hermes Machine for atomic write to `/opt/data/oauth/microsoft.json` per [ADR 0010](../../adr/0010-per-customer-oauth-token-storage.md).
+
+If the customer tenant blocks third-party multi-tenant apps, the customer's Microsoft 365 admin must first add the SMD Services AI Employee app from the Entra **Enterprise applications** blade. The error returned in that case is `AADSTS650056` — the portal callback surfaces it back to the customer as a short failure reason.
+
+## Verification
+
+After onboarding a customer:
+
+```bash
+# On the customer's Fly machine
+fly ssh console -a hermes-<customer-slug>
+ls -la /opt/data/oauth/
+# Expect: microsoft.json, mode 0600, owned by uid 10000 (hermes)
+```
+
+Run the smoke test:
+
+```bash
+fly ssh console -a hermes-<customer-slug> -C \
+  '/opt/hermes/.venv/bin/python -m ai_employee_ms_graph.smoke'
+```
+
+The smoke test calls `GET /me` against Microsoft Graph and prints the principal's `displayName` + `mail` (no token material). A 401 indicates the token is missing or expired; a 403 indicates the customer tenant did not grant a required scope.
+
+## Related references
+
+- [oauth-lifecycle.md](../../specs/ai-employee/oauth-lifecycle.md) — refresh policy, re-consent flow, failure modes
+- [ADR 0010](../../adr/0010-per-customer-oauth-token-storage.md) — token storage decision
+- [capability-contracts.md](../../specs/ai-employee/capability-contracts.md) — Email / Calendar / DocumentStorage interfaces
+- [customer-yaml-schema.md](../../specs/ai-employee/customer-yaml-schema.md) — `connectors.Email/Calendar/DocumentStorage` bindings to the `microsoft-graph` adapter

--- a/src/lib/oauth/providers.ts
+++ b/src/lib/oauth/providers.ts
@@ -27,6 +27,8 @@
 
 import { env } from 'cloudflare:workers'
 
+import { microsoftGraphProvider } from './providers/ms-graph.js'
+
 export interface ProviderTokenResponse {
   /** Short-lived access token. */
   access_token: string
@@ -55,7 +57,6 @@ export interface OAuthProvider {
   exchange_code(args: { code: string; redirect_uri: string }): Promise<ProviderTokenResponse>
 }
 
-const MS_GRAPH_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 
 interface RawTokenJson {
@@ -100,32 +101,6 @@ async function postFormForToken(
   }
 }
 
-const microsoftGraph: OAuthProvider = {
-  slug: 'microsoft-graph',
-  label: 'Microsoft Graph',
-  token_url: MS_GRAPH_TOKEN_URL,
-  async exchange_code({ code, redirect_uri }) {
-    const clientId = env.MICROSOFT_GRAPH_CLIENT_ID
-    const clientSecret = env.MICROSOFT_GRAPH_CLIENT_SECRET
-    if (!clientId || !clientSecret) {
-      throw new Error(
-        'Microsoft Graph client credentials are not configured (MICROSOFT_GRAPH_CLIENT_ID / MICROSOFT_GRAPH_CLIENT_SECRET).'
-      )
-    }
-    return postFormForToken(
-      MS_GRAPH_TOKEN_URL,
-      new URLSearchParams({
-        client_id: clientId,
-        client_secret: clientSecret,
-        code,
-        redirect_uri,
-        grant_type: 'authorization_code',
-      }),
-      microsoftGraph.label
-    )
-  },
-}
-
 const googleWorkspace: OAuthProvider = {
   slug: 'google-workspace',
   label: 'Google Workspace',
@@ -153,7 +128,7 @@ const googleWorkspace: OAuthProvider = {
 }
 
 const PROVIDERS: Record<string, OAuthProvider> = {
-  [microsoftGraph.slug]: microsoftGraph,
+  [microsoftGraphProvider.slug]: microsoftGraphProvider,
   [googleWorkspace.slug]: googleWorkspace,
 }
 

--- a/src/lib/oauth/providers/ms-graph.ts
+++ b/src/lib/oauth/providers/ms-graph.ts
@@ -1,0 +1,141 @@
+/**
+ * Microsoft Graph OAuth provider entry.
+ *
+ * Provider-specific token-exchange details for the unified callback at
+ * `src/pages/api/oauth/callback.ts` and the customer-facing portal
+ * callback at `src/pages/portal/products/ai-employee/oauth/[connector]/callback.astro`.
+ *
+ * Scope discipline mirrors `ai-employee/connectors/ms_graph/oauth.py`
+ * `PHASE_1_SCOPES`: read + draft only. `Mail.Send` is explicitly absent
+ * — programmatic send is wave-2 stream (issue #881) under a separate
+ * adapter method and a distinct delegated scope.
+ *
+ * Reference docs:
+ *   - `docs/specs/ai-employee/oauth-lifecycle.md` § "Per-connector OAuth scope inventory"
+ *   - `docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md`
+ */
+
+import { env } from 'cloudflare:workers'
+
+import type { OAuthProvider, ProviderTokenResponse } from '../providers.js'
+
+const MS_GRAPH_AUTHORIZE_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+const MS_GRAPH_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+
+/**
+ * Phase 1 delegated scopes. Identical set as
+ * `ai-employee/connectors/ms_graph/oauth.py` `PHASE_1_SCOPES`. Any
+ * change here must be paired with the Python adapter and the
+ * lifecycle spec — they are the same contract.
+ */
+export const MS_GRAPH_PHASE_1_SCOPES: readonly string[] = Object.freeze([
+  'offline_access',
+  'User.Read',
+  'Mail.Read',
+  'Mail.ReadWrite',
+  'MailboxSettings.Read',
+  'Calendars.ReadWrite',
+  'Files.Read',
+  'Files.ReadWrite.AppFolder',
+])
+
+interface RawTokenJson {
+  access_token?: unknown
+  refresh_token?: unknown
+  scope?: unknown
+  expires_in?: unknown
+}
+
+async function postFormForToken(
+  body: URLSearchParams,
+  providerLabel: string
+): Promise<ProviderTokenResponse> {
+  const response = await fetch(MS_GRAPH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`${providerLabel} token exchange failed (${response.status}): ${text}`)
+  }
+  const raw: RawTokenJson = await response.json()
+  if (typeof raw.access_token !== 'string' || raw.access_token.length === 0) {
+    throw new Error(`${providerLabel} token exchange returned no access_token`)
+  }
+  const expiresInSec = typeof raw.expires_in === 'number' ? raw.expires_in : 3600
+  const now = Date.now()
+  return {
+    access_token: raw.access_token,
+    refresh_token: typeof raw.refresh_token === 'string' ? raw.refresh_token : null,
+    scopes: typeof raw.scope === 'string' ? raw.scope : '',
+    expires_at: new Date(now + expiresInSec * 1000).toISOString(),
+    obtained_at: new Date(now).toISOString(),
+  }
+}
+
+/**
+ * Build the Microsoft Entra authorize URL for a customer's initial
+ * consent flow. The `state` parameter MUST be the signed token from
+ * `src/lib/oauth/state.ts` so the callback verifies provenance.
+ */
+export function buildMicrosoftGraphAuthorizeUrl(args: {
+  client_id: string
+  redirect_uri: string
+  state: string
+  login_hint?: string
+  scopes?: readonly string[]
+}): string {
+  if (!args.client_id) throw new Error('client_id is required')
+  if (!args.redirect_uri) throw new Error('redirect_uri is required')
+  if (!args.state) throw new Error('state is required')
+  const scopes = args.scopes ?? MS_GRAPH_PHASE_1_SCOPES
+  // Defense-in-depth: refuse to emit a URL that requests Mail.Send.
+  if (scopes.some((s) => s.toLowerCase() === 'mail.send')) {
+    throw new Error('Mail.Send is a wave-2 scope (issue #881); refusing to emit authorize URL')
+  }
+  const params = new URLSearchParams({
+    client_id: args.client_id,
+    response_type: 'code',
+    redirect_uri: args.redirect_uri,
+    response_mode: 'query',
+    scope: scopes.join(' '),
+    state: args.state,
+  })
+  if (args.login_hint) params.set('login_hint', args.login_hint)
+  return `${MS_GRAPH_AUTHORIZE_URL}?${params.toString()}`
+}
+
+/**
+ * Provider registry entry. Plugs into the registry in
+ * `src/lib/oauth/providers.ts`. The callback handler reads
+ * `client_id` / `client_secret` from Workers env at exchange time;
+ * secrets are never logged or returned in response bodies.
+ */
+export const microsoftGraphProvider: OAuthProvider = {
+  slug: 'microsoft-graph',
+  label: 'Microsoft Graph',
+  token_url: MS_GRAPH_TOKEN_URL,
+  async exchange_code({ code, redirect_uri }) {
+    const clientId = env.MICROSOFT_GRAPH_CLIENT_ID
+    const clientSecret = env.MICROSOFT_GRAPH_CLIENT_SECRET
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        'Microsoft Graph client credentials are not configured (MICROSOFT_GRAPH_CLIENT_ID / MICROSOFT_GRAPH_CLIENT_SECRET).'
+      )
+    }
+    return postFormForToken(
+      new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri,
+        grant_type: 'authorization_code',
+        scope: MS_GRAPH_PHASE_1_SCOPES.join(' '),
+      }),
+      'Microsoft Graph'
+    )
+  },
+}
+
+export { MS_GRAPH_AUTHORIZE_URL, MS_GRAPH_TOKEN_URL }

--- a/src/pages/portal/products/ai-employee/oauth/[connector]/callback.ts
+++ b/src/pages/portal/products/ai-employee/oauth/[connector]/callback.ts
@@ -1,0 +1,271 @@
+/**
+ * GET /portal/products/ai-employee/oauth/[connector]/callback
+ *
+ * Customer-facing OAuth callback. Lives on the portal subdomain
+ * (`portal.smd.services`) per the resolved decision in
+ * `docs/specs/ai-employee/oauth-lifecycle.md` § "Re-consent callback URL":
+ * customer consent flows belong on the portal where the authenticated
+ * customer is already operating; the admin subdomain stays role-gated
+ * for SMD operations only.
+ *
+ * The admin-side callback at /api/oauth/callback (PR #936) stays in
+ * place as the v1 backstop and as the SMD-initiated initial-consent
+ * surface — the audit-log trail there is the source of truth for
+ * Captain-driven provisioning. Per the issue resolution we run both
+ * surfaces in parallel during the transition.
+ *
+ * Flow:
+ *
+ *   1. Verify the signed state parameter (HMAC-SHA256, 10-minute TTL).
+ *   2. Verify the state's `reviewer_id` matches the currently
+ *      authenticated portal user (Clerk session populated by
+ *      middleware). A leaked state is useless without the customer's
+ *      Clerk cookie.
+ *   3. Dispatch to the provider registry for token exchange.
+ *   4. Proxy the resulting token to the per-customer Hermes Machine
+ *      via the OAuthTokenStore interface (currently a no-op pending
+ *      the Hermes Machine relay; see src/lib/oauth/store.ts).
+ *   5. Audit-log the outcome (no token material).
+ *   6. Redirect the customer back into the AI Employee settings page
+ *      with status=connected or status=failed&reason=<short>.
+ *
+ * Failure modes redirect with the same short reason vocabulary as the
+ * admin-side callback: provider_error, missing_params, bad_state,
+ * expired_state, reviewer_mismatch, unknown_provider, unknown_connector,
+ * exchange_failed, store_failed.
+ *
+ * No token material is logged or returned in URLs. Issuer error
+ * payloads stay server-side.
+ */
+
+import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+
+import { verifyOAuthState, type OAuthStatePayload } from '../../../../../../lib/oauth/state.js'
+import {
+  getOAuthProvider,
+  type ProviderTokenResponse,
+} from '../../../../../../lib/oauth/providers.js'
+import { getDefaultTokenStore } from '../../../../../../lib/oauth/store.js'
+import { emitAuditEvent } from '../../../../../../lib/oauth/audit.js'
+import { requirePortalBaseUrl } from '../../../../../../lib/config/app-url.js'
+
+type RedirectFn = (path: string, status?: 300 | 301 | 302 | 303 | 304 | 307 | 308) => Response
+
+interface CallbackCtx {
+  redirect: RedirectFn
+  portalBase: string
+  connectorParam: string | null
+}
+
+function buildResultUrl(portalBase: string, params: Record<string, string>): string {
+  const url = new URL(`${portalBase}/portal/products/ai-employee/settings`)
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return url.toString()
+}
+
+async function reject(
+  ctx: CallbackCtx,
+  reason: string,
+  meta: {
+    customer_id: string | null
+    provider: string | null
+    reviewer_id: string | null
+    auditReason?: string
+  }
+): Promise<Response> {
+  await emitAuditEvent({
+    action: 'token-rejected',
+    customer_id: meta.customer_id,
+    provider: meta.provider,
+    reviewer_id: meta.reviewer_id,
+    reason: meta.auditReason ?? reason,
+  })
+  const params: Record<string, string> = { status: 'failed', reason }
+  if (meta.provider) params.provider = meta.provider
+  return ctx.redirect(buildResultUrl(ctx.portalBase, params), 302)
+}
+
+async function handleProviderError(
+  ctx: CallbackCtx,
+  url: URL,
+  providerError: string,
+  providerErrorDescription: string | null
+): Promise<Response> {
+  // Provider rejected consent (customer denied, scope mismatch, tenant
+  // admin policy block, etc). Try to read the state for audit context
+  // but don't fail the failure path on a missing/invalid state.
+  const rawState = url.searchParams.get('state')
+  let customer: string | null = null
+  let provider: string | null = null
+  if (rawState) {
+    const result = await verifyOAuthState(rawState)
+    if (result.ok) {
+      customer = result.payload.customer_id
+      provider = result.payload.provider
+    }
+  }
+  const detail = providerErrorDescription ? `:${providerErrorDescription}` : ''
+  return reject(ctx, 'provider_error', {
+    customer_id: customer,
+    provider,
+    reviewer_id: null,
+    auditReason: `provider_error:${providerError}${detail}`,
+  })
+}
+
+interface ValidatedState {
+  payload: OAuthStatePayload
+}
+
+async function validateStateOrReject(
+  ctx: CallbackCtx,
+  stateParam: string
+): Promise<Response | ValidatedState> {
+  const stateResult = await verifyOAuthState(stateParam)
+  if (stateResult.ok) return { payload: stateResult.payload }
+  const reason = stateResult.error === 'expired' ? 'expired_state' : 'bad_state'
+  return reject(ctx, reason, {
+    customer_id: null,
+    provider: null,
+    reviewer_id: null,
+    auditReason: `${reason}:${stateResult.error}`,
+  })
+}
+
+async function exchangeOrReject(
+  ctx: CallbackCtx,
+  payload: OAuthStatePayload,
+  code: string
+): Promise<Response | ProviderTokenResponse> {
+  const provider = getOAuthProvider(payload.provider)
+  if (!provider) {
+    return reject(ctx, 'unknown_provider', {
+      customer_id: payload.customer_id,
+      provider: payload.provider,
+      reviewer_id: payload.reviewer_id,
+    })
+  }
+  try {
+    return await provider.exchange_code({
+      code,
+      // The redirect_uri sent to the token endpoint MUST match the one
+      // used in the authorize step. The Azure AD app registration knows
+      // it as the portal subdomain URL.
+      redirect_uri: portalCallbackUrl(ctx.portalBase, payload.provider),
+    })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'unknown'
+    console.error(`[portal/oauth/callback] exchange_failed provider=${payload.provider}: ${detail}`)
+    return reject(ctx, 'exchange_failed', {
+      customer_id: payload.customer_id,
+      provider: payload.provider,
+      reviewer_id: payload.reviewer_id,
+    })
+  }
+}
+
+function portalCallbackUrl(portalBase: string, providerSlug: string): string {
+  return `${portalBase}/portal/products/ai-employee/oauth/${encodeURIComponent(providerSlug)}/callback`
+}
+
+function reviewerMatchesClerk(
+  authResult: { userId?: string | null } | null,
+  reviewer_id: string
+): boolean {
+  return Boolean(authResult && authResult.userId && authResult.userId === reviewer_id)
+}
+
+export const GET: APIRoute = async ({ request, redirect, locals, params }) => {
+  const url = new URL(request.url)
+  const ctx: CallbackCtx = {
+    redirect,
+    portalBase: requirePortalBaseUrl(env),
+    connectorParam: typeof params.connector === 'string' ? params.connector : null,
+  }
+
+  const providerError = url.searchParams.get('error')
+  if (providerError) {
+    return handleProviderError(ctx, url, providerError, url.searchParams.get('error_description'))
+  }
+
+  const code = url.searchParams.get('code')
+  const stateParam = url.searchParams.get('state')
+  if (!code || !stateParam) {
+    return reject(ctx, 'missing_params', {
+      customer_id: null,
+      provider: null,
+      reviewer_id: null,
+    })
+  }
+
+  const stateOrFail = await validateStateOrReject(ctx, stateParam)
+  if (stateOrFail instanceof Response) return stateOrFail
+
+  const { customer_id, provider: providerSlug, reviewer_id } = stateOrFail.payload
+
+  // The connector path parameter must match the provider stamped in the
+  // signed state. Mismatch indicates a tampered or replayed URL.
+  if (ctx.connectorParam && ctx.connectorParam !== providerSlug) {
+    return reject(ctx, 'unknown_connector', {
+      customer_id,
+      provider: providerSlug,
+      reviewer_id,
+      auditReason: `unknown_connector:path=${ctx.connectorParam},state=${providerSlug}`,
+    })
+  }
+
+  // Portal auth is owned by Clerk -- middleware populated locals.auth().
+  // The auth helper returns `{ userId, sessionId, ... }` when signed in.
+  let clerkAuth: { userId?: string | null } | null = null
+  try {
+    const authFn = locals.auth as undefined | (() => { userId?: string | null })
+    if (typeof authFn === 'function') clerkAuth = authFn()
+  } catch {
+    clerkAuth = null
+  }
+  if (!reviewerMatchesClerk(clerkAuth, reviewer_id)) {
+    return reject(ctx, 'reviewer_mismatch', {
+      customer_id,
+      provider: providerSlug,
+      reviewer_id,
+    })
+  }
+
+  const tokenOrFail = await exchangeOrReject(ctx, stateOrFail.payload, code)
+  if (tokenOrFail instanceof Response) return tokenOrFail
+
+  // Proxy the token to the per-customer Hermes Machine. v1 is a no-op
+  // until the Machine relay lands (see src/lib/oauth/store.ts), but
+  // the audit-log entry still records the storage intent.
+  const storeResult = await getDefaultTokenStore().store({
+    customer_id,
+    provider: providerSlug,
+    reviewer_id,
+    token: tokenOrFail,
+  })
+
+  if (!storeResult.ok) {
+    return reject(ctx, 'store_failed', {
+      customer_id,
+      provider: providerSlug,
+      reviewer_id,
+      auditReason: `store_failed:${storeResult.reason}`,
+    })
+  }
+
+  await emitAuditEvent({
+    action: 'token-issued',
+    customer_id,
+    provider: providerSlug,
+    reviewer_id,
+  })
+
+  return redirect(
+    buildResultUrl(ctx.portalBase, {
+      status: 'connected',
+      provider: providerSlug,
+    }),
+    302
+  )
+}

--- a/tests/ms-graph-provider.test.ts
+++ b/tests/ms-graph-provider.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Coverage for the Microsoft Graph provider entry at
+ * `src/lib/oauth/providers/ms-graph.ts`. Verifies scope discipline,
+ * authorize-URL shape, and Mail.Send refusal.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+
+import {
+  MS_GRAPH_AUTHORIZE_URL,
+  MS_GRAPH_PHASE_1_SCOPES,
+  MS_GRAPH_TOKEN_URL,
+  buildMicrosoftGraphAuthorizeUrl,
+  microsoftGraphProvider,
+} from '../src/lib/oauth/providers/ms-graph'
+
+function clearEnv(): void {
+  for (const key of Object.keys(testEnv)) {
+    delete (testEnv as unknown as Record<string, unknown>)[key]
+  }
+}
+
+describe('MS_GRAPH_PHASE_1_SCOPES', () => {
+  it('does NOT include Mail.Send', () => {
+    expect(MS_GRAPH_PHASE_1_SCOPES).not.toContain('Mail.Send')
+    expect(MS_GRAPH_PHASE_1_SCOPES.every((s) => s.toLowerCase() !== 'mail.send')).toBe(true)
+  })
+
+  it('matches the lifecycle spec scope set', () => {
+    const expected = new Set([
+      'offline_access',
+      'User.Read',
+      'Mail.Read',
+      'Mail.ReadWrite',
+      'MailboxSettings.Read',
+      'Calendars.ReadWrite',
+      'Files.Read',
+      'Files.ReadWrite.AppFolder',
+    ])
+    expect(new Set(MS_GRAPH_PHASE_1_SCOPES)).toEqual(expected)
+  })
+
+  it('includes offline_access for refresh-token issuance', () => {
+    expect(MS_GRAPH_PHASE_1_SCOPES).toContain('offline_access')
+  })
+
+  it('is frozen so callers cannot mutate it', () => {
+    expect(Object.isFrozen(MS_GRAPH_PHASE_1_SCOPES)).toBe(true)
+  })
+})
+
+describe('buildMicrosoftGraphAuthorizeUrl', () => {
+  it('emits a URL on the Entra v2 authorize endpoint with every Phase-1 scope', () => {
+    const url = buildMicrosoftGraphAuthorizeUrl({
+      client_id: 'app-123',
+      redirect_uri:
+        'https://portal.smd.services/portal/products/ai-employee/oauth/microsoft-graph/callback',
+      state: 'signed-state-token',
+    })
+    expect(url.startsWith(MS_GRAPH_AUTHORIZE_URL)).toBe(true)
+    expect(url).toContain('client_id=app-123')
+    expect(url).toContain('state=signed-state-token')
+    expect(url).toContain('response_type=code')
+    for (const scope of MS_GRAPH_PHASE_1_SCOPES) {
+      expect(url).toContain(scope)
+    }
+    expect(url).not.toContain('Mail.Send')
+  })
+
+  it('includes login_hint when provided', () => {
+    const url = buildMicrosoftGraphAuthorizeUrl({
+      client_id: 'app',
+      redirect_uri: 'https://example/cb',
+      state: 's',
+      login_hint: 'user@example.com',
+    })
+    expect(url).toMatch(/login_hint=user(%40|@)example.com/)
+  })
+
+  it('refuses to emit a URL containing Mail.Send', () => {
+    expect(() =>
+      buildMicrosoftGraphAuthorizeUrl({
+        client_id: 'app',
+        redirect_uri: 'https://example/cb',
+        state: 's',
+        scopes: ['Mail.Read', 'Mail.Send'],
+      })
+    ).toThrow(/Mail\.Send is a wave-2 scope/)
+  })
+
+  it('requires client_id, redirect_uri, and state', () => {
+    expect(() =>
+      buildMicrosoftGraphAuthorizeUrl({
+        client_id: '',
+        redirect_uri: 'https://example/cb',
+        state: 's',
+      })
+    ).toThrow(/client_id is required/)
+    expect(() =>
+      buildMicrosoftGraphAuthorizeUrl({
+        client_id: 'app',
+        redirect_uri: '',
+        state: 's',
+      })
+    ).toThrow(/redirect_uri is required/)
+    expect(() =>
+      buildMicrosoftGraphAuthorizeUrl({
+        client_id: 'app',
+        redirect_uri: 'https://example/cb',
+        state: '',
+      })
+    ).toThrow(/state is required/)
+  })
+})
+
+describe('microsoftGraphProvider entry', () => {
+  const ORIGINAL_FETCH = globalThis.fetch
+
+  beforeEach(() => {
+    Object.assign(testEnv, {
+      MICROSOFT_GRAPH_CLIENT_ID: 'app-id',
+      MICROSOFT_GRAPH_CLIENT_SECRET: 'app-secret',
+    })
+  })
+
+  afterEach(() => {
+    clearEnv()
+    globalThis.fetch = ORIGINAL_FETCH
+  })
+
+  it('declares the canonical slug and label', () => {
+    expect(microsoftGraphProvider.slug).toBe('microsoft-graph')
+    expect(microsoftGraphProvider.label).toBe('Microsoft Graph')
+    expect(microsoftGraphProvider.token_url).toBe(MS_GRAPH_TOKEN_URL)
+  })
+
+  it('exchange_code POSTs to the v2 token endpoint with the Phase-1 scopes', async () => {
+    let capturedBody = ''
+    globalThis.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = (init?.body as URLSearchParams).toString()
+      return new Response(
+        JSON.stringify({
+          access_token: 'tok',
+          refresh_token: 'refresh',
+          expires_in: 3600,
+          scope: 'Mail.Read Calendars.ReadWrite',
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    })
+    const result = await microsoftGraphProvider.exchange_code({
+      code: 'AUTH123',
+      redirect_uri:
+        'https://portal.smd.services/portal/products/ai-employee/oauth/microsoft-graph/callback',
+    })
+    expect(result.access_token).toBe('tok')
+    expect(result.refresh_token).toBe('refresh')
+    expect(capturedBody).toContain('grant_type=authorization_code')
+    expect(capturedBody).toContain('client_id=app-id')
+    expect(capturedBody).toContain('code=AUTH123')
+    expect(capturedBody).toContain('offline_access')
+    expect(capturedBody).not.toContain('Mail.Send')
+  })
+
+  it('throws when MICROSOFT_GRAPH_CLIENT_ID is missing', async () => {
+    delete (testEnv as unknown as Record<string, unknown>).MICROSOFT_GRAPH_CLIENT_ID
+    await expect(
+      microsoftGraphProvider.exchange_code({
+        code: 'x',
+        redirect_uri: 'https://example/cb',
+      })
+    ).rejects.toThrow(/MICROSOFT_GRAPH_CLIENT_ID/)
+  })
+
+  it('propagates a structured error on non-2xx token responses', async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: 'invalid_grant' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+    await expect(
+      microsoftGraphProvider.exchange_code({
+        code: 'x',
+        redirect_uri: 'https://example/cb',
+      })
+    ).rejects.toThrow(/token exchange failed \(400\)/)
+  })
+})

--- a/tests/portal-oauth-callback.test.ts
+++ b/tests/portal-oauth-callback.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Coverage for the customer-facing portal OAuth callback at
+ * `src/pages/portal/products/ai-employee/oauth/[connector]/callback.ts`.
+ *
+ * Mirrors the admin-side callback test (tests/oauth-callback.test.ts)
+ * but exercises the reviewer-id-bound-to-Clerk-session path: state
+ * verification + clerk reviewer match + connector-path/state-provider
+ * agreement + redirect-to-portal on success.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { env as testEnv } from 'cloudflare:workers'
+
+import { issueOAuthState } from '../src/lib/oauth/state'
+import { GET as portalCallback } from '../src/pages/portal/products/ai-employee/oauth/[connector]/callback'
+
+const SIGNING_KEY_B64 = 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE='
+const PORTAL_BASE = 'https://portal.smd.services'
+
+function clearEnv(): void {
+  for (const key of Object.keys(testEnv)) {
+    delete (testEnv as unknown as Record<string, unknown>)[key]
+  }
+}
+
+function applyDefaultEnv(): void {
+  Object.assign(testEnv, {
+    PORTAL_BASE_URL: PORTAL_BASE,
+    APP_BASE_URL: PORTAL_BASE,
+    OAUTH_STATE_SIGNING_KEY: SIGNING_KEY_B64,
+    MICROSOFT_GRAPH_CLIENT_ID: 'msgraph-client-id',
+    MICROSOFT_GRAPH_CLIENT_SECRET: 'msgraph-client-secret',
+  })
+}
+
+function redirect(url: string, status?: number): Response {
+  return new Response(null, {
+    status: status ?? 302,
+    headers: { Location: url },
+  })
+}
+
+function makeAuth(userId: string | null): () => { userId: string | null } {
+  return () => ({ userId })
+}
+
+async function invoke(opts: {
+  url: string
+  connector: string
+  authUserId?: string | null
+}): Promise<Response> {
+  return await portalCallback({
+    request: new Request(opts.url),
+    redirect,
+    params: { connector: opts.connector },
+    locals: {
+      auth: makeAuth(opts.authUserId ?? null),
+    } as unknown as App.Locals,
+  } as unknown as Parameters<typeof portalCallback>[0])
+}
+
+function parseRedirect(response: Response): URL {
+  const location = response.headers.get('Location')
+  if (!location) throw new Error('redirect response missing Location header')
+  return new URL(location)
+}
+
+describe('portal oauth callback', () => {
+  const ORIGINAL_FETCH = globalThis.fetch
+
+  beforeEach(() => {
+    applyDefaultEnv()
+  })
+
+  afterEach(() => {
+    clearEnv()
+    globalThis.fetch = ORIGINAL_FETCH
+  })
+
+  it('redirects with missing_params when state and code are absent', async () => {
+    const response = await invoke({
+      url: `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback`,
+      connector: 'microsoft-graph',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('status')).toBe('failed')
+    expect(location.searchParams.get('reason')).toBe('missing_params')
+    // Redirects back to the AI Employee settings page on the portal subdomain.
+    expect(location.origin).toBe(PORTAL_BASE)
+    expect(location.pathname).toBe('/portal/products/ai-employee/settings')
+  })
+
+  it('redirects with provider_error when issuer rejects consent', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme-law',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user_xyz',
+    })
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback?error=consent_required&error_description=admin+consent+required&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      connector: 'microsoft-graph',
+      authUserId: 'user_xyz',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('provider_error')
+    expect(location.searchParams.get('provider')).toBe('microsoft-graph')
+  })
+
+  it('redirects with bad_state when signature does not verify', async () => {
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback?code=abc&state=garbage`
+    const response = await invoke({
+      url,
+      connector: 'microsoft-graph',
+      authUserId: 'user_xyz',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('bad_state')
+  })
+
+  it('redirects with reviewer_mismatch when Clerk userId does not match state', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme-law',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user_owner',
+    })
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      connector: 'microsoft-graph',
+      authUserId: 'user_someone_else',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('reviewer_mismatch')
+  })
+
+  it('redirects with reviewer_mismatch when no Clerk auth is present', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme-law',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user_owner',
+    })
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      connector: 'microsoft-graph',
+      authUserId: null,
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('reviewer_mismatch')
+  })
+
+  it('redirects with unknown_connector when the path connector differs from the state provider', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme-law',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user_owner',
+    })
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/google-workspace/callback?code=abc&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      connector: 'google-workspace',
+      authUserId: 'user_owner',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('unknown_connector')
+  })
+
+  it('redirects to settings with status=connected on the happy path', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme-law',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user_owner',
+    })
+
+    // Mock the Microsoft Graph token exchange.
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const target = typeof input === 'string' ? input : input.toString()
+      if (target === 'https://login.microsoftonline.com/common/oauth2/v2.0/token') {
+        const body = (init?.body as URLSearchParams).toString()
+        expect(body).toContain('grant_type=authorization_code')
+        // The redirect_uri sent to the token endpoint MUST be the portal one.
+        expect(body).toContain(
+          'redirect_uri=https%3A%2F%2Fportal.smd.services%2Fportal%2Fproducts%2Fai-employee%2Foauth%2Fmicrosoft-graph%2Fcallback'
+        )
+        return new Response(
+          JSON.stringify({
+            access_token: 'msg-access',
+            refresh_token: 'msg-refresh',
+            expires_in: 3600,
+            scope: 'Mail.Read Calendars.ReadWrite Files.ReadWrite.AppFolder',
+            token_type: 'Bearer',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+      return new Response('not mocked', { status: 500 })
+    })
+
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback?code=AUTHCODE&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      connector: 'microsoft-graph',
+      authUserId: 'user_owner',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('status')).toBe('connected')
+    expect(location.searchParams.get('provider')).toBe('microsoft-graph')
+    expect(location.pathname).toBe('/portal/products/ai-employee/settings')
+  })
+
+  it('redirects with exchange_failed when the token endpoint rejects the code', async () => {
+    const state = await issueOAuthState({
+      customer_id: 'acme-law',
+      provider: 'microsoft-graph',
+      reviewer_id: 'user_owner',
+    })
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: 'invalid_grant' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const url = `${PORTAL_BASE}/portal/products/ai-employee/oauth/microsoft-graph/callback?code=BAD&state=${encodeURIComponent(state)}`
+    const response = await invoke({
+      url,
+      connector: 'microsoft-graph',
+      authUserId: 'user_owner',
+    })
+    const location = parseRedirect(response)
+    expect(location.searchParams.get('reason')).toBe('exchange_failed')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the Phase-1 Microsoft Graph connector per [#822](https://github.com/venturecrane/ss-console/issues/822) and the resolved [OAuth lifecycle spec](docs/specs/ai-employee/oauth-lifecycle.md). Read + draft only; `Mail.Send` is intentionally deferred to wave-2 ([#881](https://github.com/venturecrane/ss-console/issues/881)).

- **Token storage** lives on the per-customer Fly volume at `/opt/data/oauth/microsoft.json` per [ADR 0010](docs/adr/0010-per-customer-oauth-token-storage.md). Atomic write, chmod 0600, never in Infisical.
- **Callback** lands on the portal subdomain per the resolved decision in `oauth-lifecycle.md` § "Re-consent callback URL". The admin-side callback shipped in PR #936 stays in place as the v1 backstop and SMD-initiated provisioning surface.
- **Scope discipline** is enforced in three independent places (Python `MSGraphOAuth` constructor, TS `buildMicrosoftGraphAuthorizeUrl`, `bin/reauth-connector.sh`): `Mail.Send` is rejected at URL-emission time.

## Files

| Layer        | Path                                                                                                                                                                                                                  |
| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Python pkg   | `ai-employee/connectors/ms_graph/{oauth.py,mailbox.py,calendar_adapter.py,drive.py,_client.py,_types.py,pyproject.toml,README.md}` + `tests/test_oauth.py`                                                             |
| TS provider  | `src/lib/oauth/providers/ms-graph.ts` + registry wiring in `src/lib/oauth/providers.ts`                                                                                                                               |
| Portal cb    | `src/pages/portal/products/ai-employee/oauth/[connector]/callback.ts`                                                                                                                                                  |
| Re-consent   | `bin/reauth-connector.sh` (Captain-invoked; signs state, builds authorize URL, emails customer principal)                                                                                                              |
| Runbook      | `docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md`                                                                                                                                                                 |
| Tests        | `tests/ms-graph-provider.test.ts`, `tests/portal-oauth-callback.test.ts` + `ai-employee/connectors/ms_graph/tests/test_oauth.py`                                                                                       |

## Acceptance criteria (#822)

- [x] **MS Graph app registered, app ID and tenant config documented** — `docs/runbooks/ai-employee/ms-graph-azure-ad-setup.md` documents multi-tenant registration, scope set, secret storage in Infisical, and rotation cadence. Actual registration is a one-time Captain action against the SMD Services Entra tenant.
- [x] **OAuth flow operational end-to-end (consent → callback → token storage → refresh)** — `MSGraphOAuth.exchange_auth_code()` / `.get_valid_tokens()` / `.refresh()` cover the four states. Portal callback in `src/pages/portal/products/ai-employee/oauth/[connector]/callback.ts` handles the redirect side. Storage hits the no-op store today; Hermes Machine relay lands with the follow-on tracked in `src/lib/oauth/store.ts`.
- [x] **Three Capability adapters wired** — `MSGraphMailbox` (Email), `MSGraphCalendar` (Calendar), `MSGraphDrive` (DocumentStorage); each implements the methods declared in `docs/specs/ai-employee/capability-contracts.md` and exposes `describe_capabilities()` + `health_check()`.
- [x] **Token revocation tested** — `test_refresh_translates_invalid_grant_to_auth_expired` exercises the `invalid_grant` path that #820 (decommission) composes with.
- [ ] **Integration test against synthetic M365 tenant** — *deferred to a separate follow-on issue.* The unit suite covers the auth-and-refresh state machine against `httpx.MockTransport`; an end-to-end test against a real M365 sandbox tenant requires Captain to register the synthetic tenant credentials in Infisical, which is out-of-scope for this PR.

## Test plan

- [x] `npm run verify` clean locally (2446 + 67 tests, 0 errors)
- [x] `pytest` clean in `ai-employee/connectors/ms_graph/` (25/25 passing)
- [x] `gh pr checks` green on CI
- [ ] One-time Azure AD app registration per the new runbook (Captain action)
- [ ] Onboard first customer-zero tenant via `bin/reauth-connector.sh` once Hermes Machine relay lands (gated by the `src/lib/oauth/store.ts` no-op TODO)

## Deferred / out of scope

- `Mail.Send` capability and `MSGraphMailbox.send_*` adapter method — explicitly reserved for wave-2 stream [#881](https://github.com/venturecrane/ss-console/issues/881).
- Hermes Machine token-relay endpoint — the portal callback hands off via `getDefaultTokenStore()` which is a no-op until the per-Machine control plane lands (`src/lib/oauth/store.ts`).
- The admin-side OAuth callback at `src/pages/api/oauth/callback.ts` is **left in place** as the v1 backstop per the team-lead instruction; both surfaces share the same provider registry + state-signing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)