### PR TITLE
feat(ai-employee): customer.yaml hermes_ref fork-tag validation (ADR 0015)

### DIFF
--- a/ai-employee/bin/fixtures/smd/customer.yaml
+++ b/ai-employee/bin/fixtures/smd/customer.yaml
@@ -11,7 +11,7 @@ vertical: marketing-agency
 fly_region: iad
 
 model: claude-opus-4-7
-hermes_ref: v0.0.0-fixture
+hermes_ref: v0.0.0-smd.0
 
 machine:
   size: shared-cpu-1x

--- a/ai-employee/customers/_template/customer.yaml
+++ b/ai-employee/customers/_template/customer.yaml
@@ -25,7 +25,7 @@ fly_region: '[FLY REGION SLUG, e.g., iad / lax / ord]'
 
 # ---- RUNTIME ----
 model: claude-opus-4-7
-hermes_ref: '[HERMES REF, e.g., v2026.5.7]'
+hermes_ref: '[HERMES FORK REF, e.g., v2026.5.7-smd.0]'
 
 machine:
   size: shared-cpu-1x

--- a/ai-employee/templates/customer-no-pm-system.yaml
+++ b/ai-employee/templates/customer-no-pm-system.yaml
@@ -44,7 +44,7 @@ fly_region: '[FLY REGION SLUG, e.g., iad / lax / ord]'
 
 # ---- RUNTIME ----
 model: claude-opus-4-7
-hermes_ref: '[HERMES REF, e.g., v2026.5.7]'
+hermes_ref: '[HERMES FORK REF, e.g., v2026.5.7-smd.0]'
 
 machine:
   size: shared-cpu-1x

--- a/docs/specs/ai-employee/customer-yaml-schema.md
+++ b/docs/specs/ai-employee/customer-yaml-schema.md
@@ -31,7 +31,7 @@ fly_region: <string> # Fly.io region slug (e.g. iad, lax, ord)
 # ---- RUNTIME (REQUIRED) ----
 
 model: <string> # Anthropic model ID (e.g. claude-opus-4-7)
-hermes_ref: <string> # Hermes content-hash SHA or date tag (e.g. v2026.5.7)
+hermes_ref: <string> # Fork tag from venturecrane/hermes-agent per ADR 0015 (e.g. v2026.5.7-smd.0)
 
 machine:
   size: <string> # Fly VM class (performance-1x, etc.)

--- a/src/lib/ai-employee/customer-yaml/helpers.ts
+++ b/src/lib/ai-employee/customer-yaml/helpers.ts
@@ -31,6 +31,36 @@ export function checkRequiredString(
   }
 }
 
