### PR TITLE
feat(ai-employee): dashboard aliveness signal (#875)

### DIFF
--- a/src/components/portal/ai-employee/AlivenessHeader.astro
+++ b/src/components/portal/ai-employee/AlivenessHeader.astro
@@ -1,0 +1,126 @@
+---
+/**
+ * Dashboard aliveness header — the "where is the agent right now?"
+ * persistent signal (issue #875). Renders one of four states (idle,
+ * running, sticky_stop, offline) plus the last-action timestamp and,
+ * for the two unhealthy states, a Captain-escalation affordance.
+ *
+ * Per-customer: the signal prop is the resolved AlivenessSignal from
+ * `src/lib/portal/ai-employee/aliveness.ts ::
+ * resolveAlivenessSignal(subscription)`. The component takes nothing
+ * about the subscription itself — it is a pure renderer over the
+ * resolved typed signal so unit tests of the resolver and the
+ * component can move independently.
+ *
+ * Empty-state contract: when `signal === null` (no data yet because
+ * the Hermes bridge is not wired), the component renders nothing.
+ * That matches `docs/style/empty-state-pattern.md` — a fabricated
+ * green chip is worse than no chip at all. When the bridge lands,
+ * the resolver starts returning real signals and the chip appears
+ * without a component change.
+ *
+ * Escalation affordance: for `sticky_stop` and `offline` we surface a
+ * single Captain-contact link. The `escalationHref` prop comes from
+ * the page (typically a `mailto:` to the assigned consultant). When
+ * the page cannot resolve one, the prop is null and the component
+ * falls back to a link to the AI Employee settings surface where the
+ * principal can review consultant assignment. The fallback is the
+ * design contract: never render an inert escalation button.
+ */
+
+import { TONE_CLASS } from '../../../lib/portal/status'
+import {
+  alivenessTone,
+  formatAlivenessLevel,
+  formatLastActionAbsolute,
+  formatLastActionRelative,
+  needsEscalationAffordance,
+  type AlivenessSignal,
+} from '../../../lib/portal/ai-employee/aliveness'
+
+interface Props {
+  /** Resolved aliveness signal or null when the bridge has no data. */
+  signal: AlivenessSignal | null
+  /**
+   * Optional `mailto:` / `tel:` href the escalation affordance should
+   * point at. Page typically supplies the assigned consultant's email.
+   * null falls back to the AI Employee settings surface.
+   */
+  escalationHref?: string | null
+  /** Optional aria label override for the escalation link. */
+  escalationLabel?: string | null
+}
+
+const { signal, escalationHref = null, escalationLabel = null } = Astro.props
+
+if (signal === null) {
+  // Empty-state branch — render nothing. The wrapping page already
+  // owns the dashboard chrome; we are silently absent until the
+  // bridge has real data to report.
+}
+
+const level = signal?.level ?? null
+const tone = level ? alivenessTone(level) : null
+const toneClass = tone ? TONE_CLASS[tone] : ''
+const headline = level ? formatAlivenessLevel(level) : ''
+const lastActionRelative = signal ? formatLastActionRelative(signal.lastActionAt) : null
+const lastActionAbsolute = signal ? formatLastActionAbsolute(signal.lastActionAt) : null
+const showEscalation = level ? needsEscalationAffordance(level) : false
+const escalationTarget = escalationHref ?? '/portal/products/ai-employee/settings'
+const escalationAria =
+  escalationLabel ??
+  (level === 'sticky_stop' ? 'Escalate to your consultant' : 'Contact your consultant')
+---
+
+{
+  signal !== null && (
+    <section
+      aria-label="AI Employee status"
+      data-testid="aliveness-header"
+      data-aliveness-level={level}
+      class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]"
+    >
+      <div class="flex flex-col gap-3 px-5 md:px-7 py-4 md:flex-row md:items-center md:justify-between md:gap-6">
+        <div class="flex flex-col gap-2 min-w-0 md:flex-row md:items-center md:gap-4">
+          <div class="flex items-center gap-3 min-w-0">
+            <span
+              class={`inline-flex items-center font-mono uppercase tracking-[var(--ss-text-letter-spacing-label)] font-semibold rounded-[var(--ss-radius-badge)] whitespace-nowrap px-3 py-1.5 text-label ${toneClass}`}
+            >
+              {headline}
+            </span>
+            {signal.level === 'running' && signal.currentSkill && (
+              <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)] truncate">
+                {signal.currentSkill}
+              </p>
+            )}
+          </div>
+          {signal.level === 'sticky_stop' && signal.stickyStopReason && (
+            <p class="text-sm text-[color:var(--ss-color-text-secondary)] min-w-0">
+              {signal.stickyStopReason}
+            </p>
+          )}
+        </div>
+
+        <div class="flex items-center justify-between gap-4 md:justify-end">
+          {lastActionRelative && lastActionAbsolute && (
+            <p
+              class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] text-[color:var(--ss-color-text-secondary)] whitespace-nowrap"
+              title={`Last action ${lastActionAbsolute}`}
+            >
+              Last action {lastActionRelative}
+            </p>
+          )}
+          {showEscalation && (
+            <a
+              href={escalationTarget}
+              aria-label={escalationAria}
+              class="inline-flex items-center min-h-11 px-3 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-background)] bg-[color:var(--ss-color-text-primary)] hover:bg-[color:var(--ss-color-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-offset-2 rounded-[var(--ss-radius-button)]"
+            >
+              Contact your consultant
+            </a>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/portal/ai-employee/aliveness.ts
+++ b/src/lib/portal/ai-employee/aliveness.ts
@@ -1,0 +1,375 @@
+/**
+ * AI Employee — dashboard aliveness signal (issue #875).
+ *
+ * Customers asked "where is the agent right now?" The aliveness signal
+ * is the persistent header chip that answers that question without
+ * making them open the audit viewer. Four states cover every observable
+ * posture of a customer's Hermes Machine:
+ *
+ *   idle        — the Machine is up; the last audit event is recent and
+ *                 nothing is currently running. Healthy default.
+ *   running     — there is an in-flight skill invocation. The signal
+ *                 carries the skill name so the header reads "Running
+ *                 inbox-triage" instead of a generic "Working".
+ *   sticky_stop — the safety substrate has pinned the agent. WARN /
+ *                 SOFT_STOP / HARD_STOP from `sticky_stop_state` all
+ *                 collapse to this signal here; the dashboard surfaces
+ *                 the reason text the substrate stored. Captain
+ *                 escalation is required to clear (see ADR for
+ *                 sticky-stop recovery contract in
+ *                 `ai-employee/safety-substrate/sticky_stop.py`).
+ *   offline     — no audit_log activity within OFFLINE_THRESHOLD_MINUTES.
+ *                 This is a derived posture: the audit writer is
+ *                 synchronous on every action (issue #891), so absence
+ *                 of audit rows past the freshness window means either
+ *                 the Machine is down, the bridge is broken, or the
+ *                 customer's agent is genuinely doing nothing.
+ *
+ * Data sources, when the Hermes bridge lands (#821):
+ *
+ *   - Latest `audit_log` row → `lastActionAt`, `currentSkill` (when the
+ *     action is in flight per a future running-action marker — today
+ *     we infer "running" only when the bridge explicitly says so), and
+ *     the audit row drives the idle/offline split via timestamp age.
+ *
+ *   - `sticky_stop_state` (per-customer D1, schema in migration 0004)
+ *     → the sticky_stop posture, reason, and the substrate condition
+ *     that pinned it.
+ *
+ * Today the bridge is not wired. `resolveAlivenessSignal` returns null
+ * and the AlivenessHeader component renders the empty-state branch
+ * (no fabricated activity, per
+ * `docs/style/empty-state-pattern.md`). When #821 lands, swap the body
+ * of `fetchAlivenessFromHermes`; the derivation, formatters, and
+ * threshold constant stay put.
+ *
+ * The derivation helper `deriveAlivenessFromBridge` is exported pure
+ * and tested directly. The component does not derive from raw inputs;
+ * it consumes the resolved signal.
+ *
+ * Per-customer: the resolver takes a `SubscriptionRow` and the bridge
+ * routes to the matching customer Machine. Aggregate is explicitly out
+ * of scope — the issue AC is "per-customer status, not aggregate."
+ */
+
+import type { SubscriptionRow } from '../product-access'
+
+/**
+ * Closed vocabulary for the dashboard aliveness signal. The page must
+ * render exactly one of these states; unknown / pending data degrades
+ * to null (empty-state) rather than fabricating a posture.
+ */
+export type AlivenessLevel = 'idle' | 'running' | 'sticky_stop' | 'offline'
+
+export const ALIVENESS_LEVELS: readonly AlivenessLevel[] = [
+  'idle',
+  'running',
+  'sticky_stop',
+  'offline',
+] as const
+
+/**
+ * Tone for the aliveness chip, drawn from the portal `Tone` vocabulary
+ * in `src/lib/portal/status.ts`. Returned as a string here to avoid
+ * importing the full tone module at the resolver layer — the component
+ * is the only consumer that needs the typed value, and it imports both
+ * sides.
+ *
+ * Assignment rationale:
+ *   idle        → success — the Machine is healthy and reachable
+ *   running     → info    — actively working; reviewer-noticeable but
+ *                           not actionable
+ *   sticky_stop → danger  — Captain escalation required
+ *   offline     → warning — degraded; may or may not need attention
+ *                           depending on hours-of-operation; reviewers
+ *                           should look at the last-action timestamp
+ */
+export function alivenessTone(level: AlivenessLevel): 'success' | 'info' | 'danger' | 'warning' {
+  switch (level) {
+    case 'idle':
+      return 'success'
+    case 'running':
+      return 'info'
+    case 'sticky_stop':
+      return 'danger'
+    case 'offline':
+      return 'warning'
+  }
+}
+
+/**
+ * Number of minutes of audit-log silence after which a Machine is
+ * considered "offline." The audit writer is synchronous on every
+ * safety-relevant action; gaps in the log past this window indicate
+ * either a downed Machine, a broken bridge, or genuine inactivity.
+ *
+ * 30 minutes is the default because the AI Employee is an
+ * assistant-class agent expected to be active during the firm's
+ * business day; a half-hour gap during work hours is the right amount
+ * of "something is probably off, take a look." Reviewers can still
+ * widen the audit page's date range to see longer-tail history.
+ *
+ * Tracked as an exported constant so the PR body, tests, and any future
+ * customer-yaml override (out of scope today) share one source of
+ * truth.
+ */
+export const OFFLINE_THRESHOLD_MINUTES = 30
+
+/**
+ * One resolved aliveness signal for the dashboard header. The component
+ * renders exactly the fields present here — no field-presence inference,
+ * no derived friendly labels beyond what the formatters below produce.
+ *
+ *   level              — the four-state enum above.
+ *   lastActionAt       — ISO 8601 UTC of the most recent audit_log row.
+ *                        null only when the customer has no audit
+ *                        history at all (first-day case).
+ *   currentSkill       — when `level === 'running'`, the slug of the
+ *                        in-flight skill. null in every other state.
+ *   stickyStopReason   — when `level === 'sticky_stop'`, the substrate's
+ *                        recorded reason string. The Captain-escalation
+ *                        affordance surfaces this verbatim. null in
+ *                        every other state.
+ */
+export interface AlivenessSignal {
+  level: AlivenessLevel
+  lastActionAt: string | null
+  currentSkill: string | null
+  stickyStopReason: string | null
+}
+
+/**
+ * Minimal shape of the data the Hermes bridge will return per request.
+ * Captured here so `deriveAlivenessFromBridge` has a stable, named
+ * contract independent of the audit_log row schema (which carries many
+ * fields the dashboard does not use). Keeps test fixtures readable.
+ */
+export interface AlivenessBridgeReading {
+  /** ISO 8601 UTC of the most recent audit_log row, null if none. */
+  lastAuditTs: string | null
+  /**
+   * Slug of an in-flight skill at the moment the bridge was polled,
+   * null if nothing is running. The bridge is responsible for the
+   * "in-flight" determination (e.g., a started-but-not-completed
+   * marker in the per-customer runtime); this module does not infer
+   * it from the audit row.
+   */
+  inFlightSkill: string | null
+  /**
+   * The forward-only sticky-stop level. 'OK' means not pinned;
+   * anything else means the agent is constrained. The level vocabulary
+   * mirrors `ai-employee/safety-substrate/sticky_stop.py::StickyStopLevel`.
+   * Unknown values surface as 'OK' rather than collapsing to
+   * sticky_stop — under-reporting is preferable to false-positive
+   * "agent is stopped" copy.
+   */
+  stickyStopLevel: 'OK' | 'WARN' | 'SOFT_STOP' | 'HARD_STOP'
+  /**
+   * Human-readable reason text the substrate stored when it pinned the
+   * stop. null when `stickyStopLevel === 'OK'`.
+   */
+  stickyStopReason: string | null
+}
+
+/**
+ * Pure derivation: bridge reading → AlivenessSignal. The four-state
+ * enum collapses from three inputs in priority order:
+ *
+ *   1. sticky_stop wins over everything else — when the substrate has
+ *      pinned the agent, no other posture is interesting until Captain
+ *      clears it.
+ *   2. an in-flight skill → 'running'.
+ *   3. lastAuditTs age compared against OFFLINE_THRESHOLD_MINUTES
+ *      decides idle vs offline. No audit history at all (null ts) is
+ *      treated as 'offline' too — the bridge is the authority on
+ *      "agent is alive enough to write audit rows" and absence is
+ *      the honest answer.
+ *
+ * `nowMs` is injectable for deterministic tests.
+ */
+export function deriveAlivenessFromBridge(
+  reading: AlivenessBridgeReading,
+  nowMs: number = Date.now()
+): AlivenessSignal {
+  if (reading.stickyStopLevel !== 'OK') {
+    return {
+      level: 'sticky_stop',
+      lastActionAt: reading.lastAuditTs,
+      currentSkill: null,
+      stickyStopReason: reading.stickyStopReason,
+    }
+  }
+
+  if (reading.inFlightSkill !== null && reading.inFlightSkill.length > 0) {
+    return {
+      level: 'running',
+      lastActionAt: reading.lastAuditTs,
+      currentSkill: reading.inFlightSkill,
+      stickyStopReason: null,
+    }
+  }
+
+  if (reading.lastAuditTs === null) {
+    return {
+      level: 'offline',
+      lastActionAt: null,
+      currentSkill: null,
+      stickyStopReason: null,
+    }
+  }
+
+  const lastMs = Date.parse(reading.lastAuditTs)
+  if (!Number.isFinite(lastMs)) {
+    return {
+      level: 'offline',
+      lastActionAt: reading.lastAuditTs,
+      currentSkill: null,
+      stickyStopReason: null,
+    }
+  }
+
+  const ageMs = nowMs - lastMs
+  const thresholdMs = OFFLINE_THRESHOLD_MINUTES * 60_000
+  if (ageMs > thresholdMs) {
+    return {
+      level: 'offline',
+      lastActionAt: reading.lastAuditTs,
+      currentSkill: null,
+      stickyStopReason: null,
+    }
+  }
+
+  return {
+    level: 'idle',
+    lastActionAt: reading.lastAuditTs,
+    currentSkill: null,
+    stickyStopReason: null,
+  }
+}
+
+/**
+ * Friendly label for an AlivenessLevel. The component pairs this with
+ * the chip tone; the label is the headline text in the header band.
+ *
+ * Closed vocabulary; the switch is exhaustive so any new level surfaces
+ * at compile time.
+ */
+export function formatAlivenessLevel(level: AlivenessLevel): string {
+  switch (level) {
+    case 'idle':
+      return 'Idle'
+    case 'running':
+      return 'Running'
+    case 'sticky_stop':
+      return 'Paused by safety check'
+    case 'offline':
+      return 'Offline'
+  }
+}
+
+/**
+ * Friendly relative-time label for the last-action timestamp.
+ *
+ * Returns "just now" for ages under a minute, "N minute(s) ago" up to
+ * an hour, "N hour(s) ago" up to a day, "N day(s) ago" beyond that.
+ * The component pairs this with the absolute ISO value in a tooltip /
+ * `title` attribute so reviewers can hover for the exact instant.
+ *
+ * Returns null when the input is null or unparseable — the component
+ * renders the absolute fallback (`ts` verbatim or omits the line)
+ * rather than fabricating "unknown ago" copy.
+ *
+ * `nowMs` is injectable for deterministic tests.
+ */
+export function formatLastActionRelative(
+  ts: string | null,
+  nowMs: number = Date.now()
+): string | null {
+  if (ts === null) return null
+  const tsMs = Date.parse(ts)
+  if (!Number.isFinite(tsMs)) return null
+  const deltaMs = nowMs - tsMs
+  if (deltaMs < 0) return 'just now'
+  const seconds = Math.floor(deltaMs / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  return `${days} day${days === 1 ? '' : 's'} ago`
+}
+
+/**
+ * Format the absolute last-action timestamp for the chip's `title`
+ * attribute and the visible secondary line. Same UTC + locale-stable
+ * shape the audit page uses (`src/lib/portal/ai-employee/audit.ts ::
+ * formatAuditTimestamp`) so the two surfaces agree at a glance.
+ *
+ * Returns the input verbatim when unparseable.
+ */
+export function formatLastActionAbsolute(ts: string | null): string | null {
+  if (ts === null) return null
+  const parsedMs = Date.parse(ts)
+  if (!Number.isFinite(parsedMs)) return ts
+  const dt = new Date(parsedMs)
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  })
+  return fmt.format(dt)
+}
+
+/**
+ * Whether the current signal warrants the Captain-escalation
+ * affordance. True for `sticky_stop` (the agent is pinned and only
+ * Captain can clear) and `offline` (the Machine is not reporting
+ * activity and may need investigation). The component renders the
+ * affordance only when this is true.
+ *
+ * `idle` and `running` are healthy postures; surfacing an escalation
+ * link there would train customers to ignore it.
+ */
+export function needsEscalationAffordance(level: AlivenessLevel): boolean {
+  return level === 'sticky_stop' || level === 'offline'
+}
+
+/**
+ * Server-side resolver invoked by the dashboard header. Today this
+ * returns null — the per-customer Hermes bridge that feeds real data
+ * is tracked in #821. When the bridge lands, replace the body of
+ * `fetchAlivenessFromHermes` and the typed contract above stays put.
+ *
+ * IMPORTANT: do not seed a synthetic "idle" reading here. Per
+ * `docs/style/empty-state-pattern.md`, the component must render the
+ * empty (silent) state until real data lands, never a fabricated
+ * "agent is healthy" chip. A green chip the customer cannot trust is
+ * worse than no chip at all.
+ */
+export async function resolveAlivenessSignal(
+  subscription: SubscriptionRow,
+  nowMs: number = Date.now()
+): Promise<AlivenessSignal | null> {
+  const reading = await fetchAlivenessFromHermes(subscription)
+  if (reading === null) return null
+  return deriveAlivenessFromBridge(reading, nowMs)
+}
+
+/**
+ * Hermes bridge stub. Returns null. When #821 (Hermes runtime wiring)
+ * lands, replace the body with the bridge fetch — the subscription
+ * row carries the customer identity needed to route to the right
+ * Machine D1.
+ */
+function fetchAlivenessFromHermes(
+  _subscription: SubscriptionRow
+): Promise<AlivenessBridgeReading | null> {
+  return Promise.resolve(null)
+}

--- a/src/pages/portal/products/ai-employee/index.astro
+++ b/src/pages/portal/products/ai-employee/index.astro
@@ -11,11 +11,16 @@ import PortalHeader from '../../../../components/portal/PortalHeader.astro'
 import PortalTabs from '../../../../components/portal/PortalTabs.astro'
 import PortalPageHead from '../../../../components/portal/PortalPageHead.astro'
 import PromotionCardList from '../../../../components/portal/ai-employee/PromotionCardList.astro'
+import AlivenessHeader from '../../../../components/portal/ai-employee/AlivenessHeader.astro'
 import SkipToMain from '../../../../components/SkipToMain.astro'
 import {
   listPromotionReadySkills,
   type PromotionCandidate,
 } from '../../../../lib/portal/ai-employee/promotion-cards'
+import {
+  resolveAlivenessSignal,
+  type AlivenessSignal,
+} from '../../../../lib/portal/ai-employee/aliveness'
 import { SignOutButton } from '@clerk/astro/components'
 import { env } from 'cloudflare:workers'
 
@@ -126,6 +131,19 @@ if (access) {
     description:
       'A full record of every action your AI Employee takes: drafts created, sends approved, identity changes.',
   })
