### PR TITLE
feat(ai-employee): adopt Namespaced* wrappers at prod call sites (#861 follow-on)

### DIFF
--- a/ai-employee/adapter/__init__.py
+++ b/ai-employee/adapter/__init__.py
@@ -15,8 +15,14 @@ Per-customer namespace isolation enforcement (issue #861, ADR 0009)
 lives in `namespace_assertion.py`. Production wiring constructs the
 three `Namespaced*` wrappers below at Machine boot and hands the
 wrapped instances to every caller that touches D1, R2, or Vectorize.
+The factory helpers (`namespaced_executor_from_env` in `d1_env.py`,
+`memory.build_namespaced_memory_runner`, and
+`voice.build_namespaced_voice_runner`) are the recommended migration
+entry points for the fork's overlay — see issue
+[#1009](https://github.com/venturecrane/ss-console/issues/1009).
 """
 
+from .d1_env import namespaced_executor_from_env
 from .namespace_assertion import (
     NamespaceAssertionError,
     NamespacedD1Executor,
@@ -31,4 +37,5 @@ __all__ = [
     "NamespacedD1Executor",
     "NamespacedR2Client",
     "NamespacedVectorizeClient",
+    "namespaced_executor_from_env",
 ]

--- a/ai-employee/adapter/__init__.py
+++ b/ai-employee/adapter/__init__.py
@@ -12,14 +12,34 @@ the customer-config loader in `connector_loader.py`; the runtime hook
 that registers with Hermes in `aie_adapter.py`.
 
 Per-customer namespace isolation enforcement (issue #861, ADR 0009)
-lives in `namespace_assertion.py`. Production wiring constructs the
-three `Namespaced*` wrappers below at Machine boot and hands the
-wrapped instances to every caller that touches D1, R2, or Vectorize.
-The factory helpers (`namespaced_executor_from_env` in `d1_env.py`,
+lives in `namespace_assertion.py`. The factory helpers
+(`namespaced_executor_from_env` in `d1_env.py`,
 `memory.build_namespaced_memory_runner`, and
-`voice.build_namespaced_voice_runner`) are the recommended migration
-entry points for the fork's overlay — see issue
-[#1009](https://github.com/venturecrane/ss-console/issues/1009).
+`voice.build_namespaced_voice_runner`) are the ONLY supported
+construction path for per-customer D1 / R2 / Vectorize access — see
+issue [#1009](https://github.com/venturecrane/ss-console/issues/1009)
+for the fork-side adoption track.
+
+Public adapter surface (TOCTOU hardening, #861 follow-on)
+---------------------------------------------------------
+
+`from ai_employee.adapter import *` produces exactly the names below:
+
+* `NamespaceAssertionError` — the structured refusal raised on
+  cross-customer access attempts.
+* `NamespacedD1Executor`, `NamespacedR2Client`,
+  `NamespacedVectorizeClient` — the three slug-bound wrappers.
+* `namespaced_executor_from_env` — the env-bound D1 entry point.
+
+The raw underlying constructors (`HttpD1Executor`, `SqliteExecutor` in
+`audit_log.py`; the `StorageClient` Protocol in `memory.pipeline`; the
+`R2Client` Protocol in `voice.pipeline`) are still importable by
+explicit name for the writer path (per the audit-log immutability
+invariant), the namespace-bridge adapters, and tests — but they are NOT
+in any `__all__` and `from ... import *` will not surface them. New
+consumers must construct per-customer storage through the factories
+above; the fork overlay built against this surface will therefore use
+namespaced wrappers from day one.
 """
 
 from .d1_env import namespaced_executor_from_env

--- a/ai-employee/adapter/audit_log.py
+++ b/ai-employee/adapter/audit_log.py
@@ -459,6 +459,15 @@ def writer_from_env() -> AuditLogWriter:
     return AuditLogWriter(executor)
 
 
+# Public surface (`from adapter.audit_log import *`) excludes the raw
+# `HttpD1Executor` and `SqliteExecutor` constructors as of issue #861's
+# TOCTOU hardening: external callers MUST go through
+# `adapter.d1_env.namespaced_executor_from_env(...)` so every D1 access
+# is bound to a customer slug. The raw classes remain importable by
+# explicit name for the in-tree writer path (per the audit-log
+# immutability design at `audit_log_immutability.py`) and for tests,
+# but they are not advertised. A future PR can mark them
+# underscore-private once the in-tree consumers migrate.
 __all__ = [
     "ACCEPTED_ACTION_TYPES",
     "ActorRole",
@@ -466,7 +475,5 @@ __all__ = [
     "AuditLogWriter",
     "AuditWriteError",
     "Executor",
-    "HttpD1Executor",
-    "SqliteExecutor",
     "writer_from_env",
 ]

--- a/ai-employee/adapter/d1_env.py
+++ b/ai-employee/adapter/d1_env.py
@@ -1,0 +1,86 @@
+"""Env-bound D1 client construction with optional namespace assertion.
+
+`audit_log.writer_from_env()` returns the raw audit-log writer — that
+path is the *one* sanctioned INSERT into `audit_log` and stays
+unwrapped by design (see `audit_log_immutability.py` for the rationale).
+Every OTHER caller that wants per-customer D1 access at the Machine
+boot level should call `namespaced_executor_from_env(customer_slug)`
+below; it returns a `NamespacedD1Executor` bound to the slug, with the
+audit writer injected so refusals land an `INVARIANT_VIOLATION` row.
+
+The wrapper is a defense-in-depth no-op against today's writer-only SQL
+(no slug tokens appear there). It locks the contract so the moment a
+caller adds slug-mentioning SQL (e.g. a maintenance script or a
+cross-table report that names a per-customer Vectorize index), the
+wrapper catches a foreign-slug name before the query reaches D1.
+
+Filed as the recommended migration entry point against
+[#1009](https://github.com/venturecrane/ss-console/issues/1009)
+(fork-side adoption tracker; do not implement there).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from .audit_log import AuditLogWriter, HttpD1Executor, writer_from_env
+from .namespace_assertion import NamespacedD1Executor
+
+
+def namespaced_executor_from_env(
+    customer_slug: Optional[str] = None,
+    *,
+    audit_writer: Optional[AuditLogWriter] = None,
+) -> NamespacedD1Executor:
+    """Return a slug-bound `NamespacedD1Executor` wired to env-bound D1.
+
+    `customer_slug` defaults to the `CUSTOMER_SLUG` env var (which
+    `templates/bootstrap.sh` step 1 already requires non-empty). Passing
+    the slug explicitly is supported for call sites that need to bind a
+    different slug than the Machine's primary tenant (none today; the
+    knob exists for future operator paths).
+
+    `audit_writer` defaults to a fresh `writer_from_env()` so the
+    wrapper's refusal-audit emission has somewhere to land. Production
+    callers that already hold a writer should pass it in to avoid
+    creating a second HTTP executor.
+
+    Raises `RuntimeError` if either the D1 env vars or the customer
+    slug is missing — that is a bootstrap-time invariant failure and
+    should abort container start.
+    """
+    slug = customer_slug if customer_slug is not None else os.environ.get(
+        "CUSTOMER_SLUG", ""
+    )
+    if not slug:
+        raise RuntimeError(
+            "d1_env.namespaced_executor_from_env: CUSTOMER_SLUG env var unset "
+            "(and no explicit slug passed); templates/bootstrap.sh step 1 "
+            "must set this from the per-customer Machine binding"
+        )
+
+    raw = HttpD1Executor(
+        account_id=_require_env("CF_ACCOUNT_ID"),
+        database_id=_require_env("AIE_D1_DATABASE_ID"),
+        api_token=_require_env("CF_API_TOKEN"),
+    )
+    writer = audit_writer if audit_writer is not None else writer_from_env()
+    return NamespacedD1Executor(
+        expected_slug=slug,
+        inner=raw,
+        audit_writer=writer,
+    )
+
+
+def _require_env(key: str) -> str:
+    value = os.environ.get(key)
+    if not value:
+        raise RuntimeError(
+            f"d1_env.namespaced_executor_from_env: required env var {key!r} unset; "
+            "bootstrap.sh must set this from the per-customer secret bundle"
+        )
+    return value
+
+
+__all__ = ["namespaced_executor_from_env"]

--- a/ai-employee/adapter/memory/__init__.py
+++ b/ai-employee/adapter/memory/__init__.py
@@ -20,6 +20,11 @@ See ADR 0006, 0008, 0009 and ``docs/specs/ai-employee/memory-ingestion.md``.
 
 from __future__ import annotations
 
+from .namespaced import (
+    RawR2Client,
+    RawVectorizeClient,
+    build_namespaced_memory_runner,
+)
 from .pipeline import (
     DocumentChunker,
     EmbeddingClient,
@@ -47,9 +52,12 @@ __all__ = [
     "MemorySourceState",
     "NoPracticeManagementSource",
     "PracticeManagementSourceAdapter",
+    "RawR2Client",
+    "RawVectorizeClient",
     "SourceDescriptor",
     "SourceStateStore",
     "StorageError",
+    "build_namespaced_memory_runner",
     "decommission_source",
     "read_source_states",
 ]

--- a/ai-employee/adapter/memory/namespaced.py
+++ b/ai-employee/adapter/memory/namespaced.py
@@ -1,0 +1,168 @@
+"""Factory helper that wires `MemoryIngestionRunner` against namespaced storage.
+
+The memory pipeline's `StorageClient` is a Protocol with two methods —
+`put_r2_object(key, body, *, content_type)` and
+`upsert_vectors(index_name, vectors)`. The namespace-assertion wrappers
+shipped in `adapter/namespace_assertion.py` use slightly different method
+names (`put_object` for R2; the Vectorize one matches), so a thin bridge
+adapter is needed to glue them onto the pipeline's expected shape.
+
+`build_namespaced_memory_runner` is the public entry point. The Hermes
+fork's per-customer Machine boot path calls this instead of constructing
+`MemoryIngestionRunner` directly with raw storage — every R2 / Vectorize
+call from the runner then routes through the namespace assertion before
+hitting the raw client.
+
+Filed as the recommended migration entry point against
+[#1009](https://github.com/venturecrane/ss-console/issues/1009)
+(fork-side adoption tracker; do not implement there).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol
+
+from ..audit_log import AuditLogWriter
+from ..namespace_assertion import (
+    NamespacedR2Client,
+    NamespacedVectorizeClient,
+)
+from .chunking import DocumentChunker
+from .pipeline import (
+    MemoryIngestionRunner,
+    PracticeManagementSourceAdapter,
+    EmbeddingClient,
+    StorageClient,
+)
+from .state import SourceStateStore
+
+
+# ---------------------------------------------------------------------------
+# Raw storage interface the fork's overlay already constructs
+#
+# The fork's overlay holds two raw clients per customer Machine: an R2
+# binding and a Vectorize binding. They map onto the wrappers exactly:
+#
+#     raw_r2.put_object(key, body, *, content_type)
+#     raw_r2.get_object(key) / raw_r2.delete_object(key)
+#     raw_vectorize.upsert_vectors(index_name, vectors)
+#     raw_vectorize.query_vectors(index_name, vector, *, top_k)
+#     raw_vectorize.delete_vectors(index_name, ids)
+#
+# These are the shapes `NamespacedR2Client` and `NamespacedVectorizeClient`
+# wrap directly, so no extra translation is needed at the raw layer.
+# ---------------------------------------------------------------------------
+
+
+class RawR2Client(Protocol):
+    """The raw R2 client interface — exactly what `NamespacedR2Client` wraps."""
+
+    async def put_object(self, key: str, body: bytes, *, content_type: str) -> None: ...
+    async def get_object(self, key: str) -> bytes: ...
+    async def delete_object(self, key: str) -> None: ...
+
+
+class RawVectorizeClient(Protocol):
+    """The raw Vectorize client interface — exactly what `NamespacedVectorizeClient` wraps."""
+
+    async def upsert_vectors(self, index_name: str, vectors: list[dict]) -> None: ...
+    async def query_vectors(
+        self, index_name: str, vector: list[float], *, top_k: int
+    ) -> Any: ...
+    async def delete_vectors(self, index_name: str, ids: list[str]) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-shaped bridge
+#
+# The memory pipeline's `StorageClient` Protocol declares two methods:
+#
+#     put_r2_object(key, body, *, content_type)
+#     upsert_vectors(index_name, vectors)
+#
+# `NamespacedR2Client.put_object` is the assertion-bearing equivalent of
+# `put_r2_object`; `NamespacedVectorizeClient.upsert_vectors` matches the
+# pipeline's vectorize method directly. This bridge owns the method-name
+# adaptation so the pipeline stays untouched.
+# ---------------------------------------------------------------------------
+
+
+class _NamespacedStorageBridge:
+    """Implements `StorageClient` by delegating through the namespace wrappers."""
+
+    def __init__(
+        self,
+        *,
+        r2: NamespacedR2Client,
+        vectorize: NamespacedVectorizeClient,
+    ) -> None:
+        self._r2 = r2
+        self._vectorize = vectorize
+
+    async def put_r2_object(
+        self, key: str, body: bytes, *, content_type: str
+    ) -> None:
+        await self._r2.put_object(key, body, content_type=content_type)
+
+    async def upsert_vectors(
+        self, index_name: str, vectors: list[dict]
+    ) -> None:
+        await self._vectorize.upsert_vectors(index_name, vectors)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_namespaced_memory_runner(
+    *,
+    customer_slug: str,
+    source_adapter: PracticeManagementSourceAdapter,
+    raw_r2: RawR2Client,
+    raw_vectorize: RawVectorizeClient,
+    embeddings: EmbeddingClient,
+    chunker: DocumentChunker,
+    state_store: SourceStateStore,
+    audit_writer: Optional[AuditLogWriter] = None,
+    clock: Optional[callable] = None,
+) -> MemoryIngestionRunner:
+    """Return a `MemoryIngestionRunner` wired through namespace-asserting storage.
+
+    The Hermes fork's per-customer Machine boot path should call this
+    factory instead of `MemoryIngestionRunner(...)` directly. Every R2
+    put and Vectorize upsert from the runner is routed through the
+    namespace assertion before it hits the raw client, so a foreign-slug
+    key or index name refuses + audits at the boundary.
+
+    `audit_writer` is recommended in production so every refusal lands
+    one `INVARIANT_VIOLATION` audit row. It may be omitted in tests; the
+    refusal still raises `NamespaceAssertionError`.
+    """
+    r2 = NamespacedR2Client(
+        expected_slug=customer_slug,
+        inner=raw_r2,
+        audit_writer=audit_writer,
+    )
+    vectorize = NamespacedVectorizeClient(
+        expected_slug=customer_slug,
+        inner=raw_vectorize,
+        audit_writer=audit_writer,
+    )
+    bridge = _NamespacedStorageBridge(r2=r2, vectorize=vectorize)
+    return MemoryIngestionRunner(
+        customer_slug=customer_slug,
+        source_adapter=source_adapter,
+        storage=bridge,  # type: ignore[arg-type]  # bridge implements StorageClient
+        embeddings=embeddings,
+        chunker=chunker,
+        state_store=state_store,
+        clock=clock,
+    )
+
+
+__all__ = [
+    "RawR2Client",
+    "RawVectorizeClient",
+    "build_namespaced_memory_runner",
+]

--- a/ai-employee/adapter/memory/pipeline.py
+++ b/ai-employee/adapter/memory/pipeline.py
@@ -594,6 +594,13 @@ def _build_vector_record(
     }
 
 
+# Public surface (`from adapter.memory.pipeline import *`) excludes the
+# raw `StorageClient` Protocol as of issue #861's TOCTOU hardening:
+# external callers MUST go through
+# `adapter.memory.build_namespaced_memory_runner(...)`, which wraps a
+# raw R2 + Vectorize pair in the namespace-asserting bridge before
+# handing it to the runner. The Protocol remains importable by explicit
+# name for the bridge in `namespaced.py` and for tests.
 __all__ = [
     "DocumentChunker",
     "EmbeddingClient",
@@ -607,6 +614,5 @@ __all__ = [
     "PracticeManagementSource",
     "PracticeManagementSourceAdapter",
     "SourceDescriptor",
-    "StorageClient",
     "StorageError",
 ]

--- a/ai-employee/adapter/namespace_assertion.py
+++ b/ai-employee/adapter/namespace_assertion.py
@@ -377,13 +377,22 @@ class _R2KeyDecision:
 def _classify_r2_key(key: str, expected_slug: str) -> _R2KeyDecision:
     """Decide whether an R2 key belongs to `expected_slug`.
 
-    The decision is:
+    Accepted shapes (both conventions live in the codebase):
 
-    * empty / non-string keys → reject (no slug)
-    * traversal sequences (`..`) → reject (no slug)
-    * `vaults/{slug}/...` → ok iff slug matches
-    * `{slug}/vault/...` → ok iff slug matches
-    * anything else → reject (no slug)
+    * `vaults/{slug}/...` — used by the no_pm connector + the original
+      spec doc convention; slug is always the second segment.
+    * `{slug}/...` — used by the memory pipeline (`{slug}/vault/...`)
+      and the voice pipeline (`{slug}/voice/cohort/...`); slug is the
+      first segment and any second segment is allowed under it.
+
+    Refusals:
+
+    * empty / non-string keys
+    * traversal sequences (`..`)
+    * multiple leading slashes
+    * single-segment keys (no place for a slug)
+    * keys whose extracted slug does not match `expected_slug`
+    * keys whose first segment is neither `vaults` nor a valid slug
 
     Returns the matched slug when one is captured so the caller can
     record it on the refusal.
@@ -424,14 +433,12 @@ def _classify_r2_key(key: str, expected_slug: str) -> _R2KeyDecision:
             )
         return _R2KeyDecision(ok=True, found_slug=second, reason="ok")
 
-    # Convention 2: {slug}/vault/...
-    if second == "vault":
-        if not _SLUG_PATTERN.match(first):
-            return _R2KeyDecision(
-                ok=False,
-                found_slug=None,
-                reason=f"slug segment {first!r} does not match slug pattern",
-            )
+    # Convention 2: {slug}/<anything>/... — slug-first, any keyspace.
+    # Covers `{slug}/vault/...` (memory pipeline) and `{slug}/voice/...`
+    # (voice pipeline). The wrapper does not constrain the second
+    # segment because new per-customer keyspaces can land without a
+    # wrapper update.
+    if _SLUG_PATTERN.match(first):
         if first != expected_slug:
             return _R2KeyDecision(
                 ok=False,
@@ -445,7 +452,7 @@ def _classify_r2_key(key: str, expected_slug: str) -> _R2KeyDecision:
         found_slug=None,
         reason=(
             "key does not match either prefix convention "
-            "(vaults/{slug}/... or {slug}/vault/...)"
+            "(vaults/{slug}/... or {slug}/...)"
         ),
     )
 

--- a/ai-employee/adapter/tests/test_namespace_adoption.py
+++ b/ai-employee/adapter/tests/test_namespace_adoption.py
@@ -1,0 +1,488 @@
+"""Tests for the namespace-assertion adoption factories (#861 follow-on).
+
+Covers three in-tree migration entry points:
+
+* `adapter.d1_env.namespaced_executor_from_env` — builds a
+  `NamespacedD1Executor` from the per-customer env, with the audit
+  writer wired in.
+* `adapter.memory.build_namespaced_memory_runner` — returns a
+  `MemoryIngestionRunner` whose `StorageClient` routes every R2 put +
+  Vectorize upsert through the namespace assertion before reaching the
+  raw client.
+* `adapter.voice.build_namespaced_voice_runner` — returns a
+  `VoiceIngestionRunner` whose `R2Client` routes every put + delete
+  through the namespace assertion.
+
+The headline test for each factory: a runner built with slug A is
+asked to do an operation that names slug B; the call refuses with
+`NamespaceAssertionError` AND emits an `INVARIANT_VIOLATION` audit
+row. This is the same shape as the wrapper-level integration test in
+`test_namespace_assertion.py`, lifted to the runner boundary.
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_namespace_adoption.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from adapter import namespaced_executor_from_env  # noqa: E402
+from adapter.audit_log import (  # noqa: E402
+    AuditLogWriter,
+    SqliteExecutor,
+)
+from adapter.memory import (  # noqa: E402
+    DocumentChunker,
+    IngestionMode,
+    NoPracticeManagementSource,
+    PracticeManagementSourceAdapter,
+    SourceDescriptor,
+    SourceStateStore,
+    build_namespaced_memory_runner,
+)
+from adapter.namespace_assertion import (  # noqa: E402
+    NamespaceAssertionError,
+    NamespacedD1Executor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Audit-log writer fixture
+# ---------------------------------------------------------------------------
+
+
+_SCHEMA_SQL = """
+CREATE TABLE audit_log (
+  id            TEXT PRIMARY KEY,
+  ts            TEXT NOT NULL,
+  action_type   TEXT NOT NULL,
+  actor         TEXT NOT NULL,
+  actor_role    TEXT,
+  skill_name    TEXT,
+  matter_ref    TEXT,
+  input_digest  TEXT,
+  output_digest TEXT,
+  diff_digest   TEXT,
+  trust_ceiling TEXT,
+  metadata      TEXT
+);
+"""
+
+
+_MEMORY_STATE_SCHEMA_SQL = """
+CREATE TABLE memory_source_state (
+  source_kind         TEXT NOT NULL,
+  source_id           TEXT NOT NULL,
+  last_ingestion_at   TEXT NOT NULL,
+  last_success_at     TEXT,
+  last_error          TEXT,
+  ingest_status       TEXT NOT NULL,
+  items_last_run      INTEGER NOT NULL DEFAULT 0,
+  schema_version      INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (source_kind, source_id)
+);
+CREATE TABLE memory_ingested_items (
+  id                   TEXT PRIMARY KEY,
+  source_kind          TEXT NOT NULL,
+  source_id            TEXT NOT NULL,
+  external_id          TEXT NOT NULL,
+  item_type            TEXT NOT NULL,
+  ingested_at          TEXT NOT NULL,
+  access_scope         TEXT NOT NULL DEFAULT 'firm-wide',
+  access_scope_detail  TEXT,
+  r2_key               TEXT,
+  vectorize_chunk_ids  TEXT,
+  content_digest       TEXT,
+  metadata             TEXT,
+  deleted_at           TEXT
+);
+"""
+
+
+def _make_audit_writer() -> tuple[AuditLogWriter, sqlite3.Connection]:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_SCHEMA_SQL)
+    return AuditLogWriter(SqliteExecutor(conn)), conn
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fakes for raw R2 / Vectorize that match the namespace wrapper's Protocols
+# ---------------------------------------------------------------------------
+
+
+class _FakeRawR2:
+    def __init__(self) -> None:
+        self.put_calls: list[tuple[str, bytes, str]] = []
+        self.delete_calls: list[str] = []
+        self.objects: dict[str, bytes] = {}
+
+    async def put_object(self, key: str, body: bytes, *, content_type: str) -> None:
+        self.put_calls.append((key, body, content_type))
+        self.objects[key] = body
+
+    async def get_object(self, key: str) -> bytes:
+        return self.objects.get(key, b"")
+
+    async def delete_object(self, key: str) -> None:
+        self.delete_calls.append(key)
+        self.objects.pop(key, None)
+
+
+class _FakeRawVectorize:
+    def __init__(self) -> None:
+        self.upserts: list[tuple[str, list[dict]]] = []
+
+    async def upsert_vectors(self, index_name: str, vectors: list[dict]) -> None:
+        self.upserts.append((index_name, vectors))
+
+    async def query_vectors(
+        self, index_name: str, vector: list[float], *, top_k: int
+    ):
+        return []
+
+    async def delete_vectors(self, index_name: str, ids: list[str]) -> None:
+        pass
+
+
+class _FakeEmbeddings:
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[float(len(t))] for t in texts]
+
+
+# ---------------------------------------------------------------------------
+# `namespaced_executor_from_env` — D1 wiring
+# ---------------------------------------------------------------------------
+
+
+def test_namespaced_executor_from_env_requires_customer_slug(monkeypatch):
+    # Unset both the slug AND the D1 env vars so the slug check fires first
+    monkeypatch.delenv("CUSTOMER_SLUG", raising=False)
+    monkeypatch.setenv("CF_ACCOUNT_ID", "acct")
+    monkeypatch.setenv("CF_API_TOKEN", "tok")
+    monkeypatch.setenv("AIE_D1_DATABASE_ID", "db")
+
+    with pytest.raises(RuntimeError, match="CUSTOMER_SLUG"):
+        namespaced_executor_from_env()
+
+
+def test_namespaced_executor_from_env_requires_d1_env_vars(monkeypatch):
+    monkeypatch.setenv("CUSTOMER_SLUG", "acme")
+    monkeypatch.delenv("CF_ACCOUNT_ID", raising=False)
+    monkeypatch.setenv("CF_API_TOKEN", "tok")
+    monkeypatch.setenv("AIE_D1_DATABASE_ID", "db")
+
+    # writer_from_env (called for the default audit writer) fails first
+    # because it scans the same env. Either error path is acceptable.
+    with pytest.raises(RuntimeError, match="CF_ACCOUNT_ID"):
+        namespaced_executor_from_env()
+
+
+def test_namespaced_executor_from_env_returns_slug_bound_wrapper(monkeypatch):
+    monkeypatch.setenv("CUSTOMER_SLUG", "acme")
+    monkeypatch.setenv("CF_ACCOUNT_ID", "acct")
+    monkeypatch.setenv("CF_API_TOKEN", "tok")
+    monkeypatch.setenv("AIE_D1_DATABASE_ID", "db")
+
+    writer, _ = _make_audit_writer()
+    executor = namespaced_executor_from_env(audit_writer=writer)
+
+    assert isinstance(executor, NamespacedD1Executor)
+    # Bound slug is read back via a refusal probe — exercising a foreign
+    # token returns a NamespaceAssertionError whose expected_slug is "acme".
+    with pytest.raises(NamespaceAssertionError) as excinfo:
+        _run(executor.execute("INSERT INTO x (key) VALUES ('hermes-other-vault')", []))
+    assert excinfo.value.expected_slug == "acme"
+
+
+def test_namespaced_executor_from_env_accepts_explicit_slug(monkeypatch):
+    monkeypatch.setenv("CF_ACCOUNT_ID", "acct")
+    monkeypatch.setenv("CF_API_TOKEN", "tok")
+    monkeypatch.setenv("AIE_D1_DATABASE_ID", "db")
+    monkeypatch.delenv("CUSTOMER_SLUG", raising=False)
+
+    writer, _ = _make_audit_writer()
+    executor = namespaced_executor_from_env("operator-slug", audit_writer=writer)
+
+    assert isinstance(executor, NamespacedD1Executor)
+    with pytest.raises(NamespaceAssertionError) as excinfo:
+        _run(executor.execute("SELECT 'hermes-other-vault'", []))
+    assert excinfo.value.expected_slug == "operator-slug"
+
+
+# ---------------------------------------------------------------------------
+# `build_namespaced_memory_runner` — memory pipeline adoption
+# ---------------------------------------------------------------------------
+
+
+def _make_state_store() -> tuple[SourceStateStore, sqlite3.Connection]:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_MEMORY_STATE_SCHEMA_SQL)
+
+    # The memory state store needs a dual executor (writes via execute,
+    # reads via query). The pattern is the same as test_memory_pipeline.py.
+    class _DualExecutor:
+        def __init__(self, c):
+            self._c = c
+
+        async def execute(self, sql: str, params: list) -> None:
+            self._c.execute(sql, params)
+            self._c.commit()
+
+        async def query(self, sql: str, params: list) -> list[dict]:
+            cur = self._c.execute(sql, params)
+            cols = [d[0] for d in cur.description] if cur.description else []
+            return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+    return SourceStateStore(_DualExecutor(conn)), conn
+
+
+def test_build_namespaced_memory_runner_refuses_foreign_r2_key_at_runtime():
+    """A runner built for slug 'acme' is given a raw R2 that would happily
+    accept anything; the wrapper inserted by the factory refuses any key
+    that doesn't match the acme slug AND lands an INVARIANT_VIOLATION row.
+
+    The pipeline writes to `{slug}/vault/...`. We construct the runner
+    with `customer_slug="acme"` but then poison the wrapper's bound slug
+    indirectly: we tell the runner its slug is "acme" but then call the
+    underlying storage method directly with a foreign-slug key, which is
+    what would happen if a buggy code path constructed the wrong key.
+    """
+    writer, audit_conn = _make_audit_writer()
+    state_store, _state_conn = _make_state_store()
+    raw_r2 = _FakeRawR2()
+    raw_vec = _FakeRawVectorize()
+
+    runner = build_namespaced_memory_runner(
+        customer_slug="acme",
+        source_adapter=PracticeManagementSourceAdapter(NoPracticeManagementSource()),
+        raw_r2=raw_r2,
+        raw_vectorize=raw_vec,
+        embeddings=_FakeEmbeddings(),
+        chunker=DocumentChunker(target_chars=200, overlap_chars=20),
+        state_store=state_store,
+        audit_writer=writer,
+    )
+
+    # Reach the bridge (the runner's `storage`) and call it directly with
+    # a foreign key. The bridge delegates to the namespace wrapper, so
+    # this is exactly what the pipeline does at write time — minus the
+    # full ingestion flow that this minimal test does not need to exercise.
+    bridge = runner._storage  # noqa: SLF001 — intentional white-box probe
+    with pytest.raises(NamespaceAssertionError) as excinfo:
+        _run(bridge.put_r2_object("vaults/other/leak.json", b"x", content_type="application/json"))
+    assert excinfo.value.expected_slug == "acme"
+    assert raw_r2.put_calls == []
+
+    rows = audit_conn.execute(
+        "SELECT action_type, metadata FROM audit_log"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "INVARIANT_VIOLATION"
+    meta = json.loads(rows[0][1])
+    assert meta["invariant"] == "namespace_isolation"
+    assert meta["violation_kind"] == "r2_key"
+    assert meta["expected_slug"] == "acme"
+
+
+def test_build_namespaced_memory_runner_refuses_foreign_vectorize_index():
+    writer, audit_conn = _make_audit_writer()
+    state_store, _state_conn = _make_state_store()
+    raw_r2 = _FakeRawR2()
+    raw_vec = _FakeRawVectorize()
+
+    runner = build_namespaced_memory_runner(
+        customer_slug="acme",
+        source_adapter=PracticeManagementSourceAdapter(NoPracticeManagementSource()),
+        raw_r2=raw_r2,
+        raw_vectorize=raw_vec,
+        embeddings=_FakeEmbeddings(),
+        chunker=DocumentChunker(target_chars=200, overlap_chars=20),
+        state_store=state_store,
+        audit_writer=writer,
+    )
+
+    bridge = runner._storage  # noqa: SLF001
+    with pytest.raises(NamespaceAssertionError) as excinfo:
+        _run(bridge.upsert_vectors("hermes-other-vault", []))
+    assert excinfo.value.expected_slug == "acme"
+    assert raw_vec.upserts == []
+
+    rows = audit_conn.execute(
+        "SELECT action_type, metadata FROM audit_log"
+    ).fetchall()
+    assert len(rows) == 1
+    meta = json.loads(rows[0][1])
+    assert meta["violation_kind"] == "vectorize_index"
+
+
+def test_build_namespaced_memory_runner_passes_through_own_namespace():
+    writer, _audit_conn = _make_audit_writer()
+    state_store, _state_conn = _make_state_store()
+    raw_r2 = _FakeRawR2()
+    raw_vec = _FakeRawVectorize()
+
+    runner = build_namespaced_memory_runner(
+        customer_slug="acme",
+        source_adapter=PracticeManagementSourceAdapter(NoPracticeManagementSource()),
+        raw_r2=raw_r2,
+        raw_vectorize=raw_vec,
+        embeddings=_FakeEmbeddings(),
+        chunker=DocumentChunker(target_chars=200, overlap_chars=20),
+        state_store=state_store,
+        audit_writer=writer,
+    )
+
+    bridge = runner._storage  # noqa: SLF001
+    _run(bridge.put_r2_object("acme/vault/narrative/foo.json", b"x", content_type="application/json"))
+    _run(bridge.upsert_vectors("hermes-acme-vault", [{"id": "v-1", "values": [0.1]}]))
+
+    assert raw_r2.put_calls == [
+        ("acme/vault/narrative/foo.json", b"x", "application/json")
+    ]
+    assert raw_vec.upserts == [("hermes-acme-vault", [{"id": "v-1", "values": [0.1]}])]
+
+
+def test_build_namespaced_memory_runner_no_op_ingestion_still_works():
+    """End-to-end smoke: a runner with the no-PM source completes one run
+    cleanly through the wrapped storage path. Nothing touches storage
+    (no matters/documents/recipients), so the run is a pure state-write —
+    the test confirms the factory's wiring doesn't break the happy path.
+    """
+    writer, _ = _make_audit_writer()
+    state_store, _state_conn = _make_state_store()
+
+    runner = build_namespaced_memory_runner(
+        customer_slug="acme",
+        source_adapter=PracticeManagementSourceAdapter(NoPracticeManagementSource()),
+        raw_r2=_FakeRawR2(),
+        raw_vectorize=_FakeRawVectorize(),
+        embeddings=_FakeEmbeddings(),
+        chunker=DocumentChunker(target_chars=200, overlap_chars=20),
+        state_store=state_store,
+        audit_writer=writer,
+    )
+
+    result = _run(
+        runner.run_ingestion(
+            SourceDescriptor(source_kind="practice_management", source_id="none"),
+            IngestionMode.SCHEDULED,
+        )
+    )
+    assert result.ok is True
+    assert result.items_ingested == 0
+
+
+# ---------------------------------------------------------------------------
+# `build_namespaced_voice_runner` — voice pipeline adoption
+# ---------------------------------------------------------------------------
+
+
+def test_build_namespaced_voice_runner_refuses_foreign_r2_key_at_runtime():
+    """Same shape as the memory test: the bridge inserted by the voice
+    factory refuses a foreign-slug R2 key at the wrapper boundary and
+    audits the violation.
+    """
+    from adapter.voice import (
+        NoEmailSource,
+        StaticCohortResolver,
+        build_namespaced_voice_runner,
+    )
+
+    writer, audit_conn = _make_audit_writer()
+    raw_r2 = _FakeRawR2()
+
+    # The voice pipeline needs an AuditDigestLookup; we stub it.
+    class _StubAuditLookup:
+        async def has_digest(self, _digest: str) -> bool:
+            return False
+
+    # The state store + cursor store are protocols; pass trivial stubs.
+    class _StubStateStore:
+        async def upsert_state(self, _update): pass
+        async def record_items(self, _items, *, ingested_at): return []
+
+    class _StubCursor:
+        async def get(self): return None
+        async def set(self, _c): pass
+
+    runner = build_namespaced_voice_runner(
+        customer_slug="acme",
+        source=NoEmailSource(),
+        cohort_resolver=StaticCohortResolver(),
+        raw_r2=raw_r2,
+        state_store=_StubStateStore(),  # type: ignore[arg-type]
+        cursor_store=_StubCursor(),  # type: ignore[arg-type]
+        audit_lookup=_StubAuditLookup(),  # type: ignore[arg-type]
+        audit_writer=writer,
+    )
+
+    bridge = runner.r2_client  # bridge implements the voice R2Client protocol
+    assert bridge.customer_slug == "acme"
+    with pytest.raises(NamespaceAssertionError) as excinfo:
+        _run(bridge.put("vaults/other/leak.json", b"x", "application/json"))
+    assert excinfo.value.expected_slug == "acme"
+    assert raw_r2.put_calls == []
+
+    rows = audit_conn.execute(
+        "SELECT action_type, metadata FROM audit_log"
+    ).fetchall()
+    assert len(rows) == 1
+    meta = json.loads(rows[0][1])
+    assert meta["violation_kind"] == "r2_key"
+
+
+def test_build_namespaced_voice_runner_passes_through_own_namespace():
+    from adapter.voice import (
+        NoEmailSource,
+        StaticCohortResolver,
+        build_namespaced_voice_runner,
+    )
+
+    writer, _ = _make_audit_writer()
+    raw_r2 = _FakeRawR2()
+
+    class _StubAuditLookup:
+        async def has_digest(self, _digest: str) -> bool:
+            return False
+
+    class _StubStateStore:
+        async def upsert_state(self, _update): pass
+        async def record_items(self, _items, *, ingested_at): return []
+
+    class _StubCursor:
+        async def get(self): return None
+        async def set(self, _c): pass
+
+    runner = build_namespaced_voice_runner(
+        customer_slug="acme",
+        source=NoEmailSource(),
+        cohort_resolver=StaticCohortResolver(),
+        raw_r2=raw_r2,
+        state_store=_StubStateStore(),  # type: ignore[arg-type]
+        cursor_store=_StubCursor(),  # type: ignore[arg-type]
+        audit_lookup=_StubAuditLookup(),  # type: ignore[arg-type]
+        audit_writer=writer,
+    )
+
+    bridge = runner.r2_client
+    _run(bridge.put("acme/voice/cohort/x/abc.json", b"x", "application/json"))
+    _run(bridge.delete("acme/voice/cohort/x/abc.json"))
+
+    assert raw_r2.put_calls == [("acme/voice/cohort/x/abc.json", b"x", "application/json")]
+    assert raw_r2.delete_calls == ["acme/voice/cohort/x/abc.json"]

--- a/ai-employee/adapter/tests/test_namespace_assertion.py
+++ b/ai-employee/adapter/tests/test_namespace_assertion.py
@@ -305,9 +305,25 @@ def test_r2_refuses_foreign_slug_under_slug_vault_prefix():
 def test_r2_refuses_key_that_matches_neither_convention():
     inner = _RecordingR2()
     wrapped = NamespacedR2Client(expected_slug="acme", inner=inner)
+    # First segment is neither `vaults` nor a valid slug shape — uppercase
+    # is disallowed by the slug regex, so the wrapper falls through to the
+    # "neither convention" refusal.
+    with pytest.raises(NamespaceAssertionError) as excinfo:
+        _run(wrapped.put_object("BAD/foo.json", b"x", content_type="application/json"))
+    assert "either prefix convention" in excinfo.value.detail
+
+
+def test_r2_refuses_misc_first_segment_as_foreign_slug():
+    # A first segment that is slug-shaped but not the expected slug is
+    # treated as a foreign-customer key — `misc` matches the slug regex,
+    # so it gets the foreign-slug refusal path (not the "neither
+    # convention" one).
+    inner = _RecordingR2()
+    wrapped = NamespacedR2Client(expected_slug="acme", inner=inner)
     with pytest.raises(NamespaceAssertionError) as excinfo:
         _run(wrapped.put_object("misc/foo.json", b"x", content_type="application/json"))
-    assert "either prefix convention" in excinfo.value.detail
+    assert excinfo.value.violation_kind == "r2_key"
+    assert "foreign customer slug" in excinfo.value.detail
 
 
 def test_r2_refuses_empty_key():

--- a/ai-employee/adapter/tests/test_namespace_surface_lockdown.py
+++ b/ai-employee/adapter/tests/test_namespace_surface_lockdown.py
@@ -1,0 +1,194 @@
+"""TOCTOU lockdown — assert the public adapter surface is namespaced-only.
+
+Issue #861's wrapper PR (#1006) shipped the namespace assertion. The
+adoption PR (#1012) added the factory helpers. This test file is the
+hardening step: it locks the public adapter surface so any future
+caller doing `from adapter import *` or `from adapter.audit_log import
+*` cannot grab a raw client by accident.
+
+Raw classes remain importable by *explicit* name — that is needed by:
+
+* the writer path itself (`audit_log.writer_from_env` constructs an
+  `HttpD1Executor` directly, per the audit-log immutability invariant
+  documented in `audit_log_immutability.py`),
+* the namespace-bridge adapters (`memory/namespaced.py` and
+  `voice/namespaced.py` import the raw R2/Vectorize Protocols),
+* and tests that build sqlite-backed harnesses.
+
+The lockdown is enforced by removing the raw names from `__all__` in
+each of: `adapter/__init__.py`, `adapter/audit_log.py`,
+`adapter/memory/pipeline.py`, `adapter/voice/pipeline.py`. This test
+guards each removal so a future PR that re-adds a raw name to `__all__`
+breaks the build.
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_namespace_surface_lockdown.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+
+# ---------------------------------------------------------------------------
+# `adapter` top-level public surface
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_public_surface_is_namespaced_only():
+    """`from adapter import *` produces exactly the namespaced surface."""
+    adapter = importlib.import_module("adapter")
+    expected = {
+        "NamespaceAssertionError",
+        "NamespacedD1Executor",
+        "NamespacedR2Client",
+        "NamespacedVectorizeClient",
+        "namespaced_executor_from_env",
+    }
+    assert set(adapter.__all__) == expected, (
+        f"adapter.__all__ drifted: {set(adapter.__all__) ^ expected}; "
+        "TOCTOU hardening requires the public surface to be namespaced-only"
+    )
+
+
+def test_adapter_star_import_does_not_pull_raw_executors():
+    """Star-importing `adapter` does not grab `HttpD1Executor`/`SqliteExecutor`.
+
+    Verifies the lockdown at the namespace level — even if a future PR
+    accidentally re-exports a raw constructor from the package, this
+    test catches it.
+    """
+    namespace: dict = {}
+    exec("from adapter import *", namespace)  # noqa: S102 — controlled exec
+    forbidden = {
+        "HttpD1Executor",
+        "SqliteExecutor",
+        "StorageClient",
+        "R2Client",
+        "Executor",  # the bare Protocol from audit_log
+    }
+    leaked = forbidden & set(namespace)
+    assert not leaked, (
+        f"`from adapter import *` leaked raw constructors: {leaked}; "
+        "TOCTOU hardening: route all raw access through "
+        "adapter.d1_env.namespaced_executor_from_env or the factories"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `adapter.audit_log` submodule surface
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_all_excludes_raw_executors():
+    audit_log = importlib.import_module("adapter.audit_log")
+    raw_names = {"HttpD1Executor", "SqliteExecutor"}
+    leaked = raw_names & set(audit_log.__all__)
+    assert not leaked, (
+        f"adapter.audit_log.__all__ exports raw executors: {leaked}; "
+        "TOCTOU hardening removes them from the public surface "
+        "(they remain importable by explicit name for the writer path "
+        "and tests, per the audit-log immutability design)"
+    )
+
+
+def test_audit_log_raw_executors_still_importable_by_explicit_name():
+    """Defense-in-depth: confirm the back-compat path still works.
+
+    The writer path (`writer_from_env`) and 19+ in-tree tests rely on
+    importing `HttpD1Executor` / `SqliteExecutor` by name. The lockdown
+    removes them from `__all__` but does NOT remove the classes — that
+    rename is deferred to a follow-on once consumers migrate.
+    """
+    from adapter.audit_log import HttpD1Executor, SqliteExecutor  # noqa: F401
+
+    # If either import raises ImportError, the lockdown went too far.
+    # The test passing means back-compat is preserved.
+
+
+def test_audit_log_star_import_does_not_pull_raw_executors():
+    namespace: dict = {}
+    exec("from adapter.audit_log import *", namespace)  # noqa: S102
+    forbidden = {"HttpD1Executor", "SqliteExecutor"}
+    leaked = forbidden & set(namespace)
+    assert not leaked, (
+        f"`from adapter.audit_log import *` leaked raw executors: {leaked}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `adapter.memory.pipeline` submodule surface
+# ---------------------------------------------------------------------------
+
+
+def test_memory_pipeline_all_excludes_raw_storage_protocol():
+    pipeline = importlib.import_module("adapter.memory.pipeline")
+    assert "StorageClient" not in pipeline.__all__, (
+        "adapter.memory.pipeline.__all__ exports the raw StorageClient "
+        "Protocol; TOCTOU hardening routes external consumers through "
+        "adapter.memory.build_namespaced_memory_runner"
+    )
+
+
+def test_memory_pipeline_storage_client_still_importable_for_bridge():
+    """The `namespaced.py` bridge imports `StorageClient` by explicit
+    name; the lockdown must preserve that path."""
+    from adapter.memory.pipeline import StorageClient  # noqa: F401
+
+
+def test_memory_pipeline_star_import_does_not_pull_raw_storage_client():
+    namespace: dict = {}
+    exec("from adapter.memory.pipeline import *", namespace)  # noqa: S102
+    assert "StorageClient" not in namespace
+
+
+# ---------------------------------------------------------------------------
+# `adapter.voice.pipeline` submodule surface
+# ---------------------------------------------------------------------------
+
+
+def test_voice_pipeline_all_excludes_raw_r2_client_protocol():
+    pipeline = importlib.import_module("adapter.voice.pipeline")
+    assert "R2Client" not in pipeline.__all__, (
+        "adapter.voice.pipeline.__all__ exports the raw R2Client "
+        "Protocol; TOCTOU hardening routes external consumers through "
+        "adapter.voice.build_namespaced_voice_runner"
+    )
+
+
+def test_voice_pipeline_r2_client_still_importable_for_bridge():
+    """The `namespaced.py` bridge imports `R2Client` by explicit name."""
+    from adapter.voice.pipeline import R2Client  # noqa: F401
+
+
+def test_voice_pipeline_star_import_does_not_pull_raw_r2_client():
+    namespace: dict = {}
+    exec("from adapter.voice.pipeline import *", namespace)  # noqa: S102
+    assert "R2Client" not in namespace
+
+
+# ---------------------------------------------------------------------------
+# `adapter.memory` and `adapter.voice` package surfaces still expose the
+# factory helpers (regression guard — accidental removal from the package
+# `__init__.py` would silently take the migration entry point offline)
+# ---------------------------------------------------------------------------
+
+
+def test_memory_package_exports_factory():
+    memory = importlib.import_module("adapter.memory")
+    assert "build_namespaced_memory_runner" in memory.__all__
+    assert callable(memory.build_namespaced_memory_runner)
+
+
+def test_voice_package_exports_factory():
+    voice = importlib.import_module("adapter.voice")
+    assert "build_namespaced_voice_runner" in voice.__all__
+    assert callable(voice.build_namespaced_voice_runner)

--- a/ai-employee/adapter/voice/__init__.py
+++ b/ai-employee/adapter/voice/__init__.py
@@ -51,6 +51,10 @@ from .filter import (
     REASON_TOO_SHORT,
     compute_body_digest,
 )
+from .namespaced import (
+    RawR2Client as NamespacedRawR2Client,
+    build_namespaced_voice_runner,
+)
 from .pipeline import (
     CohortResolver,
     CursorStore,
@@ -101,6 +105,7 @@ __all__ = [
     "IngestionResult",
     "IngestionStateUpdate",
     "MIN_WORD_COUNT_FOR_SAMPLE",
+    "NamespacedRawR2Client",
     "NoEmailSource",
     "PartnerAuthoredFilter",
     "QueryExecutor",
@@ -123,6 +128,7 @@ __all__ = [
     "VoiceSourceState",
     "VoiceSourceStateStore",
     "WriteExecutor",
+    "build_namespaced_voice_runner",
     "compute_body_digest",
     "decommission_source",
     "enforce_retention",

--- a/ai-employee/adapter/voice/namespaced.py
+++ b/ai-employee/adapter/voice/namespaced.py
@@ -1,0 +1,115 @@
+"""Factory helper that wires `VoiceIngestionRunner` against namespaced R2.
+
+The voice pipeline's `R2Client` Protocol exposes `put(key, body, content_type)`
+and `delete(key)` plus a `customer_slug` attribute. The namespace-assertion
+wrapper uses `put_object(key, body, *, content_type)` and
+`delete_object(key)` — close but not identical, so a thin bridge adapter
+glues them together without touching the pipeline.
+
+`build_namespaced_voice_runner` is the public entry point. The Hermes
+fork's per-customer Machine boot path calls this instead of constructing
+`VoiceIngestionRunner` directly with raw R2 — every put + delete from
+the runner then routes through the namespace assertion before hitting
+the raw client.
+
+Filed as the recommended migration entry point against
+[#1009](https://github.com/venturecrane/ss-console/issues/1009)
+(fork-side adoption tracker; do not implement there).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Optional, Protocol
+
+from ..audit_log import AuditLogWriter
+from ..namespace_assertion import NamespacedR2Client
+from .filter import AuditDigestLookup
+from .pipeline import (
+    CohortResolver,
+    CursorStore,
+    EmailSource,
+    VoiceIngestionRunner,
+)
+from .state import VoiceSourceStateStore
+
+
+class RawR2Client(Protocol):
+    """The raw R2 client interface — exactly what `NamespacedR2Client` wraps.
+
+    The fork's overlay constructs one of these per customer Machine. The
+    factory below wraps it with `NamespacedR2Client` and then bridges
+    that wrapper onto the pipeline's `R2Client.put` / `R2Client.delete`
+    shape.
+    """
+
+    async def put_object(self, key: str, body: bytes, *, content_type: str) -> None: ...
+    async def get_object(self, key: str) -> bytes: ...
+    async def delete_object(self, key: str) -> None: ...
+
+
+class _NamespacedVoiceR2Bridge:
+    """Implements the voice pipeline's `R2Client` Protocol via the namespace wrapper.
+
+    `customer_slug` is required by the voice pipeline's R2Client Protocol;
+    it is read from the wrapper's bound slug so the two cannot drift.
+    """
+
+    def __init__(self, *, r2: NamespacedR2Client, customer_slug: str) -> None:
+        self._r2 = r2
+        self.customer_slug = customer_slug
+
+    async def put(self, key: str, body: bytes, content_type: str) -> None:
+        await self._r2.put_object(key, body, content_type=content_type)
+
+    async def delete(self, key: str) -> None:
+        await self._r2.delete_object(key)
+
+
+def build_namespaced_voice_runner(
+    *,
+    customer_slug: str,
+    source: EmailSource,
+    cohort_resolver: CohortResolver,
+    raw_r2: RawR2Client,
+    state_store: VoiceSourceStateStore,
+    cursor_store: CursorStore,
+    audit_lookup: AuditDigestLookup,
+    audit_writer: Optional[AuditLogWriter] = None,
+    source_kind: str = "email",
+    clock: Optional[Callable[[], datetime]] = None,
+) -> VoiceIngestionRunner:
+    """Return a `VoiceIngestionRunner` wired through namespace-asserting R2.
+
+    The Hermes fork's per-customer Machine boot path should call this
+    factory instead of constructing `VoiceIngestionRunner` directly with
+    raw R2. Every R2 put + delete from the runner is routed through the
+    namespace assertion before it hits the raw client, so a foreign-slug
+    key refuses + audits at the boundary.
+
+    `audit_writer` is recommended in production so every refusal lands
+    one `INVARIANT_VIOLATION` audit row. It may be omitted in tests; the
+    refusal still raises `NamespaceAssertionError`.
+    """
+    r2 = NamespacedR2Client(
+        expected_slug=customer_slug,
+        inner=raw_r2,
+        audit_writer=audit_writer,
+    )
+    bridge = _NamespacedVoiceR2Bridge(r2=r2, customer_slug=customer_slug)
+    return VoiceIngestionRunner(
+        source=source,
+        cohort_resolver=cohort_resolver,
+        r2_client=bridge,  # type: ignore[arg-type]  # bridge implements R2Client
+        state_store=state_store,
+        cursor_store=cursor_store,
+        audit_lookup=audit_lookup,
+        source_kind=source_kind,
+        _clock=clock,
+    )
+
+
+__all__ = [
+    "RawR2Client",
+    "build_namespaced_voice_runner",
+]

--- a/ai-employee/adapter/voice/pipeline.py
+++ b/ai-employee/adapter/voice/pipeline.py
@@ -615,6 +615,12 @@ def _word_split(text: str) -> list[str]:
     return _WORD_RE.findall(text or "")
 
 
+# Public surface (`from adapter.voice.pipeline import *`) excludes the
+# raw `R2Client` Protocol as of issue #861's TOCTOU hardening: external
+# callers MUST go through `adapter.voice.build_namespaced_voice_runner(...)`,
+# which wraps a raw R2 client in the namespace-asserting bridge before
+# handing it to the runner. The Protocol remains importable by explicit
+# name for the bridge in `namespaced.py` and for tests.
 __all__ = [
     "CohortResolver",
     "CursorStore",
@@ -622,7 +628,6 @@ __all__ = [
     "IngestionMode",
     "IngestionResult",
     "NoEmailSource",
-    "R2Client",
     "SentMessage",
     "StaticCohortResolver",
     "StorageError",


### PR DESCRIPTION
Follow-on to [#1006](https://github.com/venturecrane/ss-console/pull/1006). Closes the in-tree adoption loop for the namespace-assertion wrappers (A+B+C+D); fork-side adoption is tracked at [#1009](https://github.com/venturecrane/ss-console/issues/1009).

## Captain professional-route scope

The full A+B+C+D scope: ship the factories + lock the public adapter surface to namespaced-only **now**, while no out-of-tree consumer exists to break. The upcoming Hermes fork will import the namespaced wrappers from day one, which is the correct shape.

## A+B+C: factory helpers + integration tests

Three additive entry points the Hermes fork's overlay will call at customer-Machine boot instead of constructing runners with raw clients:

| Entry point | What it does |
|---|---|
| `adapter.d1_env.namespaced_executor_from_env(customer_slug)` | Builds a `NamespacedD1Executor` wired to the per-customer Cloudflare D1 env vars, with the audit writer injected so refusals land an `INVARIANT_VIOLATION` row. `customer_slug` defaults to the `CUSTOMER_SLUG` env var. |
| `adapter.memory.build_namespaced_memory_runner(...)` | Returns a `MemoryIngestionRunner` whose `StorageClient` routes every R2 put + Vectorize upsert through the namespace wrappers before hitting the raw client. A small bridge translates `put_r2_object` ↔ `put_object`. |
| `adapter.voice.build_namespaced_voice_runner(...)` | Same shape for the voice pipeline; bridges `R2Client.put` / `delete` onto `NamespacedR2Client.put_object` / `delete_object`. |

The two `Namespaced*Bridge` adapters live in their respective pipeline subpackages (`memory/namespaced.py`, `voice/namespaced.py`).

## D: TOCTOU surface lockdown

Public-surface removals (`__all__` blocks):

* `adapter/__init__.py` — docstring rewritten to spell out the contract explicitly. Surface already namespaced-only.
* `adapter/audit_log.py` — removed `HttpD1Executor` and `SqliteExecutor` from `__all__`. New consumers MUST route through `adapter.d1_env.namespaced_executor_from_env(...)`. The raw classes remain importable by explicit name for the writer path (per the audit-log immutability invariant) and back-compat with 19+ existing tests.
* `adapter/memory/pipeline.py` — removed `StorageClient` Protocol from `__all__`. External consumers MUST go through `adapter.memory.build_namespaced_memory_runner(...)`. The bridge in `namespaced.py` imports it by explicit name and is unaffected.
* `adapter/voice/pipeline.py` — removed `R2Client` Protocol from `__all__`. External consumers MUST go through `adapter.voice.build_namespaced_voice_runner(...)`. Same bridge note as memory.

Lockdown enforcement test (`test_namespace_surface_lockdown.py` — 13 tests):

1. Each `__all__` excludes the raw name (asserted directly).
2. `from <module> import *` does not leak the raw name (exec'd in a fresh namespace and checked).
3. Each raw name remains importable by explicit `from x import RawName` so back-compat with the writer path and existing tests holds.
4. Each package `__init__.py` still exports its factory helper (regression guard against accidental removal of the migration entry point).

**Why not a full rename to `_HttpD1Executor` etc.:** that would force rewrites of 19+ in-tree test files plus `bin/lib/evidence.py`, `bin/lib/decommission_cli.py`, and `audit_log.writer_from_env` itself — ~30 files, ~300+ LOC of churn. The `__all__` lockdown delivers the same external-consumer guarantee (no accidental raw import via `*` or via the public `adapter` namespace) without the churn. The deeper rename is a separate hardening step that can land later.

## Wrapper coverage bug fix (in same PR)

While wiring the voice factory I found a real coverage gap in PR #1006's wrapper. `NamespacedR2Client` only accepted R2 keys under:

- `vaults/{slug}/...` (no_pm + spec doc)
- `{slug}/vault/...` (memory pipeline)

But the voice pipeline writes to `{slug}/voice/cohort/{cohort}/{ulid}.json` per `voice/__init__.py:6-7` — that path would have been incorrectly refused once the wrapper went live. Loosened the second convention to `{slug}/<any-keyspace>/...` (any second segment under a valid slug-shaped first segment). Foreign-slug refusals still fire; new per-customer keyspaces no longer need wrapper updates.

Updated one existing test to reflect the new classifier (a slug-shaped first segment is now a foreign-slug refusal, not "neither convention") and added a new test for the "neither convention" path against an uppercase first segment.

## Verification

- `python3 -m pytest ai-employee/adapter/ ai-employee/safety-substrate/` — 473 pass (up from 460 on main), 8 skipped
- `python3 -m pytest ai-employee/adapter/tests/test_namespace_surface_lockdown.py -v` — 13/13 pass
- `npm run verify` — exit 0
- `bin/` test failures (46/44) are pre-existing on this branch — confirmed via stash diff, not introduced by this PR

## Files touched

| File | Purpose |
|---|---|
| `ai-employee/adapter/d1_env.py` | NEW — env-bound D1 factory |
| `ai-employee/adapter/memory/namespaced.py` | NEW — memory runner factory + storage bridge |
| `ai-employee/adapter/voice/namespaced.py` | NEW — voice runner factory + R2 bridge |
| `ai-employee/adapter/tests/test_namespace_adoption.py` | NEW — integration tests for all three factories |
| `ai-employee/adapter/tests/test_namespace_surface_lockdown.py` | NEW — TOCTOU lockdown enforcement (13 tests) |
| `ai-employee/adapter/namespace_assertion.py` | MODIFIED — loosen R2 second-convention to accept `{slug}/<any-keyspace>/...` so voice + future keyspaces work |
| `ai-employee/adapter/__init__.py` | MODIFIED — re-export `namespaced_executor_from_env`; docstring spells out the public-surface contract |
| `ai-employee/adapter/audit_log.py` | MODIFIED — removed `HttpD1Executor` / `SqliteExecutor` from `__all__` |
| `ai-employee/adapter/memory/__init__.py` | MODIFIED — re-export the memory factory |
| `ai-employee/adapter/memory/pipeline.py` | MODIFIED — removed `StorageClient` Protocol from `__all__` |
| `ai-employee/adapter/voice/__init__.py` | MODIFIED — re-export the voice factory |
| `ai-employee/adapter/voice/pipeline.py` | MODIFIED — removed `R2Client` Protocol from `__all__` |
| `ai-employee/adapter/tests/test_namespace_assertion.py` | MODIFIED — update one test for the loosened classifier; add a new test for the "neither convention" path |

🤖 Generated with [Claude Code](https://claude.com/claude-code)