### PR TITLE
feat(ai-employee): per-user invite flow + audit + member listing (#880)

### DIFF
--- a/src/lib/portal/ai-employee/rbac-audit.ts
+++ b/src/lib/portal/ai-employee/rbac-audit.ts
@@ -1,0 +1,159 @@
+/**
+ * RBAC audit emission for AI Employee user-management actions.
+ *
+ * Every state-changing identity event on the AI Employee Users page
+ * emits a structured `audit:rbac_event` log line. The shape mirrors
+ * `recordSendApprovedAudit` / `recordCustomerYamlUpdateAudit` (PR #960
+ * and PR #877) so the same Hermes-side tail-log drain that will
+ * persist those to the per-customer audit_log (#821 + #891) will
+ * persist these too without a new ingestion path.
+ *
+ * Per #880 AC: "Audit log captures every user-management event."
+ * Today the portal Worker cannot bind to the per-customer Hermes D1
+ * (the bridge tracked in #821 has not landed), so the audit row's
+ * destination is the Worker tail logs. The line prefix and JSON shape
+ * are stable; when the bridge lands, only the destination changes.
+ *
+ * RBAC action vocabulary mirrored from
+ * `ai-employee/adapter/audit_log.py::ACCEPTED_ACTION_TYPES` (the
+ * `RBAC_EVENT` class). The viewer-side constant lives in
+ * `src/lib/portal/ai-employee/audit.ts`; both reference the same
+ * writer-side spec.
+ *
+ * Token material is NEVER included in audit events. Only the metadata
+ * fields below.
+ */
+
+/**
+ * Sub-classes of RBAC_EVENT this writer emits today. The audit_log
+ * column is the broader `RBAC_EVENT`; this nested `subAction` is
+ * persisted in the row's metadata so a reviewer can tell a grant from
+ * a revoke from an invite.
+ *
+ *   role_granted   — Principal granted a product role to a user
+ *   role_revoked   — Principal revoked a product role from a user
+ *   invite_sent    — Principal sent a Clerk Organization invitation
+ */
+export type RbacSubAction = 'role_granted' | 'role_revoked' | 'invite_sent'
+
+export const RBAC_SUB_ACTIONS: readonly RbacSubAction[] = [
+  'role_granted',
+  'role_revoked',
+  'invite_sent',
+] as const
+
+/**
+ * Common header for every RBAC audit event. The viewer's `AuditEntry`
+ * shape (src/lib/portal/ai-employee/audit.ts) consumes these as
+ * `action='RBAC_EVENT'`, `actor`, `actorRole='principal'`, and
+ * `decision='allow'`. The customer_id maps to the per-customer audit_log
+ * routing key.
+ */
+export interface RbacAuditEventBase {
+  type: 'audit:rbac_event'
+  subAction: RbacSubAction
+  customer_id: string
+  product_slug: string
+  actorUserId: string
+  actorClerkUserId: string | null
+  actorEmail: string
+  timestamp: string
+}
+
+export interface RoleGrantedAuditEvent extends RbacAuditEventBase {
+  subAction: 'role_granted'
+  targetUserId: string
+  targetEmail: string
+  role: string
+}
+
+export interface RoleRevokedAuditEvent extends RbacAuditEventBase {
+  subAction: 'role_revoked'
+  targetUserId: string
+  targetEmail: string
+  role: string
+}
+
+export interface InviteSentAuditEvent extends RbacAuditEventBase {
+  subAction: 'invite_sent'
+  inviteeEmail: string
+  clerkOrgId: string
+  clerkInvitationId: string
+}
+
+export type RbacAuditEvent = RoleGrantedAuditEvent | RoleRevokedAuditEvent | InviteSentAuditEvent
+
+export interface BuildRoleEventInput {
+  subAction: 'role_granted' | 'role_revoked'
+  customer_id: string
+  product_slug: string
+  actorUserId: string
+  actorClerkUserId: string | null
+  actorEmail: string
+  targetUserId: string
+  targetEmail: string
+  role: string
+  now?: Date
+}
+
+export function buildRoleAuditEvent(
+  input: BuildRoleEventInput
+): RoleGrantedAuditEvent | RoleRevokedAuditEvent {
+  const timestamp = (input.now ?? new Date()).toISOString()
+  return {
+    type: 'audit:rbac_event',
+    subAction: input.subAction,
+    customer_id: input.customer_id,
+    product_slug: input.product_slug,
+    actorUserId: input.actorUserId,
+    actorClerkUserId: input.actorClerkUserId,
+    actorEmail: input.actorEmail,
+    targetUserId: input.targetUserId,
+    targetEmail: input.targetEmail,
+    role: input.role,
+    timestamp,
+  }
+}
+
+export interface BuildInviteEventInput {
+  customer_id: string
+  product_slug: string
+  actorUserId: string
+  actorClerkUserId: string | null
+  actorEmail: string
+  inviteeEmail: string
+  clerkOrgId: string
+  clerkInvitationId: string
+  now?: Date
+}
+
+export function buildInviteAuditEvent(input: BuildInviteEventInput): InviteSentAuditEvent {
+  const timestamp = (input.now ?? new Date()).toISOString()
+  return {
+    type: 'audit:rbac_event',
+    subAction: 'invite_sent',
+    customer_id: input.customer_id,
+    product_slug: input.product_slug,
+    actorUserId: input.actorUserId,
+    actorClerkUserId: input.actorClerkUserId,
+    actorEmail: input.actorEmail,
+    inviteeEmail: input.inviteeEmail,
+    clerkOrgId: input.clerkOrgId,
+    clerkInvitationId: input.clerkInvitationId,
+    timestamp,
+  }
+}
+
+/**
+ * Emit a single RBAC audit line. Mirrors the
+ * `recordSendApprovedAudit` / `recordCustomerYamlUpdateAudit`
+ * contract: single `console.info` with a JSON-serialized payload
+ * whose `type` field is stable for the tail-log drain.
+ *
+ * Async to match the eventual bridge shape so callers stay stable
+ * when #821 lands. The Promise.resolve keeps the body sync today.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function recordRbacAuditEvent(event: RbacAuditEvent): Promise<void> {
+  console.info(JSON.stringify(event))
+}

--- a/src/lib/portal/clerk-org-members.ts
+++ b/src/lib/portal/clerk-org-members.ts
@@ -1,0 +1,243 @@
+/**
+ * Clerk Organization member + pending-invitation reader.
+ *
+ * The Users page (`/portal/products/ai-employee/settings/users`)
+ * displays one row per local users record that has a granted role.
+ * Without this helper, members who have been invited but not yet
+ * signed in (and therefore haven't JIT-created their local users row
+ * via the bridge — see `clerk-bridge.ts`) are invisible. Principals
+ * see a stale picture of "who's on this account": invited members
+ * disappear into limbo until first sign-in.
+ *
+ * This module reads the per-organization membership list AND the
+ * pending-invitation list from Clerk's Backend API, normalizes both
+ * into a shared shape, and merges them. The Users page renders the
+ * merged list so principals can see invited-but-not-signed-in members
+ * alongside fully-onboarded ones.
+ *
+ * What this does NOT do: it does not grant product roles to invitees
+ * before they sign in. Product roles (principal / operator /
+ * compliance) are stored in `product_roles` keyed by local users.id,
+ * which doesn't exist until the JIT bridge creates the row. Granting
+ * roles pre-sign-in is a future slice (carried in the invite's
+ * private_metadata, applied by a Clerk webhook on first sign-in).
+ *
+ * Errors from Clerk (network, auth) are caught and converted to an
+ * empty list. The Users page falls back gracefully — the local
+ * member list still renders. A console error records the failure so
+ * tail-log alerting can surface it.
+ */
+
+import type { APIContext } from 'astro'
+import { clerkClient } from '@clerk/astro/server'
+
+/**
+ * One Clerk-side participant in an organization. Discriminated by
+ * `kind` so the Users page can render members and pending invitees
+ * with different affordances (members get role grant/revoke buttons;
+ * pending invitees get "invitation sent on …" metadata only).
+ *
+ * Field semantics:
+ *   email          — Primary email on record at Clerk.
+ *   name           — Best-effort display name. Empty string when
+ *                    Clerk has no first/last name and the email is
+ *                    the only identifier. Caller chooses how to fall
+ *                    back (typically `name || email`).
+ *   clerkUserId    — Clerk user ID for accepted members; null for
+ *                    pending invitations.
+ *   role           — Clerk Organization role (`org:admin`,
+ *                    `org:member`, ...). Verbatim from Clerk.
+ *   joinedAt       — ISO timestamp the member joined the org (members
+ *                    only) or null for pending invitations.
+ *   invitedAt      — ISO timestamp the invitation was sent (pending
+ *                    invitations only) or null for members.
+ *   expiresAt      — Pending-invitation expiry (ISO). null for
+ *                    members and for invitations Clerk did not set
+ *                    expiry on.
+ */
+export type ClerkOrgParticipant = ClerkOrgMember | ClerkOrgPendingInvite
+
+export interface ClerkOrgMember {
+  kind: 'member'
+  email: string
+  name: string
+  clerkUserId: string
+  role: string
+  joinedAt: string | null
+  invitedAt: null
+  expiresAt: null
+}
+
+export interface ClerkOrgPendingInvite {
+  kind: 'pending_invite'
+  email: string
+  name: ''
+  clerkUserId: null
+  role: string
+  joinedAt: null
+  invitedAt: string | null
+  expiresAt: string | null
+}
+
+/**
+ * Page-cap for the Clerk API call. The principal-managed customer
+ * size is small (< 50 paralegals + compliance) so a single page is
+ * enough to render the whole list. If a customer ever exceeds this
+ * we surface the truncation in the UI (the page checks the result
+ * shape's `truncated` flag).
+ */
+export const CLERK_ORG_PARTICIPANT_PAGE_LIMIT = 100
+
+export interface ClerkOrgParticipantsResult {
+  members: readonly ClerkOrgMember[]
+  pendingInvites: readonly ClerkOrgPendingInvite[]
+  /**
+   * True when the Clerk-side member or invitation list exceeded
+   * CLERK_ORG_PARTICIPANT_PAGE_LIMIT and the result is incomplete.
+   * The Users page renders a small notice when set so principals
+   * know they're seeing a partial list.
+   */
+  truncated: boolean
+  /**
+   * True when the Clerk API call failed entirely. The page renders
+   * the local member list only and surfaces a small notice that
+   * pending invitations couldn't be loaded. Differentiates a clean
+   * "no pending invites" empty state from "we couldn't reach Clerk".
+   */
+  failed: boolean
+}
+
+/**
+ * Normalize a single Clerk OrganizationMembership into our shape.
+ * Exported so unit tests can exercise the projection without a
+ * Clerk mock.
+ */
+export function projectClerkMember(input: {
+  publicUserData?: {
+    userId?: string | null
+    identifier?: string | null
+    firstName?: string | null
+    lastName?: string | null
+  } | null
+  role: string
+  createdAt: number | null
+}): ClerkOrgMember | null {
+  const userId = input.publicUserData?.userId ?? null
+  const email = input.publicUserData?.identifier ?? null
+  if (userId === null || email === null) return null
+  const first = input.publicUserData?.firstName ?? ''
+  const last = input.publicUserData?.lastName ?? ''
+  const name = `${first} ${last}`.trim()
+  return {
+    kind: 'member',
+    email,
+    name,
+    clerkUserId: userId,
+    role: input.role,
+    joinedAt: input.createdAt !== null ? new Date(input.createdAt).toISOString() : null,
+    invitedAt: null,
+    expiresAt: null,
+  }
+}
+
+/**
+ * Normalize a Clerk OrganizationInvitation into our shape. Exported
+ * for unit tests. Only invitations whose `status === 'pending'` are
+ * surfaced — accepted invitations are already represented as
+ * members, and revoked / expired invitations are noise.
+ */
+export function projectClerkPendingInvite(input: {
+  emailAddress: string
+  role: string
+  status?: string | null
+  createdAt: number | null
+  expiresAt: number | null
+}): ClerkOrgPendingInvite | null {
+  if (input.status !== 'pending') return null
+  return {
+    kind: 'pending_invite',
+    email: input.emailAddress,
+    name: '',
+    clerkUserId: null,
+    role: input.role,
+    joinedAt: null,
+    invitedAt: input.createdAt !== null ? new Date(input.createdAt).toISOString() : null,
+    expiresAt: input.expiresAt !== null ? new Date(input.expiresAt).toISOString() : null,
+  }
+}
+
+/**
+ * Drop pending invitations whose email matches an already-joined
+ * member. Clerk leaves the invitation row in the "accepted" status
+ * after acceptance, but a fresh "pending" invitation for the same
+ * email is possible if the principal re-invites someone who left
+ * and came back; the joined record always wins to avoid a confusing
+ * double-row in the UI.
+ */
+export function dedupePendingAgainstMembers(
+  pending: readonly ClerkOrgPendingInvite[],
+  members: readonly ClerkOrgMember[]
+): ClerkOrgPendingInvite[] {
+  const joinedEmails = new Set(members.map((m) => m.email.toLowerCase()))
+  return pending.filter((inv) => !joinedEmails.has(inv.email.toLowerCase()))
+}
+
+/**
+ * Read the org's member list + pending-invitation list and merge them.
+ * Network and auth errors are caught — the function never throws.
+ * Callers see a `failed: true` result instead so the Users page can
+ * keep rendering the local member list.
+ */
+export async function listClerkOrgParticipants(
+  context: APIContext,
+  clerkOrgId: string
+): Promise<ClerkOrgParticipantsResult> {
+  try {
+    const client = clerkClient(context)
+
+    const [membershipPage, invitationPage] = await Promise.all([
+      client.organizations.getOrganizationMembershipList({
+        organizationId: clerkOrgId,
+        limit: CLERK_ORG_PARTICIPANT_PAGE_LIMIT,
+      }),
+      client.organizations.getOrganizationInvitationList({
+        organizationId: clerkOrgId,
+        status: ['pending'],
+        limit: CLERK_ORG_PARTICIPANT_PAGE_LIMIT,
+      }),
+    ])
+
+    const members: ClerkOrgMember[] = []
+    for (const m of membershipPage.data) {
+      const projected = projectClerkMember({
+        publicUserData: m.publicUserData ?? null,
+        role: m.role,
+        createdAt: m.createdAt ?? null,
+      })
+      if (projected !== null) members.push(projected)
+    }
+
+    const pendingRaw: ClerkOrgPendingInvite[] = []
+    for (const inv of invitationPage.data) {
+      const projected = projectClerkPendingInvite({
+        emailAddress: inv.emailAddress,
+        role: inv.role,
+        status: inv.status ?? null,
+        createdAt: inv.createdAt ?? null,
+        expiresAt: inv.expiresAt ?? null,
+      })
+      if (projected !== null) pendingRaw.push(projected)
+    }
+    const pendingInvites = dedupePendingAgainstMembers(pendingRaw, members)
+
+    const truncated =
+      membershipPage.totalCount > CLERK_ORG_PARTICIPANT_PAGE_LIMIT ||
+      invitationPage.totalCount > CLERK_ORG_PARTICIPANT_PAGE_LIMIT
+
+    return { members, pendingInvites, truncated, failed: false }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error('Clerk org participants fetch failed', { clerkOrgId, message })
+    return { members: [], pendingInvites: [], truncated: false, failed: true }
+  }
+}

--- a/src/pages/api/portal/products/ai-employee/invitations.ts
+++ b/src/pages/api/portal/products/ai-employee/invitations.ts
@@ -4,6 +4,10 @@ import { getPortalClient } from '../../../../../lib/portal/session'
 import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
 import type { PortalUserRow } from '../../../../../lib/auth/clerk-bridge'
 import type { Entity } from '../../../../../lib/db/entities'
+import {
+  buildInviteAuditEvent,
+  recordRbacAuditEvent,
+} from '../../../../../lib/portal/ai-employee/rbac-audit'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -32,6 +36,11 @@ import { env } from 'cloudflare:workers'
  * 'org:member'. Org-admin Clerk role is reserved for SMD-side
  * accounts. Product roles (principal | operator | compliance) are a
  * separate axis managed via role-action.ts after the invitee accepts.
+ *
+ * Audit: every successful invitation emits an `audit:rbac_event` log
+ * line with `subAction: 'invite_sent'` via `recordRbacAuditEvent`.
+ * Failed invitations (validation, Clerk rejection, duplicate) are not
+ * audited — nothing was sent to the invitee.
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -98,14 +107,16 @@ export const POST: APIRoute = async (context: APIContext) => {
   if (!email) return redirectWithStatus('invalid_email')
 
   const redirectUrl = `${new URL(context.request.url).origin}/portal/products/ai-employee`
+  let invitationId: string
   try {
-    await clerkClient(context).organizations.createOrganizationInvitation({
+    const invitation = await clerkClient(context).organizations.createOrganizationInvitation({
       organizationId: ctx.client.clerk_org_id,
       emailAddress: email,
       role: 'org:member',
       inviterUserId: ctx.user.clerk_user_id,
       redirectUrl,
     })
+    invitationId = invitation.id
   } catch (err) {
     // Clerk's typed errors: duplicate, already-member, etc. We don't
     // surface raw Clerk error codes to the principal. Instead map a
@@ -117,6 +128,19 @@ export const POST: APIRoute = async (context: APIContext) => {
     console.error('Clerk invitation failed', { email, message })
     return redirectWithStatus('invite_failed')
   }
+
+  await recordRbacAuditEvent(
+    buildInviteAuditEvent({
+      customer_id: ctx.client.id,
+      product_slug: PRODUCT_SLUG,
+      actorUserId: ctx.user.id,
+      actorClerkUserId: ctx.user.clerk_user_id,
+      actorEmail: ctx.user.email,
+      inviteeEmail: email,
+      clerkOrgId: ctx.client.clerk_org_id,
+      clerkInvitationId: invitationId,
+    })
+  )
 
   return redirectWithStatus('invited')
 }

--- a/src/pages/api/portal/products/ai-employee/role-action.ts
+++ b/src/pages/api/portal/products/ai-employee/role-action.ts
@@ -9,6 +9,10 @@ import {
 } from '../../../../../lib/portal/product-roles-mutations'
 import type { PortalUserRow } from '../../../../../lib/auth/clerk-bridge'
 import type { Entity } from '../../../../../lib/db/entities'
+import {
+  buildRoleAuditEvent,
+  recordRbacAuditEvent,
+} from '../../../../../lib/portal/ai-employee/rbac-audit'
 import { env } from 'cloudflare:workers'
 
 /**
@@ -32,6 +36,13 @@ import { env } from 'cloudflare:workers'
  *
  * Returns a 303 redirect back to the user-list page with a `status`
  * query param so the page can surface a banner.
+ *
+ * Audit: every successful grant or revoke emits an `audit:rbac_event`
+ * log line via `recordRbacAuditEvent`. No-op cases (idempotent re-grant
+ * of an active role, idempotent re-revoke of an already-revoked role)
+ * are NOT audited — nothing changed. The lock-out self-protection
+ * (`cannot_revoke_last_principal`) is also not audited; it never
+ * mutated state.
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -94,11 +105,15 @@ function parseForm(formData: FormData): ParsedAction | string {
   return { kind: action, targetUserId, role }
 }
 
-async function targetUserExists(userId: string, orgId: string): Promise<boolean> {
-  const row = await env.DB.prepare('SELECT id FROM users WHERE id = ? AND org_id = ?')
+interface TargetUserRow {
+  id: string
+  email: string
+}
+
+async function loadTargetUser(userId: string, orgId: string): Promise<TargetUserRow | null> {
+  return await env.DB.prepare('SELECT id, email FROM users WHERE id = ? AND org_id = ?')
     .bind(userId, orgId)
-    .first<{ id: string }>()
-  return row !== null
+    .first<TargetUserRow>()
 }
 
 /**
@@ -123,7 +138,32 @@ async function isSafeSelfPrincipalRevoke(
   return (row?.n ?? 0) > 0
 }
 
-async function handleRevoke(ctx: AuthorizedContext, parsed: ParsedAction): Promise<Response> {
+async function emitRoleAudit(
+  ctx: AuthorizedContext,
+  parsed: ParsedAction,
+  target: TargetUserRow,
+  subAction: 'role_granted' | 'role_revoked'
+): Promise<void> {
+  await recordRbacAuditEvent(
+    buildRoleAuditEvent({
+      subAction,
+      customer_id: ctx.client.id,
+      product_slug: PRODUCT_SLUG,
+      actorUserId: ctx.user.id,
+      actorClerkUserId: ctx.user.clerk_user_id,
+      actorEmail: ctx.user.email,
+      targetUserId: target.id,
+      targetEmail: target.email,
+      role: parsed.role,
+    })
+  )
+}
+
+async function handleRevoke(
+  ctx: AuthorizedContext,
+  parsed: ParsedAction,
+  target: TargetUserRow
+): Promise<Response> {
   if (!(await isSafeSelfPrincipalRevoke(ctx, parsed))) {
     return redirectWithStatus('cannot_revoke_last_principal')
   }
@@ -133,10 +173,15 @@ async function handleRevoke(ctx: AuthorizedContext, parsed: ParsedAction): Promi
     productSlug: PRODUCT_SLUG,
     role: parsed.role,
   })
+  if (changed) await emitRoleAudit(ctx, parsed, target, 'role_revoked')
   return redirectWithStatus(changed ? 'revoked' : 'no_change')
 }
 
-async function handleGrant(ctx: AuthorizedContext, parsed: ParsedAction): Promise<Response> {
+async function handleGrant(
+  ctx: AuthorizedContext,
+  parsed: ParsedAction,
+  target: TargetUserRow
+): Promise<Response> {
   const changed = await grantProductRole(env.DB, {
     orgId: ctx.orgId,
     userId: parsed.targetUserId,
@@ -145,6 +190,7 @@ async function handleGrant(ctx: AuthorizedContext, parsed: ParsedAction): Promis
     role: parsed.role,
     grantedBy: ctx.user.id,
   })
+  if (changed) await emitRoleAudit(ctx, parsed, target, 'role_granted')
   return redirectWithStatus(changed ? 'granted' : 'no_change')
 }
 
@@ -157,9 +203,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const parsed = parseForm(formData)
   if (typeof parsed === 'string') return redirectWithStatus(parsed)
 
-  if (!(await targetUserExists(parsed.targetUserId, ctx.orgId))) {
+  const target = await loadTargetUser(parsed.targetUserId, ctx.orgId)
+  if (target === null) {
     return redirectWithStatus('user_not_found')
   }
 
-  return parsed.kind === 'revoke' ? handleRevoke(ctx, parsed) : handleGrant(ctx, parsed)
+  return parsed.kind === 'revoke'
+    ? handleRevoke(ctx, parsed, target)
+    : handleGrant(ctx, parsed, target)
 }

--- a/src/pages/portal/products/ai-employee/settings/users.astro
+++ b/src/pages/portal/products/ai-employee/settings/users.astro
@@ -3,6 +3,7 @@ import '../../../../../styles/global.css'
 import { BRAND_NAME } from '../../../../../lib/config/brand'
 import { getPortalClient } from '../../../../../lib/portal/session'
 import { getProductSubscription, listProductRoles } from '../../../../../lib/portal/product-access'
+import { listClerkOrgParticipants } from '../../../../../lib/portal/clerk-org-members'
 import PortalHeader from '../../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../../components/portal/PortalPageHead.astro'
@@ -38,13 +39,24 @@ import { env } from 'cloudflare:workers'
  * Self-protection: server-side, the action endpoint blocks revoking
  * your own LAST principal grant (would lock the customer out).
  *
- * Not yet shipped (next slice):
- *   - Invite-new-member flow (Clerk Organization invitation API)
- *   - Audit-log entries on each role change
- *   - Listing Clerk Organization members who don't yet have a local
- *     users row (so principals can grant roles to invitees who haven't
- *     signed in yet — currently new members appear here only after
- *     their first portal sign-in JIT-creates the local users row).
+ * Invite-new-member flow lives at
+ * `/api/portal/products/ai-employee/invitations` (Clerk Organization
+ * invitation API). After the invitee accepts and signs in for the
+ * first time, the JIT bridge creates their local users row and they
+ * appear in the granted-access list above so the principal can grant
+ * them a role.
+ *
+ * Pending Clerk Organization invitations (sent but not accepted) are
+ * rendered in their own section below the granted-access list so
+ * principals see the full picture of "who's on this account": joined
+ * members + members invited but not yet signed in. Pending invitees
+ * do not have a local users row yet, so they cannot be granted
+ * product roles — that happens after first sign-in.
+ *
+ * Role-management mutations (grant, revoke, invite) emit
+ * `audit:rbac_event` log lines via the rbac-audit module. A
+ * Hermes-side tail-log drain consumes these and persists them to the
+ * per-customer audit_log (drain wiring tracked in #821).
  */
 
 const PRODUCT_SLUG = 'ai-employee'
@@ -142,6 +154,29 @@ function formatLastLogin(iso: string | null): string {
   if (Number.isNaN(d.getTime())) return 'Never'
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
+
+function formatInviteDate(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+// Pending Clerk Organization invitations. The principal needs visibility
+// into who has been invited but not yet signed in. The local member list
+// above only contains users whose first sign-in JIT-created a local users
+// row — pending invitees haven't done that yet. Reading directly from
+// Clerk closes that visibility gap.
+//
+// We surface invites only when the entity is bound to a Clerk Org. If
+// the customer has not been bound yet, there are no invitations to list
+// (the invite form returns `no_clerk_org`). A Clerk failure renders the
+// page without the invitations section but does not break the page —
+// the local members above are the load-bearing surface.
+const clerkParticipants = client.clerk_org_id
+  ? await listClerkOrgParticipants(Astro, client.clerk_org_id)
+  : null
+const pendingInvites = clerkParticipants?.pendingInvites ?? []
 
 // Status banner — set by the role-action and invitations endpoints on redirect.
 const status = Astro.url.searchParams.get('status')
@@ -337,6 +372,71 @@ const banner = status ? (STATUS_BANNERS[status] ?? null) : null
           New team members appear here after they accept their invitation and sign in for the first
           time. Grant them a role with the buttons above once they appear.
         </p>
+      </section>
+
+      <section class="mt-12">
+        <p
+          class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]"
+        >
+          Pending invitations
+          {
+            pendingInvites.length > 0 && (
+              <span class="ml-2 normal-case tracking-normal font-normal text-[color:var(--ss-color-text-muted)]">
+                {pendingInvites.length}
+              </span>
+            )
+          }
+        </p>
+
+        {
+          clerkParticipants?.failed ? (
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6">
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                We could not load pending invitations from Clerk right now. New invitations will
+                still send; refresh in a moment to see them here.
+              </p>
+            </div>
+          ) : pendingInvites.length === 0 ? (
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)] p-6">
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No pending invitations. Invite someone with the form below.
+              </p>
+            </div>
+          ) : (
+            <div class="border-[3px] border-[color:var(--ss-color-text-primary)]">
+              {pendingInvites.map((inv, idx) => (
+                <div
+                  class:list={[
+                    'px-5 py-4 flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-6',
+                    idx > 0 ? 'border-t-[2px] border-[color:var(--ss-color-text-primary)]' : '',
+                  ]}
+                >
+                  <div class="flex flex-col gap-0.5 min-w-0">
+                    <span class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)] truncate">
+                      {inv.email}
+                    </span>
+                    <span class="text-xs text-[color:var(--ss-color-text-muted)]">
+                      Invited {formatInviteDate(inv.invitedAt)}
+                      {inv.expiresAt && <span> · Expires {formatInviteDate(inv.expiresAt)}</span>}
+                    </span>
+                  </div>
+                  <span class="inline-flex items-center px-3 py-1.5 text-xs font-['Archivo_Narrow'] uppercase tracking-[0.12em] font-bold border-[2px] border-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-text-primary)]">
+                    Awaiting sign-in
+                  </span>
+                </div>
+              ))}
+            </div>
+          )
+        }
+
+        {
+          clerkParticipants?.truncated && (
+            <p class="mt-3 text-xs text-[color:var(--ss-color-text-muted)]">
+              Showing the first {pendingInvites.length} invitations. More exist than this page can
+              display.
+            </p>
+          )
+        }
       </section>
 
       <section class="mt-12">

--- a/tests/portal-clerk-org-members.test.ts
+++ b/tests/portal-clerk-org-members.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the Clerk Org member + pending-invitation projector
+ * (src/lib/portal/clerk-org-members.ts).
+ *
+ * Covers:
+ *   - projectClerkMember: full mapping of Clerk membership shape,
+ *     null returns for partial inputs (no userId or no email)
+ *   - projectClerkPendingInvite: only `status === 'pending'` rows
+ *     surface; other statuses (accepted, revoked, expired) drop
+ *     to null so the page never renders stale invitations
+ *   - dedupePendingAgainstMembers: case-insensitive email match;
+ *     joined members always win over a same-email pending row
+ *
+ * The integration with the actual Clerk Backend API (the
+ * `listClerkOrgParticipants` HTTP path) is not exercised here — it
+ * lives in the runtime caller and is verified by the Users page
+ * itself. The pure-projection layer is the load-bearing unit-tested
+ * surface; it's what the page renders.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  dedupePendingAgainstMembers,
+  projectClerkMember,
+  projectClerkPendingInvite,
+  type ClerkOrgMember,
+  type ClerkOrgPendingInvite,
+} from '../src/lib/portal/clerk-org-members'
+
+describe('projectClerkMember', () => {
+  it('maps a fully-populated membership to the member shape', () => {
+    const result = projectClerkMember({
+      publicUserData: {
+        userId: 'clerk_user_alex',
+        identifier: 'alex.paralegal@smithlaw.com',
+        firstName: 'Alex',
+        lastName: 'Reyes',
+      },
+      role: 'org:member',
+      createdAt: Date.parse('2026-05-01T10:00:00.000Z'),
+    })
+
+    expect(result).not.toBeNull()
+    const member = result as ClerkOrgMember
+    expect(member.kind).toBe('member')
+    expect(member.email).toBe('alex.paralegal@smithlaw.com')
+    expect(member.name).toBe('Alex Reyes')
+    expect(member.clerkUserId).toBe('clerk_user_alex')
+    expect(member.role).toBe('org:member')
+    expect(member.joinedAt).toBe('2026-05-01T10:00:00.000Z')
+    expect(member.invitedAt).toBeNull()
+    expect(member.expiresAt).toBeNull()
+  })
+
+  it('returns null when publicUserData has no userId', () => {
+    const result = projectClerkMember({
+      publicUserData: {
+        userId: null,
+        identifier: 'someone@example.com',
+        firstName: 'Someone',
+        lastName: null,
+      },
+      role: 'org:member',
+      createdAt: Date.parse('2026-05-01T10:00:00.000Z'),
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when publicUserData has no email identifier', () => {
+    const result = projectClerkMember({
+      publicUserData: {
+        userId: 'clerk_user_x',
+        identifier: null,
+        firstName: 'No',
+        lastName: 'Email',
+      },
+      role: 'org:member',
+      createdAt: Date.parse('2026-05-01T10:00:00.000Z'),
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('trims whitespace when only first or last name is set', () => {
+    const result = projectClerkMember({
+      publicUserData: {
+        userId: 'clerk_user_x',
+        identifier: 'firstonly@example.com',
+        firstName: 'Jordan',
+        lastName: null,
+      },
+      role: 'org:member',
+      createdAt: null,
+    })
+    expect((result as ClerkOrgMember).name).toBe('Jordan')
+  })
+
+  it('emits empty name when Clerk has neither first nor last name', () => {
+    const result = projectClerkMember({
+      publicUserData: {
+        userId: 'clerk_user_x',
+        identifier: 'noname@example.com',
+        firstName: null,
+        lastName: null,
+      },
+      role: 'org:member',
+      createdAt: null,
+    })
+    expect((result as ClerkOrgMember).name).toBe('')
+  })
+
+  it('returns null joinedAt when createdAt is missing', () => {
+    const result = projectClerkMember({
+      publicUserData: {
+        userId: 'clerk_user_x',
+        identifier: 'x@example.com',
+        firstName: 'X',
+        lastName: 'Y',
+      },
+      role: 'org:member',
+      createdAt: null,
+    })
+    expect((result as ClerkOrgMember).joinedAt).toBeNull()
+  })
+})
+
+describe('projectClerkPendingInvite', () => {
+  it('maps a pending invitation to the pending_invite shape', () => {
+    const result = projectClerkPendingInvite({
+      emailAddress: 'newhire@smithlaw.com',
+      role: 'org:member',
+      status: 'pending',
+      createdAt: Date.parse('2026-05-20T09:00:00.000Z'),
+      expiresAt: Date.parse('2026-06-19T09:00:00.000Z'),
+    })
+
+    expect(result).not.toBeNull()
+    const inv = result as ClerkOrgPendingInvite
+    expect(inv.kind).toBe('pending_invite')
+    expect(inv.email).toBe('newhire@smithlaw.com')
+    expect(inv.name).toBe('')
+    expect(inv.clerkUserId).toBeNull()
+    expect(inv.role).toBe('org:member')
+    expect(inv.joinedAt).toBeNull()
+    expect(inv.invitedAt).toBe('2026-05-20T09:00:00.000Z')
+    expect(inv.expiresAt).toBe('2026-06-19T09:00:00.000Z')
+  })
+
+  it('returns null when the invitation status is accepted', () => {
+    const result = projectClerkPendingInvite({
+      emailAddress: 'joined@example.com',
+      role: 'org:member',
+      status: 'accepted',
+      createdAt: Date.parse('2026-05-20T09:00:00.000Z'),
+      expiresAt: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for revoked and expired invitations', () => {
+    expect(
+      projectClerkPendingInvite({
+        emailAddress: 'revoked@example.com',
+        role: 'org:member',
+        status: 'revoked',
+        createdAt: null,
+        expiresAt: null,
+      })
+    ).toBeNull()
+
+    expect(
+      projectClerkPendingInvite({
+        emailAddress: 'expired@example.com',
+        role: 'org:member',
+        status: 'expired',
+        createdAt: null,
+        expiresAt: null,
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when status is missing entirely', () => {
+    const result = projectClerkPendingInvite({
+      emailAddress: 'unknown@example.com',
+      role: 'org:member',
+      status: null,
+      createdAt: null,
+      expiresAt: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('tolerates a missing expiresAt by surfacing null', () => {
+    const result = projectClerkPendingInvite({
+      emailAddress: 'noexp@example.com',
+      role: 'org:member',
+      status: 'pending',
+      createdAt: Date.parse('2026-05-20T09:00:00.000Z'),
+      expiresAt: null,
+    })
+    expect((result as ClerkOrgPendingInvite).expiresAt).toBeNull()
+  })
+})
+
+describe('dedupePendingAgainstMembers', () => {
+  function makeMember(email: string): ClerkOrgMember {
+    return {
+      kind: 'member',
+      email,
+      name: '',
+      clerkUserId: 'clerk_x',
+      role: 'org:member',
+      joinedAt: null,
+      invitedAt: null,
+      expiresAt: null,
+    }
+  }
+
+  function makeInvite(email: string): ClerkOrgPendingInvite {
+    return {
+      kind: 'pending_invite',
+      email,
+      name: '',
+      clerkUserId: null,
+      role: 'org:member',
+      joinedAt: null,
+      invitedAt: null,
+      expiresAt: null,
+    }
+  }
+
+  it('drops a pending invite whose email matches a joined member', () => {
+    const members = [makeMember('alex@smithlaw.com')]
+    const pending = [makeInvite('alex@smithlaw.com'), makeInvite('newhire@smithlaw.com')]
+    const result = dedupePendingAgainstMembers(pending, members)
+    expect(result).toHaveLength(1)
+    expect(result[0].email).toBe('newhire@smithlaw.com')
+  })
+
+  it('matches emails case-insensitively', () => {
+    const members = [makeMember('Alex@smithlaw.com')]
+    const pending = [makeInvite('ALEX@SMITHLAW.COM')]
+    const result = dedupePendingAgainstMembers(pending, members)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns the input unchanged when there are no overlaps', () => {
+    const members = [makeMember('a@x.com')]
+    const pending = [makeInvite('b@x.com'), makeInvite('c@x.com')]
+    const result = dedupePendingAgainstMembers(pending, members)
+    expect(result).toHaveLength(2)
+    expect(result.map((p) => p.email)).toEqual(['b@x.com', 'c@x.com'])
+  })
+
+  it('returns an empty list when pending is empty', () => {
+    const result = dedupePendingAgainstMembers([], [makeMember('a@x.com')])
+    expect(result).toEqual([])
+  })
+})

--- a/tests/portal-rbac-audit.test.ts
+++ b/tests/portal-rbac-audit.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the RBAC audit emission helper
+ * (src/lib/portal/ai-employee/rbac-audit.ts).
+ *
+ * Covers:
+ *   - buildRoleAuditEvent shape (role_granted, role_revoked) — full
+ *     field set incl. customer_id, actor identity, target identity,
+ *     and ISO timestamp
+ *   - buildInviteAuditEvent shape — Clerk org/invitation IDs
+ *     surfaced; timestamp deterministic when `now` injected
+ *   - recordRbacAuditEvent emission contract — single console.info
+ *     line, `audit:rbac_event` type prefix, JSON-parseable payload
+ *
+ * The Hermes-side tail-log drain (#821) keys on the `type` field, so
+ * the emission contract is load-bearing: a regression that drops the
+ * prefix or changes the JSON shape silently breaks audit ingestion.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  RBAC_SUB_ACTIONS,
+  buildInviteAuditEvent,
+  buildRoleAuditEvent,
+  recordRbacAuditEvent,
+  type InviteSentAuditEvent,
+} from '../src/lib/portal/ai-employee/rbac-audit'
+
+describe('RBAC_SUB_ACTIONS vocabulary', () => {
+  it('contains the three sub-actions the writers emit today', () => {
+    expect(RBAC_SUB_ACTIONS).toContain('role_granted')
+    expect(RBAC_SUB_ACTIONS).toContain('role_revoked')
+    expect(RBAC_SUB_ACTIONS).toContain('invite_sent')
+  })
+
+  it('has no duplicate entries', () => {
+    expect(new Set(RBAC_SUB_ACTIONS).size).toBe(RBAC_SUB_ACTIONS.length)
+  })
+})
+
+describe('buildRoleAuditEvent', () => {
+  const baseInput = {
+    customer_id: 'cust-smith-pi',
+    product_slug: 'ai-employee',
+    actorUserId: 'u-pat-001',
+    actorClerkUserId: 'clerk_user_pat',
+    actorEmail: 'pat.owner@smithlaw.com',
+    targetUserId: 'u-alex-002',
+    targetEmail: 'alex.paralegal@smithlaw.com',
+    role: 'operator',
+    now: new Date('2026-05-23T10:00:00.000Z'),
+  }
+
+  it('builds a role_granted event with the full field set', () => {
+    const event = buildRoleAuditEvent({ ...baseInput, subAction: 'role_granted' })
+
+    expect(event.type).toBe('audit:rbac_event')
+    expect(event.subAction).toBe('role_granted')
+    expect(event.customer_id).toBe('cust-smith-pi')
+    expect(event.product_slug).toBe('ai-employee')
+    expect(event.actorUserId).toBe('u-pat-001')
+    expect(event.actorClerkUserId).toBe('clerk_user_pat')
+    expect(event.actorEmail).toBe('pat.owner@smithlaw.com')
+    expect(event.targetUserId).toBe('u-alex-002')
+    expect(event.targetEmail).toBe('alex.paralegal@smithlaw.com')
+    expect(event.role).toBe('operator')
+    expect(event.timestamp).toBe('2026-05-23T10:00:00.000Z')
+  })
+
+  it('builds a role_revoked event with the same shape and only subAction differs', () => {
+    const granted = buildRoleAuditEvent({ ...baseInput, subAction: 'role_granted' })
+    const revoked = buildRoleAuditEvent({ ...baseInput, subAction: 'role_revoked' })
+
+    expect(revoked.subAction).toBe('role_revoked')
+    expect(revoked.customer_id).toBe(granted.customer_id)
+    expect(revoked.actorUserId).toBe(granted.actorUserId)
+    expect(revoked.targetUserId).toBe(granted.targetUserId)
+    expect(revoked.role).toBe(granted.role)
+    expect(revoked.timestamp).toBe(granted.timestamp)
+  })
+
+  it('tolerates null actorClerkUserId (legacy / pre-bridge users)', () => {
+    const event = buildRoleAuditEvent({
+      ...baseInput,
+      actorClerkUserId: null,
+      subAction: 'role_granted',
+    })
+
+    expect(event.actorClerkUserId).toBeNull()
+    expect(event.actorUserId).toBe('u-pat-001')
+  })
+
+  it('defaults timestamp to now() when not provided', () => {
+    const before = Date.now()
+    const event = buildRoleAuditEvent({
+      ...baseInput,
+      now: undefined,
+      subAction: 'role_granted',
+    })
+    const after = Date.now()
+
+    const ts = Date.parse(event.timestamp)
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+})
+
+describe('buildInviteAuditEvent', () => {
+  it('builds an invite_sent event with Clerk org + invitation IDs', () => {
+    const event: InviteSentAuditEvent = buildInviteAuditEvent({
+      customer_id: 'cust-smith-pi',
+      product_slug: 'ai-employee',
+      actorUserId: 'u-pat-001',
+      actorClerkUserId: 'clerk_user_pat',
+      actorEmail: 'pat.owner@smithlaw.com',
+      inviteeEmail: 'new.hire@smithlaw.com',
+      clerkOrgId: 'org_smith',
+      clerkInvitationId: 'orginv_abc123',
+      now: new Date('2026-05-23T11:00:00.000Z'),
+    })
+
+    expect(event.type).toBe('audit:rbac_event')
+    expect(event.subAction).toBe('invite_sent')
+    expect(event.customer_id).toBe('cust-smith-pi')
+    expect(event.actorEmail).toBe('pat.owner@smithlaw.com')
+    expect(event.inviteeEmail).toBe('new.hire@smithlaw.com')
+    expect(event.clerkOrgId).toBe('org_smith')
+    expect(event.clerkInvitationId).toBe('orginv_abc123')
+    expect(event.timestamp).toBe('2026-05-23T11:00:00.000Z')
+  })
+})
+
+describe('recordRbacAuditEvent — emission contract', () => {
+  it('emits a single console.info line with type=audit:rbac_event', async () => {
+    const lines: string[] = []
+    const original = console.info
+    console.info = ((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '))
+    }) as typeof console.info
+
+    try {
+      await recordRbacAuditEvent(
+        buildRoleAuditEvent({
+          subAction: 'role_granted',
+          customer_id: 'cust-1',
+          product_slug: 'ai-employee',
+          actorUserId: 'u-pat',
+          actorClerkUserId: 'clerk_pat',
+          actorEmail: 'pat@x.com',
+          targetUserId: 'u-alex',
+          targetEmail: 'alex@x.com',
+          role: 'operator',
+          now: new Date('2026-05-23T12:00:00.000Z'),
+        })
+      )
+    } finally {
+      console.info = original
+    }
+
+    expect(lines).toHaveLength(1)
+    const parsed = JSON.parse(lines[0])
+    expect(parsed.type).toBe('audit:rbac_event')
+    expect(parsed.subAction).toBe('role_granted')
+    expect(parsed.customer_id).toBe('cust-1')
+    expect(parsed.role).toBe('operator')
+    expect(parsed.timestamp).toBe('2026-05-23T12:00:00.000Z')
+  })
+
+  it('round-trips invite_sent events through JSON without losing fields', async () => {
+    const lines: string[] = []
+    const original = console.info
+    console.info = ((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '))
+    }) as typeof console.info
+
+    try {
+      await recordRbacAuditEvent(
+        buildInviteAuditEvent({
+          customer_id: 'cust-1',
+          product_slug: 'ai-employee',
+          actorUserId: 'u-pat',
+          actorClerkUserId: null,
+          actorEmail: 'pat@x.com',
+          inviteeEmail: 'hire@x.com',
+          clerkOrgId: 'org_x',
+          clerkInvitationId: 'orginv_x',
+          now: new Date('2026-05-23T12:30:00.000Z'),
+        })
+      )
+    } finally {
+      console.info = original
+    }
+
+    const parsed = JSON.parse(lines[0])
+    expect(parsed.subAction).toBe('invite_sent')
+    expect(parsed.inviteeEmail).toBe('hire@x.com')
+    expect(parsed.clerkOrgId).toBe('org_x')
+    expect(parsed.clerkInvitationId).toBe('orginv_x')
+    expect(parsed.actorClerkUserId).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Completes the three remaining slices on the AI Employee Users page so principals can manage their team end-to-end (closes #880):

1. **RBAC audit emission.** Every successful role grant, role revoke, and invite-sent emits an `audit:rbac_event` log line via the new `rbac-audit` module, mirroring `recordSendApprovedAudit` / `recordCustomerYamlUpdateAudit`. A Hermes-side tail-log drain (tracked in #821) will persist these to the per-customer audit_log.
2. **Clerk Org member + pending-invitation reader.** New `clerk-org-members` module fetches both lists from Clerk's Backend API, normalizes them to a discriminated union, and the Users page renders a Pending Invitations section so principals see invited-but-not-signed-in members alongside fully-onboarded ones. Network/auth failures degrade gracefully — the local member list still renders and a small notice surfaces.
3. **Invite flow** — endpoint already existed; this PR adds audit emission on successful invitation send.

## Acceptance criteria (#880)

- [x] Auth model: customer has many users, each user has a role (pre-existing — `users` × `product_roles`)
- [x] User invite flow (Principal can invite Operators) — Clerk Organization invitation API at `POST /api/portal/products/ai-employee/invitations`
- [x] User management UI (list, add, remove, role change) — Users page + role-action endpoint
- [x] SSO-compatible (Clerk or per existing portal auth) — full Clerk integration
- [x] Audit log captures every user-management event — `audit:rbac_event` lines on grant / revoke / invite_sent

## Files changed

- **NEW** `src/lib/portal/ai-employee/rbac-audit.ts` — RBAC audit event builders + emitter
- **NEW** `src/lib/portal/clerk-org-members.ts` — Clerk member + pending-invitation reader
- **MOD** `src/pages/api/portal/products/ai-employee/role-action.ts` — emit audit on successful grant / revoke
- **MOD** `src/pages/api/portal/products/ai-employee/invitations.ts` — emit audit on successful invite
- **MOD** `src/pages/portal/products/ai-employee/settings/users.astro` — render Pending Invitations section
- **NEW** `tests/portal-rbac-audit.test.ts` — 9 tests covering event builders + emission contract
- **NEW** `tests/portal-clerk-org-members.test.ts` — 15 tests covering projector + dedupe

## Test plan

- [x] `npm run verify` — typecheck, format, lint, build, full test suite (2495 portal tests + worker tests), exit 0
- [x] Unit tests for `rbac-audit` (9) — event shape, null-safe actor fields, emission contract via console.info stub
- [x] Unit tests for `clerk-org-members` (15) — projection of member shape, projection of pending invitation status filter, case-insensitive dedupe of pending-vs-joined
- [ ] Manual: principal sees Pending Invitations section after sending an invite; section disappears once invitee signs in (covered by integration with existing JIT bridge)

## Notes

- The RBAC audit destination is the Worker tail logs today; the Hermes-side audit_log bridge is tracked in #821. The line prefix and JSON shape are stable so the swap is destination-only.
- Granting product roles to pending invitees (pre-sign-in) is intentionally deferred — `product_roles` is keyed by local `users.id` which doesn't exist until the JIT bridge creates it on first sign-in. Pre-assigning via invitation metadata + webhook is a future slice.
- Per-user accounts substrate (`product_roles`, `subscriptions`, `entities.clerk_org_id`) shipped in earlier PRs (#904, #877, #912) — this PR is the user-facing completion.

🤖 Generated with Claude Code