+}
+
+// Aliveness signal (per #875). Per-customer "where is the agent right
+// now" header: idle / running / sticky_stop / offline + last-action
+// timestamp. The Hermes bridge (#821) is not wired today, so the
+// resolver returns null and the AlivenessHeader component renders
+// nothing (empty-state pattern). When the bridge lands, the chip
+// appears without further page changes. Surfaced for any role so
+// operators and compliance see the same posture the principal sees;
+// access to the surface is already role-gated upstream.
+let alivenessSignal: AlivenessSignal | null = null
+if (access) {
+  alivenessSignal = await resolveAlivenessSignal(access.subscription)
 }
 
 // Promotion recommendation cards (per #811). Principal-only because the
@@ -240,94 +258,99 @@ if (access?.roles.includes('principal')) {
 
       {
         surfaceState === 'active' && (
-          <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
-            <div class="flex flex-col gap-8 min-w-0">
-              <PromotionCardList candidates={promotionCandidates} />
-              <section>
-                <p class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
-                  Sections
-                </p>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]">
-                  {sectionCards.map((s, i) => {
-                    const anchor = String(i + 1).padStart(2, '0')
-                    return (
-                      <a
-                        href={s.href}
-                        class="block bg-[color:var(--ss-color-background)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
-                      >
-                        <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
-                          § {anchor}
-                        </p>
-                        <h2 class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
-                          {s.label}
-                        </h2>
-                        <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
-                          {s.description}
-                        </p>
-                      </a>
-                    )
-                  })}
-                </div>
-              </section>
+          <>
+            <div class="mt-8">
+              <AlivenessHeader signal={alivenessSignal} />
             </div>
+            <div class="mt-10 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-10 lg:gap-12 lg:items-start">
+              <div class="flex flex-col gap-8 min-w-0">
+                <PromotionCardList candidates={promotionCandidates} />
+                <section>
+                  <p class="mb-4 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-secondary)]">
+                    Sections
+                  </p>
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-px bg-[color:var(--ss-color-text-primary)] border-[3px] border-[color:var(--ss-color-text-primary)]">
+                    {sectionCards.map((s, i) => {
+                      const anchor = String(i + 1).padStart(2, '0')
+                      return (
+                        <a
+                          href={s.href}
+                          class="block bg-[color:var(--ss-color-background)] p-6 md:p-8 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                        >
+                          <p class="font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold text-[color:var(--ss-color-primary)]">
+                            § {anchor}
+                          </p>
+                          <h2 class="mt-2 font-['Archivo'] text-xl md:text-2xl font-black uppercase tracking-[-0.02em] text-[color:var(--ss-color-text-primary)]">
+                            {s.label}
+                          </h2>
+                          <p class="mt-3 text-sm text-[color:var(--ss-color-text-secondary)]">
+                            {s.description}
+                          </p>
+                        </a>
+                      )
+                    })}
+                  </div>
+                </section>
+              </div>
 
-            <aside class="flex flex-col gap-8 min-w-0">
-              <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
-                <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                  Your roles
-                </div>
-                <div class="px-5 md:px-7 py-6">
-                  <ul
-                    class="space-y-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)]"
-                    role="list"
-                  >
-                    {access?.roles.map((role) => (
-                      <li>· {role}</li>
-                    ))}
-                  </ul>
-                </div>
-              </section>
-
-              {access?.roles.includes('principal') && (
+              <aside class="flex flex-col gap-8 min-w-0">
                 <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
                   <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
-                    Manage
+                    Your roles
                   </div>
-                  <ul
-                    class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]"
-                    role="list"
-                  >
-                    <li>
-                      <a
-                        href="/portal/products/ai-employee/settings/users"
-                        class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
-                      >
-                        <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
-                          Users
-                        </p>
-                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
-                          Invite team members and manage roles.
-                        </p>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        href="/portal/products/ai-employee/settings"
-                        class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
-                      >
-                        <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
-                          Settings
-                        </p>
-                        <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
-                          Configure your AI Employee.
-                        </p>
-                      </a>
-                    </li>
-                  </ul>
+                  <div class="px-5 md:px-7 py-6">
+                    <ul
+                      class="space-y-1 font-['Archivo_Narrow'] text-label uppercase tracking-[0.14em] font-bold text-[color:var(--ss-color-text-primary)]"
+                      role="list"
+                    >
+                      {access?.roles.map((role) => (
+                        <li>· {role}</li>
+                      ))}
+                    </ul>
+                  </div>
                 </section>
-              )}
-            </aside>
-          </div>
+
+                {access?.roles.includes('principal') && (
+                  <section class="border-[3px] border-[color:var(--ss-color-text-primary)] bg-[color:var(--ss-color-background)]">
+                    <div class="bg-[color:var(--ss-color-text-primary)] text-[color:var(--ss-color-background)] px-5 py-2.5 font-['Archivo_Narrow'] text-label uppercase tracking-[0.18em] font-bold">
+                      Manage
+                    </div>
+                    <ul
+                      class="divide-y-[2px] divide-[color:var(--ss-color-text-primary)]"
+                      role="list"
+                    >
+                      <li>
+                        <a
+                          href="/portal/products/ai-employee/settings/users"
+                          class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                        >
+                          <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                            Users
+                          </p>
+                          <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
+                            Invite team members and manage roles.
+                          </p>
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="/portal/products/ai-employee/settings"
+                          class="block px-5 md:px-7 py-4 hover:bg-[color:var(--ss-color-border-subtle)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ss-color-action)] focus-visible:ring-inset"
+                        >
+                          <p class="font-['Archivo'] font-bold text-[color:var(--ss-color-text-primary)]">
+                            Settings
+                          </p>
+                          <p class="mt-1 text-sm text-[color:var(--ss-color-text-secondary)]">
+                            Configure your AI Employee.
+                          </p>
+                        </a>
+                      </li>
+                    </ul>
+                  </section>
+                )}
+              </aside>
+            </div>
+          </>
         )
       }
     </main>

