### PR TITLE
feat(ai-employee): aie_adapter.register() against fork overlay surface (ADR 0015)

### DIFF
--- a/ai-employee/adapter/aie_adapter.py
+++ b/ai-employee/adapter/aie_adapter.py
@@ -16,19 +16,41 @@ Hermes fork (per [ADR 0015](../../docs/adr/0015-hermes-fork-vs-upstream.md))
 constructs a `hermes_hook.HookRegistry`, imports this module, and calls
 `register(registry)`.
 
-The seam upstream is `agent/tool_guardrails.py`; the overlay layer wraps
-it and exposes the `HookRegistry` interface declared in
-`hermes_hook.py`. The adapter side (here) does not touch upstream files
-and does not depend on the fork's internal layout - the contract is the
-`HookRegistry` shape.
+Dual-surface contract
+---------------------
+
+`register()` installs hooks against TWO surfaces:
+
+1.  The in-tree `hermes_hook.HookRegistry` (this directory's
+    `hermes_hook.py`). This is the stable adapter contract: the
+    `FakeHermesRuntime` exercises it in tests, and the runtime overlay
+    drives it in production. The registration is unconditional.
+
+2.  The SMD overlay surface (`smd.hooks.*` in the venturecrane fork of
+    NousResearch/hermes-agent, per ADR 0015). The overlay binds the
+    in-tree registry into the actual upstream tool-dispatch loop. The
+    registration is best-effort: in dev / test / pre-overlay-fork
+    environments the `smd` package is absent or the consumer hooks raise
+    `NotImplementedError`, both of which are caught and logged. The
+    in-tree registration above does not depend on overlay availability.
+
+The dual-surface shape is what ADR 0015 §Decision specifies: "The
+adapter contract is stable across overlay-vs-upstream migration." The
+in-tree HookRegistry IS the stable contract. The `smd.hooks.*` call is
+how the runtime overlay observes and acts on that contract once the
+fork's consumer hooks are implemented (per `venturecrane/hermes-agent`
+follow-on work tracked from ss-console #842, #843, #864, #948, #953,
+and ADR 0006).
 
 Phase A.5
 ---------
 
-This file replaces the original Phase A stub. The stub asserted the
+This file replaced the original Phase A stub. The stub asserted the
 upstream seam was `agent/tool_router.py`; PR #829's runbook discovered
 the real seam at `agent/tool_guardrails.py`; ADR 0015 locked the
-overlay-plus-thin-fork strategy; this PR rewires `register()` accordingly.
+overlay-plus-thin-fork strategy; PR #1014 shipped the customer.yaml
+fork-tag validator; this PR wires `register()` against the overlay
+surface as the second leg of ADR 0015's verification list.
 
 The hook surface is testable in isolation via `hermes_hook.FakeHermesRuntime`;
 the integration tests in `tests/test_aie_adapter.py` drive the full
@@ -348,6 +370,74 @@ def _make_compaction_hook():
     return compaction
 
 
