### PR TITLE
feat(ai-employee): Curator interceptor (observer-only) per ADR 0017

### DIFF
--- a/ai-employee/adapter/aie_adapter.py
+++ b/ai-employee/adapter/aie_adapter.py
@@ -58,6 +58,16 @@ from .hermes_hook import (
     ToolCallResult,
     TrustCeilingEnforcer,
 )
+from .curator_interceptor import (
+    CuratorDraftStateError,
+    CuratorEvidenceRequired,
+    CuratorInterceptor,
+    CuratorNativeWriteBlocked,
+    CuratorTargetRequired,
+    DraftType,
+    SkillDraft,
+    verify_curator_intercepted,
+)
 from .honcho_interceptor import (
     HonchoEvidenceRequired,
     HonchoInterceptor,
@@ -76,6 +86,12 @@ from .trust_ceiling import ActionClass, Ceiling, enforce
 HONCHO_AUDIT_ACTION_OBSERVATION = "HONCHO_OBSERVATION"
 HONCHO_AUDIT_ACTION_PROMOTION = "HONCHO_PROMOTION"
 HONCHO_AUDIT_ACTION_DISMISSAL = "HONCHO_DISMISSAL"
+
+# Audit action_type classes emitted by the Skill Curator overlay (ADR 0017 §8).
+# Same import-surface rationale as the Honcho constants above.
+CURATOR_AUDIT_ACTION_DRAFT = "CURATOR_DRAFT"
+CURATOR_AUDIT_ACTION_PROMOTION = "CURATOR_PROMOTION"
+CURATOR_AUDIT_ACTION_DISMISSAL = "CURATOR_DISMISSAL"
 
 log = logging.getLogger("aie.adapter")
 
@@ -388,9 +404,18 @@ def register(
 __all__ = [
     "ActionClass",
     "BlockedToolCall",
+    "CURATOR_AUDIT_ACTION_DISMISSAL",
+    "CURATOR_AUDIT_ACTION_DRAFT",
+    "CURATOR_AUDIT_ACTION_PROMOTION",
     "Ceiling",
+    "CuratorDraftStateError",
+    "CuratorEvidenceRequired",
+    "CuratorInterceptor",
+    "CuratorNativeWriteBlocked",
+    "CuratorTargetRequired",
     "DEFAULT_PINNED_SLOT_KEYS",
     "DefaultTrustCeilingEnforcer",
+    "DraftType",
     "HONCHO_AUDIT_ACTION_DISMISSAL",
     "HONCHO_AUDIT_ACTION_OBSERVATION",
     "HONCHO_AUDIT_ACTION_PROMOTION",
@@ -403,10 +428,12 @@ __all__ = [
     "HookRegistry",
     "ObservationType",
     "PinnedSlots",
+    "SkillDraft",
     "ToolCallContext",
     "ToolCallResult",
     "TrustCeilingEnforcer",
     "enforce",
     "register",
+    "verify_curator_intercepted",
     "verify_honcho_intercepted",
 ]

--- a/ai-employee/adapter/audit_log.py
+++ b/ai-employee/adapter/audit_log.py
@@ -139,6 +139,12 @@ ACCEPTED_ACTION_TYPES = frozenset(
         "HONCHO_OBSERVATION",
         "HONCHO_PROMOTION",
         "HONCHO_DISMISSAL",
+        # Skill Curator overlay (ADR 0017) — observer-only skill drafts.
+        # Emitted by the CuratorInterceptor on every draft write,
+        # Captain promotion (crane-console PR), and dismissal.
+        "CURATOR_DRAFT",
+        "CURATOR_PROMOTION",
+        "CURATOR_DISMISSAL",
     }
 )
 

--- a/ai-employee/adapter/curator_interceptor.py
+++ b/ai-employee/adapter/curator_interceptor.py
@@ -1,0 +1,747 @@
+"""Skill Curator write-path interceptor (ADR 0017).
+
+The Hermes upstream autonomous Skill Curator generates skill candidates from
+execution traces, scores them on outcomes over a seven-day window, consolidates
+overlapping definitions, and prunes underperformers — all autonomously. For
+the upstream single-user local-deployment use case, where the operator IS the
+developer and skill drift is self-experienced, this is a productivity feature.
+For SMD's per-customer AI Employee, where reviewer-as-sender ([ADR 0005](../../docs/adr/0005-reviewer-as-sender.md))
+puts a bar-licensed partner on the hook for whatever the AI Employee does,
+autonomous skill mutation is uninsurable.
+
+[ADR 0017](../../docs/adr/0017-skill-curator-disposition.md) resolves this
+with Pattern C: the Curator runs in observer-only mode. The Curator's
+observations land in a dedicated per-customer `skill_drafts` D1 table
+(migration 0008). No skill is created, modified, consolidated, or pruned
+inside a customer Machine. Every skill-catalog change is a PR against
+`crane-console/.agents/skills/`, reviewed and merged per established skill
+governance, reaching customer Machines only through the next content-hash-
+pinned Hermes deploy.
+
+What this module does
+---------------------
+
+1. `CuratorInterceptor` — single per-Machine instance, owns the write path.
+   `record_draft()` validates source-evidence ([ADR 0017](../../docs/adr/0017-skill-curator-disposition.md) §6),
+   inserts into `skill_drafts`, and emits a `CURATOR_DRAFT` audit row.
+   `promote()` and `dismiss()` stamp the row and emit `CURATOR_PROMOTION` /
+   `CURATOR_DISMISSAL` audit rows; the actual `crane-console` PR generation
+   is the calibration-session UI's job (not in scope here).
+
+2. `CuratorNativeWriteBlocked` — exception raised when boot-time verification
+   detects a Curator-like native write surface that bypasses the interceptor
+   (direct skill-file mutation, in-memory skill-set registration/deregistration).
+   Boot fails closed.
+
+3. `verify_curator_intercepted()` — boot-time check ([ADR 0017](../../docs/adr/0017-skill-curator-disposition.md) §_Verification_
+   point 2). Confirms that (a) the interceptor is constructed and (b) no
+   competing Curator writer module has been loaded onto the runtime.
+   Halts Machine boot on failure.
+
+The no-self-promotion commitment (ADR 0017 §10)
+------------------------------------------------
+
+Honcho ([ADR 0016](../../docs/adr/0016-honcho-disposition.md)) leaves a
+Phase 2 question open: low-risk preference observations *might* one day
+self-promote without partner review. The Curator does not. Skills are
+executable behavior; the bar is absolute. This module enforces that
+structurally: the only `promote()` code path requires an explicit Captain
+identifier AND a `crane-console` PR URL the caller supplies — there is no
+"auto-promote if curator_score > threshold" gate, never has been, and
+adding one requires superseding ADR 0017 with explicit reasoning, not a
+threshold tweak.
+
+What this module does NOT do
+-----------------------------
+
+* Generate drafts. The Curator/upstream code is the source of draft text,
+  scores, and overlap detection; this module is the gate that decides
+  whether the proposed draft is accepted, where it lands, and what audit
+  row is emitted.
+
+* Read `skill_drafts` in any code path that affects runtime behavior.
+  Reads are calibration-session UI and decommission export only
+  ([ADR 0017](../../docs/adr/0017-skill-curator-disposition.md) §2). The
+  runtime skill set is content-hash-pinned per
+  [ADR 0007](../../docs/adr/0007-per-customer-machine-isolation.md) and
+  immutable for the lifetime of that Machine pin — never sourced from
+  this table.
+
+* Mutate the skill catalog. Promotion is a PR against
+  `crane-console/.agents/skills/` opened by the calibration-session UI;
+  this module records the promotion in the D1 row (with the PR URL the
+  caller supplies) and emits the audit event. The PR-and-merge plus the
+  content-hash re-pin is the audit trail and the amplification gate.
+
+* Enforce trust-ceiling. Drafts are internal proposals downstream of
+  execution; trust-ceiling does not run on draft writes. The fabrication-
+  evidence requirement (§6) and the sticky-stop volume cap (§7) are the
+  two guards that apply (the latter is a follow-on outside this module).
+
+* Reach across the customer boundary. Per
+  [ADR 0009](../../docs/adr/0009-cross-machine-query-prohibition.md) and
+  [ADR 0017](../../docs/adr/0017-skill-curator-disposition.md) §11, the
+  Curator running in customer A's Machine cannot observe customer B's
+  execution traces. Cross-customer skill-pattern discovery is a manual
+  platform-team analytical task, not a Curator function.
+
+Test isolation
+--------------
+
+The interceptor takes its `Executor` and `AuditLogWriter` by constructor
+injection; tests pass a `SqliteExecutor` against an in-memory database.
+Tests are in `tests/test_curator_interceptor.py`.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from .audit_log import (
+    ActorRole,
+    AuditEvent,
+    AuditLogWriter,
+    Executor,
+)
+
+log = logging.getLogger("aie.curator_interceptor")
+
+
+# ---------------------------------------------------------------------------
+# Draft type — closed vocabulary
+#
+# ADR 0017 §1 enumerates four draft types. The closed enum is the contract:
+# adding a new type requires updating both this enum and the calibration-
+# session UI's promotion handler so the new type has a defined PR-generation
+# shape (ADR 0017 §3 documents the four shapes).
+# ---------------------------------------------------------------------------
+
+
+class DraftType(str, enum.Enum):
+    NEW_SKILL = "new_skill"
+    CONSOLIDATION = "consolidation"
+    PRUNE_RECOMMENDATION = "prune_recommendation"
+    SCOPE_ADJUSTMENT = "scope_adjustment"
+
+
+# Draft types that operate on an existing skill (target_skill_slug required).
+# new_skill stands alone — it proposes a fresh SKILL.md and target_skill_slug
+# is null.
+_TYPES_REQUIRING_TARGET: frozenset = frozenset(
+    {
+        DraftType.CONSOLIDATION,
+        DraftType.PRUNE_RECOMMENDATION,
+        DraftType.SCOPE_ADJUSTMENT,
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Exception types
+# ---------------------------------------------------------------------------
+
+
+class CuratorEvidenceRequired(ValueError):
+    """Raised when a draft is offered without source-evidence pointers.
+
+    Per ADR 0017 §6: every draft written to `skill_drafts` must include
+    source-evidence pointers — execution-trace row IDs from the per-
+    customer audit log, outcome scores, and the trace window the Curator
+    analyzed. "The Curator thinks this is a good skill" without "here
+    are the 47 execution traces it analyzed" is not a valid draft.
+
+    The database-level CHECK constraint enforces this redundantly. The
+    runtime assertion in `CuratorInterceptor.record_draft()` raises this
+    exception first so the caller sees a clear failure mode rather than
+    a CHECK-constraint SQL error.
+    """
+
+
+class CuratorTargetRequired(ValueError):
+    """Raised when a draft that operates on an existing skill omits the target.
+
+    Per ADR 0017 §1, `target_skill_slug` is required for consolidation,
+    prune_recommendation, and scope_adjustment drafts. Only new_skill
+    drafts may set it to None (because they propose a new SKILL.md, not
+    a change to an existing one).
+    """
+
+
+class CuratorNativeWriteBlocked(RuntimeError):
+    """Raised when boot-time verification detects a Curator native writer.
+
+    Per ADR 0017 §1, the Curator's native write paths (direct skill-file
+    mutation, in-memory skill-set mutation, skill registration /
+    deregistration) are blocked at overlay boot. Detection of any such
+    surface halts Machine boot. There is no bypass.
+
+    The detection is necessarily heuristic — we cannot enumerate every
+    future upstream Curator surface. The current check covers the surfaces
+    visible at the time of writing (named module imports, attribute
+    presence on imported objects). Quarterly Hermes rebase agenda item
+    re-verifies this list per ADR 0017 §_Verification_ guards.
+    """
+
+
+class CuratorDraftStateError(RuntimeError):
+    """Raised on illegal state transitions on a draft row.
+
+    Promotion of an already-promoted or already-dismissed row, dismissal
+    of an already-dismissed or already-promoted row. Each row has at most
+    one terminal action; subsequent state changes are programmer error.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SkillDraft:
+    """Input shape for `CuratorInterceptor.record_draft()`.
+
+    Constructed by the (future) Curator integration code at the seam where
+    upstream would otherwise mutate the skill catalog. The interceptor is
+    the only legitimate consumer of this dataclass.
+
+    Fields:
+        draft_type        — closed vocabulary; see `DraftType`.
+        draft_body        — proposed SKILL.md markdown (for new_skill,
+                            consolidation, scope_adjustment) or rationale
+                            text (for prune_recommendation). Stored verbatim.
+                            Caller is responsible for shape; this module
+                            does not interpret it.
+        source_evidence   — list of stable identifiers (execution-trace
+                            row IDs, audit_log row ULIDs, outcome scores)
+                            that ground the draft. Non-empty. Serialized
+                            via json.dumps() and stored as TEXT.
+        target_skill_slug — required for consolidation, prune, and scope
+                            adjustment; must be None for new_skill.
+        curator_score     — optional; the Curator's own grading value.
+                            Surfaced for Captain review; NEVER an
+                            auto-promotion gate (ADR 0017 §10).
+    """
+
+    draft_type: DraftType
+    draft_body: str
+    source_evidence: list
+    target_skill_slug: Optional[str] = None
+    curator_score: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# ULID helper — same shape as honcho_interceptor's; vendored to keep modules
+# independent. Identical implementation.
+# ---------------------------------------------------------------------------
+
+
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _encode_crockford(value: int, length: int) -> str:
+    out = []
+    for _ in range(length):
+        value, rem = divmod(value, 32)
+        out.append(_CROCKFORD[rem])
+    return "".join(reversed(out))
+
+
+def _ulid(now_ms: Optional[int] = None) -> str:
+    ts = now_ms if now_ms is not None else int(time.time() * 1000)
+    rand = secrets.randbits(80)
+    return _encode_crockford(ts, 10) + _encode_crockford(rand, 16)
+
+
+# ---------------------------------------------------------------------------
+# SQL — the four statements the interceptor uses
+# ---------------------------------------------------------------------------
+
+
+_INSERT_DRAFT_SQL = (
+    "INSERT INTO skill_drafts "
+    "(draft_id, draft_type, target_skill_slug, draft_body, "
+    "source_evidence_json, curator_score) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
+
+_STAMP_PROMOTION_SQL = (
+    "UPDATE skill_drafts "
+    "SET promoted_at = datetime('now'), promoted_by = ?, promoted_pr_url = ? "
+    "WHERE draft_id = ? "
+    "AND promoted_at IS NULL "
+    "AND dismissed_at IS NULL"
+)
+
+_STAMP_DISMISSAL_SQL = (
+    "UPDATE skill_drafts "
+    "SET dismissed_at = datetime('now'), dismissed_by = ?, dismissed_reason = ? "
+    "WHERE draft_id = ? "
+    "AND promoted_at IS NULL "
+    "AND dismissed_at IS NULL"
+)
+
+_SELECT_STAMPS_SQL = (
+    "SELECT promoted_at, promoted_by, promoted_pr_url, "
+    "dismissed_at, dismissed_by, dismissed_reason "
+    "FROM skill_drafts WHERE draft_id = ?"
+)
+
+
+# ---------------------------------------------------------------------------
+# The interceptor
+# ---------------------------------------------------------------------------
+
+
+class CuratorInterceptor:
+    """The only legitimate write path for Curator output.
+
+    Construction takes an `Executor` (writes to `skill_drafts`) and an
+    `AuditLogWriter` (emits the per-action audit rows per ADR 0017 §8).
+    One instance per Machine; concurrency-safe to the extent the underlying
+    executor and writer are.
+
+    Public surface:
+
+      * `record_draft(draft)` — validates evidence, validates target-slug
+        requirement, inserts the row, emits `CURATOR_DRAFT` audit row.
+        Returns the draft ULID.
+
+      * `promote(draft_id, promoted_by, pr_url)` — stamps the row with
+        promotion metadata and emits `CURATOR_PROMOTION` audit row. The
+        caller (calibration-session UI) is responsible for opening the
+        `crane-console/.agents/skills/` PR and passing its URL here. The
+        PR URL is required; there is no auto-promotion path (ADR 0017 §10).
+
+      * `dismiss(draft_id, dismissed_by, reason)` — stamps dismissal and
+        emits `CURATOR_DISMISSAL` audit row. Reason is required for the
+        dismissal-corpus signal (§4).
+
+    All three methods are async. State-transition methods (promote /
+    dismiss) do the SQL UPDATE first, then defensively re-read to confirm
+    the transition landed on THIS call (not on a racing earlier call),
+    then emit the audit row. record_draft emits the audit row after the
+    INSERT succeeds for the same reason.
+    """
+
+    def __init__(
+        self,
+        *,
+        executor: Executor,
+        audit_writer: AuditLogWriter,
+        customer: str,
+    ) -> None:
+        if not customer:
+            raise ValueError("CuratorInterceptor requires a non-empty customer slug")
+        self._executor = executor
+        self._audit_writer = audit_writer
+        self._customer = customer
+
+    # ---- Draft creation -------------------------------------------------
+
+    async def record_draft(self, draft: SkillDraft) -> str:
+        """Insert one draft row + emit the CURATOR_DRAFT audit row.
+
+        Returns the draft ULID. Raises:
+          * `CuratorEvidenceRequired` if source-evidence is empty (§6)
+          * `CuratorTargetRequired` if a consolidation / prune / scope draft
+            omits `target_skill_slug`, or a new_skill draft sets it
+          * the executor's native error if D1 INSERT fails
+        """
+        if not draft.source_evidence:
+            raise CuratorEvidenceRequired(
+                "skill_drafts writes require non-empty source_evidence; "
+                "the draft must point to execution-trace row IDs, audit_log "
+                "row IDs, and outcome scores that ground the proposal "
+                "(ADR 0017 §6). A draft without evidence is not a valid draft."
+            )
+
+        if draft.draft_type in _TYPES_REQUIRING_TARGET and not draft.target_skill_slug:
+            raise CuratorTargetRequired(
+                f"draft_type={draft.draft_type.value} operates on an existing "
+                f"skill; target_skill_slug is required (ADR 0017 §1). Only "
+                "new_skill drafts may omit target_skill_slug."
+            )
+
+        if draft.draft_type == DraftType.NEW_SKILL and draft.target_skill_slug:
+            raise CuratorTargetRequired(
+                "draft_type=new_skill proposes a fresh SKILL.md and must NOT "
+                "set target_skill_slug; the proposed slug belongs in draft_body "
+                "frontmatter (ADR 0017 §3, new_skill shape)."
+            )
+
+        if not draft.draft_body:
+            raise ValueError(
+                "draft_body is required; an empty draft body has no value to "
+                "review and no signal for the Curator's extraction tuning"
+            )
+
+        draft_id = _ulid()
+        evidence_json = json.dumps(draft.source_evidence, sort_keys=True, separators=(",", ":"))
+
+        await self._executor.execute(
+            _INSERT_DRAFT_SQL,
+            [
+                draft_id,
+                draft.draft_type.value,
+                draft.target_skill_slug,
+                draft.draft_body,
+                evidence_json,
+                draft.curator_score,
+            ],
+        )
+
+        await self._audit_writer.write(
+            AuditEvent(
+                action_type="CURATOR_DRAFT",
+                actor="agent",
+                actor_role=ActorRole.AGENT,
+                skill_name=draft.target_skill_slug,
+                matter_ref=None,
+                metadata={
+                    "customer": self._customer,
+                    "draft_id": draft_id,
+                    "draft_type": draft.draft_type.value,
+                    "target_skill_slug": draft.target_skill_slug,
+                    "curator_score": draft.curator_score,
+                    "evidence_count": len(draft.source_evidence),
+                },
+            )
+        )
+
+        log.info(
+            "curator.draft: customer=%s type=%s target=%s id=%s",
+            self._customer,
+            draft.draft_type.value,
+            draft.target_skill_slug,
+            draft_id,
+        )
+        return draft_id
+
+    # ---- Promotion ------------------------------------------------------
+
+    async def promote(
+        self,
+        *,
+        draft_id: str,
+        promoted_by: str,
+        pr_url: str,
+    ) -> None:
+        """Stamp the row promoted; emit the CURATOR_PROMOTION audit row.
+
+        `promoted_by` is the Captain identifier from the calibration session.
+        `pr_url` is the `crane-console/.agents/skills/` PR the caller opened
+        — the URL is the audit-trail anchor (ADR 0017 §3).
+
+        No auto-promotion path exists; both identifiers are required by the
+        method signature. Per ADR 0017 §10, the Curator never self-promotes;
+        the structural enforcement is that this is the ONLY promotion code
+        path and it requires real values from the calibration-session UI.
+
+        Raises `CuratorDraftStateError` if the row is missing or already
+        in a terminal state.
+        """
+        if not draft_id:
+            raise ValueError("draft_id is required")
+        if not promoted_by:
+            raise ValueError(
+                "promoted_by is required (Captain identifier from calibration "
+                "session); ADR 0017 §10 — the Curator NEVER self-promotes, "
+                "every promotion has a named human actor"
+            )
+        if not pr_url:
+            raise ValueError(
+                "pr_url is required; promotion must point at the "
+                "crane-console/.agents/skills/ PR opened by the "
+                "calibration-session UI (ADR 0017 §3)"
+            )
+
+        await self._executor.execute(
+            _STAMP_PROMOTION_SQL,
+            [promoted_by, pr_url, draft_id],
+        )
+        await self._assert_transition_succeeded(
+            draft_id,
+            expected="promoted",
+            expected_actor=promoted_by,
+            expected_pr_url=pr_url,
+        )
+
+        await self._audit_writer.write(
+            AuditEvent(
+                action_type="CURATOR_PROMOTION",
+                actor=promoted_by,
+                actor_role=ActorRole.CAPTAIN,
+                skill_name=None,
+                matter_ref=None,
+                metadata={
+                    "customer": self._customer,
+                    "draft_id": draft_id,
+                    "promoted_pr_url": pr_url,
+                },
+            )
+        )
+
+        log.info(
+            "curator.promotion: customer=%s id=%s by=%s pr=%s",
+            self._customer,
+            draft_id,
+            promoted_by,
+            pr_url,
+        )
+
+    # ---- Dismissal ------------------------------------------------------
+
+    async def dismiss(
+        self,
+        *,
+        draft_id: str,
+        dismissed_by: str,
+        reason: str,
+    ) -> None:
+        """Stamp the row dismissed; emit the CURATOR_DISMISSAL audit row.
+
+        Dismissed rows remain in the table for the dismissal-corpus signal
+        (ADR 0017 §4). `reason` is required — silent dismissal hides
+        systematic over-firing of the Curator's extraction signal.
+
+        Raises `CuratorDraftStateError` if the row is missing or already
+        in a terminal state.
+        """
+        if not draft_id:
+            raise ValueError("draft_id is required")
+        if not dismissed_by:
+            raise ValueError("dismissed_by is required")
+        if not reason:
+            raise ValueError(
+                "reason is required; silent dismissal hides Curator over-firing "
+                "(ADR 0017 §4 — dismissed drafts remain in the table for "
+                "tuning extraction signal over time)"
+            )
+
+        await self._executor.execute(
+            _STAMP_DISMISSAL_SQL,
+            [dismissed_by, reason, draft_id],
+        )
+        await self._assert_transition_succeeded(
+            draft_id,
+            expected="dismissed",
+            expected_actor=dismissed_by,
+            expected_reason=reason,
+        )
+
+        await self._audit_writer.write(
+            AuditEvent(
+                action_type="CURATOR_DISMISSAL",
+                actor=dismissed_by,
+                actor_role=ActorRole.CAPTAIN,
+                skill_name=None,
+                matter_ref=None,
+                metadata={
+                    "customer": self._customer,
+                    "draft_id": draft_id,
+                    "dismissed_reason": reason,
+                },
+            )
+        )
+
+        log.info(
+            "curator.dismissal: customer=%s id=%s by=%s reason=%s",
+            self._customer,
+            draft_id,
+            dismissed_by,
+            reason[:80],
+        )
+
+    # ---- Internal -------------------------------------------------------
+
+    async def _assert_transition_succeeded(
+        self,
+        draft_id: str,
+        *,
+        expected: str,
+        expected_actor: str,
+        expected_pr_url: Optional[str] = None,
+        expected_reason: Optional[str] = None,
+    ) -> None:
+        """Verify the UPDATE actually transitioned this row to the expected state.
+
+        Both _STAMP_PROMOTION_SQL and _STAMP_DISMISSAL_SQL are guarded with
+        `AND promoted_at IS NULL AND dismissed_at IS NULL` — they no-op on
+        already-terminal rows. The Executor protocol does not expose row
+        count, so we re-read and compare the stamped actor (and pr_url /
+        reason) against what THIS call passed in. If the stamps belong to
+        an earlier call, the row was already terminal and this transition
+        was a no-op — raise CuratorDraftStateError.
+
+        Production paths can use a real D1 executor that returns row counts;
+        this re-read is the defensive-floor check that works against the
+        Protocol surface. Used by `promote()` and `dismiss()`.
+        """
+        rows = await _fetch_one(self._executor, _SELECT_STAMPS_SQL, [draft_id])
+        if rows is None:
+            raise CuratorDraftStateError(
+                f"skill_drafts row not found: draft_id={draft_id}"
+            )
+        promoted_at, promoted_by, promoted_pr_url, dismissed_at, dismissed_by, dismissed_reason = rows
+
+        if expected == "promoted":
+            this_call_landed = (
+                promoted_at is not None
+                and promoted_by == expected_actor
+                and promoted_pr_url == expected_pr_url
+            )
+            if not this_call_landed:
+                raise CuratorDraftStateError(
+                    f"promotion failed: draft_id={draft_id} is already in a "
+                    f"terminal state (promoted_at={promoted_at}, "
+                    f"dismissed_at={dismissed_at}); a row can be promoted or "
+                    "dismissed exactly once (ADR 0017 §3, §4)"
+                )
+            return
+
+        if expected == "dismissed":
+            this_call_landed = (
+                dismissed_at is not None
+                and dismissed_by == expected_actor
+                and dismissed_reason == expected_reason
+            )
+            if not this_call_landed:
+                raise CuratorDraftStateError(
+                    f"dismissal failed: draft_id={draft_id} is already in a "
+                    f"terminal state (promoted_at={promoted_at}, "
+                    f"dismissed_at={dismissed_at})"
+                )
+            return
+
+
+# ---------------------------------------------------------------------------
+# Helper — read a single row through the Executor Protocol
+#
+# Same shape as honcho_interceptor._fetch_one; the two modules share the
+# constraint and the workaround. See that module's docstring for the
+# rationale. When the Executor protocol grows a fetch surface, both
+# helpers fold back into the protocol.
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_one(executor: Executor, sql: str, params: list) -> Optional[tuple]:
+    """Adapter-layer helper that returns the first row of a SELECT.
+
+    Inspects the executor to find a fetch path: SqliteExecutor exposes its
+    `_conn` attribute (a sqlite3.Connection). The HttpD1Executor variant
+    will land in a follow-on PR — until then, calls against an unrecognized
+    executor raise an explicit RuntimeError so the failure mode is loud.
+    """
+    conn = getattr(executor, "_conn", None)
+    if conn is not None:
+        cur = conn.cursor()
+        cur.execute(sql, params)
+        row = cur.fetchone()
+        return tuple(row) if row is not None else None
+    raise RuntimeError(
+        f"_fetch_one: executor {type(executor).__name__} does not expose a "
+        "supported read path; extend this helper when wiring a new Executor "
+        "implementation"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Boot-time verification (ADR 0017 §_Verification_ point 2)
+# ---------------------------------------------------------------------------
+
+
+# Module names whose presence on the import path would indicate a Curator
+# native writer wiring. The list is intentionally conservative — false
+# positives are loud (boot halts; Captain investigates); false negatives
+# silently violate the safety floor. ADR 0017 §_Verification_ guards
+# requires this list to be re-checked at every quarterly Hermes rebase.
+#
+# Different surfaces than Honcho's: the Curator mutates skill files and
+# the in-memory skill registry, not customer.yaml or runtime persona state.
+_FORBIDDEN_CURATOR_MODULES: tuple[str, ...] = (
+    "hermes.skills.curator_writer",          # hypothetical upstream writer
+    "hermes.skills.registry_mutation",       # hypothetical in-memory mutation surface
+    "hermes.skills.autonomous_promotion",    # hypothetical auto-promote path (ADR 0017 §10)
+    "hermes.skills.auto_consolidation",      # hypothetical auto-consolidate path
+)
+
+
+def verify_curator_intercepted(
+    interceptor: Optional[CuratorInterceptor],
+    *,
+    forbidden_modules: tuple[str, ...] = _FORBIDDEN_CURATOR_MODULES,
+) -> None:
+    """Boot-time check: the interceptor is constructed; no native writer is loaded.
+
+    Per ADR 0017 §_Verification_ point 2: "The Curator interceptor is
+    active at Machine boot. Boot-time check confirms native Curator write
+    paths (skill file mutation, in-memory skill-set mutation) are blocked
+    and the interceptor is the only write surface. Failure halts Machine
+    boot."
+
+    Raises `CuratorNativeWriteBlocked` on failure. The caller (bootstrap.sh
+    → Machine boot path) does not catch — boot fails closed.
+
+    Args:
+        interceptor — the CuratorInterceptor instance constructed by the
+                      overlay. Must be present. None means the overlay
+                      booted without wiring the interceptor; that itself
+                      is a violation (no legitimate write path exists).
+
+        forbidden_modules — closed list of module names that, if present
+                            in sys.modules, indicate a competing writer.
+                            Production callers should use the default;
+                            tests pass a tuple to exercise the check.
+
+    Out of scope for this v1 check (tracked as follow-on, per ADR 0017
+    §_Verification_ point 3): the grep-level CI assertion that no code
+    path in a customer Machine mutates the loaded skill set after boot.
+    That is a static-analysis check on the codebase, not a runtime
+    function — and it lives in CI, not here.
+    """
+    import sys  # noqa: PLC0415 — local import so tests can monkeypatch
+
+    if interceptor is None:
+        raise CuratorNativeWriteBlocked(
+            "Curator interceptor was not constructed at overlay boot. The "
+            "interceptor is the ONLY legitimate write path for Curator output "
+            "(ADR 0017 §1); booting without one means there is either no "
+            "Curator integration (which is fine — return early before this "
+            "check) or there IS one with no interception (which is a safety "
+            "violation). Halting Machine boot."
+        )
+
+    loaded_forbidden = [m for m in forbidden_modules if m in sys.modules]
+    if loaded_forbidden:
+        raise CuratorNativeWriteBlocked(
+            f"Native Curator write surface detected on import path: "
+            f"{loaded_forbidden!r}. Per ADR 0017 §1, all Curator writes MUST "
+            f"flow through CuratorInterceptor — there is no allowlist for "
+            f"direct skill-file mutation, in-memory skill-set mutation, or "
+            f"autonomous promotion (the latter is structurally forbidden by "
+            f"ADR 0017 §10). The quarterly Hermes-rebase agenda item is the "
+            "maintenance hook for new forbidden surfaces; if this module name "
+            "was added intentionally, the maintenance PR must also update "
+            "_FORBIDDEN_CURATOR_MODULES in curator_interceptor.py."
+        )
+
+    log.info("verify_curator_intercepted: ok (interceptor=%r)", type(interceptor).__name__)
+
+
+__all__ = [
+    "CuratorDraftStateError",
+    "CuratorEvidenceRequired",
+    "CuratorInterceptor",
+    "CuratorNativeWriteBlocked",
+    "CuratorTargetRequired",
+    "DraftType",
+    "SkillDraft",
+    "verify_curator_intercepted",
+]

--- a/ai-employee/adapter/tests/test_curator_interceptor.py
+++ b/ai-employee/adapter/tests/test_curator_interceptor.py
@@ -1,0 +1,581 @@
+"""Tests for ai-employee/adapter/curator_interceptor.py (ADR 0017).
+
+Covers the observer-only contract: every draft lands in `skill_drafts` with
+source-evidence, every write emits the matching audit row, promotion and
+dismissal stamp the row idempotently, draft-type-specific target-slug
+requirements are enforced, and boot-time verification halts the Machine if
+a competing Curator write surface is detected.
+
+Run from ai-employee/ directory:
+
+    cd ai-employee && python -m pytest adapter/tests/test_curator_interceptor.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from adapter.audit_log import (  # noqa: E402
+    ACCEPTED_ACTION_TYPES,
+    AuditLogWriter,
+    SqliteExecutor,
+)
+from adapter.curator_interceptor import (  # noqa: E402
+    CuratorDraftStateError,
+    CuratorEvidenceRequired,
+    CuratorInterceptor,
+    CuratorNativeWriteBlocked,
+    CuratorTargetRequired,
+    DraftType,
+    SkillDraft,
+    verify_curator_intercepted,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers — mirror the migrations' tables for end-to-end tests
+# ---------------------------------------------------------------------------
+
+
+_AUDIT_LOG_SCHEMA = """
+CREATE TABLE audit_log (
+  id            TEXT PRIMARY KEY,
+  ts            TEXT NOT NULL,
+  action_type   TEXT NOT NULL,
+  actor         TEXT NOT NULL,
+  actor_role    TEXT,
+  skill_name    TEXT,
+  matter_ref    TEXT,
+  input_digest  TEXT,
+  output_digest TEXT,
+  diff_digest   TEXT,
+  trust_ceiling TEXT,
+  metadata      TEXT
+);
+"""
+
+
+_SKILL_DRAFTS_SCHEMA = """
+CREATE TABLE skill_drafts (
+  draft_id              TEXT PRIMARY KEY,
+  draft_type            TEXT NOT NULL,
+  target_skill_slug     TEXT,
+  draft_body            TEXT NOT NULL,
+  source_evidence_json  TEXT NOT NULL,
+  curator_score         REAL,
+  created_at            TEXT NOT NULL DEFAULT (datetime('now')),
+  promoted_at           TEXT,
+  promoted_by           TEXT,
+  promoted_pr_url       TEXT,
+  dismissed_at          TEXT,
+  dismissed_by          TEXT,
+  dismissed_reason      TEXT,
+  CHECK (source_evidence_json IS NOT NULL AND length(source_evidence_json) > 0)
+);
+"""
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_AUDIT_LOG_SCHEMA)
+    conn.executescript(_SKILL_DRAFTS_SCHEMA)
+    return conn
+
+
+def _make_interceptor(customer: str = "test-firm") -> tuple[CuratorInterceptor, sqlite3.Connection]:
+    conn = _make_conn()
+    executor = SqliteExecutor(conn)
+    writer = AuditLogWriter(executor)
+    interceptor = CuratorInterceptor(
+        executor=executor,
+        audit_writer=writer,
+        customer=customer,
+    )
+    return interceptor, conn
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _sample_new_skill(**overrides) -> SkillDraft:
+    defaults = {
+        "draft_type": DraftType.NEW_SKILL,
+        "draft_body": "---\nname: intake-followup\n---\n\nWhen a lead goes quiet, send a check-in.",
+        "source_evidence": ["trace-001", "trace-014", "trace-027"],
+        "target_skill_slug": None,
+        "curator_score": 0.82,
+    }
+    defaults.update(overrides)
+    return SkillDraft(**defaults)
+
+
+def _sample_consolidation(**overrides) -> SkillDraft:
+    defaults = {
+        "draft_type": DraftType.CONSOLIDATION,
+        "draft_body": "Merge intake-followup into intake-orchestration; both fire on the same trigger.",
+        "source_evidence": ["trace-101", "trace-102"],
+        "target_skill_slug": "intake-orchestration",
+        "curator_score": 0.71,
+    }
+    defaults.update(overrides)
+    return SkillDraft(**defaults)
+
+
+def _sample_prune(**overrides) -> SkillDraft:
+    defaults = {
+        "draft_type": DraftType.PRUNE_RECOMMENDATION,
+        "draft_body": "Skill triggered 12 times; 11 produced dismissed drafts. Recommend removal.",
+        "source_evidence": ["trace-201", "trace-202", "trace-203", "outcome-summary-w34"],
+        "target_skill_slug": "lead-warming-v2",
+        "curator_score": 0.18,
+    }
+    defaults.update(overrides)
+    return SkillDraft(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Audit action_type registration (ADR 0017 §8)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_action_types_registered_in_accepted_set():
+    # Per ADR 0017 §8, the writer must accept the three Curator action_types.
+    # If a future refactor renames or removes any of these from
+    # ACCEPTED_ACTION_TYPES, the interceptor's audit-emit calls will start
+    # raising ValueError and this test will catch the regression first.
+    assert "CURATOR_DRAFT" in ACCEPTED_ACTION_TYPES
+    assert "CURATOR_PROMOTION" in ACCEPTED_ACTION_TYPES
+    assert "CURATOR_DISMISSAL" in ACCEPTED_ACTION_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Draft creation
+# ---------------------------------------------------------------------------
+
+
+def test_record_new_skill_draft_inserts_row_and_returns_ulid():
+    interceptor, conn = _make_interceptor()
+    draft = _sample_new_skill()
+    draft_id = _run(interceptor.record_draft(draft))
+
+    assert isinstance(draft_id, str)
+    assert len(draft_id) == 26  # ULID shape
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT draft_type, target_skill_slug, draft_body, source_evidence_json, "
+        "curator_score FROM skill_drafts WHERE draft_id = ?",
+        [draft_id],
+    )
+    row = cur.fetchone()
+    assert row is not None
+    dtype, target, body, evidence_json, score = row
+    assert dtype == DraftType.NEW_SKILL.value
+    assert target is None  # new_skill has no target
+    assert body.startswith("---")
+    assert json.loads(evidence_json) == ["trace-001", "trace-014", "trace-027"]
+    assert abs(score - 0.82) < 1e-9
+
+
+def test_record_consolidation_draft_stores_target_skill_slug():
+    interceptor, conn = _make_interceptor()
+    draft = _sample_consolidation()
+    draft_id = _run(interceptor.record_draft(draft))
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT draft_type, target_skill_slug FROM skill_drafts WHERE draft_id = ?",
+        [draft_id],
+    )
+    dtype, target = cur.fetchone()
+    assert dtype == DraftType.CONSOLIDATION.value
+    assert target == "intake-orchestration"
+
+
+def test_record_draft_emits_audit_row():
+    interceptor, conn = _make_interceptor(customer="acme-pi")
+    draft = _sample_prune()
+    draft_id = _run(interceptor.record_draft(draft))
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT action_type, actor, actor_role, skill_name, metadata FROM audit_log "
+        "WHERE action_type = ?",
+        ["CURATOR_DRAFT"],
+    )
+    row = cur.fetchone()
+    assert row is not None
+    action_type, actor, actor_role, skill_name, metadata_json = row
+    assert action_type == "CURATOR_DRAFT"
+    assert actor == "agent"
+    assert actor_role == "agent"
+    # skill_name on the audit row is the target_skill_slug, surfaced for
+    # per-skill audit filtering.
+    assert skill_name == "lead-warming-v2"
+    metadata = json.loads(metadata_json)
+    assert metadata["customer"] == "acme-pi"
+    assert metadata["draft_id"] == draft_id
+    assert metadata["draft_type"] == DraftType.PRUNE_RECOMMENDATION.value
+    assert metadata["target_skill_slug"] == "lead-warming-v2"
+    assert metadata["evidence_count"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Draft-type / target-slug rules (ADR 0017 §1)
+# ---------------------------------------------------------------------------
+
+
+def test_consolidation_without_target_raises_before_sql():
+    interceptor, conn = _make_interceptor()
+    draft = _sample_consolidation(target_skill_slug=None)
+    with pytest.raises(CuratorTargetRequired) as exc_info:
+        _run(interceptor.record_draft(draft))
+    assert "target_skill_slug" in str(exc_info.value)
+    assert "ADR 0017" in str(exc_info.value)
+
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM skill_drafts")
+    assert cur.fetchone()[0] == 0
+
+
+def test_prune_without_target_raises():
+    interceptor, _ = _make_interceptor()
+    draft = _sample_prune(target_skill_slug=None)
+    with pytest.raises(CuratorTargetRequired):
+        _run(interceptor.record_draft(draft))
+
+
+def test_scope_adjustment_without_target_raises():
+    interceptor, _ = _make_interceptor()
+    draft = SkillDraft(
+        draft_type=DraftType.SCOPE_ADJUSTMENT,
+        draft_body="Narrow scope to PI matters only.",
+        source_evidence=["trace-301"],
+        target_skill_slug=None,
+    )
+    with pytest.raises(CuratorTargetRequired):
+        _run(interceptor.record_draft(draft))
+
+
+def test_new_skill_with_target_raises():
+    interceptor, _ = _make_interceptor()
+    draft = _sample_new_skill(target_skill_slug="existing-skill")
+    with pytest.raises(CuratorTargetRequired) as exc_info:
+        _run(interceptor.record_draft(draft))
+    assert "new_skill" in str(exc_info.value)
+    assert "must NOT" in str(exc_info.value)
+
+
+def test_empty_draft_body_raises():
+    interceptor, _ = _make_interceptor()
+    draft = _sample_new_skill(draft_body="")
+    with pytest.raises(ValueError) as exc_info:
+        _run(interceptor.record_draft(draft))
+    assert "draft_body" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Fabrication discipline (ADR 0017 §6)
+# ---------------------------------------------------------------------------
+
+
+def test_draft_without_evidence_raises_before_sql():
+    interceptor, conn = _make_interceptor()
+    draft = _sample_new_skill(source_evidence=[])
+    with pytest.raises(CuratorEvidenceRequired) as exc_info:
+        _run(interceptor.record_draft(draft))
+    assert "source_evidence" in str(exc_info.value)
+    assert "ADR 0017" in str(exc_info.value)
+
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM skill_drafts")
+    assert cur.fetchone()[0] == 0
+    cur.execute("SELECT COUNT(*) FROM audit_log")
+    assert cur.fetchone()[0] == 0
+
+
+def test_check_constraint_rejects_empty_evidence_at_db_layer():
+    # Belt-and-suspenders: even if a caller bypassed the runtime check
+    # (e.g., by writing directly through the executor), the CHECK
+    # constraint in migration 0008 rejects the row.
+    conn = _make_conn()
+    cur = conn.cursor()
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute(
+            "INSERT INTO skill_drafts "
+            "(draft_id, draft_type, draft_body, source_evidence_json) "
+            "VALUES (?, ?, ?, ?)",
+            ["test-id", "new_skill", "body", ""],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Promotion (ADR 0017 §3, §10 — no self-promotion)
+# ---------------------------------------------------------------------------
+
+
+def test_promote_stamps_row_and_emits_audit_event():
+    interceptor, conn = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+
+    pr_url = "https://github.com/venturecrane/crane-console/pull/2042"
+    _run(
+        interceptor.promote(
+            draft_id=draft_id,
+            promoted_by="captain",
+            pr_url=pr_url,
+        )
+    )
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT promoted_at, promoted_by, promoted_pr_url, dismissed_at "
+        "FROM skill_drafts WHERE draft_id = ?",
+        [draft_id],
+    )
+    promoted_at, promoted_by, promoted_pr_url, dismissed_at = cur.fetchone()
+    assert promoted_at is not None
+    assert promoted_by == "captain"
+    assert promoted_pr_url == pr_url
+    assert dismissed_at is None
+
+    cur.execute(
+        "SELECT actor, actor_role, metadata FROM audit_log "
+        "WHERE action_type = ?",
+        ["CURATOR_PROMOTION"],
+    )
+    actor, actor_role, metadata_json = cur.fetchone()
+    assert actor == "captain"
+    # Curator promotions use CAPTAIN role per ADR 0017 §10 — Captain reviews
+    # the cross-customer catalog, not the per-customer principal.
+    assert actor_role == "captain"
+    metadata = json.loads(metadata_json)
+    assert metadata["draft_id"] == draft_id
+    assert metadata["promoted_pr_url"] == pr_url
+
+
+def test_promote_requires_pr_url():
+    interceptor, _ = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+    with pytest.raises(ValueError) as exc_info:
+        _run(
+            interceptor.promote(
+                draft_id=draft_id,
+                promoted_by="captain",
+                pr_url="",
+            )
+        )
+    assert "pr_url" in str(exc_info.value)
+    assert "ADR 0017 §3" in str(exc_info.value)
+
+
+def test_promote_requires_promoted_by_per_no_self_promote_rule():
+    # ADR 0017 §10: the Curator NEVER self-promotes. The structural
+    # enforcement is that promoted_by must be a named human actor; the
+    # signature rejects empty strings so no auto-promotion path can omit
+    # the Captain identifier.
+    interceptor, _ = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+    with pytest.raises(ValueError) as exc_info:
+        _run(
+            interceptor.promote(
+                draft_id=draft_id,
+                promoted_by="",
+                pr_url="https://x/y/z",
+            )
+        )
+    assert "promoted_by" in str(exc_info.value)
+    assert "NEVER self-promotes" in str(exc_info.value)
+
+
+def test_promote_unknown_draft_raises_state_error():
+    interceptor, _ = _make_interceptor()
+    with pytest.raises(CuratorDraftStateError) as exc_info:
+        _run(
+            interceptor.promote(
+                draft_id="01HX0000000000000000000000",
+                promoted_by="captain",
+                pr_url="https://x/y/z",
+            )
+        )
+    assert "not found" in str(exc_info.value)
+
+
+def test_promote_idempotency_second_call_raises():
+    interceptor, _ = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+    _run(
+        interceptor.promote(
+            draft_id=draft_id,
+            promoted_by="captain",
+            pr_url="https://x/y/first",
+        )
+    )
+    with pytest.raises(CuratorDraftStateError) as exc_info:
+        _run(
+            interceptor.promote(
+                draft_id=draft_id,
+                promoted_by="captain",
+                pr_url="https://x/y/second",
+            )
+        )
+    assert "terminal state" in str(exc_info.value)
+
+
+def test_promote_after_dismissal_raises():
+    interceptor, _ = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+    _run(
+        interceptor.dismiss(
+            draft_id=draft_id,
+            dismissed_by="captain",
+            reason="proposed slug collides with existing skill",
+        )
+    )
+    with pytest.raises(CuratorDraftStateError):
+        _run(
+            interceptor.promote(
+                draft_id=draft_id,
+                promoted_by="captain",
+                pr_url="https://x/y/z",
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dismissal (ADR 0017 §4)
+# ---------------------------------------------------------------------------
+
+
+def test_dismiss_stamps_row_and_emits_audit_event():
+    interceptor, conn = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_prune()))
+
+    _run(
+        interceptor.dismiss(
+            draft_id=draft_id,
+            dismissed_by="captain",
+            reason="skill is essential for two other customers — outcome signal is local",
+        )
+    )
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT promoted_at, dismissed_at, dismissed_by, dismissed_reason "
+        "FROM skill_drafts WHERE draft_id = ?",
+        [draft_id],
+    )
+    promoted_at, dismissed_at, dismissed_by, dismissed_reason = cur.fetchone()
+    assert promoted_at is None
+    assert dismissed_at is not None
+    assert dismissed_by == "captain"
+    assert "essential for two other customers" in dismissed_reason
+
+    cur.execute(
+        "SELECT actor, metadata FROM audit_log WHERE action_type = ?",
+        ["CURATOR_DISMISSAL"],
+    )
+    actor, metadata_json = cur.fetchone()
+    assert actor == "captain"
+    metadata = json.loads(metadata_json)
+    assert metadata["draft_id"] == draft_id
+
+
+def test_dismiss_requires_reason():
+    interceptor, _ = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+    with pytest.raises(ValueError) as exc_info:
+        _run(
+            interceptor.dismiss(
+                draft_id=draft_id,
+                dismissed_by="captain",
+                reason="",
+            )
+        )
+    assert "reason" in str(exc_info.value)
+    assert "ADR 0017 §4" in str(exc_info.value)
+
+
+def test_dismiss_after_promotion_raises_state_error():
+    interceptor, _ = _make_interceptor()
+    draft_id = _run(interceptor.record_draft(_sample_new_skill()))
+    _run(
+        interceptor.promote(
+            draft_id=draft_id,
+            promoted_by="captain",
+            pr_url="https://x/y/z",
+        )
+    )
+    with pytest.raises(CuratorDraftStateError):
+        _run(
+            interceptor.dismiss(
+                draft_id=draft_id,
+                dismissed_by="captain",
+                reason="changed mind",
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_interceptor_requires_customer_slug():
+    conn = _make_conn()
+    executor = SqliteExecutor(conn)
+    writer = AuditLogWriter(executor)
+    with pytest.raises(ValueError):
+        CuratorInterceptor(executor=executor, audit_writer=writer, customer="")
+
+
+# ---------------------------------------------------------------------------
+# Boot-time verification (ADR 0017 §_Verification_ point 2)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_curator_intercepted_passes_with_constructed_interceptor():
+    interceptor, _ = _make_interceptor()
+    verify_curator_intercepted(interceptor)
+
+
+def test_verify_curator_intercepted_raises_when_interceptor_missing():
+    with pytest.raises(CuratorNativeWriteBlocked) as exc_info:
+        verify_curator_intercepted(None)
+    assert "interceptor was not constructed" in str(exc_info.value)
+    assert "ADR 0017 §1" in str(exc_info.value)
+
+
+def test_verify_curator_intercepted_detects_forbidden_module():
+    interceptor, _ = _make_interceptor()
+    sentinel = "curator_interceptor_test__forbidden_marker"
+    sys.modules[sentinel] = object()  # type: ignore[assignment]
+    try:
+        with pytest.raises(CuratorNativeWriteBlocked) as exc_info:
+            verify_curator_intercepted(
+                interceptor,
+                forbidden_modules=(sentinel,),
+            )
+        assert sentinel in str(exc_info.value)
+        assert "ADR 0017" in str(exc_info.value)
+    finally:
+        sys.modules.pop(sentinel, None)
+
+
+def test_verify_curator_intercepted_default_forbidden_list_is_clean_today():
+    # Sanity check: in this test environment, none of the default forbidden
+    # module names are loaded. A failure here means either a real Curator
+    # writer is loaded (genuine regression) or the default list collided
+    # with an unrelated module — either way the failure surfaces loud.
+    interceptor, _ = _make_interceptor()
+    verify_curator_intercepted(interceptor)

--- a/ai-employee/migrations/0008_skill_drafts.sql
+++ b/ai-employee/migrations/0008_skill_drafts.sql
@@ -1,0 +1,100 @@
+-- ============================================================================
+-- Migration 0008: skill_drafts table (ADR 0017)
+-- ============================================================================
+--
+-- Per-customer table that holds the Hermes autonomous Skill Curator's
+-- observation output. The Curator runs in observer-only mode in the SMD
+-- overlay: it never creates, modifies, consolidates, or prunes skills
+-- inside a customer Machine. Every catalog change is a PR against
+-- crane-console/.agents/skills/, reviewed and merged per established
+-- skill governance, reaching customer Machines only through the next
+-- content-hash-pinned Hermes deploy.
+--
+-- Schema is the authoritative copy from ADR 0017 §1.
+--
+-- Read discipline:
+--   This table is read ONLY by the calibration-session surface and the
+--   decommission-export pipeline. Runtime skill dispatch reads the
+--   content-hash-pinned skill set per ADR 0007 — never this table.
+--
+-- Write discipline (ADR 0017 §1):
+--   The overlay's CuratorInterceptor is the only write path. The Curator's
+--   native write paths (skill file mutation, in-memory skill-set mutation)
+--   are blocked at overlay boot. The interceptor is mandatory; Machine
+--   boot fails if the interception surface check fails.
+--
+-- No self-promotion (ADR 0017 §10):
+--   This is structural, not behavioral: no promotion path in code other
+--   than the calibration-session UI calling CuratorInterceptor.promote().
+--   The promotion handler opens a crane-console PR; the row is stamped
+--   only after the PR URL is supplied. Auto-promotion code paths fail
+--   review.
+--
+-- Fabrication discipline (ADR 0017 §6):
+--   Every draft MUST carry source-evidence pointers. The CHECK constraint
+--   below rejects empty or NULL source_evidence_json at the database
+--   layer, in addition to the runtime assertion in the interceptor.
+--   Belt-and-suspenders by design: a draft without evidence is not a
+--   valid draft.
+--
+-- Cross-customer prohibition (ADR 0009 + ADR 0017 §11):
+--   The Curator running in customer A's Machine cannot observe customer B's
+--   execution traces. This table is per-customer; isolation is the binding
+--   boundary, not a row-level customer_id column.
+--
+-- Compatibility:
+--   New objects only. No drops, no column changes, no constraint changes
+--   on existing tables.
+--
+-- Source spec: docs/adr/0017-skill-curator-disposition.md §1
+-- Refers to:   docs/specs/ai-employee/calibration-session.md (#867)
+--              docs/specs/ai-employee/audit-log-immutability.md (#892)
+--              docs/specs/ai-employee/decommission-customer.md (#820)
+--              reference_agents_skills_source_of_truth.md (#573)
+-- ============================================================================
+
+-- ---------- Skill drafts ----------
+-- One row per Curator observation. Four draft types:
+--   new_skill            — proposed skill markdown for a fresh SKILL.md
+--   consolidation        — merge two or more skills (target_skill_slug
+--                          is the primary; draft_body names the others)
+--   prune_recommendation — flag a skill as underperforming; target_skill_slug
+--                          is the candidate; draft_body is the rationale
+--   scope_adjustment     — narrow or widen a skill's scope; target_skill_slug
+--                          is the skill; draft_body is the proposed diff
+--
+-- Promotion (calibration-session UI) stamps promoted_at/promoted_by/
+-- promoted_pr_url and opens a crane-console PR; the row itself is the
+-- audit-trail anchor. Dismissals are recorded (never deleted) so the
+-- dismissal corpus is available for tuning Curator's extraction signal
+-- over time.
+CREATE TABLE skill_drafts (
+  draft_id              TEXT PRIMARY KEY,
+  draft_type            TEXT NOT NULL,         -- new_skill | consolidation | prune_recommendation | scope_adjustment
+  target_skill_slug     TEXT,                  -- existing skill slug; null for new_skill
+  draft_body            TEXT NOT NULL,         -- proposed markdown (new_skill, consolidation, scope) or rationale (prune)
+  source_evidence_json  TEXT NOT NULL,         -- execution-trace row IDs, audit_log row IDs, outcome scores
+  curator_score         REAL,                  -- Curator's own grading value; never an auto-promotion gate
+  created_at            TEXT NOT NULL DEFAULT (datetime('now')),
+  promoted_at           TEXT,                  -- timestamp of Captain promotion
+  promoted_by           TEXT,                  -- Captain identifier who promoted
+  promoted_pr_url       TEXT,                  -- URL of the crane-console PR the promotion generated
+  dismissed_at          TEXT,
+  dismissed_by          TEXT,
+  dismissed_reason      TEXT,
+  CHECK (source_evidence_json IS NOT NULL AND length(source_evidence_json) > 0)
+);
+
+-- Pending drafts: the calibration-session surface walks this index.
+CREATE INDEX skill_drafts_pending
+  ON skill_drafts (created_at)
+  WHERE promoted_at IS NULL AND dismissed_at IS NULL;
+
+-- Per-type time-ordered scan: powers the calibration UI's per-type pane
+-- and the decommission export.
+CREATE INDEX skill_drafts_by_type
+  ON skill_drafts (draft_type, created_at);
+
+-- ---------- Schema version ----------
+-- 0001-0006 set 1-6, 0007 set 7; this is 8.
+PRAGMA user_version = 8;


### PR DESCRIPTION
## Summary

Implements [ADR 0017](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0017-skill-curator-disposition.md) — the observer-only disposition for Hermes upstream's autonomous Skill Curator. The Curator is allowed to observe execution traces and propose skill-catalog changes, but never creates, modifies, consolidates, or prunes skills inside a customer Machine. Every catalog change is a PR against `crane-console/.agents/skills/`, reviewed and merged per established skill governance.

Sibling of [#1007](https://github.com/venturecrane/ss-console/pull/1007) (ADR 0016 / Honcho interceptor); structurally similar but with the absolute "no self-promotion" commitment of ADR 0017 §10 — there is no relaxation valve, ever, for autonomous promotion of executable behavior.

**What ships:**

- New table `skill_drafts` (migration 0008) with database-level CHECK constraint enforcing the source-evidence requirement
- `CuratorInterceptor` — the single legitimate write path; records drafts, stamps promotions/dismissals, emits audit rows
- Four draft types (`new_skill`, `consolidation`, `prune_recommendation`, `scope_adjustment`) with type-specific target-slug validation
- `verify_curator_intercepted()` — boot-time check that halts Machine boot if a competing native-write surface is loaded
- Three new audit action_type classes (`CURATOR_DRAFT`, `CURATOR_PROMOTION`, `CURATOR_DISMISSAL`) added to `ACCEPTED_ACTION_TYPES`

**Structural enforcement of ADR 0017 §10 (no self-promotion):** `CuratorInterceptor.promote()` requires both `promoted_by` (non-empty Captain identifier) AND `pr_url` (non-empty `crane-console` PR URL) by method signature. No auto-promotion code path exists; relaxing this requires superseding ADR 0017 with an explicit ADR, not a threshold tweak.

**What is explicitly out of scope** (filed as follow-on issues per ADR 0017 § _Immediate follow-on_): calibration-session UI skill-draft review surface, sticky-stop draft-flood threshold, decommission-export wiring, grep-CI assertion that no code path mutates the loaded skill set after boot, related spec updates.

## ADR 0017 Acceptance Criteria

| AC | Status | Where |
|---|---|---|
| §1 — `skill_drafts` exists per spec | shipped | `ai-employee/migrations/0008_skill_drafts.sql` |
| §1 — CHECK constraint on `source_evidence_json` | shipped | migration 0008; `test_check_constraint_rejects_empty_evidence_at_db_layer` |
| §1 — Interceptor is the only write path | shipped | `curator_interceptor.py::CuratorInterceptor` |
| §1 — Four draft types with target-slug validation | shipped | `DraftType` enum; `test_consolidation_without_target_raises_before_sql`, `test_new_skill_with_target_raises`, etc. |
| §2 — Runtime skill set is immutable after boot | structurally satisfied | no code path in this PR mutates loaded skill set; grep-CI assertion is a separate follow-on |
| §3 — Promotion records the crane-console PR URL | shipped | `CuratorInterceptor.promote()`; `test_promote_stamps_row_and_emits_audit_event` |
| §4 — Dismissals are recorded, not deleted; reason required | shipped | `CuratorInterceptor.dismiss()`; `test_dismiss_requires_reason` |
| §6 — Source-evidence required at runtime and DB layer | shipped | `CuratorEvidenceRequired` + CHECK constraint |
| §8 — Audit-log emission per draft/promotion/dismissal | shipped | three new `ACCEPTED_ACTION_TYPES` values; emitted in each interceptor method |
| §10 — No Curator self-promotion (structural) | shipped | `promote()` requires non-empty `promoted_by` + `pr_url`; `test_promote_requires_promoted_by_per_no_self_promote_rule` |
| §11 — No cross-customer reach | structurally satisfied | the interceptor is per-Machine and per-customer by construction; one instance per `customer` slug |
| § _Verification_ point 2 — Boot-time interceptor check | shipped | `verify_curator_intercepted()`; `test_verify_curator_intercepted_*` |

Follow-on ACs (calibration UI, sticky-stop threshold, decommission export, runtime-immutability CI assertion, quarterly-rebase audit) are filed separately per ADR 0017 § _Immediate follow-on_.

## Test plan

- [x] `cd ai-employee && python -m pytest adapter/tests/test_curator_interceptor.py -v` — 25/25 pass
- [x] Full adapter suite — 338 passed, 8 skipped (no regressions; matches PR #1007 + #1006 baseline + 25 new)
- [x] `npm run verify` — typecheck, lint, format, build, vitest all green (2426 tests passing)
- [ ] Captain review of the proposer/observer-distinction (PR #1007 was proposer for Honcho, this PR is observer for Curator) and the §10 no-self-promotion structural enforcement
- [ ] Merge gates this PR's branch from getting overwritten in the wave-1 sequential queue (PR 3 / ADR 0018 GEPA branch from updated main after this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)