### PR TITLE
feat(ai-employee): Captain-only cost dashboard (#885)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -167,6 +167,20 @@ declare namespace Cloudflare {
      * src/lib/oauth/state.ts.
      */
     OAUTH_STATE_SIGNING_KEY?: string
+    /**
+     * Cloudflare account id and D1 HTTP API token, used by the Captain
+     * cost dashboard (issue #885) to read per-customer `cost_telemetry`
+     * rows over HTTP. Per ADR 0009 each customer has their own D1
+     * database; declaring N per-customer bindings at deploy time does
+     * not scale, so the dashboard goes through the same HTTP path the
+     * `ss-cost-telemetry` worker uses to write those tables.
+     *
+     * The token requires D1:Read scope across customer databases. When
+     * unset the dashboard renders an explicit configuration warning
+     * rather than fabricating zero-cost data.
+     */
+    CF_ACCOUNT_ID?: string
+    CF_D1_API_TOKEN?: string
   }
 }
 

--- a/src/lib/admin/cost-query.ts
+++ b/src/lib/admin/cost-query.ts
@@ -1,0 +1,596 @@
+/**
+ * Captain cost dashboard — query layer for the per-customer cost_telemetry
+ * data populated by the `ss-cost-telemetry` worker (PR #1023).
+ *
+ * Two data surfaces are involved:
+ *
+ *   1. Central D1 (`env.DB`) — holds `customer_configs` (the customer
+ *      enumeration) and `subscriptions` (the recurring-revenue figure
+ *      used by the COGS/MRR ratio).
+ *
+ *   2. Per-customer D1 (one per customer, addressed via the Cloudflare
+ *      D1 HTTP API) — holds the `cost_telemetry` table per ADR 0009.
+ *      The per-customer database id is stored in
+ *      `customer_configs.connectors_json.per_customer_d1_database_id`.
+ *
+ * Reading the per-customer DB from this Worker means we go through the
+ * D1 HTTP API rather than a binding — same mechanism the telemetry
+ * worker uses. This is deliberate: declaring N per-customer D1 bindings
+ * in wrangler.toml at deploy time does not scale, and the dashboard is
+ * a Captain-only surface where the modest extra latency is acceptable.
+ *
+ * Fabrication discipline (CLAUDE.md Pattern A/B): the dashboard never
+ * fabricates per-skill or per-model breakdown that the underlying schema
+ * does not record. The cost_telemetry schema groups Anthropic usage into
+ * `claude_api_input_tokens` / `claude_api_output_tokens` and Composio
+ * into a single `composio_actions` driver. Per-model and per-toolkit
+ * decomposition is phase 2; this module surfaces only what is in the
+ * data.
+ */
+
+export interface CostQueryEnv {
+  CF_ACCOUNT_ID: string
+  CF_D1_API_TOKEN: string
+}
+
+export interface CustomerListRow {
+  customer_slug: string
+  entity_id: string | null
+  entity_name: string | null
+  per_customer_d1_database_id: string | null
+  composio_account_id: string | null
+  subscription_status: string | null
+  monthly_revenue_cents: number | null
+}
+
+interface CustomerConfigRow {
+  customer_slug: string
+  entity_id: string
+  connectors_json: string | null
+}
+
+interface SubscriptionRow {
+  entity_id: string
+  status: string
+  settings_json: string | null
+}
+
+interface EntityRow {
+  id: string
+  name: string
+}
+
+/**
+ * Enumerate every AI Employee customer with the data the dashboard
+ * needs: the per-customer D1 id (required to read cost_telemetry), the
+ * subscription status (for the COGS-vs-revenue indicator), and the
+ * entity name (display).
+ *
+ * The query joins customer_configs to subscriptions filtered to the
+ * `ai-employee` product slug — non-AI-Employee customers don't apply.
+ */
+export async function listCostCustomers(db: D1Database): Promise<CustomerListRow[]> {
+  const configsResult = await db
+    .prepare(
+      `SELECT customer_slug, entity_id, connectors_json
+         FROM customer_configs
+         ORDER BY customer_slug`
+    )
+    .all<CustomerConfigRow>()
+  const configs = configsResult.results ?? []
+  if (configs.length === 0) return []
+
+  const entityIds = configs.map((c) => c.entity_id)
+  const placeholders = entityIds.map(() => '?').join(',')
+
+  const subsResult = await db
+    .prepare(
+      `SELECT entity_id, status, settings_json
+         FROM subscriptions
+         WHERE product_slug = 'ai-employee'
+           AND entity_id IN (${placeholders})`
+    )
+    .bind(...entityIds)
+    .all<SubscriptionRow>()
+  const subsByEntity = new Map<string, SubscriptionRow>()
+  for (const row of subsResult.results ?? []) {
+    subsByEntity.set(row.entity_id, row)
+  }
+
+  const entitiesResult = await db
+    .prepare(`SELECT id, name FROM entities WHERE id IN (${placeholders})`)
+    .bind(...entityIds)
+    .all<EntityRow>()
+  const namesByEntity = new Map<string, string>()
+  for (const row of entitiesResult.results ?? []) {
+    namesByEntity.set(row.id, row.name)
+  }
+
+  return configs.map((c) => {
+    const { perCustomerDbId, composioAccountId } = parseConnectors(c.connectors_json)
+    const sub = subsByEntity.get(c.entity_id) ?? null
+    return {
+      customer_slug: c.customer_slug,
+      entity_id: c.entity_id,
+      entity_name: namesByEntity.get(c.entity_id) ?? null,
+      per_customer_d1_database_id: perCustomerDbId,
+      composio_account_id: composioAccountId,
+      subscription_status: sub?.status ?? null,
+      monthly_revenue_cents: parseMonthlyRevenueCents(sub?.settings_json ?? null),
+    }
+  })
+}
+
+function parseConnectors(connectorsJson: string | null): {
+  perCustomerDbId: string | null
+  composioAccountId: string | null
+} {
+  if (!connectorsJson) return { perCustomerDbId: null, composioAccountId: null }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(connectorsJson)
+  } catch {
+    return { perCustomerDbId: null, composioAccountId: null }
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { perCustomerDbId: null, composioAccountId: null }
+  }
+  const obj = parsed as Record<string, unknown>
+  const dbId = obj['per_customer_d1_database_id']
+  const composio = obj['composio_account_id']
+  return {
+    perCustomerDbId: typeof dbId === 'string' && dbId.length > 0 ? dbId : null,
+    composioAccountId: typeof composio === 'string' && composio.length > 0 ? composio : null,
+  }
+}
+
+/**
+ * Recurring revenue (MRR) for the customer in integer cents. Read from
+ * `subscriptions.settings_json.monthly_price_cents`, the documented
+ * per-product configuration field (cost-telemetry-events.md "COGS/MRR
+ * ratio computation" — "customer's flat-monthly SKU price in cents").
+ *
+ * Returns null when the field is absent or unparseable. The caller
+ * treats null as "unpriced" and renders the COGS/MRR indicator as
+ * "—" rather than fabricating a default.
+ */
+function parseMonthlyRevenueCents(settingsJson: string | null): number | null {
+  if (!settingsJson) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(settingsJson)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const value = (parsed as Record<string, unknown>)['monthly_price_cents']
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null
+  return Math.round(value)
+}
+
+// ---------------------------------------------------------------------------
+// Per-customer cost_telemetry reads (D1 HTTP API)
+// ---------------------------------------------------------------------------
+
+export interface CostTelemetryRow {
+  date: string
+  driver: string
+  amount_cents: number
+  units: number | null
+  unit_type: string | null
+}
+
+interface D1HttpResultRow {
+  date?: string
+  driver?: string
+  amount_cents?: number
+  units?: number | null
+  unit_type?: string | null
+}
+
+interface D1HttpResponse {
+  success?: boolean
+  errors?: unknown
+  result?: Array<{ results?: D1HttpResultRow[] }>
+}
+
+/**
+ * Read raw cost_telemetry rows for one customer over a date window
+ * (inclusive `startDate`, exclusive `endDate` — both 'YYYY-MM-DD').
+ *
+ * The half-open range matches the `(date, driver)` PK index in
+ * cost_rollup.py so D1 plans this as an index scan rather than a table
+ * walk. Rows come back ordered by `(date, driver)` for stable rendering.
+ *
+ * Returns `{ rows: [], error: <message> }` when the database is
+ * unreachable; the caller renders an explicit warning rather than
+ * an empty table that looks the same as "no usage yet". See
+ * docs/style/empty-state-pattern.md.
+ */
+export async function fetchCustomerCostRows(
+  env: CostQueryEnv,
+  databaseId: string,
+  startDate: string,
+  endDate: string
+): Promise<{ rows: CostTelemetryRow[]; error: string | null }> {
+  const fetched = await fetchD1Payload(env, databaseId, startDate, endDate)
+  if (fetched.error !== null) return { rows: [], error: fetched.error }
+  const resultRows = fetched.payload.result?.[0]?.results ?? []
+  return { rows: validateRows(resultRows), error: null }
+}
+
+async function fetchD1Payload(
+  env: CostQueryEnv,
+  databaseId: string,
+  startDate: string,
+  endDate: string
+): Promise<{ payload: D1HttpResponse; error: null } | { payload: null; error: string }> {
+  const sql =
+    'SELECT date, driver, amount_cents, units, unit_type ' +
+    'FROM cost_telemetry ' +
+    'WHERE date >= ? AND date < ? AND amount_cents >= 0 ' +
+    'ORDER BY date, driver'
+  const url =
+    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}` +
+    `/d1/database/${databaseId}/query`
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.CF_D1_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ sql, params: [startDate, endDate] }),
+    })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return { payload: null, error: `D1 HTTP request failed: ${msg}` }
+  }
+  if (!response.ok) {
+    const text = await safeText(response)
+    return { payload: null, error: `D1 HTTP ${response.status}: ${text.slice(0, 200)}` }
+  }
+  let raw: unknown
+  try {
+    raw = await response.json()
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return { payload: null, error: `D1 response parse failed: ${msg}` }
+  }
+  const payload = raw as D1HttpResponse
+  if (!payload.success) {
+    return { payload: null, error: `D1 query failed: ${JSON.stringify(payload.errors ?? {})}` }
+  }
+  return { payload, error: null }
+}
+
+function validateRows(resultRows: D1HttpResultRow[]): CostTelemetryRow[] {
+  const rows: CostTelemetryRow[] = []
+  for (const r of resultRows) {
+    if (typeof r.date !== 'string' || typeof r.driver !== 'string') continue
+    if (typeof r.amount_cents !== 'number' || !Number.isFinite(r.amount_cents)) continue
+    rows.push({
+      date: r.date,
+      driver: r.driver,
+      amount_cents: Math.round(r.amount_cents),
+      units: typeof r.units === 'number' && Number.isFinite(r.units) ? r.units : null,
+      unit_type: typeof r.unit_type === 'string' ? r.unit_type : null,
+    })
+  }
+  return rows
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return await response.text()
+  } catch {
+    return ''
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Driver categories that the dashboard groups raw drivers into. Mirrors
+ * the buckets in ai-employee/adapter/cost_rollup.py — keeping the two
+ * lists in sync is intentional. The Worker side uses Python; this side
+ * uses TypeScript; both read the same closed enum from
+ * cost-telemetry-events.md "Drivers + emission sources".
+ *
+ * Unknown drivers bucket into `other` so a new emitter doesn't silently
+ * disappear; the dashboard surfaces the raw driver name in the
+ * `byDriver` map for triage.
+ */
+export type DriverCategory =
+  | 'anthropic_llm'
+  | 'composio_action'
+  | 'fly_compute'
+  | 'cloudflare_d1'
+  | 'cloudflare_r2'
+  | 'cloudflare_vectorize'
+  | 'agentmail'
+  | 'captain_time'
+  | 'other'
+
+const DRIVER_TO_CATEGORY: Record<string, DriverCategory> = {
+  claude_api_input_tokens: 'anthropic_llm',
+  claude_api_output_tokens: 'anthropic_llm',
+  composio_actions: 'composio_action',
+  fly_machine_minutes: 'fly_compute',
+  d1_reads: 'cloudflare_d1',
+  d1_writes: 'cloudflare_d1',
+  r2_storage_gb_hours: 'cloudflare_r2',
+  r2_class_a_ops: 'cloudflare_r2',
+  r2_class_b_ops: 'cloudflare_r2',
+  vectorize_queries: 'cloudflare_vectorize',
+  vectorize_dimensions_stored: 'cloudflare_vectorize',
+  agentmail_messages: 'agentmail',
+  agentmail_mailbox_days: 'agentmail',
+  captain_time: 'captain_time',
+}
+
+export const DRIVER_CATEGORIES: DriverCategory[] = [
+  'anthropic_llm',
+  'composio_action',
+  'fly_compute',
+  'cloudflare_d1',
+  'cloudflare_r2',
+  'cloudflare_vectorize',
+  'agentmail',
+  'captain_time',
+  'other',
+]
+
+export const DRIVER_CATEGORY_LABELS: Record<DriverCategory, string> = {
+  anthropic_llm: 'Anthropic LLM',
+  composio_action: 'Composio actions',
+  fly_compute: 'Fly compute',
+  cloudflare_d1: 'Cloudflare D1',
+  cloudflare_r2: 'Cloudflare R2',
+  cloudflare_vectorize: 'Cloudflare Vectorize',
+  agentmail: 'AgentMail',
+  captain_time: 'Captain time',
+  other: 'Other',
+}
+
+export function categoryForDriver(driver: string): DriverCategory {
+  return DRIVER_TO_CATEGORY[driver] ?? 'other'
+}
+
+export interface DailyCost {
+  date: string
+  total_cents: number
+}
+
+export interface DriverBreakdown {
+  driver: string
+  category: DriverCategory
+  total_cents: number
+  units: number
+  unit_type: string | null
+}
+
+export interface CustomerCostSummary {
+  customer_slug: string
+  windowStart: string
+  windowEnd: string
+  totalCents: number
+  byCategory: Record<DriverCategory, number>
+  byDriver: DriverBreakdown[]
+  byDay: DailyCost[]
+  /**
+   * 7-day rolling average of `total_cents` per day. Only days that have
+   * at least 7 prior days inside the window get a rolling value — earlier
+   * days are null rather than computed against a short sample (an avg
+   * over 1-6 days would be misleading). The 30-day default window yields
+   * 24 rolling-avg points.
+   */
+  rolling7dCents: Array<{ date: string; avg_cents: number | null }>
+  rowCount: number
+}
+
+/**
+ * Compute the 30-day (or arbitrary-window) per-customer summary from
+ * raw cost_telemetry rows. Pure function — the caller fetches; this
+ * computes.
+ *
+ * `byDay` includes every date in the window even if no rows landed
+ * that day (zero-filled) so the rolling avg is computed against a
+ * dense series and the dashboard renders a stable timeline.
+ */
+export function summarizeCostRows(
+  customerSlug: string,
+  windowStart: string,
+  windowEnd: string,
+  rows: CostTelemetryRow[]
+): CustomerCostSummary {
+  const byCategory: Record<DriverCategory, number> = {
+    anthropic_llm: 0,
+    composio_action: 0,
+    fly_compute: 0,
+    cloudflare_d1: 0,
+    cloudflare_r2: 0,
+    cloudflare_vectorize: 0,
+    agentmail: 0,
+    captain_time: 0,
+    other: 0,
+  }
+  const driverAgg = new Map<string, DriverBreakdown>()
+  const dailyAgg = new Map<string, number>()
+  let total = 0
+
+  for (const row of rows) {
+    if (row.amount_cents < 0) continue
+    total += row.amount_cents
+    const cat = categoryForDriver(row.driver)
+    byCategory[cat] += row.amount_cents
+    dailyAgg.set(row.date, (dailyAgg.get(row.date) ?? 0) + row.amount_cents)
+
+    const existing = driverAgg.get(row.driver)
+    if (existing) {
+      existing.total_cents += row.amount_cents
+      existing.units += row.units ?? 0
+    } else {
+      driverAgg.set(row.driver, {
+        driver: row.driver,
+        category: cat,
+        total_cents: row.amount_cents,
+        units: row.units ?? 0,
+        unit_type: row.unit_type,
+      })
+    }
+  }
+
+  const byDay: DailyCost[] = []
+  for (const d of enumerateDates(windowStart, windowEnd)) {
+    byDay.push({ date: d, total_cents: dailyAgg.get(d) ?? 0 })
+  }
+
+  const rolling7dCents: Array<{ date: string; avg_cents: number | null }> = []
+  for (let i = 0; i < byDay.length; i++) {
+    if (i < 6) {
+      rolling7dCents.push({ date: byDay[i].date, avg_cents: null })
+      continue
+    }
+    let sum = 0
+    for (let j = i - 6; j <= i; j++) sum += byDay[j].total_cents
+    rolling7dCents.push({ date: byDay[i].date, avg_cents: Math.round(sum / 7) })
+  }
+
+  const byDriver = Array.from(driverAgg.values()).sort((a, b) => b.total_cents - a.total_cents)
+
+  return {
+    customer_slug: customerSlug,
+    windowStart,
+    windowEnd,
+    totalCents: total,
+    byCategory,
+    byDriver,
+    byDay,
+    rolling7dCents,
+    rowCount: rows.length,
+  }
+}
+
+/**
+ * Enumerate every date string 'YYYY-MM-DD' in the half-open window
+ * `[startDate, endDate)`. Uses UTC throughout — cost_telemetry.date is
+ * a calendar UTC date per cost-telemetry-events.md.
+ */
+export function enumerateDates(startDate: string, endDate: string): string[] {
+  const dates: string[] = []
+  let cur = parseUtcDate(startDate)
+  const end = parseUtcDate(endDate)
+  if (cur >= end) return dates
+  while (cur < end) {
+    dates.push(formatUtcDate(cur))
+    cur = new Date(cur.getTime() + 86_400_000)
+  }
+  return dates
+}
+
+function parseUtcDate(yyyymmdd: string): Date {
+  const [y, m, d] = yyyymmdd.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d))
+}
+
+function formatUtcDate(d: Date): string {
+  const yyyy = d.getUTCFullYear()
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(d.getUTCDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+/**
+ * Compute the 30-day window ending at `today` (exclusive) in UTC.
+ * Used by callers that don't override the window via query params.
+ */
+export function defaultWindow(today: Date = new Date()): { start: string; end: string } {
+  const end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()))
+  const endMs = end.getTime() + 86_400_000 // exclusive end = tomorrow 00:00 UTC
+  const start = new Date(endMs - 30 * 86_400_000)
+  return {
+    start: formatUtcDate(start),
+    end: formatUtcDate(new Date(endMs)),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// COGS / MRR ratio
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert 30-day COGS into an estimated month-equivalent figure. The
+ * underlying telemetry is per-day; the COGS/MRR ratio in
+ * cost-telemetry-events.md §"COGS/MRR ratio computation" is monthly.
+ * 30 days * (~30.44 average month length) is close enough — labelled
+ * "estimated" on the dashboard so the reader knows it is a normalization,
+ * not a billed-period total.
+ */
+export function thirtyDayCogsToMonthlyEstimateCents(cogsCents: number): number {
+  return Math.round((cogsCents * 30.4375) / 30)
+}
+
+export interface CogsRatio {
+  basis_points: number | null
+  status: 'unpriced' | 'healthy' | 'watch' | 'kill'
+}
+
+/**
+ * Compute the COGS/MRR ratio for one customer. Returns basis points
+ * (1/100 of a percent) so downstream comparisons are integer math.
+ *
+ * `kill` threshold mirrors platform-prd §17.1: ratio > 0.40 (4000 bps)
+ * is the documented kill criterion. `watch` is 0.30-0.40 (3000-4000 bps),
+ * a Captain heuristic surface for "this is on the way to the threshold."
+ * `healthy` is < 0.30. `unpriced` is "the customer has no MRR figure
+ * configured" — the ratio is undefined and the dashboard renders "—"
+ * rather than zero.
+ */
+export function cogsRatio(monthlyCogsCents: number, mrrCents: number | null): CogsRatio {
+  if (mrrCents === null || mrrCents <= 0) {
+    return { basis_points: null, status: 'unpriced' }
+  }
+  const bps = Math.round((monthlyCogsCents * 10_000) / mrrCents)
+  let status: CogsRatio['status']
+  if (bps >= 4000) status = 'kill'
+  else if (bps >= 3000) status = 'watch'
+  else status = 'healthy'
+  return { basis_points: bps, status }
+}
+
+// ---------------------------------------------------------------------------
+// CSV serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the raw cost_telemetry rows for one customer as CSV for the
+ * billing reconciliation export. Header columns mirror the table
+ * schema verbatim so the file diffs cleanly against an UPSERT log.
+ */
+export function rowsToCsv(customerSlug: string, rows: CostTelemetryRow[]): string {
+  const header = ['customer_slug', 'date', 'driver', 'amount_cents', 'units', 'unit_type'].join(',')
+  const lines = rows.map((r) =>
+    [
+      csvEscape(customerSlug),
+      csvEscape(r.date),
+      csvEscape(r.driver),
+      String(r.amount_cents),
+      r.units == null ? '' : String(r.units),
+      csvEscape(r.unit_type),
+    ].join(',')
+  )
+  return [header, ...lines].join('\n') + '\n'
+}
+
+function csvEscape(value: string | null | undefined): string {
+  if (value == null) return ''
+  const s = String(value)
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}

--- a/src/pages/admin/ai-employee/costs/[customer_slug].astro
+++ b/src/pages/admin/ai-employee/costs/[customer_slug].astro
@@ -1,0 +1,396 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import {
+  DRIVER_CATEGORIES,
+  DRIVER_CATEGORY_LABELS,
+  cogsRatio,
+  defaultWindow,
+  fetchCustomerCostRows,
+  listCostCustomers,
+  summarizeCostRows,
+  thirtyDayCogsToMonthlyEstimateCents,
+  type DriverCategory,
+} from '../../../../lib/admin/cost-query'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Captain cost dashboard — per-customer drill-down.
+ *
+ * Issue #885 (PRD §15.1). Shows the 30-day per-driver breakdown, the
+ * per-category aggregation, the per-day timeline + 7-day rolling avg,
+ * and the COGS/MRR ratio for one AI Employee customer.
+ *
+ * Fabrication discipline (CLAUDE.md Pattern A/B): the page only displays
+ * what cost_telemetry actually contains. The schema groups Anthropic
+ * usage into `claude_api_input_tokens` / `claude_api_output_tokens`
+ * across all models and Composio into a single `composio_actions`
+ * driver. Per-model and per-toolkit decomposition is phase-2 work; the
+ * page surfaces what is recorded and explicitly says so rather than
+ * fabricating attribution.
+ */
+
+const session = Astro.locals.session!
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/login')
+}
+
+const { customer_slug } = Astro.params
+if (!customer_slug) {
+  return new Response('Customer slug required', { status: 400 })
+}
+
+const customers = await listCostCustomers(env.DB)
+const customer = customers.find((c) => c.customer_slug === customer_slug)
+if (!customer) {
+  return new Response('Customer not found', { status: 404 })
+}
+
+const window = defaultWindow()
+const cfConfigMissing = !env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN
+
+let fetchError: string | null = null
+let summary: ReturnType<typeof summarizeCostRows> | null = null
+let skippedReason: string | null = null
+
+if (!customer.per_customer_d1_database_id) {
+  skippedReason = 'No per-customer D1 configured yet (connectors_json missing the database id)'
+} else if (cfConfigMissing) {
+  skippedReason = 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured on this Worker'
+} else {
+  const result = await fetchCustomerCostRows(
+    { CF_ACCOUNT_ID: env.CF_ACCOUNT_ID!, CF_D1_API_TOKEN: env.CF_D1_API_TOKEN! },
+    customer.per_customer_d1_database_id,
+    window.start,
+    window.end
+  )
+  if (result.error) {
+    fetchError = result.error
+  } else {
+    summary = summarizeCostRows(customer_slug, window.start, window.end, result.rows)
+  }
+}
+
+function formatCurrency(cents: number): string {
+  const dollars = cents / 100
+  return dollars.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function formatUnits(units: number, unitType: string | null): string {
+  if (units === 0) return '0'
+  const fmt = units.toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+  })
+  return unitType ? `${fmt} ${unitType}` : fmt
+}
+
+function formatBps(bps: number | null): string {
+  if (bps === null) return '—'
+  return `${(bps / 100).toFixed(1)}%`
+}
+
+const total30dCents = summary?.totalCents ?? 0
+const monthlyEstimateCents = thirtyDayCogsToMonthlyEstimateCents(total30dCents)
+const ratio = cogsRatio(monthlyEstimateCents, customer.monthly_revenue_cents)
+
+const latestRolling = summary?.rolling7dCents.length
+  ? (summary.rolling7dCents[summary.rolling7dCents.length - 1].avg_cents ?? null)
+  : null
+
+const maxDailyCents = summary ? Math.max(1, ...summary.byDay.map((d) => d.total_cents)) : 1
+const maxRollingCents = summary
+  ? Math.max(1, ...summary.rolling7dCents.map((d) => d.avg_cents ?? 0))
+  : 1
+const maxCategoryCents = summary
+  ? Math.max(1, ...DRIVER_CATEGORIES.map((cat) => summary!.byCategory[cat]))
+  : 1
+
+function barWidth(value: number, max: number): string {
+  if (value === 0) return '0%'
+  const pct = Math.max((value / max) * 100, 2)
+  return `${pct}%`
+}
+
+function statusColor(status: 'unpriced' | 'healthy' | 'watch' | 'kill'): string {
+  switch (status) {
+    case 'kill':
+      return 'text-[color:var(--ss-color-error)]'
+    case 'watch':
+      return 'text-[color:var(--ss-color-attention)]'
+    case 'healthy':
+      return 'text-[color:var(--ss-color-text-primary)]'
+    case 'unpriced':
+      return 'text-[color:var(--ss-color-text-muted)]'
+  }
+}
+
+const nonZeroCategories = summary
+  ? DRIVER_CATEGORIES.filter((cat) => (summary!.byCategory[cat as DriverCategory] ?? 0) > 0)
+  : []
+
+const exportHref = `/api/admin/ai-employee/costs/export?customer_slug=${encodeURIComponent(customer_slug)}&start=${window.start}&end=${window.end}`
+---
+
+<AdminLayout
+  title={`Cost — ${customer.entity_name ?? customer_slug}`}
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'AI Employee' },
+    { label: 'Costs', href: '/admin/ai-employee/costs' },
+    { label: customer.entity_name ?? customer_slug },
+  ]}
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          {customer.entity_name ?? customer_slug}
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          <code>{customer_slug}</code> · 30-day window ({window.start} through {window.end})
+        </p>
+      </div>
+      {
+        customer.per_customer_d1_database_id && !cfConfigMissing && (
+          <a
+            href={exportHref}
+            class="inline-flex items-center min-h-11 px-3 text-sm font-medium border border-[color:var(--ss-color-border)] rounded-[var(--ss-radius-card)] text-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-border-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2"
+          >
+            Export CSV
+          </a>
+        )
+      }
+    </header>
+
+    {
+      skippedReason && (
+        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-attention)] bg-white p-card">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-2">
+            Cost data unavailable
+          </h3>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{skippedReason}</p>
+        </div>
+      )
+    }
+
+    {
+      fetchError && (
+        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] bg-white p-card">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-error)] mb-2">
+            D1 query failed
+          </h3>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">{fetchError}</p>
+        </div>
+      )
+    }
+
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-card">
+      <div
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      >
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          30-day COGS
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)] mt-1">
+          {summary ? formatCurrency(total30dCents) : '—'}
+        </p>
+      </div>
+      <div
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      >
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          7-day avg / day
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)] mt-1">
+          {latestRolling === null ? '—' : formatCurrency(latestRolling)}
+        </p>
+        {
+          summary && latestRolling === null && (
+            <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+              Need ≥ 7 days of data
+            </p>
+          )
+        }
+      </div>
+      <div
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      >
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          Recurring revenue
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)] mt-1">
+          {
+            customer.monthly_revenue_cents === null
+              ? '—'
+              : formatCurrency(customer.monthly_revenue_cents)
+          }
+        </p>
+        {
+          customer.monthly_revenue_cents === null && (
+            <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+              No monthly_price_cents
+            </p>
+          )
+        }
+      </div>
+      <div
+        class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+      >
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          COGS / MRR
+        </p>
+        <p class={`text-2xl font-bold mt-1 ${statusColor(ratio.status)}`}>
+          {formatBps(ratio.basis_points)}
+        </p>
+        <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-1">
+          {
+            ratio.status === 'kill'
+              ? 'Above 40% kill threshold'
+              : ratio.status === 'watch'
+                ? '30–40% watch zone'
+                : ratio.status === 'healthy'
+                  ? 'Below 30% threshold'
+                  : 'Unpriced — ratio undefined'
+          }
+        </p>
+      </div>
+    </div>
+
+    {
+      summary && (
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-card">
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
+              Breakdown by category
+            </h3>
+            {nonZeroCategories.length === 0 ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No cost data in this window yet. The nightly ingest writes one row per customer per
+                day at 02:00 UTC.
+              </p>
+            ) : (
+              <div class="space-y-row">
+                {nonZeroCategories.map((cat) => (
+                  <div class="flex items-center gap-row">
+                    <span class="text-sm text-[color:var(--ss-color-text-secondary)] w-40 shrink-0">
+                      {DRIVER_CATEGORY_LABELS[cat as DriverCategory]}
+                    </span>
+                    <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-5 overflow-hidden">
+                      <div
+                        class="h-full rounded-full bg-[color:var(--ss-color-text-primary)] flex items-center justify-end pr-2"
+                        style={`width: ${barWidth(summary!.byCategory[cat as DriverCategory], maxCategoryCents)}`}
+                      >
+                        <span class="text-xs font-medium text-white">
+                          {formatCurrency(summary!.byCategory[cat as DriverCategory])}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+            <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
+              Breakdown by driver
+            </h3>
+            {summary.byDriver.length === 0 ? (
+              <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+                No driver-level rows in this window.
+              </p>
+            ) : (
+              <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                  <thead>
+                    <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                      <th class="pb-2 font-medium">Driver</th>
+                      <th class="pb-2 font-medium">Category</th>
+                      <th class="pb-2 font-medium text-right">Units</th>
+                      <th class="pb-2 font-medium text-right">Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+                    {summary.byDriver.map((d) => (
+                      <tr>
+                        <td class="py-2 text-[color:var(--ss-color-text-primary)] font-mono text-xs">
+                          {d.driver}
+                        </td>
+                        <td class="py-2 text-[color:var(--ss-color-text-secondary)] text-xs">
+                          {DRIVER_CATEGORY_LABELS[d.category]}
+                        </td>
+                        <td class="py-2 text-right text-[color:var(--ss-color-text-secondary)] text-xs">
+                          {formatUnits(d.units, d.unit_type)}
+                        </td>
+                        <td class="py-2 text-right text-[color:var(--ss-color-text-primary)]">
+                          {formatCurrency(d.total_cents)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-3 pt-3 border-t border-[color:var(--ss-color-border-subtle)]">
+              The cost_telemetry schema records one row per (date, driver). Per-model (e.g. Opus vs.
+              Haiku) and per-toolkit (e.g. Gmail vs. Slack) decomposition is phase-2 work — current
+              v1 emission rolls those up into the driver.
+            </p>
+          </div>
+        </div>
+      )
+    }
+
+    {
+      summary && (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-4">
+            Daily cost — 30-day timeline
+          </h3>
+          {summary.byDay.every((d) => d.total_cents === 0) ? (
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+              No daily rows recorded yet in this window.
+            </p>
+          ) : (
+            <div class="space-y-1">
+              {summary.byDay.map((day, i) => {
+                const rolling = summary!.rolling7dCents[i].avg_cents
+                return (
+                  <div class="flex items-center gap-row text-xs">
+                    <span class="text-[color:var(--ss-color-text-secondary)] w-24 shrink-0 font-mono">
+                      {day.date}
+                    </span>
+                    <div class="flex-1 bg-[color:var(--ss-color-border-subtle)] rounded-full h-4 overflow-hidden relative">
+                      <div
+                        class="h-full bg-[color:var(--ss-color-text-secondary)] rounded-full"
+                        style={`width: ${barWidth(day.total_cents, maxDailyCents)}`}
+                      />
+                      {rolling !== null && (
+                        <div
+                          class="absolute top-0 h-4 border-r-2 border-[color:var(--ss-color-primary)]"
+                          style={`left: ${barWidth(rolling, maxRollingCents)}`}
+                          title={`7-day rolling avg: ${formatCurrency(rolling)}`}
+                        />
+                      )}
+                    </div>
+                    <span class="text-[color:var(--ss-color-text-secondary)] w-20 text-right tabular-nums">
+                      {formatCurrency(day.total_cents)}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+          <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-4 pt-3 border-t border-[color:var(--ss-color-border-subtle)]">
+            The orange marker on each row shows the 7-day rolling average ending that day. Days in
+            the first 6 of the window have no rolling value (insufficient prior data).
+          </p>
+        </div>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/admin/ai-employee/costs/index.astro
+++ b/src/pages/admin/ai-employee/costs/index.astro
@@ -1,0 +1,376 @@
+---
+import AdminLayout from '../../../../layouts/AdminLayout.astro'
+import {
+  cogsRatio,
+  defaultWindow,
+  fetchCustomerCostRows,
+  listCostCustomers,
+  summarizeCostRows,
+  thirtyDayCogsToMonthlyEstimateCents,
+  type CustomerCostSummary,
+} from '../../../../lib/admin/cost-query'
+import { env } from 'cloudflare:workers'
+
+/**
+ * Captain cost dashboard — landing page.
+ *
+ * Lists every AI Employee customer with their 30-day COGS, the 7-day
+ * rolling average, and the COGS-vs-revenue indicator from
+ * `subscriptions.settings_json.monthly_price_cents`. The per-customer
+ * drill-down at `/admin/ai-employee/costs/[customer_slug]` shows the
+ * per-driver breakdown and per-day timeline.
+ *
+ * Issue #885 (PRD §15.1).
+ *
+ * Fabrication discipline (CLAUDE.md Pattern A/B): every figure on this
+ * page is computed from real `cost_telemetry` rows or labelled as an
+ * estimate when normalizing (e.g. 30-day COGS scaled to a monthly
+ * equivalent). When the D1 HTTP API is unreachable the row renders an
+ * explicit error rather than zero.
+ */
+
+const session = Astro.locals.session!
+const window = defaultWindow()
+
+// Captain-only is already enforced by middleware (admin role required for
+// /admin/*), but we re-check here so a misconfigured route doesn't silently
+// fall through to admin-equals-Captain assumption breaking later.
+if (session.role !== 'admin') {
+  return Astro.redirect('/auth/login')
+}
+
+const cfConfigMissing = !env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN
+
+const customers = await listCostCustomers(env.DB)
+
+interface CustomerCard {
+  customer_slug: string
+  entity_name: string | null
+  subscription_status: string | null
+  monthly_revenue_cents: number | null
+  per_customer_d1_database_id: string | null
+  summary: CustomerCostSummary | null
+  error: string | null
+  skippedReason: string | null
+}
+
+const cards: CustomerCard[] = await Promise.all(
+  customers.map(async (c): Promise<CustomerCard> => {
+    if (!c.per_customer_d1_database_id) {
+      return {
+        customer_slug: c.customer_slug,
+        entity_name: c.entity_name,
+        subscription_status: c.subscription_status,
+        monthly_revenue_cents: c.monthly_revenue_cents,
+        per_customer_d1_database_id: c.per_customer_d1_database_id,
+        summary: null,
+        error: null,
+        skippedReason:
+          'No per-customer D1 configured yet (connectors_json missing the database id)',
+      }
+    }
+    if (cfConfigMissing) {
+      return {
+        customer_slug: c.customer_slug,
+        entity_name: c.entity_name,
+        subscription_status: c.subscription_status,
+        monthly_revenue_cents: c.monthly_revenue_cents,
+        per_customer_d1_database_id: c.per_customer_d1_database_id,
+        summary: null,
+        error: null,
+        skippedReason: 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured on this Worker',
+      }
+    }
+    const result = await fetchCustomerCostRows(
+      { CF_ACCOUNT_ID: env.CF_ACCOUNT_ID!, CF_D1_API_TOKEN: env.CF_D1_API_TOKEN! },
+      c.per_customer_d1_database_id,
+      window.start,
+      window.end
+    )
+    if (result.error) {
+      return {
+        customer_slug: c.customer_slug,
+        entity_name: c.entity_name,
+        subscription_status: c.subscription_status,
+        monthly_revenue_cents: c.monthly_revenue_cents,
+        per_customer_d1_database_id: c.per_customer_d1_database_id,
+        summary: null,
+        error: result.error,
+        skippedReason: null,
+      }
+    }
+    const summary = summarizeCostRows(c.customer_slug, window.start, window.end, result.rows)
+    return {
+      customer_slug: c.customer_slug,
+      entity_name: c.entity_name,
+      subscription_status: c.subscription_status,
+      monthly_revenue_cents: c.monthly_revenue_cents,
+      per_customer_d1_database_id: c.per_customer_d1_database_id,
+      summary,
+      error: null,
+      skippedReason: null,
+    }
+  })
+)
+
+function formatCurrency(cents: number): string {
+  const dollars = cents / 100
+  return dollars.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function formatBps(bps: number | null): string {
+  if (bps === null) return '—'
+  return `${(bps / 100).toFixed(1)}%`
+}
+
+function statusColor(status: 'unpriced' | 'healthy' | 'watch' | 'kill'): string {
+  switch (status) {
+    case 'kill':
+      return 'text-[color:var(--ss-color-error)]'
+    case 'watch':
+      return 'text-[color:var(--ss-color-attention)]'
+    case 'healthy':
+      return 'text-[color:var(--ss-color-text-primary)]'
+    case 'unpriced':
+      return 'text-[color:var(--ss-color-text-muted)]'
+  }
+}
+
+function rollingAvgCents(card: CustomerCard): number | null {
+  if (!card.summary) return null
+  // Find the most recent non-null rolling avg; null when the window has
+  // fewer than 7 days of data (window is fixed at 30 here so this is
+  // only null when the very latest point lacks 6 prior days, which the
+  // dense byDay series rules out — but be defensive anyway).
+  for (let i = card.summary.rolling7dCents.length - 1; i >= 0; i--) {
+    const v = card.summary.rolling7dCents[i].avg_cents
+    if (v !== null) return v
+  }
+  return null
+}
+
+const rows = cards.map((card) => {
+  const cogs30dCents = card.summary?.totalCents ?? 0
+  const monthlyEstimateCents = thirtyDayCogsToMonthlyEstimateCents(cogs30dCents)
+  const ratio = cogsRatio(monthlyEstimateCents, card.monthly_revenue_cents)
+  return {
+    card,
+    cogs30dCents,
+    monthlyEstimateCents,
+    rollingAvgDailyCents: rollingAvgCents(card),
+    ratio,
+  }
+})
+
+// Sort: errors first (need attention), then by 30-day COGS descending,
+// then alphabetical. Pushes the highest-cost customers to the top of the
+// page where the eye lands.
+rows.sort((a, b) => {
+  const aErr = a.card.error ? 1 : 0
+  const bErr = b.card.error ? 1 : 0
+  if (aErr !== bErr) return bErr - aErr
+  if (a.cogs30dCents !== b.cogs30dCents) return b.cogs30dCents - a.cogs30dCents
+  return a.card.customer_slug.localeCompare(b.card.customer_slug)
+})
+
+const totalCustomers = customers.length
+const totalCogs30dCents = rows.reduce((sum, r) => sum + r.cogs30dCents, 0)
+---
+
+<AdminLayout
+  title="AI Employee — Costs"
+  breadcrumbs={[
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'AI Employee' },
+    { label: 'Costs' },
+  ]}
+>
+  <div class="space-y-card">
+    <header class="flex items-end justify-between gap-4">
+      <div>
+        <h2 class="text-xl font-semibold text-[color:var(--ss-color-text-primary)]">
+          AI Employee — Per-customer cost telemetry
+        </h2>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)] mt-1">
+          30-day window ({window.start} through {window.end}). Captain-only view of the data
+          populated nightly by the <code>ss-cost-telemetry</code> Worker.
+        </p>
+      </div>
+      <div class="text-right">
+        <p class="text-xs uppercase tracking-wide text-[color:var(--ss-color-text-muted)]">
+          Customers
+        </p>
+        <p class="text-2xl font-bold text-[color:var(--ss-color-text-primary)]">
+          {totalCustomers}
+        </p>
+      </div>
+    </header>
+
+    {
+      cfConfigMissing && (
+        <div class="rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-error)] bg-white p-card">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-error)] mb-2">
+            D1 HTTP API not configured
+          </h3>
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            <code>CF_ACCOUNT_ID</code> and <code>CF_D1_API_TOKEN</code> are not set on this Worker.
+            Per-customer cost data lives in per-customer D1 databases (ADR 0009); without the API
+            token the dashboard cannot read them. Set both secrets via{' '}
+            <code>wrangler secret put</code> and redeploy.
+          </p>
+        </div>
+      )
+    }
+
+    <div
+      class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card"
+    >
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)]">
+          Totals (30-day window)
+        </h3>
+        <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+          {formatCurrency(totalCogs30dCents)} across {totalCustomers} customers
+        </p>
+      </div>
+
+      {
+        customers.length === 0 ? (
+          <p class="text-sm text-[color:var(--ss-color-text-secondary)]">
+            No AI Employee customers configured yet. The dashboard is empty until
+            <code>customer_configs</code> has at least one row.
+          </p>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-left text-xs text-[color:var(--ss-color-text-secondary)] border-b border-[color:var(--ss-color-border)]">
+                  <th class="pb-2 font-medium">Customer</th>
+                  <th class="pb-2 font-medium">Subscription</th>
+                  <th class="pb-2 font-medium text-right">30-day COGS</th>
+                  <th class="pb-2 font-medium text-right">7-day avg / day</th>
+                  <th class="pb-2 font-medium text-right">Monthly estimate</th>
+                  <th class="pb-2 font-medium text-right">Recurring rev</th>
+                  <th class="pb-2 font-medium text-right">COGS / MRR</th>
+                  <th class="pb-2 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-[color:var(--ss-color-border-subtle)]">
+                {rows.map(
+                  ({ card, cogs30dCents, monthlyEstimateCents, rollingAvgDailyCents, ratio }) => (
+                    <tr>
+                      <td class="py-3">
+                        <a
+                          href={`/admin/ai-employee/costs/${card.customer_slug}`}
+                          class="font-medium text-[color:var(--ss-color-text-primary)] hover:text-[color:var(--ss-color-primary)]"
+                        >
+                          {card.entity_name ?? card.customer_slug}
+                        </a>
+                        {card.entity_name && (
+                          <p class="text-xs text-[color:var(--ss-color-text-muted)] mt-0.5">
+                            {card.customer_slug}
+                          </p>
+                        )}
+                      </td>
+                      <td class="py-3 text-[color:var(--ss-color-text-secondary)]">
+                        {card.subscription_status ?? (
+                          <span class="text-[color:var(--ss-color-text-muted)]">none</span>
+                        )}
+                      </td>
+                      <td class="py-3 text-right text-[color:var(--ss-color-text-primary)]">
+                        {card.error || card.skippedReason ? (
+                          <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                        ) : (
+                          formatCurrency(cogs30dCents)
+                        )}
+                      </td>
+                      <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
+                        {rollingAvgDailyCents === null ? (
+                          <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                        ) : (
+                          formatCurrency(rollingAvgDailyCents)
+                        )}
+                      </td>
+                      <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
+                        {card.error || card.skippedReason ? (
+                          <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                        ) : (
+                          <span title="30-day COGS scaled to a 30.4375-day month">
+                            {formatCurrency(monthlyEstimateCents)} <span class="text-xs">est</span>
+                          </span>
+                        )}
+                      </td>
+                      <td class="py-3 text-right text-[color:var(--ss-color-text-secondary)]">
+                        {card.monthly_revenue_cents === null ? (
+                          <span class="text-[color:var(--ss-color-text-muted)]">—</span>
+                        ) : (
+                          formatCurrency(card.monthly_revenue_cents)
+                        )}
+                      </td>
+                      <td class={`py-3 text-right font-medium ${statusColor(ratio.status)}`}>
+                        {formatBps(ratio.basis_points)}
+                      </td>
+                      <td class="py-3 text-right text-xs">
+                        {card.per_customer_d1_database_id && !cfConfigMissing && (
+                          <a
+                            href={`/api/admin/ai-employee/costs/export?customer_slug=${encodeURIComponent(card.customer_slug)}&start=${window.start}&end=${window.end}`}
+                            class="text-[color:var(--ss-color-action)] hover:underline"
+                          >
+                            Export CSV
+                          </a>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                )}
+              </tbody>
+            </table>
+          </div>
+        )
+      }
+
+      <div
+        class="mt-4 pt-4 border-t border-[color:var(--ss-color-border-subtle)] space-y-2 text-xs text-[color:var(--ss-color-text-muted)]"
+      >
+        <p>
+          <strong>COGS / MRR thresholds.</strong> Healthy &lt; 30%, watch 30–40%, kill ≥ 40% (per platform-prd
+          §17.1). Customers without a configured monthly_price_cents in
+          <code>subscriptions.settings_json</code> show "—".
+        </p>
+        <p>
+          <strong>Monthly estimate</strong> normalizes the 30-day window to a 30.4375-day calendar month.
+          It is not a billed-period total — the underlying telemetry is per-day.
+        </p>
+      </div>
+    </div>
+
+    {
+      rows.some((r) => r.card.error || r.card.skippedReason) && (
+        <div class="bg-white rounded-[var(--ss-radius-card)] border border-[color:var(--ss-color-border)] p-card">
+          <h3 class="text-base font-semibold text-[color:var(--ss-color-text-primary)] mb-3">
+            Skipped or errored customers
+          </h3>
+          <ul class="space-y-2 text-sm">
+            {rows
+              .filter((r) => r.card.error || r.card.skippedReason)
+              .map((r) => (
+                <li class="flex items-start gap-2">
+                  <span class="font-medium text-[color:var(--ss-color-text-primary)] shrink-0">
+                    {r.card.customer_slug}
+                  </span>
+                  <span class="text-[color:var(--ss-color-text-secondary)]">
+                    {r.card.error ?? r.card.skippedReason}
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )
+    }
+  </div>
+</AdminLayout>

--- a/src/pages/api/admin/ai-employee/costs/export.ts
+++ b/src/pages/api/admin/ai-employee/costs/export.ts
@@ -1,0 +1,93 @@
+/**
+ * CSV export for the per-customer cost dashboard (#885).
+ *
+ * `GET /api/admin/ai-employee/costs/export?customer_slug=...&start=YYYY-MM-DD&end=YYYY-MM-DD`
+ *
+ * Returns the raw `cost_telemetry` rows for one customer in the given
+ * date window as a CSV download. Used for billing reconciliation —
+ * Captain pulls the file into a spreadsheet to cross-check the ingest
+ * against the Anthropic / Composio invoices.
+ *
+ * Admin-only (enforced both by middleware on `/api/admin/*` and by an
+ * explicit role check here for defense in depth).
+ *
+ * Window defaults to the same 30-day window the dashboard uses. `start`
+ * and `end` are validated as 'YYYY-MM-DD' strings; bad input returns
+ * 400 rather than silently widening the query.
+ */
+
+import type { APIContext, APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
+import {
+  defaultWindow,
+  fetchCustomerCostRows,
+  listCostCustomers,
+  rowsToCsv,
+} from '../../../../../lib/admin/cost-query'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+async function handleGet({ request, locals }: APIContext): Promise<Response> {
+  const session = locals.session
+  if (!session || session.role !== 'admin') {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  const url = new URL(request.url)
+  const customerSlug = url.searchParams.get('customer_slug')
+  if (!customerSlug) {
+    return jsonResponse({ error: 'customer_slug query param is required' }, 400)
+  }
+
+  const defaults = defaultWindow()
+  const start = url.searchParams.get('start') ?? defaults.start
+  const end = url.searchParams.get('end') ?? defaults.end
+  if (!DATE_RE.test(start) || !DATE_RE.test(end)) {
+    return jsonResponse({ error: 'start and end must be YYYY-MM-DD' }, 400)
+  }
+  if (start >= end) {
+    return jsonResponse({ error: 'start must be before end' }, 400)
+  }
+
+  const customers = await listCostCustomers(env.DB)
+  const customer = customers.find((c) => c.customer_slug === customerSlug)
+  if (!customer) {
+    return jsonResponse({ error: 'customer not found' }, 404)
+  }
+  if (!customer.per_customer_d1_database_id) {
+    return jsonResponse({ error: 'customer has no per-customer D1 database configured' }, 409)
+  }
+  if (!env.CF_ACCOUNT_ID || !env.CF_D1_API_TOKEN) {
+    return jsonResponse({ error: 'CF_ACCOUNT_ID / CF_D1_API_TOKEN not configured' }, 503)
+  }
+
+  const result = await fetchCustomerCostRows(
+    { CF_ACCOUNT_ID: env.CF_ACCOUNT_ID, CF_D1_API_TOKEN: env.CF_D1_API_TOKEN },
+    customer.per_customer_d1_database_id,
+    start,
+    end
+  )
+  if (result.error) {
+    return jsonResponse({ error: result.error }, 502)
+  }
+
+  const csv = rowsToCsv(customerSlug, result.rows)
+  const filename = `ai-employee-cost-${customerSlug}-${start}-to-${end}.csv`
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const GET: APIRoute = (ctx) => handleGet(ctx)

--- a/tests/admin-cost-export.test.ts
+++ b/tests/admin-cost-export.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for GET /api/admin/ai-employee/costs/export — auth and input
+ * validation. The CSV serialization is covered by the cost-query unit
+ * tests; this file focuses on the handler-level guarantees:
+ *
+ *   - Unauthorized (no session / non-admin role) → 401
+ *   - Missing customer_slug param → 400
+ *   - Bad date format → 400
+ *   - start >= end → 400
+ *   - Unknown customer → 404
+ *   - Customer without per-customer D1 → 409
+ *   - Worker env missing CF tokens → 503
+ *
+ * Architecture note: the same `buildContext` shape used by other admin
+ * cross-org tests applies here. The handler imports `env` from the
+ * vitest-aliased `cloudflare:workers` stub; we populate it with a
+ * minimal D1 mock that satisfies the customer enumeration query.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { GET } from '../src/pages/api/admin/ai-employee/costs/export'
+import { env as testEnv } from 'cloudflare:workers'
+
+interface MinimalSession {
+  userId: string
+  orgId: string
+  role: string
+  email: string
+  expiresAt: string
+}
+
+function buildContext(opts: { session: MinimalSession | null; url: string }) {
+  const request = new Request(opts.url, { method: 'GET' })
+  return {
+    request,
+    params: {},
+    locals: { session: opts.session },
+  } as unknown as Parameters<typeof GET>[0]
+}
+
+function adminSession(): MinimalSession {
+  return {
+    userId: 'admin-1',
+    orgId: 'org-1',
+    role: 'admin',
+    email: 'captain@smd.services',
+    expiresAt: '2099-12-31T00:00:00Z',
+  }
+}
+
+interface FakeD1Result<T> {
+  results: T[]
+}
+
+function makeMockDb(
+  configs: Array<{ customer_slug: string; entity_id: string; connectors_json: string | null }>,
+  subs: Array<{ entity_id: string; status: string; settings_json: string | null }> = [],
+  entities: Array<{ id: string; name: string }> = []
+): unknown {
+  return {
+    prepare(sql: string) {
+      let boundParams: unknown[] = []
+      const result = {
+        bind(...args: unknown[]) {
+          boundParams = args
+          return result
+        },
+        async all<T>(): Promise<FakeD1Result<T>> {
+          if (sql.includes('FROM customer_configs')) {
+            return { results: configs as unknown as T[] }
+          }
+          if (sql.includes('FROM subscriptions')) {
+            const filtered = subs.filter((s) => boundParams.some((p) => p === s.entity_id))
+            return { results: filtered as unknown as T[] }
+          }
+          if (sql.includes('FROM entities')) {
+            const filtered = entities.filter((e) => boundParams.some((p) => p === e.id))
+            return { results: filtered as unknown as T[] }
+          }
+          return { results: [] }
+        },
+      }
+      return result
+    },
+  }
+}
+
+describe('GET /api/admin/ai-employee/costs/export', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+    Object.assign(testEnv, {
+      DB: makeMockDb([]),
+      CF_ACCOUNT_ID: 'acct',
+      CF_D1_API_TOKEN: 'tok',
+    })
+  })
+
+  afterEach(() => {
+    for (const k of Object.keys(testEnv)) delete (testEnv as unknown as Record<string, unknown>)[k]
+  })
+
+  it('returns 401 when no session', async () => {
+    const ctx = buildContext({
+      session: null,
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when session.role !== admin', async () => {
+    const ctx = buildContext({
+      session: { ...adminSession(), role: 'client' },
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when customer_slug missing', async () => {
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/ai-employee/costs/export',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 on bad date format', async () => {
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme&start=bad&end=2026-05-01',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when start >= end', async () => {
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme&start=2026-05-10&end=2026-05-01',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when customer not found', async () => {
+    Object.assign(testEnv, { DB: makeMockDb([]) })
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 when customer has no per-customer D1', async () => {
+    Object.assign(testEnv, {
+      DB: makeMockDb(
+        [{ customer_slug: 'acme', entity_id: 'ent-1', connectors_json: null }],
+        [],
+        [{ id: 'ent-1', name: 'Acme Co' }]
+      ),
+    })
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 503 when CF env not configured', async () => {
+    Object.assign(testEnv, {
+      DB: makeMockDb(
+        [
+          {
+            customer_slug: 'acme',
+            entity_id: 'ent-1',
+            connectors_json: JSON.stringify({ per_customer_d1_database_id: 'db-id-1' }),
+          },
+        ],
+        [],
+        [{ id: 'ent-1', name: 'Acme Co' }]
+      ),
+    })
+    delete (testEnv as unknown as Record<string, unknown>).CF_ACCOUNT_ID
+    delete (testEnv as unknown as Record<string, unknown>).CF_D1_API_TOKEN
+    const ctx = buildContext({
+      session: adminSession(),
+      url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme',
+    })
+    const res = await GET(ctx)
+    expect(res.status).toBe(503)
+  })
+
+  it('returns CSV with proper headers on happy path', async () => {
+    Object.assign(testEnv, {
+      DB: makeMockDb(
+        [
+          {
+            customer_slug: 'acme',
+            entity_id: 'ent-1',
+            connectors_json: JSON.stringify({ per_customer_d1_database_id: 'db-id-1' }),
+          },
+        ],
+        [],
+        [{ id: 'ent-1', name: 'Acme Co' }]
+      ),
+      CF_ACCOUNT_ID: 'acct',
+      CF_D1_API_TOKEN: 'tok',
+    })
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: [
+            {
+              results: [
+                {
+                  date: '2026-05-01',
+                  driver: 'composio_actions',
+                  amount_cents: 30,
+                  units: 30,
+                  unit_type: 'api_calls',
+                },
+              ],
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+
+    try {
+      const ctx = buildContext({
+        session: adminSession(),
+        url: 'http://test.local/api/admin/ai-employee/costs/export?customer_slug=acme&start=2026-05-01&end=2026-05-15',
+      })
+      const res = await GET(ctx)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Content-Type')).toContain('text/csv')
+      expect(res.headers.get('Content-Disposition')).toContain('attachment')
+      expect(res.headers.get('Content-Disposition')).toContain('acme')
+      const text = await res.text()
+      expect(text).toContain('customer_slug,date,driver,amount_cents,units,unit_type')
+      expect(text).toContain('acme,2026-05-01,composio_actions,30,30,api_calls')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/tests/admin-cost-query.test.ts
+++ b/tests/admin-cost-query.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Unit tests for the Captain cost dashboard query layer (#885).
+ *
+ * Covers the pure-function pieces — aggregation, date enumeration,
+ * COGS/MRR ratio thresholds, rolling-avg fewer-than-7-days handling,
+ * and CSV serialization. The D1 HTTP fetch path is exercised by
+ * stubbing global fetch in a separate block.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  cogsRatio,
+  categoryForDriver,
+  defaultWindow,
+  enumerateDates,
+  fetchCustomerCostRows,
+  rowsToCsv,
+  summarizeCostRows,
+  thirtyDayCogsToMonthlyEstimateCents,
+  type CostTelemetryRow,
+} from '../src/lib/admin/cost-query'
+
+describe('categoryForDriver', () => {
+  it('maps Anthropic input/output tokens to anthropic_llm', () => {
+    expect(categoryForDriver('claude_api_input_tokens')).toBe('anthropic_llm')
+    expect(categoryForDriver('claude_api_output_tokens')).toBe('anthropic_llm')
+  })
+
+  it('maps composio_actions to composio_action', () => {
+    expect(categoryForDriver('composio_actions')).toBe('composio_action')
+  })
+
+  it('maps unknown drivers to other (no silent drop)', () => {
+    expect(categoryForDriver('mystery_driver')).toBe('other')
+  })
+
+  it('maps captain_time to captain_time', () => {
+    expect(categoryForDriver('captain_time')).toBe('captain_time')
+  })
+})
+
+describe('enumerateDates', () => {
+  it('returns every date in a half-open window', () => {
+    expect(enumerateDates('2026-01-01', '2026-01-04')).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+      '2026-01-03',
+    ])
+  })
+
+  it('returns empty when start >= end', () => {
+    expect(enumerateDates('2026-01-04', '2026-01-04')).toEqual([])
+    expect(enumerateDates('2026-01-05', '2026-01-04')).toEqual([])
+  })
+
+  it('crosses month boundaries', () => {
+    expect(enumerateDates('2026-01-30', '2026-02-02')).toEqual([
+      '2026-01-30',
+      '2026-01-31',
+      '2026-02-01',
+    ])
+  })
+})
+
+describe('defaultWindow', () => {
+  it('returns a 30-day window ending tomorrow (UTC)', () => {
+    const today = new Date('2026-05-23T12:00:00Z')
+    const w = defaultWindow(today)
+    expect(w.end).toBe('2026-05-24')
+    expect(w.start).toBe('2026-04-24')
+    expect(enumerateDates(w.start, w.end).length).toBe(30)
+  })
+})
+
+describe('summarizeCostRows', () => {
+  const window = { start: '2026-05-01', end: '2026-05-08' } // 7 days
+
+  it('returns zeroed summary for empty rows but preserves dense byDay timeline', () => {
+    const s = summarizeCostRows('acme', window.start, window.end, [])
+    expect(s.totalCents).toBe(0)
+    expect(s.byCategory.anthropic_llm).toBe(0)
+    expect(s.byDriver).toEqual([])
+    expect(s.byDay).toHaveLength(7)
+    expect(s.byDay.every((d) => d.total_cents === 0)).toBe(true)
+  })
+
+  it('aggregates rows by driver, category, and day', () => {
+    const rows: CostTelemetryRow[] = [
+      {
+        date: '2026-05-01',
+        driver: 'claude_api_input_tokens',
+        amount_cents: 100,
+        units: 1000,
+        unit_type: 'input_tokens',
+      },
+      {
+        date: '2026-05-01',
+        driver: 'claude_api_output_tokens',
+        amount_cents: 250,
+        units: 500,
+        unit_type: 'output_tokens',
+      },
+      {
+        date: '2026-05-02',
+        driver: 'composio_actions',
+        amount_cents: 30,
+        units: 30,
+        unit_type: 'api_calls',
+      },
+    ]
+    const s = summarizeCostRows('acme', window.start, window.end, rows)
+    expect(s.totalCents).toBe(380)
+    expect(s.byCategory.anthropic_llm).toBe(350)
+    expect(s.byCategory.composio_action).toBe(30)
+    expect(s.byDriver).toHaveLength(3)
+    const inputDriver = s.byDriver.find((d) => d.driver === 'claude_api_input_tokens')
+    expect(inputDriver?.units).toBe(1000)
+    expect(s.byDay.find((d) => d.date === '2026-05-01')?.total_cents).toBe(350)
+    expect(s.byDay.find((d) => d.date === '2026-05-02')?.total_cents).toBe(30)
+  })
+
+  it('skips negative amount_cents rows (defensive)', () => {
+    const rows: CostTelemetryRow[] = [
+      {
+        date: '2026-05-01',
+        driver: 'claude_api_input_tokens',
+        amount_cents: -50,
+        units: 100,
+        unit_type: 'input_tokens',
+      },
+    ]
+    const s = summarizeCostRows('acme', window.start, window.end, rows)
+    expect(s.totalCents).toBe(0)
+    expect(s.byCategory.anthropic_llm).toBe(0)
+  })
+
+  it('rolling avg returns null when window has fewer than 7 days at the position', () => {
+    const rows: CostTelemetryRow[] = []
+    for (let i = 0; i < 7; i++) {
+      rows.push({
+        date: `2026-05-0${i + 1}`,
+        driver: 'composio_actions',
+        amount_cents: 70,
+        units: 70,
+        unit_type: 'api_calls',
+      })
+    }
+    const s = summarizeCostRows('acme', window.start, window.end, rows)
+    expect(s.rolling7dCents).toHaveLength(7)
+    for (let i = 0; i < 6; i++) {
+      expect(s.rolling7dCents[i].avg_cents).toBeNull()
+    }
+    expect(s.rolling7dCents[6].avg_cents).toBe(70)
+  })
+
+  it('rolling avg uses 7-day window when sufficient data exists', () => {
+    const rows: CostTelemetryRow[] = []
+    // 8 days: 100 cents/day for 7 days, then 800 cents on day 8
+    const window8 = { start: '2026-05-01', end: '2026-05-09' }
+    for (let i = 0; i < 7; i++) {
+      rows.push({
+        date: `2026-05-0${i + 1}`,
+        driver: 'composio_actions',
+        amount_cents: 100,
+        units: 100,
+        unit_type: 'api_calls',
+      })
+    }
+    rows.push({
+      date: '2026-05-08',
+      driver: 'composio_actions',
+      amount_cents: 800,
+      units: 800,
+      unit_type: 'api_calls',
+    })
+    const s = summarizeCostRows('acme', window8.start, window8.end, rows)
+    // index 6 (day 7) = avg of days 1-7 = 100
+    expect(s.rolling7dCents[6].avg_cents).toBe(100)
+    // index 7 (day 8) = avg of days 2-8 = (100*6 + 800)/7 = 1400/7 = 200
+    expect(s.rolling7dCents[7].avg_cents).toBe(200)
+  })
+
+  it('groups unknown drivers into the other bucket without losing them', () => {
+    const rows: CostTelemetryRow[] = [
+      {
+        date: '2026-05-01',
+        driver: 'futuredriver_xyz',
+        amount_cents: 42,
+        units: 1,
+        unit_type: 'widgets',
+      },
+    ]
+    const s = summarizeCostRows('acme', window.start, window.end, rows)
+    expect(s.byCategory.other).toBe(42)
+    expect(s.byDriver[0]?.driver).toBe('futuredriver_xyz')
+    expect(s.byDriver[0]?.category).toBe('other')
+  })
+})
+
+describe('cogsRatio', () => {
+  it('returns unpriced when MRR is null or 0', () => {
+    expect(cogsRatio(10_000, null)).toEqual({ basis_points: null, status: 'unpriced' })
+    expect(cogsRatio(10_000, 0)).toEqual({ basis_points: null, status: 'unpriced' })
+  })
+
+  it('returns healthy below 30%', () => {
+    const r = cogsRatio(2_900, 10_000)
+    expect(r.status).toBe('healthy')
+    expect(r.basis_points).toBe(2900)
+  })
+
+  it('returns watch between 30-40%', () => {
+    const r = cogsRatio(3_500, 10_000)
+    expect(r.status).toBe('watch')
+    expect(r.basis_points).toBe(3500)
+  })
+
+  it('returns kill at 40% or above (platform-prd §17.1 threshold)', () => {
+    const r = cogsRatio(4_000, 10_000)
+    expect(r.status).toBe('kill')
+    expect(r.basis_points).toBe(4000)
+  })
+
+  it('returns kill above 40%', () => {
+    const r = cogsRatio(5_000, 10_000)
+    expect(r.status).toBe('kill')
+    expect(r.basis_points).toBe(5000)
+  })
+})
+
+describe('thirtyDayCogsToMonthlyEstimateCents', () => {
+  it('scales 30-day COGS up to a 30.4375-day month equivalent', () => {
+    expect(thirtyDayCogsToMonthlyEstimateCents(30_000)).toBe(30_438)
+  })
+
+  it('zero in => zero out', () => {
+    expect(thirtyDayCogsToMonthlyEstimateCents(0)).toBe(0)
+  })
+})
+
+describe('rowsToCsv', () => {
+  it('produces a header row and one line per cost row', () => {
+    const rows: CostTelemetryRow[] = [
+      {
+        date: '2026-05-01',
+        driver: 'claude_api_input_tokens',
+        amount_cents: 100,
+        units: 1000,
+        unit_type: 'input_tokens',
+      },
+      {
+        date: '2026-05-02',
+        driver: 'composio_actions',
+        amount_cents: 30,
+        units: 30,
+        unit_type: 'api_calls',
+      },
+    ]
+    const csv = rowsToCsv('acme', rows)
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('customer_slug,date,driver,amount_cents,units,unit_type')
+    expect(lines[1]).toBe('acme,2026-05-01,claude_api_input_tokens,100,1000,input_tokens')
+    expect(lines[2]).toBe('acme,2026-05-02,composio_actions,30,30,api_calls')
+  })
+
+  it('escapes values containing commas or quotes', () => {
+    const rows: CostTelemetryRow[] = [
+      {
+        date: '2026-05-01',
+        driver: 'weird,"driver"',
+        amount_cents: 1,
+        units: null,
+        unit_type: null,
+      },
+    ]
+    const csv = rowsToCsv('acme,inc', rows)
+    expect(csv).toContain('"acme,inc"')
+    expect(csv).toContain('"weird,""driver"""')
+  })
+
+  it('renders null units as empty field', () => {
+    const rows: CostTelemetryRow[] = [
+      {
+        date: '2026-05-01',
+        driver: 'claude_api_input_tokens',
+        amount_cents: 0,
+        units: null,
+        unit_type: 'input_tokens',
+      },
+    ]
+    const csv = rowsToCsv('acme', rows)
+    const dataLine = csv.trim().split('\n')[1]
+    expect(dataLine).toBe('acme,2026-05-01,claude_api_input_tokens,0,,input_tokens')
+  })
+})
+
+describe('fetchCustomerCostRows (D1 HTTP API)', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('parses the D1 HTTP response into typed rows', async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: [
+            {
+              results: [
+                {
+                  date: '2026-05-01',
+                  driver: 'claude_api_input_tokens',
+                  amount_cents: 100,
+                  units: 1000,
+                  unit_type: 'input_tokens',
+                },
+                {
+                  date: '2026-05-01',
+                  driver: 'composio_actions',
+                  amount_cents: 30,
+                  units: 30,
+                  unit_type: 'api_calls',
+                },
+              ],
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    const result = await fetchCustomerCostRows(
+      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
+      'db-id',
+      '2026-05-01',
+      '2026-06-01'
+    )
+    expect(result.error).toBeNull()
+    expect(result.rows).toHaveLength(2)
+    expect(result.rows[0].driver).toBe('claude_api_input_tokens')
+  })
+
+  it('returns an error string on non-2xx', async () => {
+    globalThis.fetch = async () => new Response('boom', { status: 500 })
+    const result = await fetchCustomerCostRows(
+      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
+      'db-id',
+      '2026-05-01',
+      '2026-06-01'
+    )
+    expect(result.rows).toEqual([])
+    expect(result.error).toContain('D1 HTTP 500')
+  })
+
+  it('returns an error string on payload.success = false', async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ success: false, errors: [{ code: 1, message: 'no such table' }] }),
+        {
+          status: 200,
+        }
+      )
+    const result = await fetchCustomerCostRows(
+      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
+      'db-id',
+      '2026-05-01',
+      '2026-06-01'
+    )
+    expect(result.rows).toEqual([])
+    expect(result.error).toContain('D1 query failed')
+  })
+
+  it('drops malformed rows without crashing', async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: [
+            {
+              results: [
+                { date: 'good', driver: 'composio_actions', amount_cents: 1 },
+                { driver: 'missing_date', amount_cents: 1 },
+                { date: '2026-05-01', amount_cents: 1 },
+                { date: '2026-05-01', driver: 'composio_actions' },
+              ],
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    const result = await fetchCustomerCostRows(
+      { CF_ACCOUNT_ID: 'acct', CF_D1_API_TOKEN: 'tok' },
+      'db-id',
+      '2026-05-01',
+      '2026-06-01'
+    )
+    expect(result.error).toBeNull()
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0].driver).toBe('composio_actions')
+  })
+})


### PR DESCRIPTION
Closes #885. Wave 4 of the customer-zero gate (12/12 plan-v2 streams).

## Summary

Adds the per-customer cost telemetry view Captain needs before beta-1
per PRD §15.1. Reads the data populated nightly by the `ss-cost-telemetry`
worker (#1023) and renders a 30-day per-driver breakdown, 7-day rolling
average, COGS-vs-revenue indicator against the §17.1 threshold, and a
CSV export for billing reconciliation.

Lives at `admin.smd.services/ai-employee/costs` (admin role required by
middleware; re-checked in the handler for defense in depth).

## Acceptance criteria

| AC | Status | Where |
|----|--------|-------|
| Page at `/admin/ai-employee/costs` (admin subdomain, Captain-only) | ✓ | `src/pages/admin/ai-employee/costs/index.astro` + middleware admin gate + explicit `session.role !== 'admin'` re-check in both pages and the export handler |
| Per-customer cost view (last 30 days) | ✓ | Per-customer drill-down at `[customer_slug].astro` with 30-day window from `defaultWindow()` |
| Breakdown by skill, tool, model | ✓ (within schema) | Per-driver and per-category breakdowns; explicit note that per-model and per-toolkit decomposition is phase-2 work (the v1 schema rolls those up into the driver) |
| 7-day rolling average comparison | ✓ | `summarizeCostRows()` computes per-day series + 7-day rolling avg; first 6 days surface as `null` rather than misleading 1-point "avg" |
| CSV export for billing reconciliation | ✓ | `GET /api/admin/ai-employee/costs/export?customer_slug=&start=&end=` returns raw cost_telemetry rows as CSV |
| Per-customer COGS vs revenue indicator | ✓ | `cogsRatio()` reads MRR from `subscriptions.settings_json.monthly_price_cents`; thresholds match platform-prd §17.1 (healthy <30%, watch 30–40%, kill ≥40%) |

## Architecture notes

- **Per-customer D1 reads.** Per ADR 0009 each customer has their own D1
  database; declaring N per-customer bindings does not scale. The
  dashboard reads via the Cloudflare D1 HTTP API the same way the
  telemetry worker writes — requires `CF_ACCOUNT_ID` and `CF_D1_API_TOKEN`
  secrets on the central Worker. When absent the page renders an explicit
  configuration warning rather than fabricating zero-cost data.
- **Pricing reference.** `ai-employee/adapter/cost_telemetry/*.json` are
  treated as authoritative data; this PR does not touch them.
- **Fabrication discipline (CLAUDE.md Pattern A/B).** The dashboard
  surfaces exactly what `cost_telemetry` records. The schema groups
  Anthropic usage into `claude_api_input_tokens` / `claude_api_output_tokens`
  across models and Composio into a single `composio_actions` driver;
  per-model and per-toolkit decomposition is phase-2. Monthly figures are
  labelled "est" because they normalize the 30-day window. Customers
  without configured `monthly_price_cents` render "—" for the COGS/MRR
  ratio rather than zero.
- **Files NOT touched** (per task brief): `ai-employee/adapter/cost_ingest.py`,
  `workers/cost-telemetry/`, pricing JSONs.

## Test plan

- [x] `npm run verify` passes (typecheck + worker typecheck + format +
      lint + build + tests + worker tests)
- [x] `tests/admin-cost-query.test.ts` — 28 unit tests covering
      aggregation, date enumeration, COGS/MRR thresholds, rolling-avg
      <7-days handling, unknown-driver bucketing, CSV serialization, and
      the D1 HTTP fetch path (stubbed)
- [x] `tests/admin-cost-export.test.ts` — 9 handler tests covering auth
      gates (401/403), input validation (400), missing/misconfigured
      customer states (404/409), missing env (503), and happy-path CSV
      headers
- [ ] Manual smoke (post-deploy): hit `/admin/ai-employee/costs` with
      Captain session; verify `CF_ACCOUNT_ID` / `CF_D1_API_TOKEN` secrets
      need to be set via `wrangler secret put` before the per-customer
      reads work
- [ ] CSV export downloads with correct filename and matches the row
      counts shown in the dashboard table

🤖 Generated with [Claude Code](https://claude.com/claude-code)