### PR TITLE
feat(ai-employee): cost telemetry data path (#824)

### DIFF
--- a/ai-employee/adapter/cost_ingest.py
+++ b/ai-employee/adapter/cost_ingest.py
@@ -1,0 +1,558 @@
+"""Cost telemetry ingestion — pulls per-day cost data from external billing
+APIs and UPSERTs it into the per-customer `cost_telemetry` D1 table.
+
+This is the source side of the §15.1 cost-driver pipeline. The rollup side
+(`cost_rollup.py`) reads what this module writes. The cron seam is the
+Cloudflare Worker at `infra/workers/cost-telemetry/`, which iterates every
+active customer once per day at 02:00 UTC and invokes the per-customer
+ingest run.
+
+Design notes
+------------
+
+* The ingest is per-customer because cost_telemetry is per-customer
+  (ADR 0009: one D1 binding per customer; no cross-customer table). The
+  caller passes a `CostIngestExecutor` already bound to the customer's
+  database. There is no `customer_id` argument and no row-level
+  customer column.
+
+* Sources covered in this v1:
+
+    1. Anthropic billing API — input_tokens and output_tokens, costed
+       via `cost_telemetry/anthropic_pricing.json`. Daily aggregate
+       per model.
+    2. Composio usage API — per-action counts costed via
+       `cost_telemetry/composio_pricing.json`. Per the resolved
+       decision in cost-telemetry-events.md "Resolved decisions",
+       Composio does not publish per-action prices via API so the
+       JSON is the manual maintenance surface.
+
+  Cloudflare D1/R2/Vectorize and Fly compute remain in the spec but are
+  deferred per the validation-spike result documented in this module's
+  `validation_spike` section. Token cost dominates the COGS surface
+  (`docs/strategy/ai-employee-stack-evaluation-2026-05-13.md`); the
+  spec explicitly permits a phase-2 defer when the metering source is
+  unworkable.
+
+* Each source ingest is independent. A failure in one source does NOT
+  block the others — the spec calls for "log to Captain alerting; do
+  NOT block other sources" and the dashboard surfaces stale-source
+  warnings. This module returns an `IngestRunResult` that names every
+  source's outcome so the cron loop can surface failures without
+  crashing the whole pass.
+
+* UPSERT semantics match the rest of cost_telemetry: multiple events
+  for the same `(date, driver)` accumulate via
+  `ON CONFLICT (date, driver) DO UPDATE SET amount_cents =
+  amount_cents + excluded.amount_cents, units = units + excluded.units`.
+  Re-running the ingest for the same day after a fixed billing-API
+  outage does NOT double-count *within the same run* — each source's
+  ingest replaces, not accumulates, by computing a single UPSERT row
+  per `(date, driver)`. Cross-run double-counting is the caller's
+  responsibility (the cron only runs once per day per customer).
+
+* No autonomous send. This module writes to D1. It does not send
+  alerts. The §17.1 alert seam is the Captain dashboard's
+  responsibility.
+
+Validation spike (per cost-telemetry-events.md "Resolved decisions" #824)
+-----------------------------------------------------------------------
+
+This module SKIPS Cloudflare D1/R2/Vectorize metering for v1. The spec
+prescribes Cloudflare GraphQL Analytics; the validation step here is
+the live-API check. Outcome of the v1 spike (2026-05-23):
+
+  - The Cloudflare GraphQL Analytics endpoint exposes account-level
+    aggregates but does not, at the time of the spike, partition by
+    individual D1 database / R2 bucket / Vectorize index in a shape
+    that lets us attribute cost to a single customer-namespaced
+    resource. The account-aggregate signal would conflate every
+    customer's usage into one number, which violates the §15.1
+    "per-customer per-day cost driver attribution" contract.
+  - Per the cost-telemetry-events.md fallback clause ("if GraphQL
+    Analytics access turns out to be unworkable for our auth model
+    or rate limits, defer D1 cost-driver instrumentation to phase 2
+    — Anthropic API tokens dominate the COGS surface"), the D1, R2,
+    and Vectorize ingests are deferred to phase 2. The PR body
+    documents this gap.
+  - Anthropic API tokens and Composio actions cover the dominant COGS
+    surface for v1, sufficient to compute the §17.1 COGS/MRR kill
+    criterion within the modeling margin already accepted in
+    `docs/strategy/ai-employee-pricing-2026-05-13.md`.
+
+When the gap is closed (phase 2), add an `ingest_cloudflare_metrics()`
+function with the same shape as `ingest_anthropic_billing()` and wire
+it into `run_ingest_for_customer()`. No other module needs to change.
+
+Failure modes
+-------------
+
+* Anthropic billing API returns 4xx/5xx: source result `ok=False`,
+  reason logged. Other sources continue. Cron logs the summary; Captain
+  sees a stale-source warning on the dashboard.
+* Anthropic returns rows for a model not in `anthropic_pricing.json`:
+  log warning, write the row with `amount_cents=0` and `units=` the
+  raw token count. The Captain dashboard surfaces unknown-model rows
+  as triage candidates. This is preferable to silently dropping
+  usage — a missing price is a pricing-file gap, not a usage gap.
+* Composio API down: source result `ok=False`. Per the spec, Composio
+  backfills historical usage when its API recovers, so a missing day
+  is recoverable on the next successful run.
+* D1 UPSERT fails: surfaces as the underlying executor exception. The
+  module does not swallow database failures.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+log = logging.getLogger("aie.cost_ingest")
+
+
+# ---------------------------------------------------------------------------
+# Pricing file loaders
+# ---------------------------------------------------------------------------
+
+_PRICING_DIR = Path(__file__).parent / "cost_telemetry"
+
+
+def _load_pricing(filename: str) -> dict:
+    """Load a pricing JSON. Raises FileNotFoundError if missing."""
+    path = _PRICING_DIR / filename
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"cost telemetry pricing file not found: {path}; "
+            "must be checked in alongside this module"
+        )
+    return json.loads(path.read_text())
+
+
+def load_anthropic_pricing(filename: str = "anthropic_pricing.json") -> dict:
+    """Load Anthropic per-model pricing. Returns the parsed JSON."""
+    return _load_pricing(filename)
+
+
+def load_composio_pricing(filename: str = "composio_pricing.json") -> dict:
+    """Load Composio per-toolkit pricing. Returns the parsed JSON."""
+    return _load_pricing(filename)
+
+
+# ---------------------------------------------------------------------------
+# Executor / source protocols
+# ---------------------------------------------------------------------------
+
+
+class CostIngestExecutor(Protocol):
+    """D1 executor bound to the per-customer cost_telemetry table."""
+
+    async def execute(self, sql: str, params: list) -> None: ...
+
+
+class AnthropicBillingSource(Protocol):
+    """Pull token usage for a single day, grouped by model.
+
+    The production implementation calls the Anthropic billing API. Tests
+    pass in a stub. The shape returned must be a sequence of
+    (model, input_tokens, output_tokens) tuples — one row per model the
+    customer's API key used that day.
+    """
+
+    async def fetch_daily_usage(
+        self,
+        api_key: str,
+        day: date,
+    ) -> Sequence[tuple[str, int, int]]: ...
+
+
+class ComposioUsageSource(Protocol):
+    """Pull per-toolkit action counts for a single day.
+
+    Returns a sequence of (toolkit, action_count) tuples — one row per
+    toolkit the customer used that day.
+    """
+
+    async def fetch_daily_usage(
+        self,
+        api_key: str,
+        account_id: str,
+        day: date,
+    ) -> Sequence[tuple[str, int]]: ...
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceIngestResult:
+    """Outcome of a single source's ingest."""
+
+    source: str
+    ok: bool
+    rows_written: int = 0
+    cents_written: int = 0
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class IngestRunResult:
+    """Aggregate outcome of one customer's daily ingest run."""
+
+    customer_slug: str
+    day: str  # YYYY-MM-DD
+    sources: tuple[SourceIngestResult, ...]
+
+    @property
+    def any_failures(self) -> bool:
+        return any(not s.ok for s in self.sources)
+
+    @property
+    def total_cents(self) -> int:
+        return sum(s.cents_written for s in self.sources)
+
+
+# ---------------------------------------------------------------------------
+# UPSERT helper
+# ---------------------------------------------------------------------------
+
+
+_UPSERT_SQL = (
+    "INSERT INTO cost_telemetry (date, driver, amount_cents, units, unit_type) "
+    "VALUES (?, ?, ?, ?, ?) "
+    "ON CONFLICT (date, driver) DO UPDATE SET "
+    "  amount_cents = amount_cents + excluded.amount_cents, "
+    "  units = units + excluded.units"
+)
+
+
+async def _upsert_row(
+    executor: CostIngestExecutor,
+    day_str: str,
+    driver: str,
+    amount_cents: int,
+    units: float,
+    unit_type: str,
+) -> None:
+    """One UPSERT into cost_telemetry. Raises if D1 errors."""
+    await executor.execute(
+        _UPSERT_SQL,
+        [day_str, driver, amount_cents, units, unit_type],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anthropic ingest
+# ---------------------------------------------------------------------------
+
+
+def _compute_anthropic_cents(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    pricing: dict,
+) -> tuple[int, int, Optional[str]]:
+    """Return (input_cents, output_cents, warning).
+
+    `warning` is a human-readable string when the model is not in the
+    pricing file; in that case both cents values are 0 (units are still
+    written so the dashboard can surface unknown-model usage).
+    """
+    models = pricing.get("models", {})
+    entry = models.get(model)
+    if entry is None:
+        return 0, 0, (
+            f"model {model!r} not in anthropic_pricing.json; "
+            "wrote tokens with amount_cents=0"
+        )
+    in_per_m = int(entry.get("input_per_million_cents", 0))
+    out_per_m = int(entry.get("output_per_million_cents", 0))
+    in_cents = (input_tokens * in_per_m) // 1_000_000
+    out_cents = (output_tokens * out_per_m) // 1_000_000
+    return in_cents, out_cents, None
+
+
+async def ingest_anthropic_billing(
+    executor: CostIngestExecutor,
+    source: AnthropicBillingSource,
+    api_key: str,
+    day: date,
+    pricing: Optional[dict] = None,
+) -> SourceIngestResult:
+    """Pull yesterday's Anthropic token usage and UPSERT into cost_telemetry.
+
+    Emits two rows per model:
+      driver=claude_api_input_tokens,  unit_type=input_tokens
+      driver=claude_api_output_tokens, unit_type=output_tokens
+
+    Per-model rows are SUMMED into the per-driver row, mirroring how the
+    per-call buffer flush in `cost_event_buffer.py` (future work)
+    accumulates into the same `(date, driver)` PK.
+    """
+    if pricing is None:
+        pricing = load_anthropic_pricing()
+    day_str = day.isoformat()
+
+    try:
+        rows = await source.fetch_daily_usage(api_key, day)
+    except Exception as e:  # noqa: BLE001
+        log.warning(
+            "anthropic_billing fetch failed for %s: %s",
+            day_str,
+            e,
+        )
+        return SourceIngestResult(
+            source="anthropic_billing",
+            ok=False,
+            reason=f"fetch failed: {e}",
+        )
+
+    total_in_tokens = 0
+    total_out_tokens = 0
+    total_in_cents = 0
+    total_out_cents = 0
+    warnings: list[str] = []
+
+    for model, in_tokens, out_tokens in rows:
+        in_cents, out_cents, warn = _compute_anthropic_cents(
+            model, in_tokens, out_tokens, pricing
+        )
+        if warn:
+            warnings.append(warn)
+            log.warning(warn)
+        total_in_tokens += int(in_tokens)
+        total_out_tokens += int(out_tokens)
+        total_in_cents += in_cents
+        total_out_cents += out_cents
+
+    rows_written = 0
+    if total_in_tokens > 0:
+        await _upsert_row(
+            executor,
+            day_str,
+            "claude_api_input_tokens",
+            total_in_cents,
+            float(total_in_tokens),
+            "input_tokens",
+        )
+        rows_written += 1
+    if total_out_tokens > 0:
+        await _upsert_row(
+            executor,
+            day_str,
+            "claude_api_output_tokens",
+            total_out_cents,
+            float(total_out_tokens),
+            "output_tokens",
+        )
+        rows_written += 1
+
+    return SourceIngestResult(
+        source="anthropic_billing",
+        ok=True,
+        rows_written=rows_written,
+        cents_written=total_in_cents + total_out_cents,
+        reason="; ".join(warnings) if warnings else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composio ingest
+# ---------------------------------------------------------------------------
+
+
+def _compute_composio_cents(
+    toolkit: str,
+    action_count: int,
+    pricing: dict,
+) -> int:
+    """Return cents for a toolkit's action count.
+
+    Per-toolkit override wins; otherwise default. Spec: composio_pricing.json
+    "Resolved decisions" — manual maintenance is the only path.
+    """
+    overrides: Mapping[str, Any] = pricing.get("toolkit_overrides", {}) or {}
+    default = int(pricing.get("default_per_action_cents", 0))
+    per_action = int(overrides.get(toolkit, default))
+    return action_count * per_action
+
+
+async def ingest_composio_usage(
+    executor: CostIngestExecutor,
+    source: ComposioUsageSource,
+    api_key: str,
+    composio_account_id: str,
+    day: date,
+    pricing: Optional[dict] = None,
+) -> SourceIngestResult:
+    """Pull yesterday's Composio action usage and UPSERT into cost_telemetry.
+
+    Emits one row:
+      driver=composio_actions, unit_type=api_calls
+
+    Per-toolkit counts are summed into one row (matches the cost_rollup
+    bucketing). Per-toolkit breakdown is left to a phase-2 enhancement
+    when Composio exposes structured per-toolkit pricing.
+    """
+    if pricing is None:
+        pricing = load_composio_pricing()
+    day_str = day.isoformat()
+
+    try:
+        rows = await source.fetch_daily_usage(api_key, composio_account_id, day)
+    except Exception as e:  # noqa: BLE001
+        log.warning(
+            "composio_usage fetch failed for %s: %s",
+            day_str,
+            e,
+        )
+        return SourceIngestResult(
+            source="composio_usage",
+            ok=False,
+            reason=f"fetch failed: {e}",
+        )
+
+    total_actions = 0
+    total_cents = 0
+    for toolkit, count in rows:
+        total_actions += int(count)
+        total_cents += _compute_composio_cents(toolkit, int(count), pricing)
+
+    rows_written = 0
+    if total_actions > 0:
+        await _upsert_row(
+            executor,
+            day_str,
+            "composio_actions",
+            total_cents,
+            float(total_actions),
+            "api_calls",
+        )
+        rows_written = 1
+
+    return SourceIngestResult(
+        source="composio_usage",
+        ok=True,
+        rows_written=rows_written,
+        cents_written=total_cents,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-customer run entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CustomerIngestContext:
+    """Per-customer wiring passed to the daily run.
+
+    The cron loop builds one of these per customer from the customer's
+    Hermes Machine bindings (API keys are per-customer secrets) and the
+    central customer_configs row (slug + composio account id).
+    """
+
+    customer_slug: str
+    anthropic_api_key: str
+    composio_api_key: Optional[str] = None
+    composio_account_id: Optional[str] = None
+    executor: Optional[CostIngestExecutor] = field(default=None)
+
+
+async def run_ingest_for_customer(
+    ctx: CustomerIngestContext,
+    anthropic_source: AnthropicBillingSource,
+    composio_source: Optional[ComposioUsageSource],
+    day: Optional[date] = None,
+) -> IngestRunResult:
+    """Run every enabled source for one customer for one day.
+
+    Default day is yesterday-UTC (the standard nightly cron target).
+
+    Failures in one source do NOT block other sources. The
+    `IngestRunResult` aggregates per-source outcomes; the caller decides
+    whether to alert Captain.
+    """
+    if ctx.executor is None:
+        raise ValueError(
+            "CustomerIngestContext.executor is required; "
+            "the cron worker must bind a CostIngestExecutor before calling"
+        )
+
+    if day is None:
+        day = (datetime.now(timezone.utc) - timedelta(days=1)).date()
+    day_str = day.isoformat()
+
+    source_results: list[SourceIngestResult] = []
+
+    # Anthropic
+    try:
+        anthropic_result = await ingest_anthropic_billing(
+            ctx.executor,
+            anthropic_source,
+            ctx.anthropic_api_key,
+            day,
+        )
+    except Exception as e:  # noqa: BLE001
+        log.error(
+            "ingest_anthropic_billing raised for %s on %s: %s",
+            ctx.customer_slug,
+            day_str,
+            e,
+        )
+        anthropic_result = SourceIngestResult(
+            source="anthropic_billing",
+            ok=False,
+            reason=f"unhandled exception: {e}",
+        )
+    source_results.append(anthropic_result)
+
+    # Composio (only if configured)
+    if composio_source is not None and ctx.composio_api_key and ctx.composio_account_id:
+        try:
+            composio_result = await ingest_composio_usage(
+                ctx.executor,
+                composio_source,
+                ctx.composio_api_key,
+                ctx.composio_account_id,
+                day,
+            )
+        except Exception as e:  # noqa: BLE001
+            log.error(
+                "ingest_composio_usage raised for %s on %s: %s",
+                ctx.customer_slug,
+                day_str,
+                e,
+            )
+            composio_result = SourceIngestResult(
+                source="composio_usage",
+                ok=False,
+                reason=f"unhandled exception: {e}",
+            )
+        source_results.append(composio_result)
+
+    return IngestRunResult(
+        customer_slug=ctx.customer_slug,
+        day=day_str,
+        sources=tuple(source_results),
+    )
+
+
+__all__ = [
+    "AnthropicBillingSource",
+    "ComposioUsageSource",
+    "CostIngestExecutor",
+    "CustomerIngestContext",
+    "IngestRunResult",
+    "SourceIngestResult",
+    "ingest_anthropic_billing",
+    "ingest_composio_usage",
+    "load_anthropic_pricing",
+    "load_composio_pricing",
+    "run_ingest_for_customer",
+]

--- a/ai-employee/adapter/cost_telemetry/__init__.py
+++ b/ai-employee/adapter/cost_telemetry/__init__.py
@@ -1,0 +1,7 @@
+"""Cost telemetry pricing references.
+
+Hardcoded pricing JSON files for cost drivers whose source APIs do not
+expose per-action prices. See `composio_pricing.json` and
+`anthropic_pricing.json`. Loader helpers live in
+`ai-employee/adapter/cost_ingest.py`.
+"""

--- a/ai-employee/adapter/cost_telemetry/anthropic_pricing.json
+++ b/ai-employee/adapter/cost_telemetry/anthropic_pricing.json
@@ -1,0 +1,23 @@
+{
+  "_meta": {
+    "version": "1",
+    "updated": "2026-05-23",
+    "source": "https://www.anthropic.com/pricing (manually retrieved)",
+    "note": "Per-million-token pricing in cents. Captain updates on Anthropic price changes. CI test ensures every customer.yaml-declared `model` has a pricing entry. Cited in docs/specs/ai-employee/cost-telemetry-events.md 'Per-call emission (Claude API)'.",
+    "units": "cents per million tokens"
+  },
+  "models": {
+    "claude-opus-4-7": {
+      "input_per_million_cents": 1500,
+      "output_per_million_cents": 7500
+    },
+    "claude-sonnet-4-6": {
+      "input_per_million_cents": 300,
+      "output_per_million_cents": 1500
+    },
+    "claude-haiku-4-5-20251001": {
+      "input_per_million_cents": 80,
+      "output_per_million_cents": 400
+    }
+  }
+}

--- a/ai-employee/adapter/cost_telemetry/composio_pricing.json
+++ b/ai-employee/adapter/cost_telemetry/composio_pricing.json
@@ -1,0 +1,26 @@
+{
+  "_meta": {
+    "version": "1",
+    "updated": "2026-05-23",
+    "source": "https://docs.composio.dev/pricing (manually retrieved)",
+    "note": "Composio does not publish per-action pricing via API as of 2026-05; manual maintenance is the only path. Captain refreshes this file when Composio updates published rates. Anomaly check: if a billing-period rollup shows a Composio cost-driver delta >2x the prior period for any single toolkit, alert Captain to refresh against current published rates. Cited in docs/specs/ai-employee/cost-telemetry-events.md 'Resolved decisions'.",
+    "units": "cents per action invocation"
+  },
+  "default_per_action_cents": 1,
+  "toolkit_overrides": {
+    "gmail": 1,
+    "google_calendar": 1,
+    "google_drive": 1,
+    "slack": 1,
+    "github": 1,
+    "linear": 1,
+    "notion": 1,
+    "hubspot": 1,
+    "salesforce": 1,
+    "stripe": 1,
+    "lawpay": 1,
+    "docusign": 1,
+    "courtlistener": 0,
+    "agentmail": 1
+  }
+}

--- a/ai-employee/adapter/tests/test_cost_ingest.py
+++ b/ai-employee/adapter/tests/test_cost_ingest.py
@@ -1,0 +1,481 @@
+"""Tests for ai-employee/adapter/cost_ingest.py (issue #824).
+
+Exercises the Anthropic + Composio ingest paths against in-memory
+sqlite that mirrors the cost_telemetry schema from migration 0001.
+
+Coverage:
+  - Pricing JSON files load and have the expected shape
+  - Anthropic ingest: known model -> correct cents math
+  - Anthropic ingest: unknown model -> rows written with cents=0 + warning
+  - Anthropic ingest: zero-token result writes no rows
+  - Anthropic ingest: source failure is captured in SourceIngestResult.ok=False
+  - Composio ingest: per-toolkit override wins over default
+  - Composio ingest: zero actions writes no rows
+  - UPSERT accumulates on repeat: re-running same day adds to existing row
+  - run_ingest_for_customer: failure in one source does not block others
+  - run_ingest_for_customer: skips composio when not configured
+
+Run from repo root:
+
+    cd ai-employee && python -m pytest adapter/tests/test_cost_ingest.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+# Allow running from repo root or from ai-employee/.
+_HERE = Path(__file__).resolve()
+sys.path.insert(0, str(_HERE.parents[2]))  # ai-employee/ on sys.path
+
+from adapter.cost_ingest import (  # noqa: E402
+    CustomerIngestContext,
+    IngestRunResult,
+    SourceIngestResult,
+    _compute_anthropic_cents,
+    _compute_composio_cents,
+    ingest_anthropic_billing,
+    ingest_composio_usage,
+    load_anthropic_pricing,
+    load_composio_pricing,
+    run_ingest_for_customer,
+)
+
+
+_SCHEMA_SQL = """
+CREATE TABLE cost_telemetry (
+  date         TEXT NOT NULL,
+  driver       TEXT NOT NULL,
+  amount_cents INTEGER NOT NULL,
+  units        REAL,
+  unit_type    TEXT,
+  PRIMARY KEY (date, driver)
+);
+CREATE INDEX idx_cost_telemetry_date ON cost_telemetry(date);
+"""
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_SCHEMA_SQL)
+    return conn
+
+
+class _SqliteExecutor:
+    """Minimal async-shim executor backed by sqlite3."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    async def execute(self, sql: str, params: list) -> None:
+        cur = self._conn.cursor()
+        cur.execute(sql, params)
+        self._conn.commit()
+
+
+class _FakeAnthropicSource:
+    def __init__(self, rows, raises: Exception | None = None) -> None:
+        self._rows = rows
+        self._raises = raises
+        self.calls: list[tuple] = []
+
+    async def fetch_daily_usage(self, api_key, day):
+        self.calls.append((api_key, day))
+        if self._raises:
+            raise self._raises
+        return self._rows
+
+
+class _FakeComposioSource:
+    def __init__(self, rows, raises: Exception | None = None) -> None:
+        self._rows = rows
+        self._raises = raises
+        self.calls: list[tuple] = []
+
+    async def fetch_daily_usage(self, api_key, account_id, day):
+        self.calls.append((api_key, account_id, day))
+        if self._raises:
+            raise self._raises
+        return self._rows
+
+
+def _read_rows(conn: sqlite3.Connection) -> list[tuple]:
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT date, driver, amount_cents, units, unit_type "
+        "FROM cost_telemetry ORDER BY date, driver"
+    )
+    return cur.fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Pricing loaders
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_pricing_loads():
+    pricing = load_anthropic_pricing()
+    assert "models" in pricing
+    assert "claude-opus-4-7" in pricing["models"]
+    entry = pricing["models"]["claude-opus-4-7"]
+    assert entry["input_per_million_cents"] == 1500
+    assert entry["output_per_million_cents"] == 7500
+
+
+def test_composio_pricing_loads():
+    pricing = load_composio_pricing()
+    assert "default_per_action_cents" in pricing
+    assert "toolkit_overrides" in pricing
+    assert isinstance(pricing["toolkit_overrides"], dict)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic cents math
+# ---------------------------------------------------------------------------
+
+
+def test_compute_anthropic_cents_known_model():
+    pricing = load_anthropic_pricing()
+    # Opus 4.7: 1500 cents per M input, 7500 cents per M output
+    # 2,000,000 input tokens -> 3000 cents; 1,000,000 output -> 7500 cents
+    in_cents, out_cents, warn = _compute_anthropic_cents(
+        "claude-opus-4-7", 2_000_000, 1_000_000, pricing
+    )
+    assert in_cents == 3000
+    assert out_cents == 7500
+    assert warn is None
+
+
+def test_compute_anthropic_cents_unknown_model():
+    pricing = load_anthropic_pricing()
+    in_cents, out_cents, warn = _compute_anthropic_cents(
+        "claude-unknown-99", 1_000_000, 1_000_000, pricing
+    )
+    assert in_cents == 0
+    assert out_cents == 0
+    assert warn is not None
+    assert "claude-unknown-99" in warn
+
+
+def test_compute_anthropic_cents_integer_floor():
+    pricing = load_anthropic_pricing()
+    # 1 input token at 1500 cents/million = floor(1500/1_000_000) = 0
+    in_cents, out_cents, _ = _compute_anthropic_cents(
+        "claude-opus-4-7", 1, 0, pricing
+    )
+    assert in_cents == 0
+    assert out_cents == 0
+
+
+# ---------------------------------------------------------------------------
+# Composio cents math
+# ---------------------------------------------------------------------------
+
+
+def test_compute_composio_cents_uses_override():
+    pricing = {
+        "default_per_action_cents": 5,
+        "toolkit_overrides": {"gmail": 2},
+    }
+    assert _compute_composio_cents("gmail", 10, pricing) == 20
+    assert _compute_composio_cents("unknown", 10, pricing) == 50
+
+
+def test_compute_composio_cents_default_when_no_overrides():
+    pricing = {"default_per_action_cents": 3}
+    assert _compute_composio_cents("anything", 100, pricing) == 300
+
+
+# ---------------------------------------------------------------------------
+# Anthropic ingest
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_anthropic_writes_two_driver_rows():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeAnthropicSource(
+        [
+            ("claude-opus-4-7", 1_000_000, 500_000),
+            ("claude-sonnet-4-6", 2_000_000, 1_000_000),
+        ]
+    )
+
+    result = asyncio.run(
+        ingest_anthropic_billing(
+            executor,
+            source,
+            "fake-key",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert result.ok
+    assert result.rows_written == 2
+    # Opus: 1500 in + 3750 out = 5250
+    # Sonnet: 600 in + 1500 out = 2100
+    # Total: 7350
+    assert result.cents_written == 5250 + 2100
+
+    rows = _read_rows(conn)
+    assert len(rows) == 2
+    in_row = next(r for r in rows if r[1] == "claude_api_input_tokens")
+    out_row = next(r for r in rows if r[1] == "claude_api_output_tokens")
+    assert in_row[0] == "2026-05-22"
+    assert in_row[2] == 1500 + 600  # 2100 cents
+    assert in_row[3] == 3_000_000.0
+    assert in_row[4] == "input_tokens"
+    assert out_row[2] == 3750 + 1500  # 5250 cents
+    assert out_row[3] == 1_500_000.0
+    assert out_row[4] == "output_tokens"
+
+
+def test_ingest_anthropic_unknown_model_writes_zero_cents_with_units():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeAnthropicSource(
+        [
+            ("claude-mystery-7", 1_000_000, 500_000),
+        ]
+    )
+
+    result = asyncio.run(
+        ingest_anthropic_billing(
+            executor,
+            source,
+            "fake-key",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert result.ok
+    assert result.reason is not None
+    assert "claude-mystery-7" in result.reason
+    rows = _read_rows(conn)
+    # Both rows still written (units preserved for triage); cents are 0.
+    assert len(rows) == 2
+    for row in rows:
+        assert row[2] == 0  # amount_cents
+
+
+def test_ingest_anthropic_zero_tokens_writes_no_rows():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeAnthropicSource([])
+
+    result = asyncio.run(
+        ingest_anthropic_billing(
+            executor,
+            source,
+            "fake-key",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert result.ok
+    assert result.rows_written == 0
+    assert _read_rows(conn) == []
+
+
+def test_ingest_anthropic_source_failure_returns_not_ok():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeAnthropicSource([], raises=RuntimeError("HTTP 503"))
+
+    result = asyncio.run(
+        ingest_anthropic_billing(
+            executor,
+            source,
+            "fake-key",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert not result.ok
+    assert "503" in (result.reason or "")
+    assert _read_rows(conn) == []
+
+
+# ---------------------------------------------------------------------------
+# Composio ingest
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_composio_writes_single_row():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeComposioSource(
+        [
+            ("gmail", 100),
+            ("github", 50),
+            ("unknown_toolkit", 25),
+        ]
+    )
+
+    result = asyncio.run(
+        ingest_composio_usage(
+            executor,
+            source,
+            "fake-key",
+            "acct_123",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert result.ok
+    assert result.rows_written == 1
+    rows = _read_rows(conn)
+    assert len(rows) == 1
+    assert rows[0][1] == "composio_actions"
+    assert rows[0][3] == 175.0  # total actions
+    assert rows[0][4] == "api_calls"
+
+
+def test_ingest_composio_zero_writes_no_rows():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeComposioSource([])
+
+    result = asyncio.run(
+        ingest_composio_usage(
+            executor,
+            source,
+            "fake-key",
+            "acct_123",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert result.ok
+    assert result.rows_written == 0
+    assert _read_rows(conn) == []
+
+
+def test_ingest_composio_source_failure():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeComposioSource([], raises=RuntimeError("HTTP 500"))
+
+    result = asyncio.run(
+        ingest_composio_usage(
+            executor,
+            source,
+            "fake-key",
+            "acct_123",
+            date(2026, 5, 22),
+        )
+    )
+
+    assert not result.ok
+    assert _read_rows(conn) == []
+
+
+# ---------------------------------------------------------------------------
+# UPSERT accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_accumulates_on_repeat():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    source = _FakeAnthropicSource(
+        [("claude-opus-4-7", 1_000_000, 1_000_000)]
+    )
+
+    asyncio.run(
+        ingest_anthropic_billing(executor, source, "k", date(2026, 5, 22))
+    )
+    # Second run same day — UPSERT must accumulate
+    asyncio.run(
+        ingest_anthropic_billing(executor, source, "k", date(2026, 5, 22))
+    )
+
+    rows = _read_rows(conn)
+    in_row = next(r for r in rows if r[1] == "claude_api_input_tokens")
+    out_row = next(r for r in rows if r[1] == "claude_api_output_tokens")
+    # Each run wrote 1500 in_cents + 7500 out_cents; after 2 runs: 3000 / 15000
+    assert in_row[2] == 3000
+    assert out_row[2] == 15000
+    # Units doubled too
+    assert in_row[3] == 2_000_000.0
+    assert out_row[3] == 2_000_000.0
+
+
+# ---------------------------------------------------------------------------
+# Per-customer run
+# ---------------------------------------------------------------------------
+
+
+def test_run_ingest_skips_composio_when_not_configured():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    ctx = CustomerIngestContext(
+        customer_slug="acme",
+        anthropic_api_key="ak",
+        composio_api_key=None,
+        composio_account_id=None,
+        executor=executor,
+    )
+    anthropic_src = _FakeAnthropicSource([("claude-opus-4-7", 100, 200)])
+    composio_src = _FakeComposioSource([("gmail", 10)])
+
+    result = asyncio.run(
+        run_ingest_for_customer(
+            ctx, anthropic_src, composio_src, day=date(2026, 5, 22)
+        )
+    )
+
+    assert isinstance(result, IngestRunResult)
+    sources = [s.source for s in result.sources]
+    assert "anthropic_billing" in sources
+    assert "composio_usage" not in sources
+    assert composio_src.calls == []  # never invoked
+
+
+def test_run_ingest_anthropic_failure_does_not_block_composio():
+    conn = _make_conn()
+    executor = _SqliteExecutor(conn)
+    ctx = CustomerIngestContext(
+        customer_slug="acme",
+        anthropic_api_key="ak",
+        composio_api_key="ck",
+        composio_account_id="acct_1",
+        executor=executor,
+    )
+    anthropic_src = _FakeAnthropicSource([], raises=RuntimeError("HTTP 503"))
+    composio_src = _FakeComposioSource([("gmail", 100)])
+
+    result = asyncio.run(
+        run_ingest_for_customer(
+            ctx, anthropic_src, composio_src, day=date(2026, 5, 22)
+        )
+    )
+
+    sources = {s.source: s for s in result.sources}
+    assert not sources["anthropic_billing"].ok
+    assert sources["composio_usage"].ok
+    assert sources["composio_usage"].rows_written == 1
+    assert result.any_failures is True
+
+
+def test_run_ingest_requires_executor():
+    ctx = CustomerIngestContext(
+        customer_slug="acme",
+        anthropic_api_key="ak",
+        executor=None,
+    )
+    with pytest.raises(ValueError):
+        asyncio.run(
+            run_ingest_for_customer(
+                ctx,
+                _FakeAnthropicSource([]),
+                None,
+                day=date(2026, 5, 22),
+            )
+        )

--- a/workers/cost-telemetry/package-lock.json
+++ b/workers/cost-telemetry/package-lock.json
@@ -1,0 +1,3222 @@
+{
+  "name": "ss-cost-telemetry",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ss-cost-telemetry",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250327.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.2.4",
+        "wrangler": "^4.78.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260521.1.tgz",
+      "integrity": "sha512-aiNdXmxlhwGjTSajL3I7uQPpN4lAOcXjvg5ZOlJKIywnevr798n9XCS6lvuqgniM3KjurBNWRRypMJntg/eSLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260521.1.tgz",
+      "integrity": "sha512-ikN8aKSi4Ak28ndOkuSO5rq6lmV6wwDQu9F9Vu6J7EkwAOth74J/Hjn4j4EuFceW/npw2Ws0Y/muzA6WKHl4TA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260521.1.tgz",
+      "integrity": "sha512-D/gUhvQcG0pJr5aJl6yUoi2JxbFpjVtDq9xUJHPjfkAjL28TUVgCR/e5r8YGirepv4I1DK7ihuii9LZ2GGMJbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260521.1.tgz",
+      "integrity": "sha512-vhjWPIHenczegTakhRPwEmTeaavCpNqsuo3RlLCkUdU47HrwLvy/4QersGggs4+kF4Do+IE/EznCGyT40xYcLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260521.1.tgz",
+      "integrity": "sha512-wBolYC/+lnGIEbkkPdzFtjTOWip2uQH6maeAP1ZV0kyxi5SGpsa83+wD5rH5OOle+sHE5qJMdwCKjwRwj+FKJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260524.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260524.1.tgz",
+      "integrity": "sha512-9o939wce6hAlfNAIG4W58bySW7twgkqgPkxmSNrk/DV0eEexjTPyqChGdsQeKZEXJAjxSUFklaebMYJWg1GM0g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260521.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260521.0.tgz",
+      "integrity": "sha512-roRfxPq49OkuSeQsc43hRjSB1+HdHtDNKRwDEVk2hCjCBuBWxb5Wvwq88b0ULj6QVEJLN/+ZqF19M+h4VYJ/zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260521.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rosie-skills": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
+      "integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "rosie-skills": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "rosie-skills-darwin-arm64": "0.6.4",
+        "rosie-skills-freebsd-x64": "0.6.4",
+        "rosie-skills-linux-x64": "0.6.4"
+      }
+    },
+    "node_modules/rosie-skills-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rosie-skills-freebsd-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+      "integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rosie-skills-linux-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+      "integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260521.1.tgz",
+      "integrity": "sha512-HzIThcZ0ZVEuzVxpY2IYZ3yssSrTjtrWXAVfmOl5rVwyqcu7aeZXGMiwrEmi9MOcC3wjy+BNv+hFrMMY5OrjQQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260521.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260521.1",
+        "@cloudflare/workerd-linux-64": "1.20260521.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260521.1",
+        "@cloudflare/workerd-windows-64": "1.20260521.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.94.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.94.0.tgz",
+      "integrity": "sha512-GsNw0DomGFfeXFtKVTwn2X69UKcCxcTB0CXykjsMineJIxOeyrw7LovlHQ/3JU8KJHH7repLB+kOHvfTBA/Eew==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260521.0",
+        "path-to-regexp": "6.3.0",
+        "rosie-skills": "^0.6.3",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260521.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260521.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/workers/cost-telemetry/package.json
+++ b/workers/cost-telemetry/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ss-cost-telemetry",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250327.0",
+    "typescript": "^5.3.0",
+    "vitest": "^3.2.4",
+    "wrangler": "^4.78.0"
+  }
+}

--- a/workers/cost-telemetry/src/clients.ts
+++ b/workers/cost-telemetry/src/clients.ts
@@ -1,0 +1,162 @@
+/**
+ * Production HTTP clients for the cost telemetry worker.
+ *
+ * Three external surfaces:
+ *
+ *   1. Cloudflare D1 HTTP API — used to write per-customer cost_telemetry
+ *      rows. Each customer has a distinct database id, so the client
+ *      takes the id per call rather than baking it in.
+ *
+ *   2. Anthropic billing / usage API — daily token usage per model. The
+ *      Anthropic Console exposes a usage endpoint; the exact shape may
+ *      shift between API versions, so the client normalizes to
+ *      `AnthropicUsageRow[]`. If the upstream shape drifts, only this
+ *      file needs to change.
+ *
+ *   3. Composio usage API — per-toolkit action counts. Same shape: the
+ *      client normalizes to `ComposioUsageRow[]`. Per the resolved
+ *      decision in cost-telemetry-events.md, cents are computed
+ *      against the hardcoded `composio_pricing.json` rather than any
+ *      per-action pricing from Composio (which they do not publish).
+ *
+ * All three clients are thin wrappers — no caching, no retry. The
+ * cron run is the natural retry boundary (a missed day rolls forward
+ * to the next night).
+ */
+
+import type {
+  AnthropicSource,
+  AnthropicUsageRow,
+  ComposioSource,
+  ComposioUsageRow,
+  D1HttpClient,
+} from './ingest'
+
+// ---------------------------------------------------------------------------
+// Cloudflare D1 HTTP client
+// ---------------------------------------------------------------------------
+
+export class CloudflareD1Client implements D1HttpClient {
+  private readonly accountId: string
+  private readonly apiToken: string
+
+  constructor(accountId: string, apiToken: string) {
+    this.accountId = accountId
+    this.apiToken = apiToken
+  }
+
+  async execute(databaseId: string, sql: string, params: unknown[]): Promise<void> {
+    const url =
+      `https://api.cloudflare.com/client/v4/accounts/${this.accountId}` +
+      `/d1/database/${databaseId}/query`
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ sql, params }),
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`D1 HTTP ${res.status}: ${text.slice(0, 200)}`)
+    }
+    const payload: { success?: boolean; errors?: unknown } = await res.json()
+    if (!payload.success) {
+      throw new Error(`D1 query failed: ${JSON.stringify(payload.errors ?? payload)}`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic usage client
+// ---------------------------------------------------------------------------
+
+/**
+ * Anthropic usage API client.
+ *
+ * The Anthropic Usage & Cost API exposes daily token usage per
+ * workspace/model. The endpoint shape used here is the documented
+ * `/v1/organizations/usage_report/messages` form. If the API surface
+ * shifts, normalize within this class — the rest of the ingest
+ * pipeline accepts `AnthropicUsageRow[]` only.
+ */
+export class AnthropicHttpSource implements AnthropicSource {
+  async fetchDailyUsage(apiKey: string, day: string): Promise<AnthropicUsageRow[]> {
+    const url = new URL('https://api.anthropic.com/v1/organizations/usage_report/messages')
+    // The API expects a date range; we ask for exactly the one day.
+    url.searchParams.set('starting_at', `${day}T00:00:00Z`)
+    url.searchParams.set('ending_at', `${day}T23:59:59Z`)
+    url.searchParams.set('group_by[]', 'model')
+
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`Anthropic usage HTTP ${res.status}: ${text.slice(0, 200)}`)
+    }
+    const payload: {
+      data?: Array<{
+        model?: string
+        input_tokens?: number
+        output_tokens?: number
+      }>
+    } = await res.json()
+    const rows = payload.data ?? []
+    const out: AnthropicUsageRow[] = []
+    for (const r of rows) {
+      if (!r.model) continue
+      out.push({
+        model: r.model,
+        inputTokens: Number(r.input_tokens ?? 0),
+        outputTokens: Number(r.output_tokens ?? 0),
+      })
+    }
+    return out
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composio usage client
+// ---------------------------------------------------------------------------
+
+export class ComposioHttpSource implements ComposioSource {
+  async fetchDailyUsage(
+    apiKey: string,
+    accountId: string,
+    day: string
+  ): Promise<ComposioUsageRow[]> {
+    const url = new URL('https://backend.composio.dev/api/v1/usage/actions')
+    url.searchParams.set('account_id', accountId)
+    url.searchParams.set('date', day)
+
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`Composio usage HTTP ${res.status}: ${text.slice(0, 200)}`)
+    }
+    const payload: { toolkits?: Array<{ toolkit?: string; action_count?: number }> } =
+      await res.json()
+    const rows = payload.toolkits ?? []
+    const out: ComposioUsageRow[] = []
+    for (const r of rows) {
+      if (!r.toolkit) continue
+      out.push({
+        toolkit: r.toolkit,
+        actionCount: Number(r.action_count ?? 0),
+      })
+    }
+    return out
+  }
+}

--- a/workers/cost-telemetry/src/index.ts
+++ b/workers/cost-telemetry/src/index.ts
@@ -1,0 +1,201 @@
+/**
+ * Cost Telemetry Worker — daily cost-driver ingest.
+ *
+ * Runs at 02:00 UTC daily per `triggers.crons` in wrangler.toml. Per
+ * docs/specs/ai-employee/cost-telemetry-events.md "Nightly Captain job",
+ * the worker iterates every active AI Employee customer, pulls
+ * yesterday's Anthropic + Composio usage, and UPSERTs into each
+ * customer's per-customer `cost_telemetry` D1 table.
+ *
+ * Cloudflare D1/R2/Vectorize metering is deferred to phase 2 per the
+ * validation-spike outcome documented in
+ * ai-employee/adapter/cost_ingest.py. Token cost dominates the COGS
+ * surface for v1.
+ *
+ * Customer enumeration: the central D1 `customer_configs` table holds
+ * the list. The per-customer D1 database id is required to address
+ * the right database via the D1 HTTP API. v1 reads from a metadata
+ * column on `customer_configs` (`per_customer_d1_database_id` —
+ * populated by the customer provisioner at create time; this worker
+ * skips customers without one and logs the skip).
+ */
+
+import { AnthropicHttpSource, CloudflareD1Client, ComposioHttpSource } from './clients'
+import {
+  runIngestForCustomer,
+  type CustomerIngestContext,
+  type CustomerIngestResult,
+} from './ingest'
+
+export interface Env {
+  DB: D1Database
+  CF_ACCOUNT_ID: string
+  CF_D1_API_TOKEN: string
+  ANTHROPIC_API_KEY: string
+  COMPOSIO_API_KEY?: string
+  COST_INGEST_BEARER?: string
+}
+
+interface CustomerRow {
+  customer_slug: string
+  per_customer_d1_database_id: string | null
+  composio_account_id: string | null
+}
+
+/** Read the active customer list with the per-customer D1 id resolved. */
+async function listCustomers(db: D1Database): Promise<CustomerRow[]> {
+  // `connectors_json` carries non-secret references including the
+  // per-customer Hermes database id and the composio account id. The
+  // projection layer denormalizes them into the JSON blob per ADR 0012.
+  // For v1 the worker uses two convention keys; if not present the
+  // customer is skipped (logged, not errored).
+  const result = await db
+    .prepare('SELECT customer_slug, connectors_json FROM customer_configs')
+    .all<{ customer_slug: string; connectors_json: string | null }>()
+
+  const rows: CustomerRow[] = []
+  for (const row of result.results ?? []) {
+    let perCustomerDbId: string | null = null
+    let composioAccountId: string | null = null
+    if (row.connectors_json) {
+      try {
+        const parsed = JSON.parse(row.connectors_json) as Record<string, unknown>
+        const dbId = parsed['per_customer_d1_database_id']
+        const composio = parsed['composio_account_id']
+        if (typeof dbId === 'string' && dbId.length > 0) perCustomerDbId = dbId
+        if (typeof composio === 'string' && composio.length > 0) composioAccountId = composio
+      } catch {
+        // Bad JSON — skip; not the worker's job to fix projection.
+      }
+    }
+    rows.push({
+      customer_slug: row.customer_slug,
+      per_customer_d1_database_id: perCustomerDbId,
+      composio_account_id: composioAccountId,
+    })
+  }
+  return rows
+}
+
+function yesterdayUtc(now: Date = new Date()): string {
+  const ms = now.getTime() - 24 * 60 * 60 * 1000
+  const d = new Date(ms)
+  const yyyy = d.getUTCFullYear()
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(d.getUTCDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+interface RunSummary {
+  day: string
+  customersTotal: number
+  customersSkipped: number
+  customersRun: number
+  customersWithFailures: number
+  totalCentsWritten: number
+  perCustomer: CustomerIngestResult[]
+  skipped: Array<{ customer_slug: string; reason: string }>
+}
+
+export async function run(env: Env, day?: string): Promise<RunSummary> {
+  const targetDay = day ?? yesterdayUtc()
+  const customers = await listCustomers(env.DB)
+
+  const d1 = new CloudflareD1Client(env.CF_ACCOUNT_ID, env.CF_D1_API_TOKEN)
+  const anthropicSource = new AnthropicHttpSource()
+  const composioSource = env.COMPOSIO_API_KEY ? new ComposioHttpSource() : null
+
+  const summary: RunSummary = {
+    day: targetDay,
+    customersTotal: customers.length,
+    customersSkipped: 0,
+    customersRun: 0,
+    customersWithFailures: 0,
+    totalCentsWritten: 0,
+    perCustomer: [],
+    skipped: [],
+  }
+
+  for (const customer of customers) {
+    if (!customer.per_customer_d1_database_id) {
+      summary.customersSkipped++
+      summary.skipped.push({
+        customer_slug: customer.customer_slug,
+        reason: 'no per_customer_d1_database_id in connectors_json',
+      })
+      console.warn(
+        `[cost-telemetry] skip ${customer.customer_slug}: no per_customer_d1_database_id`
+      )
+      continue
+    }
+
+    const ctx: CustomerIngestContext = {
+      customerSlug: customer.customer_slug,
+      perCustomerDatabaseId: customer.per_customer_d1_database_id,
+      anthropicApiKey: env.ANTHROPIC_API_KEY,
+      composioApiKey: env.COMPOSIO_API_KEY,
+      composioAccountId: customer.composio_account_id ?? undefined,
+    }
+
+    try {
+      const result = await runIngestForCustomer(ctx, d1, anthropicSource, composioSource, targetDay)
+      summary.customersRun++
+      summary.perCustomer.push(result)
+      if (result.anyFailures) summary.customersWithFailures++
+      summary.totalCentsWritten += result.totalCents
+    } catch (e) {
+      summary.customersWithFailures++
+      summary.customersRun++
+      const msg = e instanceof Error ? e.message : String(e)
+      console.error(`[cost-telemetry] ${customer.customer_slug}: ${msg}`)
+      summary.perCustomer.push({
+        customerSlug: customer.customer_slug,
+        day: targetDay,
+        sources: [
+          {
+            source: 'orchestrator',
+            ok: false,
+            rowsWritten: 0,
+            centsWritten: 0,
+            reason: msg,
+          },
+        ],
+        anyFailures: true,
+        totalCents: 0,
+      })
+    }
+  }
+
+  console.log(
+    `[cost-telemetry] day=${summary.day} customers=${summary.customersTotal} ` +
+      `run=${summary.customersRun} skipped=${summary.customersSkipped} ` +
+      `failures=${summary.customersWithFailures} cents=${summary.totalCentsWritten}`
+  )
+
+  return summary
+}
+
+export default {
+  async scheduled(
+    _controller: ScheduledController,
+    env: Env,
+    _ctx: ExecutionContext
+  ): Promise<void> {
+    await run(env)
+  },
+
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+    if (env.COST_INGEST_BEARER) {
+      const auth = request.headers.get('Authorization')
+      if (auth !== `Bearer ${env.COST_INGEST_BEARER}`) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+    }
+    const url = new URL(request.url)
+    const day = url.searchParams.get('day') ?? undefined
+    const summary = await run(env, day)
+    return new Response(JSON.stringify(summary, null, 2), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  },
+} satisfies ExportedHandler<Env>

--- a/workers/cost-telemetry/src/ingest.test.ts
+++ b/workers/cost-telemetry/src/ingest.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ingestAnthropic,
+  ingestComposio,
+  runIngestForCustomer,
+  type AnthropicSource,
+  type AnthropicUsageRow,
+  type ComposioSource,
+  type ComposioUsageRow,
+  type CustomerIngestContext,
+  type D1HttpClient,
+} from './ingest'
+import {
+  anthropicPricing,
+  composioPricing,
+  computeAnthropicCents,
+  computeComposioCents,
+} from './pricing'
+
+class FakeD1 implements D1HttpClient {
+  public calls: Array<{ databaseId: string; sql: string; params: unknown[] }> = []
+  async execute(databaseId: string, sql: string, params: unknown[]): Promise<void> {
+    this.calls.push({ databaseId, sql, params })
+  }
+}
+
+class FakeAnthropic implements AnthropicSource {
+  constructor(
+    private rows: AnthropicUsageRow[],
+    private error?: Error
+  ) {}
+  async fetchDailyUsage(): Promise<AnthropicUsageRow[]> {
+    if (this.error) throw this.error
+    return this.rows
+  }
+}
+
+class FakeComposio implements ComposioSource {
+  constructor(
+    private rows: ComposioUsageRow[],
+    private error?: Error
+  ) {}
+  async fetchDailyUsage(): Promise<ComposioUsageRow[]> {
+    if (this.error) throw this.error
+    return this.rows
+  }
+}
+
+describe('pricing JSON shape', () => {
+  it('anthropic pricing has expected models', () => {
+    expect(anthropicPricing.models['claude-opus-4-7']).toBeDefined()
+    expect(anthropicPricing.models['claude-opus-4-7'].input_per_million_cents).toBe(1500)
+    expect(anthropicPricing.models['claude-opus-4-7'].output_per_million_cents).toBe(7500)
+  })
+
+  it('composio pricing has defaults', () => {
+    expect(composioPricing.default_per_action_cents).toBeGreaterThanOrEqual(0)
+    expect(typeof composioPricing.toolkit_overrides).toBe('object')
+  })
+})
+
+describe('cents math', () => {
+  it('computes anthropic cents from token counts', () => {
+    const r = computeAnthropicCents('claude-opus-4-7', 2_000_000, 1_000_000)
+    expect(r.inputCents).toBe(3000)
+    expect(r.outputCents).toBe(7500)
+    expect(r.warning).toBeNull()
+  })
+
+  it('returns zero cents and a warning for unknown anthropic model', () => {
+    const r = computeAnthropicCents('mystery', 1_000_000, 1_000_000)
+    expect(r.inputCents).toBe(0)
+    expect(r.outputCents).toBe(0)
+    expect(r.warning).toContain('mystery')
+  })
+
+  it('uses composio override over default', () => {
+    expect(
+      computeComposioCents('gmail', 10, {
+        default_per_action_cents: 5,
+        toolkit_overrides: { gmail: 2 },
+      })
+    ).toBe(20)
+    expect(
+      computeComposioCents('unknown', 10, {
+        default_per_action_cents: 5,
+        toolkit_overrides: { gmail: 2 },
+      })
+    ).toBe(50)
+  })
+})
+
+describe('ingestAnthropic', () => {
+  it('writes two rows when both token totals are positive', async () => {
+    const d1 = new FakeD1()
+    const src = new FakeAnthropic([
+      { model: 'claude-opus-4-7', inputTokens: 1_000_000, outputTokens: 500_000 },
+    ])
+    const result = await ingestAnthropic(d1, 'db-1', src, 'k', '2026-05-22')
+    expect(result.ok).toBe(true)
+    expect(result.rowsWritten).toBe(2)
+    expect(d1.calls).toHaveLength(2)
+    expect(d1.calls[0].params[1]).toBe('claude_api_input_tokens')
+    expect(d1.calls[1].params[1]).toBe('claude_api_output_tokens')
+  })
+
+  it('writes zero rows when token totals are zero', async () => {
+    const d1 = new FakeD1()
+    const src = new FakeAnthropic([])
+    const result = await ingestAnthropic(d1, 'db-1', src, 'k', '2026-05-22')
+    expect(result.ok).toBe(true)
+    expect(result.rowsWritten).toBe(0)
+    expect(d1.calls).toHaveLength(0)
+  })
+
+  it('returns ok=false when source throws', async () => {
+    const d1 = new FakeD1()
+    const src = new FakeAnthropic([], new Error('HTTP 503'))
+    const result = await ingestAnthropic(d1, 'db-1', src, 'k', '2026-05-22')
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('503')
+    expect(d1.calls).toHaveLength(0)
+  })
+})
+
+describe('ingestComposio', () => {
+  it('writes one composio_actions row aggregating toolkits', async () => {
+    const d1 = new FakeD1()
+    const src = new FakeComposio([
+      { toolkit: 'gmail', actionCount: 50 },
+      { toolkit: 'github', actionCount: 25 },
+    ])
+    const result = await ingestComposio(d1, 'db-1', {
+      source: src,
+      apiKey: 'k',
+      accountId: 'acct',
+      day: '2026-05-22',
+    })
+    expect(result.ok).toBe(true)
+    expect(result.rowsWritten).toBe(1)
+    expect(d1.calls).toHaveLength(1)
+    const params = d1.calls[0].params
+    expect(params[1]).toBe('composio_actions')
+    expect(params[3]).toBe(75) // total actions
+  })
+
+  it('returns ok=false when source throws', async () => {
+    const d1 = new FakeD1()
+    const src = new FakeComposio([], new Error('HTTP 500'))
+    const result = await ingestComposio(d1, 'db-1', {
+      source: src,
+      apiKey: 'k',
+      accountId: 'acct',
+      day: '2026-05-22',
+    })
+    expect(result.ok).toBe(false)
+    expect(d1.calls).toHaveLength(0)
+  })
+})
+
+describe('runIngestForCustomer', () => {
+  it('skips composio when not configured', async () => {
+    const d1 = new FakeD1()
+    const ctx: CustomerIngestContext = {
+      customerSlug: 'acme',
+      perCustomerDatabaseId: 'db-acme',
+      anthropicApiKey: 'k',
+    }
+    const result = await runIngestForCustomer(
+      ctx,
+      d1,
+      new FakeAnthropic([{ model: 'claude-opus-4-7', inputTokens: 100, outputTokens: 200 }]),
+      new FakeComposio([{ toolkit: 'gmail', actionCount: 50 }]),
+      '2026-05-22'
+    )
+    const sourceNames = result.sources.map((s) => s.source)
+    expect(sourceNames).toContain('anthropic_billing')
+    expect(sourceNames).not.toContain('composio_usage')
+  })
+
+  it('anthropic failure does not block composio', async () => {
+    const d1 = new FakeD1()
+    const ctx: CustomerIngestContext = {
+      customerSlug: 'acme',
+      perCustomerDatabaseId: 'db-acme',
+      anthropicApiKey: 'k',
+      composioApiKey: 'ck',
+      composioAccountId: 'acct-1',
+    }
+    const result = await runIngestForCustomer(
+      ctx,
+      d1,
+      new FakeAnthropic([], new Error('HTTP 503')),
+      new FakeComposio([{ toolkit: 'gmail', actionCount: 100 }]),
+      '2026-05-22'
+    )
+    const byName = Object.fromEntries(result.sources.map((s) => [s.source, s]))
+    expect(byName.anthropic_billing.ok).toBe(false)
+    expect(byName.composio_usage.ok).toBe(true)
+    expect(byName.composio_usage.rowsWritten).toBe(1)
+    expect(result.anyFailures).toBe(true)
+  })
+})

--- a/workers/cost-telemetry/src/ingest.ts
+++ b/workers/cost-telemetry/src/ingest.ts
@@ -1,0 +1,284 @@
+/**
+ * Per-customer cost telemetry ingest — TS twin of
+ * `ai-employee/adapter/cost_ingest.py`.
+ *
+ * Pulls yesterday's Anthropic + Composio usage and UPSERTs into the
+ * customer's per-customer cost_telemetry D1 table via the Cloudflare
+ * D1 HTTP API. Per ADR 0009 each customer has their own D1 database
+ * — there is no cross-customer table — so the worker addresses each
+ * customer's database id resolved from the central `customer_configs`.
+ *
+ * Failure isolation: a single source failing (Anthropic 503, Composio
+ * 500) does NOT block the other source. The result names each source's
+ * outcome so the cron summary can surface partial-success days.
+ *
+ * Source-of-truth references:
+ *   docs/specs/ai-employee/cost-telemetry-events.md
+ *   ai-employee/adapter/cost_ingest.py
+ */
+
+import { computeAnthropicCents, computeComposioCents } from './pricing'
+
+export interface AnthropicUsageRow {
+  model: string
+  inputTokens: number
+  outputTokens: number
+}
+
+export interface ComposioUsageRow {
+  toolkit: string
+  actionCount: number
+}
+
+export interface AnthropicSource {
+  fetchDailyUsage(apiKey: string, day: string): Promise<AnthropicUsageRow[]>
+}
+
+export interface ComposioSource {
+  fetchDailyUsage(apiKey: string, accountId: string, day: string): Promise<ComposioUsageRow[]>
+}
+
+/** Minimal D1 HTTP API shape used here. */
+export interface D1HttpClient {
+  execute(databaseId: string, sql: string, params: unknown[]): Promise<void>
+}
+
+export interface SourceResult {
+  source: string
+  ok: boolean
+  rowsWritten: number
+  centsWritten: number
+  reason?: string
+}
+
+export interface CustomerIngestResult {
+  customerSlug: string
+  day: string
+  sources: SourceResult[]
+  anyFailures: boolean
+  totalCents: number
+}
+
+const UPSERT_SQL =
+  'INSERT INTO cost_telemetry (date, driver, amount_cents, units, unit_type) ' +
+  'VALUES (?, ?, ?, ?, ?) ' +
+  'ON CONFLICT (date, driver) DO UPDATE SET ' +
+  '  amount_cents = amount_cents + excluded.amount_cents, ' +
+  '  units = units + excluded.units'
+
+interface UpsertRow {
+  dayStr: string
+  driver: string
+  amountCents: number
+  units: number
+  unitType: string
+}
+
+async function upsertRow(d1: D1HttpClient, databaseId: string, row: UpsertRow): Promise<void> {
+  await d1.execute(databaseId, UPSERT_SQL, [
+    row.dayStr,
+    row.driver,
+    row.amountCents,
+    row.units,
+    row.unitType,
+  ])
+}
+
+export async function ingestAnthropic(
+  d1: D1HttpClient,
+  databaseId: string,
+  source: AnthropicSource,
+  apiKey: string,
+  day: string
+): Promise<SourceResult> {
+  let rows: AnthropicUsageRow[]
+  try {
+    rows = await source.fetchDailyUsage(apiKey, day)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    console.warn(`anthropic_billing fetch failed for ${day}: ${msg}`)
+    return {
+      source: 'anthropic_billing',
+      ok: false,
+      rowsWritten: 0,
+      centsWritten: 0,
+      reason: `fetch failed: ${msg}`,
+    }
+  }
+
+  let totalInTokens = 0
+  let totalOutTokens = 0
+  let totalInCents = 0
+  let totalOutCents = 0
+  const warnings: string[] = []
+
+  for (const row of rows) {
+    const { inputCents, outputCents, warning } = computeAnthropicCents(
+      row.model,
+      row.inputTokens,
+      row.outputTokens
+    )
+    if (warning) {
+      warnings.push(warning)
+      console.warn(warning)
+    }
+    totalInTokens += row.inputTokens
+    totalOutTokens += row.outputTokens
+    totalInCents += inputCents
+    totalOutCents += outputCents
+  }
+
+  let rowsWritten = 0
+  if (totalInTokens > 0) {
+    await upsertRow(d1, databaseId, {
+      dayStr: day,
+      driver: 'claude_api_input_tokens',
+      amountCents: totalInCents,
+      units: totalInTokens,
+      unitType: 'input_tokens',
+    })
+    rowsWritten++
+  }
+  if (totalOutTokens > 0) {
+    await upsertRow(d1, databaseId, {
+      dayStr: day,
+      driver: 'claude_api_output_tokens',
+      amountCents: totalOutCents,
+      units: totalOutTokens,
+      unitType: 'output_tokens',
+    })
+    rowsWritten++
+  }
+
+  return {
+    source: 'anthropic_billing',
+    ok: true,
+    rowsWritten,
+    centsWritten: totalInCents + totalOutCents,
+    reason: warnings.length ? warnings.join('; ') : undefined,
+  }
+}
+
+export interface ComposioIngestArgs {
+  source: ComposioSource
+  apiKey: string
+  accountId: string
+  day: string
+}
+
+export async function ingestComposio(
+  d1: D1HttpClient,
+  databaseId: string,
+  args: ComposioIngestArgs
+): Promise<SourceResult> {
+  const { source, apiKey, accountId, day } = args
+  let rows: ComposioUsageRow[]
+  try {
+    rows = await source.fetchDailyUsage(apiKey, accountId, day)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    console.warn(`composio_usage fetch failed for ${day}: ${msg}`)
+    return {
+      source: 'composio_usage',
+      ok: false,
+      rowsWritten: 0,
+      centsWritten: 0,
+      reason: `fetch failed: ${msg}`,
+    }
+  }
+
+  let totalActions = 0
+  let totalCents = 0
+  for (const row of rows) {
+    totalActions += row.actionCount
+    totalCents += computeComposioCents(row.toolkit, row.actionCount)
+  }
+
+  let rowsWritten = 0
+  if (totalActions > 0) {
+    await upsertRow(d1, databaseId, {
+      dayStr: day,
+      driver: 'composio_actions',
+      amountCents: totalCents,
+      units: totalActions,
+      unitType: 'api_calls',
+    })
+    rowsWritten = 1
+  }
+
+  return {
+    source: 'composio_usage',
+    ok: true,
+    rowsWritten,
+    centsWritten: totalCents,
+  }
+}
+
+export interface CustomerIngestContext {
+  customerSlug: string
+  perCustomerDatabaseId: string
+  anthropicApiKey: string
+  composioApiKey?: string
+  composioAccountId?: string
+}
+
+export async function runIngestForCustomer(
+  ctx: CustomerIngestContext,
+  d1: D1HttpClient,
+  anthropicSource: AnthropicSource,
+  composioSource: ComposioSource | null,
+  day: string
+): Promise<CustomerIngestResult> {
+  const sources: SourceResult[] = []
+
+  try {
+    const anth = await ingestAnthropic(
+      d1,
+      ctx.perCustomerDatabaseId,
+      anthropicSource,
+      ctx.anthropicApiKey,
+      day
+    )
+    sources.push(anth)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    console.error(`anthropic ingest crashed for ${ctx.customerSlug}: ${msg}`)
+    sources.push({
+      source: 'anthropic_billing',
+      ok: false,
+      rowsWritten: 0,
+      centsWritten: 0,
+      reason: `unhandled exception: ${msg}`,
+    })
+  }
+
+  if (composioSource && ctx.composioApiKey && ctx.composioAccountId) {
+    try {
+      const comp = await ingestComposio(d1, ctx.perCustomerDatabaseId, {
+        source: composioSource,
+        apiKey: ctx.composioApiKey,
+        accountId: ctx.composioAccountId,
+        day,
+      })
+      sources.push(comp)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      console.error(`composio ingest crashed for ${ctx.customerSlug}: ${msg}`)
+      sources.push({
+        source: 'composio_usage',
+        ok: false,
+        rowsWritten: 0,
+        centsWritten: 0,
+        reason: `unhandled exception: ${msg}`,
+      })
+    }
+  }
+
+  return {
+    customerSlug: ctx.customerSlug,
+    day,
+    sources,
+    anyFailures: sources.some((s) => !s.ok),
+    totalCents: sources.reduce((sum, s) => sum + s.centsWritten, 0),
+  }
+}

--- a/workers/cost-telemetry/src/pricing.ts
+++ b/workers/cost-telemetry/src/pricing.ts
@@ -1,0 +1,59 @@
+/**
+ * Pricing JSON references for the cost telemetry worker.
+ *
+ * Source of truth is the JSON files at
+ * `ai-employee/adapter/cost_telemetry/`. The Python ingest module
+ * loads them at runtime; the TS worker can't read files in a Worker
+ * runtime, so the JSON shapes are imported here. Keep these in sync
+ * with the JSON files — the unit tests assert structural parity.
+ */
+
+import anthropicJson from '../../../ai-employee/adapter/cost_telemetry/anthropic_pricing.json'
+import composioJson from '../../../ai-employee/adapter/cost_telemetry/composio_pricing.json'
+
+export interface AnthropicModelPricing {
+  input_per_million_cents: number
+  output_per_million_cents: number
+}
+
+export interface AnthropicPricing {
+  models: Record<string, AnthropicModelPricing>
+}
+
+export interface ComposioPricing {
+  default_per_action_cents: number
+  toolkit_overrides: Record<string, number>
+}
+
+export const anthropicPricing: AnthropicPricing = anthropicJson
+export const composioPricing: ComposioPricing = composioJson
+
+export function computeAnthropicCents(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  pricing: AnthropicPricing = anthropicPricing
+): { inputCents: number; outputCents: number; warning: string | null } {
+  const entry = pricing.models[model]
+  if (!entry) {
+    return {
+      inputCents: 0,
+      outputCents: 0,
+      warning: `model ${model} not in anthropic_pricing.json; wrote tokens with amount_cents=0`,
+    }
+  }
+  const inputCents = Math.floor((inputTokens * entry.input_per_million_cents) / 1_000_000)
+  const outputCents = Math.floor((outputTokens * entry.output_per_million_cents) / 1_000_000)
+  return { inputCents, outputCents, warning: null }
+}
+
+export function computeComposioCents(
+  toolkit: string,
+  actionCount: number,
+  pricing: ComposioPricing = composioPricing
+): number {
+  const overrides = pricing.toolkit_overrides ?? {}
+  const perAction =
+    typeof overrides[toolkit] === 'number' ? overrides[toolkit] : pricing.default_per_action_cents
+  return actionCount * perAction
+}

--- a/workers/cost-telemetry/tsconfig.json
+++ b/workers/cost-telemetry/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/cost-telemetry/vitest.config.ts
+++ b/workers/cost-telemetry/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/workers/cost-telemetry/wrangler.toml
+++ b/workers/cost-telemetry/wrangler.toml
@@ -1,0 +1,43 @@
+# Cost Telemetry Worker — nightly cost-driver ingest for AI Employee
+# Per docs/specs/ai-employee/cost-telemetry-events.md "Nightly Captain job".
+#
+# The worker iterates every active AI Employee customer once per day at
+# 02:00 UTC. For each customer it pulls yesterday's Anthropic token usage
+# and Composio action usage, computes cents via the hardcoded pricing
+# JSON files at ai-employee/adapter/cost_telemetry/, and UPSERTs one or
+# more rows into the customer's per-customer cost_telemetry D1 table.
+#
+# The per-customer D1 database id is read from the central
+# customer_configs table (column lookup in src/index.ts). Per ADR 0009,
+# every customer has their own D1 database — there is no cross-customer
+# cost_telemetry table.
+#
+# Cloudflare D1/R2/Vectorize metering is deferred to phase 2 per the
+# validation-spike result documented in ai-employee/adapter/cost_ingest.py.
+# Token cost dominates the COGS surface; the missing source does not
+# block the §17.1 COGS/MRR kill criterion in v1.
+
+name = "ss-cost-telemetry"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Same central D1 database as ss-web — needed to enumerate customers
+# from customer_configs.
+[[d1_databases]]
+binding = "DB"
+database_name = "ss-console-db"
+database_id = "65171b23-d615-42a7-84e7-a4fac20d063c"
+
+# 02:00 UTC daily — matches the nightly cadence in cost-telemetry-events.md.
+[triggers]
+crons = ["0 2 * * *"]
+
+# Secrets (set via `wrangler secret put` after first deploy):
+#   CF_ACCOUNT_ID       — Cloudflare account id for per-customer D1 HTTP API
+#   CF_D1_API_TOKEN     — Token with D1:Edit scope across customer DBs
+#   ANTHROPIC_API_KEY   — Org-level key (per-customer keys would shift to
+#                         a per-customer secret lookup; v1 uses the org key
+#                         since billing rolls up at the org level)
+#   COMPOSIO_API_KEY    — Org-level Composio key for the usage API
+#   COST_INGEST_BEARER  — Bearer token for manual /run invocations


### PR DESCRIPTION
Implements the §15.1 cost-driver pipeline so per-customer per-day COGS becomes queryable. This unblocks the §17.1 COGS/MRR ≤40% kill criterion and is a prerequisite for the wave-4 cost dashboard (#885).

Closes #824.

## What's in this PR

### Python adapter (`ai-employee/adapter/cost_ingest.py`)

- Two ingest entry points: `ingest_anthropic_billing()` (per-model token usage → `claude_api_input_tokens` / `claude_api_output_tokens` rows) and `ingest_composio_usage()` (per-toolkit action counts → `composio_actions` row).
- `run_ingest_for_customer()` orchestrates both for a single customer. A failure in one source does NOT block the other — failures land in `IngestRunResult.sources[i].ok=False` with the reason preserved.
- Stub-injectable `AnthropicBillingSource` / `ComposioUsageSource` protocols mirror the `cost_rollup.py` test-seam pattern.
- Per ADR 0009: the executor is per-customer; there is no cross-customer column.

### TS twin (`workers/cost-telemetry/`)

- Cloudflare Worker on `0 2 * * *` cron — same cadence the spec prescribes.
- Iterates active customers from `customer_configs`, addresses each customer's D1 database via the D1 HTTP API, calls Anthropic + Composio APIs, UPSERTs rows.
- Fetch handler `?day=YYYY-MM-DD` (bearer-gated) for manual backfill / debugging.

### Pricing JSON (`ai-employee/adapter/cost_telemetry/`)

- `composio_pricing.json` — per the resolved decision in `cost-telemetry-events.md`, hardcoded per-toolkit cents-per-action with a default. Composio does not publish per-action pricing via API.
- `anthropic_pricing.json` — cents per million tokens per model. Matches the existing reference in cost-telemetry-events.md §"Per-call emission (Claude API)".

### Tests

- 18 Python tests in `ai-employee/adapter/tests/test_cost_ingest.py`
- 12 TS tests in `workers/cost-telemetry/src/ingest.test.ts`
- All pass under `npm run verify` (including `typecheck:workers` and `test:workers`).

## Validation spike outcome (per #824 AC)

The spec's "Resolved decisions" section directed a live validation of Cloudflare GraphQL Analytics for D1/R2/Vectorize metering. **Outcome:** the endpoint exposes account-aggregate counters but does not, at the level of access we have, partition per-resource (per individual D1 / R2 bucket / Vectorize index) in a shape that attributes cost to a single customer-namespaced resource. Account aggregation would conflate every customer's usage, violating the §15.1 per-customer attribution contract.

Per the cost-telemetry-events.md fallback clause ("if GraphQL Analytics access turns out to be unworkable…defer D1 cost-driver instrumentation to phase 2 — Anthropic API tokens dominate the COGS surface"), D1 / R2 / Vectorize ingests are deferred. The defer is documented at the top of `cost_ingest.py` under "Validation spike". A phase-2 follow-on can drop in a third `ingest_cloudflare_metrics()` with the same shape; no other module needs to change.

## Acceptance criteria (from #824)

- [x] Billing data pulled daily and stored to D1 — Anthropic + Composio. CF metering deferred (spike outcome documented).
- [x] Per-customer cost attribution working against the event spec (#804) — driver names + UPSERT semantics match cost-telemetry-events.md.
- [ ] Dashboard surface accessible to Captain only (admin auth) — out of scope for #824; tracked under wave-4 #885.
- [ ] Anomaly alert wired to Captain notification channel — out of scope for #824; the rollup primitive is shipped in `cost_rollup.py` already, the alert wiring belongs to the dashboard work.
- [ ] 30-day rolling cost view per customer — same as above, dashboard concern.

The data-path bullets (1-2) are in scope here; bullets 3-5 are the dashboard surface in #885 which is the wave-4 work this PR unblocks.

## Test plan

- [x] `npm run verify` green locally
- [x] `npm run test:workers` includes cost-telemetry (12 tests pass)
- [x] `python3 -m pytest ai-employee/adapter/tests/test_cost_ingest.py` (18 tests pass)
- [x] `npm run typecheck:workers` covers `workers/cost-telemetry/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)