+// Fork-tag pattern per ADR 0015 (docs/adr/0015-hermes-fork-vs-upstream.md).
+// hermes_ref MUST pin a fork tag of the form v{semver}-smd.{n}:
+//   - {semver} is a SemVer-2.0 core version (X.Y.Z, with optional pre-release
+//     and build metadata). The fork's tag scheme uses date-based upstream
+//     references (e.g. v2026.5.7); SemVer accommodates that since each
+//     dot-separated identifier is numeric.
+//   - {n} is a non-negative integer SMD revision counter (0 for "fork exists,
+//     no SMD code yet"; increments per SMD-side change).
+// Bare upstream tags (no -smd.N suffix) are rejected: per ADR 0015 §Decision,
+// customer.yaml pins the fork ref, not the upstream ref.
+const FORK_TAG_PATTERN =
+  /^v(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?-smd\.(?:0|[1-9]\d*)$/
+
+export function checkHermesRef(root: Record<string, unknown>, errors: ValidationError[]): void {
+  const v = root['hermes_ref']
+  // Required-string check already runs upstream of this; no-op cleanly when
+  // the field is absent or wrong-typed so we don't duplicate that error.
+  if (typeof v !== 'string' || v.length === 0) return
+  if (!FORK_TAG_PATTERN.test(v)) {
+    errors.push({
+      code: 'InvalidFormat',
+      path: 'hermes_ref',
+      message:
+        'hermes_ref must pin a fork tag of the form v{upstream}-smd.{n} ' +
+        '(e.g. v2026.5.7-smd.0); bare upstream tags are not accepted. ' +
+        'See ADR 0015 and venturecrane/hermes-agent releases.',
+    })
+  }
+}
+
 export function checkEnum<T extends string>(
   root: Record<string, unknown>,
   field: string,

--- a/src/lib/ai-employee/customer-yaml/types.ts
+++ b/src/lib/ai-employee/customer-yaml/types.ts
@@ -197,6 +197,7 @@ export type ValidationErrorCode =
   | 'InvalidBackend'
   | 'EmptyList'
   | 'SchemaVersionUnsupported'
+  | 'InvalidFormat'
 
 export interface ValidationError {
   code: ValidationErrorCode

--- a/src/lib/ai-employee/customer-yaml/validator.ts
+++ b/src/lib/ai-employee/customer-yaml/validator.ts
@@ -20,7 +20,13 @@
  */
 
 import { scanParsedValue, scanRawYaml, type ScanOptions } from './secret-detector'
-import { checkEnum, checkRequiredString, isPlainObject, secretFindingToError } from './helpers'
+import {
+  checkEnum,
+  checkHermesRef,
+  checkRequiredString,
+  isPlainObject,
+  secretFindingToError,
+} from './helpers'
 import {
   ACCEPTED_VERTICALS,
   type CustomerYaml,
@@ -165,6 +171,7 @@ function validateSections(
   checkRequiredString(root, 'fly_region', errors)
   checkRequiredString(root, 'model', errors)
   checkRequiredString(root, 'hermes_ref', errors)
+  checkHermesRef(root, errors)
   const machine = checkMachine(root, errors)
   const users = checkUsers(root, errors)
   const personas = checkPersonas(root, errors)

--- a/src/lib/portal/ai-employee/customer-yaml-editor.ts
+++ b/src/lib/portal/ai-employee/customer-yaml-editor.ts
@@ -581,7 +581,12 @@ function reconstructFromProjection(row: CustomerConfigRow): unknown {
     vertical: 'mixed',
     fly_region: 'iad',
     model: 'unknown',
-    hermes_ref: 'unknown',
+    // 'unknown' was the pre-ADR-0015 sentinel; the validator now enforces
+    // the fork-tag pattern, so the placeholder needs to satisfy it. The
+    // reconstructed projection has no real ref to point at (the DB row
+    // doesn't carry hermes_ref yet); v0.0.0-smd.0 is the unambiguous
+    // "no fork ref yet" sentinel within the fork-tag scheme.
+    hermes_ref: 'v0.0.0-smd.0',
     machine: { size: 'unknown', memory_mb: 256 },
     users: [],
     personas: row.personas,

--- a/src/pages/api/portal/ai-employee/settings/customer-yaml-update.ts
+++ b/src/pages/api/portal/ai-employee/settings/customer-yaml-update.ts
@@ -286,7 +286,12 @@ function reconstructProjection(row: Awaited<ReturnType<typeof getCustomerConfig>
     vertical: 'mixed',
     fly_region: 'iad',
     model: 'unknown',
-    hermes_ref: 'unknown',
+    // 'unknown' was the pre-ADR-0015 sentinel; the validator now enforces
+    // the fork-tag pattern, so the placeholder needs to satisfy it. The
+    // reconstructed projection has no real ref to point at (the DB row
+    // doesn't carry hermes_ref yet); v0.0.0-smd.0 is the unambiguous
+    // "no fork ref yet" sentinel within the fork-tag scheme.
+    hermes_ref: 'v0.0.0-smd.0',
     machine: { size: 'unknown', memory_mb: 256 },
     users: [],
     personas: row.personas,

--- a/tests/customer-yaml-validator.test.ts
+++ b/tests/customer-yaml-validator.test.ts
@@ -47,7 +47,7 @@ function validFixture(): Record<string, unknown> {
     practice_areas: ['personal-injury', 'workers-comp'],
     fly_region: 'lax',
     model: 'claude-opus-4-7',
-    hermes_ref: 'v2026.5.7',
+    hermes_ref: 'v2026.5.7-smd.0',
     machine: {
       size: 'performance-1x',
       memory_mb: 1024,
@@ -642,5 +642,116 @@ describe('validate — aggregate error behavior', () => {
     for (const input of adversarial) {
       expect(() => validate(input)).not.toThrow()
     }
+  })
+})
+
+// -----------------------------------------------------------------------------
+// hermes_ref fork-tag enforcement (ADR 0015)
+// -----------------------------------------------------------------------------
+
+describe('validate — hermes_ref fork-tag enforcement (ADR 0015)', () => {
+  it('accepts a fork tag at the initial -smd.0 revision', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.7-smd.0'
+    const r = validate(f)
+    if (!r.ok) {
+      throw new Error(`expected ok; got: ${JSON.stringify(r.errors)}`)
+    }
+    expect(r.value.hermes_ref).toBe('v2026.5.7-smd.0')
+  })
+
+  it('accepts a fork tag at a higher SMD revision', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.7-smd.12'
+    expect(validate(f).ok).toBe(true)
+  })
+
+  it('accepts a fork tag built on a SemVer upstream', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v0.14.0-smd.0'
+    expect(validate(f).ok).toBe(true)
+  })
+
+  it('accepts a fork tag with SemVer pre-release identifiers', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v0.14.0-rc.1-smd.0'
+    expect(validate(f).ok).toBe(true)
+  })
+
+  it('rejects a bare upstream tag (no -smd.N suffix)', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.7'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.errors.some((e) => e.path === 'hermes_ref' && e.code === 'InvalidFormat')).toBe(true)
+  })
+
+  it('rejects a missing v-prefix', () => {
+    const f = validFixture()
+    f['hermes_ref'] = '2026.5.7-smd.0'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+  })
+
+  it('rejects an -smd.N suffix with a non-integer counter', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.7-smd.beta'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+  })
+
+  it('rejects an -smd suffix without a counter', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.7-smd'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+  })
+
+  it('rejects an -smd.N counter with leading zeros', () => {
+    const f = validFixture()
+    f['hermes_ref'] = 'v2026.5.7-smd.01'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+  })
+
+  it('rejects an arbitrary content-hash SHA', () => {
+    const f = validFixture()
+    f['hermes_ref'] = '7ce6b504a269ac3f9aed5b406b7a18c432e2fdb5'
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('InvalidFormat')
+  })
+
+  it('rejects the empty string with MissingField/EmptyField, not InvalidFormat', () => {
+    const f = validFixture()
+    f['hermes_ref'] = ''
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    // The required-string check fires first and exclusively when the value
+    // is empty; the fork-tag check intentionally no-ops on the empty case
+    // so authors only see one error per defect.
+    expect(codesOf(r.errors)).toContain('EmptyField')
+    expect(codesOf(r.errors)).not.toContain('InvalidFormat')
+  })
+
+  it('rejects a missing field with MissingField, not InvalidFormat', () => {
+    const f = validFixture()
+    delete f['hermes_ref']
+    const r = validate(f)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(codesOf(r.errors)).toContain('MissingField')
+    expect(codesOf(r.errors)).not.toContain('InvalidFormat')
   })
 })

--- a/tests/portal-customer-yaml-editor.test.ts
+++ b/tests/portal-customer-yaml-editor.test.ts
@@ -47,7 +47,7 @@ function validFixture(): Record<string, unknown> {
     practice_areas: ['personal-injury', 'workers-comp'],
     fly_region: 'lax',
     model: 'claude-opus-4-7',
-    hermes_ref: 'v2026.5.7',
+    hermes_ref: 'v2026.5.7-smd.0',
     machine: { size: 'performance-1x', memory_mb: 1024 },
     users: [{ email: 'partner@firm.com', role: 'principal', full_name: 'Jane Smith' }],
     personas: [


### PR DESCRIPTION
## Summary

Per [ADR 0015 §Decision](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0015-hermes-fork-vs-upstream.md), `customer.yaml` pins the fork ref (existing `hermes_ref` field), not the upstream ref. This PR makes the validator (per [ADR 0012](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0012-customer-yaml-storage.md)) enforce the fork-tag pattern.

- New `InvalidFormat` ValidationErrorCode + `checkHermesRef` helper enforce `v{semver}-smd.{n}`. Bare upstream tags (e.g. `v2026.5.7`) are now rejected with a clear error message that names ADR 0015 and the fork releases page.
- The fork-tag check runs after the existing required-string check and intentionally no-ops on empty/missing values, so authors see exactly one error per defect (no double-reporting).
- The check is wired into `validateSections` in `validator.ts`.

## Adjacent changes (in-scope)

The new validator was strict enough that several existing fixtures and projection paths would have started failing. The minimum-blast-radius edits to keep main green:

- `src/lib/portal/ai-employee/customer-yaml-editor.ts` and `src/pages/api/portal/ai-employee/settings/customer-yaml-update.ts`: both reconstruct a `CustomerYaml`-shaped object from a DB row that doesn't yet carry `hermes_ref`. Sentinel changed from `'unknown'` to `'v0.0.0-smd.0'` so the reconstructed projection still passes `validate()`. Comment in each file explains the sentinel choice.
- `tests/customer-yaml-validator.test.ts` and `tests/portal-customer-yaml-editor.test.ts`: happy-path fixtures changed from `'v2026.5.7'` to `'v2026.5.7-smd.0'`.
- `docs/specs/ai-employee/customer-yaml-schema.md`, `ai-employee/customers/_template/customer.yaml`, `ai-employee/templates/customer-no-pm-system.yaml`, `ai-employee/bin/fixtures/smd/customer.yaml`: example tags / placeholders updated to the fork-tag scheme so authoring guidance matches the new validator.

## Tests

11 new unit tests in `tests/customer-yaml-validator.test.ts > validate — hermes_ref fork-tag enforcement (ADR 0015)`:

- Accepts initial `-smd.0` revision and higher revisions
- Accepts SemVer upstream (`v0.14.0-smd.0`) and SemVer pre-release identifiers (`v0.14.0-rc.1-smd.0`)
- Rejects bare upstream tags
- Rejects missing `v` prefix
- Rejects non-integer `-smd.N` counter
- Rejects `-smd` suffix without a counter
- Rejects `-smd.N` counter with leading zeros (SemVer compliance)
- Rejects raw content-hash SHA
- Asserts error precedence: empty string emits `EmptyField` (not `InvalidFormat`); missing field emits `MissingField` (not `InvalidFormat`)

## Deferred

Per [team-lead](https://github.com/venturecrane/ss-console/issues/844): the GitHub-API tag existence check against `venturecrane/hermes-agent` is **deferred to a follow-up PR**. Reason: the fork doesn't exist on GitHub yet (Wave 1 PR 1 — fork creation — is paused awaiting Captain authorization for ops on a brand-new external repo). There are no fork tags to validate against today. Pattern enforcement ships now; existence check follows as a separate PR once the fork lands and the first `v{upstream}-smd.{n}` tag is published.

## Verification

`npm run verify` exits 0 locally:
- `astro check` (typecheck)
- 5 worker `tsc --noEmit` runs
- `prettier --check .`
- `eslint .`
- `astro build`
- root `vitest run` (65 tests in `customer-yaml-validator.test.ts`, 27 tests in `portal-customer-yaml-editor.test.ts`, all green)
- 5 worker `vitest run` suites

## Test plan

- [ ] CI green
- [ ] `npm run test -- customer-yaml` locally
- [ ] Manual: try saving a customer.yaml with a bare upstream tag in the portal editor; confirm the validator surfaces the new `InvalidFormat` error pointing at `hermes_ref` and referencing ADR 0015
- [ ] Manual: confirm the placeholder sentinel `v0.0.0-smd.0` lets the projection-reconstruction endpoints (`/portal/ai-employee/settings/customer-yaml-update`) render without crashing

Refs: ADR 0015 §Verification item 2, ADR 0012, [#844](https://github.com/venturecrane/ss-console/issues/844)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>