--- a/tests/portal-ai-employee-aliveness.test.ts
+++ b/tests/portal-ai-employee-aliveness.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for the AI Employee dashboard aliveness signal
+ * (src/lib/portal/ai-employee/aliveness.ts).
+ *
+ * Per #875, the dashboard header carries a per-customer "where is the
+ * agent right now" signal: idle / running / sticky_stop / offline,
+ * plus a last-action timestamp and (for unhealthy postures) a
+ * Captain-escalation affordance.
+ *
+ * The Hermes runtime bridge (#821) is not wired today; the resolver
+ * returns null and the AlivenessHeader component renders nothing per
+ * docs/style/empty-state-pattern.md. These tests cover:
+ *
+ *   - The closed AlivenessLevel vocabulary
+ *   - alivenessTone → Tone mapping (closed switch)
+ *   - deriveAlivenessFromBridge — the pure transition that the Hermes
+ *     wiring will call once real readings flow. Priority and edge
+ *     cases (sticky-stop wins, in-flight wins, missing timestamp,
+ *     unparseable timestamp, threshold crossing).
+ *   - formatAlivenessLevel — friendly headline per level
+ *   - formatLastActionRelative — relative-time bucket boundaries
+ *   - formatLastActionAbsolute — null + unparseable handling
+ *   - needsEscalationAffordance — true only for the unhealthy postures
+ *   - resolveAlivenessSignal — empty-state contract (returns null
+ *     under the bridge stub)
+ *
+ * OFFLINE_THRESHOLD_MINUTES is asserted as a constant so a future
+ * customer-yaml override has a single source of truth to verify
+ * against.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  ALIVENESS_LEVELS,
+  OFFLINE_THRESHOLD_MINUTES,
+  alivenessTone,
+  deriveAlivenessFromBridge,
+  formatAlivenessLevel,
+  formatLastActionAbsolute,
+  formatLastActionRelative,
+  needsEscalationAffordance,
+  resolveAlivenessSignal,
+  type AlivenessBridgeReading,
+  type AlivenessLevel,
+} from '../src/lib/portal/ai-employee/aliveness'
+import type { SubscriptionRow } from '../src/lib/portal/product-access'
+
+function makeReading(overrides?: Partial<AlivenessBridgeReading>): AlivenessBridgeReading {
+  return {
+    lastAuditTs: '2026-05-24T12:00:00.000Z',
+    inFlightSkill: null,
+    stickyStopLevel: 'OK',
+    stickyStopReason: null,
+    ...overrides,
+  }
+}
+
+function makeSubscription(overrides?: Partial<SubscriptionRow>): SubscriptionRow {
+  return {
+    id: 'sub_test',
+    org_id: 'org_test',
+    entity_id: 'ent_test',
+    product_slug: 'ai-employee',
+    status: 'active',
+    started_at: '2026-05-01T00:00:00.000Z',
+    ended_at: null,
+    settings_json: null,
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('ALIVENESS_LEVELS', () => {
+  it('exposes the four canonical levels', () => {
+    expect(ALIVENESS_LEVELS).toEqual(['idle', 'running', 'sticky_stop', 'offline'])
+  })
+})
+
+describe('OFFLINE_THRESHOLD_MINUTES', () => {
+  it('is 30 minutes (documented default)', () => {
+    expect(OFFLINE_THRESHOLD_MINUTES).toBe(30)
+  })
+})
+
+describe('alivenessTone', () => {
+  it('maps each level to its assigned tone', () => {
+    const cases: Array<[AlivenessLevel, ReturnType<typeof alivenessTone>]> = [
+      ['idle', 'success'],
+      ['running', 'info'],
+      ['sticky_stop', 'danger'],
+      ['offline', 'warning'],
+    ]
+    for (const [level, expected] of cases) {
+      expect(alivenessTone(level)).toBe(expected)
+    }
+  })
+})
+
+describe('formatAlivenessLevel', () => {
+  it('maps each level to a friendly headline', () => {
+    expect(formatAlivenessLevel('idle')).toBe('Idle')
+    expect(formatAlivenessLevel('running')).toBe('Running')
+    expect(formatAlivenessLevel('sticky_stop')).toBe('Paused by safety check')
+    expect(formatAlivenessLevel('offline')).toBe('Offline')
+  })
+})
+
+describe('needsEscalationAffordance', () => {
+  it('is true for the unhealthy postures only', () => {
+    expect(needsEscalationAffordance('sticky_stop')).toBe(true)
+    expect(needsEscalationAffordance('offline')).toBe(true)
+    expect(needsEscalationAffordance('idle')).toBe(false)
+    expect(needsEscalationAffordance('running')).toBe(false)
+  })
+})
+
+describe('deriveAlivenessFromBridge', () => {
+  // Anchor "now" at noon UTC on the same day as the default fixture.
+  const NOW_MS = Date.parse('2026-05-24T12:05:00.000Z')
+
+  describe('sticky-stop priority', () => {
+    it('returns sticky_stop when stickyStopLevel is WARN', () => {
+      const reading = makeReading({
+        stickyStopLevel: 'WARN',
+        stickyStopReason: 'consecutive_tool_failures=3',
+      })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('sticky_stop')
+      expect(signal.stickyStopReason).toBe('consecutive_tool_failures=3')
+      expect(signal.currentSkill).toBeNull()
+    })
+
+    it('returns sticky_stop when stickyStopLevel is SOFT_STOP', () => {
+      const reading = makeReading({ stickyStopLevel: 'SOFT_STOP', stickyStopReason: 'refusals' })
+      expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('sticky_stop')
+    })
+
+    it('returns sticky_stop when stickyStopLevel is HARD_STOP', () => {
+      const reading = makeReading({ stickyStopLevel: 'HARD_STOP', stickyStopReason: 'capped' })
+      expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('sticky_stop')
+    })
+
+    it('sticky-stop wins over an in-flight skill', () => {
+      const reading = makeReading({
+        stickyStopLevel: 'HARD_STOP',
+        stickyStopReason: 'capped',
+        inFlightSkill: 'inbox-triage',
+      })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('sticky_stop')
+      expect(signal.currentSkill).toBeNull()
+    })
+
+    it('preserves the last-action timestamp even when sticky-stop', () => {
+      const reading = makeReading({
+        stickyStopLevel: 'HARD_STOP',
+        stickyStopReason: 'capped',
+        lastAuditTs: '2026-05-24T11:30:00.000Z',
+      })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.lastActionAt).toBe('2026-05-24T11:30:00.000Z')
+    })
+  })
+
+  describe('running priority', () => {
+    it('returns running when a skill is in flight', () => {
+      const reading = makeReading({ inFlightSkill: 'inbox-triage' })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('running')
+      expect(signal.currentSkill).toBe('inbox-triage')
+      expect(signal.stickyStopReason).toBeNull()
+    })
+
+    it('ignores an empty-string in-flight skill', () => {
+      const reading = makeReading({ inFlightSkill: '' })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('idle')
+    })
+  })
+
+  describe('idle vs offline by audit-row age', () => {
+    it('returns idle when the last audit row is within the threshold', () => {
+      // Default fixture ts is at 12:00; now is 12:05 → 5 minutes ago
+      // → well within 30 min threshold.
+      const signal = deriveAlivenessFromBridge(makeReading(), NOW_MS)
+      expect(signal.level).toBe('idle')
+    })
+
+    it('returns offline when the last audit row is older than the threshold', () => {
+      const reading = makeReading({ lastAuditTs: '2026-05-24T11:30:00.000Z' })
+      // now=12:05, last=11:30 → 35 minutes ago → offline (>30).
+      expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('offline')
+    })
+
+    it('returns offline when lastAuditTs is null (no history)', () => {
+      const reading = makeReading({ lastAuditTs: null })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('offline')
+      expect(signal.lastActionAt).toBeNull()
+    })
+
+    it('returns offline when lastAuditTs is unparseable', () => {
+      const reading = makeReading({ lastAuditTs: 'not a timestamp' })
+      const signal = deriveAlivenessFromBridge(reading, NOW_MS)
+      expect(signal.level).toBe('offline')
+      expect(signal.lastActionAt).toBe('not a timestamp')
+    })
+
+    it('treats exactly threshold-age as still idle (strict >)', () => {
+      // now=12:05; last=11:35 → exactly 30 min ago → still idle.
+      const reading = makeReading({ lastAuditTs: '2026-05-24T11:35:00.000Z' })
+      expect(deriveAlivenessFromBridge(reading, NOW_MS).level).toBe('idle')
+    })
+  })
+})
+
+describe('formatLastActionRelative', () => {
+  const NOW_MS = Date.parse('2026-05-24T12:00:00.000Z')
+
+  it('returns null for null input', () => {
+    expect(formatLastActionRelative(null, NOW_MS)).toBeNull()
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(formatLastActionRelative('garbage', NOW_MS)).toBeNull()
+  })
+
+  it('returns "just now" for ages under a minute', () => {
+    expect(formatLastActionRelative('2026-05-24T11:59:30.000Z', NOW_MS)).toBe('just now')
+  })
+
+  it('returns "just now" for negative ages (clock skew)', () => {
+    expect(formatLastActionRelative('2026-05-24T12:00:10.000Z', NOW_MS)).toBe('just now')
+  })
+
+  it('returns minute-bucketed labels under an hour', () => {
+    expect(formatLastActionRelative('2026-05-24T11:59:00.000Z', NOW_MS)).toBe('1 minute ago')
+    expect(formatLastActionRelative('2026-05-24T11:55:00.000Z', NOW_MS)).toBe('5 minutes ago')
+    expect(formatLastActionRelative('2026-05-24T11:01:00.000Z', NOW_MS)).toBe('59 minutes ago')
+  })
+
+  it('returns hour-bucketed labels under a day', () => {
+    expect(formatLastActionRelative('2026-05-24T11:00:00.000Z', NOW_MS)).toBe('1 hour ago')
+    expect(formatLastActionRelative('2026-05-24T05:00:00.000Z', NOW_MS)).toBe('7 hours ago')
+  })
+
+  it('returns day-bucketed labels beyond a day', () => {
+    expect(formatLastActionRelative('2026-05-23T12:00:00.000Z', NOW_MS)).toBe('1 day ago')
+    expect(formatLastActionRelative('2026-05-20T12:00:00.000Z', NOW_MS)).toBe('4 days ago')
+  })
+})
+
+describe('formatLastActionAbsolute', () => {
+  it('returns null for null input', () => {
+    expect(formatLastActionAbsolute(null)).toBeNull()
+  })
+
+  it('returns the input verbatim when unparseable', () => {
+    expect(formatLastActionAbsolute('not-a-timestamp')).toBe('not-a-timestamp')
+  })
+
+  it('formats a parseable input in UTC with month + day + time', () => {
+    const out = formatLastActionAbsolute('2026-05-24T12:00:00.000Z')
+    expect(out).not.toBeNull()
+    expect(out).toMatch(/2026/)
+    expect(out).toMatch(/UTC/)
+  })
+})
+
+describe('resolveAlivenessSignal', () => {
+  it('returns null today (Hermes bridge not wired)', async () => {
+    const signal = await resolveAlivenessSignal(makeSubscription())
+    expect(signal).toBeNull()
+  })
+
+  it('returns null for any subscription shape (empty-state contract)', async () => {
+    const provisioning = await resolveAlivenessSignal(makeSubscription({ status: 'provisioning' }))
+    const paused = await resolveAlivenessSignal(makeSubscription({ status: 'paused' }))
+    expect(provisioning).toBeNull()
+    expect(paused).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #875.

## Summary

Persistent header signal on the AI Employee dashboard surface that answers the customer question "where is the agent right now?" Four closed-vocab states (`idle` / `running` / `sticky_stop` / `offline`) cover every observable posture of a customer's Hermes Machine. Each carries the last-action timestamp; unhealthy postures surface a Captain-escalation affordance.

Per-customer by construction — the resolver takes the per-entity `SubscriptionRow`.

## Acceptance criteria

| AC | Status | Where |
| --- | --- | --- |
| Persistent signal in dashboard header: agent state (idle / running skill X / sticky-stop / offline) | done | `src/components/portal/ai-employee/AlivenessHeader.astro`, mounted in `src/pages/portal/products/ai-employee/index.astro` (active branch) |
| Last-action timestamp visible | done | `formatLastActionRelative` + `formatLastActionAbsolute` in `src/lib/portal/ai-employee/aliveness.ts`; rendered with relative label and absolute `title` tooltip |
| If sticky-stop or offline, clear Captain-escalation path | done | `needsEscalationAffordance` gates a Contact-your-consultant link; defaults to AI Employee settings when no consultant `mailto:` is wired |
| Per-customer status, not aggregate | done | `resolveAlivenessSignal(subscription)` routes by `SubscriptionRow.entity_id` |

## Offline threshold

`OFFLINE_THRESHOLD_MINUTES = 30`. The audit writer is synchronous on every safety-relevant action (per #891), so gaps in the log past 30 minutes indicate either a downed Machine, a broken bridge, or genuine inactivity. The constant is exported so a future `customer.yaml` override (out of scope today) has a single source of truth.

## Empty-state contract

The Hermes runtime bridge (#821) is not wired today. `fetchAlivenessFromHermes` returns `null`, the resolver returns `null`, and `AlivenessHeader` renders nothing — no fabricated "healthy" chip per `docs/style/empty-state-pattern.md`. When the bridge lands, swap the body of `fetchAlivenessFromHermes`; the typed `AlivenessBridgeReading` → `AlivenessSignal` derivation, formatters, tone mapping, threshold constant, and the component stay put.

## Sticky-stop bridge contract

`AlivenessBridgeReading.stickyStopLevel` mirrors `ai-employee/safety-substrate/sticky_stop.py::StickyStopLevel` (`OK | WARN | SOFT_STOP | HARD_STOP`). Any non-`OK` value collapses to the `sticky_stop` dashboard state. The reason text from the substrate surfaces verbatim in the header — never paraphrased.

## State priority

`deriveAlivenessFromBridge` resolves the four states from three inputs in priority order:

1. `stickyStopLevel !== 'OK'` → `sticky_stop` (substrate-pinned beats every other posture)
2. `inFlightSkill` non-empty → `running`
3. `lastAuditTs` null / unparseable / older than threshold → `offline`
4. otherwise → `idle`

## Test plan

- [x] `npm run verify` (typecheck + lint + unit tests across root and all workers): green
- [x] 29 unit tests in `tests/portal-ai-employee-aliveness.test.ts` cover closed-vocab integrity, the four-state derivation (sticky-stop priority, in-flight detection, idle/offline threshold boundaries, null + unparseable timestamps), tone mapping, formatters (relative-time buckets, absolute UTC), escalation gating, and the empty-state resolver contract
- [x] Existing tests untouched; the dashboard landing page renders nothing for the chip until the bridge lands (visible via the existing empty-state contract on every other AI Employee surface)
- [ ] Bridge wiring under #821 will exercise the live data path (out of scope here)