### PR TITLE
fix(book/manage): fetch slots on reschedule reveal + drop meeting link

### DIFF
--- a/src/pages/book/manage/[token].astro
+++ b/src/pages/book/manage/[token].astro
@@ -59,17 +59,6 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
               <dt class="ss-eyebrow">Guest</dt>
               <dd id="details-guest" class="ss-detail-value"></dd>
             </div>
-            <div id="details-meet-row" hidden>
-              <dt class="ss-eyebrow">Video call</dt>
-              <dd class="ss-detail-value">
-                <a
-                  id="details-meet-link"
-                  href="#"
-                  class="ss-quiet-link"
-                  target="_blank"
-                  rel="noopener"></a>
-              </dd>
-            </div>
           </dl>
 
           <div class="ss-form-actions mt-stack">
@@ -152,6 +141,7 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
 
     let bookingData = null
     let currentSlot = null
+    let slotsFetched = false
 
     const STATES = ['loading', 'details', 'reschedule', 'cancel', 'result']
 
@@ -225,12 +215,6 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
         document.getElementById('details-slot').textContent = data.slot_label
         document.getElementById('details-meeting-label').textContent = data.meeting_label
         document.getElementById('details-guest').textContent = data.guest_name
-        if (data.google_meet_url) {
-          const link = document.getElementById('details-meet-link')
-          link.href = data.google_meet_url
-          link.textContent = 'Open meeting link'
-          document.getElementById('details-meet-row').hidden = false
-        }
         setState('details')
       } catch (err) {
         showResult(
@@ -247,6 +231,14 @@ import SlotPicker from '../../../components/booking/SlotPicker.astro'
       if (!bookingData) return
       document.getElementById('reschedule-current').textContent = bookingData.slot_label
       setState('reschedule')
+      // SlotPicker does not auto-fetch on mount — the parent must call
+      // refetchSlots() when revealing the picker. Without this the
+      // loading skeleton spins forever. /book follows the same pattern.
+      const picker = document.getElementById('slot-picker')
+      if (!slotsFetched && picker && typeof picker.refetchSlots === 'function') {
+        picker.refetchSlots()
+        slotsFetched = true
+      }
     })
 
     document.getElementById('reschedule-back-btn').addEventListener('click', function () {


### PR DESCRIPTION
## Summary

Two issues from the manage rewrite:

1. **SlotPicker did not load on Reschedule.** Component does not auto-fetch on mount — parent must call `picker.refetchSlots()` when revealing. `/book` has this wiring; the manage rewrite was missing it. Loading skeleton spun forever.

2. **Meeting link surfaced in details.** A 'Video call → Open meeting link' row was rendered in the details state. That belongs on the calendar invite and confirmation email where the guest actually finds it on call day. After clicking through a manage link the guest has no reason to come back here for the URL — and surfacing it makes the page look like a portal it is not. Removed the row and the dead population logic.

## Test plan

- [x] `npm run verify`
- [ ] Open a manage link → details state shows Confirmed time + Guest only (no Video call row)
- [ ] Click Reschedule → SlotPicker calendar loads and renders available times

🤖 Generated with [Claude Code](https://claude.com/claude-code)