+# Per-surface descriptors for the SMD overlay layer in the
+# venturecrane/hermes-agent fork. The tuple is (import path, short label
+# for logging). Adding a fifth surface here is the only edit a new
+# overlay hook requires on this side. Per ADR 0015 the adapter does not
+# depend on the overlay's internal layout - only on this contract.
+_OVERLAY_SURFACES: tuple[tuple[str, str], ...] = (
+    ("smd.hooks.audit_emission", "audit_emission"),
+    ("smd.hooks.sticky_stop", "sticky_stop"),
+    ("smd.hooks.trust_ceiling", "trust_ceiling"),
+    ("smd.hooks.capability_adapter", "capability_adapter"),
+)
+
+
+def _register_overlay_surface(registry: HookRegistry, customer_id: str) -> int:
+    """Best-effort registration with the SMD overlay's per-surface hooks.
+
+    For each entry in _OVERLAY_SURFACES, import the module and call its
+    `register_smd_adapter(registry, customer_id=...)`. Per-surface errors
+    are caught so one not-yet-implemented hook does not block the others.
+
+    Caught errors:
+      ModuleNotFoundError: smd package absent from PYTHONPATH (dev / test
+                           / customer Machine without the fork installed).
+      NotImplementedError: the surface module exists but its
+                           register_smd_adapter is still a scaffold per
+                           ADR 0015 PR 1; consumer follows per the
+                           tracking issues called out in the module's
+                           own docstring.
+
+    Returns the count of surfaces that registered successfully (0 in the
+    fully-absent / fully-scaffolded case).
+    """
+    registered = 0
+    for module_path, label in _OVERLAY_SURFACES:
+        try:
+            module = __import__(module_path, fromlist=["register_smd_adapter"])
+            register_fn = getattr(module, "register_smd_adapter")
+            register_fn(registry, customer_id=customer_id)
+            registered += 1
+            log.info("SMD overlay surface registered: %s", label)
+        except ModuleNotFoundError:
+            # The smd package is not on PYTHONPATH. Expected in dev / test
+            # and in any environment that runs the adapter without the
+            # venturecrane/hermes-agent fork installed.
+            log.info(
+                "SMD overlay surface %s unavailable (smd package not on "
+                "PYTHONPATH); continuing with in-tree HookRegistry only",
+                label,
+            )
+            # All overlay surfaces share the same import root; if the smd
+            # package isn't installed, none of them will be. Bail early.
+            return registered
+        except NotImplementedError:
+            # The overlay surface exists but its consumer is still a
+            # scaffold per ADR 0015 PR 1. Per-surface skip; the other
+            # surfaces may or may not be in the same state.
+            log.warning(
+                "SMD overlay surface %s is a scaffold "
+                "(register_smd_adapter raised NotImplementedError); "
+                "continuing with in-tree HookRegistry only for this "
+                "surface. See venturecrane/hermes-agent smd/hooks/%s.py "
+                "for the tracking issue.",
+                label,
+                label,
+            )
+    return registered
+
+
 def register(
     registry: Optional[HookRegistry] = None,
     *,
@@ -386,6 +476,11 @@ def register(
       5. Build the compaction hook (re-inject pinned slots; safety
          invariant #4).
       6. Register all four against the supplied registry.
+      7. Best-effort: register the same registry against the SMD overlay
+         surface (`smd.hooks.*` in the venturecrane/hermes-agent fork)
+         so the runtime overlay can drive the hooks. Absent overlay
+         (dev/test) or scaffold overlay (pre-implementation) are caught
+         and logged; the in-tree registration above is unaffected.
     """
     if registry is None:
         registry = HookRegistry()
@@ -401,10 +496,15 @@ def register(
     registry.register_refusal(_make_refusal_hook(refusal_handler))
     registry.register_compaction(_make_compaction_hook())
 
+    overlay_count = _register_overlay_surface(registry, customer_id)
+
     log.info(
-        "AIEmployee adapter registered for customer=%s: 4 hooks installed "
-        "(pre_tool, post_tool, refusal, compaction); pinned slots=%s",
+        "AIEmployee adapter registered for customer=%s: 4 in-tree hooks "
+        "installed (pre_tool, post_tool, refusal, compaction); %d/%d SMD "
+        "overlay surface(s) bound; pinned slots=%s",
         customer_id,
+        overlay_count,
+        len(_OVERLAY_SURFACES),
         sorted(registry.pinned_slots.keys()),
     )
     return registry

--- a/ai-employee/adapter/tests/test_aie_adapter.py
+++ b/ai-employee/adapter/tests/test_aie_adapter.py
@@ -475,3 +475,174 @@ def _make_tool_fn(return_value):
         return return_value
 
     return fn
+
+
+# ---------------------------------------------------------------------------
+# SMD overlay surface registration (ADR 0015 - PR 3)
+# ---------------------------------------------------------------------------
+#
+# register() must call smd.hooks.<surface>.register_smd_adapter(...) for
+# each overlay surface IN ADDITION to the in-tree HookRegistry wiring,
+# and must tolerate three states cleanly:
+#
+#   1. smd package absent      (dev / test / pre-fork-install)
+#   2. smd present but scaffold (PR 1 ships TODO stubs that raise
+#                                NotImplementedError)
+#   3. smd present and implemented (post-consumer-PRs steady state)
+#
+# In all three states the in-tree four-hook registration is unconditional
+# and must complete. The overlay registration is best-effort and logged.
+
+
+def _import_aie_adapter_module():
+    """Resolve the actual aie_adapter module so monkeypatch can mutate it
+    regardless of whether the test imports it as `adapter.aie_adapter` or
+    `aie_adapter` depending on PYTHONPATH ordering."""
+    import adapter.aie_adapter as mod
+
+    return mod
+
+
+def test_overlay_registration_absent_smd_package_does_not_break_register(caplog):
+    """State 1: smd is not on PYTHONPATH. register() returns a fully-wired
+    in-tree registry; the overlay branch is logged at INFO level and
+    returns 0 registered surfaces."""
+    mod = _import_aie_adapter_module()
+    # Sanity: no smd package available in this test environment.
+    with pytest.raises(ModuleNotFoundError):
+        __import__("smd.hooks.audit_emission")
+
+    with caplog.at_level("INFO", logger="aie.adapter"):
+        reg = mod.register()
+
+    assert isinstance(reg, HookRegistry)
+    # In-tree four-hook installation still completed: every re-register
+    # call should raise because each slot already holds a hook.
+    with pytest.raises(RuntimeError, match="pre_tool"):
+        reg.register_pre_tool(lambda ctx: None)  # type: ignore[arg-type]
+
+    # The bail-early branch logs once and stops; expect the "0/4 SMD overlay
+    # surface(s) bound" line in the summary.
+    summary_lines = [r.message for r in caplog.records if "SMD overlay surface" in r.message]
+    assert any("0/4 SMD overlay surface(s) bound" in m for m in summary_lines)
+
+
+def test_overlay_registration_scaffold_only_continues_per_surface(monkeypatch, caplog):
+    """State 2: every overlay surface raises NotImplementedError (the
+    initial scaffold shipped by PR 1). register() catches each, warns,
+    and registered_count is 0."""
+    mod = _import_aie_adapter_module()
+
+    fake_modules: dict[str, object] = {}
+
+    class _FakeOverlaySurface:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def register_smd_adapter(self, registry, *, customer_id):
+            raise NotImplementedError(
+                f"smd.hooks.{self.label}.register_smd_adapter is a scaffold"
+            )
+
+    for module_path, label in mod._OVERLAY_SURFACES:
+        fake_modules[module_path] = _FakeOverlaySurface(label)
+        monkeypatch.setitem(sys.modules, module_path, fake_modules[module_path])
+
+    with caplog.at_level("WARNING", logger="aie.adapter"):
+        reg = mod.register()
+
+    assert isinstance(reg, HookRegistry)
+    # In-tree wiring is unaffected.
+    with pytest.raises(RuntimeError, match="pre_tool"):
+        reg.register_pre_tool(lambda ctx: None)  # type: ignore[arg-type]
+
+    scaffold_warnings = [
+        r for r in caplog.records if "is a scaffold" in r.message and r.levelname == "WARNING"
+    ]
+    assert len(scaffold_warnings) == len(mod._OVERLAY_SURFACES), (
+        f"expected one scaffold-warning per surface, got {len(scaffold_warnings)}: "
+        f"{[r.message for r in scaffold_warnings]}"
+    )
+
+
+def test_overlay_registration_calls_each_surface_with_registry_and_customer_id(monkeypatch):
+    """State 3: implemented overlay surfaces. register_smd_adapter is
+    invoked once per surface with (registry, customer_id=...). The
+    registry passed to each is the SAME object returned by register()."""
+    mod = _import_aie_adapter_module()
+
+    calls: list[tuple[str, object, str]] = []
+
+    class _LiveOverlaySurface:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def register_smd_adapter(self, registry, *, customer_id):
+            calls.append((self.label, registry, customer_id))
+
+    for module_path, label in mod._OVERLAY_SURFACES:
+        monkeypatch.setitem(sys.modules, module_path, _LiveOverlaySurface(label))
+
+    reg = mod.register()
+
+    assert isinstance(reg, HookRegistry)
+    assert len(calls) == len(mod._OVERLAY_SURFACES), calls
+    expected_labels = [label for (_, label) in mod._OVERLAY_SURFACES]
+    assert [c[0] for c in calls] == expected_labels
+    for _, registry_arg, customer_id_arg in calls:
+        assert registry_arg is reg, "overlay call must receive the same registry"
+        # customer_id defaults to "unknown" when no customer.yaml is loaded.
+        assert isinstance(customer_id_arg, str) and len(customer_id_arg) > 0
+
+
+def test_overlay_registration_one_scaffold_does_not_block_other_surfaces(monkeypatch):
+    """Mixed state: one overlay surface is implemented, one raises
+    NotImplementedError, the rest are implemented. register() must still
+    invoke the implemented surfaces and skip only the scaffold one."""
+    mod = _import_aie_adapter_module()
+
+    successful_labels: list[str] = []
+
+    class _LiveOverlaySurface:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def register_smd_adapter(self, registry, *, customer_id):
+            successful_labels.append(self.label)
+
+    class _ScaffoldOverlaySurface:
+        def register_smd_adapter(self, registry, *, customer_id):
+            raise NotImplementedError("still a scaffold")
+
+    surfaces = mod._OVERLAY_SURFACES
+    scaffold_index = 1  # arbitrary middle surface
+    for i, (module_path, label) in enumerate(surfaces):
+        if i == scaffold_index:
+            monkeypatch.setitem(sys.modules, module_path, _ScaffoldOverlaySurface())
+        else:
+            monkeypatch.setitem(sys.modules, module_path, _LiveOverlaySurface(label))
+
+    reg = mod.register()
+
+    assert isinstance(reg, HookRegistry)
+    expected_successes = [
+        label for i, (_, label) in enumerate(surfaces) if i != scaffold_index
+    ]
+    assert successful_labels == expected_successes, (
+        f"expected implemented surfaces to register; got {successful_labels}"
+    )
+
+
+def test_overlay_helper_returns_zero_when_smd_root_missing():
+    """The _register_overlay_surface helper bails early on the first
+    ModuleNotFoundError because all overlay surfaces share the same root
+    package; the helper returns the count of surfaces registered so far
+    (0 in this case)."""
+    mod = _import_aie_adapter_module()
+    # Ensure smd is not on sys.modules.
+    for module_path, _ in mod._OVERLAY_SURFACES:
+        sys.modules.pop(module_path, None)
+
+    registry = HookRegistry()
+    count = mod._register_overlay_surface(registry, customer_id="test-customer")
+    assert count == 0


### PR DESCRIPTION
## Summary

Per [ADR 0015 §Decision](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0015-hermes-fork-vs-upstream.md): "the adapter contract is stable across overlay-vs-upstream migration." The in-tree `hermes_hook.HookRegistry` IS that stable contract — the `FakeHermesRuntime` exercises it in tests, and the runtime overlay drives it in production. This PR adds the second leg: registering the same registry against the `venturecrane/hermes-agent` overlay surface (`smd.hooks.*`) so the runtime overlay can drive the hooks once its consumers are implemented.

This is the team-lead-approved Option B variant from the [PR 3 reshape thread](https://github.com/venturecrane/ss-console/issues/844): add overlay registration **ON TOP of** the existing in-tree HookRegistry installation, not in place of it. The in-tree wiring is unconditional and remains the stable contract; overlay registration is best-effort and logged.

## Why not the original PR 3 framing

The original brief described `aie_adapter.py` as "a stub against an upstream seam that doesn't exist." That framing was outdated: the file had already been rewritten past the Phase A stub (see its docstring) and already wired against an in-tree `HookRegistry` contract. Doing a literal import swap (`.hermes_hook` → `smd.hooks.*`) would have broken the working `FakeHermesRuntime` test path and replaced a real contract with one that raises `NotImplementedError` everywhere. Team-lead reshaped the scope to the dual-surface registration shape this PR ships.

## Implementation

- New module-level `_OVERLAY_SURFACES` descriptor — one row per named overlay surface from ADR 0015. Adding a fifth surface is a single-line edit here.
- New `_register_overlay_surface(registry, customer_id)` helper. For each surface, imports the module and calls `register_smd_adapter(registry, customer_id=...)`. Per-surface error handling:
  - `ModuleNotFoundError` (smd package absent — dev / test / pre-fork-install): logged at INFO, bails early since all surfaces share the same root package.
  - `NotImplementedError` (overlay module exists but its consumer is still a scaffold per ADR 0015 PR 1): logged at WARNING, continues to the next surface.
- `register()` calls `_register_overlay_surface` after the four existing in-tree hook registrations. The summary log line records overlay count alongside the four-hook summary.
- Module docstring rewritten to describe the dual-surface contract and cite tracking issues #842, #843, #864, #948, #953 + ADR 0006.

## Tests

5 new tests in `tests/test_aie_adapter.py`, on top of 8 existing register-path tests:

- `test_overlay_registration_absent_smd_package_does_not_break_register` — verifies the in-tree four-hook installation completes when `smd` is not importable and the summary logs "0/4 SMD overlay surface(s) bound"
- `test_overlay_registration_scaffold_only_continues_per_surface` — installs fake overlay modules that all raise `NotImplementedError`; asserts one WARNING per surface and that the in-tree wiring is unaffected
- `test_overlay_registration_calls_each_surface_with_registry_and_customer_id` — installs fake live overlay modules; asserts each is called once with the SAME registry object and a customer_id string
- `test_overlay_registration_one_scaffold_does_not_block_other_surfaces` — mixed state: one scaffold raises NotImplementedError, the others register cleanly; asserts only the implemented surfaces appear in the registered list
- `test_overlay_helper_returns_zero_when_smd_root_missing` — direct helper-level test of the bail-early branch

All 378 adapter tests pass (`python3 -m pytest ai-employee/adapter/tests/ -q`).

## Verification

`npm run verify` exits 0 locally: astro check, 5 worker tsc --noEmit, prettier --check, eslint, astro build, root vitest, 5 worker vitest suites.

## Coordination with Wave 1 PR 1 (fork creation)

PR 1 ([fork creation + overlay scaffolding](https://github.com/venturecrane/hermes-agent) at `venturecrane/hermes-agent`) is paused awaiting Captain authorization for ops on a brand-new external repo. The overlay surface modules (`smd/hooks/audit_emission.py`, etc.) are scaffolded on local disk but not yet pushed. This PR is intentionally tolerant of that state — it tolerates "smd missing entirely" as the steady-state until PR 1 lands.

Once PR 1 lands and `smd.hooks.*` modules exist on customer Machine PYTHONPATH (per `bootstrap.sh`), the runtime behavior is "register_smd_adapter raises NotImplementedError → WARNING logged per surface → in-tree hooks still bound." Once each surface's consumer is implemented per its tracking issue (#842, #843, etc.), the warnings go away one by one and the overlay count climbs from `0/4` toward `4/4`.

## Test plan

- [ ] CI green
- [ ] `cd ai-employee && python3 -m pytest adapter/tests/test_aie_adapter.py -v` locally — 13 passed, 2 skipped (pre-existing)
- [ ] Once PR 1 lands and a customer Machine is provisioned, confirm the boot log emits the per-surface WARNING for each scaffolded overlay hook

Refs: ADR 0015 §Verification item 4, ADR 0006, [#844](https://github.com/venturecrane/ss-console/issues/844)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>